### PR TITLE
PLT-8027: New channel gives a blank screen if created with reserved word

### DIFF
--- a/routes/route_root.jsx
+++ b/routes/route_root.jsx
@@ -153,7 +153,7 @@ export default {
                                         }
                                     },
                                     {
-                                        path: '*authorize',
+                                        path: 'oauth/authorize',
                                         getComponents: (location, callback) => {
                                             System.import('components/authorize.jsx').then(RouteUtils.importComponentSuccess(callback));
                                         }


### PR DESCRIPTION
#### Summary
Made the OAuth react route regex more strict to avoid interfering with joining a channel called 'authorize'

#### Test Instructions
1. Start a fresh server with no data in the database (`make clean-docker && make start-docker && make run` in a dev environment)
2. After creating the sys admin account, create a new team with any name _except_ "authorize". I used "test" for my testing
3. Skip the tutorial, and create a new public channel with the display name "authorize". Observe that you join and view the channel immediately, with no white screen of death
4. Check out and configure [Elias's OAuth 2.0 Sample Application](https://github.com/mattermost/mattermost-oauth2-client-sample)
5. Use the sample application to verify that Mattermost still functions as an OAuth 2.0 Provider with these changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8027

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Touches critical sections of the codebase (auth, posting, etc.)
