### PR TITLE
Fix setState calls when switching to Display tab in Account Settings

### DIFF
--- a/components/user_settings/user_settings_display.jsx
+++ b/components/user_settings/user_settings_display.jsx
@@ -41,8 +41,10 @@ export default class UserSettingsDisplay extends React.Component {
         this.updateSection = this.updateSection.bind(this);
         this.updateState = this.updateState.bind(this);
 
-        this.state = getDisplayStateFromStores();
-        this.setState({isSaving: false});
+        this.state = {
+            ...getDisplayStateFromStores(),
+            isSaving: false
+        };
     }
 
     handleSubmit() {

--- a/components/user_settings/user_settings_theme.jsx
+++ b/components/user_settings/user_settings_theme.jsx
@@ -33,8 +33,10 @@ export default class ThemeSetting extends React.Component {
         this.resetFields = this.resetFields.bind(this);
         this.handleImportModal = this.handleImportModal.bind(this);
 
-        this.state = this.getStateFromStores();
-        this.setState({isSaving: false});
+        this.state = {
+            ...this.getStateFromStores(),
+            isSaving: false
+        };
 
         this.originalTheme = Object.assign({}, this.state.theme);
     }


### PR DESCRIPTION
#### Summary
Remove setState calls in constructor of components.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7918

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed