### PR TITLE
Remove search modifiers from en.json

### DIFF
--- a/components/search_results.jsx
+++ b/components/search_results.jsx
@@ -324,22 +324,8 @@ export default class SearchResults extends React.Component {
                         id='search_results.usage.fromInSuggestion'
                         defaultMessage='Use {fromUser} to find posts from specific users and {inChannel} to find posts in specific channels'
                         values={{
-                            fromUser: (
-                                <b>
-                                    <FormattedMessage
-                                        id='search_results.usage.fromInSuggestion.fromUser'
-                                        defaultMessage='from:'
-                                    />
-                                </b>
-                            ),
-                            inChannel: (
-                                <b>
-                                    <FormattedMessage
-                                        id='search_results.usage.fromInSuggestion.inChannel'
-                                        defaultMessage='in:'
-                                    />
-                                </b>
-                            )
+                            fromUser: 'from:',
+                            inChannel: 'in:'
                         }}
                     />
                 </li>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2227,8 +2227,6 @@
   "search_results.searching": "Searching...",
   "search_results.usage.dataRetention": "Only messages posted in the last {days} days are returned. Contact your System Administrator for more detail.",
   "search_results.usage.fromInSuggestion": "Use {fromUser} to find posts from specific users and {inChannel} to find posts in specific channels",
-  "search_results.usage.fromInSuggestion.fromUser": "from:",
-  "search_results.usage.fromInSuggestion.inChannel": "in:",
   "search_results.usage.phrasesSuggestion": "Use {quotationMarks} to search for phrases",
   "search_results.usage.phrasesSuggestion.quotationMarks": "\"quotation marks\"",
   "search_results.usageFlag1": "You haven't flagged any messages yet.",


### PR DESCRIPTION
#### Summary
Remove search modifiers from en.json. These are modifiers to perform actual searches and hence shouldn't be localized.

#### Ticket Link
N/A