### PR TITLE
[PLT-7787] An extra ephemeral message posted for slash commands

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -255,6 +255,11 @@ function handleChannelUpdatedEvent(msg) {
 
 function handleNewPostEvent(msg) {
     const post = JSON.parse(msg.data.post);
+
+    if (post.message === '' && post.type === 'system_ephemeral') {
+        return;
+    }
+
     handleNewPost(post, msg);
 
     getProfilesAndStatusesForPosts([post], dispatch, getState);


### PR DESCRIPTION
#### Summary
When some commands return an empty message it should not post in the channel, this PR check if the message is empty and if it blocks the post.

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/PLT-7787
