### PR TITLE
PLT-7823: Channel members doesn't update when filter matches none.

### DIFF
--- a/components/member_list_channel/member_list_channel.jsx
+++ b/components/member_list_channel/member_list_channel.jsx
@@ -54,7 +54,7 @@ export default class MemberListChannel extends React.Component {
     }
 
     componentDidMount() {
-        UserStore.addInTeamChangeListener(this.onChange);
+        UserStore.addInChannelChangeListener(this.onChange);
         UserStore.addStatusesChangeListener(this.onChange);
         TeamStore.addChangeListener(this.onChange);
         ChannelStore.addChangeListener(this.onChange);


### PR DESCRIPTION
#### Summary
Make channel members list update when filter term doesn't match any users.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7823