### PR TITLE
Uses PureComponent wherever shouldComponentUpdate absent.

### DIFF
--- a/components/access_history_modal/access_history_modal.jsx
+++ b/components/access_history_modal/access_history_modal.jsx
@@ -15,7 +15,7 @@ import * as Utils from 'utils/utils.jsx';
 import AuditTable from 'components/audit_table.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
-export default class AccessHistoryModal extends React.Component {
+export default class AccessHistoryModal extends React.PureComponent {
     static propTypes = {
         onHide: PropTypes.func.isRequired,
         actions: PropTypes.shape({

--- a/components/activity_log_modal/activity_log_modal.jsx
+++ b/components/activity_log_modal/activity_log_modal.jsx
@@ -16,7 +16,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import LoadingScreen from 'components/loading_screen.jsx';
 
-export default class ActivityLogModal extends React.Component {
+export default class ActivityLogModal extends React.PureComponent {
     static propTypes = {
         onHide: PropTypes.func.isRequired,
         actions: PropTypes.shape({

--- a/components/add_users_to_team/add_users_to_team.jsx
+++ b/components/add_users_to_team/add_users_to_team.jsx
@@ -25,7 +25,7 @@ import ProfilePicture from 'components/profile_picture.jsx';
 const USERS_PER_PAGE = 50;
 const MAX_SELECTABLE_VALUES = 20;
 
-export default class AddUsersToTeam extends React.Component {
+export default class AddUsersToTeam extends React.PureComponent {
     static propTypes = {
         onModalDismissed: PropTypes.func,
         actions: PropTypes.shape({

--- a/components/admin_console/admin_console.jsx
+++ b/components/admin_console/admin_console.jsx
@@ -13,7 +13,7 @@ import DiscardChangesModal from 'components/discard_changes_modal.jsx';
 
 import AdminSidebar from './admin_sidebar';
 
-export default class AdminConsole extends React.Component {
+export default class AdminConsole extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
+++ b/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
@@ -19,7 +19,7 @@ import * as Utils from 'utils/utils.jsx';
 import AboutBuildModal from 'components/about_build_modal';
 import BlockableLink from 'components/admin_console/blockable_link';
 
-export default class AdminNavbarDropdown extends React.Component {
+export default class AdminNavbarDropdown extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/admin_console/admin_settings.jsx
+++ b/components/admin_console/admin_settings.jsx
@@ -9,7 +9,7 @@ import {saveConfig} from 'actions/admin_actions.jsx';
 import SaveButton from 'components/save_button.jsx';
 import FormError from 'components/form_error.jsx';
 
-export default class AdminSettings extends React.Component {
+export default class AdminSettings extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/admin_console/admin_sidebar/admin_sidebar.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.jsx
@@ -13,7 +13,7 @@ import AdminSidebarCategory from 'components/admin_console/admin_sidebar_categor
 import AdminSidebarHeader from 'components/admin_console/admin_sidebar_header.jsx';
 import AdminSidebarSection from 'components/admin_console/admin_sidebar_section.jsx';
 
-export default class AdminSidebar extends React.Component {
+export default class AdminSidebar extends React.PureComponent {
     static get contextTypes() {
         return {
             router: PropTypes.object.isRequired

--- a/components/admin_console/admin_sidebar_category.jsx
+++ b/components/admin_console/admin_sidebar_category.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
-export default class AdminSidebarCategory extends React.Component {
+export default class AdminSidebarCategory extends React.PureComponent {
     static get propTypes() {
         return {
             name: PropTypes.string,

--- a/components/admin_console/admin_sidebar_header.jsx
+++ b/components/admin_console/admin_sidebar_header.jsx
@@ -12,7 +12,7 @@ import UserStore from 'stores/user_store.jsx';
 
 import AdminNavbarDropdown from './admin_navbar_dropdown';
 
-export default class SidebarHeader extends React.Component {
+export default class SidebarHeader extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/admin_console/admin_sidebar_section.jsx
+++ b/components/admin_console/admin_sidebar_section.jsx
@@ -8,7 +8,7 @@ import BlockableLink from 'components/admin_console/blockable_link';
 
 import * as Utils from 'utils/utils.jsx';
 
-export default class AdminSidebarSection extends React.Component {
+export default class AdminSidebarSection extends React.PureComponent {
     static get propTypes() {
         return {
             name: PropTypes.string.isRequired,

--- a/components/admin_console/boolean_setting.jsx
+++ b/components/admin_console/boolean_setting.jsx
@@ -9,7 +9,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import Setting from './setting.jsx';
 
-export default class BooleanSetting extends React.Component {
+export default class BooleanSetting extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/admin_console/cluster_table.jsx
+++ b/components/admin_console/cluster_table.jsx
@@ -10,7 +10,7 @@ import * as Utils from 'utils/utils.jsx';
 import statusGreen from 'images/status_green.png';
 import statusYellow from 'images/status_yellow.png';
 
-export default class ClusterTable extends React.Component {
+export default class ClusterTable extends React.PureComponent {
     static propTypes = {
         clusterInfos: PropTypes.array.isRequired,
         reload: PropTypes.func.isRequired

--- a/components/admin_console/cluster_table_container.jsx
+++ b/components/admin_console/cluster_table_container.jsx
@@ -9,7 +9,7 @@ import LoadingScreen from '../loading_screen.jsx';
 
 import ClusterTable from './cluster_table.jsx';
 
-export default class ClusterTableContainer extends React.Component {
+export default class ClusterTableContainer extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/admin_console/dropdown_setting.jsx
+++ b/components/admin_console/dropdown_setting.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import Setting from './setting.jsx';
 
-export default class DropdownSetting extends React.Component {
+export default class DropdownSetting extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/admin_console/email_connection_test.jsx
+++ b/components/admin_console/email_connection_test.jsx
@@ -9,7 +9,7 @@ import {testEmail} from 'actions/admin_actions.jsx';
 
 import * as Utils from 'utils/utils.jsx';
 
-export default class EmailConnectionTestButton extends React.Component {
+export default class EmailConnectionTestButton extends React.PureComponent {
     static get propTypes() {
         return {
             config: PropTypes.object.isRequired,

--- a/components/admin_console/generated_setting.jsx
+++ b/components/admin_console/generated_setting.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-export default class GeneratedSetting extends React.Component {
+export default class GeneratedSetting extends React.PureComponent {
     static get propTypes() {
         return {
             id: PropTypes.string.isRequired,

--- a/components/admin_console/license_settings.jsx
+++ b/components/admin_console/license_settings.jsx
@@ -24,7 +24,7 @@ const holders = defineMessages({
     }
 });
 
-class LicenseSettings extends React.Component {
+class LicenseSettings extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
+++ b/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
@@ -10,7 +10,7 @@ import {removeUserFromTeam, updateTeamMemberRoles} from 'actions/team_actions.js
 
 import * as Utils from 'utils/utils.jsx';
 
-export default class ManageTeamsDropdown extends React.Component {
+export default class ManageTeamsDropdown extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object.isRequired,
         teamMember: PropTypes.object.isRequired,

--- a/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
+++ b/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
@@ -18,7 +18,7 @@ import LoadingScreen from 'components/loading_screen.jsx';
 import ManageTeamsDropdown from './manage_teams_dropdown.jsx';
 import RemoveFromTeamButton from './remove_from_team_button.jsx';
 
-export default class ManageTeamsModal extends React.Component {
+export default class ManageTeamsModal extends React.PureComponent {
     static propTypes = {
         onModalDismissed: PropTypes.func.isRequired,
         show: PropTypes.bool.isRequired,

--- a/components/admin_console/multiselect_settings.jsx
+++ b/components/admin_console/multiselect_settings.jsx
@@ -9,7 +9,7 @@ import FormError from 'components/form_error.jsx';
 
 import Setting from './setting.jsx';
 
-export default class MultiSelectSetting extends React.Component {
+export default class MultiSelectSetting extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -11,7 +11,7 @@ import * as Utils from 'utils/utils.jsx';
 import Banner from 'components/admin_console/banner.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
-export default class PluginManagement extends React.Component {
+export default class PluginManagement extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/admin_console/post_edit_setting.jsx
+++ b/components/admin_console/post_edit_setting.jsx
@@ -9,7 +9,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import Setting from './setting.jsx';
 
-export default class PostEditSetting extends React.Component {
+export default class PostEditSetting extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/admin_console/radio_setting.jsx
+++ b/components/admin_console/radio_setting.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import Setting from './setting.jsx';
 
-export default class RadioSetting extends React.Component {
+export default class RadioSetting extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/admin_console/request_button/request_button.jsx
+++ b/components/admin_console/request_button/request_button.jsx
@@ -12,7 +12,7 @@ import * as Utils from 'utils/utils.jsx';
  * its outcome as either success, or failure accompanied by the
  * `message` property of the `err` object.
  */
-export default class RequestButton extends React.Component {
+export default class RequestButton extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/admin_console/reset_password_modal.jsx
+++ b/components/admin_console/reset_password_modal.jsx
@@ -10,7 +10,7 @@ import {adminResetPassword} from 'actions/admin_actions.jsx';
 
 import * as Utils from 'utils/utils.jsx';
 
-export default class ResetPasswordModal extends React.Component {
+export default class ResetPasswordModal extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object,
         show: PropTypes.bool.isRequired,

--- a/components/admin_console/settings_group.jsx
+++ b/components/admin_console/settings_group.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class SettingsGroup extends React.Component {
+export default class SettingsGroup extends React.PureComponent {
     static get propTypes() {
         return {
             show: PropTypes.bool.isRequired,

--- a/components/admin_console/system_users/system_users.jsx
+++ b/components/admin_console/system_users/system_users.jsx
@@ -26,7 +26,7 @@ const NO_TEAM = 'no_team';
 const USER_ID_LENGTH = 26;
 const USERS_PER_PAGE = 50;
 
-export default class SystemUsers extends React.Component {
+export default class SystemUsers extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/admin_console/system_users/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown.jsx
@@ -18,7 +18,7 @@ import {clientLogout} from 'actions/global_actions.jsx';
 
 import ConfirmModal from 'components/confirm_modal.jsx';
 
-export default class SystemUsersDropdown extends React.Component {
+export default class SystemUsersDropdown extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/admin_console/system_users/system_users_list.jsx
+++ b/components/admin_console/system_users/system_users_list.jsx
@@ -23,7 +23,7 @@ import SystemUsersDropdown from './system_users_dropdown.jsx';
 const dispatch = store.dispatch;
 const getState = store.getState;
 
-export default class SystemUsersList extends React.Component {
+export default class SystemUsersList extends React.PureComponent {
     static propTypes = {
         users: PropTypes.arrayOf(PropTypes.object),
         usersPerPage: PropTypes.number,

--- a/components/admin_console/text_setting.jsx
+++ b/components/admin_console/text_setting.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import Setting from './setting.jsx';
 
-export default class TextSetting extends React.Component {
+export default class TextSetting extends React.PureComponent {
     static get propTypes() {
         return {
             id: PropTypes.string.isRequired,

--- a/components/admin_console/user_autocomplete_setting.jsx
+++ b/components/admin_console/user_autocomplete_setting.jsx
@@ -92,7 +92,7 @@ class UserProvider extends Provider {
     }
 }
 
-export default class UserAutocompleteSetting extends React.Component {
+export default class UserAutocompleteSetting extends React.PureComponent {
     static get propTypes() {
         return {
             id: PropTypes.string.isRequired,

--- a/components/analytics/team_analytics/team_analytics.jsx
+++ b/components/analytics/team_analytics/team_analytics.jsx
@@ -22,7 +22,7 @@ import LoadingScreen from 'components/loading_screen.jsx';
 
 const LAST_ANALYTICS_TEAM = 'last_analytics_team';
 
-export default class TeamAnalytics extends React.Component {
+export default class TeamAnalytics extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/authorize.jsx
+++ b/components/authorize.jsx
@@ -11,7 +11,7 @@ import icon50 from 'images/icon50x50.png';
 
 import FormError from 'components/form_error.jsx';
 
-export default class Authorize extends React.Component {
+export default class Authorize extends React.PureComponent {
     static get propTypes() {
         return {
             location: PropTypes.object.isRequired,

--- a/components/autosize_textarea.jsx
+++ b/components/autosize_textarea.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class AutosizeTextarea extends React.Component {
+export default class AutosizeTextarea extends React.PureComponent {
     static propTypes = {
         value: PropTypes.string,
         placeholder: PropTypes.string,

--- a/components/backstage/backstage_controller.jsx
+++ b/components/backstage/backstage_controller.jsx
@@ -14,7 +14,7 @@ import AnnouncementBar from 'components/announcement_bar';
 import BackstageNavbar from './components/backstage_navbar.jsx';
 import BackstageSidebar from './components/backstage_sidebar.jsx';
 
-export default class BackstageController extends React.Component {
+export default class BackstageController extends React.PureComponent {
     static get propTypes() {
         return {
             user: PropTypes.object,

--- a/components/backstage/components/backstage_category.jsx
+++ b/components/backstage/components/backstage_category.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
-export default class BackstageCategory extends React.Component {
+export default class BackstageCategory extends React.PureComponent {
     static get propTypes() {
         return {
             name: PropTypes.string.isRequired,

--- a/components/backstage/components/backstage_header.jsx
+++ b/components/backstage/components/backstage_header.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class BackstageHeader extends React.Component {
+export default class BackstageHeader extends React.PureComponent {
     static get propTypes() {
         return {
             children: PropTypes.node

--- a/components/backstage/components/backstage_list.jsx
+++ b/components/backstage/components/backstage_list.jsx
@@ -9,7 +9,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import LoadingScreen from 'components/loading_screen.jsx';
 
-export default class BackstageList extends React.Component {
+export default class BackstageList extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node,
         header: PropTypes.node.isRequired,

--- a/components/backstage/components/backstage_navbar.jsx
+++ b/components/backstage/components/backstage_navbar.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router';
 
-export default class BackstageNavbar extends React.Component {
+export default class BackstageNavbar extends React.PureComponent {
     static get propTypes() {
         return {
             team: PropTypes.object.isRequired

--- a/components/backstage/components/backstage_section.jsx
+++ b/components/backstage/components/backstage_section.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
-export default class BackstageSection extends React.Component {
+export default class BackstageSection extends React.PureComponent {
     static get propTypes() {
         return {
             name: PropTypes.string.isRequired,

--- a/components/backstage/components/backstage_sidebar.jsx
+++ b/components/backstage/components/backstage_sidebar.jsx
@@ -12,7 +12,7 @@ import * as Utils from 'utils/utils.jsx';
 import BackstageCategory from './backstage_category.jsx';
 import BackstageSection from './backstage_section.jsx';
 
-export default class BackstageSidebar extends React.Component {
+export default class BackstageSidebar extends React.PureComponent {
     static get propTypes() {
         return {
             team: PropTypes.object.isRequired,

--- a/components/change_url_modal.jsx
+++ b/components/change_url_modal.jsx
@@ -12,7 +12,7 @@ import TeamStore from 'stores/team_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as URL from 'utils/url.jsx';
 
-export default class ChangeUrlModal extends React.Component {
+export default class ChangeUrlModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -37,7 +37,7 @@ import ToggleModalButton from 'components/toggle_modal_button.jsx';
 
 const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
-export default class ChannelHeader extends React.Component {
+export default class ChannelHeader extends React.PureComponent {
     static propTypes = {
         channel: PropTypes.object.isRequired,
         channelMember: PropTypes.object.isRequired,

--- a/components/channel_invite_modal/channel_invite_modal.jsx
+++ b/components/channel_invite_modal/channel_invite_modal.jsx
@@ -26,7 +26,7 @@ import MultiSelect from 'components/multiselect/multiselect.jsx';
 const USERS_PER_PAGE = 50;
 const MAX_SELECTABLE_VALUES = 20;
 
-export default class ChannelInviteModal extends React.Component {
+export default class ChannelInviteModal extends React.PureComponent {
     static propTypes = {
         onHide: PropTypes.func.isRequired,
         channel: PropTypes.object.isRequired,

--- a/components/channel_members_dropdown/channel_members_dropdown.jsx
+++ b/components/channel_members_dropdown/channel_members_dropdown.jsx
@@ -14,7 +14,7 @@ import {canManageMembers} from 'utils/channel_utils.jsx';
 import {Constants} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-export default class ChannelMembersDropdown extends React.Component {
+export default class ChannelMembersDropdown extends React.PureComponent {
     static propTypes = {
         channel: PropTypes.object.isRequired,
         user: PropTypes.object.isRequired,

--- a/components/channel_members_modal.jsx
+++ b/components/channel_members_modal.jsx
@@ -15,7 +15,7 @@ import {Constants} from 'utils/constants.jsx';
 
 import MemberListChannel from 'components/member_list_channel';
 
-export default class ChannelMembersModal extends React.Component {
+export default class ChannelMembersModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/channel_notifications_modal.jsx
+++ b/components/channel_notifications_modal.jsx
@@ -15,7 +15,7 @@ import {NotificationLevels} from 'utils/constants.jsx';
 import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min.jsx';
 
-export default class ChannelNotificationsModal extends React.Component {
+export default class ChannelNotificationsModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/channel_select.jsx
+++ b/components/channel_select.jsx
@@ -10,7 +10,7 @@ import {sortChannelsByDisplayName} from 'utils/channel_utils.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-export default class ChannelSelect extends React.Component {
+export default class ChannelSelect extends React.PureComponent {
     static get propTypes() {
         return {
             onChange: PropTypes.func,

--- a/components/claim/claim_controller.jsx
+++ b/components/claim/claim_controller.jsx
@@ -8,7 +8,7 @@ import logoImage from 'images/logo.png';
 
 import BackButton from 'components/common/back_button.jsx';
 
-export default class ClaimController extends React.Component {
+export default class ClaimController extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/claim/components/email_to_ldap.jsx
+++ b/components/claim/components/email_to_ldap.jsx
@@ -12,7 +12,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import LoginMfa from 'components/login/components/login_mfa.jsx';
 
-export default class EmailToLDAP extends React.Component {
+export default class EmailToLDAP extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/claim/components/email_to_oauth.jsx
+++ b/components/claim/components/email_to_oauth.jsx
@@ -14,7 +14,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import LoginMfa from 'components/login/components/login_mfa.jsx';
 
-export default class EmailToOAuth extends React.Component {
+export default class EmailToOAuth extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/claim/components/ldap_to_email.jsx
+++ b/components/claim/components/ldap_to_email.jsx
@@ -11,7 +11,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import LoginMfa from 'components/login/components/login_mfa.jsx';
 
-export default class LDAPToEmail extends React.Component {
+export default class LDAPToEmail extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/claim/components/oauth_to_email.jsx
+++ b/components/claim/components/oauth_to_email.jsx
@@ -11,7 +11,7 @@ import {oauthToEmail} from 'actions/admin_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-export default class OAuthToEmail extends React.Component {
+export default class OAuthToEmail extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/code_preview.jsx
+++ b/components/code_preview.jsx
@@ -13,7 +13,7 @@ import loadingGif from 'images/load.gif';
 
 import FileInfoPreview from './file_info_preview.jsx';
 
-export default class CodePreview extends React.Component {
+export default class CodePreview extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/color_input.jsx
+++ b/components/color_input.jsx
@@ -6,7 +6,7 @@ import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import {ChromePicker} from 'react-color';
 
-class ColorInput extends React.Component {
+class ColorInput extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/confirm_modal.jsx
+++ b/components/confirm_modal.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
-export default class ConfirmModal extends React.Component {
+export default class ConfirmModal extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/create_post.jsx
+++ b/components/create_post.jsx
@@ -41,7 +41,7 @@ const KeyCodes = Constants.KeyCodes;
 
 export const REACTION_PATTERN = /^(\+|-):([^:\s]+):\s*$/;
 
-export default class CreatePost extends React.Component {
+export default class CreatePost extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/create_team/components/display_name.jsx
+++ b/components/create_team/components/display_name.jsx
@@ -13,7 +13,7 @@ import {cleanUpUrlable} from 'utils/url.jsx';
 
 import logoImage from 'images/logo.png';
 
-export default class TeamSignupDisplayNamePage extends React.Component {
+export default class TeamSignupDisplayNamePage extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/create_team/components/team_url.jsx
+++ b/components/create_team/components/team_url.jsx
@@ -15,7 +15,7 @@ import * as URL from 'utils/url.jsx';
 
 import logoImage from 'images/logo.png';
 
-export default class TeamUrl extends React.Component {
+export default class TeamUrl extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/create_team/create_team_controller.jsx
+++ b/components/create_team/create_team_controller.jsx
@@ -12,7 +12,7 @@ import TeamStore from 'stores/team_store.jsx';
 import AnnouncementBar from 'components/announcement_bar';
 import BackButton from 'components/common/back_button.jsx';
 
-export default class CreateTeamController extends React.Component {
+export default class CreateTeamController extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/delete_post_modal.jsx
+++ b/components/delete_post_modal.jsx
@@ -15,7 +15,7 @@ import Constants from 'utils/constants.jsx';
 
 var ActionTypes = Constants.ActionTypes;
 
-export default class DeletePostModal extends React.Component {
+export default class DeletePostModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/do_verify_email.jsx
+++ b/components/do_verify_email.jsx
@@ -14,7 +14,7 @@ import BackButton from 'components/common/back_button.jsx';
 
 import LoadingScreen from './loading_screen.jsx';
 
-export default class DoVerifyEmail extends React.Component {
+export default class DoVerifyEmail extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx
+++ b/components/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx
@@ -10,7 +10,7 @@ import {RequestStatus} from 'mattermost-redux/constants';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-export default class EditChannelPurposeModal extends React.Component {
+export default class EditChannelPurposeModal extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/emoji/components/add_emoji.jsx
+++ b/components/emoji/components/add_emoji.jsx
@@ -13,7 +13,7 @@ import BackstageHeader from 'components/backstage/components/backstage_header.js
 import FormError from 'components/form_error.jsx';
 import SpinnerButton from 'components/spinner_button.jsx';
 
-export default class AddEmoji extends React.Component {
+export default class AddEmoji extends React.PureComponent {
     static propTypes = {
         team: PropTypes.object,
         user: PropTypes.object

--- a/components/emoji/components/emoji_list.jsx
+++ b/components/emoji/components/emoji_list.jsx
@@ -16,7 +16,7 @@ import LoadingScreen from 'components/loading_screen.jsx';
 
 import EmojiListItem from './emoji_list_item.jsx';
 
-export default class EmojiList extends React.Component {
+export default class EmojiList extends React.PureComponent {
     static get propTypes() {
         return {
             team: PropTypes.object,

--- a/components/emoji/components/emoji_list_item.jsx
+++ b/components/emoji/components/emoji_list_item.jsx
@@ -11,7 +11,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import DeleteEmoji from './delete_emoji_modal.jsx';
 
-export default class EmojiListItem extends React.Component {
+export default class EmojiListItem extends React.PureComponent {
     static get propTypes() {
         return {
             emoji: PropTypes.object.isRequired,

--- a/components/emoji_picker/components/emoji_picker_category.jsx
+++ b/components/emoji_picker/components/emoji_picker_category.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class EmojiPickerCategory extends React.Component {
+export default class EmojiPickerCategory extends React.PureComponent {
     static propTypes = {
         category: PropTypes.string.isRequired,
         icon: PropTypes.node.isRequired,

--- a/components/emoji_picker/components/emoji_picker_preview.jsx
+++ b/components/emoji_picker/components/emoji_picker_preview.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import EmojiStore from 'stores/emoji_store.jsx';
 
-export default class EmojiPickerPreview extends React.Component {
+export default class EmojiPickerPreview extends React.PureComponent {
     static propTypes = {
         emoji: PropTypes.object
     }

--- a/components/emoji_picker/emoji_picker_container.jsx
+++ b/components/emoji_picker/emoji_picker_container.jsx
@@ -8,7 +8,7 @@ import EmojiStore from 'stores/emoji_store.jsx';
 
 import EmojiPicker from './emoji_picker.jsx';
 
-export default class EmojiPickerContainer extends React.Component {
+export default class EmojiPickerContainer extends React.PureComponent {
     static propTypes = {
         onEmojiClick: PropTypes.func.isRequred
     }

--- a/components/error_page.jsx
+++ b/components/error_page.jsx
@@ -11,7 +11,7 @@ import {Link} from 'react-router';
 import {ErrorPageTypes} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-export default class ErrorPage extends React.Component {
+export default class ErrorPage extends React.PureComponent {
     static propTypes = {
         location: PropTypes.object.isRequired
     };

--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -9,7 +9,7 @@ import Constants from 'utils/constants.jsx';
 import FileAttachment from 'components/file_attachment.jsx';
 import ViewImageModal from 'components/view_image.jsx';
 
-export default class FileAttachmentList extends React.Component {
+export default class FileAttachmentList extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/file_preview.jsx
+++ b/components/file_preview.jsx
@@ -11,7 +11,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import loadingGif from 'images/load.gif';
 
-export default class FilePreview extends React.Component {
+export default class FilePreview extends React.PureComponent {
     static propTypes = {
         onRemove: PropTypes.func.isRequired,
         fileInfos: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/components/file_upload.jsx
+++ b/components/file_upload.jsx
@@ -40,7 +40,7 @@ const holders = defineMessages({
 
 const OverlayTimeout = 500;
 
-class FileUpload extends React.Component {
+class FileUpload extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/filtered_user_list.jsx
+++ b/components/filtered_user_list.jsx
@@ -31,7 +31,7 @@ const holders = defineMessages({
     }
 });
 
-class FilteredUserList extends React.Component {
+class FilteredUserList extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/form_error.jsx
+++ b/components/form_error.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class FormError extends React.Component {
+export default class FormError extends React.PureComponent {
     static get propTypes() {
         // accepts either a single error or an array of errors
         return {

--- a/components/help/help_controller.jsx
+++ b/components/help/help_controller.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-export default class HelpController extends React.Component {
+export default class HelpController extends React.PureComponent {
     static get propTypes() {
         return {
             children: PropTypes.node.isRequired

--- a/components/integrations/components/abstract_incoming_webhook.jsx
+++ b/components/integrations/components/abstract_incoming_webhook.jsx
@@ -11,7 +11,7 @@ import ChannelSelect from 'components/channel_select.jsx';
 import FormError from 'components/form_error.jsx';
 import SpinnerButton from 'components/spinner_button.jsx';
 
-export default class AbstractIncomingWebhook extends React.Component {
+export default class AbstractIncomingWebhook extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/integrations/components/abstract_outgoing_webhook.jsx
+++ b/components/integrations/components/abstract_outgoing_webhook.jsx
@@ -15,7 +15,7 @@ import ChannelSelect from 'components/channel_select.jsx';
 import FormError from 'components/form_error.jsx';
 import SpinnerButton from 'components/spinner_button.jsx';
 
-export default class AbstractOutgoingWebhook extends React.Component {
+export default class AbstractOutgoingWebhook extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/integrations/components/confirm_integration/confirm_integration.jsx
+++ b/components/integrations/components/confirm_integration/confirm_integration.jsx
@@ -13,7 +13,7 @@ import Constants from 'utils/constants.jsx';
 
 import BackstageHeader from 'components/backstage/components/backstage_header.jsx';
 
-export default class ConfirmIntegration extends React.Component {
+export default class ConfirmIntegration extends React.PureComponent {
     static get propTypes() {
         return {
             team: PropTypes.object,

--- a/components/integrations/components/integration_option.jsx
+++ b/components/integrations/components/integration_option.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
-export default class IntegrationOption extends React.Component {
+export default class IntegrationOption extends React.PureComponent {
     static get propTypes() {
         return {
             image: PropTypes.string.isRequired,

--- a/components/integrations/components/integrations.jsx
+++ b/components/integrations/components/integrations.jsx
@@ -14,7 +14,7 @@ import SlashCommandIcon from 'images/slash_command_icon.jpg';
 
 import IntegrationOption from './integration_option.jsx';
 
-export default class Integrations extends React.Component {
+export default class Integrations extends React.PureComponent {
     static get propTypes() {
         return {
             team: PropTypes.object,

--- a/components/invite_member_modal.jsx
+++ b/components/invite_member_modal.jsx
@@ -47,7 +47,7 @@ const holders = defineMessages({
     }
 });
 
-class InviteMemberModal extends React.Component {
+class InviteMemberModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/leave_team_modal.jsx
+++ b/components/leave_team_modal.jsx
@@ -12,7 +12,7 @@ import WebrtcStore from 'stores/webrtc_store.jsx';
 
 import {ActionTypes, WebrtcActionTypes} from 'utils/constants.jsx';
 
-class LeaveTeamModal extends React.Component {
+class LeaveTeamModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/loading_screen.jsx
+++ b/components/loading_screen.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-export default class LoadingScreen extends React.Component {
+export default class LoadingScreen extends React.PureComponent {
     constructor(props) {
         super(props);
         this.state = {};

--- a/components/logged_in.jsx
+++ b/components/logged_in.jsx
@@ -19,7 +19,7 @@ import LoadingScreen from 'components/loading_screen.jsx';
 
 const BACKSPACE_CHAR = 8;
 
-export default class LoggedIn extends React.Component {
+export default class LoggedIn extends React.PureComponent {
     constructor(params) {
         super(params);
 

--- a/components/login/components/login_mfa.jsx
+++ b/components/login/components/login_mfa.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import * as Utils from 'utils/utils.jsx';
 
-export default class LoginMfa extends React.Component {
+export default class LoginMfa extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/login/login_controller.jsx
+++ b/components/login/login_controller.jsx
@@ -25,7 +25,7 @@ import FormError from 'components/form_error.jsx';
 
 import LoginMfa from './components/login_mfa.jsx';
 
-export default class LoginController extends React.Component {
+export default class LoginController extends React.PureComponent {
     static get propTypes() {
         return {
             location: PropTypes.object.isRequired,

--- a/components/member_list_channel/member_list_channel.jsx
+++ b/components/member_list_channel/member_list_channel.jsx
@@ -20,7 +20,7 @@ import SearchableUserList from 'components/searchable_user_list/searchable_user_
 
 const USERS_PER_PAGE = 50;
 
-export default class MemberListChannel extends React.Component {
+export default class MemberListChannel extends React.PureComponent {
     static propTypes = {
         channel: PropTypes.object.isRequired,
         actions: PropTypes.shape({

--- a/components/member_list_team/member_list_team.jsx
+++ b/components/member_list_team/member_list_team.jsx
@@ -19,7 +19,7 @@ import TeamMembersDropdown from 'components/team_members_dropdown';
 
 const USERS_PER_PAGE = 50;
 
-export default class MemberListTeam extends React.Component {
+export default class MemberListTeam extends React.PureComponent {
     static propTypes = {
         isAdmin: PropTypes.bool,
         actions: PropTypes.shape({

--- a/components/message_wrapper.jsx
+++ b/components/message_wrapper.jsx
@@ -8,7 +8,7 @@ import * as TextFormatting from 'utils/text_formatting.jsx';
 import {getSiteURL} from 'utils/url.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-export default class MessageWrapper extends React.Component {
+export default class MessageWrapper extends React.PureComponent {
     constructor(props) {
         super(props);
         this.state = {};

--- a/components/mfa/components/confirm.jsx
+++ b/components/mfa/components/confirm.jsx
@@ -11,7 +11,7 @@ import Constants from 'utils/constants.jsx';
 
 const KeyCodes = Constants.KeyCodes;
 
-export default class Confirm extends React.Component {
+export default class Confirm extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/mfa/components/setup.jsx
+++ b/components/mfa/components/setup.jsx
@@ -10,7 +10,7 @@ import UserStore from 'stores/user_store.jsx';
 
 import * as Utils from 'utils/utils.jsx';
 
-export default class Setup extends React.Component {
+export default class Setup extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/mfa/mfa_controller.jsx
+++ b/components/mfa/mfa_controller.jsx
@@ -12,7 +12,7 @@ import logoImage from 'images/logo.png';
 
 import BackButton from 'components/common/back_button.jsx';
 
-export default class MFAController extends React.Component {
+export default class MFAController extends React.PureComponent {
     componentDidMount() {
         if (window.mm_license.MFA !== 'true' || window.mm_config.EnableMultifactorAuthentication !== 'true') {
             browserHistory.push('/');

--- a/components/modals/leave_private_channel_modal.jsx
+++ b/components/modals/leave_private_channel_modal.jsx
@@ -11,7 +11,7 @@ import Constants from 'utils/constants.jsx';
 
 import ConfirmModal from 'components/confirm_modal.jsx';
 
-class LeavePrivateChannelModal extends React.Component {
+class LeavePrivateChannelModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -25,7 +25,7 @@ import ProfilePicture from 'components/profile_picture.jsx';
 const USERS_PER_PAGE = 50;
 const MAX_SELECTABLE_VALUES = Constants.MAX_USERS_IN_GM - 1;
 
-export default class MoreDirectChannels extends React.Component {
+export default class MoreDirectChannels extends React.PureComponent {
     static propTypes = {
         currentUserId: PropTypes.string.isRequired,
         startingUsers: PropTypes.arrayOf(PropTypes.object),

--- a/components/msg_typing.jsx
+++ b/components/msg_typing.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import UserTypingStore from 'stores/user_typing_store.jsx';
 
-class MsgTyping extends React.Component {
+class MsgTyping extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/multiselect/multiselect.jsx
+++ b/components/multiselect/multiselect.jsx
@@ -13,7 +13,7 @@ import MultiSelectList from './multiselect_list.jsx';
 
 const KeyCodes = Constants.KeyCodes;
 
-export default class MultiSelect extends React.Component {
+export default class MultiSelect extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/multiselect/multiselect_list.jsx
+++ b/components/multiselect/multiselect_list.jsx
@@ -10,7 +10,7 @@ import {cmdOrCtrlPressed} from 'utils/utils.jsx';
 
 const KeyCodes = Constants.KeyCodes;
 
-export default class MultiSelectList extends React.Component {
+export default class MultiSelectList extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/navbar/index.jsx
+++ b/components/navbar/index.jsx
@@ -41,7 +41,7 @@ import ToggleModalButton from 'components/toggle_modal_button.jsx';
 
 import NavbarInfoButton from './navbar_info_button.jsx';
 
-export default class Navbar extends React.Component {
+export default class Navbar extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -53,7 +53,7 @@ const Preferences = Constants.Preferences;
 
 const UNREAD_CHECK_TIME_MILLISECONDS = 10000;
 
-export default class NeedsTeam extends React.Component {
+export default class NeedsTeam extends React.PureComponent {
     static propTypes = {
         children: PropTypes.oneOfType([
             PropTypes.arrayOf(PropTypes.element),

--- a/components/new_channel_flow.jsx
+++ b/components/new_channel_flow.jsx
@@ -20,7 +20,7 @@ const SHOW_NEW_CHANNEL = 1;
 const SHOW_EDIT_URL = 2;
 const SHOW_EDIT_URL_THEN_COMPLETE = 3;
 
-export default class NewChannelFlow extends React.Component {
+export default class NewChannelFlow extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/notify_counts.jsx
+++ b/components/notify_counts.jsx
@@ -9,7 +9,7 @@ import TeamStore from 'stores/team_store.jsx';
 import {getCountsStateFromStores} from 'utils/channel_utils.jsx';
 import * as utils from 'utils/utils.jsx';
 
-export default class NotifyCounts extends React.Component {
+export default class NotifyCounts extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/password_reset_form.jsx
+++ b/components/password_reset_form.jsx
@@ -11,7 +11,7 @@ import {resetPassword} from 'actions/user_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-class PasswordResetForm extends React.Component {
+class PasswordResetForm extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/password_reset_send_link.jsx
+++ b/components/password_reset_send_link.jsx
@@ -14,7 +14,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import BackButton from 'components/common/back_button.jsx';
 
-class PasswordResetSendLink extends React.Component {
+class PasswordResetSendLink extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -25,7 +25,7 @@ import ChannelMembersModal from 'components/channel_members_modal.jsx';
 import ProfilePicture from 'components/profile_picture.jsx';
 import TeamMembersModal from 'components/team_members_modal';
 
-export default class PopoverListMembers extends React.Component {
+export default class PopoverListMembers extends React.PureComponent {
     static propTypes = {
         channel: PropTypes.object.isRequired,
         members: PropTypes.array.isRequired,

--- a/components/post_view/failed_post_options/failed_post_options.jsx
+++ b/components/post_view/failed_post_options/failed_post_options.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {createPost} from 'actions/post_actions.jsx';
 
-export default class FailedPostOptions extends React.Component {
+export default class FailedPostOptions extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/removed_from_channel_modal.jsx
+++ b/components/removed_from_channel_modal.jsx
@@ -13,7 +13,7 @@ import ChannelStore from 'stores/channel_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
-export default class RemovedFromChannelModal extends React.Component {
+export default class RemovedFromChannelModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/rhs_header_post.jsx
+++ b/components/rhs_header_post.jsx
@@ -15,7 +15,7 @@ import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 
 const ActionTypes = Constants.ActionTypes;
 
-export default class RhsHeaderPost extends React.Component {
+export default class RhsHeaderPost extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/root.jsx
+++ b/components/root.jsx
@@ -19,7 +19,7 @@ import UserStore from 'stores/user_store.jsx';
 
 import Constants from 'utils/constants.jsx';
 
-export default class Root extends React.Component {
+export default class Root extends React.PureComponent {
     constructor(props) {
         super(props);
         this.state = {

--- a/components/save_button.jsx
+++ b/components/save_button.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-export default class SaveButton extends React.Component {
+export default class SaveButton extends React.PureComponent {
     static get propTypes() {
         return {
             saving: PropTypes.bool.isRequired,

--- a/components/search_bar.jsx
+++ b/components/search_bar.jsx
@@ -24,7 +24,7 @@ import SuggestionBox from './suggestion/suggestion_box.jsx';
 const ActionTypes = Constants.ActionTypes;
 const KeyCodes = Constants.KeyCodes;
 
-export default class SearchBar extends React.Component {
+export default class SearchBar extends React.PureComponent {
     constructor() {
         super();
         this.mounted = false;

--- a/components/search_results_header.jsx
+++ b/components/search_results_header.jsx
@@ -10,7 +10,7 @@ import * as GlobalActions from 'actions/global_actions.jsx';
 
 import Constants from 'utils/constants.jsx';
 
-export default class SearchResultsHeader extends React.Component {
+export default class SearchResultsHeader extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/searchable_channel_list.jsx
+++ b/components/searchable_channel_list.jsx
@@ -17,7 +17,7 @@ import LoadingScreen from './loading_screen.jsx';
 
 const NEXT_BUTTON_TIMEOUT_MILLISECONDS = 500;
 
-export default class SearchableChannelList extends React.Component {
+export default class SearchableChannelList extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -14,7 +14,7 @@ import UserList from 'components/user_list.jsx';
 
 const NEXT_BUTTON_TIMEOUT = 500;
 
-export default class SearchableUserList extends React.Component {
+export default class SearchableUserList extends React.PureComponent {
     static propTypes = {
         users: PropTypes.arrayOf(PropTypes.object),
         usersPerPage: PropTypes.number,

--- a/components/searchable_user_list/searchable_user_list_container.jsx
+++ b/components/searchable_user_list/searchable_user_list_container.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import SearchableUserList from './searchable_user_list.jsx';
 
-export default class SearchableUserListContainer extends React.Component {
+export default class SearchableUserListContainer extends React.PureComponent {
     static propTypes = {
         users: PropTypes.arrayOf(PropTypes.object),
         usersPerPage: PropTypes.number,

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -21,7 +21,7 @@ import LoadingScreen from 'components/loading_screen.jsx';
 
 import SelectTeamItem from './components/select_team_item.jsx';
 
-export default class SelectTeam extends React.Component {
+export default class SelectTeam extends React.PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
             getTeams: PropTypes.func.isRequired

--- a/components/setting_item_max.jsx
+++ b/components/setting_item_max.jsx
@@ -10,7 +10,7 @@ import SaveButton from 'components/save_button.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-export default class SettingItemMax extends React.Component {
+export default class SettingItemMax extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/setting_upload.jsx
+++ b/components/setting_upload.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
-export default class SettingsUpload extends React.Component {
+export default class SettingsUpload extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/settings_sidebar.jsx
+++ b/components/settings_sidebar.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import * as UserAgent from 'utils/user_agent.jsx';
 
-export default class SettingsSidebar extends React.Component {
+export default class SettingsSidebar extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/should_verify_email.jsx
+++ b/components/should_verify_email.jsx
@@ -9,7 +9,7 @@ import {resendVerification} from 'actions/user_actions.jsx';
 
 import BackButton from 'components/common/back_button.jsx';
 
-export default class ShouldVerifyEmail extends React.Component {
+export default class ShouldVerifyEmail extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/sidebar_header.jsx
+++ b/components/sidebar_header.jsx
@@ -15,7 +15,7 @@ import {createMenuTip} from 'components/tutorial/tutorial_tip.jsx';
 
 import SidebarHeaderDropdown from './sidebar_header_dropdown.jsx';
 
-export default class SidebarHeader extends React.Component {
+export default class SidebarHeader extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/sidebar_header_dropdown.jsx
+++ b/components/sidebar_header_dropdown.jsx
@@ -26,7 +26,7 @@ import TeamMembersModal from 'components/team_members_modal';
 
 import SidebarHeaderDropdownButton from './sidebar_header_dropdown_button.jsx';
 
-export default class SidebarHeaderDropdown extends React.Component {
+export default class SidebarHeaderDropdown extends React.PureComponent {
     static propTypes = {
         teamType: PropTypes.string,
         teamDisplayName: PropTypes.string,

--- a/components/sidebar_right_menu.jsx
+++ b/components/sidebar_right_menu.jsx
@@ -30,7 +30,7 @@ import ToggleModalButton from './toggle_modal_button.jsx';
 const Preferences = Constants.Preferences;
 const TutorialSteps = Constants.TutorialSteps;
 
-export default class SidebarRightMenu extends React.Component {
+export default class SidebarRightMenu extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/signup/components/signup_email.jsx
+++ b/components/signup/components/signup_email.jsx
@@ -20,7 +20,7 @@ import logoImage from 'images/logo.png';
 import BackButton from 'components/common/back_button.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
-export default class SignupEmail extends React.Component {
+export default class SignupEmail extends React.PureComponent {
     static get propTypes() {
         return {
             location: PropTypes.object

--- a/components/signup/components/signup_ldap.jsx
+++ b/components/signup/components/signup_ldap.jsx
@@ -18,7 +18,7 @@ import logoImage from 'images/logo.png';
 import BackButton from 'components/common/back_button.jsx';
 import FormError from 'components/form_error.jsx';
 
-export default class SignupLdap extends React.Component {
+export default class SignupLdap extends React.PureComponent {
     static get propTypes() {
         return {
             location: PropTypes.object

--- a/components/signup/signup_controller.jsx
+++ b/components/signup/signup_controller.jsx
@@ -21,7 +21,7 @@ import BackButton from 'components/common/back_button.jsx';
 import FormError from 'components/form_error.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
-export default class SignupController extends React.Component {
+export default class SignupController extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -12,7 +12,7 @@ import {localizeMessage} from 'utils/utils.jsx';
 import BootstrapSpan from 'components/bootstrap_span.jsx';
 import StatusIcon from 'components/status_icon.jsx';
 
-export default class StatusDropdown extends React.Component {
+export default class StatusDropdown extends React.PureComponent {
 
     static propTypes = {
         style: PropTypes.object,

--- a/components/suggestion/suggestion.jsx
+++ b/components/suggestion/suggestion.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class Suggestion extends React.Component {
+export default class Suggestion extends React.PureComponent {
     static get propTypes() {
         return {
             item: PropTypes.object.isRequired,

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -14,7 +14,7 @@ import AutosizeTextarea from 'components/autosize_textarea.jsx';
 
 const KeyCodes = Constants.KeyCodes;
 
-export default class SuggestionBox extends React.Component {
+export default class SuggestionBox extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/suggestion/suggestion_list.jsx
+++ b/components/suggestion/suggestion_list.jsx
@@ -10,7 +10,7 @@ import {FormattedMessage} from 'react-intl';
 
 import SuggestionStore from 'stores/suggestion_store.jsx';
 
-export default class SuggestionList extends React.Component {
+export default class SuggestionList extends React.PureComponent {
     static propTypes = {
         suggestionId: PropTypes.string.isRequired,
         location: PropTypes.string,

--- a/components/team_general_tab.jsx
+++ b/components/team_general_tab.jsx
@@ -15,7 +15,7 @@ import * as Utils from 'utils/utils.jsx';
 import SettingItemMax from './setting_item_max.jsx';
 import SettingItemMin from './setting_item_min.jsx';
 
-class GeneralTab extends React.Component {
+class GeneralTab extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/team_import_tab.jsx
+++ b/components/team_import_tab.jsx
@@ -15,7 +15,7 @@ const holders = defineMessages({
     }
 });
 
-class TeamImportTab extends React.Component {
+class TeamImportTab extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/team_members_dropdown/team_members_dropdown.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.jsx
@@ -16,7 +16,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import ConfirmModal from 'components/confirm_modal.jsx';
 
-export default class TeamMembersDropdown extends React.Component {
+export default class TeamMembersDropdown extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object.isRequired,
         teamMember: PropTypes.object.isRequired,

--- a/components/team_settings.jsx
+++ b/components/team_settings.jsx
@@ -11,7 +11,7 @@ import * as Utils from 'utils/utils.jsx';
 import GeneralTab from './team_general_tab.jsx';
 import ImportTab from './team_import_tab.jsx';
 
-export default class TeamSettings extends React.Component {
+export default class TeamSettings extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/team_settings_modal.jsx
+++ b/components/team_settings_modal.jsx
@@ -23,7 +23,7 @@ const holders = defineMessages({
     }
 });
 
-class TeamSettingsModal extends React.Component {
+class TeamSettingsModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/team_sidebar/components/team_button.jsx
+++ b/components/team_sidebar/components/team_button.jsx
@@ -12,7 +12,7 @@ import {switchTeams} from 'actions/team_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import {isDesktopApp} from 'utils/user_agent.jsx';
 
-export default class TeamButton extends React.Component {
+export default class TeamButton extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/team_sidebar/team_sidebar_controller.jsx
+++ b/components/team_sidebar/team_sidebar_controller.jsx
@@ -15,7 +15,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import TeamButton from './components/team_button.jsx';
 
-export default class TeamSidebar extends React.Component {
+export default class TeamSidebar extends React.PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
             getTeams: PropTypes.func.isRequired

--- a/components/textbox.jsx
+++ b/components/textbox.jsx
@@ -24,7 +24,7 @@ import SuggestionList from './suggestion/suggestion_list.jsx';
 
 const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
-export default class Textbox extends React.Component {
+export default class Textbox extends React.PureComponent {
     static propTypes = {
         id: PropTypes.string.isRequired,
         channelId: PropTypes.string,

--- a/components/toggle_modal_button.jsx
+++ b/components/toggle_modal_button.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class ModalToggleButton extends React.Component {
+export default class ModalToggleButton extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/tutorial/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens.jsx
@@ -20,7 +20,7 @@ import AppIcons from 'images/appIcons.png';
 
 const NUM_SCREENS = 3;
 
-export default class TutorialIntroScreens extends React.Component {
+export default class TutorialIntroScreens extends React.PureComponent {
     static get propTypes() {
         return {
             townSquare: PropTypes.object,

--- a/components/tutorial/tutorial_tip.jsx
+++ b/components/tutorial/tutorial_tip.jsx
@@ -19,7 +19,7 @@ import tutorialGifWhite from 'images/tutorialTipWhite.gif';
 
 const Preferences = Constants.Preferences;
 
-export default class TutorialTip extends React.Component {
+export default class TutorialTip extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/tutorial/tutorial_view.jsx
+++ b/components/tutorial/tutorial_view.jsx
@@ -12,7 +12,7 @@ import Constants from 'utils/constants.jsx';
 
 import TutorialIntroScreens from './tutorial_intro_screens.jsx';
 
-export default class TutorialView extends React.Component {
+export default class TutorialView extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_list.jsx
+++ b/components/user_list.jsx
@@ -11,7 +11,7 @@ import LoadingScreen from 'components/loading_screen.jsx';
 
 import UserListRow from './user_list_row.jsx';
 
-export default class UserList extends React.Component {
+export default class UserList extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_settings/color_chooser.jsx
+++ b/components/user_settings/color_chooser.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 import ColorInput from 'components/color_input';
 
-class ColorChooser extends React.Component {
+class ColorChooser extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/user_settings/custom_theme_chooser.jsx
+++ b/components/user_settings/custom_theme_chooser.jsx
@@ -110,7 +110,7 @@ const messages = defineMessages({
     }
 });
 
-class CustomThemeChooser extends React.Component {
+class CustomThemeChooser extends React.PureComponent {
     constructor(props) {
         super(props);
         this.selectTheme = this.selectTheme.bind(this);

--- a/components/user_settings/desktop_notification_settings.jsx
+++ b/components/user_settings/desktop_notification_settings.jsx
@@ -11,7 +11,7 @@ import * as Utils from 'utils/utils.jsx';
 import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min.jsx';
 
-export default class DesktopNotificationSettings extends React.Component {
+export default class DesktopNotificationSettings extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_settings/email_notification_setting.jsx
+++ b/components/user_settings/email_notification_setting.jsx
@@ -13,7 +13,7 @@ import {localizeMessage} from 'utils/utils.jsx';
 import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min.jsx';
 
-export default class EmailNotificationSetting extends React.Component {
+export default class EmailNotificationSetting extends React.PureComponent {
     static propTypes = {
         activeSection: PropTypes.string.isRequired,
         updateSection: PropTypes.func.isRequired,

--- a/components/user_settings/import_theme_modal.jsx
+++ b/components/user_settings/import_theme_modal.jsx
@@ -11,7 +11,7 @@ import Constants from 'utils/constants.jsx';
 
 const ActionTypes = Constants.ActionTypes;
 
-export default class ImportThemeModal extends React.Component {
+export default class ImportThemeModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_settings/manage_languages.jsx
+++ b/components/user_settings/manage_languages.jsx
@@ -14,7 +14,7 @@ import * as I18n from 'i18n/i18n.jsx';
 
 import SettingItemMax from '../setting_item_max.jsx';
 
-export default class ManageLanguage extends React.Component {
+export default class ManageLanguage extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_settings/premade_theme_chooser.jsx
+++ b/components/user_settings/premade_theme_chooser.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-export default class PremadeThemeChooser extends React.Component {
+export default class PremadeThemeChooser extends React.PureComponent {
     constructor(props) {
         super(props);
         this.state = {};

--- a/components/user_settings/user_settings.jsx
+++ b/components/user_settings/user_settings.jsx
@@ -15,7 +15,7 @@ import NotificationsTab from './user_settings_notifications.jsx';
 import SecurityTab from './user_settings_security';
 import SidebarTab from './user_settings_sidebar.jsx';
 
-export default class UserSettings extends React.Component {
+export default class UserSettings extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_settings/user_settings_advanced.jsx
+++ b/components/user_settings/user_settings_advanced.jsx
@@ -17,7 +17,7 @@ import SettingItemMin from '../setting_item_min.jsx';
 
 const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
-export default class AdvancedSettingsDisplay extends React.Component {
+export default class AdvancedSettingsDisplay extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_settings/user_settings_display.jsx
+++ b/components/user_settings/user_settings_display.jsx
@@ -32,7 +32,7 @@ function getDisplayStateFromStores() {
     };
 }
 
-export default class UserSettingsDisplay extends React.Component {
+export default class UserSettingsDisplay extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_settings/user_settings_general/user_settings_general.jsx
+++ b/components/user_settings/user_settings_general/user_settings_general.jsx
@@ -80,7 +80,7 @@ const holders = defineMessages({
     }
 });
 
-class UserSettingsGeneralTab extends React.Component {
+class UserSettingsGeneralTab extends React.PureComponent {
     static propTypes = {
         intl: intlShape.isRequired,
         user: PropTypes.object.isRequired,

--- a/components/user_settings/user_settings_modal.jsx
+++ b/components/user_settings/user_settings_modal.jsx
@@ -58,7 +58,7 @@ const holders = defineMessages({
     }
 });
 
-class UserSettingsModal extends React.Component {
+class UserSettingsModal extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_settings/user_settings_notifications.jsx
+++ b/components/user_settings/user_settings_notifications.jsx
@@ -100,7 +100,7 @@ function getNotificationsStateFromStores() {
     };
 }
 
-export default class NotificationsTab extends React.Component {
+export default class NotificationsTab extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_settings/user_settings_security/user_settings_security.jsx
+++ b/components/user_settings/user_settings_security/user_settings_security.jsx
@@ -29,7 +29,7 @@ const TOKEN_CREATING = 'creating';
 const TOKEN_CREATED = 'created';
 const TOKEN_NOT_CREATING = 'not_creating';
 
-export default class SecurityTab extends React.Component {
+export default class SecurityTab extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object,
         activeSection: PropTypes.string,

--- a/components/user_settings/user_settings_sidebar.jsx
+++ b/components/user_settings/user_settings_sidebar.jsx
@@ -14,7 +14,7 @@ import Constants from 'utils/constants.jsx';
 import SettingItemMax from '../setting_item_max.jsx';
 import SettingItemMin from '../setting_item_min.jsx';
 
-export default class SidebarSettingsDisplay extends React.Component {
+export default class SidebarSettingsDisplay extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/user_settings/user_settings_theme.jsx
+++ b/components/user_settings/user_settings_theme.jsx
@@ -23,7 +23,7 @@ import SettingItemMin from '../setting_item_min.jsx';
 import CustomThemeChooser from './custom_theme_chooser.jsx';
 import PremadeThemeChooser from './premade_theme_chooser.jsx';
 
-export default class ThemeSetting extends React.Component {
+export default class ThemeSetting extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/webrtc/components/webrtc_notification.jsx
+++ b/components/webrtc/components/webrtc_notification.jsx
@@ -20,7 +20,7 @@ import ring from 'images/ring.mp3';
 
 const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
-export default class WebrtcNotification extends React.Component {
+export default class WebrtcNotification extends React.PureComponent {
     constructor() {
         super();
 

--- a/components/webrtc/webrtc_controller.jsx
+++ b/components/webrtc/webrtc_controller.jsx
@@ -33,7 +33,7 @@ const MAX_ASPECT = 1.778;
 const ALREADY_REGISTERED_ERROR = 477;
 const USERNAME_TAKEN = 476;
 
-export default class WebrtcController extends React.Component {
+export default class WebrtcController extends React.PureComponent {
     constructor(props) {
         super(props);
 


### PR DESCRIPTION
#### Summary
Switches from `Component` to `PureComponent` wherever `shouldComponentUpdate` is absent. [Apparently some teams at Facebook are doing the same](https://news.ycombinator.com/item?id=14418576). This change is predicated on the belief that re-rendering is more expensive than checking whether props have changed - which I believe to be likely in the majority of cases although I admittedly have not proven it. 

I would be happy to gather a random sampling of data from the 173 components that this PR changes and we could regroup on that data if we want to prove/disprove my assumption before moving forward.

Thoughts?

Note this PR [was originally here](https://github.com/mattermost/mattermost-webapp/pull/246) but had to be re-opened.

#### Ticket Link
n/a

#### Checklist
- [x] Touches critical sections of the codebase (auth, posting, etc.)

#### Illustration

Here's an example showing the decrease in the number of renders of the `SearchBar` component when composing a post:

Using `Component` in `SearchBar` (existing production code):
![more-renders](https://user-images.githubusercontent.com/1149597/32420582-7b02070c-c25a-11e7-82d4-8e140740babc.gif)

Using `PureComponent` in `SearchBar` (PR code):
![fewer-renders](https://user-images.githubusercontent.com/1149597/32420585-7f1a8c06-c25a-11e7-95d2-4879c9ab5a64.gif)