### PR TITLE
PLT-8089: Hides "Password updated successfully" flash after login attempt.

### DIFF
--- a/components/login/login_controller.jsx
+++ b/components/login/login_controller.jsx
@@ -75,6 +75,12 @@ export default class LoginController extends React.Component {
     preSubmit(e) {
         e.preventDefault();
 
+        const {location} = this.props;
+        const newQuery = location.search.replace(/(extra=password_change)&?/i, '');
+        if (newQuery !== location.search) {
+            browserHistory.replace(`${location.pathname}${newQuery}${location.hash}`);
+        }
+
         // password managers don't always call onInput handlers for form fields so it's possible
         // for the state to get out of sync with what the user sees in the browser
         let loginId = this.refs.loginId.value;


### PR DESCRIPTION
#### Summary
Removes the `extra=password_change` query parameter upon submitting a login form so that the "Password updated successfully" flash message disappears in cases where the route does not redirect.

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]
[Jira PLT-8089](https://mattermost.atlassian.net/browse/PLT-8089)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)