### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -10,9 +10,10 @@ When filling in a section please remove the help text and the above text.
 
 #### Checklist
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
+- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
 - [ ] Added or updated unit tests (required for all new features)
 - [ ] Has server changes (please link)
 - [ ] Has redux changes (please link)
 - [ ] Has UI changes
-- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
+- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
 - [ ] Touches critical sections of the codebase (auth, posting, etc.)


### PR DESCRIPTION
Adds ``Ran `make check-style` to check for style errors (required for all pull requests)`` and fixes localization file location

People keep hitting style errors, which are most often identified by running `make check-style`. 

Also an accompanying docs PR here: https://github.com/mattermost/docs/pull/1615