### PR TITLE
Remove unused type arg of UserActions.updateUser and remove unused/unnecessary Constants.UserUpdateEvents

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -440,7 +440,7 @@ export async function autocompleteUsers(username, success) {
     }
 }
 
-export async function updateUser(user, type, success, error) {
+export async function updateUser(user, success, error) {
     const {data, error: err} = await UserActions.updateMe(user)(dispatch, getState);
     if (data && success) {
         success(data);

--- a/components/user_settings/manage_languages.jsx
+++ b/components/user_settings/manage_languages.jsx
@@ -8,8 +8,6 @@ import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {updateUser} from 'actions/user_actions.jsx';
 
-import Constants from 'utils/constants.jsx';
-
 import * as I18n from 'i18n/i18n.jsx';
 
 import SettingItemMax from '../setting_item_max.jsx';
@@ -41,7 +39,8 @@ export default class ManageLanguage extends React.Component {
     submitUser(user) {
         this.setState({isSaving: true});
 
-        updateUser(user, Constants.UserUpdateEvents.LANGUAGE,
+        updateUser(
+            user,
             () => {
                 GlobalActions.newLocalizationSelected(user.locale);
                 this.setState({isSaving: false});

--- a/components/user_settings/user_settings_general/user_settings_general.jsx
+++ b/components/user_settings/user_settings_general/user_settings_general.jsx
@@ -144,7 +144,7 @@ class UserSettingsGeneralTab extends React.Component {
 
         trackEvent('settings', 'user_settings_update', {field: 'username'});
 
-        this.submitUser(user, Constants.UserUpdateEvents.USERNAME, false);
+        this.submitUser(user, false);
     }
 
     submitNickname(e) {
@@ -162,7 +162,7 @@ class UserSettingsGeneralTab extends React.Component {
 
         trackEvent('settings', 'user_settings_update', {field: 'username'});
 
-        this.submitUser(user, Constants.UserUpdateEvents.NICKNAME, false);
+        this.submitUser(user, false);
     }
 
     submitName(e) {
@@ -182,7 +182,7 @@ class UserSettingsGeneralTab extends React.Component {
 
         trackEvent('settings', 'user_settings_update', {field: 'fullname'});
 
-        this.submitUser(user, Constants.UserUpdateEvents.FULLNAME, false);
+        this.submitUser(user, false);
     }
 
     submitEmail(e) {
@@ -211,13 +211,14 @@ class UserSettingsGeneralTab extends React.Component {
 
         user.email = email;
         trackEvent('settings', 'user_settings_update', {field: 'email'});
-        this.submitUser(user, Constants.UserUpdateEvents.EMAIL, true);
+        this.submitUser(user, true);
     }
 
-    submitUser(user, type, emailUpdated) {
+    submitUser(user, emailUpdated) {
         this.setState({sectionIsSaving: true});
 
-        updateUser(user, type,
+        updateUser(
+            user,
             () => {
                 this.updateSection('');
                 this.props.actions.getMe();
@@ -296,7 +297,7 @@ class UserSettingsGeneralTab extends React.Component {
 
         trackEvent('settings', 'user_settings_update', {field: 'position'});
 
-        this.submitUser(user, Constants.UserUpdateEvents.Position, false);
+        this.submitUser(user, false);
     }
 
     updateUsername(e) {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -427,15 +427,6 @@ export const Constants = {
     STAT_MAX_ACTIVE_USERS: 20,
     STAT_MAX_NEW_USERS: 20,
 
-    UserUpdateEvents: {
-        USERNAME: 'username',
-        FULLNAME: 'fullname',
-        NICKNAME: 'nickname',
-        EMAIL: 'email',
-        LANGUAGE: 'language',
-        POSITION: 'position'
-    },
-
     ScrollTypes: {
         FREE: 1,
         BOTTOM: 2,


### PR DESCRIPTION
#### Summary
Remove unused `type` argumnet of UserActions.updateUser and remove unused/unnecessary Constants.UserUpdateEvents.

This initiative came after while working on PLT-8222.

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
