### PR TITLE
PLT-8170 Fixed Edit Channel Header modal

### DIFF
--- a/components/edit_channel_header_modal/edit_channel_header_modal.jsx
+++ b/components/edit_channel_header_modal/edit_channel_header_modal.jsx
@@ -76,10 +76,6 @@ class EditChannelHeaderModal extends React.PureComponent {
         };
     }
 
-    componentDidMount() {
-        this.focusTextbox();
-    }
-
     componentWillReceiveProps(nextProps) {
         const {requestStatus: nextRequestStatus} = nextProps;
         const {requestStatus} = this.props;
@@ -113,6 +109,10 @@ class EditChannelHeaderModal extends React.PureComponent {
         if (!Utils.isMobile()) {
             this.refs.editChannelHeaderTextbox.focus();
         }
+    }
+
+    handleEntering = () => {
+        this.focusTextbox();
     }
 
     handleKeyDown = (e) => {
@@ -177,6 +177,7 @@ class EditChannelHeaderModal extends React.PureComponent {
             <Modal
                 show={this.state.show}
                 onHide={this.onHide}
+                onEntering={this.handleEntering}
                 onExited={this.props.onHide}
             >
                 <Modal.Header closeButton={true}>

--- a/tests/components/__snapshots__/edit_channel_header_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/edit_channel_header_modal.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal edit dir
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -124,6 +125,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal error wi
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -241,6 +243,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal error wi
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -358,6 +361,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal hide err
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -465,6 +469,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal should m
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -572,6 +577,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal submitte
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}


### PR DESCRIPTION
The textbox doesn't exist yet when the component is first mounted because the modal isn't rendered yet, so wait until it's transitioning in to focus it.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8170
