### PR TITLE
PLT-7678 Hide trusted option in OAuth app UI for non-admins

### DIFF
--- a/components/integrations/components/add_oauth_app/add_oauth_app.jsx
+++ b/components/integrations/components/add_oauth_app/add_oauth_app.jsx
@@ -23,6 +23,11 @@ export default class AddOAuthApp extends React.PureComponent {
         */
         addOAuthAppRequest: PropTypes.object.isRequired,
 
+        /**
+        * Set if the current user is a system admin
+        */
+        isSystemAdmin: PropTypes.bool,
+
         actions: PropTypes.shape({
 
             /**
@@ -210,6 +215,57 @@ export default class AddOAuthApp extends React.PureComponent {
             );
         }
 
+        let trusted;
+        if (this.props.isSystemAdmin) {
+            trusted = (
+                <div className='form-group'>
+                    <label
+                        className='control-label col-sm-4'
+                        htmlFor='is_trusted'
+                    >
+                        <FormattedMessage
+                            id='installed_oauth_apps.trusted'
+                            defaultMessage='Is Trusted'
+                        />
+                    </label>
+                    <div className='col-md-5 col-sm-8'>
+                        <label className='radio-inline'>
+                            <input
+                                type='radio'
+                                value='true'
+                                name='is_trusted'
+                                checked={this.state.is_trusted}
+                                onChange={this.updateTrusted}
+                            />
+                            <FormattedMessage
+                                id='installed_oauth_apps.trusted.yes'
+                                defaultMessage='Yes'
+                            />
+                        </label>
+                        <label className='radio-inline'>
+                            <input
+                                type='radio'
+                                value='false'
+                                name='is_trusted'
+                                checked={!this.state.is_trusted}
+                                onChange={this.updateTrusted}
+                            />
+                            <FormattedMessage
+                                id='installed_oauth_apps.trusted.no'
+                                defaultMessage='No'
+                            />
+                        </label>
+                        <div className='form__help'>
+                            <FormattedMessage
+                                id='add_oauth_app.trusted.help'
+                                defaultMessage="When true, the OAuth 2.0 application is considered trusted by the Mattermost server and doesn't require the user to accept authorization. When false, an additional window will appear, asking the user to accept or deny the authorization."
+                            />
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+
         return (
             <div className='backstage-content'>
                 <BackstageHeader>
@@ -227,51 +283,7 @@ export default class AddOAuthApp extends React.PureComponent {
                 <div className='backstage-form'>
                     {icon}
                     <form className='form-horizontal'>
-                        <div className='form-group'>
-                            <label
-                                className='control-label col-sm-4'
-                                htmlFor='is_trusted'
-                            >
-                                <FormattedMessage
-                                    id='installed_oauth_apps.trusted'
-                                    defaultMessage='Is Trusted'
-                                />
-                            </label>
-                            <div className='col-md-5 col-sm-8'>
-                                <label className='radio-inline'>
-                                    <input
-                                        type='radio'
-                                        value='true'
-                                        name='is_trusted'
-                                        checked={this.state.is_trusted}
-                                        onChange={this.updateTrusted}
-                                    />
-                                    <FormattedMessage
-                                        id='installed_oauth_apps.trusted.yes'
-                                        defaultMessage='Yes'
-                                    />
-                                </label>
-                                <label className='radio-inline'>
-                                    <input
-                                        type='radio'
-                                        value='false'
-                                        name='is_trusted'
-                                        checked={!this.state.is_trusted}
-                                        onChange={this.updateTrusted}
-                                    />
-                                    <FormattedMessage
-                                        id='installed_oauth_apps.trusted.no'
-                                        defaultMessage='No'
-                                    />
-                                </label>
-                                <div className='form__help'>
-                                    <FormattedMessage
-                                        id='add_oauth_app.trusted.help'
-                                        defaultMessage="When true, the OAuth 2.0 application is considered trusted by the Mattermost server and doesn't require the user to accept authorization. When false, an additional window will appear, asking the user to accept or deny the authorization."
-                                    />
-                                </div>
-                            </div>
-                        </div>
+                        {trusted}
                         <div className='form-group'>
                             <label
                                 className='control-label col-sm-4'

--- a/components/integrations/components/add_oauth_app/index.js
+++ b/components/integrations/components/add_oauth_app/index.js
@@ -4,13 +4,15 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {addOAuthApp} from 'mattermost-redux/actions/integrations';
+import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 
 import AddOAuthApp from './add_oauth_app.jsx';
 
 function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
-        addOAuthAppRequest: state.requests.integrations.addOAuthApp
+        addOAuthAppRequest: state.requests.integrations.addOAuthApp,
+        isSystemAdmin: isCurrentUserSystemAdmin(state)
     };
 }
 


### PR DESCRIPTION
#### Summary
Hide trusted option in OAuth app UI for non-admins.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7678