### PR TITLE
Remove tilde sign

### DIFF
--- a/tests/utils/formatting_channel_links.test.jsx
+++ b/tests/utils/formatting_channel_links.test.jsx
@@ -26,14 +26,14 @@ describe('TextFormatting.ChannelLinks', () => {
                 channelNamesMap: {'town-square': {display_name: 'Town Square'}},
                 team: {name: 'myteam'}
             }).trim(),
-            '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~Town Square</a></p>'
+            '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">Town Square</a></p>'
         );
         assert.equal(
             TextFormatting.formatText('~town-square.', {
                 channelNamesMap: {'town-square': {display_name: 'Town Square'}},
                 team: {name: 'myteam'}
             }).trim(),
-            '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~Town Square</a>.</p>'
+            '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">Town Square</a>.</p>'
         );
 
         assert.equal(
@@ -41,7 +41,7 @@ describe('TextFormatting.ChannelLinks', () => {
                 channelNamesMap: {'town-square': {display_name: '<b>Reception</b>'}},
                 team: {name: 'myteam'}
             }).trim(),
-            '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~&lt;b&gt;Reception&lt;/b&gt;</a></p>'
+            '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">&lt;b&gt;Reception&lt;/b&gt;</a></p>'
         );
 
         done();

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -187,7 +187,7 @@ function autolinkChannelMentions(text, tokens, channelNamesMap, team) {
         }
 
         tokens.set(alias, {
-            value: `<a class="mention-link" href="${href}" data-channel-mention="${channelName}">~${displayName}</a>`,
+            value: `<a class="mention-link" href="${href}" data-channel-mention="${channelName}">${displayName}</a>`,
             originalText: mention
         });
         return alias;


### PR DESCRIPTION
webapp prepends a tilde `~` when displaying Channel Links, meanwhile mobile does not.

This ticket cleans up the matches the mobile Channel Link format.

### before
<img width="378" alt="screen shot 2017-12-11 at 5 40 30 pm" src="https://user-images.githubusercontent.com/6182543/33857638-78f83038-de9a-11e7-8114-a61b982c2be1.png">


### after
<img width="413" alt="screen shot 2017-12-07 at 2 56 55 pm" src="https://user-images.githubusercontent.com/6182543/33857633-738d8cf6-de9a-11e7-9ec8-10ce8883eacf.png">