### PR TITLE
Migrate get link modal to be pure and use Redux

### DIFF
--- a/components/get_link_modal.jsx
+++ b/components/get_link_modal.jsx
@@ -6,26 +6,32 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
-export default class GetLinkModal extends React.Component {
+export default class GetLinkModal extends React.PureComponent {
+    static propTypes = {
+        show: PropTypes.bool.isRequired,
+        onHide: PropTypes.func.isRequired,
+        title: PropTypes.string.isRequired,
+        helpText: PropTypes.string,
+        link: PropTypes.string.isRequired
+    };
+
+    static defaultProps = {
+        helpText: null
+    };
+
     constructor(props) {
         super(props);
-
-        this.onHide = this.onHide.bind(this);
-
-        this.copyLink = this.copyLink.bind(this);
-
         this.state = {
             copiedLink: false
         };
     }
 
-    onHide() {
+    onHide = () => {
         this.setState({copiedLink: false});
-
         this.props.onHide();
     }
 
-    copyLink() {
+    copyLink = () => {
         const textarea = this.refs.textarea;
         textarea.focus();
         textarea.setSelectionRange(0, this.props.link.length);
@@ -54,6 +60,7 @@ export default class GetLinkModal extends React.Component {
         }
 
         let copyLink = null;
+
         if (document.queryCommandSupported('copy')) {
             copyLink = (
                 <button
@@ -123,15 +130,3 @@ export default class GetLinkModal extends React.Component {
         );
     }
 }
-
-GetLinkModal.propTypes = {
-    show: PropTypes.bool.isRequired,
-    onHide: PropTypes.func.isRequired,
-    title: PropTypes.string.isRequired,
-    helpText: PropTypes.string,
-    link: PropTypes.string.isRequired
-};
-
-GetLinkModal.defaultProps = {
-    helpText: null
-};

--- a/components/get_link_modal.jsx
+++ b/components/get_link_modal.jsx
@@ -64,6 +64,7 @@ export default class GetLinkModal extends React.PureComponent {
         if (document.queryCommandSupported('copy')) {
             copyLink = (
                 <button
+                    id='linkModalCopyLink'
                     data-copy-btn='true'
                     type='button'
                     className='btn btn-primary pull-left'
@@ -79,6 +80,7 @@ export default class GetLinkModal extends React.PureComponent {
 
         const linkText = (
             <textarea
+                id='linkModalTextArea'
                 className='form-control no-resize min-height'
                 ref='textarea'
                 value={this.props.link}
@@ -114,6 +116,7 @@ export default class GetLinkModal extends React.PureComponent {
                 </Modal.Body>
                 <Modal.Footer>
                     <button
+                        id='linkModalCloseButton'
                         type='button'
                         className='btn btn-default'
                         onClick={this.onHide}

--- a/tests/components/__snapshots__/get_link_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/get_link_modal.test.jsx.snap
@@ -1,0 +1,346 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/GetLinkModal should have called onHide 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <h4
+      className="modal-title"
+    >
+      title
+    </h4>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <textarea
+      className="form-control no-resize min-height"
+      id="linkModalTextArea"
+      onClick={[Function]}
+      readOnly={true}
+      value="https://mattermost.com"
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-default"
+      id="linkModalCloseButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Close"
+        id="get_link.close"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary pull-left"
+      data-copy-btn="true"
+      id="linkModalCopyLink"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Copy Link"
+        id="get_link.copy"
+        values={Object {}}
+      />
+    </button>
+    <p
+      className="alert alert-success alert--confirm"
+    >
+      <i
+        className="fa fa-check"
+      />
+      <FormattedMessage
+        defaultMessage=" Link copied"
+        id="get_link.clipboard"
+        values={Object {}}
+      />
+    </p>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`components/GetLinkModal should have called onHide 2`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <h4
+      className="modal-title"
+    >
+      title
+    </h4>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <textarea
+      className="form-control no-resize min-height"
+      id="linkModalTextArea"
+      onClick={[Function]}
+      readOnly={true}
+      value="https://mattermost.com"
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-default"
+      id="linkModalCloseButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Close"
+        id="get_link.close"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary pull-left"
+      data-copy-btn="true"
+      id="linkModalCopyLink"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Copy Link"
+        id="get_link.copy"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`components/GetLinkModal should match snapshot when all props is set 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <h4
+      className="modal-title"
+    >
+      title
+    </h4>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <p>
+      help text
+      <br />
+      <br />
+    </p>
+    <textarea
+      className="form-control no-resize min-height"
+      id="linkModalTextArea"
+      onClick={[Function]}
+      readOnly={true}
+      value="https://mattermost.com"
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-default"
+      id="linkModalCloseButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Close"
+        id="get_link.close"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary pull-left"
+      data-copy-btn="true"
+      id="linkModalCopyLink"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Copy Link"
+        id="get_link.copy"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`components/GetLinkModal should match snapshot when helpText is not set 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <h4
+      className="modal-title"
+    >
+      title
+    </h4>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <textarea
+      className="form-control no-resize min-height"
+      id="linkModalTextArea"
+      onClick={[Function]}
+      readOnly={true}
+      value="https://mattermost.com"
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-default"
+      id="linkModalCloseButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Close"
+        id="get_link.close"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary pull-left"
+      data-copy-btn="true"
+      id="linkModalCopyLink"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Copy Link"
+        id="get_link.copy"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;

--- a/tests/components/get_link_modal.test.jsx
+++ b/tests/components/get_link_modal.test.jsx
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+import {Modal} from 'react-bootstrap';
+
+import GetLinkModal from 'components/get_link_modal.jsx';
+
+describe('components/GetLinkModal', () => {
+    test('should match snapshot when all props is set', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <GetLinkModal
+                show={true}
+                onHide={emptyFunction}
+                title={'title'}
+                helpText={'help text'}
+                link={'https://mattermost.com'}
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot when helpText is not set', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <GetLinkModal
+                show={true}
+                onHide={emptyFunction}
+                title={'title'}
+                link={'https://mattermost.com'}
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should have called onHide', () => {
+        const onHide = jest.fn();
+
+        const wrapper = shallow(
+            <GetLinkModal
+                show={true}
+                onHide={onHide}
+                title={'title'}
+                link={'https://mattermost.com'}
+            />
+        );
+
+        wrapper.find(Modal).first().props().onHide();
+        expect(onHide).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/components/get_link_modal.test.jsx
+++ b/tests/components/get_link_modal.test.jsx
@@ -6,53 +6,67 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {Modal} from 'react-bootstrap';
 
+import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+
 import GetLinkModal from 'components/get_link_modal.jsx';
 
 describe('components/GetLinkModal', () => {
+    const onHide = jest.fn();
+    const requiredProps = {
+        show: true,
+        onHide,
+        title: 'title',
+        link: 'https://mattermost.com'
+    };
+
     test('should match snapshot when all props is set', () => {
-        function emptyFunction() {} //eslint-disable-line no-empty-function
+        const helpText = 'help text';
+        const props = {...requiredProps, helpText};
 
         const wrapper = shallow(
-            <GetLinkModal
-                show={true}
-                onHide={emptyFunction}
-                title={'title'}
-                helpText={'help text'}
-                link={'https://mattermost.com'}
-            />
+            <GetLinkModal {...props}/>
         );
 
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot when helpText is not set', () => {
-        function emptyFunction() {} //eslint-disable-line no-empty-function
-
         const wrapper = shallow(
-            <GetLinkModal
-                show={true}
-                onHide={emptyFunction}
-                title={'title'}
-                link={'https://mattermost.com'}
-            />
+            <GetLinkModal {...requiredProps}/>
         );
 
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should have called onHide', () => {
-        const onHide = jest.fn();
+        const newOnHide = jest.fn();
+        const props = {...requiredProps, onHide: newOnHide};
 
         const wrapper = shallow(
-            <GetLinkModal
-                show={true}
-                onHide={onHide}
-                title={'title'}
-                link={'https://mattermost.com'}
-            />
+            <GetLinkModal {...props}/>
         );
 
         wrapper.find(Modal).first().props().onHide();
-        expect(onHide).toHaveBeenCalledTimes(1);
+        expect(newOnHide).toHaveBeenCalledTimes(1);
+        expect(wrapper.state('copiedLink')).toBe(false);
+
+        wrapper.setProps({show: true});
+        wrapper.setState({copiedLink: true});
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.state('copiedLink')).toBe(true);
+
+        wrapper.find('#linkModalCloseButton').simulate('click');
+        expect(newOnHide).toHaveBeenCalledTimes(2);
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.state('copiedLink')).toBe(false);
+    });
+
+    test('should have handle copyLink', () => {
+        const wrapper = mountWithIntl(
+            <GetLinkModal {...requiredProps}/>
+        );
+
+        wrapper.instance().copyLink();
+        expect(wrapper.state('copiedLink')).toBe(true);
     });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -6,17 +6,12 @@ import {configure} from 'enzyme';
 
 configure({adapter: new Adapter()});
 
-var documentMock = (function() {
-    const supportedCommands = ['copy'];
+const supportedCommands = ['copy'];
 
-    return {
-        queryCommandSupported(cmd) {
-            return supportedCommands.includes(cmd);
-        },
-        execCommand(cmd) {
-            return supportedCommands.includes(cmd);
-        }
-    };
-}());
+Object.defineProperty(document, 'queryCommandSupported', {
+  value: (cmd) => supportedCommands.includes(cmd)
+});
 
-Object.defineProperty(window, 'document', {value: documentMock});
+Object.defineProperty(document, 'execCommand', {
+  value: (cmd) => supportedCommands.includes(cmd)
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -5,3 +5,18 @@ import Adapter from 'enzyme-adapter-react-15';
 import {configure} from 'enzyme';
 
 configure({adapter: new Adapter()});
+
+var documentMock = (function() {
+    const supportedCommands = ['copy'];
+
+    return {
+        queryCommandSupported(cmd) {
+            return supportedCommands.includes(cmd);
+        },
+        execCommand(cmd) {
+            return supportedCommands.includes(cmd);
+        }
+    };
+}());
+
+Object.defineProperty(window, 'document', {value: documentMock});


### PR DESCRIPTION
#### Summary

Migrate get link modal to be pure and use Redux.

#### Ticket Link

[mattermost-server/issues/7679](https://github.com/mattermost/mattermost-server/issues/7679)

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
