### PR TITLE
PLT-8170: Fix channel name / purpose modals

### DIFF
--- a/components/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx
+++ b/components/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx
@@ -61,10 +61,6 @@ export default class EditChannelPurposeModal extends React.Component {
         };
     }
 
-    componentDidMount() {
-        Utils.placeCaretAtEnd(this.refs.purpose);
-    }
-
     componentWillReceiveProps(nextProps) {
         const {requestStatus: nextRequestStatus, serverError: nextServerError} = nextProps;
         const {requestStatus} = this.props;
@@ -95,6 +91,10 @@ export default class EditChannelPurposeModal extends React.Component {
 
     unsetError = () => {
         this.setState({serverError: ''});
+    }
+
+    handleEntering = () => {
+        Utils.placeCaretAtEnd(this.purpose);
     }
 
     handleHide = () => {
@@ -180,6 +180,7 @@ export default class EditChannelPurposeModal extends React.Component {
                 ref='modal'
                 show={this.state.show}
                 onHide={this.handleHide}
+                onEntering={this.handleEntering}
                 onExited={this.props.onModalDismissed}
             >
                 <Modal.Header closeButton={true}>
@@ -192,7 +193,9 @@ export default class EditChannelPurposeModal extends React.Component {
                         {channelPurposeModal}
                     </p>
                     <textarea
-                        ref='purpose'
+                        ref={(e) => {
+                            this.purpose = e;
+                        }}
                         className='form-control no-resize'
                         rows='6'
                         maxLength='250'

--- a/components/rename_channel_modal/rename_channel_modal.jsx
+++ b/components/rename_channel_modal/rename_channel_modal.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal, OverlayTrigger, Tooltip} from 'react-bootstrap';
-import ReactDOM from 'react-dom';
 import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
 import {browserHistory} from 'react-router';
 
@@ -110,12 +109,6 @@ export class RenameChannelModal extends React.PureComponent {
         }
     }
 
-    componentDidUpdate(prevProps) {
-        if (!prevProps.show && this.props.show) {
-            this.handleShow();
-        }
-    }
-
     setError = (err) => {
         this.setState({serverError: err.message});
     }
@@ -124,10 +117,8 @@ export class RenameChannelModal extends React.PureComponent {
         this.setState({serverError: ''});
     }
 
-    handleShow = () => {
-        const textbox = ReactDOM.findDOMNode(this.refs.displayName);
-        textbox.focus();
-        Utils.placeCaretAtEnd(textbox);
+    handleEntering = () => {
+        Utils.placeCaretAtEnd(this.textbox);
     }
 
     handleHide = (e) => {
@@ -269,6 +260,7 @@ export class RenameChannelModal extends React.PureComponent {
         return (
             <Modal
                 show={this.props.show}
+                onEntering={this.handleEntering}
                 onHide={this.handleCancel}
             >
                 <Modal.Header closeButton={true}>
@@ -291,7 +283,9 @@ export class RenameChannelModal extends React.PureComponent {
                             <input
                                 onChange={this.onDisplayNameChange}
                                 type='text'
-                                ref='displayName'
+                                ref={(e) => {
+                                    this.textbox = e;
+                                }}
                                 id='display_name'
                                 className='form-control'
                                 placeholder={formatMessage(holders.displayNameHolder)}
@@ -316,7 +310,6 @@ export class RenameChannelModal extends React.PureComponent {
                                     onChange={this.onNameChange}
                                     type='text'
                                     className={handleInputClass}
-                                    ref='channelName'
                                     id='channel_name'
                                     placeholder={formatMessage(holders.handleHolder)}
                                     value={this.state.channelName}

--- a/tests/components/__snapshots__/edit_channel_purpose_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/edit_channel_purpose_modal.test.jsx.snap
@@ -22,6 +22,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx c
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}

--- a/tests/components/__snapshots__/edit_channel_purpose_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/edit_channel_purpose_modal.test.jsx.snap
@@ -120,6 +120,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx m
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -227,6 +228,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx m
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -334,6 +336,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx s
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -431,6 +434,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx s
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -528,6 +532,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx s
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -625,6 +630,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx s
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}

--- a/tests/components/__snapshots__/rename_channel_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/rename_channel_modal.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`components/rename_channel_modal/rename_channel_modal.jsx should match s
       "remove": [Function],
     }
   }
+  onEntering={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}


### PR DESCRIPTION
#### Summary
I'm not sure what caused this to finally break, but I don't think the behavior of our code was ever well-defined. `componentDidMount` can be called before nested components mount. So instead of referencing nested components from it, we need to wait a little longer. `Modal` has an `onEntering` prop that seems appropriate.

I'm not sure it's strictly necessary, but I'm also updating the refs to use callback assignment as this is the preferred way of using refs (https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element).

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8170

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed