### PR TITLE
Fix atMention to check for user on users object only

### DIFF
--- a/components/at_mention/at_mention.jsx
+++ b/components/at_mention/at_mention.jsx
@@ -51,7 +51,7 @@ export default class AtMention extends React.PureComponent {
         let mentionName = props.mentionName;
 
         while (mentionName.length > 0) {
-            if (usersByUsername[mentionName]) {
+            if (usersByUsername.hasOwnProperty(mentionName)) {
                 return usersByUsername[mentionName];
             }
 


### PR DESCRIPTION
#### Summary
Use `hasOwnProperty` to check for user on users object

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7944

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
