### PR TITLE
Fixed channel name not showing for public and private channels

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -250,7 +250,7 @@ export default class ChannelHeader extends React.Component {
             </Popover>
         );
 
-        let channelTitle = '';
+        let channelTitle = channel.display_name;
         const isChannelAdmin = Utils.isChannelAdmin(this.props.channelMember.roles);
         const isTeamAdmin = !Utils.isEmptyObject(this.props.teamMember) && Utils.isAdmin(this.props.teamMember.roles);
         const isSystemAdmin = Utils.isSystemAdmin(this.props.currentUser.roles);


### PR DESCRIPTION
The channelTitle variable was only being set for direct and group channels