### PR TITLE
PLT-8005: If full name is not set, username is not preceeded by an @-symbol in user lists

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1057,7 +1057,7 @@ export function displayEntireNameForUser(user) {
         return '';
     }
 
-    let displayName = user.username;
+    let displayName = '@' + user.username;
     const fullName = getFullName(user);
 
     if (fullName && user.nickname) {


### PR DESCRIPTION
#### Summary
Included '@' prefix on usernames in default case when no fullname or nickname are supplied in the user profile

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8005

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes