### PR TITLE
[PLT-8064] Timestamp links in RHS on desktop app should open in permalink view in the current window

### DIFF
--- a/components/rhs_comment.jsx
+++ b/components/rhs_comment.jsx
@@ -151,7 +151,6 @@ export default class RhsComment extends React.Component {
             (
                 <Link
                     to={`/${this.state.currentTeamDisplayName}/pl/${post.id}`}
-                    target='_blank'
                     className='post__permalink'
                 >
                     {this.timeTag(post, timeOptions)}

--- a/components/rhs_root_post.jsx
+++ b/components/rhs_root_post.jsx
@@ -151,7 +151,6 @@ export default class RhsRootPost extends React.Component {
         return (
             <Link
                 to={`/${this.state.currentTeamDisplayName}/pl/${post.id}`}
-                target='_blank'
                 className='post__permalink'
             >
                 {this.timeTag(post, timeOptions)}


### PR DESCRIPTION
#### Summary
Timestamp links in RHS on desktop app should open in permalink view in the current window	

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/PLT-8064

#### Checklist
n/a
