### PR TITLE
Minor IE fixes

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -260,7 +260,7 @@
         -webkit-overflow-scrolling: touch;
         height: 100%;
         overflow-y: scroll;
-        padding: 1em 0 .5em;
+        padding: 1em 0 0;
         position: absolute;
         width: 100%;
 
@@ -642,6 +642,7 @@
     display: table;
     height: 100%;
     min-height: 350px;
+    padding-bottom: .5em;
     table-layout: fixed;
     width: 100%;
 

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -935,6 +935,10 @@
 
     .post--edited {
         // If the last paragraph of an edited post is a paragraph, make it inline-block so that the (edited) indicator can be on the same line as it
+        .post-message__text {
+            word-break: break-all;
+        }
+
         .post-message__text > p:last-child {
             display: inline-block;
             width: auto;


### PR DESCRIPTION
#### Summary
PLT-7593 - Fixing buffer space above textarea
PLT-7594 - Fixing word break in IE111

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7593
https://mattermost.atlassian.net/browse/PLT-7594

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
