### PR TITLE
PLT-2068: Switching to use Redux getTheme selector.

### DIFF
--- a/components/needs_team/index.js
+++ b/components/needs_team/index.js
@@ -5,12 +5,14 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getMyChannelMembers, viewChannel} from 'mattermost-redux/actions/channels';
+import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import NeedsTeam from './needs_team.jsx';
 
 function mapStateToProps(state, ownProps) {
     return {
-        ...ownProps
+        ...ownProps,
+        theme: getTheme(state)
     };
 }
 

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -56,6 +56,7 @@ export default class NeedsTeam extends React.Component {
             PropTypes.element
         ]),
         navbar: PropTypes.element,
+        params: PropTypes.object,
         sidebar: PropTypes.element,
         team_sidebar: PropTypes.element,
         center: PropTypes.element,
@@ -63,14 +64,14 @@ export default class NeedsTeam extends React.Component {
         actions: PropTypes.shape({
             viewChannel: PropTypes.func.isRequired,
             getMyChannelMembers: PropTypes.func.isRequired
-        }).isRequired
+        }).isRequired,
+        theme: PropTypes.object.isRequired
     }
 
     constructor(params) {
         super(params);
 
         this.onTeamChanged = this.onTeamChanged.bind(this);
-        this.onPreferencesChanged = this.onPreferencesChanged.bind(this);
         this.shortcutKeyDown = this.shortcutKeyDown.bind(this);
 
         this.blurTime = new Date().getTime();
@@ -78,8 +79,7 @@ export default class NeedsTeam extends React.Component {
         const team = TeamStore.getCurrent();
 
         this.state = {
-            team,
-            theme: PreferenceStore.getTheme(team.id)
+            team
         };
     }
 
@@ -97,17 +97,8 @@ export default class NeedsTeam extends React.Component {
         const team = TeamStore.getCurrent();
 
         this.setState({
-            team,
-            theme: PreferenceStore.getTheme(team.id)
+            team
         });
-    }
-
-    onPreferencesChanged(category) {
-        if (!category || category === Preferences.CATEGORY_THEME) {
-            this.setState({
-                theme: PreferenceStore.getTheme(this.state.team.id)
-            });
-        }
     }
 
     componentWillMount() {
@@ -120,7 +111,6 @@ export default class NeedsTeam extends React.Component {
 
     componentDidMount() {
         TeamStore.addChangeListener(this.onTeamChanged);
-        PreferenceStore.addChangeListener(this.onPreferencesChanged);
 
         startPeriodicStatusUpdates();
         startPeriodicSync();
@@ -146,7 +136,7 @@ export default class NeedsTeam extends React.Component {
             }
         });
 
-        Utils.applyTheme(this.state.theme);
+        Utils.applyTheme(this.props.theme);
 
         if (UserAgent.isIosSafari()) {
             // Use iNoBounce to prevent scrolling past the boundaries of the page
@@ -155,15 +145,8 @@ export default class NeedsTeam extends React.Component {
         document.addEventListener('keydown', this.shortcutKeyDown);
     }
 
-    componentDidUpdate(prevProps, prevState) {
-        if (!Utils.areObjectsEqual(prevState.theme, this.state.theme)) {
-            Utils.applyTheme(this.state.theme);
-        }
-    }
-
     componentWillUnmount() {
         TeamStore.removeChangeListener(this.onTeamChanged);
-        PreferenceStore.removeChangeListener(this.onPreferencesChanged);
         $(window).off('focus');
         $(window).off('blur');
 
@@ -173,6 +156,12 @@ export default class NeedsTeam extends React.Component {
         stopPeriodicStatusUpdates();
         stopPeriodicSync();
         document.removeEventListener('keydown', this.shortcutKeyDown);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (!Utils.areObjectsEqual(nextProps.theme, this.props.theme)) {
+            Utils.applyTheme(nextProps.theme);
+        }
     }
 
     render() {

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -71,8 +71,8 @@ export default class NeedsTeam extends React.Component {
     constructor(params) {
         super(params);
 
-        this.onTeamChanged = this.onTeamChanged.bind(this);
-        this.shortcutKeyDown = this.shortcutKeyDown.bind(this);
+        this.teamChanged = (e) => this.onTeamChanged(e);
+        this.shortcutKeyDown = (e) => this.onShortcutKeyDown(e);
 
         this.blurTime = new Date().getTime();
 
@@ -83,7 +83,7 @@ export default class NeedsTeam extends React.Component {
         };
     }
 
-    shortcutKeyDown(e) {
+    onShortcutKeyDown(e) {
         if (e.shiftKey && e.ctrlKey && e.keyCode === Constants.KeyCodes.L) {
             if (document.getElementById('sidebar-right').className.match('sidebar--right sidebar--right--expanded')) {
                 document.getElementById('reply_textbox').focus();
@@ -110,7 +110,7 @@ export default class NeedsTeam extends React.Component {
     }
 
     componentDidMount() {
-        TeamStore.addChangeListener(this.onTeamChanged);
+        TeamStore.addChangeListener(this.teamChanged);
 
         startPeriodicStatusUpdates();
         startPeriodicSync();
@@ -146,7 +146,7 @@ export default class NeedsTeam extends React.Component {
     }
 
     componentWillUnmount() {
-        TeamStore.removeChangeListener(this.onTeamChanged);
+        TeamStore.removeChangeListener(this.teamChanged);
         $(window).off('focus');
         $(window).off('blur');
 

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -158,9 +158,10 @@ export default class NeedsTeam extends React.Component {
         document.removeEventListener('keydown', this.shortcutKeyDown);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (!Utils.areObjectsEqual(nextProps.theme, this.props.theme)) {
-            Utils.applyTheme(nextProps.theme);
+    componentDidUpdate(prevProps) {
+        const {theme} = this.props;
+        if (!Utils.areObjectsEqual(prevProps.theme, theme)) {
+            Utils.applyTheme(theme);
         }
     }
 

--- a/components/user_settings/user_settings_theme.jsx
+++ b/components/user_settings/user_settings_theme.jsx
@@ -70,9 +70,7 @@ export default class ThemeSetting extends React.Component {
     }
 
     getStateFromStores() {
-        const teamId = TeamStore.getCurrentId();
-
-        const theme = PreferenceStore.getTheme(teamId);
+        const theme = PreferenceStore.getTheme();
         if (!theme.codeTheme) {
             theme.codeTheme = Constants.DEFAULT_CODE_THEME;
         }

--- a/stores/preference_store.jsx
+++ b/stores/preference_store.jsx
@@ -137,22 +137,8 @@ class PreferenceStore extends EventEmitter {
         this.removeListener(CHANGE_EVENT, callback);
     }
 
-    getTheme(teamId) {
-        if (this.preferences.has(this.getKey(Constants.Preferences.CATEGORY_THEME, teamId))) {
-            return this.getObject(Constants.Preferences.CATEGORY_THEME, teamId);
-        }
-
-        if (this.preferences.has(this.getKey(Constants.Preferences.CATEGORY_THEME, ''))) {
-            return this.getObject(Constants.Preferences.CATEGORY_THEME, '');
-        }
-
-        for (const k in Constants.THEMES) {
-            if (Constants.THEMES.hasOwnProperty(k) && k === global.mm_config.DefaultTheme) {
-                return Constants.THEMES[k];
-            }
-        }
-
-        return Constants.THEMES.default;
+    getTheme() {
+        return Selectors.getTheme(store.getState());
     }
 
     handleEventPayload(payload) {


### PR DESCRIPTION
#### Summary
Removes a few more references to the old `PreferenceStore.getTheme(teamId)`. There is one final reference still present that can be eliminated when `ThemeSetting` is migrated to Redux (in another story).

#### Ticket Link
Done related to [PLT-2068](https://mattermost.atlassian.net/browse/PLT-2068) (but not required for it).

#### Checklist
- [x] Ran `make check-style` to check for style errors
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has redux changes [link to redux change](https://github.com/mattermost/mattermost-redux/pull/329)