### PR TITLE
[PLT-8202] Fix radio button selection of ChannelNotificationsModal

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -77,6 +77,7 @@ export default class ChannelHeader extends React.Component {
             showEditChannelPurposeModal: false,
             showMembersModal: false,
             showRenameChannelModal: false,
+            showChannelNotificationsModal: false,
             isBusy: WebrtcStore.isBusy()
         };
     }
@@ -164,6 +165,20 @@ export default class ChannelHeader extends React.Component {
     hideRenameChannelModal = () => {
         this.setState({
             showRenameChannelModal: false
+        });
+    }
+
+    showChannelNotificationsModal = (e) => {
+        e.preventDefault();
+
+        this.setState({
+            showChannelNotificationsModal: true
+        });
+    }
+
+    hideChannelNotificationsModal = () => {
+        this.setState({
+            showChannelNotificationsModal: false
         });
     }
 
@@ -392,22 +407,17 @@ export default class ChannelHeader extends React.Component {
                     key='notification_preferences'
                     role='presentation'
                 >
-                    <ToggleModalButtonRedux
-                        id='channelnotificationPreferencesGroup'
+                    <button
+                        className='style--none'
+                        id='channelNotificationsGroup'
                         role='menuitem'
-                        modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
-                        dialogType={ChannelNotificationsModal}
-                        dialogProps={{
-                            channel,
-                            channelMember: this.props.channelMember,
-                            currentUser: this.props.currentUser
-                        }}
+                        onClick={this.showChannelNotificationsModal}
                     >
                         <FormattedMessage
                             id='channel_header.notificationPreferences'
                             defaultMessage='Notification Preferences'
                         />
-                    </ToggleModalButtonRedux>
+                    </button>
                 </li>
             );
 
@@ -476,22 +486,17 @@ export default class ChannelHeader extends React.Component {
                     key='notification_preferences'
                     role='presentation'
                 >
-                    <ToggleModalButtonRedux
-                        id='channelNotificationPreferences'
+                    <button
+                        className='style--none'
+                        id='channelNotificationsGroup'
                         role='menuitem'
-                        modalId={ModalIdentifiers.CHANNEL_NOTIFICATIONS}
-                        dialogType={ChannelNotificationsModal}
-                        dialogProps={{
-                            channel,
-                            channelMember: this.props.channelMember,
-                            currentUser: this.props.currentUser
-                        }}
+                        onClick={this.showChannelNotificationsModal}
                     >
                         <FormattedMessage
                             id='channel_header.notificationPreferences'
                             defaultMessage='Notification Preferences'
                         />
-                    </ToggleModalButtonRedux>
+                    </button>
                 </li>
             );
 
@@ -979,6 +984,13 @@ export default class ChannelHeader extends React.Component {
                 {editHeaderModal}
                 {editPurposeModal}
                 {channelMembersModal}
+                <ChannelNotificationsModal
+                    show={this.state.showChannelNotificationsModal}
+                    onHide={this.hideChannelNotificationsModal}
+                    channel={channel}
+                    channelMember={this.props.channelMember}
+                    currentUser={this.props.currentUser}
+                />
                 <RenameChannelModal
                     show={this.state.showRenameChannelModal}
                     onHide={this.hideRenameChannelModal}

--- a/components/channel_notifications_modal.jsx
+++ b/components/channel_notifications_modal.jsx
@@ -20,7 +20,6 @@ export default class ChannelNotificationsModal extends React.Component {
         super(props);
 
         this.updateSection = this.updateSection.bind(this);
-        this.onHide = this.onHide.bind(this);
 
         this.handleSubmitDesktopNotifyLevel = this.handleSubmitDesktopNotifyLevel.bind(this);
         this.handleUpdateDesktopNotifyLevel = this.handleUpdateDesktopNotifyLevel.bind(this);
@@ -36,7 +35,6 @@ export default class ChannelNotificationsModal extends React.Component {
 
         this.state = {
             activeSection: '',
-            show: true,
             notifyLevel: props.channelMember.notify_props.desktop,
             unreadLevel: props.channelMember.notify_props.mark_unread,
             pushLevel: props.channelMember.notify_props.push || NotificationLevels.DEFAULT
@@ -48,10 +46,6 @@ export default class ChannelNotificationsModal extends React.Component {
             $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
         }
         this.setState({activeSection: section});
-    }
-
-    onHide() {
-        this.setState({show: false});
     }
 
     handleSubmitDesktopNotifyLevel() {
@@ -608,9 +602,9 @@ export default class ChannelNotificationsModal extends React.Component {
 
         return (
             <Modal
-                show={this.state.show}
+                show={this.props.show}
                 dialogClassName='settings-modal settings-modal--tabless'
-                onHide={this.onHide}
+                onHide={this.props.onHide}
                 onExited={this.props.onHide}
             >
                 <Modal.Header closeButton={true}>
@@ -647,6 +641,7 @@ export default class ChannelNotificationsModal extends React.Component {
 }
 
 ChannelNotificationsModal.propTypes = {
+    show: PropTypes.bool.isRequired,
     onHide: PropTypes.func.isRequired,
     channel: PropTypes.object.isRequired,
     channelMember: PropTypes.object.isRequired,

--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -63,6 +63,7 @@ export default class Navbar extends React.Component {
             showMembersModal: false,
             showRenameChannelModal: false,
             showQuickSwitchModal: false,
+            showChannelNotificationsModal: false,
             quickSwitchMode: 'channel'
         };
     }
@@ -164,6 +165,20 @@ export default class Navbar extends React.Component {
     hideEditChannelHeaderModal = () => {
         this.setState({
             showEditChannelHeaderModal: false
+        });
+    }
+
+    showChannelNotificationsModal = (e) => {
+        e.preventDefault();
+
+        this.setState({
+            showChannelNotificationsModal: true
+        });
+    }
+
+    hideChannelNotificationsModal = () => {
+        this.setState({
+            showChannelNotificationsModal: false
         });
     }
 
@@ -275,7 +290,7 @@ export default class Navbar extends React.Component {
                         >
                             <FormattedMessage
                                 id='channel_header.channelHeader'
-                                defaultMessage='Set Channel Header...'
+                                defaultMessage='Edit Channel Header'
                             />
                         </a>
                     </li>
@@ -290,7 +305,7 @@ export default class Navbar extends React.Component {
                         >
                             <FormattedMessage
                                 id='channel_header.channelHeader'
-                                defaultMessage='Set Channel Header...'
+                                defaultMessage='Edit Channel Header'
                             />
                         </a>
                     </li>
@@ -298,20 +313,16 @@ export default class Navbar extends React.Component {
 
                 notificationPreferenceOption = (
                     <li role='presentation'>
-                        <ToggleModalButton
+                        <a
                             role='menuitem'
-                            dialogType={ChannelNotificationsModal}
-                            dialogProps={{
-                                channel,
-                                channelMember: this.state.member,
-                                currentUser: this.state.currentUser
-                            }}
+                            href='#'
+                            onClick={this.showChannelNotificationsModal}
                         >
                             <FormattedMessage
                                 id='navbar.preferences'
                                 defaultMessage='Notification Preferences'
                             />
-                        </ToggleModalButton>
+                        </a>
                     </li>
                 );
 
@@ -438,20 +449,16 @@ export default class Navbar extends React.Component {
 
                 notificationPreferenceOption = (
                     <li role='presentation'>
-                        <ToggleModalButton
+                        <a
                             role='menuitem'
-                            dialogType={ChannelNotificationsModal}
-                            dialogProps={{
-                                channel,
-                                channelMember: this.state.member,
-                                currentUser: this.state.currentUser
-                            }}
+                            href='#'
+                            onClick={this.showChannelNotificationsModal}
                         >
                             <FormattedMessage
                                 id='navbar.preferences'
                                 defaultMessage='Notification Preferences'
                             />
-                        </ToggleModalButton>
+                        </a>
                     </li>
                 );
 
@@ -710,6 +717,7 @@ export default class Navbar extends React.Component {
         var editChannelPurposeModal = null;
         let renameChannelModal = null;
         let channelMembersModal = null;
+        let channelNotificationsModal = null;
         let quickSwitchModal = null;
 
         if (channel) {
@@ -762,6 +770,16 @@ export default class Navbar extends React.Component {
                 );
             }
 
+            channelNotificationsModal = (
+                <ChannelNotificationsModal
+                    show={this.state.showChannelNotificationsModal}
+                    onHide={this.hideChannelNotificationsModal}
+                    channel={channel}
+                    channelMember={this.state.member}
+                    currentUser={this.state.currentUser}
+                />
+            );
+
             quickSwitchModal = (
                 <QuickSwitchModal
                     show={this.state.showQuickSwitchModal}
@@ -813,6 +831,7 @@ export default class Navbar extends React.Component {
                 {editChannelPurposeModal}
                 {renameChannelModal}
                 {channelMembersModal}
+                {channelNotificationsModal}
                 {quickSwitchModal}
             </div>
         );


### PR DESCRIPTION
#### Summary
This PR only fix the first issue of the ticket regarding radio button selection of ChannelNotificationsModal.

The main issue which was to restore channel notifications preferences when a member left then rejoined, I think, is a desired behavior based on our current codebase and it has not changed for a long time - https://github.com/mattermost/mattermost-server/blob/master/store/sqlstore/channel_store.go#L1040

#### Ticket Link
Jira ticket: [PLT-8202](https://mattermost.atlassian.net/browse/PLT-8202)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
