### PR TITLE
PLT-7621 Add webapp plugin post type extension support

### DIFF
--- a/components/post_view/post_message_view/index.js
+++ b/components/post_view/post_message_view/index.js
@@ -3,7 +3,7 @@
 
 import {connect} from 'react-redux';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
-import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {getTheme, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserMentionKeys, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
 
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
@@ -33,7 +33,9 @@ function makeMapStateToProps() {
             mentionKeys: getCurrentUserMentionKeys(state),
             usernameMap: getUsersByUsername(state),
             team: getCurrentTeam(state),
-            siteUrl: getSiteURL()
+            siteUrl: getSiteURL(),
+            theme: getTheme(state),
+            pluginPostTypes: state.plugins.postTypes
         };
     };
 }

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -76,14 +76,25 @@ export default class PostMessageView extends React.PureComponent {
         /**
          * Flags if the post_message_view is for the RHS (Reply).
          */
-        hasMention: PropTypes.bool
+        hasMention: PropTypes.bool,
+
+        /*
+         * Logged in user's theme
+         */
+        theme: PropTypes.object.isRequired,
+
+        /*
+         * Post type components from plugins
+         */
+        pluginPostTypes: PropTypes.object
     };
 
     static defaultProps = {
         options: {},
         mentionKeys: [],
         isRHS: false,
-        hasMention: false
+        hasMention: false,
+        pluginPostTypes: {}
     };
 
     renderDeletedPost() {
@@ -169,6 +180,23 @@ export default class PostMessageView extends React.PureComponent {
 
         if (!this.props.enableFormatting) {
             return <span>{this.props.post.message}</span>;
+        }
+
+        const postType = this.props.post.type;
+        const pluginPostTypes = this.props.pluginPostTypes;
+        if (postType) {
+            if (pluginPostTypes.hasOwnProperty(postType)) {
+                const PluginComponent = pluginPostTypes[postType].component;
+                return (
+                    <PluginComponent
+                        post={this.props.post}
+                        mentionKeys={this.props.mentionKeys}
+                        compactDisplay={this.props.compactDisplay}
+                        isRHS={this.props.isRHS}
+                        theme={this.props.theme}
+                    />
+                );
+            }
         }
 
         const options = Object.assign({}, this.props.options, {

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -10,7 +10,7 @@ import {Client4} from 'mattermost-redux/client';
 
 window.plugins = {};
 
-export function registerComponents(id, components) {
+export function registerComponents(id, components = {}, postTypes = {}) {
     const wrappedComponents = {};
     Object.keys(components).forEach((name) => {
         wrappedComponents[name] = {component: components[name], id};
@@ -19,6 +19,16 @@ export function registerComponents(id, components) {
     store.dispatch({
         type: ActionTypes.RECEIVED_PLUGIN_COMPONENTS,
         data: wrappedComponents
+    });
+
+    const wrappedPostTypes = {};
+    Object.keys(postTypes).forEach((type) => {
+        wrappedPostTypes[type] = {component: postTypes[type], id};
+    });
+
+    store.dispatch({
+        type: ActionTypes.RECEIVED_PLUGIN_POST_TYPES,
+        data: wrappedPostTypes
     });
 }
 

--- a/reducers/plugins/index.js
+++ b/reducers/plugins/index.js
@@ -76,6 +76,22 @@ function components(state = {}, action) {
     }
 }
 
+function postTypes(state = {}, action) {
+    switch (action.type) {
+    case ActionTypes.RECEIVED_PLUGIN_POST_TYPES: {
+        if (action.data) {
+            return {...action.data, ...state};
+        }
+        return state;
+    }
+    case ActionTypes.RECEIVED_WEBAPP_PLUGIN:
+    case ActionTypes.REMOVED_WEBAPP_PLUGIN:
+        return removePluginComponents(state, action);
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
 
     // object where every key is a plugin id and values are webapp plugin manifests
@@ -83,5 +99,9 @@ export default combineReducers({
 
     // object where every key is a component name and the values are components wrapped
     // in an object that contains a plugin id
-    components
+    components,
+
+    // object where every key is a post type and the values are components wrapped in an
+    // an object that contains a plugin id
+    postTypes
 });

--- a/tests/plugins/__snapshots__/post_type.test.jsx.snap
+++ b/tests/plugins/__snapshots__/post_type.test.jsx.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plugins/PostMessageView should match snapshot with extended post type 1`] = `
+<PostMessageView
+  emojis={Object {}}
+  enableFormatting={true}
+  hasMention={false}
+  isRHS={false}
+  mentionKeys={Array []}
+  options={Object {}}
+  pluginPostTypes={
+    Object {
+      "testtype": Object {
+        "component": [Function],
+      },
+    }
+  }
+  post={
+    Object {
+      "type": "testtype",
+    }
+  }
+  team={Object {}}
+  theme={Object {}}
+>
+  <PostTypePlugin
+    isRHS={false}
+    mentionKeys={Array []}
+    post={
+      Object {
+        "type": "testtype",
+      }
+    }
+    theme={Object {}}
+  >
+    <span>
+      PostTypePlugin
+    </span>
+  </PostTypePlugin>
+</PostMessageView>
+`;
+
+exports[`plugins/PostMessageView should match snapshot with no extended post type 1`] = `
+<PostMessageView
+  emojis={Object {}}
+  enableFormatting={true}
+  hasMention={false}
+  isRHS={false}
+  mentionKeys={Array []}
+  options={Object {}}
+  pluginPostTypes={Object {}}
+  post={
+    Object {
+      "type": "testtype",
+    }
+  }
+  team={Object {}}
+  theme={Object {}}
+>
+  <div>
+    <span
+      className="post-message__text"
+      id={null}
+      onClick={[Function]}
+    />
+  </div>
+</PostMessageView>
+`;

--- a/tests/plugins/post_type.test.jsx
+++ b/tests/plugins/post_type.test.jsx
@@ -1,0 +1,43 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {mount} from 'enzyme';
+
+import PostMessageView from 'components/post_view/post_message_view/post_message_view.jsx';
+
+class PostTypePlugin extends React.PureComponent {
+    render() {
+        return <span>{'PostTypePlugin'}</span>;
+    }
+}
+
+describe('plugins/PostMessageView', () => {
+    test('should match snapshot with extended post type', () => {
+        const wrapper = mount(
+            <PostMessageView
+                post={{type: 'testtype'}}
+                emojis={{}}
+                team={{}}
+                enableFormatting={true}
+                theme={{}}
+                pluginPostTypes={{testtype: {component: PostTypePlugin}}}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot with no extended post type', () => {
+        const wrapper = mount(
+            <PostMessageView
+                post={{type: 'testtype'}}
+                emojis={{}}
+                team={{}}
+                enableFormatting={true}
+                theme={{}}
+                pluginPostTypes={{}}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -196,6 +196,7 @@ export const ActionTypes = keyMirror({
     EMOJI_POSTED: null,
 
     RECEIVED_PLUGIN_COMPONENTS: null,
+    RECEIVED_PLUGIN_POST_TYPES: null,
     RECEIVED_WEBAPP_PLUGINS: null,
     RECEIVED_WEBAPP_PLUGIN: null,
     REMOVED_WEBAPP_PLUGIN: null


### PR DESCRIPTION
#### Summary
Add webapp plugin post type extension support. Very similar to your implementation @hmhealey, only major difference is I added a new reducer specifically for post type extending.

Not blocked by the server changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7621

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has server changes (mattermost/mattermost-server#7468)