### PR TITLE
[PLT-8342] DM with yourself doesn't say "(you)" in header on mobile web

### DIFF
--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -819,7 +819,19 @@ export default class Navbar extends React.Component {
             if (channel.type === Constants.DM_CHANNEL) {
                 isDirect = true;
                 const teammateId = Utils.getUserIdFromChannelName(channel);
-                channelTitle = Utils.displayUsername(teammateId);
+                if (currentId === teammateId) {
+                    channelTitle = (
+                        <FormattedMessage
+                            id='channel_header.directchannel.you'
+                            defaultMessage='{displayname} (you) '
+                            values={{
+                                displayname: Utils.displayUsername(teammateId)
+                            }}
+                        />
+                    );
+                } else {
+                    channelTitle = Utils.displayUsername(teammateId);
+                }
             } else if (channel.type === Constants.GM_CHANNEL) {
                 isGroup = true;
             }


### PR DESCRIPTION
#### Summary
DM with yourself doesn't say "(you)" in header on mobile web

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/PLT-8342

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes

