### PR TITLE
Add Config to disable Auth Transfers. Remove frontend switch to email…

### DIFF
--- a/components/admin_console/system_users/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown.jsx
@@ -444,21 +444,23 @@ export default class SystemUsersDropdown extends React.Component {
 
         let passwordReset;
         if (user.auth_service) {
-            passwordReset = (
-                <li role='presentation'>
-                    <a
-                        id='switchEmailPassword'
-                        role='menuitem'
-                        href='#'
-                        onClick={this.handleResetPassword}
-                    >
-                        <FormattedMessage
-                            id='admin.user_item.switchToEmail'
-                            defaultMessage='Switch to Email/Password'
-                        />
-                    </a>
-                </li>
-            );
+            if (global.window.mm_config.ExperimentalEnableAuthenticationTransfer === 'true') {
+                passwordReset = (
+                    <li role='presentation'>
+                        <a
+                            id='switchEmailPassword'
+                            role='menuitem'
+                            href='#'
+                            onClick={this.handleResetPassword}
+                        >
+                            <FormattedMessage
+                                id='admin.user_item.switchToEmail'
+                                defaultMessage='Switch to Email/Password'
+                            />
+                        </a>
+                    </li>
+                );
+            }
         } else {
             passwordReset = (
                 <li role='presentation'>

--- a/components/user_settings/user_settings_security/user_settings_security.jsx
+++ b/components/user_settings/user_settings_security/user_settings_security.jsx
@@ -1435,7 +1435,8 @@ export default class SecurityTab extends React.Component {
 
         // If there are other sign-in methods and either email is enabled or the user's account is email, then allow switching
         let signInSection;
-        if ((config.EnableSignUpWithEmail === 'true' || user.auth_service === '') && numMethods > 0) {
+        if ((config.EnableSignUpWithEmail === 'true' || user.auth_service === '') &&
+            numMethods > 0 && config.ExperimentalEnableAuthenticationTransfer === 'true') {
             signInSection = this.createSignInSection();
         }
 


### PR DESCRIPTION
#### Summary
Enables/Disables the ability to perform an auth transfer for a user based on the server config setting for `EnableAuthenticationTransfer`.

server pr: https://github.com/mattermost/mattermost-server/pull/7843

cc @dmeza 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, posting, etc.)
