### PR TITLE
Remove div container taking up width

### DIFF
--- a/components/post_view/new_message_indicator.jsx
+++ b/components/post_view/new_message_indicator.jsx
@@ -34,7 +34,7 @@ export default class NewMessageIndicator extends React.PureComponent {
     render() {
         const unreadIcon = Constants.UNREAD_ICON_SVG;
         let className = 'new-messages__button';
-        if (this.state.visible > 0) {
+        if (this.state.visible) {
             className += ' visible';
         }
         if (!this.state.rendered) {

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -281,12 +281,12 @@
 
     .new-messages__button {
         @include opacity(0);
+        @include translateX(-50%);
         bottom: 0;
         font-size: 13.5px;
-        left: 0;
+        left: 50%;
         margin: 5px auto;
         position: absolute;
-        right: 0;
         text-align: center;
         visibility: hidden;
         z-index: 1;


### PR DESCRIPTION
1. Certain users have been experiencing an issue with the `NewMessageIndicator` not dissapearing after getting to the bottom of the channel.
2. One user had a link that was not clickable because the `NewMessageIndicator` was blocking the clickHandler from the message.

I was not able to reproduce or the first issue.  Works fine on Chrome, Mac client, Safari.  This issue has been reported by Mac Client users.

This PR addresses the second issue. Have parent `div` wrap children. This allows the user to click the left or right side of the `NewMessageIndicator` As seen in the screenshot below

<img width="670" alt="screen shot 2017-12-06 at 2 24 47 pm" src="https://user-images.githubusercontent.com/6182543/33681574-f9f7bc28-da92-11e7-9abb-e84603bf781f.png">

@miguelespinoza 