### PR TITLE
PLT-7298 Added Edit Account Settings link to bottom of your own profile popover

### DIFF
--- a/components/profile_popover.jsx
+++ b/components/profile_popover.jsx
@@ -264,11 +264,13 @@ export default class ProfilePopover extends React.Component {
                 <div
                     data-toggle='tooltip'
                     key='user-popover-settings'
+                    className='popover__row first'
                 >
                     <a
                         href='#'
                         onClick={this.handleEditAccountSettings}
                     >
+                        <i className='fa fa-pencil-square-o'/>
                         <FormattedMessage
                             id='user_profile.account.editSettings'
                             defaultMessage='Edit Account Settings'

--- a/components/profile_popover.jsx
+++ b/components/profile_popover.jsx
@@ -31,6 +31,7 @@ export default class ProfilePopover extends React.Component {
         this.initWebrtc = this.initWebrtc.bind(this);
         this.handleShowDirectChannel = this.handleShowDirectChannel.bind(this);
         this.handleMentionKeyClick = this.handleMentionKeyClick.bind(this);
+        this.handleEditAccountSettings = this.handleEditAccountSettings.bind(this);
         this.state = {
             currentUserId: UserStore.getCurrentId(),
             loadingDMChannel: -1
@@ -120,6 +121,18 @@ export default class ProfilePopover extends React.Component {
             this.props.hide();
         }
         GlobalActions.emitPopoverMentionKeyClick(this.props.isRHS, this.props.user.username);
+    }
+
+    handleEditAccountSettings(e) {
+        e.preventDefault();
+
+        if (!this.props.user) {
+            return;
+        }
+        if (this.props.hide) {
+            this.props.hide();
+        }
+        GlobalActions.showAccountSettingsModal();
     }
 
     render() {
@@ -241,6 +254,25 @@ export default class ProfilePopover extends React.Component {
                         className='text-nowrap text-lowercase user-popover__email'
                     >
                         {email}
+                    </a>
+                </div>
+            );
+        }
+
+        if (this.props.user.id === UserStore.getCurrentId()) {
+            dataContent.push(
+                <div
+                    data-toggle='tooltip'
+                    key='user-popover-settings'
+                >
+                    <a
+                        href='#'
+                        onClick={this.handleEditAccountSettings}
+                    >
+                        <FormattedMessage
+                            id='user_profile.account.editSettings'
+                            defaultMessage='Edit Account Settings'
+                        />
                     </a>
                 </div>
             );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2768,6 +2768,7 @@
   "user.settings.tokens.tokenId": "Token ID: ",
   "user.settings.tokens.userAccessTokensNone": "No personal access tokens.",
   "user_list.notFound": "No users found",
+  "user_profile.account.editSettings": "Edit Account Settings",
   "user_profile.send.dm": "Send Message",
   "user_profile.webrtc.call": "Start Video Call",
   "user_profile.webrtc.offline": "The user is offline",


### PR DESCRIPTION
#### Summary

- Added "Edit Account Settings" link to bottom of your own profile popover (this link only appears for your own account)
- Clicking the link opens the Mattermost Account Settings, performing the same action as CTRL/CMD+SHIFT+A

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7298
https://github.com/mattermost/mattermost-server/issues/7113

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
