### PR TITLE
SignupEmail Component Doesn't Render when Invite Link Specified

### DIFF
--- a/components/signup/components/signup_email.jsx
+++ b/components/signup/components/signup_email.jsx
@@ -492,8 +492,7 @@ export default class SignupEmail extends React.Component {
                             />
                             {' '}
                             <Link
-                                to={'/login'}
-                                query={Utils.isEmptyObject(this.props.location.query) ? null : this.props.location.query}
+                                to={'/login' + this.props.location.search}
                             >
                                 <FormattedMessage
                                     id='signup_user_completed.signIn'


### PR DESCRIPTION
#### Summary
The same issue impacted the the signup_email page when an invite link was specified

#### Ticket Link
No ticket, but same problem as https://mattermost.atlassian.net/browse/PLT-8172

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed