### PR TITLE
PLT-8185: User should be notified consistently when deleting parent post from RHS

### DIFF
--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -360,7 +360,6 @@ export default class SearchResults extends React.PureComponent {
                         user={profile}
                         term={searchTerms}
                         isMentionSearch={this.props.isMentionSearch}
-                        isFlaggedSearch={this.props.isFlaggedPosts}
                         useMilitaryTime={this.props.useMilitaryTime}
                         shrink={this.props.shrink}
                         isFlagged={isFlagged}

--- a/components/search_results_item/index.js
+++ b/components/search_results_item/index.js
@@ -5,15 +5,18 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {makeGetCommentCountForPost} from 'mattermost-redux/selectors/entities/posts';
 
 import {closeRightHandSide} from 'actions/views/rhs';
 
 import SelectResultsItem from './search_results_item.jsx';
 
-function mapStateToProps(state) {
-    return {
-        currentTeamName: getCurrentTeam(state).name
-    };
+function mapStateToProps() {
+    const getCommentCountForPost = makeGetCommentCountForPost();
+    return (state, ownProps) => ({
+        currentTeamName: getCurrentTeam(state).name,
+        commentCountForPost: getCommentCountForPost(state, {post: ownProps.post})
+    });
 }
 
 function mapDispatchToProps(dispatch) {

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -82,6 +82,11 @@ export default class SearchResultsItem extends React.PureComponent {
         currentTeamName: PropTypes.string,
 
         /**
+        *  Data used for delete in DotMenu
+        */
+        commentCountForPost: PropTypes.number,
+
+        /**
         *  Function used for shrinking LHS
         *  on click of jump to message in expanded mode
         */
@@ -288,6 +293,7 @@ export default class SearchResultsItem extends React.PureComponent {
                         post={post}
                         isFlagged={this.props.isFlagged}
                         handleDropdownOpened={this.handleDropdownOpened}
+                        commentCount={this.props.commentCountForPost}
                     />
                     <CommentIcon
                         idPrefix={'searchCommentIcon'}


### PR DESCRIPTION
Add commentCount to DotMenu for search results and flagged posts
Remove unused isFlaggedSearch prop.

#### Summary
User should be notified consistently when deleting parent post from RHS

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7878

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has redux changes (please link)
- [x] Has UI changes
