### PR TITLE
Publish artifact for each commit as well

### DIFF
--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -16,11 +16,13 @@ podTemplate(label: 'jenkins-slave-webapp',
     ]
 )
 {
+    def gitCommit = ''
     node('jenkins-slave-webapp') {
         stage('Checkout') {
             container('mattermost-node') {
                 dir('mattermost-webapp') {
                     checkout scm
+                    gitCommit = sh(returnStdout: true, script: 'git rev-parse head').trim()
                 }
             }
         }
@@ -40,7 +42,6 @@ podTemplate(label: 'jenkins-slave-webapp',
             }
         }
         stage('Push to S3') {
-            gitCommit = sh(returnStdout: true, script: 'git rev-parse head').trim()
             step([$class: 'S3BucketPublisher', dontWaitForConcurrentBuildCompletion: false, entries: [[
                 bucket: 'releases.mattermost.com/mattermost-webapp/${BRANCH_NAME}',
                 excludedFile: '',

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -16,13 +16,13 @@ podTemplate(label: 'jenkins-slave-webapp',
     ]
 )
 {
-    def gitCommit = ''
+    def gitCommit
     node('jenkins-slave-webapp') {
         stage('Checkout') {
             container('mattermost-node') {
                 dir('mattermost-webapp') {
                     checkout scm
-                    gitCommit = sh(returnStdout: true, script: 'git rev-parse head').trim()
+                    gitCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
                 }
             }
         }

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -40,7 +40,38 @@ podTemplate(label: 'jenkins-slave-webapp',
             }
         }
         stage('Push to S3') {
-            step([$class: 'S3BucketPublisher', dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 'releases.mattermost.com/mattermost-webapp/${BRANCH_NAME}', excludedFile: '', flatten: true, gzipFiles: false, keepForever: false, managedArtifacts: false, noUploadOnFailure: true, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: 'mattermost-webapp/*.tar.gz', storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false, userMetadata: [[key: 'Cache-Control', value: 'no-cache']]]], profileName: 'Releases', userMetadAta: []])
+            gitCommit = sh(returnStdout: true, script: 'git rev-parse head').trim()
+            step([$class: 'S3BucketPublisher', dontWaitForConcurrentBuildCompletion: false, entries: [[
+                bucket: 'releases.mattermost.com/mattermost-webapp/${BRANCH_NAME}',
+                excludedFile: '',
+                flatten: true,
+                gzipFiles: false,
+                keepForever: false,
+                managedArtifacts: false,
+                noUploadOnFailure: true,
+                selectedRegion: 'us-east-1',
+                showDirectlyInBrowser: false,
+                sourceFile: 'mattermost-webapp/*.tar.gz',
+                storageClass: 'STANDARD',
+                uploadFromSlave: false,
+                useServerSideEncryption: false,
+                userMetadata: [[key: 'Cache-Control', value: 'no-cache']]
+            ], [
+                bucket: 'releases.mattermost.com/mattermost-webapp/commit/${gitCommit}',
+                excludedFile: '',
+                flatten: true,
+                gzipFiles: false,
+                keepForever: false,
+                managedArtifacts: false,
+                noUploadOnFailure: true,
+                selectedRegion: 'us-east-1',
+                showDirectlyInBrowser: false,
+                sourceFile: 'mattermost-webapp/*.tar.gz',
+                storageClass: 'STANDARD',
+                uploadFromSlave: false,
+                useServerSideEncryption: false,
+                userMetadata: [[key: 'Cache-Control', value: 'no-cache']]
+            ]], profileName: 'Releases', userMetadAta: []])
         }
     }
 }

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -58,7 +58,7 @@ podTemplate(label: 'jenkins-slave-webapp',
                 useServerSideEncryption: false,
                 userMetadata: [[key: 'Cache-Control', value: 'no-cache']]
             ], [
-                bucket: 'releases.mattermost.com/mattermost-webapp/commit/${gitCommit}',
+                bucket: "releases.mattermost.com/mattermost-webapp/commit/${gitCommit}",
                 excludedFile: '',
                 flatten: true,
                 gzipFiles: false,


### PR DESCRIPTION
#### Summary
Publish artifact for each commit as well. For caching within the mattermost-server job.

For example: https://releases.mattermost.com/mattermost-webapp/commit/d73250ff54071ec0e866327e771fa78e6dc3a298/mattermost-webapp.tar.gz

#### Ticket Link
N/A

#### Checklist
N/A