### PR TITLE
PLT-6453 Migrate installed_incoming_webhooks.jsx to be pure and use Redux

### DIFF
--- a/components/integrations/components/installed_incoming_webhooks/index.js
+++ b/components/integrations/components/installed_incoming_webhooks/index.js
@@ -5,16 +5,18 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import * as Actions from 'mattermost-redux/actions/integrations';
 import {getIncomingHooks} from 'mattermost-redux/selectors/entities/integrations';
-import InstalledIncomingWebhooks from './installed_incoming_webhooks.jsx';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getAllChannels} from 'mattermost-redux/selectors/entities/channels';
 import {getUsers} from 'mattermost-redux/selectors/entities/users';
+import InstalledIncomingWebhooks from './installed_incoming_webhooks.jsx';
 
 function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
         incomingWebhooks: getIncomingHooks(state),
         channels: getAllChannels(state),
-        users: getUsers(state)
+        users: getUsers(state),
+        teamId: getCurrentTeamId(state)
     };
 }
 

--- a/components/integrations/components/installed_incoming_webhooks/installed_incoming_webhooks.jsx
+++ b/components/integrations/components/installed_incoming_webhooks/installed_incoming_webhooks.jsx
@@ -1,15 +1,13 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+import * as Utils from 'utils/utils.jsx';
+import Constants from 'utils/constants.jsx';
 
 import BackstageList from 'components/backstage/components/backstage_list.jsx';
 import InstalledIncomingWebhook from 'components/integrations/components/installed_incoming_webhook.jsx';
-
-import * as Utils from 'utils/utils.jsx';
-
-import PropTypes from 'prop-types';
-
-import React from 'react';
-import {FormattedMessage} from 'react-intl';
 
 export default class InstalledIncomingWebhooks extends React.PureComponent {
     static propTypes = {
@@ -44,6 +42,11 @@ export default class InstalledIncomingWebhooks extends React.PureComponent {
         */
         users: PropTypes.object,
 
+        /**
+        *  Data used in passing as argument for loading webhooks
+        */
+
+        teamId: PropTypes.string,
         actions: PropTypes.shape({
 
             /**
@@ -70,7 +73,11 @@ export default class InstalledIncomingWebhooks extends React.PureComponent {
 
     componentDidMount() {
         if (window.mm_config.EnableIncomingWebhooks === 'true') {
-            this.props.actions.getIncomingHooks().then(
+            this.props.actions.getIncomingHooks(
+              this.props.teamId,
+              Constants.Integrations.START_PAGE_NUM,
+              Constants.Integrations.PAGE_SIZE
+            ).then(
               () => this.setState({loading: false})
             );
         }

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -937,6 +937,8 @@ export const Constants = {
     },
     Integrations: {
         COMMAND: 'commands',
+        PAGE_SIZE: '10000',
+        START_PAGE_NUM: 0,
         INCOMING_WEBHOOK: 'incoming_webhooks',
         OUTGOING_WEBHOOK: 'outgoing_webhooks',
         OAUTH_APP: 'oauth2-apps'


### PR DESCRIPTION
#### Summary
Fixes the issue of no teamId as part of incoming webhook API

#### Pull Request Link
https://github.com/mattermost/mattermost-webapp/pull/60

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has redux changes (please link)