### PR TITLE
PLT-7576 Stop inferring channel ID from posts for pinned posts

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -143,7 +143,7 @@ export function getPinnedPosts(channelId = ChannelStore.getCurrentId()) {
 
             AppDispatcher.handleServerAction({
                 type: ActionTypes.RECEIVED_SEARCH,
-                results: data,
+                results: {...data, channelId},
                 is_flagged_posts: false,
                 is_pinned_posts: true
             });

--- a/stores/search_store.jsx
+++ b/stores/search_store.jsx
@@ -186,8 +186,7 @@ SearchStore.dispatchToken = AppDispatcher.register((payload) => {
     switch (action.type) {
     case ActionTypes.RECEIVED_SEARCH: {
         const results = SearchStore.getSearchResults() || {};
-        const posts = Object.values(results.posts || {});
-        const channelId = posts.length > 0 ? posts[0].channel_id : '';
+        const channelId = results.channelId;
         if (SearchStore.getIsPinnedPosts() === action.is_pinned_posts &&
             action.is_pinned_posts === true &&
             channelId !== '' &&


### PR DESCRIPTION
#### Summary
Stop inferring channel ID from posts. This was causing incorrect pinned posts to show up in the RHS when no existing posts were present.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7576