### PR TITLE
PLT-7588: Fix password change bar / undefined reference

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -625,7 +625,7 @@ export function resetPassword(token, password, success, error) {
     UserActions.resetUserPassword(token, password)(dispatch, getState).then(
         (data) => {
             if (data) {
-                browserHistory.push('/login?extra=' + ActionTypes.PASSWORD_CHANGE);
+                browserHistory.push('/login?extra=' + Constants.PASSWORD_CHANGE);
                 if (success) {
                     success(data);
                 }

--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -12,7 +12,7 @@ import {loadStatusesForProfilesList, loadStatusesForProfilesMap} from 'actions/s
 
 import {getDirectChannelName, getUserIdFromChannelName} from 'utils/utils.jsx';
 
-import {Constants, ActionTypes, Preferences} from 'utils/constants.jsx';
+import {Constants, Preferences} from 'utils/constants.jsx';
 import {browserHistory} from 'react-router/es6';
 
 import store from 'stores/redux_store.jsx';


### PR DESCRIPTION
#### Summary
> Repro steps:
> 1) Sign out of Mattermost
> 2) Click "Forgot my password" link on login screen
> 3) Go to password reset link that's emailed to you
> 4) Enter a new password and click "Change my password"
> Observed: You're sent back to the log in screen with no feedback that your password changed. The URL reads "/login?extra=undefined. Your password is still changed
> Expected: The log in screen should display "Password updated successfully". The URL should read "/login?extra=password_change".

Bug introduced by this PR: https://github.com/mattermost/mattermost-server/pull/5167

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7588