### PR TITLE
PLT-8104: @here should not be added to search on clicking @ icon to display mentions

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -474,12 +474,19 @@ export function emitSearchMentionsEvent(user) {
     if (user.notify_props) {
         const termKeys = UserStore.getMentionKeys(user.id);
 
-        if (termKeys.indexOf('@channel') !== -1) {
-            termKeys[termKeys.indexOf('@channel')] = '';
+        const indexOfChannel = termKeys.indexOf('@channel');
+        if (indexOfChannel !== -1) {
+            termKeys.splice(indexOfChannel, 1);
         }
 
-        if (termKeys.indexOf('@all') !== -1) {
-            termKeys[termKeys.indexOf('@all')] = '';
+        const indexOfAll = termKeys.indexOf('@all');
+        if (indexOfAll !== -1) {
+            termKeys.splice(indexOfAll, 1);
+        }
+
+        const indexOfHere = termKeys.indexOf('@here');
+        if (indexOfHere !== -1) {
+            termKeys.splice(indexOfHere, 1);
         }
 
         terms = termKeys.join(' ');


### PR DESCRIPTION
#### Summary
Explicitly removed @here from search terms when the mentions button is pressed, regardless of notification preferences. Tidied up search term removal code to avoid unnecessary whitespace between search terms

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8104

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)