### PR TITLE
PLT-5549: No feedback when trying to save localization settings in System Console when Available Languages doesn't include the default client language

### DIFF
--- a/components/admin_console/localization_settings.jsx
+++ b/components/admin_console/localization_settings.jsx
@@ -17,7 +17,6 @@ export default class LocalizationSettings extends AdminSettings {
 
         this.getConfigFromState = this.getConfigFromState.bind(this);
         this.renderSettings = this.renderSettings.bind(this);
-        this.canSave = this.canSave.bind(this);
 
         const locales = I18n.getAllLanguages();
 
@@ -27,10 +26,6 @@ export default class LocalizationSettings extends AdminSettings {
                 return {value: locales[l].value, text: locales[l].name, order: locales[l].order};
             }).sort((a, b) => a.order - b.order)
         });
-    }
-
-    canSave() {
-        return true;
     }
 
     getConfigFromState(config) {

--- a/components/admin_console/localization_settings.jsx
+++ b/components/admin_console/localization_settings.jsx
@@ -16,7 +16,6 @@ export default class LocalizationSettings extends AdminSettings {
         super(props);
 
         this.getConfigFromState = this.getConfigFromState.bind(this);
-
         this.renderSettings = this.renderSettings.bind(this);
         this.canSave = this.canSave.bind(this);
 
@@ -31,7 +30,7 @@ export default class LocalizationSettings extends AdminSettings {
     }
 
     canSave() {
-        return this.state.availableLocales.join(',').indexOf(this.state.defaultClientLocale) !== -1 || this.state.availableLocales.length === 0;
+        return true;
     }
 
     getConfigFromState(config) {


### PR DESCRIPTION
#### Summary
Disabled client-side error checking

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5549

#### Checklist
- [x] Has server changes - https://github.com/mattermost/mattermost-server/pull/7554
- [x] Has UI changes
