### PR TITLE
[PLT-7526] More channels modal search doesn't remember page

### DIFF
--- a/components/more_channels/more_channels.jsx
+++ b/components/more_channels/more_channels.jsx
@@ -193,6 +193,7 @@ export default class MoreChannels extends React.Component {
                         channels={this.state.channels}
                         channelsPerPage={CHANNELS_PER_PAGE}
                         nextPage={this.nextPage}
+                        isSearch={this.state.search}
                         search={this.search}
                         handleJoin={this.handleJoin}
                         noResultsText={createChannelHelpText}

--- a/components/searchable_channel_list.jsx
+++ b/components/searchable_channel_list.jsx
@@ -48,6 +48,12 @@ export default class SearchableChannelList extends React.Component {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.isSearch && !this.props.isSearch) {
+            this.setState({page: 0});
+        }
+    }
+
     handleJoin(channel) {
         this.setState({joiningChannel: channel.id});
         this.props.handleJoin(
@@ -146,7 +152,7 @@ export default class SearchableChannelList extends React.Component {
             const channelsToDisplay = this.props.channels.slice(pageStart, pageEnd);
             listContent = channelsToDisplay.map(this.createChannelRow);
 
-            if (channelsToDisplay.length >= this.props.channelsPerPage) {
+            if (channelsToDisplay.length >= this.props.channelsPerPage && pageEnd < this.props.channels.length) {
                 nextButton = (
                     <button
                         className='btn btn-default filter-control filter-control__next'
@@ -207,13 +213,15 @@ export default class SearchableChannelList extends React.Component {
 }
 
 SearchableChannelList.defaultProps = {
-    channels: []
+    channels: [],
+    isSearch: false
 };
 
 SearchableChannelList.propTypes = {
     channels: PropTypes.arrayOf(PropTypes.object),
     channelsPerPage: PropTypes.number,
     nextPage: PropTypes.func.isRequired,
+    isSearch: PropTypes.bool,
     search: PropTypes.func.isRequired,
     handleJoin: PropTypes.func.isRequired,
     noResultsText: PropTypes.object


### PR DESCRIPTION
#### Summary
This PR resolves the issue of the More Channels modal remembering which page it was on previously when making a search. In addition, another bug was fixed where the `next` button would appear even though all the channels fit into that page.

Lastly a bug was found where not sometimes all channels are that match the search criteria are returned, and this does not seem to be due to the fixes made above. It's reproducible on master.

#### Ticket Link
https://github.com/mattermost/platform/issues/7344
https://mattermost.atlassian.net/browse/PLT-7526

This is a resubmit of a PR made earlier, prior to the splitting of the web app and server into separate repositories. Previous discussion can be found at https://github.com/mattermost/mattermost-server/pull/7383