### PR TITLE
[PLT-7845] Add username to mention keys even when not selected as a word that trigger mentions

### DIFF
--- a/components/post_view/post_message_view/index.js
+++ b/components/post_view/post_message_view/index.js
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getTheme, getBool} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentUserMentionKeys, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUser, getCurrentUserMentionKeys, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
 
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
@@ -26,6 +26,8 @@ function makeMapStateToProps() {
         }
         oldCustomEmoji = newCustomEmoji;
 
+        const user = getCurrentUser(state);
+
         return {
             ...ownProps,
             emojis: emojiMap,
@@ -35,7 +37,8 @@ function makeMapStateToProps() {
             team: getCurrentTeam(state),
             siteUrl: getSiteURL(),
             theme: getTheme(state),
-            pluginPostTypes: state.plugins.postTypes
+            pluginPostTypes: state.plugins.postTypes,
+            currentUser: user
         };
     };
 }

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -86,7 +86,12 @@ export default class PostMessageView extends React.PureComponent {
         /*
          * Post type components from plugins
          */
-        pluginPostTypes: PropTypes.object
+        pluginPostTypes: PropTypes.object,
+
+        /**
+         * The logged in user
+         */
+        currentUser: PropTypes.object.isRequired
     };
 
     static defaultProps = {
@@ -199,10 +204,12 @@ export default class PostMessageView extends React.PureComponent {
             }
         }
 
+        const mentionKeys = [...this.props.mentionKeys, this.props.currentUser.username];
+
         const options = Object.assign({}, this.props.options, {
             emojis: this.props.emojis,
             siteURL: this.props.siteUrl,
-            mentionKeys: this.props.mentionKeys,
+            mentionKeys,
             atMentions: true,
             channelNamesMap: getChannelsNameMapInCurrentTeam(store.getState()),
             team: this.props.team


### PR DESCRIPTION
#### Summary
Add username to mention keys even when not selected as a word that trigger mentions (notification).
- this is only how the mentioned username is highlighted in post message view and will not cause unnecessary notification (when not set).
- the `username` is added to `mentionKeys` at post message view. In case of `username` already included in `mentionKeys`, there will be two occurrences of username which I don't think will be an issue.

#### Ticket Link
Jira ticket: [PLT-7845](https://mattermost.atlassian.net/browse/PLT-7845)

#### Checklist
- [x] Has UI changes

Note:
Test for `PostMessageView` is not included here. Instead, I'm planning to submit it against the `master`.
