### PR TITLE
[PLT-7228] Move about_build_modal.jsx to Redux

### DIFF
--- a/components/about_build_modal/about_build_modal.jsx
+++ b/components/about_build_modal/about_build_modal.jsx
@@ -10,7 +10,34 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Constants from 'utils/constants.jsx';
 
-export default class AboutBuildModal extends React.Component {
+export default class AboutBuildModal extends React.PureComponent {
+    static defaultProps = {
+        show: false
+    };
+
+    static propTypes = {
+
+        /**
+         * Determines whether modal is shown or not
+         */
+        show: PropTypes.bool.isRequired,
+
+        /**
+         * Function that is called when the modal is dismissed
+         */
+        onModalDismissed: PropTypes.func.isRequired,
+
+        /**
+         * Global config object
+         */
+        config: PropTypes.object.isRequired,
+
+        /**
+         * Global license object
+         */
+        license: PropTypes.object.isRequired
+    };
+
     constructor(props) {
         super(props);
         this.doHide = this.doHide.bind(this);
@@ -21,8 +48,8 @@ export default class AboutBuildModal extends React.Component {
     }
 
     render() {
-        const config = global.window.mm_config;
-        const license = global.window.mm_license;
+        const config = this.props.config;
+        const license = this.props.license;
         const mattermostLogo = Constants.MATTERMOST_ICON_SVG;
 
         let title = (
@@ -202,12 +229,3 @@ export default class AboutBuildModal extends React.Component {
         );
     }
 }
-
-AboutBuildModal.defaultProps = {
-    show: false
-};
-
-AboutBuildModal.propTypes = {
-    show: PropTypes.bool.isRequired,
-    onModalDismissed: PropTypes.func.isRequired
-};

--- a/components/about_build_modal/index.js
+++ b/components/about_build_modal/index.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2017 Mattermost Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+
+import AboutBuildModal from './about_build_modal.jsx';
+
+function mapStateToProps(state, ownProps) {
+    return {
+        ...ownProps,
+        config: getConfig(state),
+        license: getLicense(state)
+    };
+}
+
+export default connect(mapStateToProps)(AboutBuildModal);

--- a/components/admin_console/admin_navbar_dropdown.jsx
+++ b/components/admin_console/admin_navbar_dropdown.jsx
@@ -6,7 +6,7 @@ import ReactDOM from 'react-dom';
 
 import TeamStore from 'stores/team_store.jsx';
 import Constants from 'utils/constants.jsx';
-import AboutBuildModal from 'components/about_build_modal.jsx';
+import AboutBuildModal from 'components/about_build_modal';
 import {sortTeamsByDisplayName} from 'utils/team_utils.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 

--- a/components/sidebar_header_dropdown.jsx
+++ b/components/sidebar_header_dropdown.jsx
@@ -10,7 +10,7 @@ import * as GlobalActions from 'actions/global_actions.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import WebrtcStore from 'stores/webrtc_store.jsx';
-import AboutBuildModal from './about_build_modal.jsx';
+import AboutBuildModal from 'components/about_build_modal';
 import SidebarHeaderDropdownButton from './sidebar_header_dropdown_button.jsx';
 import TeamMembersModal from './team_members_modal.jsx';
 import AddUsersToTeam from 'components/add_users_to_team';

--- a/components/sidebar_right_menu.jsx
+++ b/components/sidebar_right_menu.jsx
@@ -3,7 +3,7 @@
 
 import TeamMembersModal from './team_members_modal.jsx';
 import ToggleModalButton from './toggle_modal_button.jsx';
-import AboutBuildModal from './about_build_modal.jsx';
+import AboutBuildModal from 'components/about_build_modal';
 import AddUsersToTeam from 'components/add_users_to_team';
 
 import UserStore from 'stores/user_store.jsx';


### PR DESCRIPTION
#### Summary
Converts the `about_build_modal` component to be pure and use Redux. Tests for this component have already been written.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7228