### PR TITLE
[PLT-7409] Channel Member List: show status icon and sort by user's status

### DIFF
--- a/components/member_list_channel/index.js
+++ b/components/member_list_channel/index.js
@@ -8,12 +8,6 @@ import {getChannelStats} from 'mattermost-redux/actions/channels';
 
 import MemberListChannel from './member_list_channel.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
-
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
@@ -22,4 +16,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(MemberListChannel);
+export default connect(null, mapDispatchToProps)(MemberListChannel);

--- a/components/member_list_channel/member_list_channel.jsx
+++ b/components/member_list_channel/member_list_channel.jsx
@@ -12,8 +12,9 @@ import store from 'stores/redux_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
-import Constants from 'utils/constants.jsx';
+import Constants, {UserStatusesWeight} from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
+import * as Utils from 'utils/utils.jsx';
 
 import ChannelMembersDropdown from 'components/channel_members_dropdown';
 import SearchableUserList from 'components/searchable_user_list/searchable_user_list_container.jsx';
@@ -144,7 +145,9 @@ export default class MemberListChannel extends React.Component {
                 const user = users[i];
 
                 if (teamMembers[user.id] && channelMembers[user.id] && user.delete_at === 0) {
-                    usersToDisplay.push(user);
+                    const status = UserStore.getStatus(user.id);
+                    usersToDisplay.push({...user, status});
+
                     actionUserProps[user.id] = {
                         channel: this.props.channel,
                         teamMember: teamMembers[user.id],
@@ -152,6 +155,10 @@ export default class MemberListChannel extends React.Component {
                     };
                 }
             }
+
+            usersToDisplay.sort((a, b) => {
+                return UserStatusesWeight[a.status] - UserStatusesWeight[b.status] || Utils.sortUsersByDisplayName(a, b);
+            });
         }
 
         return (

--- a/components/member_list_channel/member_list_channel.jsx
+++ b/components/member_list_channel/member_list_channel.jsx
@@ -12,7 +12,7 @@ import store from 'stores/redux_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
-import Constants, {UserStatusesWeight} from 'utils/constants.jsx';
+import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -156,9 +156,7 @@ export default class MemberListChannel extends React.Component {
                 }
             }
 
-            usersToDisplay.sort((a, b) => {
-                return UserStatusesWeight[a.status] - UserStatusesWeight[b.status] || Utils.sortUsersByDisplayName(a, b);
-            });
+            usersToDisplay.sort(Utils.sortUsersByStatusAndDisplayName);
         }
 
         return (

--- a/components/member_list_channel/member_list_channel.jsx
+++ b/components/member_list_channel/member_list_channel.jsx
@@ -34,7 +34,7 @@ export default class MemberListChannel extends React.Component {
 
         this.onChange = this.onChange.bind(this);
         this.onStatsChange = this.onStatsChange.bind(this);
-        this.search = this.search.bind(this);
+        this.handleSearch = this.handleSearch.bind(this);
         this.loadComplete = this.loadComplete.bind(this);
 
         this.searchTimeoutId = 0;
@@ -47,7 +47,9 @@ export default class MemberListChannel extends React.Component {
             teamMembers: Object.assign({}, TeamStore.getMembersInTeam()),
             channelMembers: Object.assign({}, ChannelStore.getMembersInChannel()),
             total: stats.member_count,
-            loading: true
+            loading: true,
+            actionUserProps: {},
+            usersToDisplay: []
         };
     }
 
@@ -70,6 +72,65 @@ export default class MemberListChannel extends React.Component {
         ChannelStore.removeStatsChangeListener(this.onStatsChange);
     }
 
+    shouldComponentUpdate(nextProps, nextState) {
+        if (nextState.loading !== this.state.loading) {
+            return true;
+        }
+
+        if (nextState.total !== this.state.total) {
+            return true;
+        }
+
+        if (!Utils.areObjectsEqual(nextState.usersToDisplay, this.state.usersToDisplay)) {
+            return true;
+        }
+
+        if (!Utils.areObjectsEqual(nextState.actionUserProps, this.state.actionUserProps)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    componentWillUpdate(_, nextState) {
+        if (!nextState.loading) {
+            const {
+                users,
+                teamMembers,
+                channelMembers
+            } = nextState;
+
+            this.setUsersDisplayAndActionProps(users, teamMembers, channelMembers);
+        }
+    }
+
+    setUsersDisplayAndActionProps(users, teamMembers, channelMembers) {
+        const actionUserProps = {};
+        const usersToDisplay = [];
+
+        for (let i = 0; i < users.length; i++) {
+            const user = users[i];
+
+            if (teamMembers[user.id] && channelMembers[user.id] && user.delete_at === 0) {
+                const status = UserStore.getStatus(user.id);
+                usersToDisplay.push({...user, status});
+
+                actionUserProps[user.id] = {
+                    channel: this.props.channel,
+                    teamMember: teamMembers[user.id],
+                    channelMember: channelMembers[user.id]
+                };
+            }
+        }
+
+        usersToDisplay.sort(Utils.sortUsersByStatusAndDisplayName);
+
+        this.setState({
+            usersToDisplay,
+            actionUserProps
+        });
+    }
+
     loadComplete() {
         this.setState({loading: false});
     }
@@ -82,11 +143,16 @@ export default class MemberListChannel extends React.Component {
             users = UserStore.getProfileListInChannel(ChannelStore.getCurrentId(), false, true);
         }
 
+        const teamMembers = Object.assign({}, TeamStore.getMembersInTeam());
+        const channelMembers = Object.assign({}, ChannelStore.getMembersInChannel());
+
         this.setState({
             users,
-            teamMembers: Object.assign({}, TeamStore.getMembersInTeam()),
-            channelMembers: Object.assign({}, ChannelStore.getMembersInChannel())
+            teamMembers,
+            channelMembers
         });
+
+        this.setUsersDisplayAndActionProps(users, teamMembers, channelMembers);
     }
 
     onStatsChange() {
@@ -98,7 +164,7 @@ export default class MemberListChannel extends React.Component {
         loadProfilesAndTeamMembersAndChannelMembers(page + 1, USERS_PER_PAGE);
     }
 
-    search(term) {
+    handleSearch(term) {
         clearTimeout(this.searchTimeoutId);
         this.term = term;
 
@@ -130,44 +196,15 @@ export default class MemberListChannel extends React.Component {
     }
 
     render() {
-        const teamMembers = this.state.teamMembers;
-        const channelMembers = this.state.channelMembers;
-        const users = this.state.users;
-        const actionUserProps = {};
-
-        let usersToDisplay;
-        if (this.state.loading) {
-            usersToDisplay = null;
-        } else {
-            usersToDisplay = [];
-
-            for (let i = 0; i < users.length; i++) {
-                const user = users[i];
-
-                if (teamMembers[user.id] && channelMembers[user.id] && user.delete_at === 0) {
-                    const status = UserStore.getStatus(user.id);
-                    usersToDisplay.push({...user, status});
-
-                    actionUserProps[user.id] = {
-                        channel: this.props.channel,
-                        teamMember: teamMembers[user.id],
-                        channelMember: channelMembers[user.id]
-                    };
-                }
-            }
-
-            usersToDisplay.sort(Utils.sortUsersByStatusAndDisplayName);
-        }
-
         return (
             <SearchableUserList
-                users={usersToDisplay}
+                users={this.state.usersToDisplay}
                 usersPerPage={USERS_PER_PAGE}
                 total={this.state.total}
                 nextPage={this.nextPage}
-                search={this.search}
+                search={this.handleSearch}
                 actions={[ChannelMembersDropdown]}
-                actionUserProps={actionUserProps}
+                actionUserProps={this.state.actionUserProps}
                 focusOnMount={!UserAgent.isMobile()}
             />
         );

--- a/components/popover_list_members/index.js
+++ b/components/popover_list_members/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 
 import {getProfilesInChannel} from 'mattermost-redux/actions/users';
 import {getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
-import {makeGetProfilesInChannel} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUserId, makeGetProfilesInChannel} from 'mattermost-redux/selectors/entities/users';
 
 import PopoverListMembers from './popover_list_members.jsx';
 
@@ -15,10 +15,13 @@ function makeMapStateToProps() {
 
     return function mapStateToProps(state, ownProps) {
         const stats = getAllChannelStats(state)[ownProps.channel.id] || {};
+        const members = doGetProfilesInChannel(state, ownProps.channel.id, true);
+
         return {
             ...ownProps,
             memberCount: stats.member_count,
-            members: doGetProfilesInChannel(state, ownProps.channel.id, true)
+            members,
+            currentUserId: getCurrentUserId(state)
         };
     };
 }

--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -17,7 +17,7 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
 import {canManageMembers} from 'utils/channel_utils.jsx';
-import Constants from 'utils/constants.jsx';
+import Constants, {UserStatusesWeight} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import ChannelInviteModal from 'components/channel_invite_modal';
@@ -90,7 +90,6 @@ export default class PopoverListMembers extends React.Component {
     render() {
         let popoverButton;
         const popoverHtml = [];
-        const members = this.props.members;
         const teamMembers = UserStore.getProfilesUsernameMap();
         const currentUserId = UserStore.getCurrentId();
 
@@ -98,15 +97,15 @@ export default class PopoverListMembers extends React.Component {
         const isTeamAdmin = TeamStore.isTeamAdminForCurrentTeam();
         const isChannelAdmin = ChannelStore.isChannelAdminForCurrentChannel();
 
-        if (members && teamMembers) {
-            members.sort((a, b) => {
-                const aName = Utils.displayUsernameForUser(a);
-                const bName = Utils.displayUsernameForUser(b);
-
-                return aName.localeCompare(bName);
+        if (this.props.members && teamMembers) {
+            const sortedMembers = this.props.members.map((member) => {
+                const status = UserStore.getStatus(member.id);
+                return {...member, status};
+            }).sort((a, b) => {
+                return UserStatusesWeight[a.status] - UserStatusesWeight[b.status] || Utils.sortUsersByDisplayName(a, b);
             });
 
-            members.forEach((m, i) => {
+            sortedMembers.forEach((m, i) => {
                 let messageIcon;
                 if (currentUserId !== m.id && this.props.channel.type !== Constants.DM_CHANNEl) {
                     messageIcon = (
@@ -131,6 +130,7 @@ export default class PopoverListMembers extends React.Component {
                         >
                             <ProfilePicture
                                 src={Client4.getProfilePictureUrl(m.id, m.last_picture_update)}
+                                status={m.status}
                                 width='40'
                                 height='40'
                             />

--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -17,7 +17,7 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
 import {canManageMembers} from 'utils/channel_utils.jsx';
-import Constants, {UserStatusesWeight} from 'utils/constants.jsx';
+import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import ChannelInviteModal from 'components/channel_invite_modal';
@@ -101,9 +101,7 @@ export default class PopoverListMembers extends React.Component {
             const sortedMembers = this.props.members.map((member) => {
                 const status = UserStore.getStatus(member.id);
                 return {...member, status};
-            }).sort((a, b) => {
-                return UserStatusesWeight[a.status] - UserStatusesWeight[b.status] || Utils.sortUsersByDisplayName(a, b);
-            });
+            }).sort(Utils.sortUsersByStatusAndDisplayName);
 
             sortedMembers.forEach((m, i) => {
                 let messageIcon;

--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -32,6 +32,7 @@ export default class PopoverListMembers extends React.Component {
         channel: PropTypes.object.isRequired,
         members: PropTypes.array.isRequired,
         memberCount: PropTypes.number,
+        currentUserId: PropTypes.string.isRequired,
         actions: PropTypes.shape({
             getProfilesInChannel: PropTypes.func.isRequired
         }).isRequired
@@ -49,12 +50,33 @@ export default class PopoverListMembers extends React.Component {
             showPopover: false,
             showTeamMembersModal: false,
             showChannelMembersModal: false,
-            showChannelInviteModal: false
+            showChannelInviteModal: false,
+            teamMembers: UserStore.getProfilesUsernameMap(),
+            isSystemAdmin: UserStore.isSystemAdminForCurrentUser(),
+            isTeamAdmin: TeamStore.isTeamAdminForCurrentTeam(),
+            isChannelAdmin: ChannelStore.isChannelAdminForCurrentChannel(),
+            sortedMembers: []
         };
     }
 
     componentDidUpdate() {
         $('.member-list__popover .popover-content .more-modal__body').perfectScrollbar();
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (!Utils.areObjectsEqual(this.props.members, nextProps.members)) {
+            const sortedMembers = this.sortMembers(nextProps.members);
+            const teamMembers = UserStore.getProfilesUsernameMap();
+
+            this.setState({sortedMembers, teamMembers});
+        }
+    }
+
+    sortMembers(members = []) {
+        return members.map((member) => {
+            const status = UserStore.getStatus(member.id);
+            return {...member, status};
+        }).sort(Utils.sortUsersByStatusAndDisplayName);
     }
 
     handleShowDirectChannel(teammate, e) {
@@ -90,22 +112,19 @@ export default class PopoverListMembers extends React.Component {
     render() {
         let popoverButton;
         const popoverHtml = [];
-        const teamMembers = UserStore.getProfilesUsernameMap();
-        const currentUserId = UserStore.getCurrentId();
 
-        const isSystemAdmin = UserStore.isSystemAdminForCurrentUser();
-        const isTeamAdmin = TeamStore.isTeamAdminForCurrentTeam();
-        const isChannelAdmin = ChannelStore.isChannelAdminForCurrentChannel();
+        const {
+            sortedMembers,
+            teamMembers,
+            isSystemAdmin,
+            isTeamAdmin,
+            isChannelAdmin
+        } = this.state;
 
         if (this.props.members && teamMembers) {
-            const sortedMembers = this.props.members.map((member) => {
-                const status = UserStore.getStatus(member.id);
-                return {...member, status};
-            }).sort(Utils.sortUsersByStatusAndDisplayName);
-
             sortedMembers.forEach((m, i) => {
                 let messageIcon;
-                if (currentUserId !== m.id && this.props.channel.type !== Constants.DM_CHANNEl) {
+                if (this.props.currentUserId !== m.id && this.props.channel.type !== Constants.DM_CHANNEl) {
                     messageIcon = (
                         <MessageIcon
                             className='icon icon__message'
@@ -129,8 +148,8 @@ export default class PopoverListMembers extends React.Component {
                             <ProfilePicture
                                 src={Client4.getProfilePictureUrl(m.id, m.last_picture_update)}
                                 status={m.status}
-                                width='40'
-                                height='40'
+                                width='32'
+                                height='32'
                             />
                             <div className='more-modal__details'>
                                 <div

--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -265,7 +265,7 @@
             height: 50px;
             margin: 1px 0;
             overflow: hidden;
-            padding: 6px 19px 0 20px;
+            padding-left: 20px;
 
             &:hover {
                 border-left: 3px solid transparent;

--- a/sass/components/_status-icon.scss
+++ b/sass/components/_status-icon.scss
@@ -4,6 +4,7 @@
     display: inline-block;
     height: 32px;
     position: relative;
+    align-self: center;
 
     .status {
         border-radius: 100px;

--- a/tests/utils/utils.test.jsx
+++ b/tests/utils/utils.test.jsx
@@ -1,4 +1,164 @@
+
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 import * as Utils from 'utils/utils.jsx';
+
+describe('Utils.displayUsernameForUser', function() {
+    global.window.mm_config = {};
+
+    beforeEach(() => {
+        global.window.mm_config.TeammateNameDisplay = 'username';
+    });
+
+    afterEach(() => {
+        global.window.mm_config = {};
+    });
+
+    const userA = {username: 'a_user', nickname: 'a_nickname', first_name: 'a_first_name', last_name: ''};
+    const userB = {username: 'b_user', nickname: 'b_nickname', first_name: '', last_name: 'b_last_name'};
+    const userC = {username: 'c_user', nickname: '', first_name: 'c_first_name', last_name: 'c_last_name'};
+    const userD = {username: 'd_user', nickname: 'd_nickname', first_name: 'd_first_name', last_name: 'd_last_name'};
+    const userE = {username: 'e_user', nickname: '', first_name: 'e_first_name', last_name: 'e_last_name'};
+    const userF = {username: 'f_user', nickname: 'f_nickname', first_name: 'f_first_name', last_name: 'f_last_name'};
+    const userG = {username: 'g_user', nickname: '', first_name: 'g_first_name', last_name: 'g_last_name'};
+    const userH = {username: 'h_user', nickname: 'h_nickname', first_name: '', last_name: 'h_last_name'};
+    const userI = {username: 'i_user', nickname: 'i_nickname', first_name: 'i_first_name', last_name: ''};
+    const userJ = {username: 'j_user', nickname: '', first_name: 'j_first_name', last_name: ''};
+
+    test('Show display name of user with TeammateNameDisplay set to username', function() {
+        [userA, userB, userC, userD, userE, userF, userG, userH, userI, userJ].forEach((user) => {
+            expect(Utils.displayUsernameForUser(user)).toEqual(user.username);
+        });
+    });
+
+    test('Show display name of user with TeammateNameDisplay set to username', function() {
+        global.window.mm_config.TeammateNameDisplay = 'nickname_full_name';
+        for (const data of [
+            {user: userA, result: userA.nickname},
+            {user: userB, result: userB.nickname},
+            {user: userC, result: `${userC.first_name} ${userC.last_name}`},
+            {user: userD, result: userD.nickname},
+            {user: userE, result: `${userE.first_name} ${userE.last_name}`},
+            {user: userF, result: userF.nickname},
+            {user: userG, result: `${userG.first_name} ${userG.last_name}`},
+            {user: userH, result: userH.nickname},
+            {user: userI, result: userI.nickname},
+            {user: userJ, result: userJ.first_name}
+        ]) {
+            expect(Utils.displayUsernameForUser(data.user)).toEqual(data.result);
+        }
+    });
+
+    test('Show display name of user with TeammateNameDisplay set to username', function() {
+        global.window.mm_config.TeammateNameDisplay = 'full_name';
+        for (const data of [
+            {user: userA, result: userA.first_name},
+            {user: userB, result: userB.last_name},
+            {user: userC, result: `${userC.first_name} ${userC.last_name}`},
+            {user: userD, result: `${userD.first_name} ${userD.last_name}`},
+            {user: userE, result: `${userE.first_name} ${userE.last_name}`},
+            {user: userF, result: `${userF.first_name} ${userF.last_name}`},
+            {user: userG, result: `${userG.first_name} ${userG.last_name}`},
+            {user: userH, result: userH.last_name},
+            {user: userI, result: userI.first_name},
+            {user: userJ, result: userJ.first_name}
+        ]) {
+            expect(Utils.displayUsernameForUser(data.user)).toEqual(data.result);
+        }
+    });
+});
+
+describe('Utils.sortUsersByStatusAndDisplayName', function() {
+    global.window.mm_config = {};
+
+    beforeEach(() => {
+        global.window.mm_config.TeammateNameDisplay = 'username';
+    });
+
+    afterEach(() => {
+        global.window.mm_config = {};
+    });
+
+    const userA = {status: 'dnd', username: 'a_user', nickname: 'ja_nickname', first_name: 'a_first_name', last_name: 'ja_last_name'};
+    const userB = {status: 'away', username: 'b_user', nickname: 'ib_nickname', first_name: 'a_first_name', last_name: 'ib_last_name'};
+    const userC = {status: 'offline', username: 'c_user', nickname: 'hc_nickname', first_name: 'a_first_name', last_name: 'hc_last_name'};
+    const userD = {status: 'online', username: 'd_user', nickname: 'gd_nickname', first_name: 'a_first_name', last_name: 'gd_last_name'};
+    const userE = {status: 'online', username: 'e_user', nickname: 'fe_nickname', first_name: 'b_first_name', last_name: 'fe_last_name'};
+    const userF = {status: 'online', username: 'f_user', nickname: 'ef_nickname', first_name: 'b_first_name', last_name: 'ef_last_name'};
+    const userG = {status: 'dnd', username: 'g_user', nickname: 'dg_nickname', first_name: 'b_first_name', last_name: 'dg_last_name'};
+    const userH = {status: 'away', username: 'h_user', nickname: 'ch_nickname', first_name: 'c_first_name', last_name: 'ch_last_name'};
+    const userI = {status: 'offline', username: 'i_user', nickname: 'bi_nickname', first_name: 'c_first_name', last_name: 'bi_last_name'};
+    const userJ = {status: 'online', username: 'j_user', nickname: 'aj_nickname', first_name: 'c_first_name', last_name: 'aj_last_name'};
+
+    test('Users sort by status and displayname, TeammateNameDisplay set to username', function() {
+        for (const data of [
+            {
+                users: [userF, userA, userB, userC, userD, userE],
+                result: [userD, userE, userF, userB, userC, userA]
+            },
+            {
+                users: [userJ, userI, userH, userG, userF, userE],
+                result: [userE, userF, userJ, userH, userI, userG]
+            },
+            {
+                users: [userJ, userF, userE, userD],
+                result: [userD, userE, userF, userJ]
+            }
+        ]) {
+            const sortedUsers = data.users.sort(Utils.sortUsersByStatusAndDisplayName);
+            for (let i = 0; i < sortedUsers.length; i++) {
+                expect(sortedUsers[i]).toEqual(data.result[i]);
+            }
+        }
+    });
+
+    test('Users sort by status and displayname, TeammateNameDisplay set to nickname_full_name', function() {
+        global.window.mm_config.TeammateNameDisplay = 'nickname_full_name';
+        for (const data of [
+            {
+                users: [userF, userA, userB, userC, userD, userE],
+                result: [userF, userE, userD, userB, userC, userA]
+            },
+            {
+                users: [userJ, userI, userH, userG, userF, userE],
+                result: [userJ, userF, userE, userH, userI, userG]
+            },
+            {
+                users: [userJ, userF, userE, userD],
+                result: [userJ, userF, userE, userD]
+            }
+        ]) {
+            const sortedUsers = data.users.sort(Utils.sortUsersByStatusAndDisplayName);
+            for (let i = 0; i < sortedUsers.length; i++) {
+                expect(sortedUsers[i]).toEqual(data.result[i]);
+            }
+        }
+    });
+
+    test('Users sort by status and displayname, TeammateNameDisplay set to full_name', function() {
+        global.window.mm_config.TeammateNameDisplay = 'full_name';
+        for (const data of [
+            {
+                users: [userF, userA, userB, userC, userD, userE],
+                result: [userD, userF, userE, userB, userC, userA]
+            },
+            {
+                users: [userJ, userI, userH, userG, userF, userE],
+                result: [userF, userE, userJ, userH, userI, userG]
+            },
+            {
+                users: [userJ, userF, userE, userD],
+                result: [userD, userF, userE, userJ]
+            }
+        ]) {
+            const sortedUsers = data.users.sort(Utils.sortUsersByStatusAndDisplayName);
+            for (let i = 0; i < sortedUsers.length; i++) {
+                expect(sortedUsers[i]).toEqual(data.result[i]);
+            }
+        }
+    });
+});
 
 describe('Utils.isValidPassword', function() {
     test('Password min/max length enforced if no EE password requirements set', function() {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -264,6 +264,13 @@ export const UserStatuses = {
     DND: 'dnd'
 };
 
+export const UserStatusesWeight = {
+    online: 0,
+    away: 1,
+    offline: 2,
+    dnd: 3
+};
+
 export const UserSearchOptions = {
     ALLOW_INACTIVE: 'allow_inactive',
     WITHOUT_TEAM: 'without_team'

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1095,6 +1095,16 @@ export function displayUsernameForUser(user) {
 }
 
 /**
+ * Sort users according to display name, respecting the TeammateNameDisplay configuration setting
+ */
+export function sortUsersByDisplayName(a, b) {
+    const aName = displayUsernameForUser(a);
+    const bName = displayUsernameForUser(b);
+
+    return aName.localeCompare(bName);
+}
+
+/**
  * Gets the entire name, including username, full name, and nickname, of the user with the specified id
  */
 export function displayEntireName(userId) {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -18,7 +18,7 @@ import LocalizationStore from 'stores/localization_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 
-import Constants from 'utils/constants.jsx';
+import Constants, {UserStatusesWeight} from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 
 import bing from 'images/bing.mp3';
@@ -1095,13 +1095,17 @@ export function displayUsernameForUser(user) {
 }
 
 /**
- * Sort users according to display name, respecting the TeammateNameDisplay configuration setting
+ * Sort users by status then by display name, respecting the TeammateNameDisplay configuration setting
  */
-export function sortUsersByDisplayName(a, b) {
-    const aName = displayUsernameForUser(a);
-    const bName = displayUsernameForUser(b);
+export function sortUsersByStatusAndDisplayName(userA, userB) {
+    function sortByDisplayName(a, b) {
+        const aName = displayUsernameForUser(a);
+        const bName = displayUsernameForUser(b);
 
-    return aName.localeCompare(bName);
+        return aName.localeCompare(bName);
+    }
+
+    return UserStatusesWeight[userA.status] - UserStatusesWeight[userB.status] || sortByDisplayName(userA, userB);
 }
 
 /**


### PR DESCRIPTION
#### Summary
Show status icon and sort by user's status (in the order of online > away > offline > dnd) to the following components:
- MemberListChannel
- PopoverListMembers (though not specifically mentioned in the ticket)

@jasonblais @esethna You might want to check this out if according to ticket specs. (I'm not really sure about the coverage). Also not sure if this should be for v4.5 as stated in Jira ticket.
 
#### Ticket Link
Jira ticket: [PLT-7409](https://mattermost.atlassian.net/browse/PLT-7409)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
