### PR TITLE
Adds inline make documentation and 'help' command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-.PHONY: build test run clean stop check-style run-unit emojis
+.PHONY: build test run clean stop check-style run-unit emojis help
 
 BUILD_SERVER_DIR = ../mattermost-server
 EMOJI_TOOLS_DIR = ./build/emoji
 
-check-style: .yarninstall
+check-style: .yarninstall ## Checks JS file for ESLint confirmity
 	@echo Checking for style guide compliance
 
 	yarn run check
 
-test: .yarninstall
+test: .yarninstall ## Runs tests
 	@echo Running jest unit/component testing
 
 	yarn run test
@@ -21,7 +21,7 @@ test: .yarninstall
 
 	touch $@
 
-package: build
+package: build ## Packages app
 	@echo Packaging webapp
 
 	mkdir tmp
@@ -30,25 +30,24 @@ package: build
 	mv tmp/client dist
 	rmdir tmp
 
-
-build: .yarninstall
+build: .yarninstall ## Builds the app
 	@echo Building mattermost Webapp
 
 	rm -rf dist
 
 	yarn run build
 
-run: .yarninstall
+run: .yarninstall ## Runs app
 	@echo Running mattermost Webapp for development
 
 	yarn run run &
 
-run-fullmap: .yarninstall
+run-fullmap: .yarninstall ## Runs the app with the JS mapped to source (good for debugger)
 	@echo FULL SOURCE MAP Running mattermost Webapp for development FULL SOURCE MAP
 
 	yarn run run-fullmap &
 
-stop:
+stop: ## Stops webpack
 	@echo Stopping changes watching
 
 ifeq ($(OS),Windows_NT)
@@ -60,7 +59,7 @@ else
 	done
 endif
 
-clean:
+clean: ## Clears cached; deletes node_modules and dist directories
 	@echo Cleaning Webapp
 
 	yarn cache clean
@@ -69,7 +68,11 @@ clean:
 	rm -rf node_modules
 	rm -f .yarninstall
 
-emojis:
+emojis: ## Creates emoji JSX file and extracts emoji images from the system font
 	gem install bundler
 	bundle install --gemfile=$(EMOJI_TOOLS_DIR)/Gemfile
 	BUNDLE_GEMFILE=$(EMOJI_TOOLS_DIR)/Gemfile bundle exec $(EMOJI_TOOLS_DIR)/make-emojis
+
+## Help documentatin à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
#### Summary
Adds a `make help` command that uses inline comments to document the commands.

#### Ticket Link
n/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)

<img width="715" alt="screen shot 2017-12-01 at 5 25 53 pm" src="https://user-images.githubusercontent.com/1149597/33506237-06aaa748-d6bd-11e7-850e-424f60bcec90.png">

If people like this pattern I'll add it to the other repos (but don't want to add it to mattermost-server until https://github.com/mattermost/mattermost-server/pull/7892 is merged).