### PR TITLE
PLT-8028: fix town square loading on team change

### DIFF
--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -125,10 +125,10 @@ export default class Sidebar extends React.Component {
 
     componentDidUpdate(prevProps, prevState) {
         // if the active channel disappeared (which can happen when dm channels autoclose), go to town square
-        if (this.state.currentTeam === prevState.currentTeam
-            && this.state.activeId === prevState.activeId
-            && !this.stateDisplaysChannelId(this.state, this.state.activeId)
-            && this.stateDisplaysChannelId(prevState, this.state.activeId)
+        if (this.state.currentTeam === prevState.currentTeam &&
+            this.state.activeId === prevState.activeId &&
+            !this.channelIdIsDisplayedForState(this.state, this.state.activeId) &&
+            this.channelIdIsDisplayedForState(prevState, this.state.activeId)
         ) {
             this.closedDirectChannel = true;
             browserHistory.push('/' + this.state.currentTeam.name + '/channels/town-square');
@@ -354,14 +354,14 @@ export default class Sidebar extends React.Component {
     }
 
     getDisplayedChannels = () => {
-        return getDisplayedChannelsForState(this.state);
+        return this.getDisplayedChannelsForState(this.state);
     }
 
     getDisplayedChannelsForState = (state) => {
         return state.favoriteChannels.concat(state.publicChannels).concat(state.privateChannels).concat(state.directAndGroupChannels);
     }
 
-    stateDisplaysChannelId = (state, id) => {
+    channelIdIsDisplayedForState = (state, id) => {
         const allChannels = this.getDisplayedChannelsForState(state);
         for (let i = 0; i < allChannels.length; i++) {
             if (allChannels[i].id === id) {

--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -124,15 +124,12 @@ export default class Sidebar extends React.Component {
     }
 
     componentDidUpdate(prevProps, prevState) {
-        const allChannels = this.getDisplayedChannels();
-        let isDisplayingChannel = false;
-        for (let i = 0; i < allChannels.length; i++) {
-            if (allChannels[i].id === this.state.activeId) {
-                isDisplayingChannel = true;
-                break;
-            }
-        }
-        if (!isDisplayingChannel) {
+        // if the active channel disappeared (which can happen when dm channels autoclose), go to town square
+        if (this.state.currentTeam === prevState.currentTeam
+            && this.state.activeId === prevState.activeId
+            && !this.stateDisplaysChannelId(this.state, this.state.activeId)
+            && this.stateDisplaysChannelId(prevState, this.state.activeId)
+        ) {
             this.closedDirectChannel = true;
             browserHistory.push('/' + this.state.currentTeam.name + '/channels/town-square');
             return;
@@ -357,7 +354,21 @@ export default class Sidebar extends React.Component {
     }
 
     getDisplayedChannels = () => {
-        return this.state.favoriteChannels.concat(this.state.publicChannels).concat(this.state.privateChannels).concat(this.state.directAndGroupChannels);
+        return getDisplayedChannelsForState(this.state);
+    }
+
+    getDisplayedChannelsForState = (state) => {
+        return state.favoriteChannels.concat(state.publicChannels).concat(state.privateChannels).concat(state.directAndGroupChannels);
+    }
+
+    stateDisplaysChannelId = (state, id) => {
+        const allChannels = this.getDisplayedChannelsForState(state);
+        for (let i = 0; i < allChannels.length; i++) {
+            if (allChannels[i].id === id) {
+                return true;
+            }
+        }
+        return false;
     }
 
     handleLeavePublicChannel = (e, channel) => {


### PR DESCRIPTION
#### Summary
This code was intended to redirect the user to town square if the channel they were looking at disappeared (e.g. due to a sidebar settings change). This makes the condition that triggers that redirect much better.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8028

#### Checklist
N/A