### PR TITLE
Removed unneeded BrowserStore usage

### DIFF
--- a/components/edit_post_modal.jsx
+++ b/components/edit_post_modal.jsx
@@ -10,7 +10,6 @@ import * as Selectors from 'mattermost-redux/selectors/entities/posts';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {updatePost} from 'actions/post_actions.jsx';
-import BrowserStore from 'stores/browser_store.jsx';
 import MessageHistoryStore from 'stores/message_history_store.jsx';
 import PostStore from 'stores/post_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
@@ -128,9 +127,6 @@ export default class EditPostModal extends React.Component {
         MessageHistoryStore.storeMessageInHistory(updatedPost.message);
 
         if (updatedPost.message.trim().length === 0) {
-            var tempState = this.state;
-            Reflect.deleteProperty(tempState, 'editText');
-            BrowserStore.setItem('edit_state_transfer', tempState);
             $('#edit_post').modal('hide');
             GlobalActions.showDeletePostModal(Selectors.getPost(getState(), this.state.post_id), this.state.comments);
             return;


### PR DESCRIPTION
Removed the setItem of 'post_state_transfer' key, which is not used anywhere in
the rest of the mattermost-webapp source code.

I tried to deep in the repository to know where it comes from, but in the first
commit of the current directory is already there and I did't find any getItem
which access to it.