### PR TITLE
Prevent text substitutions for suggestions that are outdated

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -275,11 +275,12 @@ export function emitSelectPreviousSuggestion(suggestionId) {
     });
 }
 
-export function emitCompleteWordSuggestion(suggestionId, term = '') {
+export function emitCompleteWordSuggestion(suggestionId, term = '', override = false) {
     AppDispatcher.handleViewAction({
         type: Constants.ActionTypes.SUGGESTION_COMPLETE_WORD,
         id: suggestionId,
-        term
+        term,
+        override
     });
 }
 

--- a/components/suggestion/command_provider.jsx
+++ b/components/suggestion/command_provider.jsx
@@ -36,6 +36,9 @@ export default class CommandProvider {
     handlePretextChanged(suggestionId, pretext) {
         if (pretext.startsWith('/')) {
             getSuggestedCommands(pretext.toLowerCase(), suggestionId, CommandSuggestion, pretext.toLowerCase());
+
+            return true;
         }
+        return false;
     }
 }

--- a/stores/suggestion_store.jsx
+++ b/stores/suggestion_store.jsx
@@ -295,6 +295,7 @@ class SuggestionStore extends EventEmitter {
             this.setSuggestionsPending(id, false);
 
             if (this.isCompletePending(id)) {
+                this.setCompletePending(id, false);
                 this.completeWord(id);
             } else {
                 this.emitSuggestionsChanged(id);
@@ -315,7 +316,7 @@ class SuggestionStore extends EventEmitter {
             this.emitSuggestionsChanged(id);
             break;
         case ActionTypes.SUGGESTION_COMPLETE_WORD:
-            if (this.areSuggestionsPending(id)) {
+            if (this.areSuggestionsPending(id) && !other.override) {
                 this.setCompletePending(id, true);
             } else {
                 this.completeWord(id, other.term, other.matchedPretext);


### PR DESCRIPTION
Also, clear `completePending` flag once message has been submitted

#### Summary
1. Fixes issue with SuggestionList not displaying after certain period
2. Fixes issue with suggestion terms repeating
`@user => @u@u@user`
`:thumbsup: :thu:thu:thu:`

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7647

### reproduced by typing `@here` and pressing [ENTER] immediately. this sets `completePending` to true and never gets reset on message submission

![dec-11-2017 17-12-57](https://user-images.githubusercontent.com/6182543/33856622-b002068e-de96-11e7-89da-3a40389d3f74.gif)

### reproduced by typing `@oned` <- notice the typo. the string substitution does not account for terms that become outdated

Another scenario is where a user completes the term before the suggestion returns back
1. type `@one`
2. on [ENTER] it adds a space after the autocompleted term `@one `
3. on `handleCompleteWord` it attempts to complete & replace a pretext that has been completed by the user, therefore, you end up with a similar situation with the result: `@one@one`

![dec-11-2017 17-14-18](https://user-images.githubusercontent.com/6182543/33856726-07b10d12-de97-11e7-9fba-444340275725.gif)