### PR TITLE
 Use default color for dnd indicator if not set in theme

### DIFF
--- a/sass/components/_status-icon.scss
+++ b/sass/components/_status-icon.scss
@@ -82,6 +82,10 @@
         }
     }
 
+    .dnd--icon {
+        fill: rgb(247, 67, 67);
+    }
+
     svg {
         max-height: 14px;
     }
@@ -107,4 +111,3 @@
         top: -1px;
     }
 }
-

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -579,18 +579,18 @@ export function applyTheme(theme) {
         dndIndicator = theme.dndIndicator;
     } else {
         switch (theme.type) {
-            case 'Organization':
-                dndIndicator = Constants.THEMES.organization.dndIndicator
-                break;
-            case 'Mattermost Dark':
-                dndIndicator = Constants.THEMES.mattermostDark.dndIndicator
-                break;
-            case 'Windows Dark':
-                dndIndicator = Constants.THEMES.windows10.dndIndicator
-                break;
-            default:
-                dndIndicator = Constants.THEMES.default.dndIndicator;
-                break;
+        case 'Organization':
+            dndIndicator = Constants.THEMES.organization.dndIndicator;
+            break;
+        case 'Mattermost Dark':
+            dndIndicator = Constants.THEMES.mattermostDark.dndIndicator;
+            break;
+        case 'Windows Dark':
+            dndIndicator = Constants.THEMES.windows10.dndIndicator;
+            break;
+        default:
+            dndIndicator = Constants.THEMES.default.dndIndicator;
+            break;
         }
     }
     changeCss('.app__body .status.status--dnd', 'color:' + dndIndicator);

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -574,10 +574,27 @@ export function applyTheme(theme) {
         changeCss('.app__body .status .away--icon', 'fill:' + theme.awayIndicator);
     }
 
+    let dndIndicator;
     if (theme.dndIndicator) {
-        changeCss('.app__body .status.status--dnd', 'color:' + theme.dndIndicator);
-        changeCss('.app__body .status .dnd--icon', 'fill:' + theme.dndIndicator);
+        dndIndicator = theme.dndIndicator;
+    } else {
+        switch (theme.type) {
+            case 'Organization':
+                dndIndicator = Constants.THEMES.organization.dndIndicator
+                break;
+            case 'Mattermost Dark':
+                dndIndicator = Constants.THEMES.mattermostDark.dndIndicator
+                break;
+            case 'Windows Dark':
+                dndIndicator = Constants.THEMES.windows10.dndIndicator
+                break;
+            default:
+                dndIndicator = Constants.THEMES.default.dndIndicator;
+                break;
+        }
     }
+    changeCss('.app__body .status.status--dnd', 'color:' + dndIndicator);
+    changeCss('.app__body .status .dnd--icon', 'fill:' + dndIndicator);
 
     if (theme.mentionBj) {
         changeCss('.sidebar--left .nav-pills__unread-indicator', 'background:' + theme.mentionBj);


### PR DESCRIPTION
#### Summary
Use default color for dnd indicator if not set in theme. This isn't a proper solution to https://mattermost.atlassian.net/browse/PLT-2068 but it will patch it for the dnd feature.