### PR TITLE
PLT-8062: System Console error prints over existing text and pushes drop-down off-view

### DIFF
--- a/components/admin_console/system_users/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown.jsx
@@ -44,14 +44,18 @@ export default class SystemUsersDropdown extends React.Component {
         /*
          * Function to open manage tokens, takes user as an argument
          */
-        doManageTokens: PropTypes.func.isRequired
+        doManageTokens: PropTypes.func.isRequired,
+
+        /*
+         * The function to call when an error occurs
+         */
+        onError: PropTypes.func.isRequired
     };
 
     constructor(props) {
         super(props);
 
         this.state = {
-            serverError: null,
             showDemoteModal: false,
             showDeactivateMemberModal: false,
             showRevokeSessionsModal: false,
@@ -62,11 +66,7 @@ export default class SystemUsersDropdown extends React.Component {
 
     handleMakeActive = (e) => {
         e.preventDefault();
-        updateActive(this.props.user.id, true, null,
-            (err) => {
-                this.setState({serverError: err.message});
-            }
-        );
+        updateActive(this.props.user.id, true, null, this.props.onError);
     }
 
     handleManageTeams = (e) => {
@@ -94,17 +94,11 @@ export default class SystemUsersDropdown extends React.Component {
 
     handleResetMfa = (e) => {
         e.preventDefault();
-        adminResetMfa(this.props.user.id,
-            null,
-            (err) => {
-                this.setState({serverError: err.message});
-            }
-        );
+        adminResetMfa(this.props.user.id, null, this.props.onError);
     }
 
     handleDemoteSystemAdmin = (user, role) => {
         this.setState({
-            serverError: this.state.serverError,
             showDemoteModal: true,
             user,
             role
@@ -113,11 +107,11 @@ export default class SystemUsersDropdown extends React.Component {
 
     handleDemoteCancel = () => {
         this.setState({
-            serverError: null,
             showDemoteModal: false,
             user: null,
             role: null
         });
+        this.props.onError(null);
     }
 
     handleDemoteSubmit = () => {
@@ -136,17 +130,11 @@ export default class SystemUsersDropdown extends React.Component {
 
     handleShowDeactivateMemberModal = (e) => {
         e.preventDefault();
-
         this.setState({showDeactivateMemberModal: true});
     }
 
     handleDeactivateMember = () => {
-        updateActive(this.props.user.id, false, null,
-            (err) => {
-                this.setState({serverError: err.message});
-            }
-        );
-
+        updateActive(this.props.user.id, false, null, this.props.onError);
         this.setState({showDeactivateMemberModal: false});
     }
 
@@ -209,9 +197,7 @@ export default class SystemUsersDropdown extends React.Component {
                     clientLogout();
                 }
             },
-            (err) => {
-                this.setState({serverError: err.message});
-            }
+            this.props.onError
         );
 
         this.setState({showRevokeSessionsModal: false});
@@ -300,15 +286,6 @@ export default class SystemUsersDropdown extends React.Component {
     }
 
     render() {
-        let serverError = null;
-        if (this.state.serverError) {
-            serverError = (
-                <div className='has-error'>
-                    <label className='has-error control-label'>{this.state.serverError}</label>
-                </div>
-            );
-        }
-
         const user = this.props.user;
         if (!user) {
             return <div/>;
@@ -539,7 +516,6 @@ export default class SystemUsersDropdown extends React.Component {
                             username: me.username
                         }}
                     />
-                    {serverError}
                 </div>
             );
 
@@ -564,11 +540,6 @@ export default class SystemUsersDropdown extends React.Component {
 
         const deactivateMemberModal = this.renderDeactivateMemberModal();
         const revokeSessionsModal = this.renderRevokeSessionsModal();
-
-        let displayedName = Utils.getDisplayName(user);
-        if (displayedName !== user.username) {
-            displayedName += ' (@' + user.username + ')';
-        }
 
         return (
             <div className='dropdown member-drop text-right'>
@@ -612,7 +583,6 @@ export default class SystemUsersDropdown extends React.Component {
                 {makeDemoteModal}
                 {deactivateMemberModal}
                 {revokeSessionsModal}
-                {serverError}
             </div>
         );
     }

--- a/components/admin_console/system_users/system_users_list.jsx
+++ b/components/admin_console/system_users/system_users_list.jsx
@@ -17,7 +17,7 @@ import ManageTeamsModal from 'components/admin_console/manage_teams_modal/manage
 import ManageTokensModal from 'components/admin_console/manage_tokens_modal';
 import ResetPasswordModal from 'components/admin_console/reset_password_modal.jsx';
 import SearchableUserList from 'components/searchable_user_list/searchable_user_list.jsx';
-import UserListRowWithError from 'components/user_list_row_with_error';
+import UserListRowWithError from 'components/user_list_row_with_error.jsx';
 
 import SystemUsersDropdown from './system_users_dropdown.jsx';
 

--- a/components/admin_console/system_users/system_users_list.jsx
+++ b/components/admin_console/system_users/system_users_list.jsx
@@ -17,6 +17,7 @@ import ManageTeamsModal from 'components/admin_console/manage_teams_modal/manage
 import ManageTokensModal from 'components/admin_console/manage_tokens_modal';
 import ResetPasswordModal from 'components/admin_console/reset_password_modal.jsx';
 import SearchableUserList from 'components/searchable_user_list/searchable_user_list.jsx';
+import UserListRowWithError from 'components/user_list_row_with_error';
 
 import SystemUsersDropdown from './system_users_dropdown.jsx';
 
@@ -269,6 +270,7 @@ export default class SystemUsersList extends React.Component {
                     page={this.state.page}
                     term={this.props.term}
                     onTermChange={this.props.onTermChange}
+                    rowComponentType={UserListRowWithError}
                 />
                 <ManageTeamsModal
                     user={this.state.user}

--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -32,7 +32,10 @@ export default class SearchableUserList extends React.Component {
 
         page: PropTypes.number.isRequired,
         term: PropTypes.string.isRequired,
-        onTermChange: PropTypes.func.isRequired
+        onTermChange: PropTypes.func.isRequired,
+
+        // the type of user list row to render
+        rowComponentType: PropTypes.func
     };
 
     static defaultProps = {
@@ -239,6 +242,7 @@ export default class SearchableUserList extends React.Component {
                         actions={this.props.actions}
                         actionProps={this.props.actionProps}
                         actionUserProps={this.props.actionUserProps}
+                        rowComponentType={this.props.rowComponentType}
                     />
                 </div>
                 <div className='filter-controls'>

--- a/components/user_list.jsx
+++ b/components/user_list.jsx
@@ -26,6 +26,7 @@ export default class UserList extends React.Component {
 
     render() {
         const users = this.props.users;
+        const RowComponentType = this.props.rowComponentType;
 
         let content;
         if (users == null) {
@@ -33,7 +34,7 @@ export default class UserList extends React.Component {
         } else if (users.length > 0) {
             content = users.map((user, index) => {
                 return (
-                    <UserListRow
+                    <RowComponentType
                         key={user.id}
                         user={user}
                         extraInfo={this.props.extraInfo[user.id]}
@@ -72,7 +73,8 @@ UserList.defaultProps = {
     users: [],
     extraInfo: {},
     actions: [],
-    actionProps: {}
+    actionProps: {},
+    rowComponentType: UserListRow
 };
 
 UserList.propTypes = {
@@ -80,5 +82,8 @@ UserList.propTypes = {
     extraInfo: PropTypes.object,
     actions: PropTypes.arrayOf(PropTypes.func),
     actionProps: PropTypes.object,
-    actionUserProps: PropTypes.object
+    actionUserProps: PropTypes.object,
+
+    // the type of user list row to render
+    rowComponentType: PropTypes.func
 };

--- a/components/user_list_row.jsx
+++ b/components/user_list_row.jsx
@@ -13,84 +13,87 @@ import * as Utils from 'utils/utils.jsx';
 
 import ProfilePicture from 'components/profile_picture.jsx';
 
-export default function UserListRow({user, extraInfo, actions, actionProps, actionUserProps, userCount}) {
-    let buttons = null;
-    if (actions) {
-        buttons = actions.map((Action, index) => {
-            return (
-                <Action
-                    key={index.toString()}
-                    user={user}
-                    {...actionProps}
-                    {...actionUserProps}
+export default class UserListRow extends React.Component {
+
+    render() {
+        let buttons = null;
+        if (this.props.actions) {
+            buttons = this.props.actions.map((Action, index) => {
+                return (
+                    <Action
+                        key={index.toString()}
+                        user={this.props.user}
+                        {...this.props.actionProps}
+                        {...this.props.actionUserProps}
+                    />
+                );
+            });
+        }
+
+        // QUICK HACK, NEEDS A PROP FOR TOGGLING STATUS
+        let email = this.props.user.email;
+        let emailStyle = 'more-modal__description';
+        let status;
+        if (this.props.extraInfo && this.props.extraInfo.length > 0) {
+            email = (
+                <FormattedHTMLMessage
+                    id='admin.user_item.emailTitle'
+                    defaultMessage='<strong>Email:</strong> {email}'
+                    values={{
+                        email: this.props.user.email
+                    }}
                 />
             );
-        });
-    }
+            emailStyle = '';
+        } else if (this.props.user.status) {
+            status = this.props.user.status;
+        } else {
+            status = UserStore.getStatus(this.props.user.id);
+        }
 
-    // QUICK HACK, NEEDS A PROP FOR TOGGLING STATUS
-    let email = user.email;
-    let emailStyle = 'more-modal__description';
-    let status;
-    if (extraInfo && extraInfo.length > 0) {
-        email = (
-            <FormattedHTMLMessage
-                id='admin.user_item.emailTitle'
-                defaultMessage='<strong>Email:</strong> {email}'
-                values={{
-                    email: user.email
-                }}
-            />
+        let userCountID = null;
+        let userCountEmail = null;
+        if (this.props.userCount >= 0) {
+            userCountID = Utils.createSafeId('userListRowName' + this.props.userCount);
+            userCountEmail = Utils.createSafeId('userListRowEmail' + this.props.userCount);
+        }
+
+        return (
+            <div
+                key={this.props.user.id}
+                className='more-modal__row'
+            >
+                <ProfilePicture
+                    src={Client4.getProfilePictureUrl(this.props.user.id, this.props.user.last_picture_update)}
+                    status={status}
+                    width='32'
+                    height='32'
+                />
+                <div
+                    className='more-modal__details'
+                >
+                    <div
+                        id={userCountID}
+                        className='more-modal__name'
+                    >
+                        {Utils.displayEntireNameForUser(this.props.user)}
+                    </div>
+                    <div
+                        id={userCountEmail}
+                        className={emailStyle}
+                    >
+                        {email}
+                    </div>
+                    {this.props.extraInfo}
+                </div>
+                <div
+                    className='more-modal__actions'
+                >
+                    {buttons}
+                </div>
+            </div>
         );
-        emailStyle = '';
-    } else if (user.status) {
-        status = user.status;
-    } else {
-        status = UserStore.getStatus(user.id);
     }
-
-    let userCountID = null;
-    let userCountEmail = null;
-    if (userCount >= 0) {
-        userCountID = Utils.createSafeId('userListRowName' + userCount);
-        userCountEmail = Utils.createSafeId('userListRowEmail' + userCount);
-    }
-
-    return (
-        <div
-            key={user.id}
-            className='more-modal__row'
-        >
-            <ProfilePicture
-                src={Client4.getProfilePictureUrl(user.id, user.last_picture_update)}
-                status={status}
-                width='32'
-                height='32'
-            />
-            <div
-                className='more-modal__details'
-            >
-                <div
-                    id={userCountID}
-                    className='more-modal__name'
-                >
-                    {Utils.displayEntireNameForUser(user)}
-                </div>
-                <div
-                    id={userCountEmail}
-                    className={emailStyle}
-                >
-                    {email}
-                </div>
-                {extraInfo}
-            </div>
-            <div
-                className='more-modal__actions'
-            >
-                {buttons}
-            </div>
-        </div>
-    );
 }
 
 UserListRow.defaultProps = {

--- a/components/user_list_row_with_error.jsx
+++ b/components/user_list_row_with_error.jsx
@@ -13,7 +13,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import ProfilePicture from 'components/profile_picture.jsx';
 
-export default class UserListRow extends React.Component {
+export default class UserListRowWithError extends React.Component {
 
     static propTypes = {
         user: PropTypes.object.isRequired,
@@ -31,6 +31,18 @@ export default class UserListRow extends React.Component {
         actionUserProps: {}
     };
 
+    constructor(props) {
+        super(props);
+
+        this.onError = this.onError.bind(this);
+    }
+
+    onError(errorObj) {
+        this.state = {
+            error: errorObj
+        };
+    }
+
     render() {
         let buttons = null;
         if (this.props.actions) {
@@ -41,6 +53,7 @@ export default class UserListRow extends React.Component {
                         user={this.props.user}
                         {...this.props.actionProps}
                         {...this.props.actionUserProps}
+                        onError={this.onError}
                     />
                 );
             });
@@ -74,6 +87,15 @@ export default class UserListRow extends React.Component {
             userCountEmail = Utils.createSafeId('userListRowEmail' + this.props.userCount);
         }
 
+        let error = null;
+        if (this.state.error) {
+            error = (
+                <div className='has-error'>
+                    <label className='has-error control-label'>{this.state.error.message}</label>
+                </div>
+            );
+        }
+
         return (
             <div
                 key={this.props.user.id}
@@ -86,27 +108,32 @@ export default class UserListRow extends React.Component {
                     height='32'
                 />
                 <div
-                    className='more-modal__details'
+                    className='more-modal__top'
                 >
                     <div
-                        id={userCountID}
-                        className='more-modal__name'
+                        className='more-modal__details'
                     >
-                        {Utils.displayEntireNameForUser(this.props.user)}
+                        <div
+                            id={userCountID}
+                            className='more-modal__name'
+                        >
+                            {Utils.displayEntireNameForUser(this.props.user)}
+                        </div>
+                        <div
+                            id={userCountEmail}
+                            className={emailStyle}
+                        >
+                            {email}
+                        </div>
+                        {this.props.extraInfo}
                     </div>
                     <div
-                        id={userCountEmail}
-                        className={emailStyle}
+                        className='more-modal__actions'
                     >
-                        {email}
+                        {buttons}
                     </div>
-                    {this.props.extraInfo}
                 </div>
-                <div
-                    className='more-modal__actions'
-                >
-                    {buttons}
-                </div>
+                {error}
             </div>
         );
     }

--- a/components/user_list_row_with_error.jsx
+++ b/components/user_list_row_with_error.jsx
@@ -33,14 +33,15 @@ export default class UserListRowWithError extends React.Component {
 
     constructor(props) {
         super(props);
+        this.state = {error: null};
 
         this.onError = this.onError.bind(this);
     }
 
     onError(errorObj) {
-        this.state = {
+        this.setState({
             error: errorObj
-        };
+        });
     }
 
     render() {

--- a/components/user_list_row_with_error.jsx
+++ b/components/user_list_row_with_error.jsx
@@ -33,7 +33,7 @@ export default class UserListRowWithError extends React.Component {
 
     constructor(props) {
         super(props);
-        this.state = {error: null};
+        this.state = {};
 
         this.onError = this.onError.bind(this);
     }
@@ -108,33 +108,35 @@ export default class UserListRowWithError extends React.Component {
                     width='32'
                     height='32'
                 />
-                <div
-                    className='more-modal__top'
-                >
-                    <div
-                        className='more-modal__details'
-                    >
-                        <div
-                            id={userCountID}
-                            className='more-modal__name'
-                        >
-                            {Utils.displayEntireNameForUser(this.props.user)}
+                <div className='more-modal__right'>
+                    <div className='more-modal__top'>
+                        <div className='more-modal__details'>
+                            <div
+                                id={userCountID}
+                                className='more-modal__name'
+                            >
+                                {Utils.displayEntireNameForUser(this.props.user)}
+                            </div>
+                            <div
+                                id={userCountEmail}
+                                className={emailStyle}
+                            >
+                                {email}
+                            </div>
+                            {this.props.extraInfo}
                         </div>
                         <div
-                            id={userCountEmail}
-                            className={emailStyle}
+                            className='more-modal__actions'
                         >
-                            {email}
+                            {buttons}
                         </div>
-                        {this.props.extraInfo}
                     </div>
                     <div
-                        className='more-modal__actions'
+                        className='more-modal__bottom'
                     >
-                        {buttons}
+                        {error}
                     </div>
                 </div>
-                {error}
             </div>
         );
     }

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -670,8 +670,9 @@
         flex-direction: column;
         width: 100%;
 
-        .has-error {
-            padding-left: 10px;
+        .control-label {
+            font-weight: normal;
+            padding: 5px 0 0 5px;
         }
     }
 

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -665,6 +665,20 @@
         width: 32px;
     }
 
+    .more-modal__right {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+    }
+
+    .more-modal__top {
+        display: flex;
+    }
+
+    .more-modal__bottom>.has-error {
+        padding-left: 5px;
+    }
+
     p {
         @include opacity(.8);
         font-size: .9em;

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -669,6 +669,10 @@
         display: flex;
         flex-direction: column;
         width: 100%;
+
+        .has-error {
+            padding-left: 10px;
+        }
     }
 
     .more-modal__top {


### PR DESCRIPTION
#### Summary
Changed the page layout so that error messages are shown at the user list row level, instead of in the same div that the actions drop down is rendered in.

Testing this change requires simulating a server-side error. To make that easier, here are some screen shots of the list with and without an error message:
![screen shot 2017-11-27 at 3 37 50 pm](https://user-images.githubusercontent.com/1799952/33288326-dc1de412-d389-11e7-9611-cf1b5ace7509.png)
![screen shot 2017-11-27 at 3 37 11 pm](https://user-images.githubusercontent.com/1799952/33288330-e0b1a3d8-d389-11e7-8b97-4584b630eeb7.png)
I created these first image by modifying the default value of `state` in [user_list_row_with_error.jsx](https://github.com/mattermost/mattermost-webapp/blob/PLT-8062/components/user_list_row_with_error.jsx#L36) to be:
```Javascript
this.state = {error: { message: "This is an error message"}};
```
#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8062

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes