### PR TITLE
PLT-8302: add channelId to RECEIVED_POSTS action after edit

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -278,7 +278,8 @@ function handlePostEditEvent(msg) {
             posts: {
                 [post.id]: post
             }
-        }
+        },
+        channelId: post.channel_id
     });
 
     // Update channel state


### PR DESCRIPTION
#### Summary
This was causing the `postsInChannel` map in the redux handlers to get an "undefined" channel inserted into it since they expect this property.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8302

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed