### PR TITLE
PLT-7887 - Fixing post overflow and alignment

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -644,6 +644,7 @@
 }
 
 .post-list__table {
+    @include clearfix;
     display: table;
     height: 100%;
     min-height: 350px;
@@ -970,7 +971,6 @@
         font-size: 13.5px;
         line-height: 1.6em;
         margin: 0;
-        overflow: hidden;
         white-space: pre-wrap;
         width: 100%;
         word-break: break-word;


### PR DESCRIPTION
#### Summary
PLT-7887 - Fixing alignment for lists/edited stuff in posts

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7887

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
