### PR TITLE
[PLT-8091] Fix regression on permalink containing "undefined" site URL

### DIFF
--- a/components/get_post_link_modal/index.js
+++ b/components/get_post_link_modal/index.js
@@ -3,14 +3,18 @@
 
 import {connect} from 'react-redux';
 
-import {getCurrentTeamUrl} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import {getSiteURL} from 'utils/url.jsx';
 
 import GetPostLinkModal from './get_post_link_modal';
 
 function mapStateToProps(state, ownProps) {
+    const currentTeam = getCurrentTeam(state);
+    const currentTeamUrl = `${getSiteURL()}/${currentTeam.name}`;
     return {
         ...ownProps,
-        currentTeamUrl: getCurrentTeamUrl(state)
+        currentTeamUrl
     };
 }
 


### PR DESCRIPTION
#### Summary
Fix regression on permalink containing "undefined" site URL

Note: I don't see anywhere where we used `getCurrentTeamUrl` from `mattermost-redux`.

#### Ticket Link
Jira ticket: [PLT-8091](https://mattermost.atlassian.net/browse/PLT-8091)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
