### PR TITLE
PLT-8093 Fix prop link is required in GetLinkModal but it is undefined

### DIFF
--- a/components/get_public_link_modal/get_public_link_modal.jsx
+++ b/components/get_public_link_modal/get_public_link_modal.jsx
@@ -28,6 +28,10 @@ export default class GetPublicLinkModal extends React.PureComponent {
         }).isRequired
     }
 
+    static defaultProps = {
+        link: ''
+    }
+
     constructor(props) {
         super(props);
         this.state = {

--- a/tests/components/get_public_link_modal/__snapshots__/get_public_link_modal.test.jsx.snap
+++ b/tests/components/get_public_link_modal/__snapshots__/get_public_link_modal.test.jsx.snap
@@ -19,3 +19,13 @@ exports[`components/GetPublicLinkModal should match snapshot when link is not em
   title="Copy Public Link"
 />
 `;
+
+exports[`components/GetPublicLinkModal should match snapshot when link is undefined 1`] = `
+<GetLinkModal
+  helpText="The link below allows anyone to see this file without being registered on this server."
+  link=""
+  onHide={[Function]}
+  show={false}
+  title="Copy Public Link"
+/>
+`;

--- a/tests/components/get_public_link_modal/get_public_link_modal.test.jsx
+++ b/tests/components/get_public_link_modal/get_public_link_modal.test.jsx
@@ -19,6 +19,16 @@ describe('components/GetPublicLinkModal', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should match snapshot when link is undefined', () => {
+        const wrapper = shallow(
+            <GetPublicLinkModal
+                actions={{getFilePublicLink: jest.fn()}}
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should match snapshot when link is not empty', () => {
         const wrapper = shallow(
             <GetPublicLinkModal


### PR DESCRIPTION
#### Summary

The prop `link` is required in `GetLinkModal`, but its value is `undefined`. This fixes that.

#### Ticket Link

Github Ticket: https://github.com/mattermost/mattermost-server/issues/7804
JIRA Ticket: https://mattermost.atlassian.net/browse/PLT-8093

#### Checklist

- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Added or updated unit tests (required for all new features)