### PR TITLE
Fix incorrect message id

### DIFF
--- a/components/shortcuts_modal.jsx
+++ b/components/shortcuts_modal.jsx
@@ -97,11 +97,11 @@ const allShortcuts = defineMessages({
     },
     navMentions: {
         default: {
-            id: 'shortcuts.nav.mentions',
+            id: 'shortcuts.nav.recent_mentions',
             defaultMessage: 'Recent mentions:\tCtrl|Shift|M'
         },
         mac: {
-            id: 'shortcuts.nav.mentions.mac',
+            id: 'shortcuts.nav.recent_mentions.mac',
             defaultMessage: 'Recent mentions:\t⌘|Shift|M'
         }
     },


### PR DESCRIPTION
#### Summary
Shortcuts dialog has untranslated message because wrong id was provided in `components/shortcuts_modai.jsx`.

![image](https://user-images.githubusercontent.com/1310661/31180366-6b4948c6-a959-11e7-8bdc-fded31fbafa4.png)

#### Ticket Link
n/a

#### Checklist
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
    - No `en.json` update in this PR because `shortcuts.nav.recent_mentions` and `shortcuts.nav.recent_mentions.mac` are already defined and translated.