### PR TITLE
Fix JS error - cannot read property ‘hide’ of undefined

### DIFF
--- a/components/navbar/index.jsx
+++ b/components/navbar/index.jsx
@@ -824,6 +824,7 @@ export default class Navbar extends React.Component {
                             {collapseButtons}
                             {searchButton}
                             <NavbarInfoButton
+                                ref='headerOverlay'
                                 channel={channel}
                                 showEditChannelHeaderModal={this.showEditChannelHeaderModal}
                             />


### PR DESCRIPTION
#### Summary
Encountered JS error when navbar `x` button is clicked.

![screen shot 2017-09-20 at 3 58 17 am](https://user-images.githubusercontent.com/5334504/30612778-3fc2a820-9db8-11e7-876b-726f6aa2fb3b.png)

![screen shot 2017-09-20 at 3 52 38 am](https://user-images.githubusercontent.com/5334504/30612787-465fa3b8-9db8-11e7-94a9-c72b114ff853.png)

