### PR TITLE
[GH-7674] Migrate pdf_preview.jsx to be pure and use Redux

### DIFF
--- a/components/pdf_preview.jsx
+++ b/components/pdf_preview.jsx
@@ -123,7 +123,7 @@ export default class PDFPreview extends React.PureComponent {
     }
 
     static supports(fileInfo) {
-        return fileInfo.extension === 'pdf';
+        return Boolean(fileInfo && fileInfo.extension && fileInfo.extension === 'pdf');
     }
 
     render() {
@@ -158,7 +158,10 @@ export default class PDFPreview extends React.PureComponent {
 
             if (i < this.state.numPages - 1 && this.state.numPages > 1) {
                 pdfCanvases.push(
-                    <div className='pdf-preview-spacer'/>
+                    <div
+                        key={'previewpdfspacer' + i}
+                        className='pdf-preview-spacer'
+                    />
                 );
             }
         }
@@ -166,6 +169,7 @@ export default class PDFPreview extends React.PureComponent {
         if (this.state.pdf.numPages > MAX_PDF_PAGES) {
             pdfCanvases.push(
                 <a
+                    key='previewpdfmorepages'
                     href={this.props.fileUrl}
                     className='pdf-max-pages'
                 >

--- a/components/pdf_preview.jsx
+++ b/components/pdf_preview.jsx
@@ -13,7 +13,20 @@ import FileInfoPreview from './file_info_preview.jsx';
 
 const MAX_PDF_PAGES = 5;
 
-export default class PDFPreview extends React.Component {
+export default class PDFPreview extends React.PureComponent {
+    static propTypes = {
+
+        /**
+        * Compare file types
+        */
+        fileInfo: PropTypes.object.isRequired,
+
+        /**
+        *  URL of pdf file to output and compare to update props url
+        */
+        fileUrl: PropTypes.string.isRequired
+    }
+
     constructor(props) {
         super(props);
 
@@ -171,8 +184,3 @@ export default class PDFPreview extends React.Component {
         );
     }
 }
-
-PDFPreview.propTypes = {
-    fileInfo: PropTypes.object.isRequired,
-    fileUrl: PropTypes.string.isRequired
-};

--- a/tests/components/__snapshots__/pdf_preview.test.jsx.snap
+++ b/tests/components/__snapshots__/pdf_preview.test.jsx.snap
@@ -1,6 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`component/PDFPreview should match snapshot success file loading 1`] = `
+exports[`component/PDFPreview should match snapshot, loaded with FileInfoPreview 1`] = `
+<FileInfoPreview
+  fileInfo={
+    Object {
+      "extension": "pdf",
+    }
+  }
+  fileUrl="https://pre-release.mattermost.com/api/v4/files/ips59w4w9jnfbrs3o94m1dbdie"
+/>
+`;
+
+exports[`component/PDFPreview should match snapshot, loading 1`] = `
 <div
   className="view-image__loading"
 >

--- a/tests/components/__snapshots__/pdf_preview.test.jsx.snap
+++ b/tests/components/__snapshots__/pdf_preview.test.jsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`component/PDFPreview should match snapshot success file loading 1`] = `
+<div
+  className="view-image__loading"
+>
+  <img
+    className="loader-image"
+    src={null}
+  />
+</div>
+`;

--- a/tests/components/pdf_preview.test.jsx
+++ b/tests/components/pdf_preview.test.jsx
@@ -1,25 +1,92 @@
-import React from 'react';
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
 
+import React from 'react';
 import {shallow} from 'enzyme';
 
 import PDFPreview from 'components/pdf_preview.jsx';
+import FileInfoPreview from 'components/file_info_preview.jsx';
 
 jest.mock('pdfjs-dist', () => ({
-    getDocument: () => Promise.resolve()
+    getDocument: () => Promise.resolve({
+        numPages: 3,
+        getPage: (i) => Promise.resolve({
+            pageIndex: i,
+            getContext: (s) => Promise.resolve({s})
+        })
+    })
 }));
 
 describe('component/PDFPreview', () => {
+    const requiredProps = {
+        fileInfo: {extension: 'pdf'},
+        fileUrl: 'https://pre-release.mattermost.com/api/v4/files/ips59w4w9jnfbrs3o94m1dbdie'
+    };
+
     afterAll(() => {
         jest.clearAllMocks();
     });
 
-    test('should match snapshot success file loading', () => {
-        const wrraper = shallow(
-            <PDFPreview
-                fileInfo={{extension: 'pdf'}}
-                fileUrl={'http://www.test/api/v4/files/fzf6j6j18jgizngsb43wg1k4na'}
-            />
+    test('should match snapshot, loading', () => {
+        const wrapper = shallow(
+            <PDFPreview {...requiredProps}/>
         );
-        expect(wrraper).toMatchSnapshot();
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, loaded with FileInfoPreview', () => {
+        const wrapper = shallow(
+            <PDFPreview {...requiredProps}/>
+        );
+        wrapper.setState({loading: false});
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(FileInfoPreview).exists()).toBe(true);
+    });
+
+    test('should return correct state when updateStateFromProps is called', () => {
+        const wrapper = shallow(
+            <PDFPreview {...requiredProps}/>
+        );
+
+        wrapper.instance().updateStateFromProps(requiredProps);
+        expect(wrapper.state('pdf')).toBe(null);
+        expect(wrapper.state('pdfPages')).toEqual({});
+        expect(wrapper.state('pdfPagesLoaded')).toEqual({});
+        expect(wrapper.state('numPages')).toEqual(0);
+        expect(wrapper.state('loading')).toBe(true);
+        expect(wrapper.state('success')).toBe(false);
+    });
+
+    test('should return correct state when onDocumentLoad is called', () => {
+        const wrapper = shallow(
+            <PDFPreview {...requiredProps}/>
+        );
+
+        let pdf = {numPages: 0};
+        wrapper.instance().onDocumentLoad(pdf);
+        expect(wrapper.state('pdf')).toEqual(pdf);
+        expect(wrapper.state('numPages')).toEqual(pdf.numPages);
+
+        const MAX_PDF_PAGES = 5;
+        pdf = {
+            numPages: 6,
+            getPage: (i) => Promise.resolve(i)
+        };
+        wrapper.instance().onDocumentLoad(pdf);
+        expect(wrapper.state('pdf')).toEqual(pdf);
+        expect(wrapper.state('numPages')).toEqual(MAX_PDF_PAGES);
+    });
+
+    test('should pass supports', () => {
+        const testFileInfos = [
+            {fileInfo: null, output: false},
+            {fileInfo: {}, output: false},
+            {fileInfo: {extension: 'other'}, output: false},
+            {fileInfo: {extension: 'pdf'}, output: true}
+        ];
+
+        testFileInfos.forEach((testFileInfo) => {
+            expect(PDFPreview.supports(testFileInfo.fileInfo)).toEqual(testFileInfo.output);
+        });
     });
 });

--- a/tests/components/pdf_preview.test.jsx
+++ b/tests/components/pdf_preview.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import PDFPreview from 'components/pdf_preview.jsx';
+
+jest.mock('pdfjs-dist', () => ({
+    getDocument: () => Promise.resolve()
+}));
+
+describe('component/PDFPreview', () => {
+    afterAll(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should match snapshot success file loading', () => {
+        const wrraper = shallow(
+            <PDFPreview
+                fileInfo={{extension: 'pdf'}}
+                fileUrl={'http://www.test/api/v4/files/fzf6j6j18jgizngsb43wg1k4na'}
+            />
+        );
+        expect(wrraper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
Migrate pdf_preview component to redux

#### Ticket Link
GitHub: https://github.com/mattermost/mattermost-server/issues/7674
Jira: https://mattermost.atlassian.net/browse/PLT-7674

#### Checklist
- [x] Added or updated unit tests
