### PR TITLE
Remove helpTextContainer check in centerPage e2e test

### DIFF
--- a/tests/e2e/tests/2_center/centerPage.element.js
+++ b/tests/e2e/tests/2_center/centerPage.element.js
@@ -34,7 +34,6 @@ module.exports = {
             .assert.visible('@postTextbox')
             .assert.visible('@fileUploadButton')
             .assert.visible('@emojiPickerButton')
-            .assert.visible('@helpTextContainer')
             .assert.visible('@helpTextLink')
             .assert.hidden('@helpText')
             .assert.visible('@postCreateFooter');


### PR DESCRIPTION
The helpTextContainer was removed in the commit 5605fa952a4d682b13b3f0939d9b6b4e5e3c219b