### PR TITLE
Hide pre-release features section of advanced settings pane.

### DIFF
--- a/components/user_settings/user_settings_advanced.jsx
+++ b/components/user_settings/user_settings_advanced.jsx
@@ -451,78 +451,76 @@ export default class AdvancedSettingsDisplay extends React.Component {
 
         let previewFeaturesSection;
         let previewFeaturesSectionDivider;
-        if (this.state.previewFeaturesEnabled) {
-            if (this.state.preReleaseFeaturesKeys.length > 0) {
-                previewFeaturesSectionDivider = (
-                    <div className='divider-light'/>
-                );
+        if (this.state.previewFeaturesEnabled && this.state.preReleaseFeaturesKeys.length > 0) {
+            previewFeaturesSectionDivider = (
+                <div className='divider-light'/>
+            );
 
-                if (this.props.activeSection === 'advancedPreviewFeatures') {
-                    const inputs = [];
+            if (this.props.activeSection === 'advancedPreviewFeatures') {
+                const inputs = [];
 
-                    this.state.preReleaseFeaturesKeys.forEach((key) => {
-                        const feature = this.state.preReleaseFeatures[key];
-                        inputs.push(
-                            <div key={'advancedPreviewFeatures_' + feature.label}>
-                                <div className='checkbox'>
-                                    <label>
-                                        <input
-                                            id={'advancedPreviewFeatures' + feature.label}
-                                            type='checkbox'
-                                            checked={this.state.settings[Constants.FeatureTogglePrefix + feature.label] === 'true'}
-                                            onChange={(e) => {
-                                                this.toggleFeature(feature.label, e.target.checked);
-                                            }}
-                                        />
-                                        {this.renderFeatureLabel(key)}
-                                    </label>
-                                </div>
-                            </div>
-                        );
-                    });
-
+                this.state.preReleaseFeaturesKeys.forEach((key) => {
+                    const feature = this.state.preReleaseFeatures[key];
                     inputs.push(
-                        <div key='advancedPreviewFeatures_helptext'>
-                            <br/>
-                            <FormattedMessage
-                                id='user.settings.advance.preReleaseDesc'
-                                defaultMessage="Check any pre-released features you'd like to preview.  You may also need to refresh the page before the setting will take effect."
-                            />
+                        <div key={'advancedPreviewFeatures_' + feature.label}>
+                            <div className='checkbox'>
+                                <label>
+                                    <input
+                                        id={'advancedPreviewFeatures' + feature.label}
+                                        type='checkbox'
+                                        checked={this.state.settings[Constants.FeatureTogglePrefix + feature.label] === 'true'}
+                                        onChange={(e) => {
+                                            this.toggleFeature(feature.label, e.target.checked);
+                                        }}
+                                    />
+                                    {this.renderFeatureLabel(key)}
+                                </label>
+                            </div>
                         </div>
                     );
-                    previewFeaturesSection = (
-                        <SettingItemMax
-                            title={
-                                <FormattedMessage
-                                    id='user.settings.advance.preReleaseTitle'
-                                    defaultMessage='Preview pre-release features'
-                                />
-                            }
-                            inputs={inputs}
-                            submit={this.saveEnabledFeatures}
-                            saving={this.state.isSaving}
-                            server_error={serverError}
-                            updateSection={(e) => {
-                                this.updateSection('');
-                                e.preventDefault();
-                            }}
+                });
+
+                inputs.push(
+                    <div key='advancedPreviewFeatures_helptext'>
+                        <br/>
+                        <FormattedMessage
+                            id='user.settings.advance.preReleaseDesc'
+                            defaultMessage="Check any pre-released features you'd like to preview.  You may also need to refresh the page before the setting will take effect."
                         />
-                    );
-                } else {
-                    previewFeaturesSection = (
-                        <SettingItemMin
-                            title={Utils.localizeMessage('user.settings.advance.preReleaseTitle', 'Preview pre-release features')}
-                            describe={
-                                <FormattedMessage
-                                    id='user.settings.advance.enabledFeatures'
-                                    defaultMessage='{count, number} {count, plural, one {Feature} other {Features}} Enabled'
-                                    values={{count: this.state.enabledFeatures}}
-                                />
-                            }
-                            updateSection={() => this.props.updateSection('advancedPreviewFeatures')}
-                        />
-                    );
-                }
+                    </div>
+                );
+                previewFeaturesSection = (
+                    <SettingItemMax
+                        title={
+                            <FormattedMessage
+                                id='user.settings.advance.preReleaseTitle'
+                                defaultMessage='Preview pre-release features'
+                            />
+                        }
+                        inputs={inputs}
+                        submit={this.saveEnabledFeatures}
+                        saving={this.state.isSaving}
+                        server_error={serverError}
+                        updateSection={(e) => {
+                            this.updateSection('');
+                            e.preventDefault();
+                        }}
+                    />
+                );
+            } else {
+                previewFeaturesSection = (
+                    <SettingItemMin
+                        title={Utils.localizeMessage('user.settings.advance.preReleaseTitle', 'Preview pre-release features')}
+                        describe={
+                            <FormattedMessage
+                                id='user.settings.advance.enabledFeatures'
+                                defaultMessage='{count, number} {count, plural, one {Feature} other {Features}} Enabled'
+                                values={{count: this.state.enabledFeatures}}
+                            />
+                        }
+                        updateSection={() => this.props.updateSection('advancedPreviewFeatures')}
+                    />
+                );
             }
         }
 

--- a/components/user_settings/user_settings_advanced.jsx
+++ b/components/user_settings/user_settings_advanced.jsx
@@ -25,8 +25,8 @@ export default class AdvancedSettingsDisplay extends React.Component {
         this.updateSection = this.updateSection.bind(this);
         this.updateSetting = this.updateSetting.bind(this);
         this.toggleFeature = this.toggleFeature.bind(this);
-        this.saveEnabledFeatures = this.saveEnabledFeatures.bind(this);
 
+        this.saveEnabledFeatures = this.saveEnabledFeatures.bind(this);
         this.renderFormattingSection = this.renderFormattingSection.bind(this);
         this.renderJoinLeaveSection = this.renderJoinLeaveSection.bind(this);
 
@@ -77,11 +77,15 @@ export default class AdvancedSettingsDisplay extends React.Component {
 
         const isSaving = false;
 
-        return {preReleaseFeatures: PreReleaseFeatures,
+        const previewFeaturesEnabled = global.window.mm_config.EnablePreviewFeatures === 'true';
+
+        return {
+            preReleaseFeatures: PreReleaseFeatures,
             settings,
             preReleaseFeaturesKeys,
             enabledFeatures,
-            isSaving
+            isSaving,
+            previewFeaturesEnabled
         };
     }
 
@@ -447,76 +451,78 @@ export default class AdvancedSettingsDisplay extends React.Component {
 
         let previewFeaturesSection;
         let previewFeaturesSectionDivider;
-        if (this.state.preReleaseFeaturesKeys.length > 0) {
-            previewFeaturesSectionDivider = (
-                <div className='divider-light'/>
-            );
+        if (this.state.previewFeaturesEnabled) {
+            if (this.state.preReleaseFeaturesKeys.length > 0) {
+                previewFeaturesSectionDivider = (
+                    <div className='divider-light'/>
+                );
 
-            if (this.props.activeSection === 'advancedPreviewFeatures') {
-                const inputs = [];
+                if (this.props.activeSection === 'advancedPreviewFeatures') {
+                    const inputs = [];
 
-                this.state.preReleaseFeaturesKeys.forEach((key) => {
-                    const feature = this.state.preReleaseFeatures[key];
-                    inputs.push(
-                        <div key={'advancedPreviewFeatures_' + feature.label}>
-                            <div className='checkbox'>
-                                <label>
-                                    <input
-                                        id={'advancedPreviewFeatures' + feature.label}
-                                        type='checkbox'
-                                        checked={this.state.settings[Constants.FeatureTogglePrefix + feature.label] === 'true'}
-                                        onChange={(e) => {
-                                            this.toggleFeature(feature.label, e.target.checked);
-                                        }}
-                                    />
-                                    {this.renderFeatureLabel(key)}
-                                </label>
+                    this.state.preReleaseFeaturesKeys.forEach((key) => {
+                        const feature = this.state.preReleaseFeatures[key];
+                        inputs.push(
+                            <div key={'advancedPreviewFeatures_' + feature.label}>
+                                <div className='checkbox'>
+                                    <label>
+                                        <input
+                                            id={'advancedPreviewFeatures' + feature.label}
+                                            type='checkbox'
+                                            checked={this.state.settings[Constants.FeatureTogglePrefix + feature.label] === 'true'}
+                                            onChange={(e) => {
+                                                this.toggleFeature(feature.label, e.target.checked);
+                                            }}
+                                        />
+                                        {this.renderFeatureLabel(key)}
+                                    </label>
+                                </div>
                             </div>
+                        );
+                    });
+
+                    inputs.push(
+                        <div key='advancedPreviewFeatures_helptext'>
+                            <br/>
+                            <FormattedMessage
+                                id='user.settings.advance.preReleaseDesc'
+                                defaultMessage="Check any pre-released features you'd like to preview.  You may also need to refresh the page before the setting will take effect."
+                            />
                         </div>
                     );
-                });
-
-                inputs.push(
-                    <div key='advancedPreviewFeatures_helptext'>
-                        <br/>
-                        <FormattedMessage
-                            id='user.settings.advance.preReleaseDesc'
-                            defaultMessage="Check any pre-released features you'd like to preview.  You may also need to refresh the page before the setting will take effect."
+                    previewFeaturesSection = (
+                        <SettingItemMax
+                            title={
+                                <FormattedMessage
+                                    id='user.settings.advance.preReleaseTitle'
+                                    defaultMessage='Preview pre-release features'
+                                />
+                            }
+                            inputs={inputs}
+                            submit={this.saveEnabledFeatures}
+                            saving={this.state.isSaving}
+                            server_error={serverError}
+                            updateSection={(e) => {
+                                this.updateSection('');
+                                e.preventDefault();
+                            }}
                         />
-                    </div>
-                );
-                previewFeaturesSection = (
-                    <SettingItemMax
-                        title={
-                            <FormattedMessage
-                                id='user.settings.advance.preReleaseTitle'
-                                defaultMessage='Preview pre-release features'
-                            />
-                        }
-                        inputs={inputs}
-                        submit={this.saveEnabledFeatures}
-                        saving={this.state.isSaving}
-                        server_error={serverError}
-                        updateSection={(e) => {
-                            this.updateSection('');
-                            e.preventDefault();
-                        }}
-                    />
-                );
-            } else {
-                previewFeaturesSection = (
-                    <SettingItemMin
-                        title={Utils.localizeMessage('user.settings.advance.preReleaseTitle', 'Preview pre-release features')}
-                        describe={
-                            <FormattedMessage
-                                id='user.settings.advance.enabledFeatures'
-                                defaultMessage='{count, number} {count, plural, one {Feature} other {Features}} Enabled'
-                                values={{count: this.state.enabledFeatures}}
-                            />
-                        }
-                        updateSection={() => this.props.updateSection('advancedPreviewFeatures')}
-                    />
-                );
+                    );
+                } else {
+                    previewFeaturesSection = (
+                        <SettingItemMin
+                            title={Utils.localizeMessage('user.settings.advance.preReleaseTitle', 'Preview pre-release features')}
+                            describe={
+                                <FormattedMessage
+                                    id='user.settings.advance.enabledFeatures'
+                                    defaultMessage='{count, number} {count, plural, one {Feature} other {Features}} Enabled'
+                                    values={{count: this.state.enabledFeatures}}
+                                />
+                            }
+                            updateSection={() => this.props.updateSection('advancedPreviewFeatures')}
+                        />
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
#### Summary
Hide pre-release feature section of advance settings pane
Here’s the PR for the server: https://github.com/mattermost/mattermost-server/pull/7847

Cc @dmeza

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
