### PR TITLE
PLT-8175/PLT-8223 Fixed client-side rendering of system messages (4.4.2)

### DIFF
--- a/components/post_view/post_message_view/system_message_helpers.jsx
+++ b/components/post_view/post_message_view/system_message_helpers.jsx
@@ -256,7 +256,7 @@ export function renderSystemMessage(post, options) {
 
         return null;
     } else if (systemMessageRenderers[post.type]) {
-        systemMessageRenderers[post.type](post, options);
+        return systemMessageRenderers[post.type](post, options);
     }
 
     return null;


### PR DESCRIPTION
The system message rendered by the client wasn't being returned, causing it to fall back to the message rendered and translated by the system 

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8175
https://mattermost.atlassian.net/browse/PLT-8223
