### PR TITLE
Avoid creating a new EmojiMap for each post

### DIFF
--- a/components/post_view/post_message_view/index.js
+++ b/components/post_view/post_message_view/index.js
@@ -7,12 +7,11 @@ import {createSelector} from 'reselect';
 import {Preferences} from 'mattermost-redux/constants';
 
 import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
-import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {getTheme, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getCurrentUserMentionKeys, getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
 
-import {EmojiMap} from 'stores/emoji_store.jsx';
+import {getEmojiMap} from 'selectors/emojis';
 
 import {getSiteURL} from 'utils/url.jsx';
 
@@ -29,35 +28,24 @@ const getChannelNamesMap = createSelector(
     }
 );
 
-function makeMapStateToProps() {
-    let emojiMap;
-    let oldCustomEmoji;
+function mapStateToProps(state, ownProps) {
+    const user = getCurrentUser(state);
 
-    return function mapStateToProps(state, ownProps) {
-        const newCustomEmoji = getCustomEmojisByName(state);
-        if (newCustomEmoji !== oldCustomEmoji) {
-            emojiMap = new EmojiMap(newCustomEmoji);
-        }
-        oldCustomEmoji = newCustomEmoji;
+    const channelNamesMap = getChannelNamesMap(state, ownProps.post.props);
 
-        const user = getCurrentUser(state);
-
-        const channelNamesMap = getChannelNamesMap(state, ownProps.post.props);
-
-        return {
-            ...ownProps,
-            emojis: emojiMap,
-            enableFormatting: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true),
-            mentionKeys: getCurrentUserMentionKeys(state),
-            usernameMap: getUsersByUsername(state),
-            team: getCurrentTeam(state),
-            siteUrl: getSiteURL(),
-            theme: getTheme(state),
-            pluginPostTypes: state.plugins.postTypes,
-            currentUser: user,
-            channelNamesMap
-        };
+    return {
+        ...ownProps,
+        emojis: getEmojiMap(state),
+        enableFormatting: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true),
+        mentionKeys: getCurrentUserMentionKeys(state),
+        usernameMap: getUsersByUsername(state),
+        team: getCurrentTeam(state),
+        siteUrl: getSiteURL(),
+        theme: getTheme(state),
+        pluginPostTypes: state.plugins.postTypes,
+        currentUser: user,
+        channelNamesMap
     };
 }
 
-export default connect(makeMapStateToProps)(PostMessageView);
+export default connect(mapStateToProps)(PostMessageView);

--- a/selectors/emojis.js
+++ b/selectors/emojis.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {createSelector} from 'reselect';
+
+import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
+
+import {EmojiMap} from 'stores/emoji_store.jsx';
+
+export const getEmojiMap = createSelector(
+    getCustomEmojisByName,
+    (customEmojisByName) => {
+        console.log('recalculating emojis1');
+        return new EmojiMap(customEmojisByName);
+    }
+);

--- a/selectors/emojis.js
+++ b/selectors/emojis.js
@@ -10,7 +10,6 @@ import {EmojiMap} from 'stores/emoji_store.jsx';
 export const getEmojiMap = createSelector(
     getCustomEmojisByName,
     (customEmojisByName) => {
-        console.log('recalculating emojis1');
         return new EmojiMap(customEmojisByName);
     }
 );


### PR DESCRIPTION
This change was suggested by @sudheerDev, but it turned out it was already part of one of my other PRs so we broke it out on it's own.

@esethna I'm proposing this for 4.5 since it leads to a fair bit less memory usage on pre-release, and the change is minimal since it works the same as before except it doesn't create as many copies of some stuff in memory.