### PR TITLE
PLT-7697: Join Channels Popover Should Only Allow the User to Join One Channel

### DIFF
--- a/components/searchable_channel_list.jsx
+++ b/components/searchable_channel_list.jsx
@@ -71,6 +71,7 @@ export default class SearchableChannelList extends React.Component {
                 <button
                     onClick={this.handleJoin.bind(this, channel)}
                     className='btn btn-primary'
+                    disabled={this.state.joiningChannel !== '' && this.state.joiningChannel !== channel.id}
                 >
                     <FormattedMessage
                         id='more_channels.join'


### PR DESCRIPTION
#### Summary
Disabled other channel Join buttons during the execution of the join action, preventing users from joining more than one channel at a time

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7697

#### Checklist
- [x] Has UI changes