### PR TITLE
[PLT-6039] Remove categorization when searching in emoji picker

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -18,6 +18,8 @@ import EmojiList from './emoji_list.jsx';
 
 const ROW_SIZE = 30;
 const EMOJI_PER_ROW = 9;
+const CATEGORY_SEARCH_RESULTS = 'searchResults';
+
 export default class EmojiPicker extends React.Component {
     static propTypes = {
         style: PropTypes.object,
@@ -356,12 +358,15 @@ export default class EmojiPicker extends React.Component {
 
         let list = [];
         if (emojis.length) {
-            const emojiRows = this.generateEmojiRows(emojis, "searchResults");
+            const emojiHeaderRow = this.generateEmojiHeaderRow(CATEGORY_SEARCH_RESULTS);
+            list.push(emojiHeaderRow);
+
+            const emojiRows = this.generateEmojiRows(emojis, CATEGORY_SEARCH_RESULTS);
             list = this.addEmojiRow(list, emojiRows);
         }
 
         return list;
-    } 
+    }
 
     emojiCategories() {
         const categories = this.categories;

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -322,22 +322,20 @@ export default class EmojiPicker extends React.Component {
     }
 
     generateList(filter) {
+        if (filter) {
+            return this.generateFilteredList(filter);
+        }
         let list = [];
 
         for (const category of Object.keys(this.categories)) {
-            if (filter && category === 'recent') {
-                continue;
-            }
             const emojis = this.getEmojis(category, filter);
 
             if (emojis.length) {
                 this.categories[category].offset = list.length * ROW_SIZE;
                 this.categories[category].enable = true;
 
-                if (!filter) {
-                    const emojiHeaderRow = this.generateEmojiHeaderRow(category);
-                    list.push(emojiHeaderRow);
-                }
+                const emojiHeaderRow = this.generateEmojiHeaderRow(category);
+                list.push(emojiHeaderRow);
 
                 const emojiRows = this.generateEmojiRows(emojis, category);
                 list = this.addEmojiRow(list, emojiRows);
@@ -346,6 +344,24 @@ export default class EmojiPicker extends React.Component {
 
         return list;
     }
+
+    generateFilteredList(filter) {
+        let emojis = [];
+
+        for (const category of Object.keys(this.categories)) {
+            if (category !== 'recent') {
+                emojis = emojis.concat(this.getEmojis(category, filter));
+            }
+        }
+
+        let list = [];
+        if (emojis.length) {
+            const emojiRows = this.generateEmojiRows(emojis, "searchResults");
+            list = this.addEmojiRow(list, emojiRows);
+        }
+
+        return list;
+    } 
 
     emojiCategories() {
         const categories = this.categories;

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -169,10 +169,12 @@ export default class EmojiPicker extends React.Component {
         const list = this.generateList(filter);
 
         let activeCategory = 'recent';
-        for (const category of Object.keys(this.categories)) {
-            if (this.categories[category].enable) {
-                activeCategory = this.categories[category].name;
-                break;
+        if (!filter) {
+            for (const category of Object.keys(this.categories)) {
+                if (this.categories[category].enable) {
+                    activeCategory = this.categories[category].name;
+                    break;
+                }
             }
         }
 
@@ -217,6 +219,10 @@ export default class EmojiPicker extends React.Component {
 
     handleOnScroll(offset) {
         let activeCategory = 'recent';
+        if (this.state.filter) {
+            this.setState({activeCategory});
+            return;
+        }
         for (const cat of Object.keys(this.categories)) {
             if (offset < this.categories[cat].offset) {
                 break;
@@ -319,14 +325,19 @@ export default class EmojiPicker extends React.Component {
         let list = [];
 
         for (const category of Object.keys(this.categories)) {
+            if (filter && category === 'recent') {
+                continue;
+            }
             const emojis = this.getEmojis(category, filter);
 
             if (emojis.length) {
                 this.categories[category].offset = list.length * ROW_SIZE;
                 this.categories[category].enable = true;
 
-                const emojiHeaderRow = this.generateEmojiHeaderRow(category);
-                list.push(emojiHeaderRow);
+                if (!filter) {
+                    const emojiHeaderRow = this.generateEmojiHeaderRow(category);
+                    list.push(emojiHeaderRow);
+                }
 
                 const emojiRows = this.generateEmojiRows(emojis, category);
                 list = this.addEmojiRow(list, emojiRows);

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1496,6 +1496,7 @@
   "emoji_picker.places": "Places",
   "emoji_picker.recent": "Recently Used",
   "emoji_picker.search": "Search",
+  "emoji_picker.searchResults": "Search Results",
   "emoji_picker.symbols": "Symbols",
   "error.generic.link": "Back to Mattermost",
   "error.generic.link_message": "Back to Mattermost",


### PR DESCRIPTION
#### Summary
When searching in emoji picker, remove categorization and instead simply list all the emoji that match the search result, nine emoji per row.

#### Ticket Link
mattermost/mattermost-server#6279

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
