### PR TITLE
Update markdown.jsx

### DIFF
--- a/utils/markdown.jsx
+++ b/utils/markdown.jsx
@@ -167,7 +167,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
             return text;
         }
 
-        if (!(/[a-z+.-]+:/i).test(outHref)) {
+        if (!(/[a-z0-9+.-]+:/i).test(outHref)) {
             outHref = `http://${outHref}`;
         }
 


### PR DESCRIPTION
#### Summary

Should not add http:// if the first part have numbers:

``uri1:test`` or ``[test link](uri1:test)``

#### Ticket Link

https://github.com/mattermost/mattermost-server/issues/7405

#### Checklist

- [x] Minor change
