### PR TITLE
PLT-7592 Fixed non-http links only rendering at the start of text

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jquery": "3.2.1",
     "key-mirror": "1.0.1",
     "localforage": "1.5.0",
-    "marked": "mattermost/marked#70eba71f18ab4d2e2bae6b3490a855ac6021a21f",
+    "marked": "mattermost/marked#17945726698a03420588acd55e5b38f692c03f31",
     "match-at": "0.1.1",
     "mattermost-redux": "mattermost/mattermost-redux#master",
     "object-assign": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5266,9 +5266,9 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-marked@mattermost/marked#70eba71f18ab4d2e2bae6b3490a855ac6021a21f:
+marked@mattermost/marked#17945726698a03420588acd55e5b38f692c03f31:
   version "0.3.6"
-  resolved "https://codeload.github.com/mattermost/marked/tar.gz/70eba71f18ab4d2e2bae6b3490a855ac6021a21f"
+  resolved "https://codeload.github.com/mattermost/marked/tar.gz/17945726698a03420588acd55e5b38f692c03f31"
 
 match-at@0.1.1:
   version "0.1.1"


### PR DESCRIPTION
The problem was caused by the regex that matches plain text was capturing non-http links instead of realizing that they may be special and letting the URL regex take over

Marked changes here: https://github.com/mattermost/marked/commit/17945726698a03420588acd55e5b38f692c03f31

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7592

#### Checklist
- Added or updated unit tests (required for all new features)