### PR TITLE
PLT-8112: Icon on RHS interactive response post is inconsistent with center

### DIFF
--- a/components/rhs_comment.jsx
+++ b/components/rhs_comment.jsx
@@ -314,9 +314,7 @@ export default class RhsComment extends React.Component {
                     height='36'
                 />
             );
-        }
-
-        if (isSystemMessage) {
+        } else if (isSystemMessage) {
             profilePic = (
                 <span
                     className='icon'


### PR DESCRIPTION
#### Summary
> If I post `/poll` and respond in RHS, the profile icon does not appear to be overriding as it does in center.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8112

#### Checklist
N/A