### PR TITLE
[E2E] Add IDs and elements check to Account Settings modal - display section and refactor sidebarLeftPage

### DIFF
--- a/components/setting_item_min.jsx
+++ b/components/setting_item_min.jsx
@@ -55,7 +55,12 @@ export default function SettingItemMin(props) {
             className='section-min'
             onClick={props.updateSection}
         >
-            <li className='col-xs-12 col-sm-9 section-title'>{props.title}</li>
+            <li
+                id={Utils.createSafeId(props.title) + 'Title'}
+                className='col-xs-12 col-sm-9 section-title'
+            >
+                {props.title}
+            </li>
             {editButton}
             {describeSection}
         </ul>

--- a/components/settings_sidebar.jsx
+++ b/components/settings_sidebar.jsx
@@ -34,10 +34,12 @@ export default class SettingsSidebar extends React.Component {
 
             return (
                 <li
+                    id={`${tab.name}Li`}
                     key={key}
                     className={className}
                 >
                     <button
+                        id={`${tab.name}Button`}
                         className='cursor--pointer style--none'
                         onClick={this.handleClick.bind(null, tab)}
                     >
@@ -50,7 +52,10 @@ export default class SettingsSidebar extends React.Component {
 
         return (
             <div>
-                <ul className='nav nav-pills nav-stacked'>
+                <ul
+                    id='tabList'
+                    className='nav nav-pills nav-stacked'
+                >
                     {tabList}
                 </ul>
             </div>

--- a/components/user_settings/user_settings_display.jsx
+++ b/components/user_settings/user_settings_display.jsx
@@ -413,7 +413,7 @@ export default class UserSettingsDisplay extends React.Component {
         });
 
         const channelDisplayModeSection = this.createSection({
-            section: 'Preferences.CHANNEL_DISPLAY_MODE',
+            section: Preferences.CHANNEL_DISPLAY_MODE,
             display: 'channelDisplayMode',
             value: this.state.channelDisplayMode,
             defaultDisplay: Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
@@ -495,7 +495,7 @@ export default class UserSettingsDisplay extends React.Component {
         }
 
         return (
-            <div>
+            <div id='displaySettings'>
                 <div className='modal-header'>
                     <button
                         id='closeButton'
@@ -524,7 +524,10 @@ export default class UserSettingsDisplay extends React.Component {
                     </h4>
                 </div>
                 <div className='user-settings'>
-                    <h3 className='tab-header'>
+                    <h3
+                        id='displaySettingsTitle'
+                        className='tab-header'
+                    >
                         <FormattedMessage
                             id='user.settings.display.title'
                             defaultMessage='Display Settings'

--- a/components/user_settings/user_settings_modal.jsx
+++ b/components/user_settings/user_settings_modal.jsx
@@ -244,14 +244,18 @@ class UserSettingsModal extends React.Component {
 
         return (
             <Modal
+                id='accountSettingsModal'
                 dialogClassName='settings-modal'
                 show={this.state.show}
                 onHide={this.handleHide}
                 onExited={this.handleHidden}
                 enforceFocus={this.state.enforceFocus}
             >
-                <Modal.Header closeButton={true}>
-                    <Modal.Title>
+                <Modal.Header
+                    id='accountSettingsHeader'
+                    closeButton={true}
+                >
+                    <Modal.Title id='accountSettingsTitle'>
                         <FormattedMessage
                             id='user.settings.modal.title'
                             defaultMessage='Account Settings'

--- a/tests/e2e/pages/accountSettingsModalPage.js
+++ b/tests/e2e/pages/accountSettingsModalPage.js
@@ -1,0 +1,89 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {Constants} from '../utils';
+
+const acountSettingsModalPageCommands = {
+    navigateToPage() {
+        return this.waitForElementVisible('@accountSettingsModal', Constants.DEFAULT_WAIT);
+    }
+};
+
+const header = {selector: '#accountSettingsHeader'};
+const title = {selector: '#accountSettingsTitle'};
+const closeButton = {
+    selector: '//*[@id="accountSettingsModal"]/div/div/div[1]/button',
+    locateStrategy: 'xpath'
+};
+const generalButton = {selector: '#generalButton'};
+const securityButton = {selector: '#securityButton'};
+const notificationsButton = {selector: '#notificationsButton'};
+const displayButton = {selector: '#displayButton'};
+const advancedButton = {selector: '#advancedButton'};
+const tabList = {
+    selector: '#tabList',
+    elements: {
+        generalLi: {selector: '#generalLi'},
+        generalButton,
+        securityLi: {selector: '#securityLi'},
+        securityButton,
+        notificationsLi: {selector: '#notificationsLi'},
+        notificationsButton,
+        displayLi: {selector: '#displayLi'},
+        displayButton,
+        advancedLi: {selector: '#advancedLi'},
+        advancedButton
+    }
+};
+
+const displaySettings = {
+    selector: '#displaySettings',
+    elements: {
+        themeTitle: {selector: '#ThemeTitle'},
+        themeEdit: {selector: '#ThemeEdit'},
+        themeDesc: {selector: '#ThemeDesc'},
+        clockTitle: {selector: '#Clock_DisplayTitle'},
+        clockEdit: {selector: '#Clock_DisplayEdit'},
+        clockDesc: {selector: '#Clock_DisplayDesc'},
+        linkPreviewTitle: {selector: '#Website_Link_PreviewsTitle'},
+        linkPreviewEdit: {selector: '#Website_Link_PreviewsEdit'},
+        linkPreviewDesc: {selector: '#Website_Link_PreviewsDesc'},
+        collapseTitle: {selector: '#Default_appearance_of_image_link_previewsTitle'},
+        collapseEdit: {selector: '#Default_appearance_of_image_link_previewsEdit'},
+        collapseDesc: {selector: '#Default_appearance_of_image_link_previewsDesc'},
+        messageDisplayTitle: {selector: '#Message_DisplayTitle'},
+        messageDisplayEdit: {selector: '#Message_DisplayEdit'},
+        messageDisplayDesc: {selector: '#Message_DisplayDesc'},
+        channelDisplayModeTitle: {selector: '#Channel_Display_ModeTitle'},
+        channelDisplayModeEdit: {selector: '#Channel_Display_ModeEdit'},
+        channelDisplayModeDesc: {selector: '#Channel_Display_ModeDesc'},
+        languageTitle: {selector: '#LanguageTitle'},
+        languageEdit: {selector: '#LanguageEdit'},
+        languageDesc: {selector: '#LanguageDesc'},
+    }
+};
+
+
+module.exports = {
+    url: `${Constants.TEST_BASE_URL}`,
+    commands: [acountSettingsModalPageCommands],
+    sections: {
+        accountSettingsModal: {
+            selector: '#accountSettingsModal',
+            sections: {
+                tabList,
+                displaySettings
+            },
+            elements: {
+                header,
+                title,
+                closeButton,
+                generalButton,
+                securityButton,
+                notificationsButton,
+                displayButton,
+                advancedButton
+            }
+        }
+    }
+};

--- a/tests/e2e/pages/sidebarLeftPage.js
+++ b/tests/e2e/pages/sidebarLeftPage.js
@@ -6,6 +6,64 @@ import {Constants} from '../utils';
 const sidebarLeftPageCommands = {
     navigateToPage() {
         return this.waitForElementVisible('@sidebarLeft', Constants.DEFAULT_WAIT);
+    },
+    navigateToAccountSettingsModal() {
+        return this
+            .click('@sidebarHeaderDropdownButton')
+            .section.sidebarDropdownMenu
+            .click('@accountSettings');
+    }
+};
+
+const sidebarHeaderDropdownButton = {selector: '#sidebarHeaderDropdownButton'};
+const statusDropdown = {selector: '#status-dropdown'};
+const sidebarDropdownMenu = {
+    selector: '#sidebarDropdownMenu',
+    elements: {
+        accountSettings: {selector: '#accountSettings'},
+        sendEmailInvite: {selector: '#sendEmailInvite'},
+        getTeamInviteLink: {selector: '#getTeamInviteLink'},
+        addUsersToTeam: {selector: '#addUsersToTeam'},
+        teamSettings: {selector: '#teamSettings'},
+        manageMembers: {selector: '#manageMembers'},
+        createTeam: {selector: '#createTeam'},
+        leaveTeam: {selector: '#leaveTeam'},
+        integrations: {selector: '#Integrations'},
+        systemConsole: {selector: '#systemConsole'},
+        helpLink: {selector: '#helpLink'},
+        keyboardShortcuts: {selector: '#keyboardShortcuts'},
+        reportLink: {selector: '#reportLink'},
+        nativeAppLink: {selector: '#nativeAppLink'},
+        about: {selector: '#about'},
+        logout: {selector: '#logout'}
+    }
+};
+const headerInfo = {
+    selector: '#headerInfo',
+    elements: {
+        headerUsername: {selector: '#headerUsername'},
+        headerTeamName: {selector: '#headerTeamName'}
+    }
+};
+const editStatusMenu = {
+    selector: '#editStatusMenu',
+    elements: {
+        statusOnline: {selector: '#statusonline'},
+        statusAway: {selector: '#statusaway'},
+        statusOffline: {selector: '#statusoffline'}
+    }
+};
+const sidebarChannelContainer = {
+    selector: '#sidebarChannelContainer',
+    elements: {
+        favoriteChannel: {selector: '#favoriteChannel'},
+        publicChannel: {selector: '#publicChannel'},
+        createPublicChannel: {selector: '#createPublicChannel'},
+        morePublicChannel: {selector: '#sidebarChannelsMore'},
+        privateChannel: {selector: '#privateChannel'},
+        createPrivateChannel: {selector: '#createPrivateChannel'},
+        directChannel: {selector: '#directChannel'},
+        moreDirectChannel: {selector: '#moreDirectMessage'}
     }
 };
 
@@ -22,71 +80,34 @@ module.exports = {
                         sidebarDropdownMenuContainer: {
                             selector: '#sidebarDropdownMenuContainer',
                             sections: {
-                                sidebarDropdownMenu: {
-                                    selector: '#sidebarDropdownMenu',
-                                    elements: {
-                                        accountSettings: {selector: '#accountSettings'},
-                                        sendEmailInvite: {selector: '#sendEmailInvite'},
-                                        getTeamInviteLink: {selector: '#getTeamInviteLink'},
-                                        addUsersToTeam: {selector: '#addUsersToTeam'},
-                                        teamSettings: {selector: '#teamSettings'},
-                                        manageMembers: {selector: '#manageMembers'},
-                                        createTeam: {selector: '#createTeam'},
-                                        leaveTeam: {selector: '#leaveTeam'},
-                                        integrations: {selector: '#Integrations'},
-                                        systemConsole: {selector: '#systemConsole'},
-                                        helpLink: {selector: '#helpLink'},
-                                        keyboardShortcuts: {selector: '#keyboardShortcuts'},
-                                        reportLink: {selector: '#reportLink'},
-                                        nativeAppLink: {selector: '#nativeAppLink'},
-                                        about: {selector: '#about'},
-                                        logout: {selector: '#logout'}
-                                    }
-                                }
+                                sidebarDropdownMenu
                             },
                             elements: {
-                                sidebarHeaderDropdownButton: {selector: '#sidebarHeaderDropdownButton'}
+                                sidebarHeaderDropdownButton
                             }
                         },
-                        headerInfo: {
-                            selector: '#headerInfo',
-                            elements: {
-                                headerUsername: {selector: '#headerUsername'},
-                                headerTeamName: {selector: '#headerTeamName'}
-                            }
-                        },
-                        editStatusMenu: {
-                            selector: '#editStatusMenu',
-                            elements: {
-                                statusOnline: {selector: '#statusonline'},
-                                statusAway: {selector: '#statusaway'},
-                                statusOffline: {selector: '#statusoffline'}
-                            }
-                        }
+                        headerInfo,
+                        editStatusMenu
                     },
                     elements: {
-                        statusDropdown: {selector: '#status-dropdown'}
+                        statusDropdown
                     }
                 },
-                sidebarChannelContainer: {
-                    selector: '#sidebarChannelContainer',
-                    elements: {
-                        favoriteChannel: {selector: '#favoriteChannel'},
-                        publicChannel: {selector: '#publicChannel'},
-                        createPublicChannel: {selector: '#createPublicChannel'},
-                        morePublicChannel: {selector: '#sidebarChannelsMore'},
-                        privateChannel: {selector: '#privateChannel'},
-                        createPrivateChannel: {selector: '#createPrivateChannel'},
-                        directChannel: {selector: '#directChannel'},
-                        moreDirectChannel: {selector: '#moreDirectMessage'}
-                    }
-                }
+                sidebarChannelContainer
             },
             elements: {
                 sidebarSwitcherButton: {selector: '#sidebarSwitcherButton'},
                 unreadIndicatorTop: {selector: '#unreadIndicatorTop'},
                 unreadIndicatorBottom: {selector: '#unreadIndicatorBottom'}
             }
-        }
+        },
+        sidebarDropdownMenu,
+        headerInfo,
+        editStatusMenu,
+        sidebarChannelContainer
+    },
+    elements: {
+        sidebarHeaderDropdownButton,
+        statusDropdown
     }
 };

--- a/tests/e2e/tests/3_sidebarLeft/accountSettingsDisplay.js
+++ b/tests/e2e/tests/3_sidebarLeft/accountSettingsDisplay.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {Constants} from '../../utils';
+
+module.exports = {
+    '@tags': ['account_settings', 'account_settings_display'],
+    before: (client) => {
+        const testUser = Constants.USERS.test;
+        const loginPage = client.page.loginPage();
+
+        loginPage.navigate()
+            .login(testUser.email, testUser.password);
+    },
+    after: (client) => client.end(),
+    'Test account settings display': (client) => {
+        const sidebarLeftPage = client.page.sidebarLeftPage();
+
+        const accountSettingsSection = sidebarLeftPage
+            .click('@sidebarHeaderDropdownButton')
+            .section.sidebarDropdownMenu
+            .click('@accountSettings');
+    }
+};

--- a/tests/e2e/tests/3_sidebarLeft/accountSettingsModalPage.element.js
+++ b/tests/e2e/tests/3_sidebarLeft/accountSettingsModalPage.element.js
@@ -1,0 +1,103 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {Constants} from '../../utils';
+
+module.exports = {
+    '@tags': ['account_settings', 'account_settings_display'],
+    before: (client) => {
+        const testUser = Constants.USERS.test;
+        const loginPage = client.page.loginPage();
+
+        loginPage.navigate()
+            .login(testUser.email, testUser.password);
+    },
+    after: (client) => client.end(),
+    'Account Settings Modal page - element check': (client) => {
+        const sidebarLeftPage = client.page.sidebarLeftPage();
+        sidebarLeftPage.navigateToAccountSettingsModal();
+
+        const accountSettingsModalPage = client.page.accountSettingsModalPage();
+        accountSettingsModalPage.expect.section('@accountSettingsModal').to.be.visible;
+
+        const accountSettingsModalSection = accountSettingsModalPage.section.accountSettingsModal;
+        accountSettingsModalSection
+            .assert.visible('@header')
+            .assert.visible('@title')
+            .assert.visible('@closeButton')
+            .assert.visible('@generalButton')
+            .assert.visible('@securityButton')
+            .assert.visible('@notificationsButton')
+            .assert.visible('@displayButton')
+            .assert.visible('@advancedButton');
+
+        accountSettingsModalSection.expect.section('@tabList').to.be.visible;
+
+        accountSettingsModalSection.click('@displayButton');
+        accountSettingsModalSection.expect.section('@displaySettings').to.be.visible;
+
+        sidebarLeftPage.click('@sidebarHeaderDropdownButton')
+    },
+    'Account Settings Modal page, Tab List - element check': (client) => {
+        const sidebarLeftPage = client.page.sidebarLeftPage();
+        sidebarLeftPage.navigateToAccountSettingsModal();
+
+        const accountSettingsModalPage = client.page.accountSettingsModalPage();
+        accountSettingsModalPage.expect.section('@accountSettingsModal').to.be.visible;
+
+        const accountSettingsModalSection = accountSettingsModalPage.section.accountSettingsModal;
+        accountSettingsModalSection.expect.section('@tabList').to.be.visible;
+        const tabListSection = accountSettingsModalSection.section.tabList;
+
+        tabListSection
+            .assert.visible('@generalLi')
+            .assert.visible('@generalButton')
+            .assert.visible('@securityLi')
+            .assert.visible('@securityButton')
+            .assert.visible('@notificationsLi')
+            .assert.visible('@notificationsButton')
+            .assert.visible('@displayLi')
+            .assert.visible('@displayButton')
+            .assert.visible('@advancedLi')
+            .assert.visible('@advancedButton');
+
+        sidebarLeftPage.click('@sidebarHeaderDropdownButton');
+    },
+    'Account Settings Modal page, Display section - element check': (client) => {
+        const sidebarLeftPage = client.page.sidebarLeftPage();
+        sidebarLeftPage.navigateToAccountSettingsModal();
+
+        const accountSettingsModalPage = client.page.accountSettingsModalPage();
+        accountSettingsModalPage.expect.section('@accountSettingsModal').to.be.visible;
+
+        const accountSettingsModalSection = accountSettingsModalPage.section.accountSettingsModal;
+        accountSettingsModalSection.click('@displayButton');
+        accountSettingsModalSection.expect.section('@displaySettings').to.be.visible;
+
+        const displaySettingsSection = accountSettingsModalSection.section.displaySettings;
+        displaySettingsSection
+            .assert.visible('@themeTitle')
+            .assert.visible('@themeEdit')
+            .assert.visible('@themeDesc')
+            .assert.visible('@clockTitle')
+            .assert.visible('@clockEdit')
+            .assert.visible('@clockDesc')
+            .assert.visible('@linkPreviewTitle')
+            .assert.visible('@linkPreviewEdit')
+            .assert.visible('@linkPreviewDesc')
+            .assert.visible('@collapseTitle')
+            .assert.visible('@collapseEdit')
+            .assert.visible('@collapseDesc')
+            .assert.visible('@messageDisplayTitle')
+            .assert.visible('@messageDisplayEdit')
+            .assert.visible('@messageDisplayDesc')
+            .assert.visible('@channelDisplayModeTitle')
+            .assert.visible('@channelDisplayModeEdit')
+            .assert.visible('@channelDisplayModeDesc')
+            .assert.visible('@languageTitle')
+            .assert.visible('@languageEdit')
+            .assert.visible('@languageDesc');
+
+        sidebarLeftPage.click('@sidebarHeaderDropdownButton');
+    }
+};

--- a/tests/e2e/tests/3_sidebarLeft/sidebarLeftPage.element.js
+++ b/tests/e2e/tests/3_sidebarLeft/sidebarLeftPage.element.js
@@ -27,39 +27,52 @@ module.exports = {
     'Sidebar Left page, teamHeaderSection - element check': (client) => {
         const sidebarLeftPage = client.page.sidebarLeftPage();
         const sidebarLeftSection = sidebarLeftPage.section.sidebarLeft;
-
         sidebarLeftSection.expect.section('@teamHeader').to.be.visible;
+
         const teamHeaderSection = sidebarLeftSection.section.teamHeader;
-
-        teamHeaderSection
-            .assert.visible('@statusDropdown')
-
         teamHeaderSection.expect.section('@headerInfo').to.be.visible;
-        const headerInfoSection = teamHeaderSection.section.headerInfo;
 
+        const headerInfoSection = teamHeaderSection.section.headerInfo;
         headerInfoSection
             .assert.visible('@headerUsername')
             .assert.visible('@headerTeamName');
 
+        teamHeaderSection
+            .assert.visible('@statusDropdown')
+
         teamHeaderSection.click('@statusDropdown');
         teamHeaderSection.expect.section('@editStatusMenu').to.be.visible;
-        const editStatusMenuSection = teamHeaderSection.section.editStatusMenu;
-
-        editStatusMenuSection
-            .assert.visible('@statusOnline')
-            .assert.visible('@statusAway')
-            .assert.visible('@statusOffline');
+        teamHeaderSection.click('@statusDropdown');
 
         teamHeaderSection.expect.section('@sidebarDropdownMenuContainer').to.be.visible;
         const sidebarDropdownMenuContainerSection = teamHeaderSection.section.sidebarDropdownMenuContainer;
-
         sidebarDropdownMenuContainerSection
             .assert.visible('@sidebarHeaderDropdownButton');
 
         sidebarDropdownMenuContainerSection.click('@sidebarHeaderDropdownButton');
         sidebarDropdownMenuContainerSection.expect.section('@sidebarDropdownMenu').to.be.visible;
-        const sidebarDropdownMenuSection = sidebarDropdownMenuContainerSection.section.sidebarDropdownMenu;
+        sidebarDropdownMenuContainerSection.click('@sidebarHeaderDropdownButton');
+    },
+    'Sidebar Left page, sidebarChannelContainerSection - element check': (client) => {
+        const sidebarLeftPage = client.page.sidebarLeftPage();
+        sidebarLeftPage.expect.section('@sidebarChannelContainer').to.be.visible;
 
+        const sidebarChannelContainerSection = sidebarLeftPage.section.sidebarChannelContainer;
+        sidebarChannelContainerSection
+            .assert.visible('@publicChannel')
+            .assert.visible('@createPublicChannel')
+            .assert.visible('@morePublicChannel')
+            .assert.visible('@privateChannel')
+            .assert.visible('@createPrivateChannel')
+            .assert.visible('@directChannel')
+            .assert.visible('@moreDirectChannel');
+    },
+    'Sidebar Left page, sidebarHeaderDropdownButton click action - element check': (client) => {
+        const sidebarLeftPage = client.page.sidebarLeftPage();
+        sidebarLeftPage.click('@sidebarHeaderDropdownButton');
+        sidebarLeftPage.expect.section('@sidebarDropdownMenu').to.be.visible;
+
+        const sidebarDropdownMenuSection = sidebarLeftPage.section.sidebarDropdownMenu;
         sidebarDropdownMenuSection
             .assert.visible('@accountSettings')
             .assert.visible('@sendEmailInvite')
@@ -77,21 +90,20 @@ module.exports = {
             .assert.visible('@nativeAppLink')
             .assert.visible('@about')
             .assert.visible('@logout');
+
+        sidebarLeftPage.click('@sidebarHeaderDropdownButton');
     },
-    'Sidebar Left page, sidebarChannelContainerSection - element check': (client) => {
+    'Sidebar Left page, statusDropdown click action - element check': (client) => {
         const sidebarLeftPage = client.page.sidebarLeftPage();
-        const sidebarLeftSection = sidebarLeftPage.section.sidebarLeft;
+        sidebarLeftPage.click('@statusDropdown');
+        sidebarLeftPage.expect.section('@editStatusMenu').to.be.visible;
 
-        sidebarLeftSection.expect.section('@sidebarChannelContainer').to.be.visible;
-        const sidebarChannelContainerSection = sidebarLeftSection.section.sidebarChannelContainer;
+        const editStatusMenuSection = sidebarLeftPage.section.editStatusMenu;
+        editStatusMenuSection
+            .assert.visible('@statusOnline')
+            .assert.visible('@statusAway')
+            .assert.visible('@statusOffline');
 
-        sidebarChannelContainerSection
-            .assert.visible('@publicChannel')
-            .assert.visible('@createPublicChannel')
-            .assert.visible('@morePublicChannel')
-            .assert.visible('@privateChannel')
-            .assert.visible('@createPrivateChannel')
-            .assert.visible('@directChannel')
-            .assert.visible('@moreDirectChannel');
+        sidebarLeftPage.click('@statusDropdown');
     }
 };


### PR DESCRIPTION
#### Summary
- Add IDs and elements check to Account Settings modal - display section and refactor sidebarLeftPage.

In order not to break further to `mattermost-selenium`, I did not change IDs like:
```
collapseEdit: {selector: '#Default_appearance_of_image_link_previewsEdit'},
```

But in the future, once we are ready to have nightwatch in our CI pipeline, I plan to change it using simple ID like `#collapseEdit` only.

#### Ticket Link
Jira ticket: [PLT-7925](https://mattermost.atlassian.net/browse/PLT-7925)
