### PR TITLE
PLT-7786 Fix post edit event adding post to end of post list

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -267,7 +267,15 @@ function handleNewPostEvent(msg) {
 function handlePostEditEvent(msg) {
     // Store post
     const post = JSON.parse(msg.data.post);
-    dispatch({type: PostTypes.RECEIVED_POST, data: post});
+    dispatch({
+        type: PostTypes.RECEIVED_POSTS,
+        data: {
+            order: [],
+            posts: {
+                [post.id]: post
+            }
+        }
+    });
 
     // Update channel state
     if (ChannelStore.getCurrentId() === msg.broadcast.channel_id) {


### PR DESCRIPTION
#### Summary
Fix post edit event adding post to end of post list.

@MusikPolice the issue was that the RECEIVED_POST action type is meant for getting a new post from the server. It was being used by the post edit event which means, if the client didn't already have the post, then it would be treated as a new post and not an edited post. Changing it to use the general RECEIVED_POSTS action type, which does not make any sort of assumptions, fixed the issue. I'm probably going to refactor the action types a bit to add a RECEIVED_NEW_POST in addition to the RECEIVED_POST so that this becomes less confusing.

I'll be submitting a fix to mattermost-redux for this as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7786