### PR TITLE
Fixed mixup between channel_utils.jsx and the redux version

### DIFF
--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -734,10 +734,7 @@ export default class Sidebar extends React.Component {
         this.lastUnreadChannel = null;
 
         // create elements for all 4 types of channels
-        const visibleFavoriteChannels = this.state.favoriteChannels.
-            filter((channel) => {
-                return ChannelUtils.isOpenChannel(channel) || ChannelUtils.isPrivateChannel(channel) || ChannelUtils.isDirectChannelVisible(channel) || ChannelUtils.isGroupChannelVisible(channel);
-            });
+        const visibleFavoriteChannels = this.state.favoriteChannels.filter(ChannelUtils.isChannelVisible);
 
         const favoriteItems = visibleFavoriteChannels.
             map((channel, index, arr) => {


### PR DESCRIPTION
The sidebar was trying to call functions that only existed in the redux library on the webapp version of ChannelUtils. It was also passing in incorrect arguments as well.

The two functions I marked with TODOs should be replaced by the mattermost-redux versions, but those ones aren't exported, so I didn't want to hold up fixing master for a redux PR.