### PR TITLE
PLT-8267 Fixing LDAP nickname setting block.

### DIFF
--- a/components/user_settings/user_settings_general/user_settings_general.jsx
+++ b/components/user_settings/user_settings_general/user_settings_general.jsx
@@ -852,7 +852,7 @@ class UserSettingsGeneralTab extends React.Component {
         if (this.props.activeSection === 'nickname') {
             let extraInfo;
             let submit = null;
-            if ((this.props.user.auth_service === 'ldap' && global.window.mm_config.LdapNicknameAttributeSet) || (this.props.user.auth_service === Constants.SAML_SERVICE && global.window.mm_config.LdapNicknameAttributeSet)) {
+            if ((this.props.user.auth_service === 'ldap' && global.window.mm_config.LdapNicknameAttributeSet === 'true') || (this.props.user.auth_service === Constants.SAML_SERVICE && global.window.mm_config.LdapNicknameAttributeSet === 'true')) {
                 extraInfo = (
                     <span>
                         <FormattedMessage


### PR DESCRIPTION
#### Summary
- Fixes user settings when LDAP is enabled so you can edit your nickname if that field is not set in LDAP.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8267
