### PR TITLE
[PLT-7829] Make PostDeletedModal to show always after replying to a deleted post

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -102,7 +102,12 @@ export default class CreateComment extends React.PureComponent {
         /**
          * Called to initiate editing the user's latest post
          */
-        onEditLatestPost: PropTypes.func.isRequired
+        onEditLatestPost: PropTypes.func.isRequired,
+
+        /**
+         * Reset state of createPost
+         */
+        resetCreatePost: PropTypes.func.isRequired
     }
 
     constructor(props) {
@@ -129,6 +134,10 @@ export default class CreateComment extends React.PureComponent {
 
     componentDidMount() {
         this.focusTextbox();
+    }
+
+    componentWillUnmount() {
+        this.props.resetCreatePost();
     }
 
     componentWillReceiveProps(newProps) {
@@ -407,6 +416,8 @@ export default class CreateComment extends React.PureComponent {
         this.setState({
             showPostDeletedModal: false
         });
+
+        this.props.resetCreatePost();
     }
 
     handleBlur = () => {

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -105,9 +105,9 @@ export default class CreateComment extends React.PureComponent {
         onEditLatestPost: PropTypes.func.isRequired,
 
         /**
-         * Reset state of createPost
+         * Reset state of createPost request
          */
-        resetCreatePost: PropTypes.func.isRequired
+        resetCreatePostRequest: PropTypes.func.isRequired
     }
 
     constructor(props) {
@@ -137,7 +137,7 @@ export default class CreateComment extends React.PureComponent {
     }
 
     componentWillUnmount() {
-        this.props.resetCreatePost();
+        this.props.resetCreatePostRequest();
     }
 
     componentWillReceiveProps(newProps) {
@@ -417,7 +417,7 @@ export default class CreateComment extends React.PureComponent {
             showPostDeletedModal: false
         });
 
-        this.props.resetCreatePost();
+        this.props.resetCreatePostRequest();
     }
 
     handleBlur = () => {

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
-import {resetCreatePost, resetHistoryIndex} from 'mattermost-redux/actions/posts';
+import {resetCreatePostRequest, resetHistoryIndex} from 'mattermost-redux/actions/posts';
 import {Preferences, Posts} from 'mattermost-redux/constants';
 
 import {
@@ -82,7 +82,7 @@ function makeMapDispatchToProps() {
             onMoveHistoryIndexBack,
             onMoveHistoryIndexForward,
             onEditLatestPost,
-            resetCreatePost
+            resetCreatePostRequest
         }, dispatch);
     };
 }

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
-import {resetHistoryIndex} from 'mattermost-redux/actions/posts';
+import {resetCreatePost, resetHistoryIndex} from 'mattermost-redux/actions/posts';
 import {Preferences, Posts} from 'mattermost-redux/constants';
 
 import {
@@ -21,7 +21,7 @@ import CreateComment from './create_comment.jsx';
 
 function mapStateToProps(state, ownProps) {
     const err = state.requests.posts.createPost.error || {};
-
+    
     const getCommentDraft = makeGetCommentDraft(ownProps.rootId);
 
     const draft = getCommentDraft(state);
@@ -81,7 +81,8 @@ function makeMapDispatchToProps() {
             onResetHistoryIndex,
             onMoveHistoryIndexBack,
             onMoveHistoryIndexForward,
-            onEditLatestPost
+            onEditLatestPost,
+            resetCreatePost
         }, dispatch);
     };
 }

--- a/tests/components/create_comment/create_comment.test.jsx
+++ b/tests/components/create_comment/create_comment.test.jsx
@@ -45,7 +45,7 @@ describe('components/CreateComment', () => {
         onMoveHistoryIndexBack: jest.fn(),
         onMoveHistoryIndexForward: jest.fn(),
         onEditLatestPost: jest.fn(),
-        resetCreatePost: jest.fn()
+        resetCreatePostRequest: jest.fn()
     };
 
     test('should match snapshot, empty comment', () => {
@@ -238,15 +238,15 @@ describe('components/CreateComment', () => {
     });
 
     test('should correctly change state when hidePostDeletedModal is called', () => {
-        const resetCreatePost = jest.fn();
-        const props = {...baseProps, resetCreatePost};
+        const resetCreatePostRequest = jest.fn();
+        const props = {...baseProps, resetCreatePostRequest};
         const wrapper = shallow(
             <CreateComment {...props}/>
         );
 
         wrapper.instance().hidePostDeletedModal();
         expect(wrapper.state().showPostDeletedModal).toBe(false);
-        expect(resetCreatePost).toHaveBeenCalledTimes(1);
+        expect(resetCreatePostRequest).toHaveBeenCalledTimes(1);
     });
 
     test('handleUploadStart should update comment draft correctly', () => {

--- a/tests/components/create_comment/create_comment.test.jsx
+++ b/tests/components/create_comment/create_comment.test.jsx
@@ -12,65 +12,80 @@ jest.mock('stores/post_store.jsx', () => ({
 }));
 
 describe('components/CreateComment', () => {
+    global.window.mm_config = {};
+
     beforeEach(() => {
-        window.mm_config = {};
-        window.mm_config.EnableEmojiPicker = 'true';
+        global.window.mm_config.EnableEmojiPicker = 'true';
+    });
+
+    afterEach(() => {
+        global.window.mm_config = {};
     });
 
     const channelId = 'g6139tbospd18cmxroesdk3kkc';
     const rootId = '';
     const latestPostId = '3498nv24823948v23m4nv34';
 
+    const baseProps = {
+        channelId,
+        rootId,
+        draft: {
+            message: 'Test message',
+            uploadsInProgress: [{}],
+            fileInfos: [{}, {}, {}]
+        },
+        enableAddButton: true,
+        ctrlSend: false,
+        latestPostId,
+        getSidebarBody: jest.fn(),
+        clearCommentDraftUploads: jest.fn(),
+        onUpdateCommentDraft: jest.fn(),
+        onSubmit: jest.fn(),
+        onResetHistoryIndex: jest.fn(),
+        onMoveHistoryIndexBack: jest.fn(),
+        onMoveHistoryIndexForward: jest.fn(),
+        onEditLatestPost: jest.fn(),
+        resetCreatePost: jest.fn()
+    };
+
     test('should match snapshot, empty comment', () => {
+        const draft = {
+            message: '',
+            uploadsInProgress: [],
+            fileInfos: []
+        };
+        const enableAddButton = false;
+        const ctrlSend = true;
+        const props = {...baseProps, draft, enableAddButton, ctrlSend};
+
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: '',
-                    uploadsInProgress: [],
-                    fileInfos: []
-                }}
-                enableAddButton={false}
-                ctrlSend={true}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
 
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot, comment with message', () => {
+        const clearCommentDraftUploads = jest.fn();
+        const onResetHistoryIndex = jest.fn();
+        const draft = {
+            message: 'Test message',
+            uploadsInProgress: [],
+            fileInfos: []
+        };
+        const ctrlSend = true;
+        const props = {...baseProps, ctrlSend, draft, clearCommentDraftUploads, onResetHistoryIndex};
+
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [],
-                    fileInfos: []
-                }}
-                enableAddButton={true}
-                ctrlSend={true}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
+
+        // should clear draft uploads on mount
+        expect(clearCommentDraftUploads).toHaveBeenCalled();
+
+        // should reset message history index on mount
+        expect(onResetHistoryIndex).toHaveBeenCalled();
+
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -80,176 +95,51 @@ describe('components/CreateComment', () => {
             uploadsInProgress: [{}],
             fileInfos: [{}, {}, {}]
         };
+
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={draft}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...baseProps}/>
         );
+
         wrapper.setState({draft});
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should clear draft uploads on mount', () => {
-        const clearCommentDraftUploads = jest.fn();
-
-        shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [{}],
-                    fileInfos: [{}, {}, {}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={clearCommentDraftUploads}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
-        );
-
-        expect(clearCommentDraftUploads).toHaveBeenCalled();
-    });
-
-    test('should reset message history index on mount', () => {
-        const onResetHistoryIndex = jest.fn();
-
-        shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [{}],
-                    fileInfos: [{}, {}, {}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={onResetHistoryIndex}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
-        );
-
-        expect(onResetHistoryIndex).toHaveBeenCalled();
-    });
-
     test('should correctly change state when toggleEmojiPicker is called', () => {
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [{}],
-                    fileInfos: [{}, {}, {}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...baseProps}/>
         );
 
         wrapper.instance().toggleEmojiPicker();
-
         expect(wrapper.state().showEmojiPicker).toBe(true);
 
         wrapper.instance().toggleEmojiPicker();
-
         expect(wrapper.state().showEmojiPicker).toBe(false);
     });
 
     test('should correctly change state when hideEmojiPicker is called', () => {
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [{}],
-                    fileInfos: [{}, {}, {}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...baseProps}/>
         );
 
         wrapper.instance().hideEmojiPicker();
-
         expect(wrapper.state().showEmojiPicker).toBe(false);
     });
 
     test('should correctly update draft when handleEmojiClick is called', () => {
         const onUpdateCommentDraft = jest.fn();
+        const draft = {
+            message: '',
+            uploadsInProgress: [],
+            fileInfos: []
+        };
+        const enableAddButton = false;
+        const props = {...baseProps, draft, onUpdateCommentDraft, enableAddButton};
 
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: '',
-                    uploadsInProgress: [],
-                    fileInfos: []
-                }}
-                enableAddButton={false}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={onUpdateCommentDraft}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
 
         wrapper.instance().handleEmojiClick({name: 'smile'});
-
         expect(onUpdateCommentDraft).toHaveBeenCalled();
 
         // Empty message case
@@ -259,7 +149,6 @@ describe('components/CreateComment', () => {
         expect(wrapper.state().draft.message).toBe(':smile: ');
 
         wrapper.setState({draft: {message: 'test', uploadsInProgress: [], fileInfos: []}});
-
         wrapper.instance().handleEmojiClick({name: 'smile'});
 
         // Message with no space at the end
@@ -269,7 +158,6 @@ describe('components/CreateComment', () => {
         expect(wrapper.state().draft.message).toBe('test :smile: ');
 
         wrapper.setState({draft: {message: 'test ', uploadsInProgress: [], fileInfos: []}});
-
         wrapper.instance().handleEmojiClick({name: 'smile'});
 
         // Message with space at the end
@@ -283,34 +171,13 @@ describe('components/CreateComment', () => {
 
     test('handlePostError should update state with the correct error', () => {
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [{}],
-                    fileInfos: [{}, {}, {}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...baseProps}/>
         );
 
         wrapper.instance().handlePostError('test error 1');
-
         expect(wrapper.state().postError).toBe('test error 1');
 
         wrapper.instance().handlePostError('test error 2');
-
         expect(wrapper.state().postError).toBe('test error 2');
     });
 
@@ -321,143 +188,65 @@ describe('components/CreateComment', () => {
             uploadsInProgress: [1, 2, 3],
             fileInfos: [{}, {}, {}]
         };
+        const props = {...baseProps, draft, onUpdateCommentDraft};
 
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={draft}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={onUpdateCommentDraft}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
 
         const testError1 = 'test error 1';
-
         wrapper.setState({draft});
-
         wrapper.instance().handleUploadError(testError1, 1);
 
         expect(onUpdateCommentDraft).toHaveBeenCalled();
-
         expect(onUpdateCommentDraft.mock.calls[0][0]).toEqual(
             expect.objectContaining({uploadsInProgress: [2, 3]})
         );
-
         expect(wrapper.state().serverError).toBe(testError1);
         expect(wrapper.state().draft.uploadsInProgress).toEqual([2, 3]);
 
         // clientId = -1
         const testError2 = 'test error 2';
-
         wrapper.instance().handleUploadError(testError2, -1);
 
         // should not call onUpdateCommentDraft
         expect(onUpdateCommentDraft.mock.calls.length).toBe(1);
-
         expect(wrapper.state().serverError).toBe(testError2);
     });
 
     test('getFileCount should return the correct count', () => {
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [{}],
-                    fileInfos: [{}, {}, {}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...baseProps}/>
         );
 
         expect(wrapper.instance().getFileCount()).toBe(3);
 
         wrapper.setState({draft: {message: 'test', uploadsInProgress: [{}], fileInfos: [{}, {}, {}]}});
-
         expect(wrapper.instance().getFileCount()).toBe(4);
 
         wrapper.setState({draft: {message: 'test', uploadsInProgress: [], fileInfos: []}});
-
         expect(wrapper.instance().getFileCount()).toBe(0);
     });
 
     test('should correctly change state when showPostDeletedModal is called', () => {
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [{}],
-                    fileInfos: [{}, {}, {}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...baseProps}/>
         );
 
         wrapper.instance().showPostDeletedModal();
-
         expect(wrapper.state().showPostDeletedModal).toBe(true);
     });
 
     test('should correctly change state when hidePostDeletedModal is called', () => {
+        const resetCreatePost = jest.fn();
+        const props = {...baseProps, resetCreatePost};
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [{}],
-                    fileInfos: [{}, {}, {}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
 
         wrapper.instance().hidePostDeletedModal();
-
         expect(wrapper.state().showPostDeletedModal).toBe(false);
+        expect(resetCreatePost).toHaveBeenCalledTimes(1);
     });
 
     test('handleUploadStart should update comment draft correctly', () => {
@@ -467,41 +256,23 @@ describe('components/CreateComment', () => {
             uploadsInProgress: [1, 2, 3],
             fileInfos: [{}, {}, {}]
         };
+        const props = {...baseProps, onUpdateCommentDraft, draft};
 
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={draft}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={onUpdateCommentDraft}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
 
         const focusTextbox = jest.fn();
         wrapper.setState({draft});
-
         wrapper.instance().focusTextbox = focusTextbox;
-
         wrapper.instance().handleUploadStart([4, 5]);
 
         expect(onUpdateCommentDraft).toHaveBeenCalled();
-
         expect(onUpdateCommentDraft.mock.calls[0][0]).toEqual(
             expect.objectContaining({uploadsInProgress: [1, 2, 3, 4, 5]})
         );
 
         expect(wrapper.state().draft.uploadsInProgress === [1, 2, 3, 4, 5]);
-
         expect(focusTextbox).toHaveBeenCalled();
     });
 
@@ -512,32 +283,16 @@ describe('components/CreateComment', () => {
             uploadsInProgress: [1, 2, 3],
             fileInfos: [{test: 1}, {test: 2}]
         };
+        const props = {...baseProps, onUpdateCommentDraft, draft};
 
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={draft}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={onUpdateCommentDraft}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
 
         wrapper.setState({draft});
 
         wrapper.instance().handleFileUploadComplete([{test: 3}], [3]);
-
         expect(onUpdateCommentDraft).toHaveBeenCalled();
-
         expect(onUpdateCommentDraft.mock.calls[0][0]).toEqual(
             expect.objectContaining({uploadsInProgress: [1, 2], fileInfos: [{test: 1}, {test: 2}, {test: 3}]})
         );
@@ -547,112 +302,65 @@ describe('components/CreateComment', () => {
     });
 
     test('calls showPostDeletedModal when createPostErrorId === api.post.create_post.root_id.app_error', () => {
+        const onUpdateCommentDraft = jest.fn();
+        const draft = {
+            message: 'Test message',
+            uploadsInProgress: [1, 2, 3],
+            fileInfos: [{test: 1}, {test: 2}]
+        };
+        const props = {...baseProps, onUpdateCommentDraft, draft};
+
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [1, 2, 3],
-                    fileInfos: [{test: 1}, {test: 2}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-                createPostErrorId={null}
-            />
+            <CreateComment {...props}/>
         );
 
         const showPostDeletedModal = jest.fn();
-
         wrapper.instance().showPostDeletedModal = showPostDeletedModal;
-
         wrapper.setProps({createPostErrorId: 'api.post.create_post.root_id.app_error'});
-
         expect(showPostDeletedModal).toHaveBeenCalled();
     });
 
     test('calls focusTextbox when rootId changes', () => {
+        const draft = {
+            message: 'Test message',
+            uploadsInProgress: [1, 2, 3],
+            fileInfos: [{test: 1}, {test: 2}]
+        };
+        const props = {...baseProps, draft};
+
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [1, 2, 3],
-                    fileInfos: [{test: 1}, {test: 2}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-                createPostErrorId={null}
-            />
+            <CreateComment {...props}/>
         );
 
         const focusTextbox = jest.fn();
-
         wrapper.instance().focusTextbox = focusTextbox;
-
         wrapper.setProps({rootId: 'testid123'});
-
         expect(focusTextbox).toHaveBeenCalled();
     });
 
     test('handleChange should update comment draft correctly', () => {
         const onUpdateCommentDraft = jest.fn();
+        const draft = {
+            message: 'Test message',
+            uploadsInProgress: [1, 2, 3],
+            fileInfos: [{}, {}, {}]
+        };
+        const props = {...baseProps, onUpdateCommentDraft, draft};
 
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [1, 2, 3],
-                    fileInfos: [{}, {}, {}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={onUpdateCommentDraft}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
 
         const testMessage = 'new msg';
         const scrollToBottom = jest.fn();
-
         wrapper.instance().scrollToBottom = scrollToBottom;
         wrapper.instance().handleChange({target: {value: testMessage}});
 
         expect(onUpdateCommentDraft).toHaveBeenCalled();
-
         expect(onUpdateCommentDraft.mock.calls[0][0]).toEqual(
             expect.objectContaining({message: testMessage})
         );
         expect(wrapper.state().draft.message).toBe(testMessage);
-
         expect(scrollToBottom).toHaveBeenCalled();
     });
 
@@ -662,65 +370,33 @@ describe('components/CreateComment', () => {
             uploadsInProgress: [1, 2, 3],
             fileInfos: [{}, {}, {}]
         };
+        const props = {...baseProps, draft};
 
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={draft}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
 
         const scrollToBottom = jest.fn();
-
         wrapper.instance().scrollToBottom = scrollToBottom;
-
         wrapper.setState({draft: {...draft, uploadsInProgress: [1, 2, 3, 4]}});
-
         expect(scrollToBottom).toHaveBeenCalled();
     });
 
     test('handleSubmit should call onSubmit prop', () => {
         const onSubmit = jest.fn();
+        const draft = {
+            message: 'Test message',
+            uploadsInProgress: [],
+            fileInfos: [{}, {}, {}]
+        };
+        const props = {...baseProps, draft, onSubmit};
 
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={{
-                    message: 'Test message',
-                    uploadsInProgress: [],
-                    fileInfos: [{}, {}, {}]
-                }}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={jest.fn()}
-                onSubmit={onSubmit}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
 
         const preventDefault = jest.fn();
-
         wrapper.instance().handleSubmit({preventDefault});
-
         expect(onSubmit).toHaveBeenCalled();
         expect(preventDefault).toHaveBeenCalled();
     });
@@ -732,39 +408,22 @@ describe('components/CreateComment', () => {
             uploadsInProgress: [4, 5, 6],
             fileInfos: [{id: 1}, {id: 2}, {id: 3}]
         };
+        const props = {...baseProps, draft, onUpdateCommentDraft};
 
         const wrapper = shallow(
-            <CreateComment
-                channelId={channelId}
-                rootId={rootId}
-                draft={draft}
-                enableAddButton={true}
-                ctrlSend={false}
-                latestPostId={latestPostId}
-                getSidebarBody={jest.fn()}
-                clearCommentDraftUploads={jest.fn()}
-                onUpdateCommentDraft={onUpdateCommentDraft}
-                onSubmit={jest.fn()}
-                onResetHistoryIndex={jest.fn()}
-                onMoveHistoryIndexBack={jest.fn()}
-                onMoveHistoryIndexForward={jest.fn()}
-                onEditLatestPost={jest.fn()}
-            />
+            <CreateComment {...props}/>
         );
 
         wrapper.setState({draft});
 
         wrapper.instance().removePreview(3);
-
         expect(onUpdateCommentDraft).toHaveBeenCalled();
-
         expect(onUpdateCommentDraft.mock.calls[0][0]).toEqual(
             expect.objectContaining({fileInfos: [{id: 1}, {id: 2}]})
         );
         expect(wrapper.state().draft.fileInfos).toEqual([{id: 1}, {id: 2}]);
 
         wrapper.instance().removePreview(5);
-
         expect(onUpdateCommentDraft.mock.calls[1][0]).toEqual(
             expect.objectContaining({uploadsInProgress: [4, 6]})
         );


### PR DESCRIPTION
#### Summary
Make PostDeletedModal to show always after replying to a deleted post
- by clearing createPost status/error after hiding `PostDeletedModal` or on `componentWillUnmount`

#### Ticket Link
Jira ticket: [PLT-7829](https://mattermost.atlassian.net/browse/PLT-7829)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has redux changes (https://github.com/mattermost/mattermost-redux/pull/343) [updated link]
