### PR TITLE
[PLT-8339] Fix header link to be clickable on mobile web view

### DIFF
--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -24,7 +24,7 @@ import UserStore from 'stores/user_store.jsx';
 import WebrtcStore from 'stores/webrtc_store.jsx';
 
 import * as ChannelUtils from 'utils/channel_utils.jsx';
-import {ActionTypes, Constants, UserStatuses, RHSStates} from 'utils/constants.jsx';
+import {ActionTypes, Constants, ModalIdentifiers, RHSStates, UserStatuses} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import ChannelInfoModal from 'components/channel_info_modal';
@@ -437,6 +437,7 @@ export default class Navbar extends React.Component {
                     <li role='presentation'>
                         <ToggleModalButtonRedux
                             role='menuitem'
+                            modalId={ModalIdentifiers.CHANNEL_INFO}
                             dialogType={ChannelInfoModal}
                             dialogProps={{channel}}
                         >

--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -39,6 +39,7 @@ import QuickSwitchModal from 'components/quick_switch_modal';
 import RenameChannelModal from 'components/rename_channel_modal';
 import StatusIcon from 'components/status_icon.jsx';
 import ToggleModalButton from 'components/toggle_modal_button.jsx';
+import ToggleModalButtonRedux from 'components/toggle_modal_button_redux';
 
 import Pluggable from 'plugins/pluggable';
 
@@ -434,7 +435,7 @@ export default class Navbar extends React.Component {
             } else {
                 viewInfoOption = (
                     <li role='presentation'>
-                        <ToggleModalButton
+                        <ToggleModalButtonRedux
                             role='menuitem'
                             dialogType={ChannelInfoModal}
                             dialogProps={{channel}}
@@ -443,7 +444,7 @@ export default class Navbar extends React.Component {
                                 id='navbar.viewInfo'
                                 defaultMessage='View Info'
                             />
-                        </ToggleModalButton>
+                        </ToggleModalButtonRedux>
                     </li>
                 );
 

--- a/tests/components/navbar/__snapshots__/navbar.test.jsx.snap
+++ b/tests/components/navbar/__snapshots__/navbar.test.jsx.snap
@@ -129,6 +129,7 @@ exports[`components/navbar/Navbar should match snapshot, for private channel 1`]
                     }
                   }
                   dialogType={[Function]}
+                  modalId="channel_info"
                   role="menuitem"
                 >
                   <FormattedMessage
@@ -492,6 +493,7 @@ exports[`components/navbar/Navbar should match snapshot, if WebRTC is not enable
                     }
                   }
                   dialogType={[Function]}
+                  modalId="channel_info"
                   role="menuitem"
                 >
                   <FormattedMessage
@@ -1055,6 +1057,7 @@ exports[`components/navbar/Navbar should match snapshot, if not licensed 1`] = `
                     }
                   }
                   dialogType={[Function]}
+                  modalId="channel_info"
                   role="menuitem"
                 >
                   <FormattedMessage
@@ -1420,6 +1423,7 @@ exports[`components/navbar/Navbar should match snapshot, valid state 1`] = `
                     }
                   }
                   dialogType={[Function]}
+                  modalId="channel_info"
                   role="menuitem"
                 >
                   <FormattedMessage

--- a/tests/components/navbar/__snapshots__/navbar.test.jsx.snap
+++ b/tests/components/navbar/__snapshots__/navbar.test.jsx.snap
@@ -118,8 +118,7 @@ exports[`components/navbar/Navbar should match snapshot, for private channel 1`]
               <li
                 role="presentation"
               >
-                <ModalToggleButton
-                  className=""
+                <Connect(ModalToggleButtonRedux)
                   dialogProps={
                     Object {
                       "channel": Object {
@@ -137,7 +136,7 @@ exports[`components/navbar/Navbar should match snapshot, for private channel 1`]
                     id="navbar.viewInfo"
                     values={Object {}}
                   />
-                </ModalToggleButton>
+                </Connect(ModalToggleButtonRedux)>
               </li>
               <li
                 role="presentation"
@@ -482,8 +481,7 @@ exports[`components/navbar/Navbar should match snapshot, if WebRTC is not enable
               <li
                 role="presentation"
               >
-                <ModalToggleButton
-                  className=""
+                <Connect(ModalToggleButtonRedux)
                   dialogProps={
                     Object {
                       "channel": Object {
@@ -501,7 +499,7 @@ exports[`components/navbar/Navbar should match snapshot, if WebRTC is not enable
                     id="navbar.viewInfo"
                     values={Object {}}
                   />
-                </ModalToggleButton>
+                </Connect(ModalToggleButtonRedux)>
               </li>
               <li
                 role="presentation"
@@ -1046,8 +1044,7 @@ exports[`components/navbar/Navbar should match snapshot, if not licensed 1`] = `
               <li
                 role="presentation"
               >
-                <ModalToggleButton
-                  className=""
+                <Connect(ModalToggleButtonRedux)
                   dialogProps={
                     Object {
                       "channel": Object {
@@ -1065,7 +1062,7 @@ exports[`components/navbar/Navbar should match snapshot, if not licensed 1`] = `
                     id="navbar.viewInfo"
                     values={Object {}}
                   />
-                </ModalToggleButton>
+                </Connect(ModalToggleButtonRedux)>
               </li>
               <li
                 role="presentation"
@@ -1412,8 +1409,7 @@ exports[`components/navbar/Navbar should match snapshot, valid state 1`] = `
               <li
                 role="presentation"
               >
-                <ModalToggleButton
-                  className=""
+                <Connect(ModalToggleButtonRedux)
                   dialogProps={
                     Object {
                       "channel": Object {
@@ -1431,7 +1427,7 @@ exports[`components/navbar/Navbar should match snapshot, valid state 1`] = `
                     id="navbar.viewInfo"
                     values={Object {}}
                   />
-                </ModalToggleButton>
+                </Connect(ModalToggleButtonRedux)>
               </li>
               <li
                 role="presentation"


### PR DESCRIPTION
#### Summary
- Fix header link to be clickable on mobile web view by changing `ToggleModalButton` to `ToggleModalButtonRedux`. There might be something with React-16 that made the former component failed to propagate click event.

Note: I'll submit separate PR to master changing all `ToggleModalButton` to `ToggleModalButtonRedux`.

#### Ticket Link
Jira ticket: [PLT-8339](https://mattermost.atlassian.net/browse/PLT-8339)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
