### PR TITLE
[PLT-6441] Move channel_info_modal to use Redux

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -6,7 +6,7 @@ import MessageWrapper from 'components/message_wrapper.jsx';
 import PopoverListMembers from 'components/popover_list_members';
 import EditChannelHeaderModal from 'components/edit_channel_header_modal.jsx';
 import EditChannelPurposeModal from 'components/edit_channel_purpose_modal.jsx';
-import ChannelInfoModal from 'components/channel_info_modal.jsx';
+import ChannelInfoModal from 'components/channel_info_modal/channel_info_modal.jsx';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import ChannelMembersModal from 'components/channel_members_modal.jsx';
 import ChannelNotificationsModal from 'components/channel_notifications_modal.jsx';

--- a/components/channel_info_modal/channel_info_modal.jsx
+++ b/components/channel_info_modal/channel_info_modal.jsx
@@ -6,14 +6,32 @@ import Constants from 'utils/constants.jsx';
 
 import {FormattedMessage} from 'react-intl';
 import {Modal} from 'react-bootstrap';
-import TeamStore from 'stores/team_store.jsx';
 import * as TextFormatting from 'utils/text_formatting.jsx';
+import {getSiteURL} from 'utils/url.jsx';
 
 import PropTypes from 'prop-types';
 
 import React from 'react';
 
-export default class ChannelInfoModal extends React.Component {
+export default class ChannelInfoModal extends React.PureComponent {
+    static propTypes = {
+
+        /**
+         * Function that is called when modal is hidden
+         */
+        onHide: PropTypes.func.isRequired,
+
+        /**
+         * Channel object
+         */
+        channel: PropTypes.object.isRequired,
+
+        /**
+         * Current team object
+         */
+        currentTeam: PropTypes.object.isRequired
+    };
+
     constructor(props) {
         super(props);
 
@@ -60,7 +78,7 @@ export default class ChannelInfoModal extends React.Component {
             );
         }
 
-        const channelURL = TeamStore.getCurrentTeamUrl() + '/channels/' + channel.name;
+        const channelURL = getSiteURL() + '/' + this.props.currentTeam.name + '/channels/' + channel.name;
 
         let channelPurpose;
         if (channel.purpose) {
@@ -149,8 +167,3 @@ export default class ChannelInfoModal extends React.Component {
         );
     }
 }
-
-ChannelInfoModal.propTypes = {
-    onHide: PropTypes.func.isRequired,
-    channel: PropTypes.object.isRequired
-};

--- a/components/channel_info_modal/index.js
+++ b/components/channel_info_modal/index.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import ChannelInfoModal from './channel_info_modal.jsx';
+
+function mapStateToProps(state, ownProps) {
+    return {
+        ...ownProps,
+        currentTeam: getCurrentTeam(state)
+    };
+}
+
+export default connect(mapStateToProps)(ChannelInfoModal);

--- a/components/navbar/index.jsx
+++ b/components/navbar/index.jsx
@@ -11,7 +11,7 @@ import * as ChannelActions from 'actions/channel_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {getPinnedPosts} from 'actions/post_actions.jsx';
 
-import ChannelInfoModal from 'components/channel_info_modal.jsx';
+import ChannelInfoModal from 'components/channel_info_modal';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import ChannelMembersModal from 'components/channel_members_modal.jsx';
 import ChannelNotificationsModal from 'components/channel_notifications_modal.jsx';

--- a/tests/components/__snapshots__/channel_info_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/channel_info_modal.test.jsx.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/ChannelInfoModal should match snapshot 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="about-modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onExited={[Function]}
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="About"
+        id="channel_info.about"
+        values={Object {}}
+      />
+      <strong />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <div
+      className="form-group"
+    >
+      <div
+        className="info__label"
+      >
+        <FormattedMessage
+          defaultMessage="URL:"
+          id="channel_info.url"
+          values={Object {}}
+        />
+      </div>
+      <div
+        className="info__value"
+      >
+        null/testteam/channels/testchannel
+      </div>
+    </div>
+    <div
+      className="about-modal__hash form-group padding-top x2"
+    >
+      <p>
+        <FormattedMessage
+          defaultMessage="ID: "
+          id="channel_info.id"
+          values={Object {}}
+        />
+      </p>
+    </div>
+  </ModalBody>
+</Modal>
+`;

--- a/tests/components/channel_info_modal.test.jsx
+++ b/tests/components/channel_info_modal.test.jsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+
+import ChannelInfoModal from 'components/channel_info_modal/channel_info_modal.jsx';
+import {Modal} from 'react-bootstrap';
+
+describe('components/ChannelInfoModal', () => {
+    test('should match snapshot', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <ChannelInfoModal
+                channel={{name: 'testchannel', displayName: 'testchannel', header: '', purpose: ''}}
+                currentTeam={{id: 'testid', name: 'testteam'}}
+                onHide={emptyFunction}
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should call onHide callback when modal is hidden', (done) => {
+        function onHide() {
+            done();
+        }
+
+        const wrapper = mountWithIntl(
+            <ChannelInfoModal
+                channel={{name: 'testchannel', displayName: 'testchannel', header: '', purpose: ''}}
+                currentTeam={{id: 'testid', name: 'testteam'}}
+                onHide={onHide}
+            />
+        );
+
+        wrapper.find(Modal).first().props().onExited();
+    });
+});


### PR DESCRIPTION
#### Summary
Moved the `channel_info_modal` component to use Redux and added tests.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/6441

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)