### PR TITLE
PLT-7708 Added a maximum depth to the Markdown block parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jquery": "3.2.1",
     "key-mirror": "1.0.1",
     "localforage": "1.5.0",
-    "marked": "mattermost/marked#b516702c460c68df0b68fa9f4916f3100572ce99",
+    "marked": "mattermost/marked#70eba71f18ab4d2e2bae6b3490a855ac6021a21f",
     "match-at": "0.1.0",
     "mattermost-redux": "mattermost/mattermost-redux#master",
     "object-assign": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5047,9 +5047,9 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-marked@mattermost/marked#b516702c460c68df0b68fa9f4916f3100572ce99:
+marked@mattermost/marked#70eba71f18ab4d2e2bae6b3490a855ac6021a21f:
   version "0.3.6"
-  resolved "https://codeload.github.com/mattermost/marked/tar.gz/b516702c460c68df0b68fa9f4916f3100572ce99"
+  resolved "https://codeload.github.com/mattermost/marked/tar.gz/70eba71f18ab4d2e2bae6b3490a855ac6021a21f"
 
 match-at@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This'll prevent anything strange from happening by someone deeply nesting Markdown blocks (mostly quotes and lists). I picked a depth of 100 since it's a nice, round number, but we could go even further if we wanted. Anything past that depth can still have inline stuff rendered (styling, links, etc), but won't be able to use block styles (lists, code blocks, etc)

Marked changes: https://github.com/mattermost/marked/commit/70eba71f18ab4d2e2bae6b3490a855ac6021a21f

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7708

#### Checklist
- Added or updated unit tests (required for all new features)
