### PR TITLE
PLT-6432 Channel preferences are restored when closing a DM/GM channel and then re-opening later

### DIFF
--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -666,7 +666,7 @@ export default class Sidebar extends React.Component {
         // create elements for all 4 types of channels
         const visibleFavoriteChannels = this.state.favoriteChannels.
             filter((channel) => {
-                return ChannelUtils.isDirectChannelVisible(channel) || ChannelUtils.isGroupChannelVisible(channel);
+                return ChannelUtils.isOpenChannel(channel) || ChannelUtils.isPrivateChannel(channel) || ChannelUtils.isDirectChannelVisible(channel) || ChannelUtils.isGroupChannelVisible(channel);
             });
 
         const favoriteItems = visibleFavoriteChannels.

--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -380,10 +380,6 @@ export default class Sidebar extends React.Component {
                 }
             );
 
-            if (ChannelUtils.isFavoriteChannel(channel)) {
-                ChannelActions.unmarkFavorite(channel.id);
-            }
-
             this.setState(this.getStateFromStores());
             trackEvent('ui', 'ui_direct_channel_x_button_clicked');
         }
@@ -668,7 +664,12 @@ export default class Sidebar extends React.Component {
         this.lastUnreadChannel = null;
 
         // create elements for all 4 types of channels
-        const favoriteItems = this.state.favoriteChannels.
+        const visibleFavoriteChannels = this.state.favoriteChannels.
+            filter((channel) => {
+                return ChannelUtils.isDirectChannelVisible(channel) || ChannelUtils.isGroupChannelVisible(channel);
+            });
+
+        const favoriteItems = visibleFavoriteChannels.
             map((channel, index, arr) => {
                 if (channel.type === Constants.DM_CHANNEL || channel.type === Constants.GM_CHANNEL) {
                     return this.createChannelElement(channel, index, arr, this.handleLeaveDirectChannel);


### PR DESCRIPTION
#### Summary
Fixed an issue where a closed favorite channel was being unmarked as a favorite channel. For example, let's say you open a direct message channel with someone and favorite the channel. If you click "x" on the left sidebar to close/hide the channel from the sidebar, when you re-open the direct message channel it is not listed under FAVORITE CHANNELS. This is now fixed for DM and GM channels

**Note**: I was not seeing the observed behavior for Case 2 originally in the ticket before and after my changes but I can look in to it if needed 😄 

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/6326

#### Checklist
- [x] Has UI changes