### PR TITLE
cleaned type-o in gitlab "admin.clientSecretDescription" references from "gitab" to "gitlab"

### DIFF
--- a/components/admin_console/gitlab_settings.jsx
+++ b/components/admin_console/gitlab_settings.jsx
@@ -108,7 +108,7 @@ export default class GitLabSettings extends AdminSettings {
                     placeholder={Utils.localizeMessage('admin.gitlab.clientSecretExample', 'Ex "jcuS8PuvcpGhpgHhlcpT1Mx42pnqMxQY"')}
                     helpText={
                         <FormattedMessage
-                            id='admin.gitab.clientSecretDescription'
+                            id='admin.gitlab.clientSecretDescription'
                             defaultMessage='Obtain this value via the instructions above for logging into GitLab.'
                         />
                     }

--- a/components/admin_console/oauth_settings.jsx
+++ b/components/admin_console/oauth_settings.jsx
@@ -302,7 +302,7 @@ export default class OAuthSettings extends AdminSettings {
                     placeholder={Utils.localizeMessage('admin.gitlab.clientSecretExample', 'Ex "jcuS8PuvcpGhpgHhlcpT1Mx42pnqMxQY"')}
                     helpText={
                         <FormattedMessage
-                            id='admin.gitab.clientSecretDescription'
+                            id='admin.gitlab.clientSecretDescription'
                             defaultMessage='Obtain this value via the instructions above for logging into GitLab.'
                         />
                     }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -457,7 +457,7 @@
   "admin.general.policy.teamInviteTitle": "Enable sending team invites from:",
   "admin.general.privacy": "Privacy",
   "admin.general.usersAndTeams": "Users and Teams",
-  "admin.gitab.clientSecretDescription": "Obtain this value via the instructions above for logging into GitLab.",
+  "admin.gitlab.clientSecretDescription": "Obtain this value via the instructions above for logging into GitLab.",
   "admin.gitlab.EnableHtmlDesc": "<ol><li>Log in to your GitLab account and go to Profile Settings -> Applications.</li><li>Enter Redirect URIs \"<your-mattermost-url>/login/gitlab/complete\" (example: http://localhost:8065/login/gitlab/complete) and \"<your-mattermost-url>/signup/gitlab/complete\". </li><li>Then use \"Application Secret Key\" and \"Application ID\" fields from GitLab to complete the options below.</li><li>Complete the Endpoint URLs below. </li></ol>",
   "admin.gitlab.authDescription": "Enter https://<your-gitlab-url>/oauth/authorize (example https://example.com:3000/oauth/authorize).   Make sure you use HTTP or HTTPS in your URL depending on your server configuration.",
   "admin.gitlab.authExample": "E.g.: \"https://<your-gitlab-url>/oauth/authorize\"",


### PR DESCRIPTION
#### Summary
As I was learning mattermost codebase, I found an error in which `gitlab` was referenced as `gitab` with no `l` (L).  Although I could not find a **[Help Wanted]** ticket for this, I wanted to contribute to get me started on this project.  Later, I would like to contribute more significantly when I better understand the mattermost codebase, and hope to be able to contribute to a [Help Wanted] Ticket in the issues section.  I think mattermost is a great system as it uses `go`, `react` & `redux`, and I hope to become a more significant contributor!

#### Ticket Link
I could not find this error (maybe it isn't an error?) in the issues tab.

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, posting, etc.)
