### PR TITLE
[PLT-8387] Fix regression on Rename Channel URL box showing undefined for domain name

### DIFF
--- a/components/rename_channel_modal/index.js
+++ b/components/rename_channel_modal/index.js
@@ -6,16 +6,20 @@ import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
 import {updateChannel as UpdateChannel} from 'mattermost-redux/actions/channels';
 
-import {getCurrentTeamUrl, getTeam} from 'mattermost-redux/selectors/entities/teams';
+import {getTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import {getSiteURL} from 'utils/url.jsx';
 
 import RenameChannelModal from './rename_channel_modal.jsx';
 
 const mapStateToProps = createSelector(
     (state) => {
         const currentTeamId = state.entities.teams.currentTeamId;
+        const team = getTeam(state, currentTeamId);
+        const currentTeamUrl = `${getSiteURL()}/${team.name}`;
         return {
-            currentTeamUrl: getCurrentTeamUrl(state),
-            team: getTeam(state, currentTeamId)
+            currentTeamUrl,
+            team
         };
     },
     (teamInfo) => ({...teamInfo})


### PR DESCRIPTION
#### Summary
Fix regression on Rename Channel URL box showing undefined for domain name

#### Ticket Link
Jira ticket: [PLT-8387](https://mattermost.atlassian.net/browse/PLT-8387)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
