### PR TITLE
PLT-7986 Switch file input button to div tag

### DIFF
--- a/components/setting_picture.jsx
+++ b/components/setting_picture.jsx
@@ -197,7 +197,7 @@ export default class SettingPicture extends Component {
                                 errors={[this.props.clientError, this.props.serverError]}
                                 type={'modal'}
                             />
-                            <button
+                            <div
                                 className='btn btn-sm btn-primary btn-file sel-btn'
                                 disabled={fileInputDisabled}
                             >
@@ -213,7 +213,7 @@ export default class SettingPicture extends Component {
                                     onChange={this.props.onFileChange}
                                     disabled={fileInputDisabled}
                                 />
-                            </button>
+                            </div>
                             {confirmButton}
                             <a
                                 className='btn btn-sm theme'


### PR DESCRIPTION
#### Summary
Firefox doesn't like input elements inside of button tags.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7986