### PR TITLE
Remove optional tag from AWS region help text

### DIFF
--- a/components/admin_console/storage_settings.jsx
+++ b/components/admin_console/storage_settings.jsx
@@ -255,7 +255,7 @@ export default class StorageSettings extends AdminSettings {
                     helpText={
                         <FormattedMessage
                             id='admin.image.amazonS3RegionDescription'
-                            defaultMessage='(Optional) AWS region you selected when creating your S3 bucket. If no region is set, Mattermost attempts to get the appropriate region from AWS, or sets it to "us-east-1" if none found.'
+                            defaultMessage='AWS region you selected when creating your S3 bucket. If no region is set, Mattermost attempts to get the appropriate region from AWS, or sets it to "us-east-1" if none found.'
                         />
                     }
                     value={this.state.amazonS3Region}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -487,7 +487,7 @@
   "admin.image.amazonS3IdDescription": "Obtain this credential from your Amazon EC2 administrator.",
   "admin.image.amazonS3IdExample": "E.g.: \"AKIADTOVBGERKLCBV\"",
   "admin.image.amazonS3IdTitle": "Amazon S3 Access Key ID:",
-  "admin.image.amazonS3RegionDescription": "(Optional) AWS region you selected when creating your S3 bucket. If no region is set, Mattermost attempts to get the appropriate region from AWS, or sets it to 'us-east-1' if none found.",
+  "admin.image.amazonS3RegionDescription": "AWS region you selected when creating your S3 bucket. If no region is set, Mattermost attempts to get the appropriate region from AWS, or sets it to 'us-east-1' if none found.",
   "admin.image.amazonS3RegionExample": "E.g.: \"us-east-1\"",
   "admin.image.amazonS3RegionTitle": "Amazon S3 Region:",
   "admin.image.amazonS3SSEDescription": "When true, encrypt files in Amazon S3 using server-side encryption with Amazon S3-managed keys. See <a href=\"https://about.mattermost.com/default-server-side-encryption\">documentation</a> to learn more.",


### PR DESCRIPTION
The setting itself is not optional, as an AWS region needs to exist for you to connect, but you can leave the field blank for auto-detection, if preferred.

See https://github.com/mattermost/mattermost-server/pull/7830#issuecomment-346679604 for more details.