### PR TITLE
Expose common libraries on window for plugins

### DIFF
--- a/plugins/index.js
+++ b/plugins/index.js
@@ -12,6 +12,13 @@ import {getSiteURL} from 'utils/url.jsx';
 
 window.plugins = {};
 
+// Common libraries exposed on window for plugins to access
+window.react = require('react');
+window['react-dom'] = require('react-dom');
+window.redux = require('redux');
+window['react-redux'] = require('react-redux');
+window['react-bootstrap'] = require('react-bootstrap');
+
 export function registerComponents(id, components = {}, postTypes = {}) {
     const wrappedComponents = {};
     Object.keys(components).forEach((name) => {


### PR DESCRIPTION
#### Summary
I've been trying to come up with better ways to handle common dependencies between the webapp and webapp plugins. Initially, it was looking like it would be fine to manage dependencies for plugins separately and if plugins included multiple copies of a library that would be fine. However, I was never fully confident in this working in cases where the webapp upgraded React and a plugin was using a very old version of React. The deal breaker however was some libraries, such as react-bootstrap, will only work if there is only a single copy of React included on the page.

The new solution here is to have the plugins share the major libraries with the webapp. The major  downside to this is plugins could potentially break if we upgrade to a version of one of these libraries that contains breaking changes. The other downside is it feels hacky to expose libraries on window, but it's likely going to feel a bit hacky inevitably no matter what we do.

Plugins can access these libraries by replacing regular imports with variable setting:
```
const React = window.react;

export default class ProfilePopover extends React.PureComponent {
    // component stuff
}
```

I'm very open to suggestions on how to do this better
