### PR TITLE
PLT-8172 Fix sign-up page

### DIFF
--- a/components/signup/signup_controller.jsx
+++ b/components/signup/signup_controller.jsx
@@ -8,7 +8,6 @@ import {browserHistory, Link} from 'react-router';
 
 import {Client4} from 'mattermost-redux/client';
 
-import * as Utils from 'utils/utils.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {addUserToTeamFromInvite, getInviteInfo} from 'actions/team_actions.jsx';
 import {loadMe} from 'actions/user_actions.jsx';
@@ -348,8 +347,7 @@ export default class SignupController extends React.Component {
                             />
                             {' '}
                             <Link
-                                to={'/login'}
-                                query={Utils.isEmptyObject(this.props.location.query) ? null : this.props.location.query}
+                                to={'/login' + this.props.location.search}
                             >
                                 <FormattedMessage
                                     id='signup_user_completed.signIn'


### PR DESCRIPTION
#### Summary
I'm assuming this had something to do with the client dependencies updating and some things not playing well together, but for some reason the way the `query` prop was getting set was causing havoc between react-router and react-intl.

I just simplified to pass the query parameters with `location.search` which will be blank if there are no query parameters and have the query needed if set.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8172