### PR TITLE
Migrate rename_channel_modal.jsx to use Redux

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -30,7 +30,7 @@ import EditChannelHeaderModal from 'components/edit_channel_header_modal';
 import EditChannelPurposeModal from 'components/edit_channel_purpose_modal';
 import MessageWrapper from 'components/message_wrapper.jsx';
 import PopoverListMembers from 'components/popover_list_members';
-import RenameChannelModal from 'components/rename_channel_modal.jsx';
+import RenameChannelModal from 'components/rename_channel_modal';
 import NavbarSearchBox from 'components/search_bar.jsx';
 import StatusIcon from 'components/status_icon.jsx';
 import ToggleModalButton from 'components/toggle_modal_button.jsx';

--- a/components/navbar/index.jsx
+++ b/components/navbar/index.jsx
@@ -35,7 +35,7 @@ import DeleteChannelModal from 'components/delete_channel_modal';
 
 import NotifyCounts from 'components/notify_counts.jsx';
 import QuickSwitchModal from 'components/quick_switch_modal';
-import RenameChannelModal from 'components/rename_channel_modal.jsx';
+import RenameChannelModal from 'components/rename_channel_modal';
 import StatusIcon from 'components/status_icon.jsx';
 import ToggleModalButton from 'components/toggle_modal_button.jsx';
 

--- a/components/rename_channel_modal/index.js
+++ b/components/rename_channel_modal/index.js
@@ -18,14 +18,7 @@ const mapStateToProps = createSelector(
             team: getTeam(state, currentTeamId)
         };
     },
-    ({requests}) => {
-        const {channels: {updateChannel}} = requests;
-        return {
-            serverError: updateChannel.error,
-            requestStatus: updateChannel.status
-        };
-    },
-    (teamInfo, requestInfo) => ({...teamInfo, ...requestInfo})
+    (teamInfo) => ({...teamInfo})
 );
 
 function mapDispatchToProps(dispatch) {

--- a/components/rename_channel_modal/index.js
+++ b/components/rename_channel_modal/index.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+import {createSelector} from 'reselect';
+import {updateChannel as UpdateChannel} from 'mattermost-redux/actions/channels';
+
+import {getCurrentTeamUrl, getTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import RenameChannelModal from './rename_channel_modal.jsx';
+
+const mapStateToProps = createSelector(
+    (state) => {
+        const currentTeamId = state.entities.teams.currentTeamId;
+        return {
+            currentTeamUrl: getCurrentTeamUrl(state),
+            team: getTeam(state, currentTeamId)
+        };
+    },
+    ({requests}) => {
+        const {channels: {updateChannel}} = requests;
+        return {
+            serverError: updateChannel.error,
+            requestStatus: updateChannel.status
+        };
+    },
+    (teamInfo, requestInfo) => ({...teamInfo, ...requestInfo})
+);
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: {
+            updateChannel: bindActionCreators(UpdateChannel, dispatch)
+        }
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(RenameChannelModal);

--- a/components/rename_channel_modal/rename_channel_modal.jsx
+++ b/components/rename_channel_modal/rename_channel_modal.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {Modal, OverlayTrigger, Tooltip} from 'react-bootstrap';
 import ReactDOM from 'react-dom';
 import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
-import {RequestStatus} from 'mattermost-redux/constants';
 import {browserHistory} from 'react-router/es6';
 
 import Constants from 'utils/constants.jsx';
@@ -66,16 +65,6 @@ export class RenameChannelModal extends React.PureComponent {
          * Object with info about current channel
          */
         channel: PropTypes.object.isRequired,
-
-        /**
-         * Status of patch info about channel request
-         */
-        requestStatus: PropTypes.string,
-
-        /**
-         * Info about patch serverError
-         */
-        serverError: PropTypes.object,
 
         /**
          * Object with info about current team

--- a/components/rename_channel_modal/rename_channel_modal.jsx
+++ b/components/rename_channel_modal/rename_channel_modal.jsx
@@ -113,25 +113,11 @@ export class RenameChannelModal extends React.PureComponent {
     }
 
     componentWillReceiveProps(nextProps) {
-        const {requestStatus: nextRequestStatus, serverError: nextServerError} = nextProps;
-        const {requestStatus, team} = this.props;
-
         if (!Utils.areObjectsEqual(nextProps.channel, this.props.channel)) {
             this.setState({
                 displayName: nextProps.channel.display_name,
                 channelName: nextProps.channel.name
             });
-        }
-
-        if (requestStatus !== nextRequestStatus && nextRequestStatus === RequestStatus.SUCCESS) {
-            this.handleHide();
-            browserHistory.push('/' + team.name + '/channels/' + this.state.channelName);
-        }
-
-        if (requestStatus !== nextRequestStatus && nextRequestStatus === RequestStatus.FAILURE) {
-            this.setError(nextServerError);
-        } else {
-            this.unsetError();
         }
     }
 
@@ -170,7 +156,7 @@ export class RenameChannelModal extends React.PureComponent {
         });
     }
 
-    handleSubmit = (e) => {
+    handleSubmit = async (e) => {
         if (e) {
             e.preventDefault();
         }
@@ -180,7 +166,7 @@ export class RenameChannelModal extends React.PureComponent {
         const oldDisplayName = channel.display_name;
         const state = {serverError: ''};
         const {formatMessage} = this.props.intl;
-        const {actions: {updateChannel}} = this.props;
+        const {actions: {updateChannel}, team} = this.props;
 
         channel.display_name = this.state.displayName.trim();
         if (!channel.display_name) {
@@ -227,7 +213,15 @@ export class RenameChannelModal extends React.PureComponent {
             return;
         }
 
-        updateChannel(channel);
+        const {data, error} = await updateChannel(channel);
+
+        if (data) {
+            this.handleHide();
+            this.unsetError();
+            browserHistory.push('/' + team.name + '/channels/' + this.state.channelName);
+        } else if (error) {
+            this.setError(error);
+        }
     }
 
     handleCancel = (e) => {

--- a/tests/components/__snapshots__/rename_channel_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/rename_channel_modal.test.jsx.snap
@@ -1,0 +1,154 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/rename_channel_modal/rename_channel_modal.jsx should match snapshot 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Rename Channel"
+        id="rename_channel.title"
+        values={Object {}}
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <form
+    role="form"
+  >
+    <ModalBody
+      bsClass="modal-body"
+      componentClass="div"
+    >
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label"
+        >
+          <FormattedMessage
+            defaultMessage="Display Name"
+            id="rename_channel.displayName"
+            values={Object {}}
+          />
+        </label>
+        <input
+          className="form-control"
+          id="display_name"
+          maxLength={22}
+          onChange={[Function]}
+          placeholder="Enter display name"
+          type="text"
+          value="Fake Channel"
+        />
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label"
+        >
+          URL
+        </label>
+        <div
+          className="input-group input-group--limit"
+        >
+          <OverlayTrigger
+            defaultOverlayShown={false}
+            delayShow={400}
+            overlay={
+              <Tooltip
+                bsClass="tooltip"
+                id="urlTooltip"
+                placement="right"
+              >
+                fake-channel/channels
+              </Tooltip>
+            }
+            placement="top"
+            trigger={
+              Array [
+                "hover",
+                "focus",
+              ]
+            }
+          >
+            <span
+              className="input-group-addon"
+            >
+              fake-channel/channels/
+            </span>
+          </OverlayTrigger>
+          <input
+            className="form-control"
+            id="channel_name"
+            maxLength={22}
+            onChange={[Function]}
+            placeholder="lowercase alphanumeric characters"
+            readOnly={false}
+            type="text"
+            value="fake-channel"
+          />
+        </div>
+      </div>
+    </ModalBody>
+    <ModalFooter
+      bsClass="modal-footer"
+      componentClass="div"
+    >
+      <button
+        className="btn btn-default"
+        onClick={[Function]}
+        type="button"
+      >
+        <FormattedMessage
+          defaultMessage="Cancel"
+          id="rename_channel.cancel"
+          values={Object {}}
+        />
+      </button>
+      <button
+        className="btn btn-primary"
+        id="save-button"
+        onClick={[Function]}
+        type="submit"
+      >
+        <FormattedMessage
+          defaultMessage="Save"
+          id="rename_channel.save"
+          values={Object {}}
+        />
+      </button>
+    </ModalFooter>
+  </form>
+</Modal>
+`;

--- a/tests/components/rename_channel_modal.test.jsx
+++ b/tests/components/rename_channel_modal.test.jsx
@@ -9,6 +9,7 @@ import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import RenameChannelModal from 'components/rename_channel_modal/rename_channel_modal.jsx';
 
 describe('components/rename_channel_modal/rename_channel_modal.jsx', () => {
+    global.window.mm_config = {};
     const channel = {
         id: 'fake-id',
         name: 'fake-channel',
@@ -19,35 +20,39 @@ describe('components/rename_channel_modal/rename_channel_modal.jsx', () => {
         name: 'Fake Team', display_name: 'fake-team', type: 'O'
     };
 
-    function emptyFunction() {} //eslint-disable-line no-empty-function
+    const baseProps = {
+        show: true,
+        onHide: jest.fn(),
+        channel: {...channel},
+        requestStatus: RequestStatus.NOT_STARTED,
+        team: {...team},
+        currentTeamUrl: 'fake-channel',
+        actions: {updateChannel: jest.fn()}
+    };
+
+    afterEach(() => {
+        global.window.mm_config = {};
+    });
+
+    beforeEach(() => {
+        global.window.mm_config.EnableLinkPreviews = 'true';
+        global.window.mm_config.EnableThemeSelection = 'false';
+        global.window.mm_config.DefaultClientLocale = 'en';
+    });
 
     test('should match snapshot', () => {
         const wrapper = shallowWithIntl(
-            <RenameChannelModal
-                show={true}
-                onHide={emptyFunction}
-                channel={channel}
-                requestStatus={RequestStatus.NOT_STARTED}
-                team={team}
-                currentTeamUrl={'fake-channel'}
-                actions={{updateChannel: emptyFunction}}
-            />
+            <RenameChannelModal {...baseProps}/>
         ).dive({disableLifecycleMethods: true});
+
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should submit form', () => {
-        const updateChannel = jest.fn();
+        const {actions: {updateChannel}} = baseProps;
+        const props = {...baseProps, requestStatus: RequestStatus.STARTED};
         const wrapper = shallowWithIntl(
-            <RenameChannelModal
-                show={true}
-                onHide={emptyFunction}
-                channel={channel}
-                requestStatus={RequestStatus.STARTED}
-                team={team}
-                currentTeamUrl={'fake-channel'}
-                actions={{updateChannel: emptyFunction}}
-            />
+            <RenameChannelModal {...props}/>
         ).dive({disableLifecycleMethods: true});
 
         wrapper.find('#save-button').simulate('click');
@@ -56,17 +61,9 @@ describe('components/rename_channel_modal/rename_channel_modal.jsx', () => {
     });
 
     test('should not call updateChannel as channel.name.length > Constants.MAX_CHANNELNAME_LENGTH (22)', () => {
-        const updateChannel = jest.fn();
+        const {actions: {updateChannel}} = baseProps;
         const wrapper = shallowWithIntl(
-            <RenameChannelModal
-                show={true}
-                onHide={emptyFunction}
-                channel={channel}
-                requestStatus={RequestStatus.NOT_STARTED}
-                team={team}
-                currentTeamUrl={'fake-channel'}
-                actions={{updateChannel: emptyFunction}}
-            />
+            <RenameChannelModal {...baseProps}/>
         ).dive({disableLifecycleMethods: true});
 
         wrapper.find('#display_name').simulate(
@@ -80,15 +77,7 @@ describe('components/rename_channel_modal/rename_channel_modal.jsx', () => {
 
     test('should change state when display_name is edited', () => {
         const wrapper = shallowWithIntl(
-            <RenameChannelModal
-                show={true}
-                onHide={emptyFunction}
-                channel={channel}
-                requestStatus={RequestStatus.NOT_STARTED}
-                team={team}
-                currentTeamUrl={'fake-channel'}
-                actions={{updateChannel: emptyFunction}}
-            />
+            <RenameChannelModal {...baseProps}/>
         ).dive({disableLifecycleMethods: true});
 
         wrapper.find('#display_name').simulate(
@@ -96,5 +85,87 @@ describe('components/rename_channel_modal/rename_channel_modal.jsx', () => {
         );
 
         expect(wrapper.state('displayName')).toBe('New Fake Channel');
+    });
+
+    test('should call componentWillReceiveProps', () => {
+        const nextProps = {...baseProps, channel: {display_name: 'Changed Name', name: 'changed-name'}};
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal {...baseProps}/>
+        ).dive({disableLifecycleMethods: true});
+
+        wrapper.setProps(nextProps);
+        expect(wrapper.state('displayName')).toBe('Changed Name');
+    });
+
+    test('should call setError function', () => {
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal {...baseProps}/>
+        ).dive({disableLifecycleMethods: true});
+
+        const instance = wrapper.instance();
+
+        instance.setError({message: 'This is an error message'});
+        expect(wrapper.state('serverError')).toBe('This is an error message');
+    });
+
+    test('should call unsetError function', () => {
+        const props = {...baseProps, serverError: {message: 'This is an error message'}};
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal {...props}/>
+        ).dive({disableLifecycleMethods: true});
+
+        wrapper.setState({serverError: props.serverError.message});
+        expect(wrapper.state('serverError')).toBe('This is an error message');
+
+        wrapper.find('#save-button').simulate('click');
+        expect(wrapper.state('serverError')).toBe('');
+    });
+
+    test('should call handleSubmit function', () => {
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal {...baseProps}/>
+        ).dive({disableLifecycleMethods: true});
+
+        wrapper.setState({displayName: 'Changed Name', channelName: 'changed-name'});
+
+        const instance = wrapper.instance();
+        instance.handleSubmit();
+
+        expect(wrapper.state('displayName')).toBe('Changed Name');
+        expect(wrapper.state('channelName')).toBe('changed-name');
+    });
+
+    test('should call handleCancel', () => {
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal {...baseProps}/>
+        ).dive({disableLifecycleMethods: true});
+
+        const instance = wrapper.instance();
+        instance.handleCancel();
+
+        expect(wrapper.state('show')).toBeFalsy();
+    });
+
+    test('should call handleHide function', () => {
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal {...baseProps}/>
+        ).dive({disableLifecycleMethods: true});
+
+        const instance = wrapper.instance();
+        instance.handleHide();
+
+        expect(wrapper.state('show')).toBeFalsy();
+    });
+
+    test('should call onNameChange function', () => {
+        const changedName = {target: {value: 'changed-name'}};
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal {...baseProps}/>
+        ).dive({disableLifecycleMethods: true});
+
+        const instance = wrapper.instance();
+        instance.onNameChange(changedName);
+
+        expect(wrapper.state('channelName')).toBe('changed-name');
     });
 });

--- a/tests/components/rename_channel_modal.test.jsx
+++ b/tests/components/rename_channel_modal.test.jsx
@@ -30,16 +30,6 @@ describe('components/rename_channel_modal/rename_channel_modal.jsx', () => {
         actions: {updateChannel: jest.fn()}
     };
 
-    afterEach(() => {
-        global.window.mm_config = {};
-    });
-
-    beforeEach(() => {
-        global.window.mm_config.EnableLinkPreviews = 'true';
-        global.window.mm_config.EnableThemeSelection = 'false';
-        global.window.mm_config.DefaultClientLocale = 'en';
-    });
-
     test('should match snapshot', () => {
         const wrapper = shallowWithIntl(
             <RenameChannelModal {...baseProps}/>

--- a/tests/components/rename_channel_modal.test.jsx
+++ b/tests/components/rename_channel_modal.test.jsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {RequestStatus} from 'mattermost-redux/constants';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
+
+import RenameChannelModal from 'components/rename_channel_modal/rename_channel_modal.jsx';
+
+describe('components/rename_channel_modal/rename_channel_modal.jsx', () => {
+    const channel = {
+        id: 'fake-id',
+        name: 'fake-channel',
+        display_name: 'Fake Channel'
+    };
+
+    const team = {
+        name: 'Fake Team', display_name: 'fake-team', type: 'O'
+    };
+
+    function emptyFunction() {} //eslint-disable-line no-empty-function
+
+    test('should match snapshot', () => {
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal
+                show={true}
+                onHide={emptyFunction}
+                channel={channel}
+                requestStatus={RequestStatus.NOT_STARTED}
+                team={team}
+                currentTeamUrl={'fake-channel'}
+                actions={{updateChannel: emptyFunction}}
+            />
+        ).dive({disableLifecycleMethods: true});
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should submit form', () => {
+        const updateChannel = jest.fn();
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal
+                show={true}
+                onHide={emptyFunction}
+                channel={channel}
+                requestStatus={RequestStatus.STARTED}
+                team={team}
+                currentTeamUrl={'fake-channel'}
+                actions={{updateChannel: emptyFunction}}
+            />
+        ).dive({disableLifecycleMethods: true});
+
+        wrapper.find('#save-button').simulate('click');
+
+        expect(updateChannel).not.toHaveBeenCalled();
+    });
+
+    test('should not call updateChannel as channel.name.length > Constants.MAX_CHANNELNAME_LENGTH (22)', () => {
+        const updateChannel = jest.fn();
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal
+                show={true}
+                onHide={emptyFunction}
+                channel={channel}
+                requestStatus={RequestStatus.NOT_STARTED}
+                team={team}
+                currentTeamUrl={'fake-channel'}
+                actions={{updateChannel: emptyFunction}}
+            />
+        ).dive({disableLifecycleMethods: true});
+
+        wrapper.find('#display_name').simulate(
+            'change', {preventDefault: jest.fn(), target: {value: 'string-above-twentytwo-characters'}}
+        );
+
+        wrapper.find('#save-button').simulate('click');
+
+        expect(updateChannel).not.toHaveBeenCalled();
+    });
+
+    test('should change state when display_name is edited', () => {
+        const wrapper = shallowWithIntl(
+            <RenameChannelModal
+                show={true}
+                onHide={emptyFunction}
+                channel={channel}
+                requestStatus={RequestStatus.NOT_STARTED}
+                team={team}
+                currentTeamUrl={'fake-channel'}
+                actions={{updateChannel: emptyFunction}}
+            />
+        ).dive({disableLifecycleMethods: true});
+
+        wrapper.find('#display_name').simulate(
+            'change', {preventDefault: jest.fn(), target: {value: 'New Fake Channel'}}
+        );
+
+        expect(wrapper.state('displayName')).toBe('New Fake Channel');
+    });
+});


### PR DESCRIPTION

#### Summary
Migrated `rename_channel_modal.jsx` to Redux and added tests

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7677

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)