### PR TITLE
[E2E] Enable E2E at Jenkins with headless chrome only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run clean stop check-style run-unit emojis help
+.PHONY: build test test-e2e run clean stop check-style run-unit emojis help
 
 BUILD_SERVER_DIR = ../mattermost-server
 EMOJI_TOOLS_DIR = ./build/emoji
@@ -12,6 +12,11 @@ test: .yarninstall ## Runs tests
 	@echo Running jest unit/component testing
 
 	yarn run test
+
+test-e2e: .yarninstall ## Run end-to-end testing
+	@echo Running end-to-end testing
+
+	yarn run test:e2e
 
 .yarninstall: package.json
 	@echo Getting dependencies using yarn

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@ When filling in a section please remove the help text and the above text.
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 - [ ] Ran `make check-style` to check for style errors (required for all pull requests)
 - [ ] Ran `make test` to ensure unit and component tests passed
+- [ ] Ran `make test-e2e` to ensure end-to-end tests passed
 - [ ] Added or updated unit tests (required for all new features)
 - [ ] Has server changes (please link)
 - [ ] Has redux changes (please link)

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -12,6 +12,9 @@ node {
     stage('Unit/Component Tests') {
         sh 'make test'
     }
+    stage('End-to-End Tests') {
+        sh 'make test-e2e'
+    }
     stage('Build') {
         sh 'make build'
         sh 'make package'

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -46,7 +46,12 @@
                 "javascriptEnabled": true,
                 "acceptSslCerts": true,
                 "chromeOptions": {
-                    "args": ["window-position=0,0", "window-size=1920,1080", "--disable-popup-blocking"]
+                    "args": [
+                        "window-position=0,0",
+                        "window-size=1920,1080",
+                        "--disable-popup-blocking",
+                        "--headless"
+                    ]
                 }
             }
         },

--- a/tests/e2e/test.sh
+++ b/tests/e2e/test.sh
@@ -87,9 +87,6 @@ function local_tests {
     else
         message "E2E full local chrome starts..."
         nightwatch -e chrome --suiteRetries 1
-
-        message "E2E full local firefox starts..."
-        nightwatch -e firefox --skiptags tutorial --suiteRetries 1
     fi
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5614,9 +5614,9 @@ math-expression-evaluator@^1.2.14:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz#b357fa1ca9faefb8e48d10c14ef2bcb2d9f0a7c9"
 
-mattermost-redux@1.1.0:
+"mattermost-redux@https://github.com/mattermost/mattermost-redux.git#3688abb1a0b820305e371dfda38017b66ccf232e":
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mattermost-redux/-/mattermost-redux-1.1.0.tgz#176ea90457a6be4bffe6b0b05cbb2b2ba0afcf77"
+  resolved "https://github.com/mattermost/mattermost-redux.git#3688abb1a0b820305e371dfda38017b66ccf232e"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"


### PR DESCRIPTION
#### Summary
This PR enables end-to-end testing at Jenkins build. It uses headless chrome to run the testing.

#### Ticket Link
none

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Touches critical sections of the codebase (Jenkins build)
