### PR TITLE
PLT-7906 Handle not-yet-loaded user in DM channel headers

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -56,6 +56,11 @@ export default class ChannelHeader extends React.Component {
         }).isRequired
     }
 
+    static defaultProps = {
+        dmUser: {},
+        dmUserStatus: {status: UserStatuses.OFFLINE}
+    }
+
     constructor(props) {
         super(props);
 


### PR DESCRIPTION
#### Summary
Handle not-yet-loaded user in DM channel headers.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7906