### PR TITLE
PLT-7551/RN-319/PLT-7553 Updated markdown renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jquery": "3.2.1",
     "key-mirror": "1.0.1",
     "localforage": "1.5.0",
-    "marked": "mattermost/marked#5d184f0aa02f1202d1f4c23cb01b72b10e28b318",
+    "marked": "mattermost/marked#b516702c460c68df0b68fa9f4916f3100572ce99",
     "match-at": "0.1.0",
     "mattermost-redux": "mattermost/mattermost-redux#master",
     "object-assign": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jquery": "3.2.1",
     "key-mirror": "1.0.1",
     "localforage": "1.5.0",
-    "marked": "mattermost/marked#5194fc037b35036910c6542b04bb471fe56b27a9",
+    "marked": "mattermost/marked#5d184f0aa02f1202d1f4c23cb01b72b10e28b318",
     "match-at": "0.1.0",
     "mattermost-redux": "mattermost/mattermost-redux#master",
     "object-assign": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5047,9 +5047,9 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-marked@mattermost/marked#5d184f0aa02f1202d1f4c23cb01b72b10e28b318:
+marked@mattermost/marked#b516702c460c68df0b68fa9f4916f3100572ce99:
   version "0.3.6"
-  resolved "https://codeload.github.com/mattermost/marked/tar.gz/5d184f0aa02f1202d1f4c23cb01b72b10e28b318"
+  resolved "https://codeload.github.com/mattermost/marked/tar.gz/b516702c460c68df0b68fa9f4916f3100572ce99"
 
 match-at@0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5047,9 +5047,9 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-marked@mattermost/marked#5194fc037b35036910c6542b04bb471fe56b27a9:
+marked@mattermost/marked#5d184f0aa02f1202d1f4c23cb01b72b10e28b318:
   version "0.3.6"
-  resolved "https://codeload.github.com/mattermost/marked/tar.gz/5194fc037b35036910c6542b04bb471fe56b27a9"
+  resolved "https://codeload.github.com/mattermost/marked/tar.gz/5d184f0aa02f1202d1f4c23cb01b72b10e28b318"
 
 match-at@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This fixes:
1. Linking www links that don't start words like `testwww.google.ca` (changes [here](https://github.com/mattermost/marked/compare/f513ac53ac83ecb2f4a7d284804f9c1852749a7e%5E...5d184f0aa02f1202d1f4c23cb01b72b10e28b318))
2. Not capturing the closing square bracket in IPv6 links like `http://[::1]` (changes [here](https://github.com/mattermost/marked/compare/5d184f0aa02f1202d1f4c23cb01b72b10e28b318...b516702c460c68df0b68fa9f4916f3100572ce99))

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-319
https://mattermost.atlassian.net/browse/PLT-7551
https://mattermost.atlassian.net/browse/PLT-7553

#### Checklist
- Added or updated unit tests (required for all new features)