### PR TITLE
PLT-5458: use channel_mention hints

### DIFF
--- a/components/post_view/post_message_view/index.js
+++ b/components/post_view/post_message_view/index.js
@@ -8,6 +8,7 @@ import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis'
 import {getTheme, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getCurrentUserMentionKeys, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
+import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';   // eslint-disable-line import/order
 
 import {EmojiMap} from 'stores/emoji_store.jsx';
 
@@ -28,6 +29,11 @@ function makeMapStateToProps() {
 
         const user = getCurrentUser(state);
 
+        let channelNamesMap = getChannelsNameMapInCurrentTeam(state);
+        if (ownProps.post.props && ownProps.post.props.channel_mentions) {
+            channelNamesMap = Object.assign({}, ownProps.post.props.channel_mentions, channelNamesMap);
+        }
+
         return {
             ...ownProps,
             emojis: emojiMap,
@@ -38,7 +44,8 @@ function makeMapStateToProps() {
             siteUrl: getSiteURL(),
             theme: getTheme(state),
             pluginPostTypes: state.plugins.postTypes,
-            currentUser: user
+            currentUser: user,
+            channelNamesMap
         };
     };
 }

--- a/components/post_view/post_message_view/index.js
+++ b/components/post_view/post_message_view/index.js
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
+import {createSelector} from 'reselect';
 
 import {Preferences} from 'mattermost-redux/constants';
 
@@ -17,6 +18,17 @@ import {getSiteURL} from 'utils/url.jsx';
 
 import PostMessageView from './post_message_view.jsx';
 
+const getChannelNamesMap = createSelector(
+    (state) => getChannelsNameMapInCurrentTeam(state),
+    (state, props) => props,
+    (channelNamesMap, props) => {
+        if (props && props.channel_mentions) {
+            return Object.assign({}, props.channel_mentions, channelNamesMap);
+        }
+        return channelNamesMap;
+    }
+);
+
 function makeMapStateToProps() {
     let emojiMap;
     let oldCustomEmoji;
@@ -30,10 +42,7 @@ function makeMapStateToProps() {
 
         const user = getCurrentUser(state);
 
-        let channelNamesMap = getChannelsNameMapInCurrentTeam(state);
-        if (ownProps.post.props && ownProps.post.props.channel_mentions) {
-            channelNamesMap = Object.assign({}, ownProps.post.props.channel_mentions, channelNamesMap);
-        }
+        const channelNamesMap = getChannelNamesMap(state, ownProps.post.props);
 
         return {
             ...ownProps,

--- a/components/post_view/post_message_view/index.js
+++ b/components/post_view/post_message_view/index.js
@@ -4,11 +4,12 @@
 import {connect} from 'react-redux';
 
 import {Preferences} from 'mattermost-redux/constants';
+
+import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getTheme, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getCurrentUserMentionKeys, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
-import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';   // eslint-disable-line import/order
 
 import {EmojiMap} from 'stores/emoji_store.jsx';
 

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -5,8 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import store from 'stores/redux_store.jsx';
-
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 import * as Utils from 'utils/utils.jsx';

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -131,7 +131,8 @@ export default class PostMessageView extends React.PureComponent {
             emojis,
             siteUrl,
             team,
-            lastPostCount
+            lastPostCount,
+            channelNamesMap
         } = this.props;
 
         if (post.state === Posts.POST_DELETED) {
@@ -165,7 +166,7 @@ export default class PostMessageView extends React.PureComponent {
             siteURL: siteUrl,
             mentionKeys,
             atMentions: true,
-            channelNamesMap: this.props.channelNamesMap,
+            channelNamesMap,
             team
         });
 

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -12,7 +12,6 @@ import * as TextFormatting from 'utils/text_formatting.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import {Posts} from 'mattermost-redux/constants';   // eslint-disable-line import/order
-import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';   // eslint-disable-line import/order
 
 import {renderSystemMessage} from './system_message_helpers.jsx';
 
@@ -82,7 +81,12 @@ export default class PostMessageView extends React.PureComponent {
         /**
          * The logged in user
          */
-        currentUser: PropTypes.object.isRequired
+        currentUser: PropTypes.object.isRequired,
+
+        /**
+         * A map of channel names to channel objects
+         */
+        channelNamesMap: PropTypes.object.isRequired
     };
 
     static defaultProps = {
@@ -163,7 +167,7 @@ export default class PostMessageView extends React.PureComponent {
             siteURL: siteUrl,
             mentionKeys,
             atMentions: true,
-            channelNamesMap: getChannelsNameMapInCurrentTeam(store.getState()),
+            channelNamesMap: this.props.channelNamesMap,
             team
         });
 


### PR DESCRIPTION
#### Summary
Uses the "channel_mention" hints generated by https://github.com/mattermost/mattermost-server/pull/7833 when users aren't in the linked channel.

Before the repo split this was part of https://github.com/mattermost/mattermost-server/pull/7324

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5458

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed