### PR TITLE
[PLT-5535] Timestamp links on desktop app should open in permalink view in the current window

### DIFF
--- a/components/post_view/post_time.jsx
+++ b/components/post_view/post_time.jsx
@@ -87,7 +87,6 @@ export default class PostTime extends React.PureComponent {
         return (
             <Link
                 to={`/${this.state.currentTeamDisplayName}/pl/${this.props.postId}`}
-                target='_blank'
                 className='post__permalink'
             >
                 {this.renderTimeTag()}


### PR DESCRIPTION
#### Summary
Timestamp links on desktop app should open in permalink view in the current window

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/PLT-5535
Github: https://github.com/mattermost/mattermost-server/issues/5586
