### PR TITLE
PLT-7545 Add plugin support for a root component

### DIFF
--- a/components/backstage/backstage_controller.jsx
+++ b/components/backstage/backstage_controller.jsx
@@ -1,9 +1,10 @@
-import PropTypes from 'prop-types';
-
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 import React from 'react';
+import PropTypes from 'prop-types';
+
+import Pluggable from 'plugins/pluggable';
 
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
@@ -57,6 +58,7 @@ export default class BackstageController extends React.Component {
             <div className='backstage'>
                 <AnnouncementBar/>
                 <BackstageNavbar team={this.state.team}/>
+                <Pluggable overrideName='Root'/>
                 <div className='backstage-body'>
                     <BackstageSidebar
                         team={this.state.team}

--- a/components/backstage/backstage_controller.jsx
+++ b/components/backstage/backstage_controller.jsx
@@ -58,7 +58,7 @@ export default class BackstageController extends React.Component {
             <div className='backstage'>
                 <AnnouncementBar/>
                 <BackstageNavbar team={this.state.team}/>
-                <Pluggable overrideName='Root'/>
+                <Pluggable pluggableName='Root'/>
                 <div className='backstage-body'>
                     <BackstageSidebar
                         team={this.state.team}

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -29,6 +29,8 @@ import WebrtcSidebar from 'components/webrtc/components/webrtc_sidebar.jsx';
 
 import WebrtcNotification from 'components/webrtc/components/webrtc_notification.jsx';
 
+import Pluggable from 'plugins/pluggable';
+
 import store from 'stores/redux_store.jsx';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
@@ -221,6 +223,7 @@ export default class NeedsTeam extends React.Component {
                     <WebrtcSidebar/>
                     {content}
 
+                    <Pluggable overrideName='Root'/>
                     <UserSettingsModal/>
                     <GetPostLinkModal/>
                     <GetPublicLinkModal/>

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -223,7 +223,7 @@ export default class NeedsTeam extends React.Component {
                     <WebrtcSidebar/>
                     {content}
 
-                    <Pluggable overrideName='Root'/>
+                    <Pluggable pluggableName='Root'/>
                     <UserSettingsModal/>
                     <GetPostLinkModal/>
                     <GetPublicLinkModal/>

--- a/plugins/pluggable/pluggable.jsx
+++ b/plugins/pluggable/pluggable.jsx
@@ -10,14 +10,14 @@ export default class Pluggable extends React.PureComponent {
     static propTypes = {
 
         /*
-         * Should be a single overridable React component. One of this or overrideName is required
+         * Should be a single overridable React component. One of this or pluggableName is required
          */
         children: PropTypes.element,
 
         /*
          * Override the component to be plugged. One of this or children is required
          */
-        overrideName: PropTypes.string,
+        pluggableName: PropTypes.string,
 
         /*
          * Components for overriding provided by plugins
@@ -31,24 +31,24 @@ export default class Pluggable extends React.PureComponent {
     }
 
     render() {
-        const overrideName = this.props.overrideName;
+        const pluggableName = this.props.pluggableName;
 
         let child;
         if (this.props.children) {
             child = React.Children.only(this.props.children).type;
-        } else if (!overrideName) {
+        } else if (!pluggableName) {
             return null;
         }
 
         const components = this.props.components;
         const childrenProps = child ? this.props.children.props : {};
-        const componentName = overrideName || child.getComponentName();
+        const componentName = pluggableName || child.getComponentName();
 
         // Include any props passed to this component or to the child component
         let props = {...this.props};
         Reflect.deleteProperty(props, 'children');
         Reflect.deleteProperty(props, 'components');
-        Reflect.deleteProperty(props, 'overrideName');
+        Reflect.deleteProperty(props, 'pluggableName');
         props = {...props, ...childrenProps};
 
         // Override the default component with any registered plugin's component

--- a/plugins/pluggable/pluggable.jsx
+++ b/plugins/pluggable/pluggable.jsx
@@ -10,9 +10,14 @@ export default class Pluggable extends React.PureComponent {
     static propTypes = {
 
         /*
-         * Should be a single overridable React component
+         * Should be a single overridable React component. One of this or overrideName is required
          */
-        children: PropTypes.element.isRequired,
+        children: PropTypes.element,
+
+        /*
+         * Override the component to be plugged. One of this or children is required
+         */
+        overrideName: PropTypes.string,
 
         /*
          * Components for overriding provided by plugins
@@ -26,30 +31,39 @@ export default class Pluggable extends React.PureComponent {
     }
 
     render() {
-        const child = React.Children.only(this.props.children).type;
-        const components = this.props.components;
+        const overrideName = this.props.overrideName;
 
-        if (child == null) {
+        let child;
+        if (this.props.children) {
+            child = React.Children.only(this.props.children).type;
+        } else if (!overrideName) {
             return null;
         }
 
-        const childName = child.getComponentName();
+        const components = this.props.components;
+        const childrenProps = child ? this.props.children.props : {};
+        const componentName = overrideName || child.getComponentName();
 
         // Include any props passed to this component or to the child component
         let props = {...this.props};
         Reflect.deleteProperty(props, 'children');
         Reflect.deleteProperty(props, 'components');
-        props = {...props, ...this.props.children.props};
+        Reflect.deleteProperty(props, 'overrideName');
+        props = {...props, ...childrenProps};
 
         // Override the default component with any registered plugin's component
-        if (components.hasOwnProperty(childName)) {
-            const PluginComponent = components[childName].component;
+        if (components.hasOwnProperty(componentName)) {
+            const PluginComponent = components[componentName].component;
             return (
                 <PluginComponent
                     {...props}
                     theme={this.props.theme}
                 />
             );
+        }
+
+        if (child == null) {
+            return null;
         }
 
         return React.cloneElement(this.props.children, {...props});


### PR DESCRIPTION
#### Summary
This can be used to create a post-login modal and other modals. Adds support for plugin points that don't override an existing component.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7545
