### PR TITLE
Replace modal store with redux view reducer #6784

### DIFF
--- a/actions/views/modals.js
+++ b/actions/views/modals.js
@@ -1,0 +1,25 @@
+import {ActionTypes} from 'utils/constants';
+import * as Utils from 'utils/utils';
+
+export function openModal(modalData) {
+    return (dispatch, getState) => {
+        const action = {
+            type: ActionTypes.MODAL_OPEN,
+            modalId: modalData.modalId,
+            dialogProps: modalData.dialogProps
+        };
+
+        dispatch(action);
+    };
+}
+
+export function closeModal(modalId) {
+    return (dispatch, getState) => {
+        const action = {
+            type: ActionTypes.MODAL_CLOSE,
+            modalId: modalId
+        };
+
+        dispatch(action);
+    };
+}

--- a/actions/views/modals.js
+++ b/actions/views/modals.js
@@ -6,7 +6,8 @@ export function openModal(modalData) {
         const action = {
             type: ActionTypes.MODAL_OPEN,
             modalId: modalData.modalId,
-            dialogProps: modalData.dialogProps
+            dialogProps: modalData.dialogProps,
+            dialogType: modalData.dialogType
         };
 
         dispatch(action);

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -14,7 +14,7 @@ import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import WebrtcStore from 'stores/webrtc_store.jsx';
 
 import * as ChannelUtils from 'utils/channel_utils.jsx';
-import {ActionTypes, Constants, RHSStates, UserStatuses} from 'utils/constants.jsx';
+import {ActionTypes, Constants, RHSStates, UserStatuses, ModalIdentifiers} from 'utils/constants.jsx';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 import {getSiteURL} from 'utils/url.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -32,6 +32,7 @@ import RenameChannelModal from 'components/rename_channel_modal';
 import NavbarSearchBox from 'components/search_bar';
 import StatusIcon from 'components/status_icon.jsx';
 import ToggleModalButton from 'components/toggle_modal_button.jsx';
+import ToggleModalButtonRedux from 'components/toggle_modal_button_redux';
 
 import Pluggable from 'plugins/pluggable';
 
@@ -629,17 +630,17 @@ export default class ChannelHeader extends React.Component {
                         key='delete_channel'
                         role='presentation'
                     >
-                        <ToggleModalButton
+                        <ToggleModalButtonRedux
                             id='channelDelete'
                             role='menuitem'
-                            dialogType={DeleteChannelModal}
+                            modalId={ModalIdentifiers.DELETE_CHANNEL}
                             dialogProps={{channel}}
                         >
                             <FormattedMessage
                                 id='channel_header.delete'
                                 defaultMessage='Delete Channel'
                             />
-                        </ToggleModalButton>
+                        </ToggleModalButtonRedux>
                     </li>
                 );
             }

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -31,7 +31,6 @@ import PopoverListMembers from 'components/popover_list_members';
 import RenameChannelModal from 'components/rename_channel_modal';
 import NavbarSearchBox from 'components/search_bar';
 import StatusIcon from 'components/status_icon.jsx';
-import ToggleModalButton from 'components/toggle_modal_button.jsx';
 import ToggleModalButtonRedux from 'components/toggle_modal_button_redux';
 
 import Pluggable from 'plugins/pluggable';
@@ -354,7 +353,7 @@ export default class ChannelHeader extends React.Component {
                     <ToggleModalButtonRedux
                         id='channelEditHeaderDirect'
                         role='menuitem'
-                        modalId={modalIdentifiers.EDIT_CHANNEL_HEADER}
+                        modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
                         dialogType={EditChannelHeaderModal}
                         dialogProps={{channel}}
                     >
@@ -374,7 +373,7 @@ export default class ChannelHeader extends React.Component {
                     <ToggleModalButtonRedux
                         id='channelEditHeaderGroup'
                         role='menuitem'
-                        modalId={modalIdentifiers.EDIT_CHANNEL_HEADER}
+                        modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
                         dialogType={EditChannelHeaderModal}
                         dialogProps={{channel}}
                     >
@@ -394,7 +393,7 @@ export default class ChannelHeader extends React.Component {
                     <ToggleModalButtonRedux
                         id='channelnotificationPreferencesGroup'
                         role='menuitem'
-                        modalId={modalIdentifiers.EDIT_CHANNEL_HEADER}
+                        modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
                         dialogType={ChannelNotificationsModal}
                         dialogProps={{
                             channel,
@@ -580,7 +579,7 @@ export default class ChannelHeader extends React.Component {
                         <ToggleModalButtonRedux
                             id='channelEditHeader'
                             role='menuitem'
-                                modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
+                            modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
                             dialogType={EditChannelHeaderModal}
                             dialogProps={{channel}}
                         >

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -351,9 +351,10 @@ export default class ChannelHeader extends React.Component {
                     key='edit_header_direct'
                     role='presentation'
                 >
-                    <ToggleModalButton
+                    <ToggleModalButtonRedux
                         id='channelEditHeaderDirect'
                         role='menuitem'
+                        modalId={modalIdentifiers.EDIT_CHANNEL_HEADER}
                         dialogType={EditChannelHeaderModal}
                         dialogProps={{channel}}
                     >
@@ -361,7 +362,7 @@ export default class ChannelHeader extends React.Component {
                             id='channel_header.channelHeader'
                             defaultMessage='Edit Channel Header'
                         />
-                    </ToggleModalButton>
+                    </ToggleModalButtonRedux>
                 </li>
             );
         } else if (isGroup) {
@@ -370,9 +371,10 @@ export default class ChannelHeader extends React.Component {
                     key='edit_header_direct'
                     role='presentation'
                 >
-                    <ToggleModalButton
+                    <ToggleModalButtonRedux
                         id='channelEditHeaderGroup'
                         role='menuitem'
+                        modalId={modalIdentifiers.EDIT_CHANNEL_HEADER}
                         dialogType={EditChannelHeaderModal}
                         dialogProps={{channel}}
                     >
@@ -380,7 +382,7 @@ export default class ChannelHeader extends React.Component {
                             id='channel_header.channelHeader'
                             defaultMessage='Edit Channel Header'
                         />
-                    </ToggleModalButton>
+                    </ToggleModalButtonRedux>
                 </li>
             );
 
@@ -389,9 +391,10 @@ export default class ChannelHeader extends React.Component {
                     key='notification_preferences'
                     role='presentation'
                 >
-                    <ToggleModalButton
+                    <ToggleModalButtonRedux
                         id='channelnotificationPreferencesGroup'
                         role='menuitem'
+                        modalId={modalIdentifiers.EDIT_CHANNEL_HEADER}
                         dialogType={ChannelNotificationsModal}
                         dialogProps={{
                             channel,
@@ -403,7 +406,7 @@ export default class ChannelHeader extends React.Component {
                             id='channel_header.notificationPreferences'
                             defaultMessage='Notification Preferences'
                         />
-                    </ToggleModalButton>
+                    </ToggleModalButtonRedux>
                 </li>
             );
 
@@ -431,9 +434,10 @@ export default class ChannelHeader extends React.Component {
                     key='view_info'
                     role='presentation'
                 >
-                    <ToggleModalButton
+                    <ToggleModalButtonRedux
                         id='channelViewInfo'
                         role='menuitem'
+                        modalId={ModalIdentifiers.CHANNEL_INFO}
                         dialogType={ChannelInfoModal}
                         dialogProps={{channel}}
                     >
@@ -441,7 +445,7 @@ export default class ChannelHeader extends React.Component {
                             id='channel_header.viewInfo'
                             defaultMessage='View Info'
                         />
-                    </ToggleModalButton>
+                    </ToggleModalButtonRedux>
                 </li>
             );
 
@@ -471,9 +475,10 @@ export default class ChannelHeader extends React.Component {
                     key='notification_preferences'
                     role='presentation'
                 >
-                    <ToggleModalButton
+                    <ToggleModalButtonRedux
                         id='channelNotificationPreferences'
                         role='menuitem'
+                        modalId={ModalIdentifiers.CHANNEL_NOTIFICATIONS}
                         dialogType={ChannelNotificationsModal}
                         dialogProps={{
                             channel,
@@ -485,7 +490,7 @@ export default class ChannelHeader extends React.Component {
                             id='channel_header.notificationPreferences'
                             defaultMessage='Notification Preferences'
                         />
-                    </ToggleModalButton>
+                    </ToggleModalButtonRedux>
                 </li>
             );
 
@@ -503,10 +508,11 @@ export default class ChannelHeader extends React.Component {
                             key='add_members'
                             role='presentation'
                         >
-                            <ToggleModalButton
+                            <ToggleModalButtonRedux
                                 id='channelAddMembers'
                                 ref='channelInviteModalButton'
                                 role='menuitem'
+                                modalId={ModalIdentifiers.CHANNEL_INVITE}
                                 dialogType={ChannelInviteModal}
                                 dialogProps={{channel, currentUser: this.props.currentUser}}
                             >
@@ -514,7 +520,7 @@ export default class ChannelHeader extends React.Component {
                                     id='channel_header.addMembers'
                                     defaultMessage='Add Members'
                                 />
-                            </ToggleModalButton>
+                            </ToggleModalButtonRedux>
                         </li>
                     );
 
@@ -571,9 +577,10 @@ export default class ChannelHeader extends React.Component {
                         key='set_channel_header'
                         role='presentation'
                     >
-                        <ToggleModalButton
+                        <ToggleModalButtonRedux
                             id='channelEditHeader'
                             role='menuitem'
+                                modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
                             dialogType={EditChannelHeaderModal}
                             dialogProps={{channel}}
                         >
@@ -581,7 +588,7 @@ export default class ChannelHeader extends React.Component {
                                 id='channel_header.setHeader'
                                 defaultMessage='Edit Channel Header'
                             />
-                        </ToggleModalButton>
+                        </ToggleModalButtonRedux>
                     </li>
                 );
 
@@ -634,6 +641,7 @@ export default class ChannelHeader extends React.Component {
                             id='channelDelete'
                             role='menuitem'
                             modalId={ModalIdentifiers.DELETE_CHANNEL}
+                            dialogType={DeleteChannelModal}
                             dialogProps={{channel}}
                         >
                             <FormattedMessage

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -198,8 +198,6 @@ export default class ChannelHeader extends React.Component {
 
         const channel = this.props.channel;
 
-        console.log('channel', channel);
-
         const recentMentionsTooltip = (
             <Tooltip id='recentMentionsTooltip'>
                 <FormattedMessage
@@ -829,7 +827,6 @@ export default class ChannelHeader extends React.Component {
                 dialogType: ChannelInviteModal,
                 dialogProps: {channel, currentUser: this.props.currentUser}
             };
-
 
             const {openModal} = this.props.actions;
 

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -197,6 +197,9 @@ export default class ChannelHeader extends React.Component {
         const mentionsIcon = Constants.MENTIONS_ICON_SVG;
 
         const channel = this.props.channel;
+
+        console.log('channel', channel);
+
         const recentMentionsTooltip = (
             <Tooltip id='recentMentionsTooltip'>
                 <FormattedMessage
@@ -826,6 +829,7 @@ export default class ChannelHeader extends React.Component {
                 dialogType: ChannelInviteModal,
                 dialogProps: {channel, currentUser: this.props.currentUser}
             };
+
 
             const {openModal} = this.props.actions;
 

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -59,7 +59,8 @@ export default class ChannelHeader extends React.Component {
             showFlaggedPosts: PropTypes.func.isRequired,
             showPinnedPosts: PropTypes.func.isRequired,
             showMentions: PropTypes.func.isRequired,
-            closeRightHandSide: PropTypes.func.isRequired
+            closeRightHandSide: PropTypes.func.isRequired,
+            openModal: PropTypes.func.isRequired
         }).isRequired
     }
 
@@ -820,10 +821,18 @@ export default class ChannelHeader extends React.Component {
 
         let channelMembersModal;
         if (this.state.showMembersModal) {
+            const inviteModalData = {
+                modalId: ModalIdentifiers.CHANNEL_INVITE,
+                dialogType: ChannelInviteModal,
+                dialogProps: {channel, currentUser: this.props.currentUser}
+            };
+
+            const {openModal} = this.props.actions;
+
             channelMembersModal = (
                 <ChannelMembersModal
                     onModalDismissed={() => this.setState({showMembersModal: false})}
-                    showInviteModal={() => this.refs.channelInviteModalButton.show()}
+                    showInviteModal={() => openModal(inviteModalData)}
                     channel={channel}
                 />
             );

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -13,6 +13,7 @@ import {getCurrentUser, getStatusForUserId, getUser} from 'mattermost-redux/sele
 import {getUserIdFromChannelName, isDefault, isFavoriteChannel} from 'mattermost-redux/utils/channel_utils';
 
 import {showFlaggedPosts, showPinnedPosts, showMentions, closeRightHandSide} from 'actions/views/rhs';
+import {openModal} from 'actions/views/modals';
 
 import {getRhsState} from 'selectors/rhs';
 
@@ -54,7 +55,8 @@ function mapDispatchToProps(dispatch) {
             showFlaggedPosts,
             showPinnedPosts,
             showMentions,
-            closeRightHandSide
+            closeRightHandSide,
+            openModal
         }, dispatch)
     };
 }

--- a/components/modal_controller/index.js
+++ b/components/modal_controller/index.js
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {closeModal} from '../../actions/views/modals';
+import {closeModal} from 'actions/views/modals';
 
 import ModalController from './modal_controller.jsx';
 

--- a/components/modal_controller/index.js
+++ b/components/modal_controller/index.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {closeModal} from '../../actions/views/modals';
+
+import ModalController from './modal_controller.jsx';
+
+function mapStateToProps(state, ownProps) {
+    return {
+        ...ownProps,
+        modals: state.views.modals
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            closeModal
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ModalController);

--- a/components/modal_controller/modal_controller.jsx
+++ b/components/modal_controller/modal_controller.jsx
@@ -6,8 +6,6 @@ import React from 'react';
 
 import {ModalIdentifiers} from 'utils/constants.jsx';
 
-import DeleteChannelModal from 'components/delete_channel_modal';
-
 export default class ModalController extends React.Component {
 
     constructor(params) {
@@ -16,24 +14,30 @@ export default class ModalController extends React.Component {
 
     render() {
         const {modals, ...props} = this.props;
+        const {modalState} = modals;
 
         if (!modals) {
             return <div></div>;
         }
 
-        let modalOutput;
 
-        const deleteChannelModal = modals.modalState[ModalIdentifiers.DELETE_CHANNEL];
 
-        if (deleteChannelModal && deleteChannelModal.open) {
-            console.log('is open');
-            modalOutput = (
-                <DeleteChannelModal
-                    onHide={props.actions.closeModal.bind(this, ModalIdentifiers.DELETE_CHANNEL)}
-                    {...deleteChannelModal.dialogProps}
-                />
-            );
+        const modalOutput = [];
+
+        for (let modalId in modalState) {
+            if (modalState.hasOwnProperty(modalId)) {
+                const modal = modalState[modalId];
+                if (modal.open) {
+                    const modalComponent = React.createElement(modal.dialogType, Object.assign({}, modal.dialogProps, {
+                        onHide: props.actions.closeModal.bind(this, modalId),
+                        key: `${modalId}_modal`
+                    }));
+
+                    modalOutput.push(modalComponent);
+                }
+            }
         }
+
 
         return (
             <div>

--- a/components/modal_controller/modal_controller.jsx
+++ b/components/modal_controller/modal_controller.jsx
@@ -4,12 +4,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {ModalIdentifiers} from 'utils/constants.jsx';
-
 export default class ModalController extends React.Component {
-
-    constructor(params) {
-        super(params);
+    static propTypes = {
+        modals: PropTypes.object.isRequired,
+        actions: PropTypes.shape({
+            closeModal: PropTypes.func.isRequired
+        }).isRequired
     }
 
     render() {
@@ -17,14 +17,12 @@ export default class ModalController extends React.Component {
         const {modalState} = modals;
 
         if (!modals) {
-            return <div></div>;
+            return <div/>;
         }
-
-
 
         const modalOutput = [];
 
-        for (let modalId in modalState) {
+        for (const modalId in modalState) {
             if (modalState.hasOwnProperty(modalId)) {
                 const modal = modalState[modalId];
                 if (modal.open) {
@@ -38,11 +36,11 @@ export default class ModalController extends React.Component {
             }
         }
 
-
         return (
             <div>
                 {modalOutput}
             </div>
         );
     }
+
 }

--- a/components/modal_controller/modal_controller.jsx
+++ b/components/modal_controller/modal_controller.jsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {ModalIdentifiers} from 'utils/constants.jsx';
+
+import DeleteChannelModal from 'components/delete_channel_modal';
+
+export default class ModalController extends React.Component {
+
+    constructor(params) {
+        super(params);
+    }
+
+    render() {
+        const {modals, ...props} = this.props;
+
+        if (!modals) {
+            return <div></div>;
+        }
+
+        let modalOutput;
+
+        const deleteChannelModal = modals.modalState[ModalIdentifiers.DELETE_CHANNEL];
+
+        if (deleteChannelModal && deleteChannelModal.open) {
+            console.log('is open');
+            modalOutput = (
+                <DeleteChannelModal
+                    onHide={props.actions.closeModal.bind(this, ModalIdentifiers.DELETE_CHANNEL)}
+                    {...deleteChannelModal.dialogProps}
+                />
+            );
+        }
+
+        return (
+            <div>
+                {modalOutput}
+            </div>
+        );
+    }
+}

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -43,6 +43,7 @@ import ImportThemeModal from 'components/user_settings/import_theme_modal.jsx';
 import UserSettingsModal from 'components/user_settings/user_settings_modal.jsx';
 import WebrtcNotification from 'components/webrtc/components/webrtc_notification.jsx';
 import WebrtcSidebar from 'components/webrtc/components/webrtc_sidebar.jsx';
+import ModalController from 'components/modal_controller';
 
 const TutorialSteps = Constants.TutorialSteps;
 const Preferences = Constants.Preferences;
@@ -222,6 +223,7 @@ export default class NeedsTeam extends React.Component {
                     <ResetStatusModal/>
                     <LeavePrivateChannelModal/>
                     <ShortcutsModal isMac={Utils.isMac()}/>
+                    <ModalController/>
                 </div>
             </div>
         );

--- a/components/toggle_modal_button_redux/index.js
+++ b/components/toggle_modal_button_redux/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 
 import ModalToggleButtonRedux from './toggle_modal_button_redux.jsx';
 
-import {openModal, closeModal} from '../../actions/views/modals';
+import {openModal, closeModal} from 'actions/views/modals';
 
 function mapStateToProps(state, ownProps) {
     return {

--- a/components/toggle_modal_button_redux/index.js
+++ b/components/toggle_modal_button_redux/index.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import ModalToggleButtonRedux from './toggle_modal_button_redux.jsx';
+
+import {openModal, closeModal} from '../../actions/views/modals';
+
+function mapStateToProps(state, ownProps) {
+    return {
+        ...ownProps
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            openModal,
+            closeModal
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ModalToggleButtonRedux);

--- a/components/toggle_modal_button_redux/index.js
+++ b/components/toggle_modal_button_redux/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 
 import ModalToggleButtonRedux from './toggle_modal_button_redux.jsx';
 
-import {openModal, closeModal} from 'actions/views/modals';
+import {openModal} from 'actions/views/modals';
 
 function mapStateToProps(state, ownProps) {
     return {
@@ -17,8 +17,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            openModal,
-            closeModal
+            openModal
         }, dispatch)
     };
 }

--- a/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
+++ b/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class ModalToggleButtonRedux extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.show = this.show.bind(this);
+        this.hide = this.hide.bind(this);
+
+        this.state = {
+            show: false
+        };
+    }
+
+    show(e) {
+        if (e) {
+            e.preventDefault();
+        }
+
+        this.setState({show: true});
+
+        const {modalId, dialogProps} = this.props;
+
+        const modalData = {
+            modalId: modalId,
+            dialogProps: dialogProps
+        };
+
+        this.props.actions.openModal(modalData);
+    }
+
+    hide() {
+        this.setState({show: false});
+        const {modalId} = this.props;
+
+        this.props.actions.closeModal(modalId);
+    }
+
+    render() {
+        const {children, onClick, modalId, dialogType, dialogProps, ...props} = this.props;
+
+        // allow callers to provide an onClick which will be called before the modal is shown
+        let clickHandler = this.show;
+        if (onClick) {
+            clickHandler = (e) => {
+                onClick();
+
+                this.show(e);
+            };
+        }
+
+        // nesting the dialog in the anchor tag looks like it shouldn't work, but it does due to how react-bootstrap
+        // renders modals at the top level of the DOM instead of where you specify in the virtual DOM
+        return (
+            <button
+                {...props}
+                className={'style--none ' + props.className}
+                onClick={clickHandler}
+            >
+                {children}
+            </button>
+        );
+    }
+}
+
+ModalToggleButtonRedux.propTypes = {
+    children: PropTypes.node.isRequired,
+    modalId: PropTypes.string.isRequired,
+    dialogProps: PropTypes.object,
+    onClick: PropTypes.func,
+    className: PropTypes.string
+};
+
+ModalToggleButtonRedux.defaultProps = {
+    dialogProps: {},
+    className: ''
+};

--- a/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
+++ b/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
@@ -77,8 +77,6 @@ export default class ModalToggleButtonRedux extends React.Component {
             };
         }
 
-        // nesting the dialog in the anchor tag looks like it shouldn't work, but it does due to how react-bootstrap
-        // renders modals at the top level of the DOM instead of where you specify in the virtual DOM
         return (
             <button
                 {...props}

--- a/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
+++ b/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
@@ -62,6 +62,7 @@ export default class ModalToggleButtonRedux extends React.Component {
     render() {
         const {children, onClick, ...props} = this.props;
 
+        // removing these three props since they are not valid props on buttons
         delete props.modalId;
         delete props.dialogType;
         delete props.dialogProps;

--- a/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
+++ b/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
@@ -23,11 +23,12 @@ export default class ModalToggleButtonRedux extends React.Component {
 
         this.setState({show: true});
 
-        const {modalId, dialogProps} = this.props;
+        const {modalId, dialogProps, dialogType} = this.props;
 
         const modalData = {
-            modalId: modalId,
-            dialogProps: dialogProps
+            modalId,
+            dialogProps,
+            dialogType
         };
 
         this.props.actions.openModal(modalData);
@@ -70,6 +71,7 @@ export default class ModalToggleButtonRedux extends React.Component {
 ModalToggleButtonRedux.propTypes = {
     children: PropTypes.node.isRequired,
     modalId: PropTypes.string.isRequired,
+    dialogType: PropTypes.func.isRequired,
     dialogProps: PropTypes.object,
     onClick: PropTypes.func,
     className: PropTypes.string

--- a/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
+++ b/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
@@ -5,6 +5,24 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 export default class ModalToggleButtonRedux extends React.Component {
+    static propTypes = {
+        children: PropTypes.node.isRequired,
+        modalId: PropTypes.string.isRequired,
+        dialogType: PropTypes.func.isRequired,
+        dialogProps: PropTypes.object,
+        onClick: PropTypes.func,
+        className: PropTypes.string,
+        actions: PropTypes.shape({
+            openModal: PropTypes.func.isRequired,
+            closeModal: PropTypes.func.isRequired
+        }).isRequired
+    };
+
+    static defaultProps = {
+        dialogProps: {},
+        className: ''
+    };
+
     constructor(props) {
         super(props);
 
@@ -42,7 +60,11 @@ export default class ModalToggleButtonRedux extends React.Component {
     }
 
     render() {
-        const {children, onClick, modalId, dialogType, dialogProps, ...props} = this.props;
+        const {children, onClick, ...props} = this.props;
+
+        delete props.modalId;
+        delete props.dialogType;
+        delete props.dialogProps;
 
         // allow callers to provide an onClick which will be called before the modal is shown
         let clickHandler = this.show;
@@ -68,16 +90,3 @@ export default class ModalToggleButtonRedux extends React.Component {
     }
 }
 
-ModalToggleButtonRedux.propTypes = {
-    children: PropTypes.node.isRequired,
-    modalId: PropTypes.string.isRequired,
-    dialogType: PropTypes.func.isRequired,
-    dialogProps: PropTypes.object,
-    onClick: PropTypes.func,
-    className: PropTypes.string
-};
-
-ModalToggleButtonRedux.defaultProps = {
-    dialogProps: {},
-    className: ''
-};

--- a/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
+++ b/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
@@ -13,8 +13,7 @@ export default class ModalToggleButtonRedux extends React.Component {
         onClick: PropTypes.func,
         className: PropTypes.string,
         actions: PropTypes.shape({
-            openModal: PropTypes.func.isRequired,
-            closeModal: PropTypes.func.isRequired
+            openModal: PropTypes.func.isRequired
         }).isRequired
     };
 
@@ -23,23 +22,10 @@ export default class ModalToggleButtonRedux extends React.Component {
         className: ''
     };
 
-    constructor(props) {
-        super(props);
-
-        this.show = this.show.bind(this);
-        this.hide = this.hide.bind(this);
-
-        this.state = {
-            show: false
-        };
-    }
-
     show(e) {
         if (e) {
             e.preventDefault();
         }
-
-        this.setState({show: true});
 
         const {modalId, dialogProps, dialogType} = this.props;
 
@@ -52,13 +38,6 @@ export default class ModalToggleButtonRedux extends React.Component {
         this.props.actions.openModal(modalData);
     }
 
-    hide() {
-        this.setState({show: false});
-        const {modalId} = this.props;
-
-        this.props.actions.closeModal(modalId);
-    }
-
     render() {
         const {children, onClick, ...props} = this.props;
 
@@ -68,7 +47,7 @@ export default class ModalToggleButtonRedux extends React.Component {
         delete props.dialogProps;
 
         // allow callers to provide an onClick which will be called before the modal is shown
-        let clickHandler = this.show;
+        let clickHandler = () => this.show();
         if (onClick) {
             clickHandler = (e) => {
                 onClick();

--- a/reducers/views/index.js
+++ b/reducers/views/index.js
@@ -7,10 +7,12 @@ import admin from './admin'
 import channel from './channel';
 import rhs from './rhs';
 import posts from './posts';
+import modals from './modals';
 
 export default combineReducers({
     admin,
     channel,
     rhs,
-    posts
+    posts,
+    modals
 });

--- a/reducers/views/modals.js
+++ b/reducers/views/modals.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {combineReducers} from 'redux';
+
+import {ActionTypes, ModalIdentifiers} from 'utils/constants.jsx';
+
+function modalState(state = {}, action) {
+    let nextState = {...state};
+
+    switch (action.type) {
+        case ActionTypes.MODAL_OPEN:
+
+
+            nextState[action.modalId] = {
+                open: true,
+                dialogProps: action.dialogProps
+            };
+
+            console.log('modal open', action);
+
+
+            return nextState;
+        case ActionTypes.MODAL_CLOSE:
+            nextState[action.modalId] = {
+                open: false
+            };
+
+            console.log('modal closed', action);
+
+            return nextState;
+        default:
+            return state;
+    }
+}
+
+export default combineReducers({
+    modalState
+});

--- a/reducers/views/modals.js
+++ b/reducers/views/modals.js
@@ -10,23 +10,19 @@ function modalState(state = {}, action) {
 
     switch (action.type) {
         case ActionTypes.MODAL_OPEN:
-
-
             nextState[action.modalId] = {
                 open: true,
-                dialogProps: action.dialogProps
+                dialogProps: action.dialogProps,
+                dialogType: action.dialogType
             };
 
-            console.log('modal open', action);
-
+            console.log('open modal', nextState);
 
             return nextState;
         case ActionTypes.MODAL_CLOSE:
             nextState[action.modalId] = {
                 open: false
             };
-
-            console.log('modal closed', action);
 
             return nextState;
         default:

--- a/reducers/views/modals.js
+++ b/reducers/views/modals.js
@@ -16,8 +16,6 @@ function modalState(state = {}, action) {
                 dialogType: action.dialogType
             };
 
-            console.log('open modal', nextState);
-
             return nextState;
         case ActionTypes.MODAL_CLOSE:
             nextState[action.modalId] = {

--- a/tests/components/__snapshots__/modal_controller.test.jsx.snap
+++ b/tests/components/__snapshots__/modal_controller.test.jsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/ModalController component should match snapshot without any modals 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(ModalController)>
+    <ModalController
+      actions={
+        Object {
+          "closeModal": [Function],
+        }
+      }
+      modals={
+        Object {
+          "modalState": Object {},
+        }
+      }
+    >
+      <div />
+    </ModalController>
+  </Connect(ModalController)>
+</Provider>
+`;

--- a/tests/components/__snapshots__/toggle_modal_button_redux.test.jsx.snap
+++ b/tests/components/__snapshots__/toggle_modal_button_redux.test.jsx.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/ToggleModalButtonRedux component should match snapshot 1`] = `
+<ModalToggleButtonRedux
+  actions={
+    Object {
+      "openModal": [Function],
+    }
+  }
+  className=""
+  dialogProps={
+    Object {
+      "channel": Object {
+        "create_at": 1511983748292,
+        "creator_id": "pj9tn4tyupfbbjuoah76575xso",
+        "delete_at": 0,
+        "display_name": "Test",
+        "extra_update_at": 1511983748307,
+        "header": "",
+        "id": "izpbgcd5e38xpkhgdeqwuijnoh",
+        "last_post_at": 1511983748333,
+        "name": "test",
+        "purpose": "",
+        "team_id": "s5c6yy6jo3n57khrqeq85motnr",
+        "total_msg_count": 0,
+        "type": "O",
+        "update_at": 1511983748292,
+      },
+    }
+  }
+  dialogType={[Function]}
+  id="channelDelete"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  modalId="delete_channel"
+  role="menuitem"
+>
+  <button
+    actions={
+      Object {
+        "openModal": [Function],
+      }
+    }
+    className="style--none "
+    id="channelDelete"
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "textComponent": "span",
+      }
+    }
+    onClick={[Function]}
+    role="menuitem"
+  >
+    <FormattedMessage
+      defaultMessage="Delete Channel"
+      id="channel_header.delete"
+      values={Object {}}
+    >
+      <span>
+        Delete Channel
+      </span>
+    </FormattedMessage>
+  </button>
+</ModalToggleButtonRedux>
+`;

--- a/tests/components/__snapshots__/toggle_modal_button_redux.test.jsx.snap
+++ b/tests/components/__snapshots__/toggle_modal_button_redux.test.jsx.snap
@@ -8,26 +8,7 @@ exports[`components/ToggleModalButtonRedux component should match snapshot 1`] =
     }
   }
   className=""
-  dialogProps={
-    Object {
-      "channel": Object {
-        "create_at": 1511983748292,
-        "creator_id": "pj9tn4tyupfbbjuoah76575xso",
-        "delete_at": 0,
-        "display_name": "Test",
-        "extra_update_at": 1511983748307,
-        "header": "",
-        "id": "izpbgcd5e38xpkhgdeqwuijnoh",
-        "last_post_at": 1511983748333,
-        "name": "test",
-        "purpose": "",
-        "team_id": "s5c6yy6jo3n57khrqeq85motnr",
-        "total_msg_count": 0,
-        "type": "O",
-        "update_at": 1511983748292,
-      },
-    }
-  }
+  dialogProps={Object {}}
   dialogType={[Function]}
   id="channelDelete"
   intl={

--- a/tests/components/modal_controller.test.jsx
+++ b/tests/components/modal_controller.test.jsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {Modal} from 'react-bootstrap';
+
+import {Provider} from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import {mount} from 'enzyme';
+
+import ModalController from 'components/modal_controller';
+
+class TestModal extends React.Component {
+    render() {
+        return (
+            <Modal
+                show={true}
+            >
+                <Modal.Header closeButton={true}/>
+                <Modal.Body/>
+            </Modal>
+        );
+    }
+}
+
+describe('components/ModalController', () => {
+    const mockStore = configureStore();
+
+    test('component should match snapshot without any modals', () => {
+        const state = {
+            views: {
+                modals: {
+                    modalState: {}
+                }
+            }
+        };
+
+        const store = mockStore(state);
+
+        const wrapper = mount(
+            <Provider store={store}>
+                <ModalController/>
+            </Provider>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('div').first().html()).toBe('<div></div>');
+        expect(document.getElementsByClassName('modal-dialog').length).toBeFalsy();
+    });
+
+    test('test model should be open', () => {
+        const state = {
+            views: {
+                modals: {
+                    modalState: {
+                        test_modal: {
+                            open: true,
+                            dialogProps: {},
+                            dialogType: TestModal
+                        }
+                    }
+                }
+            }
+        };
+
+        const store = mockStore(state);
+
+        mount(
+            <Provider store={store}>
+                <ModalController/>
+            </Provider>
+        );
+
+        expect(document.getElementsByClassName('modal-dialog').length).toBe(1);
+    });
+});

--- a/tests/components/toggle_modal_button_redux.test.jsx
+++ b/tests/components/toggle_modal_button_redux.test.jsx
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import React from 'react';
+import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
@@ -9,34 +10,29 @@ import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 import {ModalIdentifiers} from 'utils/constants.jsx';
 
 import ToggleModalButtonRedux from 'components/toggle_modal_button_redux/toggle_modal_button_redux.jsx';
-import DeleteChannelModal from 'components/delete_channel_modal';
+
+class TestModal extends React.Component {
+    render() {
+        return (
+            <Modal
+                show={true}
+            >
+                <Modal.Header closeButton={true}/>
+                <Modal.Body/>
+            </Modal>
+        );
+    }
+}
 
 describe('components/ToggleModalButtonRedux', () => {
     test('component should match snapshot', () => {
-        const channel = {
-            create_at: 1511983748292,
-            creator_id: 'pj9tn4tyupfbbjuoah76575xso',
-            delete_at: 0,
-            display_name: 'Test',
-            extra_update_at: 1511983748307,
-            header: '',
-            id: 'izpbgcd5e38xpkhgdeqwuijnoh',
-            last_post_at: 1511983748333,
-            name: 'test',
-            purpose: '',
-            team_id: 's5c6yy6jo3n57khrqeq85motnr',
-            total_msg_count: 0,
-            type: 'O',
-            update_at: 1511983748292
-        };
-
         const wrapper = mountWithIntl(
             <ToggleModalButtonRedux
                 id='channelDelete'
                 role='menuitem'
                 modalId={ModalIdentifiers.DELETE_CHANNEL}
-                dialogType={DeleteChannelModal}
-                dialogProps={{channel}}
+                dialogType={TestModal}
+                dialogProps={{}}
                 actions={{openModal: () => true}}
             >
                 <FormattedMessage

--- a/tests/components/toggle_modal_button_redux.test.jsx
+++ b/tests/components/toggle_modal_button_redux.test.jsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+
+import {ModalIdentifiers} from 'utils/constants.jsx';
+
+import ToggleModalButtonRedux from 'components/toggle_modal_button_redux/toggle_modal_button_redux.jsx';
+import DeleteChannelModal from 'components/delete_channel_modal';
+
+describe('components/ToggleModalButtonRedux', () => {
+    test('component should match snapshot', () => {
+        const channel = {
+            create_at: 1511983748292,
+            creator_id: 'pj9tn4tyupfbbjuoah76575xso',
+            delete_at: 0,
+            display_name: 'Test',
+            extra_update_at: 1511983748307,
+            header: '',
+            id: 'izpbgcd5e38xpkhgdeqwuijnoh',
+            last_post_at: 1511983748333,
+            name: 'test',
+            purpose: '',
+            team_id: 's5c6yy6jo3n57khrqeq85motnr',
+            total_msg_count: 0,
+            type: 'O',
+            update_at: 1511983748292
+        };
+
+        const wrapper = mountWithIntl(
+            <ToggleModalButtonRedux
+                id='channelDelete'
+                role='menuitem'
+                modalId={ModalIdentifiers.DELETE_CHANNEL}
+                dialogType={DeleteChannelModal}
+                dialogProps={{channel}}
+                actions={{openModal: () => true}}
+            >
+                <FormattedMessage
+                    id='channel_header.delete'
+                    defaultMessage='Delete Channel'
+                />
+            </ToggleModalButtonRedux>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('button span').first().html()).toBe('<span>Delete Channel</span>');
+    });
+});

--- a/tests/redux/actions/views/modals.test.js
+++ b/tests/redux/actions/views/modals.test.js
@@ -1,6 +1,9 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import React from 'react';
+import {Modal} from 'react-bootstrap';
+
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
@@ -8,7 +11,18 @@ import {openModal, closeModal} from 'actions/views/modals';
 
 import {ActionTypes, ModalIdentifiers} from 'utils/constants.jsx';
 
-import DeleteChannelModal from 'components/delete_channel_modal';
+class TestModal extends React.Component {
+    render() {
+        return (
+            <Modal
+                show={true}
+            >
+                <Modal.Header closeButton={true}/>
+                <Modal.Body/>
+            </Modal>
+        );
+    }
+}
 
 describe('modals view actions', () => {
     const mockStore = configureStore([thunk]);
@@ -18,24 +32,9 @@ describe('modals view actions', () => {
     });
 
     test(ActionTypes.MODAL_OPEN, () => {
-        const dialogType = DeleteChannelModal;
+        const dialogType = TestModal;
         const dialogProps = {
-            channel: {
-                create_at: 1511983748292,
-                creator_id: 'pj9tn4tyupfbbjuoah76575xso',
-                delete_at: 0,
-                display_name: 'Test',
-                extra_update_at: 1511983748307,
-                header: '',
-                id: 'izpbgcd5e38xpkhgdeqwuijnoh',
-                last_post_at: 1511983748333,
-                name: 'test',
-                purpose: '',
-                team_id: 's5c6yy6jo3n57khrqeq85motnr',
-                total_msg_count: 0,
-                type: 'O',
-                update_at: 1511983748292
-            }
+            test: true
         };
 
         const modalData = {

--- a/tests/redux/actions/views/modals.test.js
+++ b/tests/redux/actions/views/modals.test.js
@@ -1,0 +1,70 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import {openModal, closeModal} from 'actions/views/modals';
+
+import {ActionTypes, ModalIdentifiers} from 'utils/constants.jsx';
+
+import DeleteChannelModal from 'components/delete_channel_modal';
+
+describe('modals view actions', () => {
+    const mockStore = configureStore([thunk]);
+
+    beforeEach(() => {
+        store = mockStore();
+    });
+
+    test(ActionTypes.MODAL_OPEN, () => {
+        const dialogType = DeleteChannelModal;
+        const dialogProps = {
+            channel: {
+                create_at: 1511983748292,
+                creator_id: 'pj9tn4tyupfbbjuoah76575xso',
+                delete_at: 0,
+                display_name: 'Test',
+                extra_update_at: 1511983748307,
+                header: '',
+                id: 'izpbgcd5e38xpkhgdeqwuijnoh',
+                last_post_at: 1511983748333,
+                name: 'test',
+                purpose: '',
+                team_id: 's5c6yy6jo3n57khrqeq85motnr',
+                total_msg_count: 0,
+                type: 'O',
+                update_at: 1511983748292
+            }
+        };
+
+        const modalData = {
+            type: ActionTypes.MODAL_OPEN,
+            modalId: ModalIdentifiers.DELETE_CHANNEL,
+            dialogType,
+            dialogProps
+        };
+
+        store.dispatch(openModal(modalData));
+
+        const action = {
+            type: ActionTypes.MODAL_OPEN,
+            modalId: ModalIdentifiers.DELETE_CHANNEL,
+            dialogType,
+            dialogProps
+        };
+
+        expect(store.getActions()).toEqual([action]);
+    });
+
+    test(ActionTypes.MODAL_CLOSE, () => {
+        store.dispatch(closeModal(ModalIdentifiers.DELETE_CHANNEL));
+
+        const action = {
+            type: ActionTypes.MODAL_CLOSE,
+            modalId: ModalIdentifiers.DELETE_CHANNEL
+        };
+
+        expect(store.getActions()).toEqual([action]);
+    });
+});

--- a/tests/redux/reducers/views/modals.test.js
+++ b/tests/redux/reducers/views/modals.test.js
@@ -1,0 +1,89 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+
+import modalsReducer from 'reducers/views/modals';
+
+import {ActionTypes, ModalIdentifiers} from 'utils/constants.jsx';
+
+import DeleteChannelModal from 'components/delete_channel_modal';
+
+describe('Reducers.Modals', () => {
+    test('Initial state', () => {
+        const nextState = modalsReducer(
+            {},
+            {}
+        );
+
+        const expectedState = {
+            modalState: {}
+        };
+
+        expect(nextState).toEqual(expectedState);
+    });
+
+    test(ActionTypes.MODAL_OPEN, () => {
+        const dialogType = DeleteChannelModal;
+        const dialogProps = {
+            channel: {
+                create_at: 1511983748292,
+                creator_id: 'pj9tn4tyupfbbjuoah76575xso',
+                delete_at: 0,
+                display_name: 'Test',
+                extra_update_at: 1511983748307,
+                header: '',
+                id: 'izpbgcd5e38xpkhgdeqwuijnoh',
+                last_post_at: 1511983748333,
+                name: 'test',
+                purpose: '',
+                team_id: 's5c6yy6jo3n57khrqeq85motnr',
+                total_msg_count: 0,
+                type: 'O',
+                update_at: 1511983748292
+            }
+        };
+
+        const nextState = modalsReducer(
+            {},
+            {
+                type: ActionTypes.MODAL_OPEN,
+                modalId: ModalIdentifiers.DELETE_CHANNEL,
+                dialogType,
+                dialogProps
+            }
+        );
+
+        const expectedState = {
+            modalState: {}
+        };
+
+        expectedState.modalState[ModalIdentifiers.DELETE_CHANNEL] = {
+            open: true,
+            dialogProps,
+            dialogType
+        };
+
+        expect(nextState).toEqual(expectedState);
+    });
+
+    test(ActionTypes.MODAL_CLOSE, () => {
+        const nextState = modalsReducer(
+            {},
+            {
+                type: ActionTypes.MODAL_CLOSE,
+                modalId: ModalIdentifiers.DELETE_CHANNEL
+            }
+        );
+
+        const expectedState = {
+            modalState: {}
+        };
+
+        expectedState.modalState[ModalIdentifiers.DELETE_CHANNEL] = {
+            open: false
+        };
+
+        expect(nextState).toEqual(expectedState);
+    });
+
+});

--- a/tests/redux/reducers/views/modals.test.js
+++ b/tests/redux/reducers/views/modals.test.js
@@ -1,12 +1,27 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import React from 'react';
+import {Modal} from 'react-bootstrap';
 
 import modalsReducer from 'reducers/views/modals';
 
 import {ActionTypes, ModalIdentifiers} from 'utils/constants.jsx';
 
 import DeleteChannelModal from 'components/delete_channel_modal';
+
+class TestModal extends React.Component {
+    render() {
+        return (
+            <Modal
+                show={true}
+            >
+                <Modal.Header closeButton={true}/>
+                <Modal.Body/>
+            </Modal>
+        );
+    }
+}
 
 describe('Reducers.Modals', () => {
     test('Initial state', () => {
@@ -23,24 +38,9 @@ describe('Reducers.Modals', () => {
     });
 
     test(ActionTypes.MODAL_OPEN, () => {
-        const dialogType = DeleteChannelModal;
+        const dialogType = TestModal;
         const dialogProps = {
-            channel: {
-                create_at: 1511983748292,
-                creator_id: 'pj9tn4tyupfbbjuoah76575xso',
-                delete_at: 0,
-                display_name: 'Test',
-                extra_update_at: 1511983748307,
-                header: '',
-                id: 'izpbgcd5e38xpkhgdeqwuijnoh',
-                last_post_at: 1511983748333,
-                name: 'test',
-                purpose: '',
-                team_id: 's5c6yy6jo3n57khrqeq85motnr',
-                total_msg_count: 0,
-                type: 'O',
-                update_at: 1511983748292
-            }
+            test: true
         };
 
         const nextState = modalsReducer(

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -238,7 +238,11 @@ export const WebrtcActionTypes = keyMirror({
 });
 
 export const ModalIdentifiers = {
-    DELETE_CHANNEL: 'delete_channel'
+    CHANNEL_INFO: 'channel_info',
+    DELETE_CHANNEL: 'delete_channel',
+    CHANNEL_NOTIFICATIONS: 'channel_notifications',
+    CHANNEL_INVITE: 'channel_invite',
+    EDIT_CHANNEL_HEADER: 'edit_channel_header'
 };
 
 export const UserStatuses = {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -214,7 +214,10 @@ export const ActionTypes = keyMirror({
     RECEIVED_PLUGIN_POST_TYPES: null,
     RECEIVED_WEBAPP_PLUGINS: null,
     RECEIVED_WEBAPP_PLUGIN: null,
-    REMOVED_WEBAPP_PLUGIN: null
+    REMOVED_WEBAPP_PLUGIN: null,
+
+    MODAL_OPEN: null,
+    MODAL_CLOSE: null
 });
 
 export const WebrtcActionTypes = keyMirror({
@@ -233,6 +236,10 @@ export const WebrtcActionTypes = keyMirror({
     DISABLED: null,
     RHS: null
 });
+
+export const ModalIdentifiers = {
+    DELETE_CHANNEL: 'delete_channel'
+};
 
 export const UserStatuses = {
     OFFLINE: 'offline',


### PR DESCRIPTION
#### Summary
Added Redux reducer to toggle modal state. Use ToggleModalButtonRedux instead of ToggleModalButton and provide a modalId prop (defined in constants->modalIdentifiers). There is a ModalController component in the NeedsTeam component that displays the modals.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/6784

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)