### PR TITLE
GH-7231 Migrate delete_channel_modal.jsx to be pure and use Redux 

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -25,7 +25,7 @@ import ChannelInfoModal from 'components/channel_info_modal';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import ChannelMembersModal from 'components/channel_members_modal.jsx';
 import ChannelNotificationsModal from 'components/channel_notifications_modal.jsx';
-import DeleteChannelModal from 'components/delete_channel_modal.jsx';
+import DeleteChannelModal from 'components/delete_channel_modal';
 import EditChannelHeaderModal from 'components/edit_channel_header_modal';
 import EditChannelPurposeModal from 'components/edit_channel_purpose_modal';
 import MessageWrapper from 'components/message_wrapper.jsx';

--- a/components/delete_channel_modal/delete_channel_modal.jsx
+++ b/components/delete_channel_modal/delete_channel_modal.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
@@ -9,7 +8,6 @@ import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
 import {browserHistory} from 'react-router/es6';
 
 import Constants from 'utils/constants.jsx';
-
 
 export default class DeleteChannelModal extends React.PureComponent {
     static propTypes = {

--- a/components/delete_channel_modal/delete_channel_modal.jsx
+++ b/components/delete_channel_modal/delete_channel_modal.jsx
@@ -1,35 +1,59 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
 import {browserHistory} from 'react-router/es6';
 
-import {deleteChannel} from 'actions/channel_actions.jsx';
-import TeamStore from 'stores/team_store.jsx';
-
 import Constants from 'utils/constants.jsx';
 
-export default class DeleteChannelModal extends React.Component {
+
+export default class DeleteChannelModal extends React.PureComponent {
+    static propTypes = {
+
+        /**
+        * Function called when modal is dismissed
+        */
+        onHide: PropTypes.func.isRequired,
+
+        /**
+         * channel data
+         */
+        channel: PropTypes.object.isRequired,
+
+        /**
+         * currentTeamDetails used for redirection after deleting channel
+         */
+        currentTeamDetails: PropTypes.object.isRequired,
+
+        actions: PropTypes.shape({
+
+            /**
+            * Function called for deleting channel,
+            */
+
+            deleteChannel: PropTypes.func.isRequired
+        })
+    }
+
     constructor(props) {
         super(props);
 
         this.handleDelete = this.handleDelete.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
         this.onHide = this.onHide.bind(this);
-
         this.state = {show: true};
     }
 
     handleDelete() {
-        if (this.props.channel.id.length !== 26) {
+        if (this.props.channel.id.length !== Constants.CHANNEL_ID_LENGTH) {
             return;
         }
-
-        browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/town-square');
-        deleteChannel(this.props.channel.id);
+        browserHistory.push('/' + this.props.currentTeamDetails.name + '/channels/' + Constants.DEFAULT_CHANNEL);
+        this.props.actions.deleteChannel(this.props.channel.id);
         this.onHide();
     }
 
@@ -97,8 +121,3 @@ export default class DeleteChannelModal extends React.Component {
         );
     }
 }
-
-DeleteChannelModal.propTypes = {
-    onHide: PropTypes.func.isRequired,
-    channel: PropTypes.object.isRequired
-};

--- a/components/delete_channel_modal/index.js
+++ b/components/delete_channel_modal/index.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+
+import {deleteChannel} from 'mattermost-redux/actions/channels';
+
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import DeleteChannelModal from './delete_channel_modal.jsx';
+
+function mapStateToProps(state, ownProps) {
+    return {
+        ...ownProps,
+        currentTeamDetails: getCurrentTeam(state)
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            deleteChannel
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DeleteChannelModal);

--- a/components/navbar/index.jsx
+++ b/components/navbar/index.jsx
@@ -27,9 +27,10 @@ import ChannelInfoModal from 'components/channel_info_modal';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import ChannelMembersModal from 'components/channel_members_modal.jsx';
 import ChannelNotificationsModal from 'components/channel_notifications_modal.jsx';
-import DeleteChannelModal from 'components/delete_channel_modal.jsx';
-import EditChannelHeaderModal from 'components/edit_channel_header_modal';
-import EditChannelPurposeModal from 'components/edit_channel_purpose_modal';
+
+import DeleteChannelModal from 'components/delete_channel_modal';
+import EditChannelHeaderModal from 'components/edit_channel_header_modal.jsx';
+import EditChannelPurposeModal from 'components/edit_channel_purpose_modal.jsx';
 import NotifyCounts from 'components/notify_counts.jsx';
 import QuickSwitchModal from 'components/quick_switch_modal';
 import RenameChannelModal from 'components/rename_channel_modal.jsx';

--- a/components/navbar/index.jsx
+++ b/components/navbar/index.jsx
@@ -8,6 +8,9 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router/es6';
 
+import EditChannelHeaderModal from 'components/edit_channel_header_modal';
+import EditChannelPurposeModal from 'components/edit_channel_purpose_modal';
+
 import * as ChannelActions from 'actions/channel_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {getPinnedPosts} from 'actions/post_actions.jsx';
@@ -29,8 +32,7 @@ import ChannelMembersModal from 'components/channel_members_modal.jsx';
 import ChannelNotificationsModal from 'components/channel_notifications_modal.jsx';
 
 import DeleteChannelModal from 'components/delete_channel_modal';
-import EditChannelHeaderModal from 'components/edit_channel_header_modal.jsx';
-import EditChannelPurposeModal from 'components/edit_channel_purpose_modal.jsx';
+
 import NotifyCounts from 'components/notify_counts.jsx';
 import QuickSwitchModal from 'components/quick_switch_modal';
 import RenameChannelModal from 'components/rename_channel_modal.jsx';

--- a/tests/components/__snapshots__/delete_channel_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/delete_channel_modal.test.jsx.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/delete_channel_modal should match snapshot for delete_channel_modal 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <h4
+      className="modal-title"
+    >
+      <FormattedMessage
+        defaultMessage="Confirm DELETE Channel"
+        id="delete_channel.confirm"
+        values={Object {}}
+      />
+    </h4>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <div
+      className="alert alert-danger"
+    >
+      <FormattedHTMLMessage
+        defaultMessage="This will delete the channel from the team and make its contents inaccessible for all users. <br /><br />Are you sure you wish to delete the <strong>{display_name}</strong> channel?"
+        id="delete_channel.question"
+        values={
+          Object {
+            "display_name": "testing",
+          }
+        }
+      />
+    </div>
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-default"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="delete_channel.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-danger"
+      data-dismiss="modal"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Delete"
+        id="delete_channel.del"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;

--- a/tests/components/delete_channel_modal.test.jsx
+++ b/tests/components/delete_channel_modal.test.jsx
@@ -1,0 +1,116 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import {Modal} from 'react-bootstrap';
+
+import DeleteChannelModal from 'components/delete_channel_modal/delete_channel_modal.jsx';
+
+jest.mock('react-router/es6', () => ({
+    browserHistory: {
+        push: jest.fn()
+    }
+}));
+
+describe('components/delete_channel_modal', () => {
+    test('should match snapshot for delete_channel_modal', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+        const wrapper = shallow(
+            <DeleteChannelModal
+                onHide={emptyFunction}
+                currentTeamDetails={{
+                    name: 'mattermostDev'
+                }}
+                channel={{
+                    create_at: 1508265709607,
+                    creator_id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                    delete_at: 0,
+                    display_name: 'testing',
+                    extra_update_at: 1508265709628,
+                    header: 'test',
+                    id: 'owsyt8n43jfxjpzh9np93mx1wa',
+                    last_post_at: 1508265709635,
+                    name: 'testing',
+                    purpose: 'test',
+                    team_id: 'eatxocwc3bg9ffo9xyybnj4omr',
+                    total_msg_count: 0,
+                    type: 'O',
+                    update_at: 1508265709607
+                }}
+                actions={{
+                    deleteChannel: emptyFunction
+                }}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should call delete channel on keyDown', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+        const mockFunc = jest.fn();
+        const wrapper = shallow(
+            <DeleteChannelModal
+                onHide={emptyFunction}
+                currentTeamDetails={{
+                    name: 'mattermostDev'
+                }}
+                channel={{
+                    create_at: 1508265709607,
+                    creator_id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                    delete_at: 0,
+                    display_name: 'testing',
+                    extra_update_at: 1508265709628,
+                    header: 'test',
+                    id: 'owsyt8n43jfxjpzh9np93mx1wa',
+                    last_post_at: 1508265709635,
+                    name: 'testing',
+                    purpose: 'test',
+                    team_id: 'eatxocwc3bg9ffo9xyybnj4omr',
+                    total_msg_count: 0,
+                    type: 'O',
+                    update_at: 1508265709607
+                }}
+                actions={{
+                    deleteChannel: mockFunc
+                }}
+            />
+        );
+        wrapper.find(Modal).prop('onKeyDown')({keyCode: 13});
+        expect(mockFunc).toHaveBeenCalled();
+    });
+
+    test('should not call delete channel on keyDown as id length !== defaultLength ', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+        const mockFunc = jest.fn();
+        const wrapper = shallow(
+            <DeleteChannelModal
+                onHide={emptyFunction}
+                currentTeamDetails={{
+                    name: 'mattermostDev'
+                }}
+                channel={{
+                    create_at: 1508265709607,
+                    creator_id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                    delete_at: 0,
+                    display_name: 'testing',
+                    extra_update_at: 1508265709628,
+                    header: 'test',
+                    id: 'owsyt8n43jfxjpzh9np93mx1w',
+                    last_post_at: 1508265709635,
+                    name: 'testing',
+                    purpose: 'test',
+                    team_id: 'eatxocwc3bg9ffo9xyybnj4omr',
+                    total_msg_count: 0,
+                    type: 'O',
+                    update_at: 1508265709607
+                }}
+                actions={{
+                    deleteChannel: mockFunc
+                }}
+            />
+        );
+        wrapper.find(Modal).prop('onKeyDown')({keyCode: 13});
+        expect(mockFunc).not.toHaveBeenCalled();
+    });
+});

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1018,7 +1018,8 @@ export const Constants = {
         SHOW_NICKNAME_FULLNAME: 'nickname_full_name',
         SHOW_FULLNAME: 'full_name'
     },
-    SEARCH_POST: 'searchpost'
+    SEARCH_POST: 'searchpost',
+    CHANNEL_ID_LENGTH: 26
 };
 
 export default Constants;


### PR DESCRIPTION
#### Summary
Migrate delete_channel_modal.jsx to be pure and use Redux

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7231

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Has redux changes (please link)