### PR TITLE
PLT-8333  Fix endCount in the searchable user list model's pagination

### DIFF
--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -127,7 +127,8 @@ export default class SearchableUserList extends React.Component {
             endCount = -1;
         } else {
             startCount = this.props.page * this.props.usersPerPage;
-            endCount = startCount + count;
+            endCount = startCount + this.props.usersPerPage;
+            endCount = endCount > total ? total : endCount;
         }
 
         if (this.props.renderCount) {

--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -127,8 +127,7 @@ export default class SearchableUserList extends React.Component {
             endCount = -1;
         } else {
             startCount = this.props.page * this.props.usersPerPage;
-            endCount = startCount + this.props.usersPerPage;
-            endCount = endCount > total ? total : endCount;
+            endCount = Math.min(startCount + this.props.usersPerPage, total);
         }
 
         if (this.props.renderCount) {


### PR DESCRIPTION
#### Summary
In the searchable user list modal, it now computes `endCount` without having to rely on network requests. On a per page basis this was causing a race case where the pagination would show 50 - 96 then show 50 - 100 half a second later.  Its due to `count` being computed by the incoming network request per page which was being used to compute `endCount`. This is redundant and we can instead compute `endCount` based on the current page number and the total number of users of the team / channel (see code).  [Closes mattermost-server#7964](https://github.com/mattermost/mattermost-server/issues/7964)

#### Ticket Link

- [Jira PLT-8333](https://mattermost.atlassian.net/browse/PLT-8333)
- https://github.com/mattermost/mattermost-server/issues/7964

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] ~~Added or updated unit tests (required for all new features)~~
- [x] ~~Has server changes (please link)~~
- [x] ~~Has redux changes (please link)~~
- [x] ~~Has UI changes~~
- [x] ~~Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates~~
- [x] ~~Touches critical sections of the codebase (auth, posting, etc.)~~
