### PR TITLE
PLT-8208 Use ref callback to set focus on channel switcher

### DIFF
--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -98,6 +98,11 @@ export default class QuickSwitchModal extends React.PureComponent {
         }
     }
 
+    setSwitchBoxRef = (input) => {
+        this.switchBox = input;
+        this.focusTextbox();
+    }
+
     onShow() {
         this.setState({
             text: ''
@@ -309,10 +314,7 @@ export default class QuickSwitchModal extends React.PureComponent {
                         {help}
                     </div>
                     <SuggestionBox
-                        ref={(input) => {
-                            this.switchBox = input;
-                            this.focusTextbox();
-                        }}
+                        ref={this.setSwitchBoxRef}
                         className='form-control focused'
                         type='input'
                         onChange={this.onChange}

--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -72,16 +72,12 @@ export default class QuickSwitchModal extends React.PureComponent {
         this.channelProviders = [new SwitchChannelProvider()];
         this.teamProviders = [new SwitchTeamProvider()];
 
+        this.switchBox = null;
+
         this.state = {
             text: '',
             mode: props.initialMode
         };
-    }
-
-    componentDidUpdate(prevProps) {
-        if (this.props.show && !prevProps.show) {
-            this.focusTextbox();
-        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -91,13 +87,15 @@ export default class QuickSwitchModal extends React.PureComponent {
     }
 
     focusTextbox() {
-        if (this.refs.switchbox == null) {
+        if (this.switchBox == null) {
             return;
         }
 
-        const textbox = this.refs.switchbox.getTextbox();
-        textbox.focus();
-        Utils.placeCaretAtEnd(textbox);
+        const textbox = this.switchBox.getTextbox();
+        if (document.activeElement !== textbox) {
+            textbox.focus();
+            Utils.placeCaretAtEnd(textbox);
+        }
     }
 
     onShow() {
@@ -311,7 +309,10 @@ export default class QuickSwitchModal extends React.PureComponent {
                         {help}
                     </div>
                     <SuggestionBox
-                        ref='switchbox'
+                        ref={(input) => {
+                            this.switchBox = input;
+                            this.focusTextbox();
+                        }}
                         className='form-control focused'
                         type='input'
                         onChange={this.onChange}


### PR DESCRIPTION
#### Summary
It looks like this was caused by the upgrade to React 16. For some reason the component `refs` isn't getting set in time for `componentDidUpdate()`, when in the past it would.

There are some mentions in the changelog about changes to lifecycle and refs https://github.com/facebook/react/releases/tag/v16.0.0 but nothing that I can see that should directly affect this behavior and all the docs I can find seem to state that refs should be available in time for `componentDidUpate()`.

Fixed by making use of the ref callback.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8208