### PR TITLE
PLT-8209 Use CMD instead of CTRL for textbox focusing on Mac

### DIFF
--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -85,7 +85,7 @@ export default class NeedsTeam extends React.Component {
     }
 
     onShortcutKeyDown(e) {
-        if (e.shiftKey && e.ctrlKey && e.keyCode === Constants.KeyCodes.L) {
+        if (e.shiftKey && Utils.cmdOrCtrlPressed(e) && e.keyCode === Constants.KeyCodes.L) {
             if (document.getElementById('sidebar-right').className.match('sidebar--right sidebar--right--expanded')) {
                 document.getElementById('reply_textbox').focus();
             } else {


### PR DESCRIPTION
#### Summary
Use CMD instead of CTRL for textbox focusing on Mac.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8209