### PR TITLE
[PLT-7852] Fix scrolling issues at user's Account Setting modal

### DIFF
--- a/components/user_settings/user_settings_advanced.jsx
+++ b/components/user_settings/user_settings_advanced.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import $ from 'jquery';
 import SettingItemMin from '../setting_item_min.jsx';
 import SettingItemMax from '../setting_item_max.jsx';
 
@@ -142,9 +141,6 @@ export default class AdvancedSettingsDisplay extends React.Component {
     }
 
     updateSection(section) {
-        if ($('.section-max').length) {
-            $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
-        }
         if (!section) {
             this.setState(this.getStateFromStores());
         }

--- a/components/user_settings/user_settings_display.jsx
+++ b/components/user_settings/user_settings_display.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import $ from 'jquery';
 import SettingItemMin from '../setting_item_min.jsx';
 import SettingItemMax from '../setting_item_max.jsx';
 import ManageLanguages from './manage_languages.jsx';
@@ -96,9 +95,6 @@ export default class UserSettingsDisplay extends React.Component {
     }
 
     updateSection(section) {
-        if ($('.section-max').length) {
-            $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
-        }
         this.updateState();
         this.props.updateSection(section);
     }

--- a/components/user_settings/user_settings_general/user_settings_general.jsx
+++ b/components/user_settings/user_settings_general/user_settings_general.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import $ from 'jquery';
 import SettingItemMin from 'components/setting_item_min.jsx';
 import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingPicture from 'components/setting_picture.jsx';
@@ -340,9 +339,6 @@ class UserSettingsGeneralTab extends React.Component {
     }
 
     updateSection(section) {
-        if ($('.section-max').length) {
-            $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
-        }
         const emailChangeInProgress = this.state.emailChangeInProgress;
         this.setState(Object.assign({}, this.setupInitialState(this.props), {emailChangeInProgress, clientError: '', serverError: '', emailError: ''}));
         this.submitActive = false;

--- a/components/user_settings/user_settings_modal.jsx
+++ b/components/user_settings/user_settings_modal.jsx
@@ -107,7 +107,7 @@ class UserSettingsModal extends React.Component {
     componentDidUpdate() {
         UserStore.removeChangeListener(this.onUserChanged);
         if (!Utils.isMobile()) {
-            $('.settings-modal .modal-body').perfectScrollbar();
+            $('.settings-content .minimize-settings').perfectScrollbar('update');
         }
     }
 
@@ -217,10 +217,6 @@ class UserSettingsModal extends React.Component {
                 active_tab: tab,
                 active_section: ''
             });
-        }
-
-        if (!Utils.isMobile()) {
-            $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
         }
     }
 

--- a/components/user_settings/user_settings_notifications.jsx
+++ b/components/user_settings/user_settings_notifications.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import $ from 'jquery';
 import SettingItemMin from 'components/setting_item_min.jsx';
 import SettingItemMax from 'components/setting_item_max.jsx';
 import DesktopNotificationSettings from './desktop_notification_settings.jsx';
@@ -151,7 +150,6 @@ export default class NotificationsTab extends React.Component {
             data,
             () => {
                 this.props.updateSection('');
-                $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
             },
             (err) => {
                 this.setState({serverError: err.message});
@@ -163,7 +161,6 @@ export default class NotificationsTab extends React.Component {
         e.preventDefault();
         this.updateState();
         this.props.updateSection('');
-        $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
     }
 
     setStateValue(key, value) {

--- a/components/user_settings/user_settings_security/user_settings_security.jsx
+++ b/components/user_settings/user_settings_security/user_settings_security.jsx
@@ -17,7 +17,6 @@ import {updatePassword, getAuthorizedApps, deactivateMfa, deauthorizeOAuthApp} f
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import {isMobile} from 'utils/user_agent.jsx';
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import * as UserUtils from 'mattermost-redux/utils/user_utils';
@@ -510,7 +509,6 @@ export default class SecurityTab extends React.Component {
                 this.props.updateSection('');
                 this.setState({currentPassword: '', newPassword: '', confirmPassword: '', serverError: null, passwordError: null});
                 e.preventDefault();
-                $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
             }.bind(this);
 
             return (


### PR DESCRIPTION
#### Summary
Fix scrolling issues at user's Account Setting modal
- by calling `...perfectScrollbar('update')` at ComponentDidUpdate of UserSettingsModal
- by removing other multiple calls in updating perfect-scrollbar

In the future, we might need to decouple `perfect-scrollbar` from `jquery` by removing:
```
require('perfect-scrollbar/jquery')($);
```
and then adding where necessary:
```
import PerfectScrollbar from 'perfect-scrollbar';
```

#### Ticket Link
Jira ticket: [PLT-7852](https://mattermost.atlassian.net/browse/PLT-7852)

#### Checklist
- [x] Has UI changes

