### PR TITLE
[PLT-8123] Fix emoji picker not showing up when RHS is expanded

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -429,9 +429,14 @@ export default class EmojiPicker extends React.Component {
             pickerStyle.top += this.props.topOffset;
         }
 
+        let pickerClass = 'emoji-picker';
+        if (this.props.placement === 'bottom') {
+            pickerClass += ' bottom';
+        }
+
         return (
             <div
-                className='emoji-picker'
+                className={pickerClass}
                 style={pickerStyle}
             >
                 {this.emojiCategories()}

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -57,6 +57,10 @@
     height: 362px;
     width: 278px;
     z-index: 10;
+
+    &.bottom {
+        margin-top: 10px;
+    }
 }
 
 .emoji-picker__categories {

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -53,10 +53,15 @@
     border: 1px solid;
     display: flex;
     flex-direction: column;
-    position: absolute;
     height: 362px;
+    margin-right: 3px;
+    position: absolute;
     width: 278px;
     z-index: 10;
+
+    .app__content & {
+        margin-right: 0;
+    }
 
     &.bottom {
         margin-top: 10px;

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -56,7 +56,7 @@
     position: absolute;
     height: 362px;
     width: 278px;
-    z-index: 8;
+    z-index: 10;
 }
 
 .emoji-picker__categories {


### PR DESCRIPTION
#### Summary
Fix emoji picker not showing up when RHS is expanded

@asaadmahmood Please help validate position of emoji picker in reference to addReaction button. It feels like it's not consistently aligned with each other. Let me know if it should be fixed and if fix can be made via CSS. Thanks!

#### Ticket Link
Jira ticket: [PLT-8123](https://mattermost.atlassian.net/browse/PLT-8123)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Has UI changes


![screen shot 2017-11-20 at 10 48 52 pm](https://user-images.githubusercontent.com/5334504/33024076-10bbf83e-ce45-11e7-8036-59d82ff8b742.png)
