### PR TITLE
PLT-7853 Added thumbnail for SVG attachments

### DIFF
--- a/components/file_attachment.jsx
+++ b/components/file_attachment.jsx
@@ -49,6 +49,8 @@ export default class FileAttachment extends React.Component {
             const thumbnailUrl = getFileThumbnailUrl(fileInfo.id);
 
             Utils.loadImage(thumbnailUrl, this.handleImageLoaded);
+        } else if (fileInfo.extesnion === 'svg') {
+            Utils.loadImage(getFileUrl(fileInfo.id), this.handleImageLoaded);
         }
     }
 
@@ -87,6 +89,13 @@ export default class FileAttachment extends React.Component {
                         style={{
                             backgroundImage: `url(${getFileThumbnailUrl(fileInfo.id)})`
                         }}
+                    />
+                );
+            } else if (fileInfo.extension === 'svg') {
+                thumbnail = (
+                    <img
+                        className='post-image normal'
+                        src={getFileUrl(fileInfo.id)}
                     />
                 );
             } else {

--- a/components/file_attachment.jsx
+++ b/components/file_attachment.jsx
@@ -29,8 +29,10 @@ export default class FileAttachment extends React.Component {
 
     componentWillReceiveProps(nextProps) {
         if (nextProps.fileInfo.id !== this.props.fileInfo.id) {
+            const extension = nextProps.fileInfo.extension;
+
             this.setState({
-                loaded: Utils.getFileType(nextProps.fileInfo.extension) !== 'image'
+                loaded: Utils.getFileType(extension) !== 'image' && extension !== 'svg'
             });
         }
     }
@@ -49,7 +51,7 @@ export default class FileAttachment extends React.Component {
             const thumbnailUrl = getFileThumbnailUrl(fileInfo.id);
 
             Utils.loadImage(thumbnailUrl, this.handleImageLoaded);
-        } else if (fileInfo.extesnion === 'svg') {
+        } else if (fileInfo.extension === 'svg') {
             Utils.loadImage(getFileUrl(fileInfo.id), this.handleImageLoaded);
         }
     }


### PR DESCRIPTION
It just uses the raw SVG file since that's probably smaller than loading a rasterized thumbnail image

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7853

#### Checklist
- Has UI changes

<img width="316" alt="screen shot 2017-10-20 at 5 09 10 pm" src="https://user-images.githubusercontent.com/3277310/31841868-6afed374-b5b9-11e7-869b-7cd52ccb36af.png">
