### PR TITLE
PLT-8243: Load DM and GM data when needed on /groupmsg or /msg

### DIFF
--- a/routes/route_team.jsx
+++ b/routes/route_team.jsx
@@ -53,7 +53,13 @@ function doChannelChange(state, replace, callback) {
             joinChannel(UserStore.getCurrentId(), TeamStore.getCurrentId(), null, state.params.channel)(dispatch, getState).then(
                 (result) => {
                     if (result.data) {
-                        GlobalActions.emitChannelClickEvent(result.data.channel);
+                        channel = result.data.channel;
+                        if (channel && channel.type === Constants.DM_CHANNEL) {
+                            loadNewDMIfNeeded(channel.id);
+                        } else if (channel && channel.type === Constants.GM_CHANNEL) {
+                            loadNewGMIfNeeded(channel.id);
+                        }
+                        GlobalActions.emitChannelClickEvent(channel);
                     } else if (result.error) {
                         if (state.params.team) {
                             replace('/' + state.params.team + '/channels/town-square');


### PR DESCRIPTION
#### Summary
This is only part of the solution, the other part is in mattermost/mattermost-redux#337

#### Ticket Link
[PLT-7111](https://mattermost.atlassian.net/browse/PLT-7111)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed