### PR TITLE
PLT-8003: CTRL+/ should toggle keyboard shortcuts dialog

### DIFF
--- a/actions/channel_actions.jsx
+++ b/actions/channel_actions.jsx
@@ -66,7 +66,7 @@ export function executeCommand(message, args, success, error) {
             return;
         }
 
-        GlobalActions.showShortcutsModal();
+        GlobalActions.toggleShortcutsModal();
         return;
     case '/leave': {
         // /leave command not supported in reply threads.

--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -196,7 +196,7 @@ export function showAccountSettingsModal() {
     });
 }
 
-export function showShortcutsModal() {
+export function toggleShortcutsModal() {
     AppDispatcher.handleViewAction({
         type: ActionTypes.TOGGLE_SHORTCUTS_MODAL,
         value: true

--- a/components/create_post.jsx
+++ b/components/create_post.jsx
@@ -450,7 +450,7 @@ export default class CreatePost extends React.Component {
         if ((e.ctrlKey || e.metaKey) && e.keyCode === Constants.KeyCodes.FORWARD_SLASH) {
             e.preventDefault();
 
-            GlobalActions.showShortcutsModal();
+            GlobalActions.toggleShortcutsModal();
         }
     }
 

--- a/components/shortcuts_modal.jsx
+++ b/components/shortcuts_modal.jsx
@@ -259,9 +259,10 @@ class ShortcutsModal extends React.PureComponent {
         ModalStore.removeModalListener(Constants.ActionTypes.TOGGLE_SHORTCUTS_MODAL, this.handleToggle);
     }
 
-    handleToggle = (value) => {
+    handleToggle = () => {
+        //toggles the state of shortcut dialog
         this.setState({
-            show: value
+            show: !this.state.show
         });
     }
 

--- a/components/sidebar_header_dropdown.jsx
+++ b/components/sidebar_header_dropdown.jsx
@@ -52,7 +52,7 @@ export default class SidebarHeaderDropdown extends React.Component {
         this.showGetTeamInviteLinkModal = this.showGetTeamInviteLinkModal.bind(this);
         this.showTeamMembersModal = this.showTeamMembersModal.bind(this);
         this.hideTeamMembersModal = this.hideTeamMembersModal.bind(this);
-        this.showShortcutsModal = this.showShortcutsModal.bind(this);
+        this.toggleShortcutsModal = this.toggleShortcutsModal.bind(this);
 
         this.onTeamChange = this.onTeamChange.bind(this);
 
@@ -111,11 +111,11 @@ export default class SidebarHeaderDropdown extends React.Component {
         GlobalActions.showAccountSettingsModal();
     }
 
-    showShortcutsModal(e) {
+    toggleShortcutsModal(e) {
         e.preventDefault();
         this.setState({showDropdown: false});
 
-        GlobalActions.showShortcutsModal();
+        GlobalActions.toggleShortcutsModal();
     }
 
     showAddUsersToTeamModal(e) {
@@ -513,7 +513,7 @@ export default class SidebarHeaderDropdown extends React.Component {
                 <button
                     className='style--none'
                     id='keyboardShortcuts'
-                    onClick={this.showShortcutsModal}
+                    onClick={this.toggleShortcutsModal}
                 >
                     <FormattedMessage
                         id='navbar_dropdown.keyboardShortcuts'


### PR DESCRIPTION
#### Summary
Earlier ctrl+/ used to show 'Keyboard shortcuts' dialog but didn't hide dialog box. Fixed to toggle the dialog box to show and hide. @jasonblais

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8003
#7751 
#### Checklist

- [] Added or updated unit tests (required for all new features)
- [] Has server changes (please link)
- [] Has redux changes (please link)
- [x] Has UI changes
- [] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [] Touches critical sections of the codebase (auth, posting, etc.)
