### PR TITLE
PLT-7930 Don't show emoji autocomplete when the text is an emoticon

### DIFF
--- a/components/suggestion/emoticon_provider.jsx
+++ b/components/suggestion/emoticon_provider.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 
-import {default as EmojiStore, EmojiMap} from 'stores/emoji_store.jsx';
+import EmojiStore, {EmojiMap} from 'stores/emoji_store.jsx';
 import store from 'stores/redux_store.jsx';
 import SuggestionStore from 'stores/suggestion_store.jsx';
 
@@ -50,7 +50,7 @@ export default class EmoticonProvider {
     handlePretextChanged(suggestionId, pretext) {
         let hasSuggestions = false;
 
-        // look for the potential emoticons at the start of the text, after whitespace, and at the start of emoji reaction commands
+        // Look for the potential emoticons at the start of the text, after whitespace, and at the start of emoji reaction commands
         const captured = (/(^|\s|^\+|^-)(:([^:\s]*))$/g).exec(pretext);
         if (captured) {
             const prefix = captured[1];
@@ -62,23 +62,20 @@ export default class EmoticonProvider {
                 return false;
             }
 
-            const matched = [];
-
-            // check for text emoticons if this isn't for an emoji reaction
+            // Check for text emoticons if this isn't for an emoji reaction
             if (prefix !== '-' && prefix !== '+') {
                 for (const emoticon of Object.keys(Emoticons.emoticonPatterns)) {
                     if (Emoticons.emoticonPatterns[emoticon].test(text)) {
-                        SuggestionStore.addSuggestion(suggestionId, text, EmojiStore.get(emoticon), EmoticonSuggestion, text);
-
-                        hasSuggestions = true;
+                        // Don't show the autocomplete for text emoticons
+                        return false;
                     }
                 }
             }
 
-            const emojis = new EmojiMap(getCustomEmojisByName(store.getState()));
+            const matched = [];
 
-            // check for named emoji
-            for (const [name, emoji] of emojis) {
+            // Check for named emoji
+            for (const [name, emoji] of new EmojiMap(getCustomEmojisByName(store.getState()))) {
                 if (emoji.aliases) {
                     // This is a system emoji so it may have multiple names
                     for (const alias of emoji.aliases) {
@@ -93,7 +90,7 @@ export default class EmoticonProvider {
                 }
             }
 
-            // sort the emoticons so that emoticons starting with the entered text come first
+            // Sort the emoticons so that emoticons starting with the entered text come first
             matched.sort((a, b) => {
                 const aName = a.name;
                 const bName = b.name;


### PR DESCRIPTION
This is to prevent it from showing up for emoticons that are more than 2 characters long (eg. `:-D`). I removed the previous code that was supposed to show the autocomplete for emoticons since that was supposed to be removed when we added a minimum length required before the autocomplete triggered

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7930