### PR TITLE
PLT-8210: Store/Restore fields of storage independently in the localStorage

### DIFF
--- a/actions/storage.js
+++ b/actions/storage.js
@@ -82,10 +82,10 @@ export function actionOnItemsWithPrefix(prefix, action) {
 
 export function storageRehydrate(incoming) {
     return async (dispatch) => {
-        if (incoming.storage) {
+        Object.keys(incoming).forEach((key) => {
             let storage = {};
             try {
-                storage = JSON.parse(incoming.storage);
+                storage[key] = JSON.parse(incoming[key]);
             } catch (err) {
                 if (process.env.NODE_ENV !== 'production') console.warn(`Error rehydrating data for key "storage"`, err)
             }
@@ -93,7 +93,7 @@ export function storageRehydrate(incoming) {
                 type: StorageTypes.STORAGE_REHYDRATE,
                 data: storage
             });
-        }
+        });
         return {data: true};
     };
 }

--- a/store/index.js
+++ b/store/index.js
@@ -92,8 +92,8 @@ export default function configureStore(initialState, persistorStorage = null) {
                     });
                     observable.subscribe({
                         next: (args) => {
-                            if(args.key && args.key.indexOf(KEY_PREFIX) === 0 && args.oldValue === null){
-                                const keyspace = args.key.substr(KEY_PREFIX.length);
+                            if(args.key && args.key.indexOf(KEY_PREFIX+"storage:") === 0 && args.oldValue === null){
+                                const keyspace = args.key.substr((KEY_PREFIX+"storage:").length);
 
                                 var statePartial = {};
                                 statePartial[keyspace] = args.newValue;
@@ -139,7 +139,34 @@ export default function configureStore(initialState, persistorStorage = null) {
             debounce: 500,
             transforms: [
                 setTransformer
-            ]
+            ],
+            _stateIterator: (collection, callback) => {
+                return Object.keys(collection).forEach((key) => {
+                    if (key === 'storage') {
+                        Object.keys(collection[key]).forEach((subkey) => {
+                            callback(collection[key][subkey], key+":"+subkey)
+                        })
+                    } else {
+                        callback(collection[key], key)
+                    }
+                });
+            },
+            _stateGetter: (state, key) => {
+                if (key.indexOf('storage:') == 0) {
+                    state.storage = state.storage || {};
+                    return state.storage[key.substr(8)];
+                }
+                return state[key];
+            },
+            _stateSetter: (state, key, value) => {
+                if (key.indexOf('storage:') == 0) {
+                    state.storage = state.storage || {};
+                    state.storage[key.substr(8)] = value;
+                }
+                state[key] = value;
+                return state;
+            }
+
         },
         detectNetwork: detect
     };

--- a/tests/redux/actions/storage.test.js
+++ b/tests/redux/actions/storage.test.js
@@ -105,17 +105,17 @@ describe('Actions.Storage', () => {
     });
 
     it('rehydrate', async () => {
-        await Actions.storageRehydrate({storage: '{"test": "123"}'})(store.dispatch, store.getState);
+        await Actions.storageRehydrate({test: "123"})(store.dispatch, store.getState);
         assert.deepEqual(
             store.getState().storage,
             {test: '123'}
         );
-        await Actions.storageRehydrate({storage: '{"test": "456"}'})(store.dispatch, store.getState);
+        await Actions.storageRehydrate({test: "456"})(store.dispatch, store.getState);
         assert.deepEqual(
             store.getState().storage,
             {test: '456'}
         );
-        await Actions.storageRehydrate({storage: '{"test2": "789"}'})(store.dispatch, store.getState);
+        await Actions.storageRehydrate({test2: "789"})(store.dispatch, store.getState);
         assert.deepEqual(
             store.getState().storage,
             {test: '456', test2: '789'}


### PR DESCRIPTION
#### About
I don't love this solution, after investigating a lot other options it is where I ended.

The problem here is how redux-persist works. For each store first level field, it's store one localStorage key, (in our case, the key storage) this force to rehydrate the entire storage in one block. Then, when other tab change something, this restore everything, overwriting the current state with the other tab state.

The solution use the _stateIterator, _stateGetter, and _stateSetter (where though for implement support for other kind of data structure to store the data, like Immutable.js), I used it to virtually move the storage keys to the first level. This allow to each key be stored and restored independently.

The other options are remove the redux-persist usage and use our own implementation of the persistence in the localStorage, or fork redux-persist to support this.

The solution works (in my machine) and solve the glitch when you are using different fields, but if you are modifying the same field in the store, still can see some kind of glitch. For example, if you are editing the same reply to same message in two different tabs switching fast between them, you can still see some glitches.

#### Ticket Link
[PLT-8210](https://mattermost.atlassian.net/browse/PLT-8210)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed