### PR TITLE
PLT-7640 Updated marked to better handle non-latin characters in URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "key-mirror": "1.0.1",
     "localforage": "1.5.3",
     "localforage-observable": "1.4.0",
-    "marked": "mattermost/marked#17945726698a03420588acd55e5b38f692c03f31",
+    "marked": "mattermost/marked#802e981ade71149a497cbe79d12b8a3f82f7657e",
     "match-at": "0.1.1",
     "mattermost-redux": "https://github.com/mattermost/mattermost-redux.git#fe024abaec677c06969940a09f9aed433a56c904",
     "object-assign": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5591,9 +5591,9 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-marked@mattermost/marked#17945726698a03420588acd55e5b38f692c03f31:
+marked@mattermost/marked#802e981ade71149a497cbe79d12b8a3f82f7657e:
   version "0.3.6"
-  resolved "https://codeload.github.com/mattermost/marked/tar.gz/17945726698a03420588acd55e5b38f692c03f31"
+  resolved "https://codeload.github.com/mattermost/marked/tar.gz/802e981ade71149a497cbe79d12b8a3f82f7657e"
 
 match-at@0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Adds the XRegExp library (that we use in text_formatting.jsx already) and changes the URL pattern to use `\pL` which matches all unicode letters (including CJK characters, Cyrillic letters, accented letters, etc) instead of using `[a-z]` which only matches latin letters

Marked changes here: https://github.com/mattermost/marked/commit/802e981ade71149a497cbe79d12b8a3f82f7657e

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7640

#### Checklist
- Added or updated unit tests (required for all new features)
