### PR TITLE
PLT-8365 mute at-mention when the message is a command

### DIFF
--- a/tests/utils/post_utils.test.jsx
+++ b/tests/utils/post_utils.test.jsx
@@ -137,6 +137,26 @@ describe('PostUtils.containsAtMention', function() {
                 text: '~~~\n@all\n~~~',
                 key: '@all',
                 result: false
+            },
+            {
+                text: ' /not_cmd @all',
+                key: '@all',
+                result: true
+            },
+            {
+                text: '/cmd @all',
+                key: '@all',
+                result: false
+            },
+            {
+                text: '/cmd @all test',
+                key: '@all',
+                result: false
+            },
+            {
+                text: '/cmd test @all',
+                key: '@all',
+                result: false
             }
         ]) {
             const containsAtMention = PostUtils.containsAtMention(data.text, data.key);

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -124,7 +124,7 @@ export function containsAtMention(text, key) {
     }
 
     // This doesn't work for at mentions containing periods or hyphens
-    return new RegExp(`\\B${key}\\b`, 'i').test(removeCode(text));
+    return !text.startsWith('/') && new RegExp(`\\B${key}\\b`, 'i').test(removeCode(text));
 }
 
 // Returns a given text string with all Markdown code replaced with whitespace.


### PR DESCRIPTION

#### Summary
Update regex so that to mute at-mention when the message is a command. A command can be any string that starts with `/` character. 

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7975

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Ran `make check-style` to check for style errors (required for all pull requests)
- [X] Ran `make test` to ensure unit and component tests passed
- [X] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
