### PR TITLE
Update markdown.jsx for numbers in uris

### DIFF
--- a/utils/markdown.jsx
+++ b/utils/markdown.jsx
@@ -156,7 +156,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
             return text;
         }
 
-        if (!(/[a-z+.-]+:/i).test(outHref)) {
+        if (!(/[a-z0-9+.-]+:/i).test(outHref)) {
             outHref = `http://${outHref}`;
         }
 


### PR DESCRIPTION
Rebasing #16 on top of release-4.3.

Should not add http:// if the first part have numbers:

``uri1:test``

cc @ccbrown 