### PR TITLE
[PLT-8359] Clear announcement localStorage on logout, and add StoragePrefixes constants

### DIFF
--- a/components/announcement_bar/announcement_bar.jsx
+++ b/components/announcement_bar/announcement_bar.jsx
@@ -11,7 +11,7 @@ import AnalyticsStore from 'stores/analytics_store.jsx';
 import ErrorStore from 'stores/error_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
-import {ErrorBarTypes, StatTypes} from 'utils/constants.jsx';
+import {ErrorBarTypes, StatTypes, StoragePrefixes} from 'utils/constants.jsx';
 import {displayExpiryDate, isLicenseExpired, isLicenseExpiring, isLicensePastGracePeriod} from 'utils/license_utils.jsx';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -21,8 +21,6 @@ const RENEWAL_LINK = 'https://licensing.mattermost.com/renew';
 const BAR_DEVELOPER_TYPE = 'developer';
 const BAR_CRITICAL_TYPE = 'critical';
 const BAR_ANNOUNCEMENT_TYPE = 'announcement';
-
-const ANNOUNCEMENT_KEY = 'announcement--';
 
 export default class AnnouncementBar extends React.PureComponent {
     static propTypes = {
@@ -81,19 +79,20 @@ export default class AnnouncementBar extends React.PureComponent {
 
     getState() {
         const error = ErrorStore.getLastError();
-        if (error) {
+        if (error && Object.keys(error).length > 0 && error.message && error.type) {
             return {message: error.message, color: null, textColor: null, type: error.type, allowDismissal: true};
         }
 
         const bannerText = global.window.mm_config.BannerText || '';
         const allowDismissal = global.window.mm_config.AllowBannerDismissal === 'true';
-        const bannerDismissed = localStorage.getItem(ANNOUNCEMENT_KEY + global.window.mm_config.BannerText);
+        const bannerDismissed = localStorage.getItem(StoragePrefixes.ANNOUNCEMENT + global.window.mm_config.BannerText);
 
         if (global.window.mm_config.EnableBanner === 'true' &&
-                bannerText.length > 0 &&
-                (!bannerDismissed || !allowDismissal)) {
+            bannerText.length > 0 &&
+            (!bannerDismissed || !allowDismissal)
+        ) {
             // Remove old local storage items
-            Utils.removePrefixFromLocalStorage(ANNOUNCEMENT_KEY);
+            Utils.removePrefixFromLocalStorage(StoragePrefixes.ANNOUNCEMENT);
             return {
                 message: bannerText,
                 color: global.window.mm_config.BannerColor,
@@ -168,7 +167,7 @@ export default class AnnouncementBar extends React.PureComponent {
         }
 
         if (this.state.type === BAR_ANNOUNCEMENT_TYPE) {
-            localStorage.setItem(ANNOUNCEMENT_KEY + this.state.message, true);
+            localStorage.setItem(StoragePrefixes.ANNOUNCEMENT + this.state.message, true);
         }
 
         if (ErrorStore.getLastError() && ErrorStore.getLastError().notification) {

--- a/components/root.jsx
+++ b/components/root.jsx
@@ -17,7 +17,7 @@ import BrowserStore from 'stores/browser_store.jsx';
 import LocalizationStore from 'stores/localization_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
-import Constants from 'utils/constants.jsx';
+import Constants, {StoragePrefixes} from 'utils/constants.jsx';
 
 export default class Root extends React.Component {
     constructor(props) {
@@ -58,7 +58,7 @@ export default class Root extends React.Component {
         // Force logout of all tabs if one tab is logged out
         $(window).bind('storage', (e) => {
             // when one tab on a browser logs out, it sets __logout__ in localStorage to trigger other tabs to log out
-            if (e.originalEvent.key === '__logout__' && e.originalEvent.storageArea === localStorage && e.originalEvent.newValue) {
+            if (e.originalEvent.key === StoragePrefixes.LOGOUT && e.originalEvent.storageArea === localStorage && e.originalEvent.newValue) {
                 // make sure it isn't this tab that is sending the logout signal (only necessary for IE11)
                 if (BrowserStore.isSignallingLogout(e.originalEvent.newValue)) {
                     return;
@@ -68,7 +68,7 @@ export default class Root extends React.Component {
                 GlobalActions.emitUserLoggedOutEvent('/', false);
             }
 
-            if (e.originalEvent.key === '__login__' && e.originalEvent.storageArea === localStorage && e.originalEvent.newValue) {
+            if (e.originalEvent.key === StoragePrefixes.LOGIN && e.originalEvent.storageArea === localStorage && e.originalEvent.newValue) {
                 // make sure it isn't this tab that is sending the logout signal (only necessary for IE11)
                 if (BrowserStore.isSignallingLogin(e.originalEvent.newValue)) {
                     return;

--- a/stores/browser_store.jsx
+++ b/stores/browser_store.jsx
@@ -8,7 +8,7 @@ import * as Actions from 'actions/storage';
 
 import store from 'stores/redux_store.jsx';
 
-import {ErrorPageTypes} from 'utils/constants.jsx';
+import {ErrorPageTypes, StoragePrefixes} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 const dispatch = store.dispatch;
@@ -44,14 +44,16 @@ class BrowserStoreClass {
             // PLT-1285 store an identifier in session storage so we can catch if the logout came from this tab on IE11
             const logoutId = Utils.generateId();
 
-            sessionStorage.setItem('__logout__', logoutId);
-            localStorage.setItem('__logout__', logoutId);
-            localStorage.removeItem('__logout__');
+            Utils.removePrefixFromLocalStorage(StoragePrefixes.ANNOUNCEMENT);
+
+            sessionStorage.setItem(StoragePrefixes.LOGOUT, logoutId);
+            localStorage.setItem(StoragePrefixes.LOGOUT, logoutId);
+            localStorage.removeItem(StoragePrefixes.LOGOUT);
         }
     }
 
     isSignallingLogout(logoutId) {
-        return logoutId === sessionStorage.getItem('__logout__');
+        return logoutId === sessionStorage.getItem(StoragePrefixes.LOGOUT);
     }
 
     signalLogin() {
@@ -59,14 +61,14 @@ class BrowserStoreClass {
             // PLT-1285 store an identifier in session storage so we can catch if the logout came from this tab on IE11
             const loginId = Utils.generateId();
 
-            sessionStorage.setItem('__login__', loginId);
-            localStorage.setItem('__login__', loginId);
-            localStorage.removeItem('__login__');
+            sessionStorage.setItem(StoragePrefixes.LOGIN, loginId);
+            localStorage.setItem(StoragePrefixes.LOGIN, loginId);
+            localStorage.removeItem(StoragePrefixes.LOGIN);
         }
     }
 
     isSignallingLogin(loginId) {
-        return loginId === sessionStorage.getItem('__login__');
+        return loginId === sessionStorage.getItem(StoragePrefixes.LOGIN);
     }
 
     /**

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -352,7 +352,10 @@ export const StorageTypes = keyMirror({
 
 export const StoragePrefixes = {
     EMBED_VISIBLE: 'isVisible_',
-    COMMENT_DRAFT: 'comment_draft_'
+    COMMENT_DRAFT: 'comment_draft_',
+    LOGOUT: '__logout__',
+    LOGIN: '__login__',
+    ANNOUNCEMENT: '__announcement__'
 };
 
 export const ErrorPageTypes = {


### PR DESCRIPTION
#### Summary
- Clear announcement localStorage on logout
- add StoragePrefixes constants ('__logout__', '__login__', '__announcement__')

#### Ticket Link
Jira ticket: [PLT-8359](https://mattermost.atlassian.net/browse/PLT-8359)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
