### PR TITLE
PLT-7605 Fall back to default desktop notification level when user.notify_props is undefined

### DIFF
--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import Constants from 'utils/constants.jsx';
+import Constants, {NotificationLevels} from 'utils/constants.jsx';
 import UserStore from 'stores/user_store.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 import NotificationStore from 'stores/notification_store.jsx';
@@ -30,14 +30,14 @@ export function sendDesktopNotification(post, msgProps) {
     const user = UserStore.getCurrentUser();
     const member = ChannelStore.getMyMember(post.channel_id);
 
-    let notifyLevel = member && member.notify_props ? member.notify_props.desktop : 'default';
-    if (notifyLevel === 'default') {
+    let notifyLevel = member && member.notify_props ? member.notify_props.desktop : NotificationLevels.DEFAULT;
+    if (notifyLevel === NotificationLevels.DEFAULT) {
         notifyLevel = user.notify_props.desktop;
     }
 
-    if (notifyLevel === 'none') {
+    if (notifyLevel === NotificationLevels.NONE) {
         return;
-    } else if (notifyLevel === 'mention' && mentions.indexOf(user.id) === -1 && msgProps.channel_type !== Constants.DM_CHANNEL) {
+    } else if (notifyLevel === NotificationLevels.MENTION && mentions.indexOf(user.id) === -1 && msgProps.channel_type !== Constants.DM_CHANNEL) {
         return;
     }
 

--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -32,7 +32,7 @@ export function sendDesktopNotification(post, msgProps) {
 
     let notifyLevel = member && member.notify_props ? member.notify_props.desktop : NotificationLevels.DEFAULT;
     if (notifyLevel === NotificationLevels.DEFAULT) {
-        notifyLevel = user.notify_props.desktop;
+        notifyLevel = user && user.notify_props ? user.notify_props.desktop : NotificationLevels.ALL;
     }
 
     if (notifyLevel === NotificationLevels.NONE) {

--- a/components/channel_notifications_modal.jsx
+++ b/components/channel_notifications_modal.jsx
@@ -12,6 +12,8 @@ import {FormattedMessage} from 'react-intl';
 
 import {updateChannelNotifyProps} from 'actions/channel_actions.jsx';
 
+import {NotificationLevels} from 'utils/constants.jsx';
+
 export default class ChannelNotificationsModal extends React.Component {
     constructor(props) {
         super(props);
@@ -36,7 +38,7 @@ export default class ChannelNotificationsModal extends React.Component {
             show: true,
             notifyLevel: props.channelMember.notify_props.desktop,
             unreadLevel: props.channelMember.notify_props.mark_unread,
-            pushLevel: props.channelMember.notify_props.push || 'default'
+            pushLevel: props.channelMember.notify_props.push || NotificationLevels.DEFAULT
         };
     }
 
@@ -83,16 +85,16 @@ export default class ChannelNotificationsModal extends React.Component {
 
     createDesktopNotifyLevelSection(serverError) {
         // Get glabal user setting for notifications
-        const globalNotifyLevel = this.props.currentUser.notify_props ? this.props.currentUser.notify_props.desktop : 'all';
+        const globalNotifyLevel = this.props.currentUser.notify_props ? this.props.currentUser.notify_props.desktop : NotificationLevels.ALL;
         let globalNotifyLevelName;
-        if (globalNotifyLevel === 'all') {
+        if (globalNotifyLevel === NotificationLevels.ALL) {
             globalNotifyLevelName = (
                 <FormattedMessage
                     id='channel_notifications.allActivity'
                     defaultMessage='For all activity'
                 />
             );
-        } else if (globalNotifyLevel === 'mention') {
+        } else if (globalNotifyLevel === NotificationLevels.MENTION) {
             globalNotifyLevelName = (
                 <FormattedMessage
                     id='channel_notifications.onlyMentions'
@@ -119,11 +121,11 @@ export default class ChannelNotificationsModal extends React.Component {
 
         if (this.state.activeSection === 'desktop') {
             const notifyActive = [false, false, false, false];
-            if (notificationLevel === 'default') {
+            if (notificationLevel === NotificationLevels.DEFAULT) {
                 notifyActive[0] = true;
-            } else if (notificationLevel === 'all') {
+            } else if (notificationLevel === NotificationLevels.ALL) {
                 notifyActive[1] = true;
-            } else if (notificationLevel === 'mention') {
+            } else if (notificationLevel === NotificationLevels.MENTION) {
                 notifyActive[2] = true;
             } else {
                 notifyActive[3] = true;
@@ -140,7 +142,7 @@ export default class ChannelNotificationsModal extends React.Component {
                                 type='radio'
                                 name='desktopNotificationLevel'
                                 checked={notifyActive[0]}
-                                onChange={this.handleUpdateDesktopNotifyLevel.bind(this, 'default')}
+                                onChange={this.handleUpdateDesktopNotifyLevel.bind(this, NotificationLevels.DEFAULT)}
                             />
                             <FormattedMessage
                                 id='channel_notifications.globalDefault'
@@ -159,7 +161,7 @@ export default class ChannelNotificationsModal extends React.Component {
                                 type='radio'
                                 name='desktopNotificationLevel'
                                 checked={notifyActive[1]}
-                                onChange={this.handleUpdateDesktopNotifyLevel.bind(this, 'all')}
+                                onChange={this.handleUpdateDesktopNotifyLevel.bind(this, NotificationLevels.ALL)}
                             />
                             <FormattedMessage id='channel_notifications.allActivity'/>
                         </label>
@@ -172,7 +174,7 @@ export default class ChannelNotificationsModal extends React.Component {
                                 type='radio'
                                 name='desktopNotificationLevel'
                                 checked={notifyActive[2]}
-                                onChange={this.handleUpdateDesktopNotifyLevel.bind(this, 'mention')}
+                                onChange={this.handleUpdateDesktopNotifyLevel.bind(this, NotificationLevels.MENTION)}
                             />
                             <FormattedMessage id='channel_notifications.onlyMentions'/>
                         </label>
@@ -185,7 +187,7 @@ export default class ChannelNotificationsModal extends React.Component {
                                 type='radio'
                                 name='desktopNotificationLevel'
                                 checked={notifyActive[3]}
-                                onChange={this.handleUpdateDesktopNotifyLevel.bind(this, 'none')}
+                                onChange={this.handleUpdateDesktopNotifyLevel.bind(this, NotificationLevels.NONE)}
                             />
                             <FormattedMessage id='channel_notifications.never'/>
                         </label>
@@ -223,7 +225,7 @@ export default class ChannelNotificationsModal extends React.Component {
         }
 
         var describe;
-        if (notificationLevel === 'default') {
+        if (notificationLevel === NotificationLevels.DEFAULT) {
             describe = (
                 <FormattedMessage
                     id='channel_notifications.globalDefault'
@@ -232,9 +234,9 @@ export default class ChannelNotificationsModal extends React.Component {
                     }}
                 />
             );
-        } else if (notificationLevel === 'mention') {
+        } else if (notificationLevel === NotificationLevels.MENTION) {
             describe = (<FormattedMessage id='channel_notifications.onlyMentions'/>);
-        } else if (notificationLevel === 'all') {
+        } else if (notificationLevel === NotificationLevels.ALL) {
             describe = (<FormattedMessage id='channel_notifications.allActivity'/>);
         } else {
             describe = (<FormattedMessage id='channel_notifications.never'/>);
@@ -298,8 +300,8 @@ export default class ChannelNotificationsModal extends React.Component {
                                 id='channelUnreadAll'
                                 type='radio'
                                 name='markUnreadLevel'
-                                checked={this.state.unreadLevel === 'all'}
-                                onChange={this.handleUpdateMarkUnreadLevel.bind(this, 'all')}
+                                checked={this.state.unreadLevel === NotificationLevels.ALL}
+                                onChange={this.handleUpdateMarkUnreadLevel.bind(this, NotificationLevels.ALL)}
                             />
                             <FormattedMessage
                                 id='channel_notifications.allUnread'
@@ -314,8 +316,8 @@ export default class ChannelNotificationsModal extends React.Component {
                                 id='channelUnreadMentions'
                                 type='radio'
                                 name='markUnreadLevel'
-                                checked={this.state.unreadLevel === 'mention'}
-                                onChange={this.handleUpdateMarkUnreadLevel.bind(this, 'mention')}
+                                checked={this.state.unreadLevel === NotificationLevels.MENTION}
+                                onChange={this.handleUpdateMarkUnreadLevel.bind(this, NotificationLevels.MENTION)}
                             />
                             <FormattedMessage id='channel_notifications.onlyMentions'/>
                         </label>
@@ -354,7 +356,7 @@ export default class ChannelNotificationsModal extends React.Component {
         } else {
             let describe;
 
-            if (!this.state.unreadLevel || this.state.unreadLevel === 'all') {
+            if (!this.state.unreadLevel || this.state.unreadLevel === NotificationLevels.ALL) {
                 describe = (
                     <FormattedMessage
                         id='channel_notifications.allUnread'
@@ -421,16 +423,16 @@ export default class ChannelNotificationsModal extends React.Component {
         }
 
         // Get glabal user setting for notifications
-        const globalNotifyLevel = this.props.currentUser.notify_props ? this.props.currentUser.notify_props.push : 'all';
+        const globalNotifyLevel = this.props.currentUser.notify_props ? this.props.currentUser.notify_props.push : NotificationLevels.ALL;
         let globalNotifyLevelName;
-        if (globalNotifyLevel === 'all') {
+        if (globalNotifyLevel === NotificationLevels.ALL) {
             globalNotifyLevelName = (
                 <FormattedMessage
                     id='channel_notifications.allActivity'
                     defaultMessage='For all activity'
                 />
             );
-        } else if (globalNotifyLevel === 'mention') {
+        } else if (globalNotifyLevel === NotificationLevels.MENTION) {
             globalNotifyLevelName = (
                 <FormattedMessage
                     id='channel_notifications.onlyMentions'
@@ -458,11 +460,11 @@ export default class ChannelNotificationsModal extends React.Component {
         let content;
         if (this.state.activeSection === 'push') {
             const notifyActive = [false, false, false, false];
-            if (notificationLevel === 'default') {
+            if (notificationLevel === NotificationLevels.DEFAULT) {
                 notifyActive[0] = true;
-            } else if (notificationLevel === 'all') {
+            } else if (notificationLevel === NotificationLevels.ALL) {
                 notifyActive[1] = true;
-            } else if (notificationLevel === 'mention') {
+            } else if (notificationLevel === NotificationLevels.MENTION) {
                 notifyActive[2] = true;
             } else {
                 notifyActive[3] = true;
@@ -479,7 +481,7 @@ export default class ChannelNotificationsModal extends React.Component {
                                 type='radio'
                                 name='pushNotificationLevel'
                                 checked={notifyActive[0]}
-                                onChange={this.handleUpdatePushNotificationLevel.bind(this, 'default')}
+                                onChange={this.handleUpdatePushNotificationLevel.bind(this, NotificationLevels.DEFAULT)}
                             />
                             <FormattedMessage
                                 id='channel_notifications.globalDefault'
@@ -498,7 +500,7 @@ export default class ChannelNotificationsModal extends React.Component {
                                 type='radio'
                                 name='pushNotificationLevel'
                                 checked={notifyActive[1]}
-                                onChange={this.handleUpdatePushNotificationLevel.bind(this, 'all')}
+                                onChange={this.handleUpdatePushNotificationLevel.bind(this, NotificationLevels.ALL)}
                             />
                             <FormattedMessage id='channel_notifications.allActivity'/>
                         </label>
@@ -511,7 +513,7 @@ export default class ChannelNotificationsModal extends React.Component {
                                 type='radio'
                                 name='pushNotificationLevel'
                                 checked={notifyActive[2]}
-                                onChange={this.handleUpdatePushNotificationLevel.bind(this, 'mention')}
+                                onChange={this.handleUpdatePushNotificationLevel.bind(this, NotificationLevels.MENTION)}
                             />
                             <FormattedMessage id='channel_notifications.onlyMentions'/>
                         </label>
@@ -524,7 +526,7 @@ export default class ChannelNotificationsModal extends React.Component {
                                 type='radio'
                                 name='pushNotificationLevel'
                                 checked={notifyActive[3]}
-                                onChange={this.handleUpdatePushNotificationLevel.bind(this, 'none')}
+                                onChange={this.handleUpdatePushNotificationLevel.bind(this, NotificationLevels.NONE)}
                             />
                             <FormattedMessage id='channel_notifications.never'/>
                         </label>
@@ -535,7 +537,7 @@ export default class ChannelNotificationsModal extends React.Component {
             const handleUpdateSection = function updateSection(e) {
                 this.updateSection('');
                 this.setState({
-                    pushLevel: this.props.channelMember.notify_props.push || 'default'
+                    pushLevel: this.props.channelMember.notify_props.push || NotificationLevels.DEFAULT
                 });
                 e.preventDefault();
             }.bind(this);
@@ -561,7 +563,7 @@ export default class ChannelNotificationsModal extends React.Component {
             );
         } else {
             let describe;
-            if (notificationLevel === 'default') {
+            if (notificationLevel === NotificationLevels.DEFAULT) {
                 describe = (
                     <FormattedMessage
                         id='channel_notifications.globalDefault'
@@ -570,9 +572,9 @@ export default class ChannelNotificationsModal extends React.Component {
                         }}
                     />
                 );
-            } else if (notificationLevel === 'mention') {
+            } else if (notificationLevel === NotificationLevels.MENTION) {
                 describe = (<FormattedMessage id='channel_notifications.onlyMentions'/>);
-            } else if (notificationLevel === 'all') {
+            } else if (notificationLevel === NotificationLevels.ALL) {
                 describe = (<FormattedMessage id='channel_notifications.allActivity'/>);
             } else {
                 describe = (<FormattedMessage id='channel_notifications.never'/>);

--- a/components/user_settings/desktop_notification_settings.jsx
+++ b/components/user_settings/desktop_notification_settings.jsx
@@ -4,6 +4,7 @@
 import SettingItemMin from 'components/setting_item_min.jsx';
 import SettingItemMax from 'components/setting_item_max.jsx';
 
+import {NotificationLevels} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import PropTypes from 'prop-types';
@@ -26,9 +27,9 @@ export default class DesktopNotificationSettings extends React.Component {
         let extraInfo = null;
 
         const activityRadio = [false, false, false];
-        if (this.props.activity === 'mention') {
+        if (this.props.activity === NotificationLevels.MENTION) {
             activityRadio[1] = true;
-        } else if (this.props.activity === 'none') {
+        } else if (this.props.activity === NotificationLevels.NONE) {
             activityRadio[2] = true;
         } else {
             activityRadio[0] = true;
@@ -36,7 +37,7 @@ export default class DesktopNotificationSettings extends React.Component {
 
         let soundSection;
         let durationSection;
-        if (this.props.activity !== 'none') {
+        if (this.props.activity !== NotificationLevels.NONE) {
             const soundRadio = [false, false];
             if (this.props.sound === 'false') {
                 soundRadio[1] = true;
@@ -236,7 +237,7 @@ export default class DesktopNotificationSettings extends React.Component {
                             type='radio'
                             name='desktopNotificationLevel'
                             checked={activityRadio[0]}
-                            onChange={() => this.props.setParentState('desktopActivity', 'all')}
+                            onChange={() => this.props.setParentState('desktopActivity', NotificationLevels.ALL)}
                         />
                         <FormattedMessage
                             id='user.settings.notifications.allActivity'
@@ -252,7 +253,7 @@ export default class DesktopNotificationSettings extends React.Component {
                             type='radio'
                             name='desktopNotificationLevel'
                             checked={activityRadio[1]}
-                            onChange={() => this.props.setParentState('desktopActivity', 'mention')}
+                            onChange={() => this.props.setParentState('desktopActivity', NotificationLevels.MENTION)}
                         />
                         <FormattedMessage
                             id='user.settings.notifications.onlyMentions'
@@ -268,7 +269,7 @@ export default class DesktopNotificationSettings extends React.Component {
                             type='radio'
                             name='desktopNotificationLevel'
                             checked={activityRadio[2]}
-                            onChange={() => this.props.setParentState('desktopActivity', 'none')}
+                            onChange={() => this.props.setParentState('desktopActivity', NotificationLevels.NONE)}
                         />
                         <FormattedMessage
                             id='user.settings.notifications.never'
@@ -302,7 +303,7 @@ export default class DesktopNotificationSettings extends React.Component {
 
     buildMinimizedSetting() {
         let describe = '';
-        if (this.props.activity === 'mention') {
+        if (this.props.activity === NotificationLevels.MENTION) {
             if (Utils.hasSoundOptions() && this.props.sound !== 'false') {
                 if (this.props.duration === '0') { //eslint-disable-line no-lonely-if
                     describe = (
@@ -361,7 +362,7 @@ export default class DesktopNotificationSettings extends React.Component {
                     );
                 }
             }
-        } else if (this.props.activity === 'none') {
+        } else if (this.props.activity === NotificationLevels.NONE) {
             describe = (
                 <FormattedMessage
                     id='user.settings.notifications.off'

--- a/components/user_settings/user_settings_notifications.jsx
+++ b/components/user_settings/user_settings_notifications.jsx
@@ -9,7 +9,7 @@ import DesktopNotificationSettings from './desktop_notification_settings.jsx';
 import UserStore from 'stores/user_store.jsx';
 
 import * as Utils from 'utils/utils.jsx';
-import Constants from 'utils/constants.jsx';
+import Constants, {Notifications} from 'utils/constants.jsx';
 import {updateUserNotifyProps} from 'actions/user_actions.jsx';
 
 import EmailNotificationSetting from './email_notification_setting.jsx';
@@ -18,12 +18,12 @@ import {FormattedMessage} from 'react-intl';
 function getNotificationsStateFromStores() {
     const user = UserStore.getCurrentUser();
 
-    let desktop = 'default';
+    let desktop = NotificationLevels.DEFAULT;
     let sound = 'true';
     let desktopDuration = '5';
     let comments = 'never';
     let enableEmail = 'true';
-    let pushActivity = 'mention';
+    let pushActivity = NotificationLevels.MENTION;
     let pushStatus = Constants.UserStatuses.ONLINE;
 
     if (user.notify_props) {
@@ -254,9 +254,9 @@ export default class NotificationsTab extends React.Component {
 
             if (global.window.mm_config.SendPushNotifications === 'true') {
                 const pushActivityRadio = [false, false, false];
-                if (this.state.pushActivity === 'all') {
+                if (this.state.pushActivity === NotificationLevels.ALL) {
                     pushActivityRadio[0] = true;
-                } else if (this.state.pushActivity === 'none') {
+                } else if (this.state.pushActivity === NotificationLevels.NONE) {
                     pushActivityRadio[2] = true;
                 } else {
                     pushActivityRadio[1] = true;
@@ -272,7 +272,7 @@ export default class NotificationsTab extends React.Component {
                 }
 
                 let pushStatusSettings;
-                if (this.state.pushActivity !== 'none') {
+                if (this.state.pushActivity !== NotificationLevels.NONE) {
                     pushStatusSettings = (
                         <div>
                             <hr/>
@@ -359,7 +359,7 @@ export default class NotificationsTab extends React.Component {
                                     type='radio'
                                     name='pushNotificationLevel'
                                     checked={pushActivityRadio[0]}
-                                    onChange={this.handlePushRadio.bind(this, 'all')}
+                                    onChange={this.handlePushRadio.bind(this, NotificationLevels.ALL)}
                                 />
                                 <FormattedMessage
                                     id='user.settings.push_notification.allActivity'
@@ -375,7 +375,7 @@ export default class NotificationsTab extends React.Component {
                                     type='radio'
                                     name='pushNotificationLevel'
                                     checked={pushActivityRadio[1]}
-                                    onChange={this.handlePushRadio.bind(this, 'mention')}
+                                    onChange={this.handlePushRadio.bind(this, NotificationLevels.MENTION)}
                                 />
                                 <FormattedMessage
                                     id='user.settings.push_notification.onlyMentions'
@@ -391,7 +391,7 @@ export default class NotificationsTab extends React.Component {
                                     type='radio'
                                     name='pushNotificationLevel'
                                     checked={pushActivityRadio[2]}
-                                    onChange={this.handlePushRadio.bind(this, 'none')}
+                                    onChange={this.handlePushRadio.bind(this, NotificationLevels.NONE)}
                                 />
                                 <FormattedMessage
                                     id='user.settings.notifications.never'
@@ -438,7 +438,7 @@ export default class NotificationsTab extends React.Component {
         }
 
         let describe = '';
-        if (this.state.pushActivity === 'all') {
+        if (this.state.pushActivity === NotificationLevels.ALL) {
             if (this.state.pushStatus === Constants.UserStatuses.AWAY) {
                 describe = (
                     <FormattedMessage
@@ -461,7 +461,7 @@ export default class NotificationsTab extends React.Component {
                     />
                 );
             }
-        } else if (this.state.pushActivity === 'none') {
+        } else if (this.state.pushActivity === NotificationLevels.NONE) {
             describe = (
                 <FormattedMessage
                     id='user.settings.notifications.never'

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -332,6 +332,13 @@ export const ErrorBarTypes = {
     WEBSOCKET_PORT_ERROR: 'channel_loader.socketError'
 };
 
+export const NotificationLevels = {
+    DEFAULT: 'default',
+    ALL: 'all',
+    MENTION: 'mention',
+    NONE: 'none'
+};
+
 export const Constants = {
     Preferences,
     SocketEvents,


### PR DESCRIPTION
Most of this refactoring is moving a bunch of magic strings into constants which makes it a lot wordier, but it does mean we have a list of all the values at hand.

Non-refactoring changes are here: https://github.com/mattermost/mattermost-webapp/commit/19bdd077f282cb215a1ffcfc29b13481833d73ee

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7605
