### PR TITLE
PLT-8002 Fix refresh on edit channel URL button

### DIFF
--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -279,7 +279,10 @@ export default class NewChannelModal extends React.PureComponent {
                                         {'URL: ' + prettyTeamURL + this.props.channelData.name + ' ('}
                                         <button
                                             className='color--link style--none'
-                                            onClick={this.props.onChangeURLPressed}
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                this.props.onChangeURLPressed();
+                                            }}
                                         >
                                             <FormattedMessage
                                                 id='channel_modal.edit'


### PR DESCRIPTION
#### Summary
Fix refresh on edit channel URL button. Not sure what changed recently to break this, but an event was getting fired that would refresh the page if not intercepted.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8002