### PR TITLE
Add spinner on all user settings button (#6487)

### DIFF
--- a/components/admin_console/admin_settings.jsx
+++ b/components/admin_console/admin_settings.jsx
@@ -134,6 +134,7 @@ export default class AdminSettings extends React.Component {
                                 disabled={!this.state.saveNeeded || (this.canSave && !this.canSave())}
                                 onClick={this.handleSubmit}
                                 savingMessageId='admin.saving'
+                                defaultMessage='Saving'
                             />
                         </div>
                     </div>

--- a/components/admin_console/admin_settings.jsx
+++ b/components/admin_console/admin_settings.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import {saveConfig} from 'actions/admin_actions.jsx';
 
-import SaveButton from 'components/admin_console/save_button.jsx';
+import SaveButton from 'components/save_button.jsx';
 import FormError from 'components/form_error.jsx';
 
 export default class AdminSettings extends React.Component {
@@ -133,6 +133,7 @@ export default class AdminSettings extends React.Component {
                                 saving={this.state.saving}
                                 disabled={!this.state.saveNeeded || (this.canSave && !this.canSave())}
                                 onClick={this.handleSubmit}
+                                savingMessageId='admin.saving'
                             />
                         </div>
                     </div>

--- a/components/admin_console/save_button.jsx
+++ b/components/admin_console/save_button.jsx
@@ -9,18 +9,20 @@ export default class SaveButton extends React.Component {
     static get propTypes() {
         return {
             saving: PropTypes.bool.isRequired,
-            disabled: PropTypes.bool
+            disabled: PropTypes.bool,
+            savingMessageId: PropTypes.string
         };
     }
 
     static get defaultProps() {
         return {
-            disabled: false
+            disabled: false,
+            savingMessageId: 'admin.saving'
         };
     }
 
     render() {
-        const {saving, disabled, ...props} = this.props; // eslint-disable-line no-use-before-define
+        const {saving, disabled, savingMessageId, ...props} = this.props; // eslint-disable-line no-use-before-define
 
         let contents;
         if (saving) {
@@ -28,7 +30,7 @@ export default class SaveButton extends React.Component {
                 <span>
                     <span className='icon fa fa-refresh icon--rotate'/>
                     <FormattedMessage
-                        id='admin.saving'
+                        id={savingMessageId}
                         defaultMessage='Saving Config...'
                     />
                 </span>

--- a/components/save_button.jsx
+++ b/components/save_button.jsx
@@ -11,7 +11,7 @@ export default class SaveButton extends React.Component {
             saving: PropTypes.bool.isRequired,
             disabled: PropTypes.bool,
             savingMessageId: PropTypes.string,
-            defaultMessage: ProTypes.string
+            defaultMessage: PropTypes.string
         };
     }
 

--- a/components/save_button.jsx
+++ b/components/save_button.jsx
@@ -10,19 +10,21 @@ export default class SaveButton extends React.Component {
         return {
             saving: PropTypes.bool.isRequired,
             disabled: PropTypes.bool,
-            savingMessageId: PropTypes.string
+            savingMessageId: PropTypes.string,
+            defaultMessage: ProTypes.string
         };
     }
 
     static get defaultProps() {
         return {
             disabled: false,
-            savingMessageId: 'admin.saving'
+            savingMessageId: 'setting_item_max.saving',
+            defaultMessage: 'Saving'
         };
     }
 
     render() {
-        const {saving, disabled, savingMessageId, ...props} = this.props; // eslint-disable-line no-use-before-define
+        const {saving, disabled, savingMessageId, defaultMessage, ...props} = this.props; // eslint-disable-line no-use-before-define
 
         let contents;
         if (saving) {
@@ -31,7 +33,7 @@ export default class SaveButton extends React.Component {
                     <span className='icon fa fa-refresh icon--rotate'/>
                     <FormattedMessage
                         id={savingMessageId}
-                        defaultMessage='Saving Config...'
+                        defaultMessage={defaultMessage}
                     />
                 </span>
             );

--- a/components/setting_item_max.jsx
+++ b/components/setting_item_max.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import SaveButton from 'components/admin_console/save_button.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
@@ -71,13 +72,11 @@ export default class SettingItemMax extends React.Component {
         var submit = '';
         if (this.props.submit) {
             submit = (
-                <input
-                    id='saveSetting'
-                    type='submit'
-                    className='btn btn-sm btn-primary'
-                    href='#'
+                <SaveButton
+                    saving={this.props.saving}
+                    disabled={this.props.saving}
                     onClick={this.props.submit}
-                    value={Utils.localizeMessage('setting_item_max.save', 'Save')}
+                    messageId='setting_item_max.saving'
                 />
             );
         }
@@ -163,6 +162,7 @@ SettingItemMax.propTypes = {
     infoPosition: PropTypes.string,
     updateSection: PropTypes.func,
     submit: PropTypes.func,
+    saving: PropTypes.bool,
     title: PropTypes.node,
     width: PropTypes.string,
     submitExtra: PropTypes.node,
@@ -170,5 +170,6 @@ SettingItemMax.propTypes = {
 };
 
 SettingItemMax.defaultProps = {
-    infoPosition: 'bottom'
+    infoPosition: 'bottom',
+    saving: false
 };

--- a/components/setting_item_max.jsx
+++ b/components/setting_item_max.jsx
@@ -1,11 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import SaveButton from 'components/admin_console/save_button.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
+import SaveButton from 'components/admin_console/save_button.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -76,7 +76,6 @@ export default class SettingItemMax extends React.Component {
                     saving={this.props.saving}
                     disabled={this.props.saving}
                     onClick={this.props.submit}
-                    messageId='setting_item_max.saving'
                 />
             );
         }

--- a/components/setting_item_max.jsx
+++ b/components/setting_item_max.jsx
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import SaveButton from 'components/admin_console/save_button.jsx';
+import SaveButton from 'components/save_button.jsx';
+
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 

--- a/components/setting_picture.jsx
+++ b/components/setting_picture.jsx
@@ -139,6 +139,8 @@ export default class SettingPicture extends Component {
         }
 
         let confirmButton;
+        let selectButtonSpinner;
+        let fileInputDisabled = false;
         if (this.props.loadingPicture) {
             confirmButton = (
                 <img
@@ -146,6 +148,10 @@ export default class SettingPicture extends Component {
                     src={loadingGif}
                 />
             );
+            selectButtonSpinner = (
+                <span className='icon fa fa-refresh icon--rotate'/>
+            );
+            fileInputDisabled = true;
         } else {
             let confirmButtonClass = 'btn btn-sm';
             if (this.props.submitActive) {
@@ -191,7 +197,11 @@ export default class SettingPicture extends Component {
                                 errors={[this.props.clientError, this.props.serverError]}
                                 type={'modal'}
                             />
-                            <span className='btn btn-sm btn-primary btn-file sel-btn'>
+                            <button
+                                className='btn btn-sm btn-primary btn-file sel-btn'
+                                disabled={fileInputDisabled}
+                            >
+                                {selectButtonSpinner}
                                 <FormattedMessage
                                     id='setting_picture.select'
                                     defaultMessage='Select'
@@ -201,8 +211,9 @@ export default class SettingPicture extends Component {
                                     accept='.jpg,.png,.bmp'
                                     type='file'
                                     onChange={this.props.onFileChange}
+                                    disabled={fileInputDisabled}
                                 />
-                            </span>
+                            </button>
                             {confirmButton}
                             <a
                                 className='btn btn-sm theme'

--- a/components/user_settings/desktop_notification_settings.jsx
+++ b/components/user_settings/desktop_notification_settings.jsx
@@ -294,6 +294,7 @@ export default class DesktopNotificationSettings extends React.Component {
                 extraInfo={extraInfo}
                 inputs={inputs}
                 submit={this.props.submit}
+                saving={this.props.saving}
                 server_error={this.props.error}
                 updateSection={this.props.cancel}
             />
@@ -460,5 +461,6 @@ DesktopNotificationSettings.propTypes = {
     submit: PropTypes.func,
     cancel: PropTypes.func,
     error: PropTypes.string,
-    active: PropTypes.bool
+    active: PropTypes.bool,
+    saving: PropTypes.bool
 };

--- a/components/user_settings/email_notification_setting.jsx
+++ b/components/user_settings/email_notification_setting.jsx
@@ -21,7 +21,8 @@ export default class EmailNotificationSetting extends React.Component {
         emailInterval: PropTypes.number.isRequired,
         onSubmit: PropTypes.func.isRequired,
         onCancel: PropTypes.func.isRequired,
-        serverError: PropTypes.string
+        serverError: PropTypes.string,
+        saving: PropTypes.bool
     };
 
     constructor(props) {
@@ -254,6 +255,7 @@ export default class EmailNotificationSetting extends React.Component {
                     </div>
                 ]}
                 submit={this.handleSubmit}
+                saving={this.props.saving}
                 server_error={this.props.serverError}
                 updateSection={this.handleCancel}
             />

--- a/components/user_settings/manage_languages.jsx
+++ b/components/user_settings/manage_languages.jsx
@@ -22,7 +22,8 @@ export default class ManageLanguage extends React.Component {
         this.changeLanguage = this.changeLanguage.bind(this);
         this.submitUser = this.submitUser.bind(this);
         this.state = {
-            locale: props.locale
+            locale: props.locale,
+            isSaving: false
         };
     }
 
@@ -38,9 +39,12 @@ export default class ManageLanguage extends React.Component {
         });
     }
     submitUser(user) {
+        this.setState({isSaving: true});
+
         updateUser(user, Constants.UserUpdateEvents.LANGUAGE,
             () => {
                 GlobalActions.newLocalizationSelected(user.locale);
+                this.setState({isSaving: false});
             },
             (err) => {
                 let serverError;
@@ -49,7 +53,7 @@ export default class ManageLanguage extends React.Component {
                 } else {
                     serverError = err;
                 }
-                this.setState({serverError});
+                this.setState({serverError, isSaving: false});
             }
         );
     }
@@ -123,6 +127,7 @@ export default class ManageLanguage extends React.Component {
                 }
                 width='medium'
                 submit={this.changeLanguage}
+                saving={this.state.isSaving}
                 inputs={[input]}
                 updateSection={this.props.updateSection}
             />

--- a/components/user_settings/user_settings_advanced.jsx
+++ b/components/user_settings/user_settings_advanced.jsx
@@ -82,10 +82,13 @@ export default class AdvancedSettingsDisplay extends React.Component {
             }
         }
 
+        const isSaving = false;
+
         return {preReleaseFeatures: PreReleaseFeatures,
             settings,
             preReleaseFeaturesKeys,
-            enabledFeatures
+            enabledFeatures,
+            isSaving
         };
     }
 
@@ -134,6 +137,8 @@ export default class AdvancedSettingsDisplay extends React.Component {
             });
         });
 
+        this.setState({isSaving: true});
+
         savePreferences(
             preferences,
             () => {
@@ -149,6 +154,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
         if (!section) {
             this.setState(this.getStateFromStores());
         }
+        this.setState({isSaving: false});
         this.props.updateSection(section);
     }
 
@@ -224,6 +230,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
                         </div>
                     ]}
                     submit={() => this.handleSubmit('formatting')}
+                    saving={this.state.isSaving}
                     server_error={this.state.serverError}
                     updateSection={(e) => {
                         this.updateSection('');
@@ -302,6 +309,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
                             </div>
                         ]}
                         submit={() => this.handleSubmit('join_leave')}
+                        saving={this.state.isSaving}
                         server_error={this.state.serverError}
                         updateSection={(e) => {
                             this.updateSection('');
@@ -419,6 +427,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
                     }
                     inputs={inputs}
                     submit={() => this.handleSubmit('send_on_ctrl_enter')}
+                    saving={this.state.isSaving}
                     server_error={serverError}
                     updateSection={(e) => {
                         this.updateSection('');
@@ -503,6 +512,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
                         }
                         inputs={inputs}
                         submit={this.saveEnabledFeatures}
+                        saving={this.state.isSaving}
                         server_error={serverError}
                         updateSection={(e) => {
                             this.updateSection('');

--- a/components/user_settings/user_settings_display.jsx
+++ b/components/user_settings/user_settings_display.jsx
@@ -44,6 +44,7 @@ export default class UserSettingsDisplay extends React.Component {
         this.createCollapseSection = this.createCollapseSection.bind(this);
 
         this.state = getDisplayStateFromStores();
+        this.setState({isSaving: false});
     }
 
     handleSubmit() {
@@ -74,6 +75,8 @@ export default class UserSettingsDisplay extends React.Component {
             name: Preferences.COLLAPSE_DISPLAY,
             value: this.state.collapseDisplay
         };
+
+        this.setState({isSaving: true});
 
         savePreferences([timePreference, channelDisplayModePreference, messageDisplayPreference, collapseDisplayPreference],
             () => {
@@ -111,6 +114,8 @@ export default class UserSettingsDisplay extends React.Component {
         if (!Utils.areObjectsEqual(newState, this.state)) {
             this.setState(newState);
         }
+
+        this.setState({isSaving: false});
     }
 
     createCollapseSection() {
@@ -181,6 +186,7 @@ export default class UserSettingsDisplay extends React.Component {
                     }
                     inputs={inputs}
                     submit={this.handleSubmit}
+                    saving={this.state.isSaving}
                     server_error={this.state.serverError}
                     updateSection={handleUpdateCollapseSection}
                 />
@@ -298,6 +304,7 @@ export default class UserSettingsDisplay extends React.Component {
                     }
                     inputs={inputs}
                     submit={this.handleSubmit}
+                    saving={this.state.isSaving}
                     server_error={serverError}
                     updateSection={handleUpdateClockSection}
                 />
@@ -414,6 +421,7 @@ export default class UserSettingsDisplay extends React.Component {
                     }
                     inputs={inputs}
                     submit={this.handleSubmit}
+                    saving={this.state.isSaving}
                     server_error={serverError}
                     updateSection={(e) => {
                         this.updateSection('');
@@ -517,6 +525,7 @@ export default class UserSettingsDisplay extends React.Component {
                     }
                     inputs={inputs}
                     submit={this.handleSubmit}
+                    saving={this.state.isSaving}
                     server_error={serverError}
                     updateSection={(e) => {
                         this.updateSection('');

--- a/components/user_settings/user_settings_general/user_settings_general.jsx
+++ b/components/user_settings/user_settings_general/user_settings_general.jsx
@@ -217,6 +217,8 @@ class UserSettingsGeneralTab extends React.Component {
     }
 
     submitUser(user, type, emailUpdated) {
+        this.setState({sectionIsSaving: true});
+
         updateUser(user, type,
             () => {
                 this.updateSection('');
@@ -236,7 +238,7 @@ class UserSettingsGeneralTab extends React.Component {
                 } else {
                     serverError = err;
                 }
-                this.setState({serverError, emailError: '', clientError: ''});
+                this.setState({serverError, emailError: '', clientError: '', sectionIsSaving: false});
             }
         );
     }
@@ -343,7 +345,7 @@ class UserSettingsGeneralTab extends React.Component {
             $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
         }
         const emailChangeInProgress = this.state.emailChangeInProgress;
-        this.setState(Object.assign({}, this.setupInitialState(this.props), {emailChangeInProgress, clientError: '', serverError: '', emailError: ''}));
+        this.setState(Object.assign({}, this.setupInitialState(this.props), {emailChangeInProgress, clientError: '', serverError: '', emailError: '', sectionIsSaving: false}));
         this.submitActive = false;
         this.props.updateSection(section);
     }
@@ -363,7 +365,8 @@ class UserSettingsGeneralTab extends React.Component {
             pictureFile: null,
             loadingPicture: false,
             emailChangeInProgress: false,
-            maxFileSize: global.window.mm_config.MaxFileSize
+            maxFileSize: global.window.mm_config.MaxFileSize,
+            sectionIsSaving: false
         };
     }
 
@@ -579,6 +582,7 @@ class UserSettingsGeneralTab extends React.Component {
                     }
                     inputs={inputs}
                     submit={submit}
+                    saving={this.state.sectionIsSaving}
                     server_error={this.state.serverError}
                     client_error={this.state.emailError}
                     updateSection={(e) => {
@@ -799,6 +803,7 @@ class UserSettingsGeneralTab extends React.Component {
                     title={formatMessage(holders.fullName)}
                     inputs={inputs}
                     submit={submit}
+                    saving={this.state.sectionIsSaving}
                     server_error={serverError}
                     client_error={clientError}
                     updateSection={(e) => {
@@ -906,6 +911,7 @@ class UserSettingsGeneralTab extends React.Component {
                     title={formatMessage(holders.nickname)}
                     inputs={inputs}
                     submit={submit}
+                    saving={this.state.sectionIsSaving}
                     server_error={serverError}
                     client_error={clientError}
                     updateSection={(e) => {
@@ -1008,6 +1014,7 @@ class UserSettingsGeneralTab extends React.Component {
                     title={formatMessage(holders.username)}
                     inputs={inputs}
                     submit={submit}
+                    saving={this.state.sectionIsSaving}
                     server_error={serverError}
                     client_error={clientError}
                     updateSection={(e) => {
@@ -1090,6 +1097,7 @@ class UserSettingsGeneralTab extends React.Component {
                     title={formatMessage(holders.position)}
                     inputs={inputs}
                     submit={submit}
+                    saving={this.state.sectionIsSaving}
                     server_error={serverError}
                     client_error={clientError}
                     updateSection={(e) => {

--- a/components/user_settings/user_settings_notifications.jsx
+++ b/components/user_settings/user_settings_notifications.jsx
@@ -97,7 +97,8 @@ function getNotificationsStateFromStores() {
         customKeysChecked: customKeys.length > 0,
         firstNameKey,
         channelKey,
-        notifyCommentsLevel: comments
+        notifyCommentsLevel: comments,
+        isSaving: false
     };
 }
 
@@ -147,6 +148,8 @@ export default class NotificationsTab extends React.Component {
         data.first_name = this.state.firstNameKey.toString();
         data.channel = this.state.channelKey.toString();
 
+        this.setState({isSaving: true});
+
         updateUserNotifyProps(
             data,
             () => {
@@ -154,7 +157,7 @@ export default class NotificationsTab extends React.Component {
                 $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
             },
             (err) => {
-                this.setState({serverError: err.message});
+                this.setState({serverError: err.message, isSaving: false});
             }
         );
     }
@@ -182,6 +185,8 @@ export default class NotificationsTab extends React.Component {
         if (!Utils.areObjectsEqual(newState, this.state)) {
             this.setState(newState);
         }
+
+        this.setState({isSaving: false});
     }
 
     componentDidMount() {
@@ -641,6 +646,7 @@ export default class NotificationsTab extends React.Component {
                     title={Utils.localizeMessage('user.settings.notifications.wordsTrigger', 'Words that trigger mentions')}
                     inputs={inputs}
                     submit={this.handleSubmit}
+                    saving={this.state.isSaving}
                     server_error={serverError}
                     updateSection={this.handleCancel}
                     extraInfo={extraInfo}
@@ -776,6 +782,7 @@ export default class NotificationsTab extends React.Component {
                     extraInfo={extraInfo}
                     inputs={inputs}
                     submit={this.handleSubmit}
+                    saving={this.state.isSaving}
                     server_error={serverError}
                     updateSection={this.handleCancel}
                 />
@@ -867,6 +874,7 @@ export default class NotificationsTab extends React.Component {
                         updateSection={this.updateSection}
                         setParentState={this.setStateValue}
                         submit={this.handleSubmit}
+                        saving={this.state.isSaving}
                         cancel={this.handleCancel}
                         error={this.state.serverError}
                         active={this.props.activeSection === 'desktop'}
@@ -879,6 +887,7 @@ export default class NotificationsTab extends React.Component {
                         emailInterval={Utils.getEmailInterval(enableEmail)}
                         onSubmit={this.handleSubmit}
                         onCancel={this.handleCancel}
+                        saving={this.state.isSaving}
                         serverError={this.state.serverError}
                     />
                     <div className='divider-light'/>

--- a/components/user_settings/user_settings_security/user_settings_security.jsx
+++ b/components/user_settings/user_settings_security/user_settings_security.jsx
@@ -91,7 +91,8 @@ export default class SecurityTab extends React.Component {
             serverError: '',
             tokenError: '',
             showConfirmModal: false,
-            authService: this.props.user.auth_service
+            authService: this.props.user.auth_service,
+            savingPassword: false
         };
     }
 
@@ -141,6 +142,8 @@ export default class SecurityTab extends React.Component {
             this.setState(defaultState);
             return;
         }
+
+        this.setState({savingPassword: true});
 
         updatePassword(
             user.id,
@@ -524,6 +527,7 @@ export default class SecurityTab extends React.Component {
                     }
                     inputs={inputs}
                     submit={submit}
+                    saving={this.state.savingPassword}
                     server_error={this.state.serverError}
                     client_error={this.state.passwordError}
                     updateSection={updateSectionStatus}

--- a/components/user_settings/user_settings_theme.jsx
+++ b/components/user_settings/user_settings_theme.jsx
@@ -184,9 +184,9 @@ export default class ThemeSetting extends React.Component {
         const displayCustom = this.state.type === 'custom';
         const allowCustomThemes = global.mm_config.AllowCustomThemes !== 'false';
 
-                let custom;
-                let premade;
-                if (displayCustom && allowCustomThemes) {
+        let custom;
+        let premade;
+        if (displayCustom && allowCustomThemes) {
             custom = (
                 <div key='customThemeChooser'>
                     <CustomThemeChooser
@@ -211,33 +211,33 @@ export default class ThemeSetting extends React.Component {
         if (this.props.selected) {
             const inputs = [];
 
-                if (allowCustomThemes) {
-                    inputs.push(
-                        <div
-                            className='radio'
-                            key='premadeThemeColorLabel'
-                        >
-                            <label>
-                                <input
-                                    id='standardThemes'
-                                    type='radio'
-                                    name='theme'
-                                    checked={!displayCustom}
-                                    onChange={this.updateType.bind(this, 'premade')}
-                                />
-                                <FormattedMessage
-                                    id='user.settings.display.theme.themeColors'
-                                    defaultMessage='Theme Colors'
-                                />
-                            </label>
-                            <br/>
-                        </div>
-                    );
-                }
+            if (allowCustomThemes) {
+                inputs.push(
+                    <div
+                        className='radio'
+                        key='premadeThemeColorLabel'
+                    >
+                        <label>
+                            <input
+                                id='standardThemes'
+                                type='radio'
+                                name='theme'
+                                checked={!displayCustom}
+                                onChange={this.updateType.bind(this, 'premade')}
+                            />
+                            <FormattedMessage
+                                id='user.settings.display.theme.themeColors'
+                                defaultMessage='Theme Colors'
+                            />
+                        </label>
+                        <br/>
+                    </div>
+                );
+            }
 
-                inputs.push(premade);
+            inputs.push(premade);
 
-                if (allowCustomThemes) {
+            if (allowCustomThemes) {
                 inputs.push(
                     <div
                         className='radio'
@@ -295,7 +295,7 @@ export default class ThemeSetting extends React.Component {
                         </a>
                     </div>
                 );
-        }
+            }
 
             let allTeamsCheckbox = null;
             if (this.state.showAllTeamsCheckbox) {

--- a/components/user_settings/user_settings_theme.jsx
+++ b/components/user_settings/user_settings_theme.jsx
@@ -34,6 +34,7 @@ export default class ThemeSetting extends React.Component {
         this.handleImportModal = this.handleImportModal.bind(this);
 
         this.state = this.getStateFromStores();
+        this.setState({isSaving: false});
 
         this.originalTheme = Object.assign({}, this.state.theme);
     }
@@ -115,6 +116,8 @@ export default class ThemeSetting extends React.Component {
 
         const teamId = this.state.applyToAllTeams ? '' : this.state.teamId;
 
+        this.setState({isSaving: true});
+
         UserActions.saveTheme(
             teamId,
             this.state.theme,
@@ -123,6 +126,7 @@ export default class ThemeSetting extends React.Component {
                 this.originalTheme = Object.assign({}, this.state.theme);
                 this.scrollToTop();
                 this.props.updateSection('');
+                this.setState({isSaving: false});
             }
         );
     }
@@ -180,9 +184,9 @@ export default class ThemeSetting extends React.Component {
         const displayCustom = this.state.type === 'custom';
         const allowCustomThemes = global.mm_config.AllowCustomThemes !== 'false';
 
-        let custom;
-        let premade;
-        if (displayCustom && allowCustomThemes) {
+                let custom;
+                let premade;
+                if (displayCustom && allowCustomThemes) {
             custom = (
                 <div key='customThemeChooser'>
                     <CustomThemeChooser
@@ -207,33 +211,33 @@ export default class ThemeSetting extends React.Component {
         if (this.props.selected) {
             const inputs = [];
 
-            if (allowCustomThemes) {
-                inputs.push(
-                    <div
-                        className='radio'
-                        key='premadeThemeColorLabel'
-                    >
-                        <label>
-                            <input
-                                id='standardThemes'
-                                type='radio'
-                                name='theme'
-                                checked={!displayCustom}
-                                onChange={this.updateType.bind(this, 'premade')}
-                            />
-                            <FormattedMessage
-                                id='user.settings.display.theme.themeColors'
-                                defaultMessage='Theme Colors'
-                            />
-                        </label>
-                        <br/>
-                    </div>
-                );
-            }
+                if (allowCustomThemes) {
+                    inputs.push(
+                        <div
+                            className='radio'
+                            key='premadeThemeColorLabel'
+                        >
+                            <label>
+                                <input
+                                    id='standardThemes'
+                                    type='radio'
+                                    name='theme'
+                                    checked={!displayCustom}
+                                    onChange={this.updateType.bind(this, 'premade')}
+                                />
+                                <FormattedMessage
+                                    id='user.settings.display.theme.themeColors'
+                                    defaultMessage='Theme Colors'
+                                />
+                            </label>
+                            <br/>
+                        </div>
+                    );
+                }
 
-            inputs.push(premade);
+                inputs.push(premade);
 
-            if (allowCustomThemes) {
+                if (allowCustomThemes) {
                 inputs.push(
                     <div
                         className='radio'
@@ -291,7 +295,7 @@ export default class ThemeSetting extends React.Component {
                         </a>
                     </div>
                 );
-            }
+        }
 
             let allTeamsCheckbox = null;
             if (this.state.showAllTeamsCheckbox) {
@@ -318,6 +322,7 @@ export default class ThemeSetting extends React.Component {
                     inputs={inputs}
                     submitExtra={allTeamsCheckbox}
                     submit={this.submitTheme}
+                    saving={this.state.isSaving}
                     server_error={serverError}
                     width='full'
                     updateSection={(e) => {


### PR DESCRIPTION
#### Summary
This is a re-submission of PR [#7082](https://github.com/mattermost/mattermost-server/pull/7082). It fixes [#6487](https://github.com/mattermost/mattermost-server/issues/6487). Add a spinner to all save buttons and change the button text to "Saving..." for each section of the Account Setting Dialog when saving.

#### Ticket Link
[PLT-3505] (https://mattermost.atlassian.net/browse/PLT-3505)

#### Checklist
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../webapp/i18n/en.json]) updates
