### PR TITLE
PLT-6871: Change at-mention autocomplete to prioritize entries where …

### DIFF
--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -168,6 +168,19 @@ export default class SearchableUserList extends React.Component {
 
         if (this.props.term || !this.props.users) {
             usersToDisplay = this.props.users;
+
+            if (this.props.term) {
+                const searchTerm = this.props.term.replace(/^@/, '');
+                usersToDisplay.sort((a, b) => {
+                    if (a.username.startsWith(searchTerm)) {
+                        return -1;
+                    }
+                    if (b.username.startsWith(searchTerm)) {
+                        return 1;
+                    }
+                    return 0;
+                });
+            }
         } else if (!this.props.term) {
             const pageStart = this.props.page * this.props.usersPerPage;
             const pageEnd = pageStart + this.props.usersPerPage;

--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -169,7 +169,7 @@ export default class SearchableUserList extends React.Component {
         if (this.props.term || !this.props.users) {
             usersToDisplay = this.props.users;
 
-            if (this.props.term) {
+            if (this.props.term && usersToDisplay) {
                 const searchTerm = this.props.term.replace(/^@/, '');
                 usersToDisplay.sort((a, b) => {
                     if (a.username.startsWith(searchTerm)) {

--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -167,7 +167,7 @@ export default class SearchableUserList extends React.Component {
         let usersToDisplay;
 
         if (this.props.term || !this.props.users) {
-            usersToDisplay = this.props.users;
+            usersToDisplay = [...this.props.users];
 
             if (this.props.term && usersToDisplay) {
                 const searchTerm = this.props.term.replace(/^@/, '');

--- a/stores/suggestion_store.jsx
+++ b/stores/suggestion_store.jsx
@@ -137,6 +137,28 @@ class SuggestionStore extends EventEmitter {
 
     addSuggestions(id, terms, items, component, matchedPretext) {
         const suggestion = this.getSuggestions(id);
+        const searchTerm = matchedPretext.replace(/^@/, '');
+
+        // Sort suggestions
+        terms.sort((a, b) => {
+            if (a.startsWith(searchTerm)) {
+                return -1;
+            }
+            if (b.startsWith(searchTerm)) {
+                return 1;
+            }
+            return 0;
+        });
+
+        items.sort((a, b) => {
+            if (a.username.startsWith(searchTerm)) {
+                return -1;
+            }
+            if (b.username.startsWith(searchTerm)) {
+                return 1;
+            }
+            return 0;
+        });
 
         suggestion.terms.push(...terms);
         suggestion.items.push(...items);


### PR DESCRIPTION
…the username starts with the search string

PS: Recreated https://github.com/mattermost/mattermost-server/pull/7024

#### Summary
Change at-mention autocomplete to prioritize entries where the username starts with the search string

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6871

#### Checklist
- [x] Has UI changes
