### PR TITLE
PLT-7622 Improvements to webapp plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "localforage": "1.5.0",
     "marked": "mattermost/marked#5194fc037b35036910c6542b04bb471fe56b27a9",
     "match-at": "0.1.0",
-    "mattermost-redux": "mattermost/mattermost-redux#plt-7622",
+    "mattermost-redux": "mattermost/mattermost-redux#master",
     "object-assign": "4.1.1",
     "pdfjs-dist": "1.9.441",
     "perfect-scrollbar": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "localforage": "1.5.0",
     "marked": "mattermost/marked#5194fc037b35036910c6542b04bb471fe56b27a9",
     "match-at": "0.1.0",
-    "mattermost-redux": "mattermost/mattermost-redux#master",
+    "mattermost-redux": "mattermost/mattermost-redux#plt-7622",
     "object-assign": "4.1.1",
     "pdfjs-dist": "1.9.441",
     "perfect-scrollbar": "0.7.1",

--- a/plugins/pluggable/pluggable.jsx
+++ b/plugins/pluggable/pluggable.jsx
@@ -43,7 +43,7 @@ export default class Pluggable extends React.PureComponent {
 
         // Override the default component with any registered plugin's component
         if (components.hasOwnProperty(childName)) {
-            const PluginComponent = components[childName];
+            const PluginComponent = components[childName].component;
             return (
                 <PluginComponent
                     {...props}

--- a/reducers/plugins/index.js
+++ b/reducers/plugins/index.js
@@ -4,6 +4,62 @@
 import {combineReducers} from 'redux';
 import {ActionTypes} from 'utils/constants.jsx';
 
+function removePluginComponents(state, action) {
+    if (!action.data) {
+        return state;
+    }
+
+    const nextState = {...state};
+    let modified = false;
+    Object.keys(nextState).forEach((k) => {
+        const c = nextState[k];
+        if (c.id === action.data.id) {
+            Reflect.deleteProperty(nextState, k);
+            modified = true;
+        }
+    });
+
+    if (modified) {
+        return nextState;
+    }
+
+    return state;
+}
+
+function plugins(state = {}, action) {
+    switch (action.type) {
+    case ActionTypes.RECEIVED_WEBAPP_PLUGINS: {
+        if (action.data) {
+            const nextState = {};
+            action.data.forEach((p) => {
+                nextState[p.id] = p;
+            });
+            return nextState;
+        }
+        return state;
+    }
+    case ActionTypes.RECEIVED_WEBAPP_PLUGIN: {
+        if (action.data) {
+            const nextState = {...state};
+            nextState[action.data.id] = action.data;
+            return nextState;
+        }
+        return state;
+    }
+    case ActionTypes.REMOVED_WEBAPP_PLUGIN: {
+        if (action.data && state[action.data.id]) {
+            const nextState = {...state};
+            Reflect.deleteProperty(nextState, action.data.id);
+            return nextState;
+        }
+        return state;
+    }
+
+    default:
+        return state;
+    }
+}
+
 function components(state = {}, action) {
     switch (action.type) {
     case ActionTypes.RECEIVED_PLUGIN_COMPONENTS: {
@@ -12,11 +68,20 @@ function components(state = {}, action) {
         }
         return state;
     }
+    case ActionTypes.RECEIVED_WEBAPP_PLUGIN:
+    case ActionTypes.REMOVED_WEBAPP_PLUGIN:
+        return removePluginComponents(state, action);
     default:
         return state;
     }
 }
 
 export default combineReducers({
+
+    // object where every key is a plugin id and values are webapp plugin manifests
+    plugins,
+
+    // object where every key is a component name and the values are components wrapped
+    // in an object that contains a plugin id
     components
 });

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -195,7 +195,10 @@ export const ActionTypes = keyMirror({
 
     EMOJI_POSTED: null,
 
-    RECEIVED_PLUGIN_COMPONENTS: null
+    RECEIVED_PLUGIN_COMPONENTS: null,
+    RECEIVED_WEBAPP_PLUGINS: null,
+    RECEIVED_WEBAPP_PLUGIN: null,
+    REMOVED_WEBAPP_PLUGIN: null
 });
 
 export const WebrtcActionTypes = keyMirror({
@@ -254,7 +257,9 @@ export const SocketEvents = {
     WEBRTC: 'webrtc',
     REACTION_ADDED: 'reaction_added',
     REACTION_REMOVED: 'reaction_removed',
-    EMOJI_ADDED: 'emoji_added'
+    EMOJI_ADDED: 'emoji_added',
+    PLUGIN_ACTIVATED: 'plugin_activated',
+    PLUGIN_DEACTIVATED: 'plugin_deactivated'
 };
 
 export const TutorialSteps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5063,9 +5063,9 @@ math-expression-evaluator@^1.2.14:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz#b357fa1ca9faefb8e48d10c14ef2bcb2d9f0a7c9"
 
-mattermost-redux@mattermost/mattermost-redux#plt-7622:
+mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/c05585c38e0b1fcb31a22bb60257bf2a8656ab8e"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/b09a04337301c1a3cbe8a5a7e726e305a9af4f41"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5063,9 +5063,9 @@ math-expression-evaluator@^1.2.14:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz#b357fa1ca9faefb8e48d10c14ef2bcb2d9f0a7c9"
 
-mattermost-redux@mattermost/mattermost-redux#master:
+mattermost-redux@mattermost/mattermost-redux#plt-7622:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/e732a173be8c2547d7c8269020dff2f5e44baa26"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/c05585c38e0b1fcb31a22bb60257bf2a8656ab8e"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
#### Summary
* Added support for loading plugins separate from client config
* Made use of new websocket events to add/remove plugins without a refresh
* Added functionality to load/remove plugins on reconnect in case of missed websocket event 
* Added a reducer to store plugin manifests
* Updated plugin components reducer to store the owner plugin's id

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7622

#### Checklist
- [x] Has server changes (mattermost/mattermost-server#7445)
- [x] Has redux changes (mattermost/mattermost-redux#252)