### PR TITLE
[PLT-7814] Upgrade to enzyme-adapter-react-16 and enable unit/components tests a…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ check-style: .yarninstall
 	yarn run check
 
 test: .yarninstall
-	cd $(BUILD_SERVER_DIR) && $(MAKE) internal-test-web-client
+	@echo Running jest unit/component testing
+
+	yarn run test
 
 .yarninstall: package.json
 	@echo Getting dependencies using yarn

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@ When filling in a section please remove the help text and the above text.
 #### Checklist
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 - [ ] Ran `make check-style` to check for style errors (required for all pull requests)
+- [ ] Ran `make test` to ensure unit and component tests passed
 - [ ] Added or updated unit tests (required for all new features)
 - [ ] Has server changes (please link)
 - [ ] Has redux changes (please link)

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -33,6 +33,13 @@ podTemplate(label: 'jenkins-slave-webapp',
                 }
             }
         }
+        stage('Unit/Component Tests') {
+            container('mattermost-node') {
+                dir('mattermost-webapp') {
+                    sh 'make test'
+                }
+            }
+        }
         stage('Build') {
             container('mattermost-node') {
                 dir('mattermost-webapp') {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "cross-env": "5.1.1",
     "css-loader": "0.28.7",
     "enzyme": "3.1.1",
-    "enzyme-adapter-react-15": "1.0.5",
+    "enzyme-adapter-react-16": "1.1.0",
     "enzyme-to-json": "3.2.2",
     "eslint": "3.17.1",
     "eslint-import-resolver-webpack": "0.8.3",
@@ -114,12 +114,15 @@
       "/node_modules/",
       "/non_npm_dependencies/"
     ],
+    "clearMocks": true,
     "collectCoverageFrom": [
       "actions/**/*.{js,jsx}",
       "client/**/*.{js,jsx}",
       "components/**/*.jsx",
       "plugins/**/*.{js,jsx}",
+      "reducers/**/*.{js,jsx}",
       "routes/**/*.{js,jsx}",
+      "selectors/**/*.{js,jsx}",
       "stores/**/*.{js,jsx}",
       "utils/**/*.{js,jsx}"
     ],

--- a/tests/components/about_build_modal.test.jsx
+++ b/tests/components/about_build_modal.test.jsx
@@ -3,7 +3,6 @@
 
 import React from 'react';
 import {Modal} from 'react-bootstrap';
-
 import {shallow} from 'enzyme';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';

--- a/tests/components/audio_video_preview.test.jsx
+++ b/tests/components/audio_video_preview.test.jsx
@@ -16,10 +16,6 @@ describe('component/AudioVideoPreview', () => {
         fileUrl: '/api/v4/files/file_id'
     };
 
-    afterAll(() => {
-        jest.clearAllMocks();
-    });
-
     test('should match snapshot without children', () => {
         const wrapper = shallow(
             <AudioVideoPreview {...requiredProps}/>

--- a/tests/components/channel_info_modal.test.jsx
+++ b/tests/components/channel_info_modal.test.jsx
@@ -3,7 +3,6 @@
 
 import React from 'react';
 import {Modal} from 'react-bootstrap';
-
 import {shallow} from 'enzyme';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';

--- a/tests/components/get_link_modal.test.jsx
+++ b/tests/components/get_link_modal.test.jsx
@@ -2,7 +2,6 @@
 // See License.txt for license information.
 
 import React from 'react';
-
 import {shallow} from 'enzyme';
 import {Modal} from 'react-bootstrap';
 

--- a/tests/components/integrations/__snapshots__/installed_command.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/installed_command.test.jsx.snap
@@ -101,287 +101,103 @@ exports[`components/integrations/InstalledCommand should call onDelete function 
 `;
 
 exports[`components/integrations/InstalledCommand should call onRegenToken function 1`] = `
-<InstalledCommand
-  canChange={true}
-  command={
-    Object {
-      "auto_complete": true,
-      "auto_complete_hint": "auto_complete_hint",
-      "create_at": "1499722850203",
-      "description": "description",
-      "display_name": "display_name",
-      "id": "r5tpgt4iepf45jt768jz84djic",
-      "token": "testToken",
-      "trigger": "trigger",
-    }
-  }
-  creator={
-    Object {
-      "username": "username",
-    }
-  }
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "textComponent": "span",
-    }
-  }
-  onDelete={[Function]}
-  onRegenToken={[Function]}
-  team={
-    Object {
-      "name": "team_name",
-    }
-  }
+<div
+  className="backstage-list__item"
 >
   <div
-    className="backstage-list__item"
+    className="item-details"
   >
     <div
-      className="item-details"
+      className="item-details__row"
     >
-      <div
-        className="item-details__row"
+      <span
+        className="item-details__name"
       >
-        <span
-          className="item-details__name"
-        >
-          display_name
-        </span>
-        <span
-          className="item-details__trigger"
-        >
-          - /trigger auto_complete_hint
-        </span>
-      </div>
-      <div
-        className="item-details__row"
+        display_name
+      </span>
+      <span
+        className="item-details__trigger"
       >
-        <span
-          className="item-details__description"
-        >
-          description
-        </span>
-      </div>
-      <div
-        className="item-details__row"
-      >
-        <span
-          className="item-details__token"
-        >
-          <FormattedMessage
-            defaultMessage="Token: {token}"
-            id="installed_integrations.token"
-            values={
-              Object {
-                "token": "testToken",
-              }
-            }
-          >
-            <span>
-              Token: testToken
-            </span>
-          </FormattedMessage>
-        </span>
-      </div>
-      <div
-        className="item-details__row"
-      >
-        <span
-          className="item-details__creation"
-        >
-          <FormattedMessage
-            defaultMessage="Created by {creator} on {createAt, date, full}"
-            id="installed_integrations.creation"
-            values={
-              Object {
-                "createAt": "1499722850203",
-                "creator": "username",
-              }
-            }
-          >
-            <span>
-              Created by username on Tuesday, July 11, 2017
-            </span>
-          </FormattedMessage>
-        </span>
-      </div>
+        - /trigger auto_complete_hint
+      </span>
     </div>
     <div
-      className="item-actions"
+      className="item-details__row"
     >
-      <button
-        className="style--none color--link"
-        onClick={[Function]}
+      <span
+        className="item-details__description"
+      >
+        description
+      </span>
+    </div>
+    <div
+      className="item-details__row"
+    >
+      <span
+        className="item-details__token"
       >
         <FormattedMessage
-          defaultMessage="Regenerate Token"
-          id="installed_integrations.regenToken"
-          values={Object {}}
-        >
-          <span>
-            Regenerate Token
-          </span>
-        </FormattedMessage>
-      </button>
-       - 
-      <Link
-        onlyActiveOnIndex={false}
-        style={Object {}}
-        to="/team_name/integrations/commands/edit?id=r5tpgt4iepf45jt768jz84djic"
+          defaultMessage="Token: {token}"
+          id="installed_integrations.token"
+          values={
+            Object {
+              "token": "testToken",
+            }
+          }
+        />
+      </span>
+    </div>
+    <div
+      className="item-details__row"
+    >
+      <span
+        className="item-details__creation"
       >
-        <a
-          onClick={[Function]}
-          style={Object {}}
-        >
-          <FormattedMessage
-            defaultMessage="Edit"
-            id="installed_integrations.edit"
-            values={Object {}}
-          >
-            <span>
-              Edit
-            </span>
-          </FormattedMessage>
-        </a>
-      </Link>
-       - 
-      <DeleteIntegration
-        messageId="installed_commands.delete.confirm"
-        onDelete={[Function]}
-      >
-        <span>
-          <button
-            className="color--link style--none"
-            onClick={[Function]}
-          >
-            <FormattedMessage
-              defaultMessage="Delete"
-              id="installed_integrations.delete"
-              values={Object {}}
-            >
-              <span>
-                Delete
-              </span>
-            </FormattedMessage>
-          </button>
-          <ConfirmModal
-            confirmButtonClass="btn btn-primary"
-            confirmButtonText={
-              <FormattedMessage
-                defaultMessage="Delete"
-                id="integrations.delete.confirm.button"
-                values={Object {}}
-              />
+        <FormattedMessage
+          defaultMessage="Created by {creator} on {createAt, date, full}"
+          id="installed_integrations.creation"
+          values={
+            Object {
+              "createAt": "1499722850203",
+              "creator": "username",
             }
-            message={
-              <div
-                className="alert alert-warning"
-              >
-                <i
-                  className="fa fa-warning fa-margin--right"
-                />
-                <FormattedMessage
-                  defaultMessage="This action permanently deletes the integration and breaks any integrations using it. Are you sure you want to delete it?"
-                  id="installed_commands.delete.confirm"
-                  values={Object {}}
-                />
-              </div>
-            }
-            modalClass=""
-            onCancel={[Function]}
-            onConfirm={[Function]}
-            onKeyDown={[Function]}
-            show={false}
-            title={
-              <FormattedMessage
-                defaultMessage="Delete Integration"
-                id="integrations.delete.confirm.title"
-                values={Object {}}
-              />
-            }
-          >
-            <Modal
-              animation={true}
-              autoFocus={true}
-              backdrop={true}
-              bsClass="modal"
-              className="modal-confirm "
-              dialogComponentClass={[Function]}
-              enforceFocus={true}
-              keyboard={true}
-              manager={
-                ModalManager {
-                  "add": [Function],
-                  "containers": Array [],
-                  "data": Array [],
-                  "handleContainerOverflow": true,
-                  "hideSiblingNodes": true,
-                  "isTopModal": [Function],
-                  "modals": Array [],
-                  "remove": [Function],
-                }
-              }
-              onHide={[Function]}
-              renderBackdrop={[Function]}
-              restoreFocus={true}
-              show={false}
-            >
-              <Modal
-                autoFocus={true}
-                backdrop={true}
-                backdropClassName="modal-backdrop"
-                backdropTransitionTimeout={150}
-                containerClassName="modal-open"
-                dialogTransitionTimeout={300}
-                enforceFocus={true}
-                keyboard={true}
-                manager={
-                  ModalManager {
-                    "add": [Function],
-                    "containers": Array [],
-                    "data": Array [],
-                    "handleContainerOverflow": true,
-                    "hideSiblingNodes": true,
-                    "isTopModal": [Function],
-                    "modals": Array [],
-                    "remove": [Function],
-                  }
-                }
-                onEntering={[Function]}
-                onExited={[Function]}
-                onHide={[Function]}
-                renderBackdrop={[Function]}
-                restoreFocus={true}
-                show={false}
-                transition={[Function]}
-              />
-            </Modal>
-          </ConfirmModal>
-        </span>
-      </DeleteIntegration>
+          }
+        />
+      </span>
     </div>
   </div>
-</InstalledCommand>
+  <div
+    className="item-actions"
+  >
+    <button
+      className="style--none color--link"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Regenerate Token"
+        id="installed_integrations.regenToken"
+        values={Object {}}
+      />
+    </button>
+     - 
+    <Link
+      onlyActiveOnIndex={false}
+      style={Object {}}
+      to="/team_name/integrations/commands/edit?id=r5tpgt4iepf45jt768jz84djic"
+    >
+      <FormattedMessage
+        defaultMessage="Edit"
+        id="installed_integrations.edit"
+        values={Object {}}
+      />
+    </Link>
+     - 
+    <DeleteIntegration
+      messageId="installed_commands.delete.confirm"
+      onDelete={[Function]}
+    />
+  </div>
+</div>
 `;
 
 exports[`components/integrations/InstalledCommand should filter out command 1`] = `""`;

--- a/tests/components/integrations/installed_command.test.jsx
+++ b/tests/components/integrations/installed_command.test.jsx
@@ -2,10 +2,7 @@
 // See License.txt for license information.
 
 import React from 'react';
-
 import {shallow} from 'enzyme';
-
-import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 
 import InstalledCommand from 'components/integrations/components/installed_command.jsx';
 
@@ -64,10 +61,10 @@ describe('components/integrations/InstalledCommand', () => {
         const canChange = true;
         const props = {...requiredProps, onRegenToken, canChange};
 
-        const wrapper = mountWithIntl(<InstalledCommand {...props}/>);
+        const wrapper = shallow(<InstalledCommand {...props}/>);
         expect(wrapper).toMatchSnapshot();
 
-        wrapper.find('div.item-actions button').first().simulate('click');
+        wrapper.find('div.item-actions button').first().simulate('click', {preventDefault: jest.fn()});
         expect(onRegenToken).toHaveBeenCalledTimes(1);
         expect(onRegenToken).toHaveBeenCalledWith(props.command);
     });

--- a/tests/components/integrations/installed_outgoing_webhooks.test.jsx
+++ b/tests/components/integrations/installed_outgoing_webhooks.test.jsx
@@ -13,8 +13,8 @@ describe('components/integrations/InstalledOutgoingWebhooks', () => {
     const teamId = 'testteamid';
     beforeEach(() => {
         mockFunc = jest.fn();
-        outgoingWebhooks = {
-            '7h88x419ubbyuxzs7dfwtgkffr': {
+        outgoingWebhooks = [
+            {
                 callback_urls: ['http://adsfdasd.com'],
                 channel_id: 'mdpzfpfcxi85zkkqkzkch4b85h',
                 content_type: 'application/x-www-form-urlencoded',
@@ -31,7 +31,7 @@ describe('components/integrations/InstalledOutgoingWebhooks', () => {
                 0: 'asdf',
                 update_at: 1508329149618
             },
-            '7h88x419ubbyuxzs7dfwtgkfff': {
+            {
                 callback_urls: ['http://adsfdasd.com'],
                 channel_id: 'mdpzfpfcxi85zkkqkzkch4b85h',
                 content_type: 'application/x-www-form-urlencoded',
@@ -48,7 +48,7 @@ describe('components/integrations/InstalledOutgoingWebhooks', () => {
                 0: 'asdf',
                 update_at: 1508329149618
             }
-        };
+        ];
     });
 
     test('should match snapshot', () => {

--- a/tests/components/pdf_preview.test.jsx
+++ b/tests/components/pdf_preview.test.jsx
@@ -23,10 +23,6 @@ describe('component/PDFPreview', () => {
         fileUrl: 'https://pre-release.mattermost.com/api/v4/files/ips59w4w9jnfbrs3o94m1dbdie'
     };
 
-    afterAll(() => {
-        jest.clearAllMocks();
-    });
-
     test('should match snapshot, loading', () => {
         const wrapper = shallow(
             <PDFPreview {...requiredProps}/>

--- a/tests/plugins/__snapshots__/pluggable.test.jsx.snap
+++ b/tests/plugins/__snapshots__/pluggable.test.jsx.snap
@@ -163,7 +163,6 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
           <div
             data-toggle="tooltip"
             key="user-popover-email"
-            title={undefined}
           >
             <a
               className="text-nowrap text-lowercase user-popover__email"

--- a/tests/plugins/__snapshots__/post_type.test.jsx.snap
+++ b/tests/plugins/__snapshots__/post_type.test.jsx.snap
@@ -76,7 +76,6 @@ exports[`plugins/PostMessageView should match snapshot with extended post type 1
     }
   >
     <PostTypePlugin
-      compactDisplay={undefined}
       isRHS={false}
       mentionKeys={Array []}
       post={

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 import {configure} from 'enzyme';
 import $ from 'jquery';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2607,15 +2607,16 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-adapter-react-15@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-15/-/enzyme-adapter-react-15-1.0.5.tgz#99f9a03ff2c2303e517342935798a6bdfbb75fac"
+enzyme-adapter-react-16@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.0.tgz#86c5db7c10f0be6ec25d54ca41b59f2abb397cf4"
   dependencies:
     enzyme-adapter-utils "^1.1.0"
     lodash "^4.17.4"
     object.assign "^4.0.4"
     object.values "^1.0.4"
     prop-types "^15.5.10"
+    react-test-renderer "^16.0.0-0"
 
 enzyme-adapter-utils@^1.1.0:
   version "1.1.1"
@@ -5713,7 +5714,7 @@ mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
-mime-types@^2.1.12:
+mime-types@^2.1.12, mime-types@~2.1.17:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
@@ -5724,12 +5725,6 @@ mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
     mime-db "~1.27.0"
-
-mime-types@~2.1.17:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
-  dependencies:
-    mime-db "~1.30.0"
 
 mime@1.3.4:
   version "1.3.4"
@@ -7108,6 +7103,14 @@ react-select@1.0.0-rc.10:
 react-test-renderer@16.1.0:
   version "16.1.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.1.0.tgz#33a1d3ce896311e0dd1547649b1456ffa7fda415"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-test-renderer@^16.0.0-0:
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.1.1.tgz#a05184688d564be799f212449262525d1e350537"
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"


### PR DESCRIPTION
#### Summary
This is the final batch for PLT-7814, resolving existing (and additional) component test failures.

This is resubmitted as branch. Original PR from https://github.com/mattermost/mattermost-webapp/pull/303.

Included in this PR:
1. Add `make test` command
2. Enable unit/components tests at Jenkins build.
3. Add `make test` to PR checklist
4. Add `reducers` and `selectors` folders for test coverage computation
5. Add `"clearMocks": true` to jest config to automatically clear mock calls and instances between every test.

#### Ticket Link
Jira ticket: [PLT-7814](https://mattermost.atlassian.net/browse/PLT-7814)

(UPDATE): Jira ticket to revert component tests - [PLT-8133](https://mattermost.atlassian.net/browse/PLT-8133)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (Jenkins build, make file)
