### PR TITLE
PLT-8124 Remove all code using regex

### DIFF
--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -131,8 +131,8 @@ export function containsAtMention(text, key) {
 export function removeCode(text) {
     // These patterns should match the ones in app/notification.go, except JavaScript doesn't
     // support \z for the end of the text in multiline mode, so we use $(?![\r\n])
-    const codeBlockPattern = /^[^\S\n]*[`~]{3}.*$[\s\S]+?(^[^\S\n]*[`~]{3}$|$(?![\r\n]))/m;
-    const inlineCodePattern = /`+(?:.+?|.*?\n(.*?\S.*?\n)*.*?)`+/m;
+    const codeBlockPattern = /^[^\S\n]*[`~]{3}.*$[\s\S]+?(^[^\S\n]*[`~]{3}$|$(?![\r\n]))/mg;
+    const inlineCodePattern = /`+(?:.+?|.*?(.*?\S.*?\n)*.*?)`+/mg;
 
     return text.replace(codeBlockPattern, '').replace(inlineCodePattern, ' ');
 }


### PR DESCRIPTION
#### Summary
Fix freeze on certain style code blocks

1. When replacing code blocks with empty string it must remove every single code block (globally) using /regex/g
2. Only accept single-line code using inlineCode regex.
If multi-line code block is wrapped with `` ignore.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8124

via @miguelespinoza