### PR TITLE
PLT-7777 Pre-populate SAML Service Provider Login URL (#7559)

### DIFF
--- a/components/admin_console/configuration_settings.jsx
+++ b/components/admin_console/configuration_settings.jsx
@@ -82,8 +82,6 @@ export default class ConfigurationSettings extends AdminSettings {
     handleSamlUrlChange(config, siteURL) {
         if (config.SamlSettings.AssertionConsumerServiceURL.length > 0 && siteURL.length > 0) {
             config.SamlSettings.AssertionConsumerServiceURL = this.state.siteURL + '/login/sso/saml';
-        } else {
-            config.SamlSettings.AssertionConsumerServiceURL = 'https://';
         }
     }
 

--- a/components/admin_console/configuration_settings.jsx
+++ b/components/admin_console/configuration_settings.jsx
@@ -26,6 +26,8 @@ export default class ConfigurationSettings extends AdminSettings {
 
         this.handleSaved = this.handleSaved.bind(this);
 
+        this.handleSamlUrlChange = this.handleSamlUrlChange.bind(this);
+
         this.renderSettings = this.renderSettings.bind(this);
     }
 
@@ -36,6 +38,8 @@ export default class ConfigurationSettings extends AdminSettings {
     }
 
     getConfigFromState(config) {
+        this.handleSamlUrlChange(config, this.state.siteURL);
+
         config.ServiceSettings.SiteURL = this.state.siteURL;
         config.ServiceSettings.ListenAddress = this.state.listenAddress;
         config.ServiceSettings.WebserverMode = this.state.webserverMode;
@@ -72,6 +76,14 @@ export default class ConfigurationSettings extends AdminSettings {
     handleSaved(newConfig) {
         if (newConfig.ServiceSettings.SiteURL) {
             ErrorStore.clearError(ErrorBarTypes.SITE_URL);
+        }
+    }
+
+    handleSamlUrlChange(config, siteURL) {
+        if (config.SamlSettings.AssertionConsumerServiceURL.length > 0 && siteURL.length > 0) {
+            config.SamlSettings.AssertionConsumerServiceURL = this.state.siteURL + '/login/sso/saml';
+        } else {
+            config.SamlSettings.AssertionConsumerServiceURL = 'https://';
         }
     }
 

--- a/components/admin_console/saml_settings.jsx
+++ b/components/admin_console/saml_settings.jsx
@@ -51,13 +51,21 @@ export default class SamlSettings extends AdminSettings {
     getStateFromConfig(config) {
         const settings = config.SamlSettings;
 
+        // pre-populate Service Provider Login URL page
+        const siteUrl = config.ServiceSettings.SiteURL;
+        let consumerServiceUrl = settings.AssertionConsumerServiceURL;
+        if(siteUrl.length > 0 && consumerServiceUrl.length == 0) {
+           consumerServiceUrl = siteUrl + '/login/sso/saml';
+        }
+
         return {
+            siteUrlSet: siteUrl.length > 0,
             enable: settings.Enable,
             verify: settings.Verify,
             encrypt: settings.Encrypt,
             idpUrl: settings.IdpUrl,
             idpDescriptorUrl: settings.IdpDescriptorUrl,
-            assertionConsumerServiceURL: settings.AssertionConsumerServiceURL,
+            assertionConsumerServiceURL: consumerServiceUrl,
             idpCertificateFile: settings.IdpCertificateFile,
             publicCertificateFile: settings.PublicCertificateFile,
             privateKeyFile: settings.PrivateKeyFile,
@@ -302,6 +310,19 @@ export default class SamlSettings extends AdminSettings {
             );
         }
 
+        let consumerServiceUrlHelp;
+        if(this.state.siteUrlSet) {
+           consumerServiceUrlHelp = <FormattedMessage
+               id='admin.saml.assertionConsumerServiceURLPopulatedDesc'
+               defaultMessage='This field is also known as the Assertion Consumer Service URL.'
+           />
+         } else {
+            consumerServiceUrlHelp = <FormattedMessage
+                id='admin.saml.assertionConsumerServiceURLDesc'
+                defaultMessage='Enter https://<your-mattermost-url>/login/sso/saml. Make sure you use HTTP or HTTPS in your URL depending on your server configuration. This field is also known as the Assertion Consumer Service URL.'
+            />
+         }
+
         return (
             <SettingsGroup>
                 <div className='banner'>
@@ -395,15 +416,10 @@ export default class SamlSettings extends AdminSettings {
                         />
                     }
                     placeholder={Utils.localizeMessage('admin.saml.assertionConsumerServiceURLEx', 'Ex "https://<your-mattermost-url>/login/sso/saml"')}
-                    helpText={
-                        <FormattedMessage
-                            id='admin.saml.assertionConsumerServiceURLDesc'
-                            defaultMessage='Enter https://<your-mattermost-url>/login/sso/saml. Make sure you use HTTP or HTTPS in your URL depending on your server configuration. This field is also known as the Assertion Consumer Service URL.'
-                        />
-                    }
+                    helpText={consumerServiceUrlHelp}
                     value={this.state.assertionConsumerServiceURL}
                     onChange={this.handleChange}
-                    disabled={!this.state.enable || !this.state.verify}
+                    disabled={!this.state.enable || !this.state.verify || this.state.siteUrlSet}
                 />
                 <BooleanSetting
                     id='encrypt'

--- a/components/admin_console/saml_settings.jsx
+++ b/components/admin_console/saml_settings.jsx
@@ -312,15 +312,19 @@ export default class SamlSettings extends AdminSettings {
 
         let consumerServiceUrlHelp;
         if (this.state.siteUrlSet) {
-            consumerServiceUrlHelp = (<FormattedMessage
-                id='admin.saml.assertionConsumerServiceURLPopulatedDesc'
-                defaultMessage='This field is also known as the Assertion Consumer Service URL.'
-                                      />);
+            consumerServiceUrlHelp = (
+                <FormattedMessage
+                    id='admin.saml.assertionConsumerServiceURLPopulatedDesc'
+                    defaultMessage='This field is also known as the Assertion Consumer Service URL.'
+                />
+            );
         } else {
-            consumerServiceUrlHelp = (<FormattedMessage
-                id='admin.saml.assertionConsumerServiceURLDesc'
-                defaultMessage='Enter https://<your-mattermost-url>/login/sso/saml. Make sure you use HTTP or HTTPS in your URL depending on your server configuration. This field is also known as the Assertion Consumer Service URL.'
-                                      />);
+            consumerServiceUrlHelp = (
+                <FormattedMessage
+                    id='admin.saml.assertionConsumerServiceURLDesc'
+                    defaultMessage='Enter https://<your-mattermost-url>/login/sso/saml. Make sure you use HTTP or HTTPS in your URL depending on your server configuration. This field is also known as the Assertion Consumer Service URL.'
+                />
+            );
         }
 
         return (

--- a/components/admin_console/saml_settings.jsx
+++ b/components/admin_console/saml_settings.jsx
@@ -54,8 +54,8 @@ export default class SamlSettings extends AdminSettings {
         // pre-populate Service Provider Login URL page
         const siteUrl = config.ServiceSettings.SiteURL;
         let consumerServiceUrl = settings.AssertionConsumerServiceURL;
-        if(siteUrl.length > 0 && consumerServiceUrl.length == 0) {
-           consumerServiceUrl = siteUrl + '/login/sso/saml';
+        if (siteUrl.length > 0 && consumerServiceUrl.length === 0) {
+            consumerServiceUrl = siteUrl + '/login/sso/saml';
         }
 
         return {
@@ -311,17 +311,17 @@ export default class SamlSettings extends AdminSettings {
         }
 
         let consumerServiceUrlHelp;
-        if(this.state.siteUrlSet) {
-           consumerServiceUrlHelp = <FormattedMessage
-               id='admin.saml.assertionConsumerServiceURLPopulatedDesc'
-               defaultMessage='This field is also known as the Assertion Consumer Service URL.'
-           />
-         } else {
-            consumerServiceUrlHelp = <FormattedMessage
+        if (this.state.siteUrlSet) {
+            consumerServiceUrlHelp = (<FormattedMessage
+                id='admin.saml.assertionConsumerServiceURLPopulatedDesc'
+                defaultMessage='This field is also known as the Assertion Consumer Service URL.'
+                                      />);
+        } else {
+            consumerServiceUrlHelp = (<FormattedMessage
                 id='admin.saml.assertionConsumerServiceURLDesc'
                 defaultMessage='Enter https://<your-mattermost-url>/login/sso/saml. Make sure you use HTTP or HTTPS in your URL depending on your server configuration. This field is also known as the Assertion Consumer Service URL.'
-            />
-         }
+                                      />);
+        }
 
         return (
             <SettingsGroup>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -778,6 +778,7 @@
   "admin.reset_password.titleReset": "Reset Password",
   "admin.reset_password.titleSwitch": "Switch Account to Email/Password",
   "admin.saml.assertionConsumerServiceURLDesc": "Enter https://<your-mattermost-url>/login/sso/saml. Make sure you use HTTP or HTTPS in your URL depending on your server configuration. This field is also known as the Assertion Consumer Service URL.",
+  "admin.saml.assertionConsumerServiceURLPopulatedDesc": "This field is also known as the Assertion Consumer Service URL.",
   "admin.saml.assertionConsumerServiceURLEx": "E.g.: \"https://<your-mattermost-url>/login/sso/saml\"",
   "admin.saml.assertionConsumerServiceURLTitle": "Service Provider Login URL:",
   "admin.saml.bannerDesc": "User attributes in SAML server, including user deactivation or removal, are updated in Mattermost during user login. Learn more at: <a href=\"https://docs.mattermost.com/deployment/sso-saml.html\">https://docs.mattermost.com/deployment/sso-saml.html</a>",


### PR DESCRIPTION
#### Summary
Pre-populates the SAML Service provider login URL in the System Console if the Site URL is set.

#### Ticket Link
The issue opened for this is [mattermost-server/#7559](https://github.com/mattermost/mattermost-server/issues/7559)

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
