### PR TITLE
add config option to hide tutorial screens

### DIFF
--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -27,7 +27,7 @@ function mapStateToProps(state, ownProps) {
     return {
         channelId,
         deactivatedChannel: getDeactivatedChannel(state, channelId),
-        showTutorial: Number(get(state, Preferences.TUTORIAL_STEP, state.entities.users.currentUserId, 999)) <= TutorialSteps.INTRO_SCREENS
+        showTutorial: Number(get(state, Preferences.TUTORIAL_STEP, state.entities.users.currentUserId, 999)) <= TutorialSteps.INTRO_SCREENS && global.window.mm_config.EnableTutorial === 'true'
     };
 }
 

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -734,7 +734,7 @@ export default class CreatePost extends React.Component {
         }
 
         let tutorialTip = null;
-        if (parseInt(this.props.showTutorialTip, 10) === TutorialSteps.POST_POPOVER) {
+        if (parseInt(this.props.showTutorialTip, 10) === TutorialSteps.POST_POPOVER && global.window.mm_config.EnableTutorial === 'true') {
             tutorialTip = this.createTutorialTip();
         }
 

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -105,7 +105,7 @@ export default class NeedsTeam extends React.Component {
     componentWillMount() {
         // Go to tutorial if we are first arriving
         const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), 999);
-        if (tutorialStep <= TutorialSteps.INTRO_SCREENS) {
+        if (tutorialStep <= TutorialSteps.INTRO_SCREENS && global.window.mm_config.EnableTutorial === 'true') {
             browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/tutorial');
         }
     }

--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -87,7 +87,7 @@ export default class Sidebar extends React.Component {
             teamMembers,
             ...displayableChannels,
             unreadCounts: JSON.parse(JSON.stringify(ChannelStore.getUnreadCounts())),
-            showTutorialTip: tutorialStep === TutorialSteps.CHANNEL_POPOVER,
+            showTutorialTip: tutorialStep === TutorialSteps.CHANNEL_POPOVER && global.window.mm_config.EnableTutorial === 'true',
             currentTeam: TeamStore.getCurrent(),
             currentUser: UserStore.getCurrentUser(),
             townSquare: ChannelStore.getByName(Constants.DEFAULT_CHANNEL),

--- a/components/sidebar_header.jsx
+++ b/components/sidebar_header.jsx
@@ -42,7 +42,7 @@ export default class SidebarHeader extends React.Component {
             return {};
         }
         const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, this.props.currentUser.id, 999);
-        const showTutorialTip = tutorialStep === TutorialSteps.MENU_POPOVER && !Utils.isMobile();
+        const showTutorialTip = tutorialStep === TutorialSteps.MENU_POPOVER && !Utils.isMobile() && global.window.mm_config.EnableTutorial === 'true';
 
         return {showTutorialTip};
     }

--- a/components/sidebar_right_menu/sidebar_right_menu.jsx
+++ b/components/sidebar_right_menu/sidebar_right_menu.jsx
@@ -103,7 +103,7 @@ export default class SidebarRightMenu extends React.Component {
             currentUser: UserStore.getCurrentUser(),
             teamMembers: TeamStore.getMyTeamMembers(),
             teamListings: TeamStore.getTeamListings(),
-            showTutorialTip: tutorialStep === TutorialSteps.MENU_POPOVER && Utils.isMobile()
+            showTutorialTip: tutorialStep === TutorialSteps.MENU_POPOVER && Utils.isMobile() && global.window.mm_config.EnableTutorial === 'true'
         };
     }
 

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -100,7 +100,8 @@ describe('components/create_post', () => {
     window.mm_config = {
         EnableEmojiPicker: 'true',
         EnableFileAttachments: 'true',
-        EnableConfirmNotificationsToChannel: 'true'
+        EnableConfirmNotificationsToChannel: 'true',
+        EnableTutorial: 'true'
     };
 
     it('should match snapshot, init', () => {


### PR DESCRIPTION
#### Summary
Enable tutorial screen with `EnableTutorial` property
Here’s the PR for the server: https://github.com/mattermost/mattermost-server/pull/7840

cc @dmeza 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
