### PR TITLE
UCHAT-60 change default notification settings for new users

### DIFF
--- a/components/user_settings/user_settings_notifications.jsx
+++ b/components/user_settings/user_settings_notifications.jsx
@@ -26,7 +26,7 @@ function getNotificationsStateFromStores() {
     let comments = 'never';
     let enableEmail = 'true';
     let pushActivity = NotificationLevels.MENTION;
-    let pushStatus = Constants.UserStatuses.ONLINE;
+    let pushStatus = Constants.UserStatuses.AWAY;
 
     if (user.notify_props) {
         if (user.notify_props.desktop) {

--- a/components/user_settings/user_settings_notifications.jsx
+++ b/components/user_settings/user_settings_notifications.jsx
@@ -20,7 +20,7 @@ import EmailNotificationSetting from './email_notification_setting.jsx';
 function getNotificationsStateFromStores() {
     const user = UserStore.getCurrentUser();
 
-    let desktop = NotificationLevels.DEFAULT;
+    let desktop = NotificationLevels.MENTION;
     let sound = 'true';
     let desktopDuration = '5';
     let comments = 'never';


### PR DESCRIPTION
#### Summary
Changed the default notification setting for  pushStatus to away for new users. It doesn't make sense to default the most noisy setting.

cc @dmeza 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
