### PR TITLE
Note that desktop notification duration is a max of 5 seconds for desktop apps

### DIFF
--- a/components/user_settings/desktop_notification_settings.jsx
+++ b/components/user_settings/desktop_notification_settings.jsx
@@ -214,7 +214,7 @@ export default class DesktopNotificationSettings extends React.Component {
                 <span>
                     <FormattedMessage
                         id='user.settings.notifications.desktop.durationInfo'
-                        defaultMessage='Sets how long desktop notifications will remain on screen when using Firefox or Chrome. Desktop notifications in Edge and Safari can only stay on screen for a maximum of 5 seconds.'
+                        defaultMessage='Sets how long desktop notifications will remain on screen when using Firefox or Chrome. Desktop notifications in Edge, Safari and Mattermost Desktop Apps can only stay on screen for a maximum of 5 seconds.'
                     />
                 </span>
             );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2725,7 +2725,7 @@
   "user.settings.notifications.desktop.allSoundHiddenTimed": "For all activity, shown for {seconds} seconds",
   "user.settings.notifications.desktop.allSoundTimed": "For all activity, with sound, shown for {seconds} seconds",
   "user.settings.notifications.desktop.duration": "Notification duration",
-  "user.settings.notifications.desktop.durationInfo": "Sets how long desktop notifications will remain on screen when using Firefox or Chrome. Desktop notifications in Edge and Safari can only stay on screen for a maximum of 5 seconds.",
+  "user.settings.notifications.desktop.durationInfo": "Sets how long desktop notifications will remain on screen when using Firefox or Chrome. Desktop notifications in Edge, Safari and Mattermost Desktop Apps can only stay on screen for a maximum of 5 seconds.",
   "user.settings.notifications.desktop.mentionsNoSoundForever": "For mentions and direct messages, without sound, shown indefinitely",
   "user.settings.notifications.desktop.mentionsNoSoundTimed": "For mentions and direct messages, without sound, shown for {seconds} seconds",
   "user.settings.notifications.desktop.mentionsSoundForever": "For mentions and direct messages, with sound, shown indefinitely",


### PR DESCRIPTION
Note that desktop notification duration is a max of 5 seconds for desktop apps.

To fix it requires upstream changes in Electron. The required level of effort doesn't exceed the benefit: https://github.com/mattermost/desktop/issues/304#issuecomment-346902736

cc: @yuya-oc @esethna 