### PR TITLE
PLT-6362 Add full date tooltip to post timestamps (#6172)

### DIFF
--- a/components/rhs_comment.jsx
+++ b/components/rhs_comment.jsx
@@ -129,12 +129,15 @@ export default class RhsComment extends React.Component {
     }
 
     timeTag(post, timeOptions) {
+        const date = Utils.getDateForUnixTicks(post.create_at);
+
         return (
             <time
                 className='post__time'
-                dateTime={Utils.getDateForUnixTicks(post.create_at).toISOString()}
+                dateTime={date.toISOString()}
+                title={date}
             >
-                {Utils.getDateForUnixTicks(post.create_at).toLocaleString('en', timeOptions)}
+                {date.toLocaleString('en', timeOptions)}
             </time>
         );
     }

--- a/components/rhs_root_post.jsx
+++ b/components/rhs_root_post.jsx
@@ -121,12 +121,15 @@ export default class RhsRootPost extends React.Component {
     }
 
     timeTag(post, timeOptions) {
+        const date = Utils.getDateForUnixTicks(post.create_at);
+
         return (
             <time
                 className='post__time'
-                dateTime={Utils.getDateForUnixTicks(post.create_at).toISOString()}
+                dateTime={date.toISOString()}
+                title={date}
             >
-                {Utils.getDateForUnixTicks(post.create_at).toLocaleString('en', timeOptions)}
+                {date.toLocaleString('en', timeOptions)}
             </time>
         );
     }

--- a/components/search_results_item.jsx
+++ b/components/search_results_item.jsx
@@ -95,10 +95,13 @@ export default class SearchResultsItem extends React.Component {
     }
 
     timeTag(post) {
+        const date = Utils.getDateForUnixTicks(post.create_at);
+
         return (
             <time
                 className='search-item-time'
-                dateTime={Utils.getDateForUnixTicks(post.create_at).toISOString()}
+                dateTime={date.toISOString()}
+                title={date}
             >
                 <FormattedDate
                     value={post.create_at}


### PR DESCRIPTION
#### Summary
This pull request adds the full date and time tooltip to post timestamps in the right-hand sidebar and search results.

#### Ticket Link
The issue related to this PR is [mattermost-server#6172](https://github.com/mattermost/mattermost-server/issues/6172)

#### Checklist
- [x] Has UI changes
