### PR TITLE
Fix closure memory issue in GC

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -119,12 +119,12 @@ export default class PostList extends React.PureComponent {
         this.loadPosts(this.props.channel.id, this.props.focusedPostId);
         GlobalEventEmitter.addListener(EventTypes.POST_LIST_SCROLL_CHANGE, this.handleResize);
 
-        window.addEventListener('resize', () => this.handleResize());
+        window.addEventListener('resize', this.handleResize);
     }
 
     componentWillUnmount() {
         GlobalEventEmitter.removeListener(EventTypes.POST_LIST_SCROLL_CHANGE, this.handleResize);
-        window.removeEventListener('resize', () => this.handleResize());
+        window.removeEventListener('resize', this.handleResize);
     }
 
     componentWillReceiveProps(nextProps) {

--- a/components/post_view/post_time.jsx
+++ b/components/post_view/post_time.jsx
@@ -48,11 +48,11 @@ export default class PostTime extends React.PureComponent {
     }
 
     componentDidMount() {
-        window.addEventListener('resize', this.setDimentions);
+        window.addEventListener('resize', this.setDimensions);
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', this.setDimentions);
+        window.removeEventListener('resize', this.setDimensions);
     }
 
     setDimensions = () => {

--- a/components/post_view/post_time.jsx
+++ b/components/post_view/post_time.jsx
@@ -7,7 +7,7 @@ import {Link} from 'react-router';
 
 import TeamStore from 'stores/team_store.jsx';
 
-import {isMobile, getWindowDimentions} from 'utils/utils.jsx';
+import {isMobile, getWindowDimensions} from 'utils/utils.jsx';
 
 export default class PostTime extends React.PureComponent {
     static propTypes = {
@@ -43,7 +43,7 @@ export default class PostTime extends React.PureComponent {
 
         this.state = {
             currentTeamDisplayName: TeamStore.getCurrent().name,
-            ...getWindowDimentions()
+            ...getWindowDimensions()
         };
     }
 
@@ -55,9 +55,9 @@ export default class PostTime extends React.PureComponent {
         window.removeEventListener('resize', this.setDimentions);
     }
 
-    setDimentions = () => {
+    setDimensions = () => {
         this.setState({
-            ...getWindowDimentions()
+            ...getWindowDimensions()
         });
     }
 

--- a/components/post_view/post_time.jsx
+++ b/components/post_view/post_time.jsx
@@ -7,7 +7,7 @@ import {Link} from 'react-router';
 
 import TeamStore from 'stores/team_store.jsx';
 
-import {isMobile, updateWindowDimensions} from 'utils/utils.jsx';
+import {isMobile, getWindowDimentions} from 'utils/utils.jsx';
 
 export default class PostTime extends React.PureComponent {
     static propTypes = {
@@ -43,20 +43,21 @@ export default class PostTime extends React.PureComponent {
 
         this.state = {
             currentTeamDisplayName: TeamStore.getCurrent().name,
-            width: '',
-            height: ''
+            ...getWindowDimentions()
         };
     }
 
     componentDidMount() {
-        window.addEventListener('resize', () => {
-            updateWindowDimensions(this);
-        });
+        window.addEventListener('resize', this.setDimentions);
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', () => {
-            updateWindowDimensions(this);
+        window.removeEventListener('resize', this.setDimentions);
+    }
+
+    setDimentions = () => {
+        this.setState({
+            ...getWindowDimentions()
         });
     }
 

--- a/components/rhs_comment.jsx
+++ b/components/rhs_comment.jsx
@@ -51,24 +51,9 @@ export default class RhsComment extends React.Component {
         this.state = {
             currentTeamDisplayName: TeamStore.getCurrent().name,
             showEmojiPicker: false,
-            dropdownOpened: false
+            dropdownOpened: false,
+            ...Utils.getWindowDimentions()
         };
-    }
-
-    removePost() {
-        this.props.removePost(this.props.post);
-    }
-
-    createRemovePostButton() {
-        return (
-            <button
-                className='post__remove theme color--link style--none'
-                type='button'
-                onClick={this.removePost}
-            >
-                {'×'}
-            </button>
-        );
     }
 
     shouldComponentUpdate(nextProps, nextState) {
@@ -124,7 +109,41 @@ export default class RhsComment extends React.Component {
             return true;
         }
 
+        if ((this.state.width !== nextState.width) || this.state.height !== nextState.height) {
+            return true;
+        }
+
         return false;
+    }
+
+    componentDidMount() {
+        window.addEventListener('resize', this.setDimentions);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.setDimentions);
+    }
+
+    setDimentions = () => {
+        this.setState({
+            ...Utils.getWindowDimentions()
+        });
+    }
+
+    removePost() {
+        this.props.removePost(this.props.post);
+    }
+
+    createRemovePostButton() {
+        return (
+            <button
+                className='post__remove theme color--link style--none'
+                type='button'
+                onClick={this.removePost}
+            >
+                {'×'}
+            </button>
+        );
     }
 
     timeTag(post, timeOptions) {

--- a/components/rhs_comment.jsx
+++ b/components/rhs_comment.jsx
@@ -50,23 +50,9 @@ export default class RhsComment extends React.Component {
 
         this.state = {
             currentTeamDisplayName: TeamStore.getCurrent().name,
-            width: '',
-            height: '',
             showEmojiPicker: false,
             dropdownOpened: false
         };
-    }
-
-    componentDidMount() {
-        window.addEventListener('resize', () => {
-            Utils.updateWindowDimensions(this);
-        });
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener('resize', () => {
-            Utils.updateWindowDimensions(this);
-        });
     }
 
     removePost() {

--- a/components/rhs_comment.jsx
+++ b/components/rhs_comment.jsx
@@ -52,7 +52,7 @@ export default class RhsComment extends React.Component {
             currentTeamDisplayName: TeamStore.getCurrent().name,
             showEmojiPicker: false,
             dropdownOpened: false,
-            ...Utils.getWindowDimentions()
+            ...Utils.getWindowDimensions()
         };
     }
 
@@ -117,16 +117,16 @@ export default class RhsComment extends React.Component {
     }
 
     componentDidMount() {
-        window.addEventListener('resize', this.setDimentions);
+        window.addEventListener('resize', this.setDimensions);
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', this.setDimentions);
+        window.removeEventListener('resize', this.setDimensions);
     }
 
-    setDimentions = () => {
+    setDimensions = () => {
         this.setState({
-            ...Utils.getWindowDimentions()
+            ...Utils.getWindowDimensions()
         });
     }
 

--- a/components/rhs_root_post.jsx
+++ b/components/rhs_root_post.jsx
@@ -121,16 +121,16 @@ export default class RhsRootPost extends React.Component {
     }
 
     componentDidMount() {
-        window.addEventListener('resize', this.setDimentions);
+        window.addEventListener('resize', this.setDimensions);
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', this.setDimentions);
+        window.removeEventListener('resize', this.setDimensions);
     }
 
-    setDimentions = () => {
+    setDimensions = () => {
         this.setState({
-            ...Utils.getWindowDimentions()
+            ...Utils.getWindowDimensions()
         });
     }
 

--- a/components/rhs_root_post.jsx
+++ b/components/rhs_root_post.jsx
@@ -113,7 +113,25 @@ export default class RhsRootPost extends React.Component {
             return true;
         }
 
+        if ((this.state.width !== nextState.width) || this.state.height !== nextState.height) {
+            return true;
+        }
+
         return false;
+    }
+
+    componentDidMount() {
+        window.addEventListener('resize', this.setDimentions);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.setDimentions);
+    }
+
+    setDimentions = () => {
+        this.setState({
+            ...Utils.getWindowDimentions()
+        });
     }
 
     timeTag(post, timeOptions) {

--- a/components/rhs_root_post.jsx
+++ b/components/rhs_root_post.jsx
@@ -54,24 +54,10 @@ export default class RhsRootPost extends React.Component {
 
         this.state = {
             currentTeamDisplayName: TeamStore.getCurrent().name,
-            width: '',
-            height: '',
             showEmojiPicker: false,
             testStateObj: true,
             dropdownOpened: false
         };
-    }
-
-    componentDidMount() {
-        window.addEventListener('resize', () => {
-            Utils.updateWindowDimensions(this);
-        });
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener('resize', () => {
-            Utils.updateWindowDimensions(this);
-        });
     }
 
     shouldComponentUpdate(nextProps, nextState) {

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -108,26 +108,6 @@ export default class SearchResultsItem extends React.PureComponent {
         };
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
-        if (!Utils.areObjectsEqual(nextState.post, this.props.post)) {
-            return true;
-        }
-
-        if (nextProps.isFlagged !== this.props.isFlagged) {
-            return true;
-        }
-
-        if (nextState.dropdownOpened !== this.state.dropdownOpened) {
-            return true;
-        }
-
-        if ((this.state.width !== nextState.width) || this.state.height !== nextState.height) {
-            return true;
-        }
-
-        return false;
-    }
-
     componentDidMount() {
         window.addEventListener('resize', this.setDimensions);
     }

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -104,12 +104,17 @@ export default class SearchResultsItem extends React.PureComponent {
         super(props);
 
         this.state = {
+<<<<<<< HEAD:components/search_results_item/search_results_item.jsx
             width: '',
             height: '',
+=======
+            currentTeamDisplayName: TeamStore.getCurrent().name,
+>>>>>>> Remove updateWindowDimensions references:components/search_results_item.jsx
             dropdownOpened: false
         };
     }
 
+<<<<<<< HEAD:components/search_results_item/search_results_item.jsx
     componentDidMount() {
         window.addEventListener('resize', this.onUpdateWindowDimensions);
     }
@@ -123,6 +128,25 @@ export default class SearchResultsItem extends React.PureComponent {
     }
 
     shrinkSidebar = () => {
+=======
+    shouldComponentUpdate(nextProps, nextState) {
+        if (!Utils.areObjectsEqual(nextState.post, this.props.post)) {
+            return true;
+        }
+
+        if (nextProps.isFlagged !== this.props.isFlagged) {
+            return true;
+        }
+
+        if (nextState.dropdownOpened !== this.state.dropdownOpened) {
+            return true;
+        }
+
+        return false;
+    }
+
+    shrinkSidebar() {
+>>>>>>> Remove updateWindowDimensions references:components/search_results_item.jsx
         setTimeout(() => {
             this.props.shrink();
         });

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -104,31 +104,10 @@ export default class SearchResultsItem extends React.PureComponent {
         super(props);
 
         this.state = {
-<<<<<<< HEAD:components/search_results_item/search_results_item.jsx
-            width: '',
-            height: '',
-=======
-            currentTeamDisplayName: TeamStore.getCurrent().name,
->>>>>>> Remove updateWindowDimensions references:components/search_results_item.jsx
             dropdownOpened: false
         };
     }
 
-<<<<<<< HEAD:components/search_results_item/search_results_item.jsx
-    componentDidMount() {
-        window.addEventListener('resize', this.onUpdateWindowDimensions);
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener('resize', this.onUpdateWindowDimensions);
-    }
-
-    onUpdateWindowDimensions = () => {
-        Utils.updateWindowDimensions(this);
-    }
-
-    shrinkSidebar = () => {
-=======
     shouldComponentUpdate(nextProps, nextState) {
         if (!Utils.areObjectsEqual(nextState.post, this.props.post)) {
             return true;
@@ -164,7 +143,6 @@ export default class SearchResultsItem extends React.PureComponent {
     }
 
     shrinkSidebar() {
->>>>>>> Remove updateWindowDimensions references:components/search_results_item.jsx
         setTimeout(() => {
             this.props.shrink();
         });

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -150,16 +150,16 @@ export default class SearchResultsItem extends React.PureComponent {
     }
 
     componentDidMount() {
-        window.addEventListener('resize', this.setDimentions);
+        window.addEventListener('resize', this.setDimensions);
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', this.setDimentions);
+        window.removeEventListener('resize', this.setDimensions);
     }
 
-    setDimentions = () => {
+    setDimensions = () => {
         this.setState({
-            ...Utils.getWindowDimentions()
+            ...Utils.getWindowDimensions()
         });
     }
 

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -142,7 +142,25 @@ export default class SearchResultsItem extends React.PureComponent {
             return true;
         }
 
+        if ((this.state.width !== nextState.width) || this.state.height !== nextState.height) {
+            return true;
+        }
+
         return false;
+    }
+
+    componentDidMount() {
+        window.addEventListener('resize', this.setDimentions);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.setDimentions);
+    }
+
+    setDimentions = () => {
+        this.setState({
+            ...Utils.getWindowDimentions()
+        });
     }
 
     shrinkSidebar() {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1237,6 +1237,13 @@ export function windowHeight() {
     return $(window).height();
 }
 
+export function getWindowDimentions() {
+    return {
+        width: window.innerWidth,
+        height: window.innerHeight
+    };
+}
+
 export function getChannelTerm(channelType) {
     let channelTerm = 'Channel';
     if (channelType === Constants.PRIVATE_CHANNEL) {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1237,7 +1237,7 @@ export function windowHeight() {
     return $(window).height();
 }
 
-export function getWindowDimentions() {
+export function getWindowDimensions() {
     return {
         width: window.innerWidth,
         height: window.innerHeight

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1458,10 +1458,6 @@ export function isEmptyObject(object) {
     return false;
 }
 
-export function updateWindowDimensions(component) {
-    component.setState({width: window.innerWidth, height: window.innerHeight});
-}
-
 export function removePrefixFromLocalStorage(prefix) {
     const keys = [];
     for (let i = 0; i < localStorage.length; i++) {


### PR DESCRIPTION
#### Summary
Fix memory leak caused by post_time.jsx component.

Results are compared between release-4.5 branch and this commit. 
Note: Numbers might vary little depending on posts in thread.

Stats are for one of the two threads i was using for switch and same is being used for all comparisons.

Normal channel switch is about `3.4mb allocation` with `2.7mb retained` on every switch
![screen shot 2017-12-09 at 3 00 40 pm](https://user-images.githubusercontent.com/4973621/33794401-c432e8ea-dcf1-11e7-812b-388ebbb167dd.png)

With the PR almost `same memory is allocated` and about `415kb is retained`(Mostly less than this).

![screen shot 2017-12-09 at 2 40 36 pm](https://user-images.githubusercontent.com/4973621/33794404-d400e862-dcf1-11e7-908c-a8b8e1460af2.png)

![screen shot 2017-12-09 at 2 55 52 pm](https://user-images.githubusercontent.com/4973621/33794408-f709d35a-dcf1-11e7-80ac-de998fc1bb30.png)


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
