### PR TITLE
PLT-8113: Fixes missing values on OAuth2 setup success page.

### DIFF
--- a/components/integrations/components/add_oauth_app/add_oauth_app.jsx
+++ b/components/integrations/components/add_oauth_app/add_oauth_app.jsx
@@ -48,7 +48,7 @@ export default class AddOAuthApp extends React.PureComponent {
     addOAuthApp = async (app) => {
         this.setState({serverError: ''});
 
-        const data = await this.props.actions.addOAuthApp(app);
+        const {data} = await this.props.actions.addOAuthApp(app);
         if (data) {
             browserHistory.push(`/${this.props.team.name}/integrations/confirm?type=oauth2-apps&id=${data.id}`);
             return;


### PR DESCRIPTION
#### Summary
Expected keys in JS object were nested within JSON payload's `data` key.

#### Ticket Link
[PLT-8113](https://mattermost.atlassian.net/browse/PLT-8113)

#### Checklist
- [x] Ran `make check-style` to check for style errors