### PR TITLE
Marking data retention as beta in the sidebar

### DIFF
--- a/components/admin_console/admin_sidebar.jsx
+++ b/components/admin_console/admin_sidebar.jsx
@@ -286,7 +286,7 @@ export default class AdminSidebar extends React.Component {
                     title={
                         <FormattedMessage
                             id='admin.sidebar.data_retention'
-                            defaultMessage='Data Retention Policy'
+                            defaultMessage='Data Retention Policy (Beta)'
                         />
                     }
                 />

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -141,7 +141,7 @@
   "add_outgoing_webhook.triggerWordsTriggerWhenFullWord": "First word matches a trigger word exactly",
   "add_outgoing_webhook.triggerWordsTriggerWhenStartsWith": "First word starts with a trigger word",
   "add_users_to_team.title": "Add New Members To {teamName} Team",
-  "admin.sidebar.data_retention": "Data Retention Policy",
+  "admin.sidebar.data_retention": "Data Retention Policy (Beta)",
   "admin.data_retention.title": "Data Retention Policy (Beta)",
   "admin.data_retention.deletionJobStartTime.description": "Set the start time of the daily scheduled data retention job. Choose a time when fewer people are using your system. Must be a 24-hour time stamp in the form HH:MM.",
   "admin.data_retention.deletionJobStartTime.example": "E.g.: \"02:00\"",


### PR DESCRIPTION
It was already marked Beta on the System Console page, adding the label to the sidebar too