### PR TITLE
PLT-7933 Implement custom network detector

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -14,6 +14,7 @@ import reduxInitialState from 'mattermost-redux/store/initial_state';
 import appReducer from 'reducers';
 
 import {transformSet} from './utils';
+import {detect} from 'utils/network.js';
 
 function getAppReducer() {
     return require('../reducers'); // eslint-disable-line global-require
@@ -137,7 +138,8 @@ export default function configureStore(initialState, persistorStorage = null) {
             transforms: [
                 setTransformer
             ]
-        }
+        },
+        detectNetwork: detect
     };
 
     return configureServiceStore({}, appReducer, offlineOptions, getAppReducer, {enableBuffer: false});

--- a/utils/network.js
+++ b/utils/network.js
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {Client4} from 'mattermost-redux/client';
+
+const MAX_NETWORK_RETRIES = 7;
+const MIN_NETWORK_RETRY_TIME = 3000; // 3 sec
+const MAX_NETWORK_RETRY_TIME = 300000; // 5 mins
+
+function handle(callback, online) {
+    console.log('Network status set to ' + online); //eslint-disable-line no-console
+    if (window.requestAnimationFrame) {
+        window.requestAnimationFrame(() => callback(online));
+    } else {
+        setTimeout(() => callback(online), 0);
+    }
+}
+
+async function isOnline() {
+    if (window.navigator && window.navigator.onLine) {
+        return true;
+    }
+
+    try {
+        await Client4.ping();
+    } catch (err) {
+        return false;
+    }
+
+    return true;
+}
+
+let retryTimeoutId;
+let retryCount;
+
+async function checkNetworkStatus(callback) {
+    const online = await isOnline();
+
+    if (online) {
+        retryCount = 0;
+        clearTimeout(retryTimeoutId);
+
+        handle(callback, true);
+        return;
+    }
+
+    let retryTime = MIN_NETWORK_RETRY_TIME;
+
+    // If we've failed a bunch of connections then start backing off
+    if (retryCount > MAX_NETWORK_RETRIES) {
+        retryTime = MIN_NETWORK_RETRY_TIME * retryCount;
+        if (retryTime > MAX_NETWORK_RETRY_TIME) {
+            retryTime = MAX_NETWORK_RETRY_TIME;
+        }
+    }
+
+    retryCount += 1;
+
+    retryTimeoutId = setTimeout(() => checkNetworkStatus(callback), retryTime);
+
+    handle(callback, false);
+}
+
+export async function detect(callback) {
+    window.addEventListener('online', () => checkNetworkStatus(callback));
+    window.addEventListener('offline', () => checkNetworkStatus(callback));
+    checkNetworkStatus(callback);
+}


### PR DESCRIPTION
#### Summary
This should remedy the issue we've seen reported where the browser provides a false negative network status, causing redux-offline optimistic actions to fail immediately (posts immediately failing without network requests).

The custom network detector expands on the default, which would rely on the online/offline events and `window.navigator.onLine` provided by the browser. The new flow is:
* The browser reports an online status, trust it and assume we're online
* The browser reports an offline status, don't trust it and try to ping the server to confirm
  * If the ping fails, report offline then retry pings continuously with a back-off pattern similar to the websocket reconnect logic to make sure we don't miss an online event

Not implemented in mattermost-redux as this is specific to the webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7933

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Touches critical sections of the codebase (network status affecting critical actions)
