### PR TITLE
PLT-7751: Add jobs table to data retention admin UI.

### DIFF
--- a/components/admin_console/data_retention_settings.jsx
+++ b/components/admin_console/data_retention_settings.jsx
@@ -10,6 +10,8 @@ import DropdownSetting from './dropdown_setting.jsx';
 import {FormattedMessage} from 'react-intl';
 import SettingsGroup from './settings_group.jsx';
 import TextSetting from './text_setting.jsx';
+import {JobTypes} from 'utils/constants.jsx';
+import JobsTable from './jobs';
 
 export default class DataRetentionSettings extends AdminSettings {
     constructor(props) {
@@ -177,6 +179,22 @@ export default class DataRetentionSettings extends AdminSettings {
                     }
                     value={this.state.deletionJobStartTime}
                     onChange={this.handleChange}
+                />
+                <JobsTable
+                    jobType={JobTypes.DATA_RETENTION}
+                    disabled={!this.state.enableMessageDeletion && !this.state.enableFileDeletion}
+                    createJobButtonText={
+                        <FormattedMessage
+                            id='admin.data_retention.createJob.title'
+                            defaultMessage='Run Deletion Job Now'
+                        />
+                    }
+                    createJobHelpText={
+                        <FormattedMessage
+                            id='admin.data_retention.createJob.help'
+                            defaultMessage='Initiates a Data Retention deletion job immediately.'
+                        />
+                    }
                 />
             </SettingsGroup>
         );

--- a/components/admin_console/jobs/table.jsx
+++ b/components/admin_console/jobs/table.jsx
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
@@ -9,7 +8,7 @@ import * as Utils from 'utils/utils.jsx';
 import {FormattedMessage, FormattedDate, FormattedTime, injectIntl, intlShape} from 'react-intl';
 
 import {createJob, cancelJob} from 'actions/job_actions.jsx';
-import {JobTypes, JobStatuses} from 'utils/constants.jsx';
+import {JobStatuses} from 'utils/constants.jsx';
 import ErrorStore from 'stores/error_store.jsx';
 
 class JobTable extends React.PureComponent {
@@ -37,7 +36,7 @@ class JobTable extends React.PureComponent {
         /**
          * Function called when displaying extra text.
          */
-        getExtraInfoText: PropTypes.func.isRequired,
+        getExtraInfoText: PropTypes.func,
 
         /**
          * Grey buttons out when disabled
@@ -52,7 +51,12 @@ class JobTable extends React.PureComponent {
         /**
          * Button text to create a new job
          */
-        createJobButtonText: PropTypes.element.isRequired
+        createJobButtonText: PropTypes.element.isRequired,
+
+        /**
+         * The type of jobs to include in this table.
+         */
+        jobType: PropTypes.string.isRequired
     };
 
     constructor(props) {
@@ -69,7 +73,7 @@ class JobTable extends React.PureComponent {
     }
 
     componentDidMount() {
-        this.props.actions.getJobsByType(JobTypes.LDAP_SYNC).then(
+        this.props.actions.getJobsByType(this.props.jobType).then(
             () => this.setState({loading: false})
          );
     }
@@ -256,7 +260,7 @@ class JobTable extends React.PureComponent {
     reload = () => {
         this.setState({loading: true});
 
-        this.props.actions.getJobsByType(JobTypes.LDAP_SYNC).then(
+        this.props.actions.getJobsByType(this.props.jobType).then(
             () => {
                 this.setState({
                     loading: false
@@ -285,7 +289,7 @@ class JobTable extends React.PureComponent {
         e.preventDefault();
 
         const job = {
-            type: JobTypes.LDAP_SYNC
+            type: this.props.jobType
         };
 
         createJob(

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -160,6 +160,8 @@
   "admin.data_retention.enableMessageDeletion.description": "Set how long Mattermost keeps messages in channels and direct messages.",
   "admin.data_retention.enableFileDeletion.title": "File Retention:",
   "admin.data_retention.enableFileDeletion.description": "Set how long Mattermost keeps file uploads in channels and direct messages.",
+  "admin.data_retention.createJob.title": "Run Deletion Job Now",
+  "admin.data_retention.createJob.help": "Initiates a Data Retention deletion job immediately.",
   "admin.advance.cluster": "High Availability",
   "admin.advance.metrics": "Performance Monitoring",
   "admin.audits.reload": "Reload User Activity Logs",


### PR DESCRIPTION
#### Summary
Adds a jobs table and a "run now" button to the Data Retention page of the system console.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7751

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file updates
