### PR TITLE
PLT-8198: Set the message export timestamp to the date feature was enabled, and remove the setting from the System Console

### DIFF
--- a/components/admin_console/message_export_settings.jsx
+++ b/components/admin_console/message_export_settings.jsx
@@ -22,7 +22,6 @@ export default class MessageExportSettings extends AdminSettings {
     getConfigFromState(config) {
         config.MessageExportSettings.EnableExport = this.state.enableMessageExport;
         config.MessageExportSettings.DailyRunTime = this.state.exportJobStartTime;
-        config.MessageExportSettings.ExportFromTimestamp = parseInt(this.state.exportFromTimestamp, 10);
         config.MessageExportSettings.FileLocation = this.state.exportLocation;
         return config;
     }
@@ -31,7 +30,6 @@ export default class MessageExportSettings extends AdminSettings {
         return {
             enableMessageExport: config.MessageExportSettings.EnableExport,
             exportJobStartTime: config.MessageExportSettings.DailyRunTime,
-            exportFromTimestamp: String(config.MessageExportSettings.ExportFromTimestamp),
             exportLocation: config.MessageExportSettings.FileLocation
         };
     }
@@ -95,26 +93,6 @@ export default class MessageExportSettings extends AdminSettings {
                         />
                     }
                     value={this.state.exportJobStartTime}
-                    disabled={!this.state.enableMessageExport}
-                    onChange={this.handleChange}
-                />
-
-                <TextSetting
-                    id='exportFromTimestamp'
-                    label={
-                        <FormattedMessage
-                            id='admin.messageExport.exportFromTimestamp.title'
-                            defaultMessage='Creation Time of Oldest Post to Export:'
-                        />
-                    }
-                    placeholder={Utils.localizeMessage('admin.messageExport.exportFromTimestamp.example', 'E.g.: Tuesday October 24, 2017 @ 12pm UTC = 1508846400')}
-                    helpText={
-                        <FormattedMessage
-                            id='admin.messageExport.exportFromTimestamp.description'
-                            defaultMessage='Posts older than this will not be exported. Expressed as the number of seconds since the Unix Epoch (January 1, 1970).'
-                        />
-                    }
-                    value={this.state.exportFromTimestamp}
                     disabled={!this.state.enableMessageExport}
                     onChange={this.handleChange}
                 />


### PR DESCRIPTION
#### Summary
Removed exportFromTimestamp from admin panel. It will be managed automatically by the server when config is changed

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8198

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] [Has server changes](https://github.com/mattermost/mattermost-server/pull/7925)
- [x] Has UI changes