### PR TITLE
PLT-8244 Prevented web app from loading before storage is loaded

### DIFF
--- a/components/create_post.jsx
+++ b/components/create_post.jsx
@@ -78,16 +78,15 @@ export default class CreatePost extends React.Component {
 
         const channel = ChannelStore.getCurrent();
         const channelId = channel.id;
-        const draft = PostStore.getDraft(channelId);
         const stats = ChannelStore.getCurrentStats();
         const members = stats.member_count - 1;
 
         this.state = {
             channelId,
             channel,
-            message: draft.message,
-            uploadsInProgress: draft.uploadsInProgress,
-            fileInfos: draft.fileInfos,
+            message: '', // These are loaded in componentWillMount
+            uploadsInProgress: [],
+            fileInfos: [],
             submitting: false,
             ctrlSend: PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
             fullWidthTextBox: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
@@ -422,6 +421,14 @@ export default class CreatePost extends React.Component {
             fullWidthTextBox: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
             showTutorialTip: tutorialStep === TutorialSteps.POST_POPOVER,
             enableSendButton
+        });
+
+        const draft = PostStore.getDraft(this.state.channelId);
+
+        this.setState({
+            message: draft.message,
+            uploadsInProgress: draft.uploadsInProgress,
+            fileInfos: draft.fileInfos
         });
     }
 

--- a/components/persist_gate/index.js
+++ b/components/persist_gate/index.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import PersistGate from './persist_gate';
+
+function mapStateToProps(state) {
+    return {
+        initialized: state.storage.initialized
+    };
+}
+
+export default connect(mapStateToProps)(PersistGate);

--- a/components/persist_gate/persist_gate.js
+++ b/components/persist_gate/persist_gate.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// This component mirrors redux-persist v5's PersistGate component, but it
+// is built to support redux-persist v4 which we use
+export default class PersistGate extends React.PureComponent {
+    static propTypes = {
+
+        /**
+         * Whether or not the local storage has been initialized
+         */
+        initialized: PropTypes.bool.isRequired,
+
+        /**
+         * What to show while waiting for local storage to be initialized
+         */
+        loading: PropTypes.node,
+
+        /**
+         * The children that will be rendered once storage has been initialized
+         */
+        children: PropTypes.node.isRequired
+    };
+
+    render() {
+        if (!this.props.initialized) {
+            return this.props.loading;
+        }
+
+        return this.props.children;
+    }
+}

--- a/reducers/storage.js
+++ b/reducers/storage.js
@@ -1,9 +1,13 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import {combineReducers} from 'redux';
+
+import {General} from 'mattermost-redux/constants';
+
 import {StorageTypes} from 'utils/constants';
 
-export default function storage(state = {}, action) {
+function storage(state = {}, action) {
     const nextState = {...state};
     var key;
 
@@ -59,3 +63,18 @@ export default function storage(state = {}, action) {
         return state;
     }
 }
+
+function initialized(state = false, action) {
+    switch (action.type) {
+    case General.STORE_REHYDRATION_COMPLETE:
+        return state || action.complete;
+
+    default:
+        return state;
+    }
+}
+
+export default combineReducers({
+    storage,
+    initialized
+});

--- a/root.jsx
+++ b/root.jsx
@@ -12,6 +12,7 @@ import PDFJS from 'pdfjs-dist';
 
 import * as Websockets from 'actions/websocket_actions.jsx';
 import {loadMeAndConfig} from 'actions/user_actions.jsx';
+import PersistGate from 'components/persist_gate';
 import ChannelStore from 'stores/channel_store.jsx';
 import * as I18n from 'i18n/i18n.jsx';
 import {initializePlugins} from 'plugins';
@@ -118,10 +119,12 @@ function preRenderSetup(callwhendone) {
 function renderRootComponent() {
     ReactDOM.render((
         <Provider store={store}>
-            <Router
-                history={browserHistory}
-                routes={rRoot}
-            />
+            <PersistGate loading={null}>
+                <Router
+                    history={browserHistory}
+                    routes={rRoot}
+                />
+            </PersistGate>
         </Provider>
     ),
     document.getElementById('root'));

--- a/selectors/rhs.jsx
+++ b/selectors/rhs.jsx
@@ -66,7 +66,7 @@ export function makeGetCommentDraft(rootId) {
 
 export function makeGetPostsEmbedVisibleObj() {
     return createSelector(
-        (state) => state.storage,
+        (state) => state.storage.storage,
         (state) => getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.COLLAPSE_DISPLAY, Preferences.COLLAPSE_DISPLAY_DEFAULT),
         (state, posts) => posts,
         (storage, previewCollapsed, posts) => {

--- a/selectors/storage.js
+++ b/selectors/storage.js
@@ -4,9 +4,12 @@
 import {getPrefix} from 'utils/storage_utils';
 
 function getGlobalItem(state, name, defaultValue) {
-    if (state && state.storage && typeof state.storage[name] !== 'undefined' && state.storage[name] !== null) {
-        return state.storage[name];
+    const storage = state && state.storage && state.storage.storage;
+
+    if (storage && storage[name] !== 'undefined' && storage[name] !== null) {
+        return storage[name];
     }
+
     return defaultValue;
 }
 
@@ -26,5 +29,6 @@ export function getItemFromStorage(storage, name, defaultValue) {
     if (storage && typeof storage[name] !== 'undefined' && storage[name] !== null) {
         return storage[name];
     }
+
     return defaultValue;
 }

--- a/selectors/storage.js
+++ b/selectors/storage.js
@@ -6,7 +6,7 @@ import {getPrefix} from 'utils/storage_utils';
 function getGlobalItem(state, name, defaultValue) {
     const storage = state && state.storage && state.storage.storage;
 
-    if (storage && storage[name] !== 'undefined' && storage[name] !== null) {
+    if (storage && typeof storage[name] !== 'undefined' && storage[name] !== null) {
         return storage[name];
     }
 

--- a/store/index.js
+++ b/store/index.js
@@ -152,8 +152,8 @@ export default function configureStore(initialState, persistorStorage = null) {
             _stateIterator: (collection, callback) => {
                 return Object.keys(collection).forEach((key) => {
                     if (key === 'storage') {
-                        Object.keys(collection[key]).forEach((subkey) => {
-                            callback(collection[key][subkey], key+":"+subkey)
+                        Object.keys(collection.storage.storage).forEach((storageKey) => {
+                            callback(collection.storage.storage[storageKey], 'storage:' + storageKey)
                         })
                     } else {
                         callback(collection[key], key)
@@ -162,15 +162,15 @@ export default function configureStore(initialState, persistorStorage = null) {
             },
             _stateGetter: (state, key) => {
                 if (key.indexOf('storage:') == 0) {
-                    state.storage = state.storage || {};
-                    return state.storage[key.substr(8)];
+                    state.storage = state.storage || {storage: {}};
+                    return state.storage.storage[key.substr(8)];
                 }
                 return state[key];
             },
             _stateSetter: (state, key, value) => {
                 if (key.indexOf('storage:') == 0) {
-                    state.storage = state.storage || {};
-                    state.storage[key.substr(8)] = value;
+                    state.storage = state.storage || {storage: {}};
+                    state.storage.storage[key.substr(8)] = value;
                 }
                 state[key] = value;
                 return state;

--- a/tests/redux/actions/storage.test.js
+++ b/tests/redux/actions/storage.test.js
@@ -16,7 +16,7 @@ describe('Actions.Storage', () => {
     it('setItem', async () => {
         await Actions.setItem('test', 'value')(store.dispatch, store.getState);
         assert.deepEqual(
-            store.getState().storage,
+            store.getState().storage.storage,
             {unknown_test: 'value'}
         );
     });
@@ -25,7 +25,7 @@ describe('Actions.Storage', () => {
         await Actions.setItem('test1', 'value1')(store.dispatch, store.getState);
         await Actions.setItem('test2', 'value2')(store.dispatch, store.getState);
         assert.deepEqual(
-            store.getState().storage,
+            store.getState().storage.storage,
             {
                 unknown_test1: 'value1',
                 unknown_test2: 'value2'
@@ -33,7 +33,7 @@ describe('Actions.Storage', () => {
         );
         await Actions.removeItem('test1')(store.dispatch, store.getState);
         assert.deepEqual(
-            store.getState().storage,
+            store.getState().storage.storage,
             {unknown_test2: 'value2'}
         );
     });
@@ -41,7 +41,7 @@ describe('Actions.Storage', () => {
     it('setGlobalItem', async () => {
         await Actions.setGlobalItem('test', 'value')(store.dispatch, store.getState);
         assert.deepEqual(
-            store.getState().storage,
+            store.getState().storage.storage,
             {test: 'value'}
         );
     });
@@ -50,7 +50,7 @@ describe('Actions.Storage', () => {
         await Actions.setGlobalItem('test1', 'value1')(store.dispatch, store.getState);
         await Actions.setGlobalItem('test2', 'value2')(store.dispatch, store.getState);
         assert.deepEqual(
-            store.getState().storage,
+            store.getState().storage.storage,
             {
                 test1: 'value1',
                 test2: 'value2'
@@ -58,7 +58,7 @@ describe('Actions.Storage', () => {
         );
         await Actions.removeGlobalItem('test1')(store.dispatch, store.getState);
         assert.deepEqual(
-            store.getState().storage,
+            store.getState().storage.storage,
             {test2: 'value2'}
         );
     });
@@ -99,7 +99,7 @@ describe('Actions.Storage', () => {
         await Actions.setGlobalItem('excluded', 'not-cleared')(store.dispatch, store.getState);
         await Actions.clear({exclude: ['excluded']})(store.dispatch, store.getState);
         assert.deepEqual(
-            store.getState().storage,
+            store.getState().storage.storage,
             {excluded: 'not-cleared'}
         );
     });
@@ -111,17 +111,17 @@ describe('Actions.Storage', () => {
         };
         await Actions.storageRehydrate({test: "123"})(store.dispatch, persistor);
         assert.deepEqual(
-            store.getState().storage,
+            store.getState().storage.storage,
             {test: '123'}
         );
         await Actions.storageRehydrate({test: "456"})(store.dispatch, persistor);
         assert.deepEqual(
-            store.getState().storage,
+            store.getState().storage.storage,
             {test: '456'}
         );
         await Actions.storageRehydrate({test2: "789"})(store.dispatch, persistor);
         assert.deepEqual(
-            store.getState().storage,
+            store.getState().storage.storage,
             {test: '456', test2: '789'}
         );
     });

--- a/tests/redux/actions/views/create_comment.test.jsx
+++ b/tests/redux/actions/views/create_comment.test.jsx
@@ -5,10 +5,10 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import {
-  addReaction,
-  removeReaction,
-  addMessageIntoHistory,
-  moveHistoryIndexBack
+    addReaction,
+    removeReaction,
+    addMessageIntoHistory,
+    moveHistoryIndexBack
 } from 'mattermost-redux/actions/posts';
 
 import {Posts} from 'mattermost-redux/constants';
@@ -314,10 +314,12 @@ describe('rhs view actions', () => {
             store = mockStore({
                 ...initialState,
                 storage: {
-                    [`${StoragePrefixes.COMMENT_DRAFT}${latestPostId}`]: {
-                        message: '+:smile:',
-                        fileInfos: [],
-                        uploadsInProgress: []
+                    storage: {
+                        [`${StoragePrefixes.COMMENT_DRAFT}${latestPostId}`]: {
+                            message: '+:smile:',
+                            fileInfos: [],
+                            uploadsInProgress: []
+                        }
                     }
                 }
             });

--- a/tests/redux/reducers/storage.test.js
+++ b/tests/redux/reducers/storage.test.js
@@ -9,7 +9,9 @@ import {StorageTypes} from 'utils/constants';
 describe('Reducers.Storage', () => {
     it('Storage.SET_ITEM', async () => {
         const nextState = storageReducer(
-            {},
+            {
+                storage: {}
+            },
             {
                 type: StorageTypes.SET_ITEM,
                 data: {
@@ -20,7 +22,7 @@ describe('Reducers.Storage', () => {
             }
         );
         assert.deepEqual(
-            nextState,
+            nextState.storage,
             {
                 user_id_key: 'value'
             }
@@ -29,7 +31,9 @@ describe('Reducers.Storage', () => {
 
     it('Storage.SET_GLOBAL_ITEM', async () => {
         const nextState = storageReducer(
-            {},
+            {
+                storage: {}
+            },
             {
                 type: StorageTypes.SET_GLOBAL_ITEM,
                 data: {
@@ -39,7 +43,7 @@ describe('Reducers.Storage', () => {
             }
         );
         assert.deepEqual(
-            nextState,
+            nextState.storage,
             {
                 key: 'value'
             }
@@ -49,7 +53,9 @@ describe('Reducers.Storage', () => {
     it('Storage.REMOVE_ITEM', async () => {
         var nextState = storageReducer(
             {
-                user_id_key: 'value'
+                storage: {
+                    user_id_key: 'value'
+                }
             },
             {
                 type: StorageTypes.REMOVE_ITEM,
@@ -60,11 +66,13 @@ describe('Reducers.Storage', () => {
             }
         );
         assert.deepEqual(
-            nextState,
+            nextState.storage,
             {}
         );
         nextState = storageReducer(
-            {},
+            {
+                storage: {}
+            },
             {
                 type: StorageTypes.REMOVE_ITEM,
                 data: {
@@ -74,7 +82,7 @@ describe('Reducers.Storage', () => {
             }
         );
         assert.deepEqual(
-            nextState,
+            nextState.storage,
             {}
         );
     });
@@ -82,7 +90,9 @@ describe('Reducers.Storage', () => {
     it('Storage.REMOVE_GLOBAL_ITEM', async () => {
         var nextState = storageReducer(
             {
-                key: 'value'
+                storage: {
+                    key: 'value'
+                }
             },
             {
                 type: StorageTypes.REMOVE_GLOBAL_ITEM,
@@ -92,11 +102,13 @@ describe('Reducers.Storage', () => {
             }
         );
         assert.deepEqual(
-            nextState,
+            nextState.storage,
             {}
         );
         nextState = storageReducer(
-            {},
+            {
+                storage: {}
+            },
             {
                 type: StorageTypes.REMOVE_GLOBAL_ITEM,
                 data: {
@@ -105,7 +117,7 @@ describe('Reducers.Storage', () => {
             }
         );
         assert.deepEqual(
-            nextState,
+            nextState.storage,
             {}
         );
     });
@@ -113,8 +125,10 @@ describe('Reducers.Storage', () => {
     it('Storage.CLEAR', async () => {
         const nextState = storageReducer(
             {
-                key: 'value',
-                excluded: 'not-cleared'
+                storage: {
+                    key: 'value',
+                    excluded: 'not-cleared'
+                }
             },
             {
                 type: StorageTypes.CLEAR,
@@ -124,7 +138,7 @@ describe('Reducers.Storage', () => {
             }
         );
         assert.deepEqual(
-            nextState,
+            nextState.storage,
             {
                 excluded: 'not-cleared'
             }
@@ -135,9 +149,11 @@ describe('Reducers.Storage', () => {
         var touchedPairs = [];
         storageReducer(
             {
-                user_id_prefix_key1: 1,
-                user_id_prefix_key2: 2,
-                user_id_not_prefix_key: 3
+                storage: {
+                    user_id_prefix_key1: 1,
+                    user_id_prefix_key2: 2,
+                    user_id_not_prefix_key: 3
+                }
             },
             {
                 type: StorageTypes.ACTION_ON_ITEMS_WITH_PREFIX,
@@ -158,9 +174,11 @@ describe('Reducers.Storage', () => {
         var touchedPairs = [];
         storageReducer(
             {
-                prefix_key1: 1,
-                prefix_key2: 2,
-                not_prefix_key: 3
+                storage: {
+                    prefix_key1: 1,
+                    prefix_key2: 2,
+                    not_prefix_key: 3
+                }
             },
             {
                 type: StorageTypes.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX,
@@ -178,14 +196,16 @@ describe('Reducers.Storage', () => {
 
     it('Storage.STORAGE_REHYDRATE', async () => {
         var nextState = storageReducer(
-            {},
+            {
+                storage: {}
+            },
             {
                 type: StorageTypes.STORAGE_REHYDRATE,
                 data: {test: '123'}
             }
         );
         assert.deepEqual(
-            nextState,
+            nextState.storage,
             {test: '123'}
         );
         nextState = storageReducer(
@@ -196,7 +216,7 @@ describe('Reducers.Storage', () => {
             }
         );
         assert.deepEqual(
-            nextState,
+            nextState.storage,
             {test: '456'}
         );
         nextState = storageReducer(
@@ -207,7 +227,7 @@ describe('Reducers.Storage', () => {
             }
         );
         assert.deepEqual(
-            nextState,
+            nextState.storage,
             {test: '456', test2: '789'}
         );
     });

--- a/tests/redux/selectors/rhs.test.js
+++ b/tests/redux/selectors/rhs.test.js
@@ -48,8 +48,10 @@ describe('Selectors.makeGetPostsEmbedVisibleObj', () => {
                 }
             },
             storage: {
-                [`${StoragePrefixes.EMBED_VISIBLE}c`]: false,
-                [`${StoragePrefixes.EMBED_VISIBLE}d`]: false
+                storage: {
+                    [`${StoragePrefixes.EMBED_VISIBLE}c`]: false,
+                    [`${StoragePrefixes.EMBED_VISIBLE}d`]: false
+                }
             }
         };
     });
@@ -67,7 +69,10 @@ describe('Selectors.makeGetPostsEmbedVisibleObj', () => {
             ...state,
             storage: {
                 ...state.storage,
-                [`${StoragePrefixes.EMBED_VISIBLE}c`]: null
+                storage: {
+                    ...state.storage.storage,
+                    [`${StoragePrefixes.EMBED_VISIBLE}c`]: null
+                }
             }
         };
 
@@ -140,7 +145,10 @@ describe('Selectors.makeGetPostsEmbedVisibleObj', () => {
             ...state,
             storage: {
                 ...state.storage,
-                [`${StoragePrefixes.EMBED_VISIBLE}c`]: true
+                storage: {
+                    ...state.storage.storage,
+                    [`${StoragePrefixes.EMBED_VISIBLE}c`]: true
+                }
             }
         };
 
@@ -166,7 +174,10 @@ describe('Selectors.makeGetPostsEmbedVisibleObj', () => {
             ...state,
             storage: {
                 ...state.storage,
-                [`${StoragePrefixes.EMBED_VISIBLE}d`]: false
+                storage: {
+                    ...state.storage.storage,
+                    [`${StoragePrefixes.EMBED_VISIBLE}d`]: false
+                }
             }
         };
 

--- a/tests/redux/selectors/storage.test.js
+++ b/tests/redux/selectors/storage.test.js
@@ -19,8 +19,10 @@ describe('Selectors.Storage', () => {
             }
         },
         storage: {
-            'global-item': 'global-item-value',
-            user_id_item: 'item-value'
+            storage: {
+                'global-item': 'global-item-value',
+                user_id_item: 'item-value'
+            }
         }
     };
 


### PR DESCRIPTION
Because previously storage wasn't always loaded when the app started it would cause two things:
1. The post draft for the current channel wouldn't usually be loaded
2. The previous team/channel wouldn't be loaded if you didn't explicitly navigate to them

This prevents the app from loading until the storage is loaded. Ideally, we would lock the individual parts, but because the routing code controls the current team/channel, we needed to prevent even that from running.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8244

#### Checklist
- Added or updated unit tests (required for all new features)
- Touches critical sections of the codebase (auth, posting, etc.)
