### PR TITLE
Get channelType from initial props in NewChannelFlow

### DIFF
--- a/components/new_channel_flow.jsx
+++ b/components/new_channel_flow.jsx
@@ -34,7 +34,7 @@ export default class NewChannelFlow extends React.Component {
 
         this.state = {
             serverError: '',
-            channelType: 'O',
+            channelType: props.channelType || 'O',
             flowState: SHOW_NEW_CHANNEL,
             channelDisplayName: '',
             channelName: '',


### PR DESCRIPTION
#### Summary
Get channelType from initial props in NewChannelFlow

Cc @dmeza

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
