### PR TITLE
Migrate file_info_preview.jsx to use Redux & Added tests

### DIFF
--- a/components/file_info_preview.jsx
+++ b/components/file_info_preview.jsx
@@ -7,18 +7,19 @@ import React from 'react';
 import * as FileUtils from 'utils/file_utils';
 import * as Utils from 'utils/utils.jsx';
 
-export default class FileInfoPreview extends React.Component {
-    shouldComponentUpdate(nextProps) {
-        if (nextProps.fileUrl !== this.props.fileUrl) {
-            return true;
-        }
+export default class FileInfoPreview extends React.PureComponent {
+    static propTypes = {
 
-        if (!Utils.areObjectsEqual(nextProps.fileInfo, this.props.fileInfo)) {
-            return true;
-        }
+        /**
+         * Object with info about file
+         */
+        fileInfo: PropTypes.object.isRequired,
 
-        return false;
-    }
+        /**
+         * String containing file URL
+         */
+        fileUrl: PropTypes.string.isRequired
+    };
 
     render() {
         const fileInfo = this.props.fileInfo;
@@ -68,8 +69,3 @@ export default class FileInfoPreview extends React.Component {
         );
     }
 }
-
-FileInfoPreview.propTypes = {
-    fileInfo: PropTypes.object.isRequired,
-    fileUrl: PropTypes.string.isRequired
-};

--- a/tests/components/__snapshots__/file_info_preview.test.jsx.snap
+++ b/tests/components/__snapshots__/file_info_preview.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`components/file_info_preview.jsx should match snapshot 1`] = `
 >
   <a
     className="file-details__preview"
-    href="http://www.catphotos.org/wp-content/uploads/2013/02/cat-standing.jpg"
+    href="https://pre-release.mattermost.com/api/v4/files/rqir81f7a7ft8m6j6ej7g1txuo"
     rel="noopener noreferrer"
     target="_blank"
   >

--- a/tests/components/__snapshots__/file_info_preview.test.jsx.snap
+++ b/tests/components/__snapshots__/file_info_preview.test.jsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/file_info_preview.jsx should match snapshot 1`] = `
+<div
+  className="file-details__container"
+>
+  <a
+    className="file-details__preview"
+    href="http://www.catphotos.org/wp-content/uploads/2013/02/cat-standing.jpg"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <span
+      className="file-details__preview-helper"
+    />
+    <img
+      src={null}
+    />
+  </a>
+  <div
+    className="file-details"
+  >
+    <div
+      className="file-details__name"
+    >
+      Test Image
+    </div>
+    <div
+      className="file-details__info"
+    >
+      File type JPG, Size 100B
+    </div>
+  </div>
+</div>
+`;

--- a/tests/components/file_info_preview.test.jsx
+++ b/tests/components/file_info_preview.test.jsx
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import FileInfoPreview from 'components/file_info_preview.jsx';
+
+describe('components/file_info_preview.jsx', () => {
+    const requiredProps = {
+        fileUrl: 'http://www.catphotos.org/wp-content/uploads/2013/02/cat-standing.jpg',
+        fileInfo: {name: 'Test Image', size: 100, extension: 'jpg'}
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <FileInfoPreview {...requiredProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should receive props', () => {
+        const wrapper = shallow(
+            <FileInfoPreview {...requiredProps}/>
+        );
+
+        const instance = wrapper.instance();
+
+        expect(instance.props.fileUrl).toBe(requiredProps.fileUrl);
+        expect(wrapper.find('.file-details__name').text()).toBe(requiredProps.fileInfo.name);
+    });
+});

--- a/tests/components/file_info_preview.test.jsx
+++ b/tests/components/file_info_preview.test.jsx
@@ -9,7 +9,7 @@ import FileInfoPreview from 'components/file_info_preview.jsx';
 
 describe('components/file_info_preview.jsx', () => {
     const requiredProps = {
-        fileUrl: 'http://www.catphotos.org/wp-content/uploads/2013/02/cat-standing.jpg',
+        fileUrl: 'https://pre-release.mattermost.com/api/v4/files/rqir81f7a7ft8m6j6ej7g1txuo',
         fileInfo: {name: 'Test Image', size: 100, extension: 'jpg'}
     };
 


### PR DESCRIPTION
#### Summary
Migrates file_info_preview.jsx to Redux & adds tests

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7788

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Added or updated unit tests (required for all new features)
