### PR TITLE
Improve support for bidirectional text

### DIFF
--- a/sass/components/_mentions.scss
+++ b/sass/components/_mentions.scss
@@ -99,6 +99,7 @@
 
 .mention--highlight {
     background-color: $yellow;
+    unicode-bidi: isolate;
 }
 
 .mention__purpose {

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -10,6 +10,7 @@
     resize: none;
     white-space: pre-wrap;
     word-wrap: break-word;
+    unicode-bidi: plaintext;
 
     &:focus {
         border-color: #cccccc;
@@ -974,6 +975,7 @@
         white-space: pre-wrap;
         width: 100%;
         word-break: break-word;
+        unicode-bidi: plaintext;
     }
 
     .post__header--info {


### PR DESCRIPTION
#### Summary
Text with mixed direction (i.e. mixed right-to-left text like Arabic and left-to-right text like English) is currently broken since both the input text area and the posts default to LTR direction and left
alignment which renders mixed text unreadable.

This commit sets `unicode-bidi: plaintext` on the post paragraphs and the text area which lets the web browser handle the base direcion and alignment automatically, and sets `unicode-bidi: isolate` on the mentions so that they are ignored during text direction calculation as they almost always contain LTR text.

`isolate` and `plaintext` values are supported only by Firefox and Chrome, though, other browsers will continue with the current stat of things.

Before:
![screenshot-2017-10-25 town square - test mattermost 1](https://user-images.githubusercontent.com/93914/32004601-d5c2f466-b9aa-11e7-8bf5-0cd44bd22e4c.png)
After:
![screenshot-2017-10-25 town square - test mattermost](https://user-images.githubusercontent.com/93914/32004610-dd77256a-b9aa-11e7-8d30-bf6b78ec07f7.png)


#### Ticket Link
N/A

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
