### PR TITLE
Fix prop type validation for SettingItemMax(PLT-8212)

### DIFF
--- a/components/setting_item_max.jsx
+++ b/components/setting_item_max.jsx
@@ -155,8 +155,8 @@ export default class SettingItemMax extends React.Component {
 
 SettingItemMax.propTypes = {
     inputs: PropTypes.array,
-    client_error: PropTypes.string,
-    server_error: PropTypes.string,
+    client_error: PropTypes.node,
+    server_error: PropTypes.node,
     extraInfo: PropTypes.element,
     infoPosition: PropTypes.string,
     updateSection: PropTypes.func,


### PR DESCRIPTION
#### Summary
While fixing PLT-8212, a prop type validation for SettingItemMax was missed, which is fixed in this commit

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed