### PR TITLE
Migrate ViewImagePopover to follow the guideline

### DIFF
--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -97,7 +97,7 @@ export default class FileAttachmentList extends React.Component {
                 <ViewImageModal
                     show={this.state.showPreviewModal}
                     onModalDismissed={() => this.setState({showPreviewModal: false})}
-                    startId={this.state.startImgIndex}
+                    startIndex={this.state.startImgIndex}
                     fileInfos={fileInfos}
                 />
             </div>

--- a/components/view_image.jsx
+++ b/components/view_image.jsx
@@ -44,8 +44,8 @@ export default class ViewImageModal extends React.Component {
         this.onMouseLeaveImage = this.onMouseLeaveImage.bind(this);
 
         this.state = {
-            imgId: this.props.startId,
-            imgHeight: '100%',
+            imageIndex: this.props.startIndex,
+            imageHeight: '100%',
             loaded: Utils.fillArray(false, this.props.fileInfos.length),
             progress: Utils.fillArray(0, this.props.fileInfos.length),
             showFooter: false
@@ -56,7 +56,7 @@ export default class ViewImageModal extends React.Component {
         if (e) {
             e.stopPropagation();
         }
-        let id = this.state.imgId + 1;
+        let id = this.state.imageIndex + 1;
         if (id > this.props.fileInfos.length - 1) {
             id = 0;
         }
@@ -67,7 +67,7 @@ export default class ViewImageModal extends React.Component {
         if (e) {
             e.stopPropagation();
         }
-        let id = this.state.imgId - 1;
+        let id = this.state.imageIndex - 1;
         if (id < 0) {
             id = this.props.fileInfos.length - 1;
         }
@@ -85,7 +85,7 @@ export default class ViewImageModal extends React.Component {
     onModalShown(nextProps) {
         $(window).on('keyup', this.handleKeyPress);
 
-        this.showImage(nextProps.startId);
+        this.showImage(nextProps.startIndex);
     }
 
     onModalHidden() {
@@ -112,10 +112,10 @@ export default class ViewImageModal extends React.Component {
     }
 
     showImage(id) {
-        this.setState({imgId: id});
+        this.setState({imageIndex: id});
 
-        const imgHeight = $(window).height() - 100;
-        this.setState({imgHeight});
+        const imageHeight = $(window).height() - 100;
+        this.setState({imageHeight});
 
         if (!this.state.loaded[id]) {
             this.loadImage(id);
@@ -171,7 +171,7 @@ export default class ViewImageModal extends React.Component {
     handleGetPublicLink() {
         this.props.onModalDismissed();
 
-        GlobalActions.showGetPublicLinkModal(this.props.fileInfos[this.state.imgId].id);
+        GlobalActions.showGetPublicLinkModal(this.props.fileInfos[this.state.imageIndex].id);
     }
 
     onMouseEnterImage() {
@@ -183,15 +183,15 @@ export default class ViewImageModal extends React.Component {
     }
 
     render() {
-        if (this.props.fileInfos.length < 1 || this.props.fileInfos.length - 1 < this.state.imgId) {
+        if (this.props.fileInfos.length < 1 || this.props.fileInfos.length - 1 < this.state.imageIndex) {
             return null;
         }
 
-        const fileInfo = this.props.fileInfos[this.state.imgId];
+        const fileInfo = this.props.fileInfos[this.state.imageIndex];
         const fileUrl = getFileUrl(fileInfo.id);
 
         let content;
-        if (this.state.loaded[this.state.imgId]) {
+        if (this.state.loaded[this.state.imageIndex]) {
             const fileType = Utils.getFileType(fileInfo.extension);
 
             if (fileType === 'image' || fileType === 'svg') {
@@ -232,7 +232,7 @@ export default class ViewImageModal extends React.Component {
             }
         } else {
             // display a progress indicator when the preview for an image is still loading
-            const progress = Math.floor(this.state.progress[this.state.imgId]);
+            const progress = Math.floor(this.state.progress[this.state.imageIndex]);
 
             content = (
                 <LoadingImagePreview
@@ -302,7 +302,7 @@ export default class ViewImageModal extends React.Component {
                             </div>
                             <ViewImagePopoverBar
                                 show={this.state.showFooter}
-                                fileId={this.state.imgId}
+                                fileIndex={this.state.imageIndex}
                                 totalFiles={this.props.fileInfos.length}
                                 filename={fileInfo.name}
                                 fileURL={fileUrl}
@@ -321,13 +321,13 @@ export default class ViewImageModal extends React.Component {
 ViewImageModal.defaultProps = {
     show: false,
     fileInfos: [],
-    startId: 0
+    startIndex: 0
 };
 ViewImageModal.propTypes = {
     show: PropTypes.bool.isRequired,
     onModalDismissed: PropTypes.func.isRequired,
     fileInfos: PropTypes.arrayOf(PropTypes.object).isRequired,
-    startId: PropTypes.number
+    startIndex: PropTypes.number
 };
 
 function LoadingImagePreview({progress, loading}) {

--- a/components/view_image_popover_bar.jsx
+++ b/components/view_image_popover_bar.jsx
@@ -18,7 +18,7 @@ export default class ViewImagePopoverBar extends React.PureComponent {
         /**
          * The index number of the current file.
          */
-        fileId: PropTypes.number.isRequired,
+        fileIndex: PropTypes.number.isRequired,
 
         /**
          * The count of total files.
@@ -43,7 +43,7 @@ export default class ViewImagePopoverBar extends React.PureComponent {
 
     static defaultProps = {
         show: false,
-        imgId: 0,
+        fileIndex: 0,
         totalFiles: 0,
         filename: '',
         fileURL: ''
@@ -106,7 +106,7 @@ export default class ViewImagePopoverBar extends React.PureComponent {
                         id='view_image_popover.file'
                         defaultMessage='File {count, number} of {total, number}'
                         values={{
-                            count: (this.props.fileId + 1),
+                            count: (this.props.fileIndex + 1),
                             total: this.props.totalFiles
                         }}
                     />

--- a/components/view_image_popover_bar.jsx
+++ b/components/view_image_popover_bar.jsx
@@ -9,11 +9,35 @@ import * as FileUtils from 'utils/file_utils';
 
 export default class ViewImagePopoverBar extends React.PureComponent {
     static propTypes = {
+
+        /**
+         * Set whether to show this component or not
+         */
         show: PropTypes.bool.isRequired,
+
+        /**
+         * The index number of the current file.
+         */
         fileId: PropTypes.number.isRequired,
+
+        /**
+         * The count of total files.
+         */
         totalFiles: PropTypes.number.isRequired,
+
+        /**
+         * The name of current file. 
+         */
         filename: PropTypes.string.isRequired,
+
+        /**
+         * The API route to get current file.
+         */
         fileURL: PropTypes.string.isRequired,
+
+        /**
+         * Function to call when click on "Get Public Link"
+         */
         onGetPublicLink: PropTypes.func.isRequired
     };
 

--- a/components/view_image_popover_bar.jsx
+++ b/components/view_image_popover_bar.jsx
@@ -8,6 +8,23 @@ import {FormattedMessage} from 'react-intl';
 import * as FileUtils from 'utils/file_utils';
 
 export default class ViewImagePopoverBar extends React.PureComponent {
+    static propTypes = {
+        show: PropTypes.bool.isRequired,
+        fileId: PropTypes.number.isRequired,
+        totalFiles: PropTypes.number.isRequired,
+        filename: PropTypes.string.isRequired,
+        fileURL: PropTypes.string.isRequired,
+        onGetPublicLink: PropTypes.func.isRequired
+    };
+
+    static defaultProps = {
+        show: false,
+        imgId: 0,
+        totalFiles: 0,
+        filename: '',
+        fileURL: ''
+    };
+
     render() {
         var publicLink = '';
         if (global.window.mm_config.EnablePublicLink === 'true') {
@@ -75,19 +92,3 @@ export default class ViewImagePopoverBar extends React.PureComponent {
         );
     }
 }
-ViewImagePopoverBar.defaultProps = {
-    show: false,
-    imgId: 0,
-    totalFiles: 0,
-    filename: '',
-    fileURL: ''
-};
-
-ViewImagePopoverBar.propTypes = {
-    show: PropTypes.bool.isRequired,
-    fileId: PropTypes.number.isRequired,
-    totalFiles: PropTypes.number.isRequired,
-    filename: PropTypes.string.isRequired,
-    fileURL: PropTypes.string.isRequired,
-    onGetPublicLink: PropTypes.func.isRequired
-};

--- a/components/view_image_popover_bar.jsx
+++ b/components/view_image_popover_bar.jsx
@@ -38,7 +38,7 @@ export default class ViewImagePopoverBar extends React.PureComponent {
         /**
          * Function to call when click on "Get Public Link"
          */
-        onGetPublicLink: PropTypes.func.isRequired
+        onGetPublicLink: PropTypes.func
     };
 
     static defaultProps = {

--- a/components/view_image_popover_bar.jsx
+++ b/components/view_image_popover_bar.jsx
@@ -26,7 +26,7 @@ export default class ViewImagePopoverBar extends React.PureComponent {
         totalFiles: PropTypes.number.isRequired,
 
         /**
-         * The name of current file. 
+         * The name of current file.
          */
         filename: PropTypes.string.isRequired,
 

--- a/tests/components/__snapshots__/view_image_popover_bar.test.jsx.snap
+++ b/tests/components/__snapshots__/view_image_popover_bar.test.jsx.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/ViewImagePopoverBar should match snapshot 1`] = `
+<div
+  className="modal-button-bar footer--show"
+>
+  <span
+    className="pull-left text"
+  >
+    <FormattedMessage
+      defaultMessage="File {count, number} of {total, number}"
+      id="view_image_popover.file"
+      values={
+        Object {
+          "count": 1,
+          "total": 0,
+        }
+      }
+    />
+  </span>
+  <div
+    className="image-links"
+  >
+    <a
+      className="text"
+      download=""
+      href=""
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <FormattedMessage
+        defaultMessage="Download"
+        id="view_image_popover.download"
+        values={Object {}}
+      />
+    </a>
+  </div>
+</div>
+`;
+
+exports[`components/ViewImagePopoverBar should match snapshot 2`] = `
+<div
+  className="modal-button-bar footer--show"
+>
+  <span
+    className="pull-left text"
+  >
+    <FormattedMessage
+      defaultMessage="File {count, number} of {total, number}"
+      id="view_image_popover.file"
+      values={
+        Object {
+          "count": 1,
+          "total": 0,
+        }
+      }
+    />
+  </span>
+  <div
+    className="image-links"
+  >
+    <div>
+      <a
+        className="public-link text"
+        data-title="Public Image"
+        href="#"
+      >
+        <FormattedMessage
+          defaultMessage="Get Public Link"
+          id="view_image_popover.publicLink"
+          values={Object {}}
+        />
+      </a>
+      <span
+        className="text"
+      >
+         | 
+      </span>
+    </div>
+    <a
+      className="text"
+      download=""
+      href=""
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <FormattedMessage
+        defaultMessage="Download"
+        id="view_image_popover.download"
+        values={Object {}}
+      />
+    </a>
+  </div>
+</div>
+`;

--- a/tests/components/view_image_popover_bar.test.jsx
+++ b/tests/components/view_image_popover_bar.test.jsx
@@ -14,8 +14,9 @@ describe('components/ViewImagePopoverBar', () => {
     });
 
     test('should match snapshot', () => {
-        let makeWrapper = () => shallow(
-            <ViewImagePopoverBar 
+        /* eslint func-style: "off" */
+        const makeWrapper = () => shallow(
+            <ViewImagePopoverBar
                 show={true}
             />
         );
@@ -31,7 +32,7 @@ describe('components/ViewImagePopoverBar', () => {
         const mockOnClick = jest.fn();
 
         const wrapper = shallow(
-            <ViewImagePopoverBar 
+            <ViewImagePopoverBar
                 show={true}
                 onGetPublicLink={mockOnClick}
             />

--- a/tests/components/view_image_popover_bar.test.jsx
+++ b/tests/components/view_image_popover_bar.test.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import ViewImagePopoverBar from 'components/view_image_popover_bar';
+
+describe('components/ViewImagePopoverBar', () => {
+    beforeEach(() => {
+        global.window.mm_config = {};
+    });
+
+    afterEach(() => {
+        global.window.mm_config = {};
+    });
+
+    test('should match snapshot', () => {
+        let makeWrapper = () => shallow(
+            <ViewImagePopoverBar 
+                show={true}
+            />
+        );
+
+        expect(makeWrapper()).toMatchSnapshot();
+
+        global.window.mm_config.EnablePublicLink = 'true';
+        expect(makeWrapper()).toMatchSnapshot();
+    });
+
+    test('should call publick link callback', () => {
+        global.window.mm_config.EnablePublicLink = 'true';
+        const mockOnClick = jest.fn();
+
+        const wrapper = shallow(
+            <ViewImagePopoverBar 
+                show={true}
+                onGetPublicLink={mockOnClick}
+            />
+        );
+
+        wrapper.find('a.public-link').first().simulate('click');
+        expect(mockOnClick).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
#### Summary
Migrate ViewImagePopover to follow the guideline.
The component does not use any stores and actions.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7685

#### Checklist
- [x] Added or updated unit tests (required for all new features)
