### PR TITLE
PLT-8119 Reverted redux-persist to 4.9.1 to match mattermost-redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-select": "1.0.0-rc.10",
     "redux": "3.7.2",
     "redux-batched-actions": "0.1.6",
-    "redux-persist": "4.10.1",
+    "redux-persist": "4.9.1",
     "redux-persist-transform-filter": "0.0.16",
     "reselect": "3.0.1",
     "superagent": "3.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7312,14 +7312,6 @@ redux-persist-transform-filter@0.0.16:
     lodash.set "^4.3.2"
     lodash.unset "^4.5.2"
 
-redux-persist@4.10.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-4.10.1.tgz#4fb2b789942f10f56d51cc7ad068d9d6beb46124"
-  dependencies:
-    json-stringify-safe "^5.0.1"
-    lodash "^4.17.4"
-    lodash-es "^4.17.4"
-
 redux-persist@4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-4.9.1.tgz#271fa31d1c782ebf9082fb5174e829db24faf59e"


### PR DESCRIPTION
There is some extra migration needed to go from 4.9.x to 4.10.x, and we'll need to do it at the same time that we change it for the redux library and mobile apps to prevent doubling up on our dependencies since we currently have 2 versions of the library installed. I'll also create a separate ticket to upgrade the library in both repos at once

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8119