### PR TITLE
WIP: Use selector for creating emoji's Map

### DIFF
--- a/components/post_view/post_message_view/index.js
+++ b/components/post_view/post_message_view/index.js
@@ -4,33 +4,23 @@
 import {connect} from 'react-redux';
 
 import {Preferences} from 'mattermost-redux/constants';
-import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getTheme, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getCurrentUserMentionKeys, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
 
-import {EmojiMap} from 'stores/emoji_store.jsx';
+import {getEmojis} from 'selectors/emojis.js';
 
 import {getSiteURL} from 'utils/url.jsx';
 
 import PostMessageView from './post_message_view.jsx';
 
 function makeMapStateToProps() {
-    let emojiMap;
-    let oldCustomEmoji;
-
     return function mapStateToProps(state, ownProps) {
-        const newCustomEmoji = getCustomEmojisByName(state);
-        if (newCustomEmoji !== oldCustomEmoji) {
-            emojiMap = new EmojiMap(newCustomEmoji);
-        }
-        oldCustomEmoji = newCustomEmoji;
-
         const user = getCurrentUser(state);
 
         return {
             ...ownProps,
-            emojis: emojiMap,
+            emojis: getEmojis(state),
             enableFormatting: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true),
             mentionKeys: getCurrentUserMentionKeys(state),
             usernameMap: getUsersByUsername(state),

--- a/selectors/emojis.js
+++ b/selectors/emojis.js
@@ -1,0 +1,9 @@
+import {createSelector} from 'reselect';
+import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
+
+import {EmojiMap} from 'stores/emoji_store.jsx';
+
+export const getEmojis = createSelector(
+    getCustomEmojisByName,
+    (newCustomEmoji) => new EmojiMap(newCustomEmoji)
+);


### PR DESCRIPTION
#### Summary
 Creating a new object on for every message render creates lot of emoji map instances causing a bloat of memory particularly with a high number of custom emoji's.

On pre-release as of now there is about `9.7mb` of memory being allocated on every channel (And mostly lot of it is not being freed by GC). You can see from below screenshot that there is a total of 32 such `emojiArray` being allocated along with another 32 objects of `emojiMap`. 

![screen shot 2017-12-08 at 6 33 13 pm](https://user-images.githubusercontent.com/4973621/33767339-365bf692-dc47-11e7-96a2-0e9977969620.png)

I simulated similar custom emoji setup on my local for profiling and found similar results. On page load Heapshot
![screen shot 2017-12-08 at 12 11 37 am](https://user-images.githubusercontent.com/4973621/33767441-8ea1a2c0-dc47-11e7-815e-752dbaa866ea.png)

After switching between same channels to and for 4 times
Memory shot up from 105mb to 145mb
![screen shot 2017-12-08 at 12 26 49 am](https://user-images.githubusercontent.com/4973621/33767480-bae12c3e-dc47-11e7-9c39-44182e09548d.png).

Trying same scenarios with this PR changed the memory allocation between channels to 2.7Mb and 3 `emojiArray` and emojiMap instances.
![screen shot 2017-12-08 at 6 47 03 pm](https://user-images.githubusercontent.com/4973621/33767714-ec4cf4dc-dc48-11e7-8f94-321147d0fcb9.png)

Page load heapshot
![screen shot 2017-12-08 at 6 48 45 pm](https://user-images.githubusercontent.com/4973621/33767756-20d1886c-dc49-11e7-983f-4cc2b5b998cc.png)

After switching between same channels to and for 4 times
Memory shot up from 100mb to 112mb.
![screen shot 2017-12-08 at 6 53 21 pm](https://user-images.githubusercontent.com/4973621/33767783-3d8009b6-dc49-11e7-94cc-fab9d1f986ca.png)

I ran these scenarios few times and the numbers are more or less the same.

- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has redux changes (please link)
