### PR TITLE
color formatting

### DIFF
--- a/utils/markdown.jsx
+++ b/utils/markdown.jsx
@@ -7,6 +7,9 @@ import * as SyntaxHighlighting from './syntax_highlighting.jsx';
 import marked from 'marked';
 import katex from 'katex';
 
+const COLOR_REGEX = /^(\w+|#([0-9a-f]{3}){1,2})$/i;
+const COLOR_MAGIC = 'color://';
+
 class MattermostMarkdownRenderer extends marked.Renderer {
     constructor(options, formattingOptions = {}) {
         super(options);
@@ -146,6 +149,13 @@ class MattermostMarkdownRenderer extends marked.Renderer {
 
     link(href, title, text) {
         let outHref = href;
+
+        if (href.startsWith(COLOR_MAGIC) && !title) {
+            const color = href.substr(COLOR_MAGIC.length);
+            if (color.match(COLOR_REGEX)) {
+                return `<span style="color:${color}">${text}</span>`;
+            }
+        }
 
         if (this.formattingOptions.linkFilter && !this.formattingOptions.linkFilter(outHref)) {
             return text;


### PR DESCRIPTION
Color formatting is now supported via link syntax.

``[My red warning](color://red)``
will now render as:
![image](https://user-images.githubusercontent.com/12269446/31151362-cac0e288-a89f-11e7-8f54-d0a88e386694.png)

Color formatting is not supported in the markdown standard, but is a lovely feature to have.
Corresponding PR to docs: https://github.com/mattermost/docs/pull/1539

(This PR has no ticket, but since it's a minor improvement the guidelines lead me to believe that such ticket is not needed)