### PR TITLE
PLT-7376 Fixed background colour of mobile header icons on IE11 and some refactoring of navbar

### DIFF
--- a/components/navbar/navbar_info_button.jsx
+++ b/components/navbar/navbar_info_button.jsx
@@ -1,0 +1,102 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Popover, OverlayTrigger} from 'react-bootstrap';
+import {FormattedMessage} from 'react-intl';
+
+import MessageWrapper from 'components/message_wrapper.jsx';
+
+import Constants from 'utils/constants.jsx';
+
+export default class NavbarInfoButton extends React.PureComponent {
+    static propTypes = {
+        channel: PropTypes.object,
+        showEditChannelHeaderModal: PropTypes.func.isRequired
+    };
+
+    showEditChannelHeaderModal = () => {
+        this.refs.headerOverlay.hide();
+
+        this.props.showEditChannelHeaderModal();
+    }
+
+    hide = () => {
+        this.refs.headerOverlay.hide();
+    }
+
+    render() {
+        let popoverContent = null;
+        if (this.props.channel) {
+            if (this.props.channel.header) {
+                popoverContent = (
+                    <MessageWrapper
+                        message={this.props.channel.header}
+                        options={{singleline: true, mentionHighlight: false}}
+                    />
+                );
+            } else {
+                const link = (
+                    <a
+                        href='#'
+                        onClick={this.showEditChannelHeaderModal}
+                    >
+                        <FormattedMessage
+                            id='navbar.click'
+                            defaultMessage='Click here'
+                        />
+                    </a>
+                );
+
+                popoverContent = (
+                    <div>
+                        <FormattedMessage
+                            id='navbar.noHeader'
+                            defaultMessage='No channel header yet.{newline}{link} to add one.'
+                            values={{
+                                newline: (<br/>),
+                                link
+                            }}
+                        />
+                    </div>
+                );
+            }
+        }
+
+        const popover = (
+            <Popover
+                bsStyle='info'
+                placement='bottom'
+                id='header-popover'
+            >
+                {popoverContent}
+                <div
+                    className='close visible-xs-block'
+                    onClick={this.hide}
+                >
+                    {'×'}
+                </div>
+            </Popover>
+        );
+
+        return (
+            <OverlayTrigger
+                ref='headerOverlay'
+                trigger='click'
+                placement='bottom'
+                overlay={popover}
+                className='description'
+                rootClose={true}
+            >
+                <div className='navbar-toggle navbar-right__icon navbar-info-button pull-right'>
+                    <span
+                        className='icon icon__info'
+                        dangerouslySetInnerHTML={{__html: Constants.INFO_ICON_SVG}}
+                        aria-hidden='true'
+                    />
+                </div>
+            </OverlayTrigger>
+        );
+    }
+}

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -24,7 +24,7 @@ const Preferences = Constants.Preferences;
 import AnnouncementBar from 'components/announcement_bar';
 import SidebarRight from 'components/sidebar_right';
 import SidebarRightMenu from 'components/sidebar_right_menu.jsx';
-import Navbar from 'components/navbar.jsx';
+import Navbar from 'components/navbar';
 import WebrtcSidebar from 'components/webrtc/components/webrtc_sidebar.jsx';
 
 import WebrtcNotification from 'components/webrtc/components/webrtc_notification.jsx';

--- a/sass/layout/_navigation.scss
+++ b/sass/layout/_navigation.scss
@@ -93,7 +93,7 @@
             &:hover,
             &:active,
             &:focus {
-                background: inherit;
+                background: transparent;
             }
         }
 

--- a/sass/layout/_navigation.scss
+++ b/sass/layout/_navigation.scss
@@ -50,6 +50,7 @@
         .navbar-toggle {
             border-color: transparent;
             border-radius: 0;
+            border-width: 0;
             fill: $white;
             float: left;
             height: 50px;
@@ -96,6 +97,23 @@
             }
         }
 
+        .navbar-info-button {
+            @include border-radius(50px);
+            cursor: pointer;
+            height: 32px;
+            line-height: 32px;
+            margin: 9px 10px 0 0;
+            position: relative;
+            text-align: center;
+            vertical-align: top;
+            width: 32px;
+
+            svg {
+                position: relative;
+                top: 5px;
+            }
+        }
+
         .navbar-brand {
             float: none;
             font-size: 16px;
@@ -121,33 +139,6 @@
 
             .dropdown-toggle {
                 color: $white;
-            }
-
-            .description {
-                color: $white;
-                display: inline-block;
-                margin-right: 1em;
-
-                &.info-popover {
-                    @include border-radius(50px);
-                    cursor: pointer;
-                    height: 32px;
-                    line-height: 32px;
-                    margin: 9px 10px 0 0;
-                    position: relative;
-                    text-align: center;
-                    vertical-align: top;
-                    width: 32px;
-
-                    &:hover {
-                        background: transparent;
-                    }
-
-                    svg {
-                        position: relative;
-                        top: 5px;
-                    }
-                }
             }
         }
     }

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -889,30 +889,6 @@
                 display: block;
             }
 
-            .navbar-brand {
-                white-space: nowrap;
-
-                .heading {
-                    font-size: 17px;
-                    font-weight: 400;
-                    line-height: 50px;
-                    position: relative;
-                    vertical-align: top;
-
-                    .ios & {
-                        line-height: 48px;
-                    }
-                }
-
-                .header-dropdown__icon {
-                    font-size: 12px;
-                    line-height: 50px;
-                    margin-left: 5px;
-                    top: 0;
-                    vertical-align: top;
-                }
-            }
-
             .dropdown {
                 &.open {
                     .dropdown-menu {


### PR DESCRIPTION
Turns out this was a lot easier than what I was expecting, but I ended up refactoring some of the navbar because I was having a really hard time telling what CSS affected the info button since it was located in a different place than the search and menu buttons.

Adding Asaad to make sure I didn't break anything horrible with the CSS changes. I made sure the popover still displayed correctly despite these changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7376

#### Checklist
- Has UI changes