### PR TITLE
PLT-8092 Deep clone drafts to prevent modifying immutable object

### DIFF
--- a/stores/post_store.jsx
+++ b/stores/post_store.jsx
@@ -156,7 +156,8 @@ class PostStoreClass extends EventEmitter {
     }
 
     getDraft(channelId) {
-        return this.normalizeDraft(BrowserStore.getGlobalItem('draft_' + channelId));
+        // deep clone because many components need to modify the draft
+        return JSON.parse(JSON.stringify(this.normalizeDraft(BrowserStore.getGlobalItem('draft_' + channelId))));
     }
 
     storeCommentDraft(parentPostId, draft) {
@@ -164,7 +165,8 @@ class PostStoreClass extends EventEmitter {
     }
 
     getCommentDraft(parentPostId) {
-        return this.normalizeDraft(BrowserStore.getGlobalItem('comment_draft_' + parentPostId));
+        // deep clone because many components need to modify the draft
+        return JSON.parse(JSON.stringify(this.normalizeDraft(BrowserStore.getGlobalItem('comment_draft_' + parentPostId))));
     }
 
     clearDraftUploads() {


### PR DESCRIPTION
#### Summary
Deep clone drafts to prevent modifying immutable object. This was caused by the fact that redux is now used for the BrowserStore and was sealing objects. Once all the components using drafts are moved over to use the BrowserStore directly, this can go away.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8092