### PR TITLE
PLT-8358 Fixed editing a post after too late not showing an error

### DIFF
--- a/actions/views/edit_post_modal.js
+++ b/actions/views/edit_post_modal.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import * as PostActions from 'mattermost-redux/actions/posts';
+
+import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
+
+import {ActionTypes} from 'utils/constants.jsx';
+
+export function editPost(post) {
+    return async (dispatch, getState) => {
+        const result = await PostActions.editPost(post)(dispatch, getState);
+
+        if (result.error) {
+            AppDispatcher.handleServerAction({
+                type: ActionTypes.RECEIVED_ERROR,
+                err: {
+                    id: result.error.server_error_id,
+                    ...result.error
+                }
+            });
+        }
+
+        return result;
+    };
+}

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -160,7 +160,7 @@ export default class EditPostModal extends React.PureComponent {
 
         this.props.actions.addMessageIntoHistory(updatedPost.message);
 
-        const data = await this.props.actions.editPost(updatedPost);
+        const {data} = await this.props.actions.editPost(updatedPost);
         if (data) {
             window.scrollTo(0, 0);
         }

--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -3,12 +3,16 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+
+import {addMessageIntoHistory} from 'mattermost-redux/actions/posts';
 import {Preferences} from 'mattermost-redux/constants';
+import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
-import {getEditingPost} from 'selectors/posts';
+
 import {setEditingPost} from 'actions/post_actions';
-import {editPost, addMessageIntoHistory} from 'mattermost-redux/actions/posts';
+import {editPost} from 'actions/views/edit_post_modal';
+
+import {getEditingPost} from 'selectors/posts';
 
 import EditPostModal from './edit_post_modal.jsx';
 
@@ -22,13 +26,12 @@ function mapStateToProps(state, ownProps) {
     };
 }
 
-
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             editPost,
             setEditingPost,
-            addMessageIntoHistory,
+            addMessageIntoHistory
         }, dispatch)
     };
 }

--- a/tests/components/edit_post_modal.test.jsx
+++ b/tests/components/edit_post_modal.test.jsx
@@ -304,7 +304,9 @@ describe('comoponents/edit_post_modal/edit_post_modal.jsx', () => {
 
     it('should scroll up when editPost return data', async () => {
         const actions = {
-            editPost: jest.fn((data) => data),
+            editPost: jest.fn((data) => {
+                return {data};
+            }),
             addMessageIntoHistory: jest.fn(),
             setEditingPost: jest.fn()
         };


### PR DESCRIPTION
When moving this modal to redux, we stopped using PostActions.updatePost which had threw any error to the error bar. This re-adds it in a react-friendly way

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8358