### PR TITLE
Hide locale setting if there's a single locale available

### DIFF
--- a/components/user_settings/user_settings_display.jsx
+++ b/components/user_settings/user_settings_display.jsx
@@ -495,6 +495,10 @@ export default class UserSettingsDisplay extends React.Component {
             );
         }
 
+        if (global.window.mm_config.EnableLocaleSetting !== 'true') {
+            languagesSection = null;
+        }
+
         let themeSection;
         if (global.mm_config.EnableThemeSelection !== 'false') {
             themeSection = (

--- a/components/user_settings/user_settings_display.jsx
+++ b/components/user_settings/user_settings_display.jsx
@@ -495,7 +495,7 @@ export default class UserSettingsDisplay extends React.Component {
             );
         }
 
-        if (global.window.mm_config.EnableLocaleSetting !== 'true') {
+        if (Object.keys(I18n.getLanguages()).length === 1) {
             languagesSection = null;
         }
 


### PR DESCRIPTION
#### Summary
Hide locale setting if there's a single locale available Ex: "AvailableLocales": "en"
Remove the part of the server PR that's not needed any more

Cc @dmeza

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
