### PR TITLE
PLT-7544 Begin migrating channel header to redux pattern

### DIFF
--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {getChannel, getMyChannelMember} from 'mattermost-redux/selectors/entities/channels';
+import {getMyTeamMember} from 'mattermost-redux/selectors/entities/teams';
+import {getUser, getStatusForUserId, getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
+import {leaveChannel, favoriteChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
+
+import {isFavoriteChannel, isDefault, getUserIdFromChannelName} from 'mattermost-redux/utils/channel_utils';
+import {General, Preferences} from 'mattermost-redux/constants';
+
+import ChannelHeader from './channel_header.jsx';
+
+function mapStateToProps(state, ownProps) {
+    const channel = getChannel(state, ownProps.channelId);
+    const prefs = state.entities.preferences.myPreferences;
+    const user = getCurrentUser(state);
+
+    let dmUser;
+    let dmUserStatus;
+    if (channel && channel.type === General.DM_CHANNEL) {
+        const dmUserId = getUserIdFromChannelName(user.id, channel.name);
+        dmUser = getUser(state, dmUserId);
+        dmUserStatus = {status: getStatusForUserId(state, dmUserId)};
+    }
+
+    return {
+        channel,
+        channelMember: getMyChannelMember(state, ownProps.channelId),
+        teamMember: getMyTeamMember(state, channel.team_id),
+        isFavorite: isFavoriteChannel(prefs, {...channel}),
+        isDefault: isDefault(channel),
+        currentUser: user,
+        dmUser,
+        dmUserStatus,
+        enableFormatting: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', false)
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            leaveChannel,
+            favoriteChannel,
+            unfavoriteChannel
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ChannelHeader);

--- a/components/channel_view.jsx
+++ b/components/channel_view.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
-import ChannelHeader from 'components/channel_header.jsx';
+import ChannelHeader from 'components/channel_header';
 import FileUploadOverlay from 'components/file_upload_overlay.jsx';
 import CreatePost from 'components/create_post.jsx';
 import PostView from 'components/post_view';

--- a/components/navbar/index.jsx
+++ b/components/navbar/index.jsx
@@ -252,7 +252,7 @@ export default class Navbar extends React.Component {
         AppDispatcher.handleViewAction({
             type: ActionTypes.TOGGLE_DM_MODAL,
             value: true,
-            startingUsers: UserStore.getProfileListInChannel(this.state.channel.id, true)
+            channelId: this.state.channel.id
         });
     }
 

--- a/components/permalink_view.jsx
+++ b/components/permalink_view.jsx
@@ -5,7 +5,7 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import ChannelHeader from 'components/channel_header.jsx';
+import ChannelHeader from 'components/channel_header';
 import PostView from 'components/post_view';
 
 import ChannelStore from 'stores/channel_store.jsx';

--- a/components/popover_list_members/index.js
+++ b/components/popover_list_members/index.js
@@ -3,13 +3,24 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+
+import {makeGetProfilesInChannel} from 'mattermost-redux/selectors/entities/users';
+import {getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
+
 import {getProfilesInChannel} from 'mattermost-redux/actions/users';
 
 import PopoverListMembers from './popover_list_members.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
+function makeMapStateToProps() {
+    const doGetProfilesInChannel = makeGetProfilesInChannel();
+
+    return function mapStateToProps(state, ownProps) {
+        const stats = getAllChannelStats(state)[ownProps.channel.id] || {};
+        return {
+            ...ownProps,
+            memberCount: stats.member_count,
+            members: doGetProfilesInChannel(state, ownProps.channel.id, true)
+        };
     };
 }
 
@@ -21,4 +32,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(PopoverListMembers);
+export default connect(makeMapStateToProps, mapDispatchToProps)(PopoverListMembers);

--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -162,7 +162,7 @@ export default class Sidebar extends React.Component {
     }
 
     onModalChange = (value, args) => {
-        this.showMoreDirectChannelsModal(args.startingUsers);
+        this.showMoreDirectChannelsModal(UserStore.getProfileListInChannel(args.channelId, true, false));
     }
 
     handleOpenMoreDirectChannelsModal = (e) => {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "localforage": "1.5.0",
     "marked": "mattermost/marked#b516702c460c68df0b68fa9f4916f3100572ce99",
     "match-at": "0.1.0",
-    "mattermost-redux": "mattermost/mattermost-redux#plt-7544",
+    "mattermost-redux": "mattermost/mattermost-redux#master",
     "object-assign": "4.1.1",
     "pdfjs-dist": "1.9.441",
     "perfect-scrollbar": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "localforage": "1.5.0",
     "marked": "mattermost/marked#b516702c460c68df0b68fa9f4916f3100572ce99",
     "match-at": "0.1.0",
-    "mattermost-redux": "mattermost/mattermost-redux#master",
+    "mattermost-redux": "mattermost/mattermost-redux#plt-7544",
     "object-assign": "4.1.1",
     "pdfjs-dist": "1.9.441",
     "perfect-scrollbar": "0.7.1",

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -345,6 +345,13 @@ export const NotificationLevels = {
     NONE: 'none'
 };
 
+export const RHSStates = {
+    MENTION: 'mention',
+    SEARCH: 'search',
+    FLAG: 'flag',
+    PIN: 'pin'
+};
+
 export const Constants = {
     Preferences,
     SocketEvents,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5065,7 +5065,7 @@ math-expression-evaluator@^1.2.14:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/b09a04337301c1a3cbe8a5a7e726e305a9af4f41"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/c6115b3cfa934ed97a60a10727fa487df39a4043"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
#### Summary
Part 1 of migrating the channel header to the Redux pattern.

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/PLT-7544

#### Still to do in future PR
* Move out modals
* Migrate webrtc store/actions to redux
* Use redux for search store
* Supply all actions through props
* Add component test