### PR TITLE
PLT-6739 Convert theme color pickers to use react-color

### DIFF
--- a/components/color_input.jsx
+++ b/components/color_input.jsx
@@ -1,0 +1,107 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import ReactDom from 'react-dom';
+import PropTypes from 'prop-types';
+import {ChromePicker} from 'react-color';
+
+class ColorInput extends React.Component {
+    static propTypes = {
+
+        /*
+         * Selected color
+         */
+        color: PropTypes.string.isRequired,
+
+        /*
+         * Function called when color changed. Takes hex format of color Ex: #ffeec0
+         */
+        onChange: PropTypes.func
+    };
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            idOpened: false
+        };
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        const {isOpened: prevIsOpened} = prevState;
+        const {isOpened} = this.state;
+
+        if (isOpened !== prevIsOpened) {
+            if (isOpened) {
+                document.addEventListener('click', this.checkClick);
+            } else {
+                document.removeEventListener('click', this.checkClick);
+            }
+        }
+    }
+
+    checkClick = (e) => {
+        const colorPickerDOMNode = ReactDom.findDOMNode(this.colorPicker);
+        if (!colorPickerDOMNode.contains(e.target)) {
+            this.setState({isOpened: false});
+        }
+    };
+
+    togglePicker = () => {
+        this.setState({isOpened: !this.state.isOpened});
+    };
+
+    handleChange = (newColorData) => {
+        const {hex} = newColorData;
+        const {onChange: handleChange} = this.props;
+
+        if (handleChange) {
+            handleChange(hex);
+        }
+    };
+
+    render() {
+        const {color} = this.props;
+        const {isOpened} = this.state;
+
+        return (
+            <div className='color-input input-group'>
+                <input
+                    className='form-control'
+                    type='text'
+                    value={color}
+                    style={{
+                        background: '#fff'
+                    }}
+                    readOnly={true}
+                />
+                <span
+                    className='input-group-addon'
+                    onClick={this.togglePicker}
+                >
+                    <i
+                        className='color-icon'
+                        style={{
+                            backgroundColor: color
+                        }}
+                    />
+                </span>
+                {isOpened && (
+                    <div
+                        ref={(item) => {
+                            this.colorPicker = item;
+                        }}
+                        className='color-popover'
+                    >
+                        <ChromePicker
+                            color={color}
+                            onChange={this.handleChange}
+                        />
+                    </div>
+                )}
+            </div>
+        );
+    }
+}
+
+export default ColorInput;

--- a/components/user_settings/color_chooser.jsx
+++ b/components/user_settings/color_chooser.jsx
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ColorInput from 'components/color_input';
+
+class ColorChooser extends React.Component {
+    static propTypes = {
+
+        /*
+         * The id of setting that we will change
+         */
+        id: PropTypes.string.isRequired,
+
+        /*
+         * The label of setting that we will choose
+         */
+        label: PropTypes.string.isRequired,
+
+        /*
+         * Selected color
+         */
+        color: PropTypes.string.isRequired,
+
+        /*
+         * Function called when color changed takes 2 arguments: Id of changing setting and new color
+         */
+        onChange: PropTypes.func
+    }
+
+    handleChange = (newColor) => {
+        const {id, onChange: handleChange} = this.props;
+        if (handleChange) {
+            handleChange(id, newColor);
+        }
+    }
+
+    render() {
+        const {label, color} = this.props;
+        return (
+            <div>
+                <label className='custom-label'>{label}</label>
+                <ColorInput
+                    color={color}
+                    onChange={this.handleChange}
+                />
+            </div>
+        );
+    }
+}
+
+export default ColorChooser;

--- a/components/user_settings/custom_theme_chooser.jsx
+++ b/components/user_settings/custom_theme_chooser.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import 'bootstrap-colorpicker';
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -10,7 +9,7 @@ import {defineMessages, FormattedMessage, intlShape, injectIntl} from 'react-int
 
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
-import * as Utils from 'utils/utils.jsx';
+import ColorChooser from './color_chooser.jsx';
 
 const messages = defineMessages({
     sidebarBg: {
@@ -103,8 +102,6 @@ const messages = defineMessages({
     }
 });
 
-const HEX_CODE_LENGTH = 7;
-
 class CustomThemeChooser extends React.Component {
     constructor(props) {
         super(props);
@@ -120,47 +117,21 @@ class CustomThemeChooser extends React.Component {
     }
 
     componentDidMount() {
-        $('.color-picker').colorpicker({
-            format: 'hex'
-        });
-        $('.color-picker').on('changeColor', this.onPickerChange);
         $('.group--code').on('change', this.onCodeThemeChange);
-        document.addEventListener('click', this.closeColorpicker);
     }
 
     componentWillUnmount() {
-        $('.color-picker').off('changeColor', this.onPickerChange);
         $('.group--code').off('change', this.onCodeThemeChange);
-        document.removeEventListener('click', this.closeColorpicker);
     }
 
-    componentDidUpdate() {
-        const theme = this.props.theme;
-        Constants.THEME_ELEMENTS.forEach((element) => {
-            if (theme.hasOwnProperty(element.id) && element.id !== 'codeTheme') {
-                $('#' + element.id).data('colorpicker').color.setColor(theme[element.id]);
-                $('#' + element.id).colorpicker('update');
-            }
-        });
-    }
-
-    closeColorpicker(e) {
-        if (!$(e.target).closest('.color-picker').length && Utils.isMobile()) {
-            $('.color-picker').colorpicker('hide');
-        }
-    }
-
-    onPickerChange = (e) => {
-        const inputBox = e.target.childNodes[0];
-        if (document.activeElement === inputBox && inputBox.value.length !== HEX_CODE_LENGTH) {
-            return;
-        }
-
-        const theme = this.props.theme;
-        if (theme[e.target.id] !== e.color.toHex()) {
-            theme[e.target.id] = e.color.toHex();
-            theme.type = 'custom';
-            this.props.updateTheme(theme);
+    handleColorChange = (settingId, color) => {
+        const {updateTheme, theme} = this.props;
+        if (theme[settingId] !== color) {
+            updateTheme({
+                ...theme,
+                type: 'custom',
+                [settingId]: color
+            });
         }
     }
 
@@ -315,18 +286,12 @@ class CustomThemeChooser extends React.Component {
                         className='col-sm-6 form-group element'
                         key={'custom-theme-key' + index}
                     >
-                        <label className='custom-label'>{formatMessage(messages[element.id])}</label>
-                        <div
-                            className='input-group color-picker'
+                        <ColorChooser
                             id={element.id}
-                        >
-                            <input
-                                className='form-control'
-                                type='text'
-                                defaultValue={theme[element.id]}
-                            />
-                            <span className='input-group-addon'><i/></span>
-                        </div>
+                            label={formatMessage(messages[element.id])}
+                            color={theme[element.id]}
+                            onChange={this.handleColorChange}
+                        />
                     </div>
                 );
             } else if (element.group === 'sidebarElements') {
@@ -335,18 +300,12 @@ class CustomThemeChooser extends React.Component {
                         className='col-sm-6 form-group element'
                         key={'custom-theme-key' + index}
                     >
-                        <label className='custom-label'>{formatMessage(messages[element.id])}</label>
-                        <div
-                            className='input-group color-picker'
+                        <ColorChooser
                             id={element.id}
-                        >
-                            <input
-                                className='form-control'
-                                type='text'
-                                defaultValue={theme[element.id]}
-                            />
-                            <span className='input-group-addon'><i/></span>
-                        </div>
+                            label={formatMessage(messages[element.id])}
+                            color={theme[element.id]}
+                            onChange={this.handleColorChange}
+                        />
                     </div>
                 );
             } else {
@@ -355,18 +314,12 @@ class CustomThemeChooser extends React.Component {
                         className='col-sm-6 form-group element'
                         key={'custom-theme-key' + index}
                     >
-                        <label className='custom-label'>{formatMessage(messages[element.id])}</label>
-                        <div
-                            className='input-group color-picker'
+                        <ColorChooser
                             id={element.id}
-                        >
-                            <input
-                                className='form-control'
-                                type='text'
-                                defaultValue={theme[element.id]}
-                            />
-                            <span className='input-group-addon'><i/></span>
-                        </div>
+                            label={formatMessage(messages[element.id])}
+                            color={theme[element.id]}
+                            onChange={this.handleColorChange}
+                        />
                     </div>
                 );
             }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bootstrap-colorpicker": "2.5.2",
     "chart.js": "2.7.0",
     "compass-mixins": "0.12.10",
+    "enzyme-adapter-react-15": "^1.0.1",
     "exif2css": "1.2.0",
     "fastclick": "1.0.6",
     "flux": "3.1.3",
@@ -40,6 +41,7 @@
     "react-redux": "5.0.6",
     "react-router": "2.8.1",
     "react-select": "1.0.0-rc.10",
+    "react-test-renderer": "15",
     "redux": "3.7.2",
     "redux-batched-actions": "0.2.0",
     "redux-persist": "4.10.1",
@@ -130,7 +132,8 @@
     ],
     "transformIgnorePatterns": [
       "node_modules/(?!react-native|react-router)"
-    ]
+    ],
+    "setupTestFrameworkScriptFile": "<rootDir>/tests/setup.js"
   },
   "scripts": {
     "check": "eslint --ext \".jsx\" --ignore-pattern node_modules --quiet .",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap-colorpicker": "2.5.2",
     "chart.js": "2.7.0",
     "compass-mixins": "0.12.10",
-    "enzyme-adapter-react-15": "^1.0.1",
+    "enzyme-adapter-react-15": "1.0.1",
     "exif2css": "1.2.0",
     "fastclick": "1.0.6",
     "flux": "3.1.3",

--- a/sass/components/_color-input.scss
+++ b/sass/components/_color-input.scss
@@ -1,0 +1,19 @@
+@charset 'UTF-8';
+
+.color-input {
+    position: relative;
+}
+
+.color-icon {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+}
+
+.color-popover {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    padding-top: 8px;
+    z-index: 12;
+}

--- a/sass/components/_module.scss
+++ b/sass/components/_module.scss
@@ -23,3 +23,4 @@
 @import 'tutorial';
 @import 'videos';
 @import 'webrtc';
+@import 'color-input';

--- a/tests/components/__snapshots__/color_input.test.jsx.snap
+++ b/tests/components/__snapshots__/color_input.test.jsx.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/ColorInput should match snapshot, click on picker 1`] = `
+<div
+  className="color-input input-group"
+>
+  <input
+    className="form-control"
+    readOnly={true}
+    style={
+      Object {
+        "background": "#fff",
+      }
+    }
+    type="text"
+  />
+  <span
+    className="input-group-addon"
+    onClick={[Function]}
+  >
+    <i
+      className="color-icon"
+      style={
+        Object {
+          "backgroundColor": undefined,
+        }
+      }
+    />
+  </span>
+  <div
+    className="color-popover"
+  >
+    <ColorPicker
+      color={
+        Object {
+          "a": 1,
+          "h": 250,
+          "l": 0.2,
+          "s": 0.5,
+        }
+      }
+      disableAlpha={false}
+      onChange={[Function]}
+    />
+  </div>
+</div>
+`;
+
+exports[`components/ColorInput should match snapshot, init 1`] = `
+<div
+  className="color-input input-group"
+>
+  <input
+    className="form-control"
+    readOnly={true}
+    style={
+      Object {
+        "background": "#fff",
+      }
+    }
+    type="text"
+  />
+  <span
+    className="input-group-addon"
+    onClick={[Function]}
+  >
+    <i
+      className="color-icon"
+      style={
+        Object {
+          "backgroundColor": undefined,
+        }
+      }
+    />
+  </span>
+</div>
+`;
+
+exports[`components/ColorInput should match snapshot, opened 1`] = `
+<div
+  className="color-input input-group"
+>
+  <input
+    className="form-control"
+    readOnly={true}
+    style={
+      Object {
+        "background": "#fff",
+      }
+    }
+    type="text"
+  />
+  <span
+    className="input-group-addon"
+    onClick={[Function]}
+  >
+    <i
+      className="color-icon"
+      style={
+        Object {
+          "backgroundColor": undefined,
+        }
+      }
+    />
+  </span>
+  <div
+    className="color-popover"
+  >
+    <ColorPicker
+      color={
+        Object {
+          "a": 1,
+          "h": 250,
+          "l": 0.2,
+          "s": 0.5,
+        }
+      }
+      disableAlpha={false}
+      onChange={[Function]}
+    />
+  </div>
+</div>
+`;
+
+exports[`components/ColorInput should match snapshot, toggle picker 1`] = `
+<div
+  className="color-input input-group"
+>
+  <input
+    className="form-control"
+    readOnly={true}
+    style={
+      Object {
+        "background": "#fff",
+      }
+    }
+    type="text"
+  />
+  <span
+    className="input-group-addon"
+    onClick={[Function]}
+  >
+    <i
+      className="color-icon"
+      style={
+        Object {
+          "backgroundColor": undefined,
+        }
+      }
+    />
+  </span>
+</div>
+`;

--- a/tests/components/color_input.test.jsx
+++ b/tests/components/color_input.test.jsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import ColorInput from 'components/color_input.jsx';
+
+describe('components/ColorInput', () => {
+    test('should match snapshot, init', () => {
+        const wrapper = shallow(
+            <ColorInput
+                value='#ffffff'
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, opened', () => {
+        const wrapper = shallow(
+            <ColorInput
+                value='#ffffff'
+            />
+        );
+
+        wrapper.find('.input-group-addon').simulate('click');
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, toggle picker', () => {
+        const wrapper = shallow(
+            <ColorInput
+                value='#ffffff'
+            />
+        );
+
+        wrapper.find('.input-group-addon').simulate('click');
+        wrapper.find('.input-group-addon').simulate('click');
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, click on picker', () => {
+        const wrapper = shallow(
+            <ColorInput
+                value='#ffffff'
+            />
+        );
+
+        wrapper.find('.input-group-addon').simulate('click');
+        wrapper.find('.color-popover').simulate('click');
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/tests/components/user_settings/__snapshots__/color_chooser.test.jsx.snap
+++ b/tests/components/user_settings/__snapshots__/color_chooser.test.jsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/user_settings/ColorChooser should match, init 1`] = `
+<div>
+  <label
+    className="custom-label"
+  >
+    Choose color
+  </label>
+  <ColorInput
+    color="#ffeec0"
+    onChange={[Function]}
+  />
+</div>
+`;

--- a/tests/components/user_settings/color_chooser.test.jsx
+++ b/tests/components/user_settings/color_chooser.test.jsx
@@ -1,0 +1,1 @@
+import React from 'react';

--- a/tests/components/user_settings/color_chooser.test.jsx
+++ b/tests/components/user_settings/color_chooser.test.jsx
@@ -1,1 +1,21 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 import React from 'react';
+import {shallow} from 'enzyme';
+
+import ColorChooser from 'components/user_settings/color_chooser.jsx';
+
+describe('components/user_settings/ColorChooser', () => {
+    it('should match, init', () => {
+        const wrapper = shallow(
+            <ColorChooser
+                color='#ffeec0'
+                label='Choose color'
+                id='choose-color'
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import Adapter from 'enzyme-adapter-react-15';
+import {configure} from 'enzyme';
+
+configure({adapter: new Adapter()});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,6 +2461,24 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+enzyme-adapter-react-15@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-15/-/enzyme-adapter-react-15-1.0.1.tgz#c1a3e5966bf1c7221c40aa0f877850175035406f"
+  dependencies:
+    enzyme-adapter-utils "^1.0.0"
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    object.values "^1.0.4"
+    prop-types "^15.5.10"
+
+enzyme-adapter-utils@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.0.1.tgz#fcd81223339a55a312f7552641e045c404084009"
+  dependencies:
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    prop-types "^15.5.10"
+
 enzyme-to-json@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.0.1.tgz#16468e2ff3e4db817d84f9df38760abbc322273d"
@@ -6715,6 +6733,13 @@ react-select@1.0.0-rc.10:
     classnames "^2.2.4"
     prop-types "^15.5.8"
     react-input-autosize "^2.0.1"
+
+react-test-renderer@15:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
 
 react@15.6.1:
   version "15.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,7 +2461,7 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-adapter-react-15@^1.0.1:
+enzyme-adapter-react-15@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-react-15/-/enzyme-adapter-react-15-1.0.1.tgz#c1a3e5966bf1c7221c40aa0f877850175035406f"
   dependencies:


### PR DESCRIPTION
#### Summary
Added ColorInput component. Replaced `bootstrap-picker` with new component in `components/user_settings/custom_theme_chooser.jsx`

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/6595

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

