### PR TITLE
PLT-6450: Migrate installed_outgoing_webhooks.jsx and installed_outgoing_webhook.jsx to be pure and use Redux

### DIFF
--- a/components/integrations/components/installed_outgoing_webhook.jsx
+++ b/components/integrations/components/installed_outgoing_webhook.jsx
@@ -6,21 +6,50 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router';
 
-import ChannelStore from 'stores/channel_store.jsx';
-
 import DeleteIntegration from './delete_integration.jsx';
 
-export default class InstalledOutgoingWebhook extends React.Component {
-    static get propTypes() {
-        return {
-            outgoingWebhook: PropTypes.object.isRequired,
-            onRegenToken: PropTypes.func.isRequired,
-            onDelete: PropTypes.func.isRequired,
-            filter: PropTypes.string,
-            creator: PropTypes.object.isRequired,
-            canChange: PropTypes.bool.isRequired,
-            team: PropTypes.object.isRequired
-        };
+export default class InstalledOutgoingWebhook extends React.PureComponent {
+    static propTypes = {
+
+        /**
+        * Data used for showing webhook details
+        */
+        outgoingWebhook: PropTypes.object.isRequired,
+
+        /**
+        * Function used for webhook token regeneration
+        */
+        onRegenToken: PropTypes.func.isRequired,
+
+        /**
+        * Function to call when webhook delete button is pressed
+        */
+        onDelete: PropTypes.func.isRequired,
+
+        /**
+        * String used for filtering webhook item
+        */
+        filter: PropTypes.string,
+
+        /**
+        * Data used for showing created by details
+        */
+        creator: PropTypes.object.isRequired,
+
+        /**
+        *  Set to show available actions on webhook
+        */
+        canChange: PropTypes.bool.isRequired,
+
+        /**
+        *  Data used in routing of webhook for modifications
+        */
+        team: PropTypes.object.isRequired,
+
+        /**
+        *  Data used for filtering of webhooks based in filter prop
+        */
+        channel: PropTypes.object
     }
 
     constructor(props) {
@@ -40,7 +69,21 @@ export default class InstalledOutgoingWebhook extends React.Component {
         this.props.onDelete(this.props.outgoingWebhook);
     }
 
-    matchesFilter(outgoingWebhook, channel, filter) {
+    static makeDisplayName(outgoingWebhook, channel) {
+        if (outgoingWebhook.display_name) {
+            return outgoingWebhook.display_name;
+        } else if (channel) {
+            return channel.display_name;
+        }
+        return (
+            <FormattedMessage
+                id='installed_outgoing_webhooks.unknown_channel'
+                defaultMessage='A Private Webhook'
+            />
+        );
+    }
+
+    static matchesFilter(outgoingWebhook, channel, filter) {
         if (!filter) {
             return true;
         }
@@ -67,28 +110,16 @@ export default class InstalledOutgoingWebhook extends React.Component {
 
     render() {
         const outgoingWebhook = this.props.outgoingWebhook;
-        const channel = ChannelStore.get(outgoingWebhook.channel_id);
+        const channel = this.props.channel;
         const filter = this.props.filter ? this.props.filter.toLowerCase() : '';
         const triggerWordsFull = 0;
         const triggerWordsStartsWith = 1;
 
-        if (!this.matchesFilter(outgoingWebhook, channel, filter)) {
+        if (!InstalledOutgoingWebhook.matchesFilter(outgoingWebhook, channel, filter)) {
             return null;
         }
 
-        let displayName;
-        if (outgoingWebhook.display_name) {
-            displayName = outgoingWebhook.display_name;
-        } else if (channel) {
-            displayName = channel.display_name;
-        } else {
-            displayName = (
-                <FormattedMessage
-                    id='installed_outgoing_webhooks.unknown_channel'
-                    defaultMessage='A Private Webhook'
-                />
-            );
-        }
+        const displayName = InstalledOutgoingWebhook.makeDisplayName(outgoingWebhook, channel);
 
         let description = null;
         if (outgoingWebhook.description) {

--- a/components/integrations/components/installed_outgoing_webhooks/index.js
+++ b/components/integrations/components/installed_outgoing_webhooks/index.js
@@ -1,0 +1,31 @@
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import * as Actions from 'mattermost-redux/actions/integrations';
+import {getOutgoingHooks} from 'mattermost-redux/selectors/entities/integrations';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {getAllChannels} from 'mattermost-redux/selectors/entities/channels';
+import {getUsers} from 'mattermost-redux/selectors/entities/users';
+
+import InstalledOutgoingWebhook from './installed_outgoing_webhooks.jsx';
+
+function mapStateToProps(state, ownProps) {
+    return {
+        ...ownProps,
+        outgoingWebhooks: getOutgoingHooks(state),
+        channels: getAllChannels(state),
+        users: getUsers(state),
+        teamId: getCurrentTeamId(state)
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getOutgoingHooks: Actions.getOutgoingHooks,
+            removeOutgoingHook: Actions.removeOutgoingHook,
+            regenOutgoingHookToken: Actions.regenOutgoingHookToken
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(InstalledOutgoingWebhook);

--- a/routes/route_integrations.jsx
+++ b/routes/route_integrations.jsx
@@ -40,7 +40,7 @@ export default {
             path: 'outgoing_webhooks',
             indexRoute: {
                 getComponents: (location, callback) => {
-                    System.import('components/integrations/components/installed_outgoing_webhooks.jsx').then(RouteUtils.importComponentSuccess(callback));
+                    System.import('components/integrations/components/installed_outgoing_webhooks').then(RouteUtils.importComponentSuccess(callback));
                 }
             },
             childRoutes: [

--- a/tests/components/integrations/__snapshots__/installed_outgoing_webhook.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/installed_outgoing_webhook.test.jsx.snap
@@ -1,0 +1,168 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/integrations/InstalledOutgoingWebhook should match snapshot 1`] = `
+<div
+  className="backstage-list__item"
+>
+  <div
+    className="item-details"
+  >
+    <div
+      className="item-details__row"
+    >
+      <span
+        className="item-details__name"
+      >
+        build
+      </span>
+    </div>
+    <div
+      className="item-details__row"
+    >
+      <span
+        className="item-details__description"
+      >
+        build status
+      </span>
+    </div>
+    <div
+      className="item-details__row"
+    >
+      <span
+        className="item-details__content_type"
+      >
+        <FormattedMessage
+          defaultMessage="Content-Type: {contentType}"
+          id="installed_integrations.content_type"
+          values={
+            Object {
+              "contentType": "application/x-www-form-urlencoded",
+            }
+          }
+        />
+      </span>
+    </div>
+    <div
+      className="item-details__row"
+    >
+      <span
+        className="item-details__trigger-words"
+      >
+        <FormattedMessage
+          defaultMessage="Trigger Words: {triggerWords}"
+          id="installed_integrations.triggerWords"
+          values={
+            Object {
+              "triggerWords": "build",
+            }
+          }
+        />
+      </span>
+    </div>
+    <div
+      className="item-details__row"
+    >
+      <span
+        className="item-details__trigger-when"
+      >
+        <FormattedMessage
+          defaultMessage="Trigger When: {triggerWhen}"
+          id="installed_integrations.triggerWhen"
+          values={
+            Object {
+              "triggerWhen": <FormattedMessage
+                defaultMessage="First word matches a trigger word exactly"
+                id="add_outgoing_webhook.triggerWordsTriggerWhenFullWord"
+                values={Object {}}
+              />,
+            }
+          }
+        />
+      </span>
+    </div>
+    <div
+      className="item-details__row"
+    >
+      <span
+        className="item-details__token"
+      >
+        <FormattedMessage
+          defaultMessage="Token: {token}"
+          id="installed_integrations.token"
+          values={
+            Object {
+              "token": "xoxz1z7c3tgi9xhrfudn638q9r",
+            }
+          }
+        />
+      </span>
+    </div>
+    <div
+      className="item-details__row"
+    >
+      <span
+        className="item-details__creation"
+      >
+        <FormattedMessage
+          defaultMessage="Created by {creator} on {createAt, date, full}"
+          id="installed_integrations.creation"
+          values={
+            Object {
+              "createAt": 1508327769020,
+              "creator": undefined,
+            }
+          }
+        />
+      </span>
+    </div>
+    <div
+      className="item-details__row"
+    >
+      <span
+        className="item-details__url"
+      >
+        <FormattedMessage
+          defaultMessage="Callback URLs: {urls}"
+          id="installed_integrations.callback_urls"
+          values={
+            Object {
+              "urls": "http://adsfdasd.com",
+            }
+          }
+        />
+      </span>
+    </div>
+  </div>
+  <div
+    className="item-actions"
+  >
+    <a
+      href="#"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Regen Token"
+        id="installed_integrations.regenToken"
+        values={Object {}}
+      />
+    </a>
+     - 
+    <Link
+      onlyActiveOnIndex={false}
+      style={Object {}}
+      to="/test/integrations/outgoing_webhooks/edit?id=7h88x419ubbyuxzs7dfwtgkffr"
+    >
+      <FormattedMessage
+        defaultMessage="Edit"
+        id="installed_integrations.edit"
+        values={Object {}}
+      />
+    </Link>
+     - 
+    <DeleteIntegration
+      messageId="installed_outgoing_webhooks.delete.confirm"
+      onDelete={[Function]}
+    />
+  </div>
+</div>
+`;

--- a/tests/components/integrations/__snapshots__/installed_outgoing_webhooks.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/installed_outgoing_webhooks.test.jsx.snap
@@ -1,0 +1,163 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/integrations/InstalledOutgoingWebhooks should match snapshot 1`] = `
+<BackstageList
+  addLink="/test/integrations/outgoing_webhooks/add"
+  addText={
+    <FormattedMessage
+      defaultMessage="Add Outgoing Webhook"
+      id="installed_outgoing_webhooks.add"
+      values={Object {}}
+    />
+  }
+  emptyText={
+    <FormattedMessage
+      defaultMessage="No outgoing webhooks found"
+      id="installed_outgoing_webhooks.empty"
+      values={Object {}}
+    />
+  }
+  header={
+    <FormattedMessage
+      defaultMessage="Installed Outgoing Webhooks"
+      id="installed_outgoing_webhooks.header"
+      values={Object {}}
+    />
+  }
+  helpText={
+    <FormattedMessage
+      defaultMessage="Use outgoing webhooks to connect external tools to Mattermost. {buildYourOwn} or visit the {appDirectory} to find self-hosted, third-party apps and integrations."
+      id="installed_outgoing_webhooks.help"
+      values={
+        Object {
+          "appDirectory": <a
+            href="https://about.mattermost.com/default-app-directory/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              defaultMessage="App Directory"
+              id="installed_outgoing_webhooks.help.appDirectory"
+              values={Object {}}
+            />
+          </a>,
+          "buildYourOwn": <a
+            href="http://docs.mattermost.com/developer/webhooks-outgoing.html"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              defaultMessage="Build your own"
+              id="installed_outgoing_webhooks.help.buildYourOwn"
+              values={Object {}}
+            />
+          </a>,
+        }
+      }
+    />
+  }
+  loading={true}
+  searchPlaceholder="Search Outgoing Webhooks"
+>
+  <InstalledOutgoingWebhook
+    canChange={true}
+    channel={
+      Object {
+        "display_name": "town-square",
+        "id": "mdpzfpfcxi85zkkqkzkch4b85h",
+        "name": "town-square",
+      }
+    }
+    creator={
+      Object {
+        "first_name": "sudheer",
+        "id": "zaktnt8bpbgu8mb6ez9k64r7sa",
+        "roles": "system_admin system_user",
+        "username": "sudheerdev",
+      }
+    }
+    key="7h88x419ubbyuxzs7dfwtgkfgr"
+    onDelete={[Function]}
+    onRegenToken={[Function]}
+    outgoingWebhook={
+      Object {
+        "0": "asdf",
+        "callback_urls": Array [
+          "http://adsfdasd.com",
+        ],
+        "channel_id": "mdpzfpfcxi85zkkqkzkch4b85h",
+        "content_type": "application/x-www-form-urlencoded",
+        "create_at": 1508327769020,
+        "creator_id": "zaktnt8bpbgu8mb6ez9k64r7sa",
+        "delete_at": 0,
+        "description": "build status",
+        "display_name": "",
+        "id": "7h88x419ubbyuxzs7dfwtgkfgr",
+        "team_id": "eatxocwc3bg9ffo9xyybnj4omr",
+        "token": "xoxz1z7c3tgi9xhrfudn638q9r",
+        "trigger_when": 0,
+        "trigger_words": Array [
+          "build",
+        ],
+        "update_at": 1508329149618,
+      }
+    }
+    team={
+      Object {
+        "id": "testteamid",
+        "name": "test",
+      }
+    }
+  />
+  <InstalledOutgoingWebhook
+    canChange={true}
+    channel={
+      Object {
+        "display_name": "town-square",
+        "id": "mdpzfpfcxi85zkkqkzkch4b85h",
+        "name": "town-square",
+      }
+    }
+    creator={
+      Object {
+        "first_name": "sudheer",
+        "id": "zaktnt8bpbgu8mb6ez9k64r7sa",
+        "roles": "system_admin system_user",
+        "username": "sudheerdev",
+      }
+    }
+    key="7h88x419ubbyuxzs7dfwtgkffr"
+    onDelete={[Function]}
+    onRegenToken={[Function]}
+    outgoingWebhook={
+      Object {
+        "0": "asdf",
+        "callback_urls": Array [
+          "http://adsfdasd.com",
+        ],
+        "channel_id": "mdpzfpfcxi85zkkqkzkch4b85h",
+        "content_type": "application/x-www-form-urlencoded",
+        "create_at": 1508327769020,
+        "creator_id": "zaktnt8bpbgu8mb6ez9k64r7sa",
+        "delete_at": 0,
+        "description": "test",
+        "display_name": "",
+        "id": "7h88x419ubbyuxzs7dfwtgkffr",
+        "team_id": "eatxocwc3bg9ffo9xyybnj4omr",
+        "token": "xoxz1z7c3tgi9xhrfudn638q9r",
+        "trigger_when": 0,
+        "trigger_words": Array [
+          "test",
+        ],
+        "update_at": 1508329149618,
+      }
+    }
+    team={
+      Object {
+        "id": "testteamid",
+        "name": "test",
+      }
+    }
+  />
+</BackstageList>
+`;

--- a/tests/components/integrations/installed_outgoing_webhook.test.jsx
+++ b/tests/components/integrations/installed_outgoing_webhook.test.jsx
@@ -1,0 +1,259 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {Link} from 'react-router';
+
+import DeleteIntegration from 'components/integrations/components/delete_integration.jsx';
+import InstalledOutgoingWebhook from 'components/integrations/components/installed_outgoing_webhook.jsx';
+
+describe('components/integrations/InstalledOutgoingWebhook', () => {
+    let outgoingWebhook = {};
+    let mockFunc;
+    const teamId = 'testteamid';
+    beforeEach(() => {
+        mockFunc = jest.fn();
+        outgoingWebhook = {
+            callback_urls: ['http://adsfdasd.com'],
+            channel_id: 'mdpzfpfcxi85zkkqkzkch4b85h',
+            content_type: 'application/x-www-form-urlencoded',
+            create_at: 1508327769020,
+            creator_id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+            delete_at: 0,
+            description: 'build status',
+            display_name: 'build',
+            id: '7h88x419ubbyuxzs7dfwtgkffr',
+            team_id: 'eatxocwc3bg9ffo9xyybnj4omr',
+            token: 'xoxz1z7c3tgi9xhrfudn638q9r',
+            trigger_when: 0,
+            trigger_words: ['build'],
+            0: 'asdf',
+            update_at: 1508329149618
+        };
+    });
+
+    test('should match snapshot', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <InstalledOutgoingWebhook
+                key={1}
+                outgoingWebhook={outgoingWebhook}
+                onDelete={emptyFunction}
+                onRegenToken={emptyFunction}
+                creator={{}}
+                canChange={true}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channel={{
+                    id: '1jiw9kphbjrntfyrm7xpdcya4o',
+                    name: 'town-square'
+                }}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should not have edit and delete actions if user does not have permissions to change', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <InstalledOutgoingWebhook
+                key={1}
+                outgoingWebhook={outgoingWebhook}
+                onDelete={emptyFunction}
+                onRegenToken={emptyFunction}
+                creator={{}}
+                canChange={false}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channel={{
+                    id: '1jiw9kphbjrntfyrm7xpdcya4o',
+                    name: 'town-square'
+                }}
+            />
+        );
+        expect(wrapper.find('.item-actions').length).toBe(0);
+    });
+
+    test('should have edit and delete actions if user can change webhook', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <InstalledOutgoingWebhook
+                key={1}
+                outgoingWebhook={outgoingWebhook}
+                onDelete={emptyFunction}
+                onRegenToken={emptyFunction}
+                creator={{}}
+                canChange={true}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channel={{
+                    id: '1jiw9kphbjrntfyrm7xpdcya4o',
+                    name: 'town-square'
+                }}
+            />
+        );
+        expect(wrapper.find('.item-actions').find(Link).exists()).toBe(true);
+        expect(wrapper.find('.item-actions').find(DeleteIntegration).exists()).toBe(true);
+    });
+
+    test('Should have the same name and description on view as it has in outgoingWebhook', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <InstalledOutgoingWebhook
+                key={1}
+                outgoingWebhook={outgoingWebhook}
+                onDelete={emptyFunction}
+                onRegenToken={emptyFunction}
+                creator={{}}
+                canChange={false}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channel={{
+                    id: '1jiw9kphbjrntfyrm7xpdcya4o',
+                    name: 'town-square'
+                }}
+            />
+        );
+
+        expect(wrapper.find('.item-details__description').text()).toBe('build status');
+        expect(wrapper.find('.item-details__name').text()).toBe('build');
+    });
+
+    test('Should not display description as it is null', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+        outgoingWebhook.description = null;
+        const wrapper = shallow(
+            <InstalledOutgoingWebhook
+                key={1}
+                outgoingWebhook={outgoingWebhook}
+                onDelete={emptyFunction}
+                onRegenToken={emptyFunction}
+                creator={{}}
+                canChange={false}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channel={{
+                    id: '1jiw9kphbjrntfyrm7xpdcya4o',
+                    name: 'town-square'
+                }}
+            />
+        );
+        expect(wrapper.find('.item-details__description').length).toBe(0);
+    });
+
+    test('Should not render any nodes as there are no filtered results', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+        const wrapper = shallow(
+            <InstalledOutgoingWebhook
+                key={1}
+                outgoingWebhook={outgoingWebhook}
+                onDelete={emptyFunction}
+                onRegenToken={emptyFunction}
+                creator={{}}
+                filter={'someLongText'}
+                canChange={false}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channel={{
+                    id: '1jiw9kphbjrntfyrm7xpdcya4o',
+                    name: 'town-square'
+                }}
+            />
+        );
+        expect(wrapper.getElement()).toBe(null);
+    });
+
+    test('Should render a webhook item as filtered result is true', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+        const wrapper = shallow(
+            <InstalledOutgoingWebhook
+                key={1}
+                outgoingWebhook={outgoingWebhook}
+                onDelete={emptyFunction}
+                onRegenToken={emptyFunction}
+                creator={{}}
+                filter={'buil'}
+                canChange={true}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channel={{
+                    id: '1jiw9kphbjrntfyrm7xpdcya4o',
+                    name: 'town-square'
+                }}
+            />
+        );
+        expect(wrapper.find('.item-details').exists()).toBe(true);
+    });
+
+    test('Should call onRegenToken function once', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+        const wrapper = shallow(
+            <InstalledOutgoingWebhook
+                key={1}
+                outgoingWebhook={outgoingWebhook}
+                onDelete={emptyFunction}
+                onRegenToken={mockFunc}
+                creator={{}}
+                filter={'buil'}
+                canChange={true}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channel={{
+                    id: '1jiw9kphbjrntfyrm7xpdcya4o',
+                    name: 'town-square'
+                }}
+            />
+        );
+        wrapper.find('.item-actions a').first().simulate('click', {preventDefault() {
+            return jest.fn();
+        }});
+        expect(mockFunc).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should call onDelete function once', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+        const wrapper = shallow(
+            <InstalledOutgoingWebhook
+                key={1}
+                outgoingWebhook={outgoingWebhook}
+                onDelete={mockFunc}
+                onRegenToken={emptyFunction}
+                creator={{}}
+                filter={'buil'}
+                canChange={true}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channel={{
+                    id: '1jiw9kphbjrntfyrm7xpdcya4o',
+                    name: 'town-square'
+                }}
+            />
+        );
+        wrapper.find(DeleteIntegration).first().prop('onDelete')();
+        expect(mockFunc).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/components/integrations/installed_outgoing_webhooks.test.jsx
+++ b/tests/components/integrations/installed_outgoing_webhooks.test.jsx
@@ -1,0 +1,190 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import InstalledOutgoingWebhooks from 'components/integrations/components/installed_outgoing_webhooks/installed_outgoing_webhooks.jsx';
+import InstalledOutgoingWebhook from 'components/integrations/components/installed_outgoing_webhook.jsx';
+
+describe('components/integrations/InstalledOutgoingWebhooks', () => {
+    let outgoingWebhooks = {};
+    let mockFunc;
+    const teamId = 'testteamid';
+    beforeEach(() => {
+        mockFunc = jest.fn();
+        outgoingWebhooks = {
+            '7h88x419ubbyuxzs7dfwtgkffr': {
+                callback_urls: ['http://adsfdasd.com'],
+                channel_id: 'mdpzfpfcxi85zkkqkzkch4b85h',
+                content_type: 'application/x-www-form-urlencoded',
+                create_at: 1508327769020,
+                creator_id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                delete_at: 0,
+                description: 'build status',
+                display_name: '',
+                id: '7h88x419ubbyuxzs7dfwtgkfgr',
+                team_id: 'eatxocwc3bg9ffo9xyybnj4omr',
+                token: 'xoxz1z7c3tgi9xhrfudn638q9r',
+                trigger_when: 0,
+                trigger_words: ['build'],
+                0: 'asdf',
+                update_at: 1508329149618
+            },
+            '7h88x419ubbyuxzs7dfwtgkfff': {
+                callback_urls: ['http://adsfdasd.com'],
+                channel_id: 'mdpzfpfcxi85zkkqkzkch4b85h',
+                content_type: 'application/x-www-form-urlencoded',
+                create_at: 1508327769020,
+                creator_id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                delete_at: 0,
+                description: 'test',
+                display_name: '',
+                id: '7h88x419ubbyuxzs7dfwtgkffr',
+                team_id: 'eatxocwc3bg9ffo9xyybnj4omr',
+                token: 'xoxz1z7c3tgi9xhrfudn638q9r',
+                trigger_when: 0,
+                trigger_words: ['test'],
+                0: 'asdf',
+                update_at: 1508329149618
+            }
+        };
+    });
+
+    test('should match snapshot', () => {
+        global.window.mm_config = {EnableOutgoingWebhooks: true};
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <InstalledOutgoingWebhooks
+                key={1}
+                outgoingWebhooks={outgoingWebhooks}
+                canChange={true}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channels={{
+                    mdpzfpfcxi85zkkqkzkch4b85h: {
+                        id: 'mdpzfpfcxi85zkkqkzkch4b85h',
+                        name: 'town-square',
+                        display_name: 'town-square'
+                    }
+                }}
+                teamId={teamId}
+                actions={{
+                    removeOutgoingHook: emptyFunction,
+                    getOutgoingHooks: emptyFunction,
+                    regenOutgoingHookToken: emptyFunction
+                }}
+                user={{
+                    first_name: 'sudheer',
+                    id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                    roles: 'system_admin system_user',
+                    username: 'sudheerdev'
+                }}
+                users={{
+                    zaktnt8bpbgu8mb6ez9k64r7sa: {
+                        first_name: 'sudheer',
+                        id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                        roles: 'system_admin system_user',
+                        username: 'sudheerdev'
+                    }
+                }}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should call regenOutgoingHookToken function', () => {
+        global.window.mm_config = {EnableOutgoingWebhooks: true};
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <InstalledOutgoingWebhooks
+                key={1}
+                outgoingWebhooks={outgoingWebhooks}
+                canChange={true}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channels={{
+                    mdpzfpfcxi85zkkqkzkch4b85h: {
+                        id: 'mdpzfpfcxi85zkkqkzkch4b85h',
+                        name: 'town-square',
+                        display_name: 'town-square'
+                    }
+                }}
+                teamId={teamId}
+                actions={{
+                    removeOutgoingHook: emptyFunction,
+                    getOutgoingHooks: emptyFunction,
+                    regenOutgoingHookToken: mockFunc
+                }}
+                user={{
+                    first_name: 'sudheer',
+                    id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                    roles: 'system_admin system_user',
+                    username: 'sudheerdev'
+                }}
+                users={{
+                    zaktnt8bpbgu8mb6ez9k64r7sa: {
+                        first_name: 'sudheer',
+                        id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                        roles: 'system_admin system_user',
+                        username: 'sudheerdev'
+                    }
+                }}
+            />
+        );
+        wrapper.find(InstalledOutgoingWebhook).first().prop('onRegenToken')(outgoingWebhooks['7h88x419ubbyuxzs7dfwtgkffr']);
+        expect(mockFunc).toHaveBeenCalled();
+    });
+
+    test('should call removeOutgoingHook function', () => {
+        global.window.mm_config = {EnableOutgoingWebhooks: true};
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <InstalledOutgoingWebhooks
+                key={1}
+                outgoingWebhooks={outgoingWebhooks}
+                canChange={true}
+                team={{
+                    id: teamId,
+                    name: 'test'
+                }}
+                channels={{
+                    mdpzfpfcxi85zkkqkzkch4b85h: {
+                        id: 'mdpzfpfcxi85zkkqkzkch4b85h',
+                        name: 'town-square',
+                        display_name: 'town-square'
+                    }
+                }}
+                teamId={teamId}
+                actions={{
+                    removeOutgoingHook: mockFunc,
+                    getOutgoingHooks: emptyFunction,
+                    regenOutgoingHookToken: emptyFunction
+                }}
+                user={{
+                    first_name: 'sudheer',
+                    id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                    roles: 'system_admin system_user',
+                    username: 'sudheerdev'
+                }}
+                users={{
+                    zaktnt8bpbgu8mb6ez9k64r7sa: {
+                        first_name: 'sudheer',
+                        id: 'zaktnt8bpbgu8mb6ez9k64r7sa',
+                        roles: 'system_admin system_user',
+                        username: 'sudheerdev'
+                    }
+                }}
+            />
+        );
+        wrapper.find(InstalledOutgoingWebhook).first().prop('onDelete')(outgoingWebhooks['7h88x419ubbyuxzs7dfwtgkfff']);
+        expect(mockFunc).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
#### Summary
WIP: Migrated installed_outgoing_webhooks.jsx and installed_outgoing_webhook.jsx to be pure and use Redux
 * Moved ChannelStore dependency from installed_outgoing_webhook.jsx to
   installed_outgoing_webhooks.js and made it available through props
 * Changed matchesFilter to be static method.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/6454
https://github.com/mattermost/mattermost-server/issues/6450

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Has redux changes (please link)
