### PR TITLE
PLT-7833 Fixed channel autocomplete not opening after using a tilde outside of a link

### DIFF
--- a/components/suggestion/channel_mention_provider.jsx
+++ b/components/suggestion/channel_mention_provider.jsx
@@ -53,7 +53,7 @@ export default class ChannelMentionProvider extends Provider {
     constructor() {
         super();
 
-        this.lastTermWithNoResults = '';
+        this.lastPrefixWithNoResults = '';
         this.lastCompletedWord = '';
     }
 
@@ -65,7 +65,7 @@ export default class ChannelMentionProvider extends Provider {
             return false;
         }
 
-        if (this.lastTermWithNoResults && pretext.startsWith(this.lastTermWithNoResults)) {
+        if (this.lastPrefixWithNoResults && pretext.startsWith(this.lastPrefixWithNoResults)) {
             // Just give up since we know it won't return any results
             return false;
         }
@@ -90,7 +90,7 @@ export default class ChannelMentionProvider extends Provider {
                 }
 
                 if (channels.length === 0) {
-                    this.lastTermWithNoResults = pretext;
+                    this.lastPrefixWithNoResults = prefix;
                 }
 
                 // Wrap channels in an outer object to avoid overwriting the 'type' property.
@@ -138,5 +138,6 @@ export default class ChannelMentionProvider extends Provider {
 
     handleCompleteWord(term) {
         this.lastCompletedWord = term;
+        this.lastPrefixWithNoResults = '';
     }
 }


### PR DESCRIPTION
The previous version captured everything before the cursor, so it would see that that hadn't changed and not display the autocomplete. Now it only captures everything back to the last tilde so it'll see that change after the user types another tilde to start a new channel link

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7833