### PR TITLE
[PLT-8268] Do not show DeletePostModal if edited message is empty but with attachment

### DIFF
--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -62,12 +62,12 @@ export default class EditPostModal extends React.PureComponent {
             postError: '',
             errorClass: null,
             showEmojiPicker: false,
-            hidding: false
+            hiding: false
         };
     }
 
     mustBeShown = () => {
-        if (this.state.hidding) {
+        if (this.state.hiding) {
             return false;
         }
         if (!this.props.editingPost || !this.props.editingPost.post) {
@@ -132,10 +132,11 @@ export default class EditPostModal extends React.PureComponent {
     }
 
     handleEdit = async () => {
+        const {actions, editingPost} = this.props;
         const updatedPost = {
             message: this.state.editText,
-            id: this.props.editingPost.postId,
-            channel_id: this.props.editingPost.post.channel_id
+            id: editingPost.postId,
+            channel_id: editingPost.post.channel_id
         };
 
         if (this.state.postError) {
@@ -146,21 +147,22 @@ export default class EditPostModal extends React.PureComponent {
             return;
         }
 
-        if (updatedPost.message === this.props.editingPost.post.message) {
+        if (updatedPost.message === editingPost.post.message) {
             // no changes so just close the modal
             this.handleHide();
             return;
         }
 
-        if (updatedPost.message.trim().length === 0) {
+        const hasAttachment = editingPost.post.file_ids && editingPost.post.file_ids.length > 0;
+        if (updatedPost.message.trim().length === 0 && !hasAttachment) {
             this.handleHide();
-            GlobalActions.showDeletePostModal(Selectors.getPost(getState(), this.props.editingPost.postId), this.props.editingPost.commentsCount);
+            GlobalActions.showDeletePostModal(Selectors.getPost(getState(), editingPost.postId), editingPost.commentsCount);
             return;
         }
 
-        this.props.actions.addMessageIntoHistory(updatedPost.message);
+        actions.addMessageIntoHistory(updatedPost.message);
 
-        const data = await this.props.actions.editPost(updatedPost);
+        const data = await actions.editPost(updatedPost);
         if (data) {
             window.scrollTo(0, 0);
         }
@@ -194,7 +196,7 @@ export default class EditPostModal extends React.PureComponent {
     }
 
     handleHide = () => {
-        this.setState({hidding: true});
+        this.setState({hiding: true});
     }
 
     handleEnter = () => {
@@ -223,7 +225,7 @@ export default class EditPostModal extends React.PureComponent {
             });
         }
         this.props.actions.setEditingPost();
-        this.setState({editText: '', postError: '', errorClass: null, hidding: false, showEmojiPicker: false});
+        this.setState({editText: '', postError: '', errorClass: null, hiding: false, showEmojiPicker: false});
     }
 
     render() {


### PR DESCRIPTION
#### Summary
- Do not show DeletePostModal if edited message is empty but with attachment
- Only show DeletePostModal if edited message is empty and without attachment

Others:
- corrected spelling to `hiding`

#### Ticket Link
Jira ticket: [PLT-8268](https://mattermost.atlassian.net/browse/PLT-8268)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Updated unit tests (required for all new features)
