### PR TITLE
[webapp-perf] Migrate SettingItemMin and SettingItemMax to pure component, and replace anonymous function on props

### DIFF
--- a/components/channel_notifications_modal.jsx
+++ b/components/channel_notifications_modal.jsx
@@ -15,6 +15,10 @@ import {NotificationLevels} from 'utils/constants.jsx';
 import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min.jsx';
 
+const SECTION_MARK_UNREAD_LEVEL = 'markUnreadLevel';
+const SECTION_DESKTOP = 'desktop';
+const SECTION_PUSH = 'push';
+
 export default class ChannelNotificationsModal extends React.Component {
     constructor(props) {
         super(props);
@@ -78,6 +82,45 @@ export default class ChannelNotificationsModal extends React.Component {
         this.setState({notifyLevel});
     }
 
+    setUnreadLevel = () => {
+        this.setState({
+            unreadLevel: this.props.channelMember.notify_props.mark_unread
+        });
+    }
+
+    handleMinUpdateSection = (section) => {
+        this.updateSection(section);
+
+        switch (section) {
+        case SECTION_MARK_UNREAD_LEVEL:
+            this.setUnreadLevel();
+            break;
+        default:
+        }
+    }
+
+    handleMaxUpdateSection = (section) => {
+        this.updateSection(section);
+
+        switch (this.state.activeSection) {
+        case SECTION_DESKTOP:
+            this.setState({
+                notifyLevel: this.props.channelMember.notify_props.desktop
+            });
+            break;
+        case SECTION_MARK_UNREAD_LEVEL:
+            this.setUnreadLevel();
+            break;
+
+        case SECTION_PUSH:
+            this.setState({
+                pushLevel: this.props.channelMember.notify_props.push || NotificationLevels.DEFAULT
+            });
+            break;
+        default:
+        }
+    }
+
     createDesktopNotifyLevelSection(serverError) {
         // Get glabal user setting for notifications
         const globalNotifyLevel = this.props.currentUser.notify_props ? this.props.currentUser.notify_props.desktop : NotificationLevels.ALL;
@@ -114,7 +157,7 @@ export default class ChannelNotificationsModal extends React.Component {
 
         const notificationLevel = this.state.notifyLevel;
 
-        if (this.state.activeSection === 'desktop') {
+        if (this.state.activeSection === SECTION_DESKTOP) {
             const notifyActive = [false, false, false, false];
             if (notificationLevel === NotificationLevels.DEFAULT) {
                 notifyActive[0] = true;
@@ -190,14 +233,6 @@ export default class ChannelNotificationsModal extends React.Component {
                 </div>
             );
 
-            const handleUpdateSection = function updateSection(e) {
-                this.updateSection('');
-                this.setState({
-                    notifyLevel: this.props.channelMember.notify_props.desktop
-                });
-                e.preventDefault();
-            }.bind(this);
-
             const extraInfo = (
                 <span>
                     <FormattedMessage
@@ -213,7 +248,7 @@ export default class ChannelNotificationsModal extends React.Component {
                     inputs={inputs}
                     submit={this.handleSubmitDesktopNotifyLevel}
                     server_error={serverError}
-                    updateSection={handleUpdateSection}
+                    updateSection={this.handleMaxUpdateSection}
                     extraInfo={extraInfo}
                 />
             );
@@ -241,9 +276,8 @@ export default class ChannelNotificationsModal extends React.Component {
             <SettingItemMin
                 title={sendDesktop}
                 describe={describe}
-                updateSection={() => {
-                    this.updateSection('desktop');
-                }}
+                section={SECTION_DESKTOP}
+                updateSection={this.handleMinUpdateSection}
             />
         );
     }
@@ -286,7 +320,7 @@ export default class ChannelNotificationsModal extends React.Component {
                 defaultMessage='Mark Channel Unread'
             />
         );
-        if (this.state.activeSection === 'markUnreadLevel') {
+        if (this.state.activeSection === SECTION_MARK_UNREAD_LEVEL) {
             const inputs = [(
                 <div key='channel-notification-unread-radio'>
                     <div className='radio'>
@@ -321,14 +355,6 @@ export default class ChannelNotificationsModal extends React.Component {
                 </div>
             )];
 
-            const handleUpdateSection = function handleUpdateSection(e) {
-                this.updateSection('');
-                this.setState({
-                    unreadLevel: this.props.channelMember.notify_props.mark_unread
-                });
-                e.preventDefault();
-            }.bind(this);
-
             const extraInfo = (
                 <span>
                     <FormattedMessage
@@ -344,7 +370,7 @@ export default class ChannelNotificationsModal extends React.Component {
                     inputs={inputs}
                     submit={this.handleSubmitMarkUnreadLevel}
                     server_error={serverError}
-                    updateSection={handleUpdateSection}
+                    updateSection={this.handleMaxUpdateSection}
                     extraInfo={extraInfo}
                 />
             );
@@ -362,19 +388,12 @@ export default class ChannelNotificationsModal extends React.Component {
                 describe = (<FormattedMessage id='channel_notifications.onlyMentions'/>);
             }
 
-            const handleUpdateSection = function handleUpdateSection(e) {
-                this.updateSection('markUnreadLevel');
-                this.setState({
-                    unreadLevel: this.props.channelMember.notify_props.mark_unread
-                });
-                e.preventDefault();
-            }.bind(this);
-
             content = (
                 <SettingItemMin
                     title={markUnread}
                     describe={describe}
-                    updateSection={handleUpdateSection}
+                    section={SECTION_MARK_UNREAD_LEVEL}
+                    updateSection={this.handleMinUpdateSection}
                 />
             );
         }
@@ -453,7 +472,7 @@ export default class ChannelNotificationsModal extends React.Component {
         const notificationLevel = this.state.pushLevel;
 
         let content;
-        if (this.state.activeSection === 'push') {
+        if (this.state.activeSection === SECTION_PUSH) {
             const notifyActive = [false, false, false, false];
             if (notificationLevel === NotificationLevels.DEFAULT) {
                 notifyActive[0] = true;
@@ -529,14 +548,6 @@ export default class ChannelNotificationsModal extends React.Component {
                 </div>
             );
 
-            const handleUpdateSection = function updateSection(e) {
-                this.updateSection('');
-                this.setState({
-                    pushLevel: this.props.channelMember.notify_props.push || NotificationLevels.DEFAULT
-                });
-                e.preventDefault();
-            }.bind(this);
-
             const extraInfo = (
                 <span>
                     <FormattedMessage
@@ -552,7 +563,7 @@ export default class ChannelNotificationsModal extends React.Component {
                     inputs={inputs}
                     submit={this.handleSubmitPushNotificationLevel}
                     server_error={serverError}
-                    updateSection={handleUpdateSection}
+                    updateSection={this.handleMaxUpdateSection}
                     extraInfo={extraInfo}
                 />
             );
@@ -579,9 +590,8 @@ export default class ChannelNotificationsModal extends React.Component {
                 <SettingItemMin
                     title={sendPushNotifications}
                     describe={describe}
-                    updateSection={() => {
-                        this.updateSection('push');
-                    }}
+                    section={SECTION_PUSH}
+                    updateSection={this.handleMinUpdateSection}
                 />
             );
         }

--- a/components/setting_item_max.jsx
+++ b/components/setting_item_max.jsx
@@ -10,17 +10,84 @@ import SaveButton from 'components/save_button.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-export default class SettingItemMax extends React.Component {
-    constructor(props) {
-        super(props);
+export default class SettingItemMax extends React.PureComponent {
+    static defaultProps = {
+        infoPosition: 'bottom',
+        saving: false,
+        section: ''
+    };
 
-        this.onKeyDown = this.onKeyDown.bind(this);
-    }
+    static propTypes = {
 
-    onKeyDown(e) {
-        if (e.keyCode === Constants.KeyCodes.ENTER && this.props.submit) {
-            this.props.submit(e);
-        }
+        /**
+         * Array of inputs selection
+         */
+        inputs: PropTypes.array,
+
+        /**
+         * Client error
+         */
+        client_error: PropTypes.string,
+
+        /**
+         * Server error
+         */
+        server_error: PropTypes.string,
+
+        /**
+         * Settings extra information
+         */
+        extraInfo: PropTypes.element,
+
+        /**
+         * Info position
+         */
+        infoPosition: PropTypes.string,
+
+        /**
+         * Settings or tab section
+         */
+        section: PropTypes.string,
+
+        /**
+         * Function to update section
+         */
+        updateSection: PropTypes.func,
+
+        /**
+         * setting to submit
+         */
+        setting: PropTypes.string,
+
+        /**
+         * Function to submit setting
+         */
+        submit: PropTypes.func,
+
+        /**
+         * Extra information on submit
+         */
+        submitExtra: PropTypes.node,
+
+        /**
+         * Indicates whether setting is on saving
+         */
+        saving: PropTypes.bool,
+
+        /**
+         * Settings title
+         */
+        title: PropTypes.node,
+
+        /**
+         * Settings width
+         */
+        width: PropTypes.string,
+
+        /**
+         * Text of cancel button
+         */
+        cancelButtonText: PropTypes.node
     }
 
     componentDidMount() {
@@ -31,8 +98,29 @@ export default class SettingItemMax extends React.Component {
         document.removeEventListener('keydown', this.onKeyDown);
     }
 
+    onKeyDown = (e) => {
+        if (e.keyCode === Constants.KeyCodes.ENTER && this.props.submit) {
+            this.handleSubmit(e);
+        }
+    }
+
+    handleSubmit = (e) => {
+        e.preventDefault();
+
+        if (this.props.setting) {
+            this.props.submit(this.props.setting);
+        } else {
+            this.props.submit();
+        }
+    }
+
+    handleUpdateSection = (e) => {
+        this.props.updateSection(this.props.section);
+        e.preventDefault();
+    }
+
     render() {
-        var clientError = null;
+        let clientError = null;
         if (this.props.client_error) {
             clientError = (
                 <div className='form-group'>
@@ -46,7 +134,7 @@ export default class SettingItemMax extends React.Component {
             );
         }
 
-        var serverError = null;
+        let serverError = null;
         if (this.props.server_error) {
             serverError = (
                 <div className='form-group'>
@@ -60,7 +148,7 @@ export default class SettingItemMax extends React.Component {
             );
         }
 
-        var extraInfo = null;
+        let extraInfo = null;
         let hintClass = 'setting-list__hint';
         if (this.props.infoPosition === 'top') {
             hintClass = 'padding-bottom x2';
@@ -70,19 +158,19 @@ export default class SettingItemMax extends React.Component {
             extraInfo = (<div className={hintClass}>{this.props.extraInfo}</div>);
         }
 
-        var submit = '';
+        let submit = '';
         if (this.props.submit) {
             submit = (
                 <SaveButton
                     saving={this.props.saving}
                     disabled={this.props.saving}
-                    onClick={this.props.submit}
+                    onClick={this.handleSubmit}
                 />
             );
         }
 
-        var inputs = this.props.inputs;
-        var widthClass;
+        const inputs = this.props.inputs;
+        let widthClass;
         if (this.props.width === 'full') {
             widthClass = 'col-sm-12';
         } else if (this.props.width === 'medium') {
@@ -141,7 +229,7 @@ export default class SettingItemMax extends React.Component {
                             <button
                                 id={Utils.createSafeId(titleProp) + 'Cancel'}
                                 className='btn btn-sm cursor--pointer style--none'
-                                onClick={this.props.updateSection}
+                                onClick={this.handleUpdateSection}
                             >
                                 {cancelButtonText}
                             </button>
@@ -152,23 +240,3 @@ export default class SettingItemMax extends React.Component {
         );
     }
 }
-
-SettingItemMax.propTypes = {
-    inputs: PropTypes.array,
-    client_error: PropTypes.node,
-    server_error: PropTypes.node,
-    extraInfo: PropTypes.element,
-    infoPosition: PropTypes.string,
-    updateSection: PropTypes.func,
-    submit: PropTypes.func,
-    saving: PropTypes.bool,
-    title: PropTypes.node,
-    width: PropTypes.string,
-    submitExtra: PropTypes.node,
-    cancelButtonText: PropTypes.node
-};
-
-SettingItemMax.defaultProps = {
-    infoPosition: 'bottom',
-    saving: false
-};

--- a/components/setting_item_max.jsx
+++ b/components/setting_item_max.jsx
@@ -27,12 +27,12 @@ export default class SettingItemMax extends React.PureComponent {
         /**
          * Client error
          */
-        client_error: PropTypes.string,
+        clientError: PropTypes.string,
 
         /**
          * Server error
          */
-        server_error: PropTypes.string,
+        serverError: PropTypes.string,
 
         /**
          * Settings extra information
@@ -121,28 +121,28 @@ export default class SettingItemMax extends React.PureComponent {
 
     render() {
         let clientError = null;
-        if (this.props.client_error) {
+        if (this.props.clientError) {
             clientError = (
                 <div className='form-group'>
                     <label
                         id='clientError'
                         className='col-sm-12 has-error'
                     >
-                        {this.props.client_error}
+                        {this.props.clientError}
                     </label>
                 </div>
             );
         }
 
         let serverError = null;
-        if (this.props.server_error) {
+        if (this.props.serverError) {
             serverError = (
                 <div className='form-group'>
                     <label
                         id='serverError'
                         className='col-sm-12 has-error'
                     >
-                        {this.props.server_error}
+                        {this.props.serverError}
                     </label>
                 </div>
             );

--- a/components/setting_item_min.jsx
+++ b/components/setting_item_min.jsx
@@ -7,69 +7,102 @@ import {FormattedMessage} from 'react-intl';
 
 import * as Utils from 'utils/utils.jsx';
 
-export default function SettingItemMin(props) {
-    let editButton = null;
-    let describeSection = null;
-    if (!props.disableOpen && Utils.isMobile()) {
-        editButton = (
-            <li className='col-xs-12 col-sm-3 section-edit'>
-                <button
-                    id={Utils.createSafeId(props.title) + 'Edit'}
-                    className='color--link cursor--pointer style--none'
-                    onClick={props.updateSection}
-                >
-                    <i className='fa fa-pencil'/>
-                    {props.describe}
-                </button>
-            </li>
-        );
-    } else if (!props.disableOpen) {
-        editButton = (
-            <li className='col-xs-12 col-sm-3 section-edit'>
-                <button
-                    id={Utils.createSafeId(props.title) + 'Edit'}
-                    className='color--link cursor--pointer style--none text-left'
-                    onClick={props.updateSection}
-                >
-                    <i className='fa fa-pencil'/>
-                    <FormattedMessage
-                        id='setting_item_min.edit'
-                        defaultMessage='Edit'
-                    />
-                </button>
-            </li>
-        );
+export default class SettingItemMin extends React.PureComponent {
+    static defaultProps = {
+        section: ''
+    };
 
-        describeSection = (
-            <li
-                id={Utils.createSafeId(props.title) + 'Desc'}
-                className='col-xs-12 section-describe'
-            >
-                {props.describe}
-            </li>
-        );
+    static propTypes = {
+
+        /**
+         * Settings title
+         */
+        title: PropTypes.node,
+
+        /**
+         * Option to disable opening the setting
+         */
+        disableOpen: PropTypes.bool,
+
+        /**
+         * Settings or tab section
+         */
+        section: PropTypes.string,
+
+        /**
+         * Function to update section
+         */
+        updateSection: PropTypes.func,
+
+        /**
+         * Settings description
+         */
+        describe: PropTypes.node
+    };
+
+    handleUpdateSection = (e) => {
+        e.preventDefault();
+        this.props.updateSection(this.props.section);
     }
 
-    return (
-        <ul
-            className='section-min'
-            onClick={props.updateSection}
-        >
-            <li
-                id={Utils.createSafeId(props.title) + 'Title'}
-                className='col-xs-12 col-sm-9 section-title'
-            >
-                {props.title}
-            </li>
-            {editButton}
-            {describeSection}
-        </ul>
-    );
-}
+    render() {
+        let editButton = null;
+        let describeSection = null;
 
-SettingItemMin.propTypes = {
-    title: PropTypes.node,
-    disableOpen: PropTypes.bool,
-    updateSection: PropTypes.func,
-    describe: PropTypes.node
-};
+        if (!this.props.disableOpen && Utils.isMobile()) {
+            editButton = (
+                <li className='col-xs-12 col-sm-3 section-edit'>
+                    <button
+                        id={Utils.createSafeId(this.props.title) + 'Edit'}
+                        className='color--link cursor--pointer style--none'
+                        onClick={this.handleUpdateSection}
+                    >
+                        <i className='fa fa-pencil'/>
+                        {this.props.describe}
+                    </button>
+                </li>
+            );
+        } else if (!this.props.disableOpen) {
+            editButton = (
+                <li className='col-xs-12 col-sm-3 section-edit'>
+                    <button
+                        id={Utils.createSafeId(this.props.title) + 'Edit'}
+                        className='color--link cursor--pointer style--none text-left'
+                        onClick={this.handleUpdateSection}
+                    >
+                        <i className='fa fa-pencil'/>
+                        <FormattedMessage
+                            id='setting_item_min.edit'
+                            defaultMessage='Edit'
+                        />
+                    </button>
+                </li>
+            );
+
+            describeSection = (
+                <li
+                    id={Utils.createSafeId(this.props.title) + 'Desc'}
+                    className='col-xs-12 section-describe'
+                >
+                    {this.props.describe}
+                </li>
+            );
+        }
+
+        return (
+            <ul
+                className='section-min'
+                onClick={this.handleUpdateSection}
+            >
+                <li
+                    id={Utils.createSafeId(this.props.title) + 'Title'}
+                    className='col-xs-12 col-sm-9 section-title'
+                >
+                    {this.props.title}
+                </li>
+                {editButton}
+                {describeSection}
+            </ul>
+        );
+    }
+}

--- a/components/team_general_tab.jsx
+++ b/components/team_general_tab.jsx
@@ -291,7 +291,7 @@ class GeneralTab extends React.Component {
                     title={Utils.localizeMessage('general_tab.openInviteTitle', 'Allow any user with an account on this server to join this team')}
                     inputs={inputs}
                     submit={this.handleOpenInviteSubmit}
-                    server_error={serverError}
+                    serverError={serverError}
                     section={'open_invite'}
                     updateSection={this.handleUpdateSection}
                 />
@@ -369,8 +369,8 @@ class GeneralTab extends React.Component {
                     title={Utils.localizeMessage('general_tab.codeTitle', 'Invite Code')}
                     inputs={inputs}
                     submit={this.handleInviteIdSubmit}
-                    server_error={serverError}
-                    client_error={clientError}
+                    serverError={serverError}
+                    clientError={clientError}
                     section={'invite_id'}
                     updateSection={this.handleUpdateSection}
                 />
@@ -426,8 +426,8 @@ class GeneralTab extends React.Component {
                     title={Utils.localizeMessage('general_tab.teamName', 'Team Name')}
                     inputs={inputs}
                     submit={this.handleNameSubmit}
-                    server_error={serverError}
-                    client_error={clientError}
+                    serverError={serverError}
+                    clientError={clientError}
                     section={'name'}
                     updateSection={this.handleUpdateSection}
                     extraInfo={nameExtraInfo}
@@ -486,8 +486,8 @@ class GeneralTab extends React.Component {
                     title={Utils.localizeMessage('general_tab.teamDescription', 'Team Description')}
                     inputs={inputs}
                     submit={this.handleDescriptionSubmit}
-                    server_error={serverError}
-                    client_error={clientError}
+                    serverError={serverError}
+                    clientError={clientError}
                     section={'description'}
                     updateSection={this.handleUpdateSection}
                     extraInfo={descriptionExtraInfo}

--- a/components/team_general_tab.jsx
+++ b/components/team_general_tab.jsx
@@ -12,8 +12,8 @@ import {updateTeam} from 'actions/team_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-import SettingItemMax from './setting_item_max.jsx';
-import SettingItemMin from './setting_item_min.jsx';
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min.jsx';
 
 class GeneralTab extends React.Component {
     constructor(props) {
@@ -25,13 +25,9 @@ class GeneralTab extends React.Component {
         this.handleOpenInviteSubmit = this.handleOpenInviteSubmit.bind(this);
         this.handleDescriptionSubmit = this.handleDescriptionSubmit.bind(this);
         this.handleClose = this.handleClose.bind(this);
-        this.onUpdateNameSection = this.onUpdateNameSection.bind(this);
         this.updateName = this.updateName.bind(this);
         this.updateDescription = this.updateDescription.bind(this);
-        this.onUpdateDescriptionSection = this.onUpdateDescriptionSection.bind(this);
-        this.onUpdateInviteIdSection = this.onUpdateInviteIdSection.bind(this);
         this.updateInviteId = this.updateInviteId.bind(this);
-        this.onUpdateOpenInviteSection = this.onUpdateOpenInviteSection.bind(this);
         this.handleOpenInviteRadio = this.handleOpenInviteRadio.bind(this);
         this.handleGenerateInviteId = this.handleGenerateInviteId.bind(this);
 
@@ -83,9 +79,7 @@ class GeneralTab extends React.Component {
         this.setState({allow_open_invite: openInvite});
     }
 
-    handleOpenInviteSubmit(e) {
-        e.preventDefault();
-
+    handleOpenInviteSubmit() {
         var state = {serverError: '', clientError: ''};
 
         var data = {...this.props.team};
@@ -101,9 +95,7 @@ class GeneralTab extends React.Component {
         );
     }
 
-    handleNameSubmit(e) {
-        e.preventDefault();
-
+    handleNameSubmit() {
         var state = {serverError: '', clientError: ''};
         let valid = true;
 
@@ -148,9 +140,7 @@ class GeneralTab extends React.Component {
         );
     }
 
-    handleInviteIdSubmit(e) {
-        e.preventDefault();
-
+    handleInviteIdSubmit() {
         var state = {serverError: '', clientError: ''};
         let valid = true;
 
@@ -185,9 +175,7 @@ class GeneralTab extends React.Component {
         this.updateSection('');
     }
 
-    handleDescriptionSubmit(e) {
-        e.preventDefault();
-
+    handleDescriptionSubmit() {
         var state = {serverError: '', clientError: ''};
         let valid = true;
 
@@ -226,40 +214,8 @@ class GeneralTab extends React.Component {
         $('#team_settings').off('hidden.bs.modal', this.handleClose);
     }
 
-    onUpdateNameSection(e) {
-        e.preventDefault();
-        if (this.props.activeSection === 'name') {
-            this.updateSection('');
-        } else {
-            this.updateSection('name');
-        }
-    }
-
-    onUpdateDescriptionSection(e) {
-        e.preventDefault();
-        if (this.props.activeSection === 'description') {
-            this.updateSection('');
-        } else {
-            this.updateSection('description');
-        }
-    }
-
-    onUpdateInviteIdSection(e) {
-        e.preventDefault();
-        if (this.props.activeSection === 'invite_id') {
-            this.updateSection('');
-        } else {
-            this.updateSection('invite_id');
-        }
-    }
-
-    onUpdateOpenInviteSection(e) {
-        e.preventDefault();
-        if (this.props.activeSection === 'open_invite') {
-            this.updateSection('');
-        } else {
-            this.updateSection('open_invite');
-        }
+    handleUpdateSection = (section) => {
+        this.updateSection(section);
     }
 
     updateName(e) {
@@ -336,7 +292,8 @@ class GeneralTab extends React.Component {
                     inputs={inputs}
                     submit={this.handleOpenInviteSubmit}
                     server_error={serverError}
-                    updateSection={this.onUpdateOpenInviteSection}
+                    section={'open_invite'}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         } else {
@@ -351,7 +308,7 @@ class GeneralTab extends React.Component {
                 <SettingItemMin
                     title={Utils.localizeMessage('general_tab.openInviteTitle', 'Allow any user with an account on this server to join this team')}
                     describe={describe}
-                    updateSection={this.onUpdateOpenInviteSection}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
@@ -414,7 +371,8 @@ class GeneralTab extends React.Component {
                     submit={this.handleInviteIdSubmit}
                     server_error={serverError}
                     client_error={clientError}
-                    updateSection={this.onUpdateInviteIdSection}
+                    section={'invite_id'}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         } else {
@@ -422,7 +380,7 @@ class GeneralTab extends React.Component {
                 <SettingItemMin
                     title={Utils.localizeMessage('general_tab.codeTitle', 'Invite Code')}
                     describe={Utils.localizeMessage('general_tab.codeDesc', "Click 'Edit' to regenerate Invite Code.")}
-                    updateSection={this.onUpdateInviteIdSection}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
@@ -470,7 +428,8 @@ class GeneralTab extends React.Component {
                     submit={this.handleNameSubmit}
                     server_error={serverError}
                     client_error={clientError}
-                    updateSection={this.onUpdateNameSection}
+                    section={'name'}
+                    updateSection={this.handleUpdateSection}
                     extraInfo={nameExtraInfo}
                 />
             );
@@ -481,7 +440,7 @@ class GeneralTab extends React.Component {
                 <SettingItemMin
                     title={Utils.localizeMessage('general_tab.teamName', 'Team Name')}
                     describe={describe}
-                    updateSection={this.onUpdateNameSection}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
@@ -529,7 +488,8 @@ class GeneralTab extends React.Component {
                     submit={this.handleDescriptionSubmit}
                     server_error={serverError}
                     client_error={clientError}
-                    updateSection={this.onUpdateDescriptionSection}
+                    section={'description'}
+                    updateSection={this.handleUpdateSection}
                     extraInfo={descriptionExtraInfo}
                 />
             );
@@ -550,7 +510,7 @@ class GeneralTab extends React.Component {
                 <SettingItemMin
                     title={Utils.localizeMessage('general_tab.teamDescription', 'Team Description')}
                     describe={describemsg}
-                    updateSection={this.onUpdateDescriptionSection}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }

--- a/components/user_settings/desktop_notification_settings.jsx
+++ b/components/user_settings/desktop_notification_settings.jsx
@@ -21,6 +21,16 @@ export default class DesktopNotificationSettings extends React.Component {
         this.state = {};
     }
 
+    handleMinUpdateSection = (section) => {
+        this.props.updateSection(section);
+
+        this.props.cancel();
+    }
+
+    handleMaxUpdateSection = (section) => {
+        this.props.updateSection(section);
+    }
+
     buildMaximizedSetting() {
         const inputs = [];
         let extraInfo = null;
@@ -296,7 +306,7 @@ export default class DesktopNotificationSettings extends React.Component {
                 submit={this.props.submit}
                 saving={this.props.saving}
                 server_error={this.props.error}
-                updateSection={this.props.cancel}
+                updateSection={this.handleMaxUpdateSection}
             />
         );
     }
@@ -430,15 +440,12 @@ export default class DesktopNotificationSettings extends React.Component {
             }
         }
 
-        const handleUpdateDesktopSection = function updateDesktopSection() {
-            this.props.updateSection('desktop');
-        }.bind(this);
-
         return (
             <SettingItemMin
                 title={Utils.localizeMessage('user.settings.notifications.desktop.title', 'Desktop notifications')}
                 describe={describe}
-                updateSection={handleUpdateDesktopSection}
+                section={'desktop'}
+                updateSection={this.handleMinUpdateSection}
             />
         );
     }

--- a/components/user_settings/email_notification_setting.jsx
+++ b/components/user_settings/email_notification_setting.jsx
@@ -56,7 +56,7 @@ export default class EmailNotificationSetting extends React.Component {
             // until the rest of the notification settings are moved to preferences, we have to do this separately
             savePreference(Preferences.CATEGORY_NOTIFICATIONS, Preferences.EMAIL_INTERVAL, emailInterval.toString());
 
-            this.props.onSubmit({enableEmail});
+            this.props.onSubmit(enableEmail);
         } else {
             this.props.updateSection('');
         }

--- a/components/user_settings/email_notification_setting.jsx
+++ b/components/user_settings/email_notification_setting.jsx
@@ -62,16 +62,18 @@ export default class EmailNotificationSetting extends React.Component {
         }
     }
 
-    handleExpand = () => {
-        this.props.updateSection('email');
-    }
+    handleUpdateSection = (section) => {
+        if (section) {
+            this.props.updateSection(section);
+        } else {
+            this.props.updateSection('');
 
-    handleCancel = (e) => {
-        this.setState({
-            enableEmail: this.props.enableEmail,
-            emailInterval: this.props.emailInterval
-        });
-        this.props.onCancel(e);
+            this.setState({
+                enableEmail: this.props.enableEmail,
+                emailInterval: this.props.emailInterval
+            });
+            this.props.onCancel();
+        }
     }
 
     render() {
@@ -95,7 +97,8 @@ export default class EmailNotificationSetting extends React.Component {
                     title={localizeMessage('user.settings.notifications.emailNotifications', 'Email notifications')}
                     inputs={inputs}
                     server_error={this.state.serverError}
-                    updateSection={this.handleCancel}
+                    section={'email'}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
@@ -150,7 +153,8 @@ export default class EmailNotificationSetting extends React.Component {
                 <SettingItemMin
                     title={localizeMessage('user.settings.notifications.emailNotifications', 'Email notifications')}
                     describe={description}
-                    updateSection={this.handleExpand}
+                    section={'email'}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
@@ -261,7 +265,7 @@ export default class EmailNotificationSetting extends React.Component {
                 submit={this.handleSubmit}
                 saving={this.props.saving}
                 server_error={this.props.serverError}
-                updateSection={this.handleCancel}
+                updateSection={this.handleUpdateSection}
             />
         );
     }

--- a/components/user_settings/manage_languages.jsx
+++ b/components/user_settings/manage_languages.jsx
@@ -10,7 +10,7 @@ import {updateUser} from 'actions/user_actions.jsx';
 
 import * as I18n from 'i18n/i18n.jsx';
 
-import SettingItemMax from '../setting_item_max.jsx';
+import SettingItemMax from 'components/setting_item_max.jsx';
 
 export default class ManageLanguage extends React.Component {
     constructor(props) {

--- a/components/user_settings/user_settings_advanced.jsx
+++ b/components/user_settings/user_settings_advanced.jsx
@@ -12,8 +12,8 @@ import UserStore from 'stores/user_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-import SettingItemMax from '../setting_item_max.jsx';
-import SettingItemMin from '../setting_item_min.jsx';
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min.jsx';
 
 const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
@@ -22,7 +22,6 @@ export default class AdvancedSettingsDisplay extends React.Component {
         super(props);
 
         this.getStateFromStores = this.getStateFromStores.bind(this);
-        this.updateSection = this.updateSection.bind(this);
         this.updateSetting = this.updateSetting.bind(this);
         this.toggleFeature = this.toggleFeature.bind(this);
 
@@ -120,7 +119,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
         this.handleSubmit(features);
     }
 
-    handleSubmit(settings) {
+    handleSubmit = (settings) => {
         const preferences = [];
         const userId = UserStore.getCurrentId();
 
@@ -139,12 +138,12 @@ export default class AdvancedSettingsDisplay extends React.Component {
         savePreferences(
             preferences,
             () => {
-                this.updateSection('');
+                this.handleUpdateSection('');
             }
         );
     }
 
-    updateSection(section) {
+    handleUpdateSection = (section) => {
         if (!section) {
             this.setState(this.getStateFromStores());
         }
@@ -223,13 +222,11 @@ export default class AdvancedSettingsDisplay extends React.Component {
                             </div>
                         </div>
                     ]}
-                    submit={() => this.handleSubmit('formatting')}
+                    setting={'formatting'}
+                    submit={this.handleSubmit}
                     saving={this.state.isSaving}
                     server_error={this.state.serverError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
@@ -243,7 +240,8 @@ export default class AdvancedSettingsDisplay extends React.Component {
                     />
                 }
                 describe={this.renderOnOffLabel(this.state.settings.formatting)}
-                updateSection={() => this.props.updateSection('formatting')}
+                section={'formatting'}
+                updateSection={this.handleUpdateSection}
             />
         );
     }
@@ -302,13 +300,11 @@ export default class AdvancedSettingsDisplay extends React.Component {
                                 </div>
                             </div>
                         ]}
-                        submit={() => this.handleSubmit('join_leave')}
+                        setting={'join_leave'}
+                        submit={this.handleSubmit}
                         saving={this.state.isSaving}
                         server_error={this.state.serverError}
-                        updateSection={(e) => {
-                            this.updateSection('');
-                            e.preventDefault();
-                        }}
+                        updateSection={this.handleUpdateSection}
                     />
                 );
             }
@@ -322,7 +318,8 @@ export default class AdvancedSettingsDisplay extends React.Component {
                         />
                     }
                     describe={this.renderOnOffLabel(this.state.settings.join_leave)}
-                    updateSection={() => this.props.updateSection('join_leave')}
+                    section={'join_leave'}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
@@ -413,13 +410,11 @@ export default class AdvancedSettingsDisplay extends React.Component {
                         />
                     }
                     inputs={inputs}
-                    submit={() => this.handleSubmit('send_on_ctrl_enter')}
+                    setting={'send_on_ctrl_enter'}
+                    submit={this.handleSubmit}
                     saving={this.state.isSaving}
                     server_error={serverError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         } else {
@@ -432,7 +427,8 @@ export default class AdvancedSettingsDisplay extends React.Component {
                         />
                     }
                     describe={this.renderOnOffLabel(this.state.settings.send_on_ctrl_enter)}
-                    updateSection={() => this.props.updateSection('advancedCtrlSend')}
+                    section={'advancedCtrlSend'}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
@@ -501,10 +497,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
                         submit={this.saveEnabledFeatures}
                         saving={this.state.isSaving}
                         server_error={serverError}
-                        updateSection={(e) => {
-                            this.updateSection('');
-                            e.preventDefault();
-                        }}
+                        updateSection={this.handleUpdateSection}
                     />
                 );
             } else {
@@ -518,7 +511,8 @@ export default class AdvancedSettingsDisplay extends React.Component {
                                 values={{count: this.state.enabledFeatures}}
                             />
                         }
-                        updateSection={() => this.props.updateSection('advancedPreviewFeatures')}
+                        section={'advancedPreviewFeatures'}
+                        updateSection={this.handleUpdateSection}
                     />
                 );
             }

--- a/components/user_settings/user_settings_display.jsx
+++ b/components/user_settings/user_settings_display.jsx
@@ -14,8 +14,8 @@ import * as Utils from 'utils/utils.jsx';
 
 import * as I18n from 'i18n/i18n.jsx';
 
-import SettingItemMax from '../setting_item_max.jsx';
-import SettingItemMin from '../setting_item_min.jsx';
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min.jsx';
 
 import ManageLanguages from './manage_languages.jsx';
 import ThemeSetting from './user_settings_theme.jsx';
@@ -84,7 +84,14 @@ export default class UserSettingsDisplay extends React.Component {
 
         this.setState({isSaving: true});
 
-        savePreferences([timePreference, channelDisplayModePreference, messageDisplayPreference, collapseDisplayPreference, linkPreviewDisplayPreference],
+        savePreferences(
+            [
+                timePreference,
+                channelDisplayModePreference,
+                messageDisplayPreference,
+                collapseDisplayPreference,
+                linkPreviewDisplayPreference
+            ],
             () => {
                 this.updateSection('');
             }
@@ -202,11 +209,6 @@ export default class UserSettingsDisplay extends React.Component {
                 format[1] = true;
             }
 
-            const handleUpdateSection = (e) => {
-                this.updateSection('');
-                e.preventDefault();
-            };
-
             const name = section + 'Format';
             const key = section + 'UserDisplay';
 
@@ -263,7 +265,7 @@ export default class UserSettingsDisplay extends React.Component {
                         submit={this.handleSubmit}
                         saving={this.state.isSaving}
                         server_error={this.state.serverError}
-                        updateSection={handleUpdateSection}
+                        updateSection={this.updateSection}
                     />
                     <div className='divider-dark'/>
                 </div>
@@ -277,16 +279,13 @@ export default class UserSettingsDisplay extends React.Component {
             describe = secondMessage;
         }
 
-        const handleUpdateSection = () => {
-            this.props.updateSection(section);
-        };
-
         return (
             <div>
                 <SettingItemMin
                     title={messageTitle}
                     describe={describe}
-                    updateSection={handleUpdateSection}
+                    section={section}
+                    updateSection={this.updateSection}
                 />
                 <div className='divider-dark'/>
             </div>
@@ -459,10 +458,7 @@ export default class UserSettingsDisplay extends React.Component {
                     <ManageLanguages
                         user={this.props.user}
                         locale={userLocale}
-                        updateSection={(e) => {
-                            this.updateSection('');
-                            e.preventDefault();
-                        }}
+                        updateSection={this.updateSection}
                     />
                     <div className='divider-dark'/>
                 </div>
@@ -486,9 +482,8 @@ export default class UserSettingsDisplay extends React.Component {
                         }
                         width='medium'
                         describe={locale}
-                        updateSection={() => {
-                            this.updateSection('languages');
-                        }}
+                        section={'languages'}
+                        updateSection={this.updateSection}
                     />
                     <div className='divider-dark'/>
                 </div>

--- a/components/user_settings/user_settings_general/user_settings_general.jsx
+++ b/components/user_settings/user_settings_general/user_settings_general.jsx
@@ -119,9 +119,7 @@ class UserSettingsGeneralTab extends React.Component {
         this.state = this.setupInitialState(props);
     }
 
-    submitUsername(e) {
-        e.preventDefault();
-
+    submitUsername() {
         const user = Object.assign({}, this.props.user);
         const username = this.state.username.trim().toLowerCase();
 
@@ -147,9 +145,7 @@ class UserSettingsGeneralTab extends React.Component {
         this.submitUser(user, false);
     }
 
-    submitNickname(e) {
-        e.preventDefault();
-
+    submitNickname() {
         const user = Object.assign({}, this.props.user);
         const nickname = this.state.nickname.trim();
 
@@ -165,9 +161,7 @@ class UserSettingsGeneralTab extends React.Component {
         this.submitUser(user, false);
     }
 
-    submitName(e) {
-        e.preventDefault();
-
+    submitName() {
         const user = Object.assign({}, this.props.user);
         const firstName = this.state.firstName.trim();
         const lastName = this.state.lastName.trim();
@@ -185,9 +179,7 @@ class UserSettingsGeneralTab extends React.Component {
         this.submitUser(user, false);
     }
 
-    submitEmail(e) {
-        e.preventDefault();
-
+    submitEmail() {
         const user = Object.assign({}, this.props.user);
         const email = this.state.email.trim().toLowerCase();
         const confirmEmail = this.state.confirmEmail.trim().toLowerCase();
@@ -282,9 +274,7 @@ class UserSettingsGeneralTab extends React.Component {
         );
     }
 
-    submitPosition(e) {
-        e.preventDefault();
-
+    submitPosition() {
         const user = Object.assign({}, this.props.user);
         const position = this.state.position.trim();
 
@@ -581,10 +571,7 @@ class UserSettingsGeneralTab extends React.Component {
                     saving={this.state.sectionIsSaving}
                     server_error={this.state.serverError}
                     client_error={this.state.emailError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
+                    updateSection={this.updateSection}
                 />
             );
         } else {
@@ -674,9 +661,8 @@ class UserSettingsGeneralTab extends React.Component {
                         />
                     }
                     describe={describe}
-                    updateSection={() => {
-                        this.updateSection('email');
-                    }}
+                    section={'email'}
+                    updateSection={this.updateSection}
                 />
             );
         }
@@ -805,10 +791,7 @@ class UserSettingsGeneralTab extends React.Component {
                     saving={this.state.sectionIsSaving}
                     server_error={serverError}
                     client_error={clientError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
+                    updateSection={this.updateSection}
                     extraInfo={extraInfo}
                 />
             );
@@ -842,9 +825,8 @@ class UserSettingsGeneralTab extends React.Component {
                 <SettingItemMin
                     title={formatMessage(holders.fullName)}
                     describe={describe}
-                    updateSection={() => {
-                        this.updateSection('name');
-                    }}
+                    section={'name'}
+                    updateSection={this.updateSection}
                 />
             );
         }
@@ -913,10 +895,7 @@ class UserSettingsGeneralTab extends React.Component {
                     saving={this.state.sectionIsSaving}
                     server_error={serverError}
                     client_error={clientError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
+                    updateSection={this.updateSection}
                     extraInfo={extraInfo}
                 />
             );
@@ -945,9 +924,8 @@ class UserSettingsGeneralTab extends React.Component {
                 <SettingItemMin
                     title={formatMessage(holders.nickname)}
                     describe={describe}
-                    updateSection={() => {
-                        this.updateSection('nickname');
-                    }}
+                    section={'nickname'}
+                    updateSection={this.updateSection}
                 />
             );
         }
@@ -1016,10 +994,7 @@ class UserSettingsGeneralTab extends React.Component {
                     saving={this.state.sectionIsSaving}
                     server_error={serverError}
                     client_error={clientError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
+                    updateSection={this.updateSection}
                     extraInfo={extraInfo}
                 />
             );
@@ -1028,9 +1003,8 @@ class UserSettingsGeneralTab extends React.Component {
                 <SettingItemMin
                     title={formatMessage(holders.username)}
                     describe={UserStore.getCurrentUser().username}
-                    updateSection={() => {
-                        this.updateSection('username');
-                    }}
+                    section={'username'}
+                    updateSection={this.updateSection}
                 />
             );
         }
@@ -1099,10 +1073,7 @@ class UserSettingsGeneralTab extends React.Component {
                     saving={this.state.sectionIsSaving}
                     server_error={serverError}
                     client_error={clientError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
+                    updateSection={this.updateSection}
                     extraInfo={extraInfo}
                 />
             );
@@ -1131,9 +1102,8 @@ class UserSettingsGeneralTab extends React.Component {
                 <SettingItemMin
                     title={formatMessage(holders.position)}
                     describe={describe}
-                    updateSection={() => {
-                        this.updateSection('position');
-                    }}
+                    section={'position'}
+                    updateSection={this.updateSection}
                 />
             );
         }
@@ -1186,9 +1156,8 @@ class UserSettingsGeneralTab extends React.Component {
                 <SettingItemMin
                     title={formatMessage(holders.profilePicture)}
                     describe={minMessage}
-                    updateSection={() => {
-                        this.updateSection('picture');
-                    }}
+                    section={'picture'}
+                    updateSection={this.updateSection}
                 />
             );
         }

--- a/components/user_settings/user_settings_general/user_settings_general.jsx
+++ b/components/user_settings/user_settings_general/user_settings_general.jsx
@@ -569,8 +569,8 @@ class UserSettingsGeneralTab extends React.Component {
                     inputs={inputs}
                     submit={submit}
                     saving={this.state.sectionIsSaving}
-                    server_error={this.state.serverError}
-                    client_error={this.state.emailError}
+                    serverError={this.state.serverError}
+                    clientError={this.state.emailError}
                     updateSection={this.updateSection}
                 />
             );
@@ -789,8 +789,8 @@ class UserSettingsGeneralTab extends React.Component {
                     inputs={inputs}
                     submit={submit}
                     saving={this.state.sectionIsSaving}
-                    server_error={serverError}
-                    client_error={clientError}
+                    serverError={serverError}
+                    clientError={clientError}
                     updateSection={this.updateSection}
                     extraInfo={extraInfo}
                 />
@@ -893,8 +893,8 @@ class UserSettingsGeneralTab extends React.Component {
                     inputs={inputs}
                     submit={submit}
                     saving={this.state.sectionIsSaving}
-                    server_error={serverError}
-                    client_error={clientError}
+                    serverError={serverError}
+                    clientError={clientError}
                     updateSection={this.updateSection}
                     extraInfo={extraInfo}
                 />
@@ -992,8 +992,8 @@ class UserSettingsGeneralTab extends React.Component {
                     inputs={inputs}
                     submit={submit}
                     saving={this.state.sectionIsSaving}
-                    server_error={serverError}
-                    client_error={clientError}
+                    serverError={serverError}
+                    clientError={clientError}
                     updateSection={this.updateSection}
                     extraInfo={extraInfo}
                 />
@@ -1071,8 +1071,8 @@ class UserSettingsGeneralTab extends React.Component {
                     inputs={inputs}
                     submit={submit}
                     saving={this.state.sectionIsSaving}
-                    server_error={serverError}
-                    client_error={clientError}
+                    serverError={serverError}
+                    clientError={clientError}
                     updateSection={this.updateSection}
                     extraInfo={extraInfo}
                 />

--- a/components/user_settings/user_settings_notifications.jsx
+++ b/components/user_settings/user_settings_notifications.jsx
@@ -160,10 +160,20 @@ export default class NotificationsTab extends React.Component {
     }
 
     handleCancel(e) {
-        e.preventDefault();
+        if (e) {
+            e.preventDefault();
+        }
         this.updateState();
-        this.props.updateSection('');
     }
+
+    handleUpdateSection = (section) => {
+        if (section) {
+            this.props.updateSection(section);
+        } else {
+            this.props.updateSection('');
+            this.handleCancel();
+        }
+    };
 
     setStateValue(key, value) {
         const data = {};
@@ -433,7 +443,7 @@ export default class NotificationsTab extends React.Component {
                     inputs={inputs}
                     submit={submit}
                     server_error={this.state.serverError}
-                    updateSection={this.handleCancel}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
@@ -501,15 +511,12 @@ export default class NotificationsTab extends React.Component {
             }
         }
 
-        const handleUpdatePushSection = () => {
-            this.props.updateSection('push');
-        };
-
         return (
             <SettingItemMin
                 title={Utils.localizeMessage('user.settings.notifications.push', 'Mobile push notifications')}
                 describe={describe}
-                updateSection={handleUpdatePushSection}
+                section={'push'}
+                updateSection={this.handleUpdateSection}
             />
         );
     }
@@ -519,7 +526,6 @@ export default class NotificationsTab extends React.Component {
         const user = this.props.user;
 
         let keysSection;
-        let handleUpdateKeysSection;
         if (this.props.activeSection === 'keys') {
             const inputs = [];
 
@@ -644,7 +650,7 @@ export default class NotificationsTab extends React.Component {
                     submit={this.handleSubmit}
                     saving={this.state.isSaving}
                     server_error={serverError}
-                    updateSection={this.handleCancel}
+                    updateSection={this.handleUpdateSection}
                     extraInfo={extraInfo}
                 />
             );
@@ -684,21 +690,17 @@ export default class NotificationsTab extends React.Component {
                 );
             }
 
-            handleUpdateKeysSection = function updateKeysSection() {
-                this.props.updateSection('keys');
-            }.bind(this);
-
             keysSection = (
                 <SettingItemMin
                     title={Utils.localizeMessage('user.settings.notifications.wordsTrigger', 'Words that trigger mentions')}
                     describe={describe}
-                    updateSection={handleUpdateKeysSection}
+                    section={'keys'}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
 
         let commentsSection;
-        let handleUpdateCommentsSection;
         if (this.props.activeSection === 'comments') {
             const commentsActive = [false, false, false];
             if (this.state.notifyCommentsLevel === 'never') {
@@ -780,7 +782,7 @@ export default class NotificationsTab extends React.Component {
                     submit={this.handleSubmit}
                     saving={this.state.isSaving}
                     server_error={serverError}
-                    updateSection={this.handleCancel}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         } else {
@@ -808,15 +810,12 @@ export default class NotificationsTab extends React.Component {
                 );
             }
 
-            handleUpdateCommentsSection = function updateCommentsSection() {
-                this.props.updateSection('comments');
-            }.bind(this);
-
             commentsSection = (
                 <SettingItemMin
                     title={Utils.localizeMessage('user.settings.notifications.comments', 'Reply notifications')}
                     describe={describe}
-                    updateSection={handleUpdateCommentsSection}
+                    section={'comments'}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }

--- a/components/user_settings/user_settings_notifications.jsx
+++ b/components/user_settings/user_settings_notifications.jsx
@@ -121,7 +121,7 @@ export default class NotificationsTab extends React.Component {
         this.state = getNotificationsStateFromStores();
     }
 
-    handleSubmit({enableEmail = this.state.enableEmail}) {
+    handleSubmit(enableEmail = this.state.enableEmail) {
         const data = {};
         data.user_id = this.props.user.id;
         data.email = enableEmail;

--- a/components/user_settings/user_settings_security/user_settings_security.jsx
+++ b/components/user_settings/user_settings_security/user_settings_security.jsx
@@ -372,7 +372,7 @@ export default class SecurityTab extends React.Component {
                     title={Utils.localizeMessage('user.settings.mfa.title', 'Multi-factor Authentication')}
                     inputs={inputs}
                     extraInfo={extraInfo}
-                    server_error={this.state.serverError}
+                    serverError={this.state.serverError}
                     updateSection={this.handleUpdateSection}
                     width='medium'
                 />
@@ -553,8 +553,8 @@ export default class SecurityTab extends React.Component {
                     inputs={inputs}
                     submit={submit}
                     saving={this.state.savingPassword}
-                    server_error={this.state.serverError}
-                    client_error={this.state.passwordError}
+                    serverError={this.state.serverError}
+                    clientError={this.state.passwordError}
                     updateSection={this.handleUpdateSection}
                 />
             );
@@ -788,7 +788,7 @@ export default class SecurityTab extends React.Component {
                     title={Utils.localizeMessage('user.settings.security.method', 'Sign-in Method')}
                     extraInfo={extraInfo}
                     inputs={inputs}
-                    server_error={this.state.serverError}
+                    serverError={this.state.serverError}
                     updateSection={this.handleUpdateSection}
                 />
             );
@@ -950,7 +950,7 @@ export default class SecurityTab extends React.Component {
                 <SettingItemMax
                     title={title}
                     inputs={inputs}
-                    server_error={this.state.serverError}
+                    serverError={this.state.serverError}
                     updateSection={this.handleUpdateSection}
                     width='full'
                     cancelButtonText={
@@ -1382,7 +1382,7 @@ export default class SecurityTab extends React.Component {
                     inputs={inputs}
                     extraInfo={extraInfo}
                     infoPosition='top'
-                    server_error={this.state.serverError}
+                    serverError={this.state.serverError}
                     updateSection={this.handleUpdateSection}
                     width='full'
                     cancelButtonText={

--- a/components/user_settings/user_settings_security/user_settings_security.jsx
+++ b/components/user_settings/user_settings_security/user_settings_security.jsx
@@ -28,6 +28,11 @@ import ToggleModalButton from 'components/toggle_modal_button.jsx';
 const TOKEN_CREATING = 'creating';
 const TOKEN_CREATED = 'created';
 const TOKEN_NOT_CREATING = 'not_creating';
+const SECTION_MFA = 'mfa';
+const SECTION_PASSWORD = 'password';
+const SECTION_SIGNIN = 'signin';
+const SECTION_APPS = 'apps';
+const SECTION_TOKENS = 'tokens';
 
 export default class SecurityTab extends React.Component {
     static propTypes = {
@@ -123,13 +128,11 @@ export default class SecurityTab extends React.Component {
         }
     }
 
-    submitPassword = (e) => {
-        e.preventDefault();
-
-        var user = this.props.user;
-        var currentPassword = this.state.currentPassword;
-        var newPassword = this.state.newPassword;
-        var confirmPassword = this.state.confirmPassword;
+    submitPassword = () => {
+        const user = this.props.user;
+        const currentPassword = this.state.currentPassword;
+        const newPassword = this.state.newPassword;
+        const confirmPassword = this.state.confirmPassword;
 
         if (currentPassword === '') {
             this.setState({passwordError: Utils.localizeMessage('user.settings.security.currentPasswordError', 'Please enter your current password.'), serverError: ''});
@@ -146,7 +149,7 @@ export default class SecurityTab extends React.Component {
         }
 
         if (newPassword !== confirmPassword) {
-            var defaultState = Object.assign(this.getDefaultState(), {passwordError: Utils.localizeMessage('user.settings.security.passwordMatchError', 'The new passwords you entered do not match.'), serverError: ''});
+            const defaultState = Object.assign(this.getDefaultState(), {passwordError: Utils.localizeMessage('user.settings.security.passwordMatchError', 'The new passwords you entered do not match.'), serverError: ''});
             this.setState(defaultState);
             return;
         }
@@ -235,11 +238,44 @@ export default class SecurityTab extends React.Component {
         );
     }
 
-    createMfaSection = () => {
-        let updateSectionStatus;
-        let submit;
+    handleUpdateSection = (section) => {
+        if (section) {
+            this.props.updateSection(section);
+        } else {
+            switch (this.props.activeSection) {
+            case SECTION_MFA:
+            case SECTION_SIGNIN:
+            case SECTION_APPS:
+                this.setState({
+                    serverError: null
+                });
+                break;
+            case SECTION_PASSWORD:
+                this.setState({
+                    currentPassword: '',
+                    newPassword: '',
+                    confirmPassword: '',
+                    serverError: null,
+                    passwordError: null
+                });
+                break;
+            case SECTION_TOKENS:
+                this.setState({
+                    newToken: null,
+                    tokenCreationState: TOKEN_NOT_CREATING,
+                    serverError: null,
+                    tokenError: ''
+                });
+                break;
+            default:
+            }
 
-        if (this.props.activeSection === 'mfa') {
+            this.props.updateSection('');
+        }
+    }
+
+    createMfaSection = () => {
+        if (this.props.activeSection === SECTION_MFA) {
             let content;
             let extraInfo;
             if (this.props.user.mfa_active) {
@@ -331,20 +367,13 @@ export default class SecurityTab extends React.Component {
                 </div>
             );
 
-            updateSectionStatus = function resetSection(e) {
-                this.props.updateSection('');
-                this.setState({serverError: null});
-                e.preventDefault();
-            }.bind(this);
-
             return (
                 <SettingItemMax
                     title={Utils.localizeMessage('user.settings.mfa.title', 'Multi-factor Authentication')}
                     inputs={inputs}
                     extraInfo={extraInfo}
-                    submit={submit}
                     server_error={this.state.serverError}
-                    updateSection={updateSectionStatus}
+                    updateSection={this.handleUpdateSection}
                     width='medium'
                 />
             );
@@ -357,23 +386,18 @@ export default class SecurityTab extends React.Component {
             describe = Utils.localizeMessage('user.settings.security.inactive', 'Inactive');
         }
 
-        updateSectionStatus = function updateSection() {
-            this.props.updateSection('mfa');
-        }.bind(this);
-
         return (
             <SettingItemMin
                 title={Utils.localizeMessage('user.settings.mfa.title', 'Multi-factor Authentication')}
                 describe={describe}
-                updateSection={updateSectionStatus}
+                section={SECTION_MFA}
+                updateSection={this.handleUpdateSection}
             />
         );
     }
 
     createPasswordSection = () => {
-        let updateSectionStatus;
-
-        if (this.props.activeSection === 'password') {
+        if (this.props.activeSection === SECTION_PASSWORD) {
             const inputs = [];
             let submit;
 
@@ -518,12 +542,6 @@ export default class SecurityTab extends React.Component {
                 );
             }
 
-            updateSectionStatus = function resetSection(e) {
-                this.props.updateSection('');
-                this.setState({currentPassword: '', newPassword: '', confirmPassword: '', serverError: null, passwordError: null});
-                e.preventDefault();
-            }.bind(this);
-
             return (
                 <SettingItemMax
                     title={
@@ -537,7 +555,7 @@ export default class SecurityTab extends React.Component {
                     saving={this.state.savingPassword}
                     server_error={this.state.serverError}
                     client_error={this.state.passwordError}
-                    updateSection={updateSectionStatus}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
@@ -609,10 +627,6 @@ export default class SecurityTab extends React.Component {
             );
         }
 
-        updateSectionStatus = function updateSection() {
-            this.props.updateSection('password');
-        }.bind(this);
-
         return (
             <SettingItemMin
                 title={
@@ -622,16 +636,16 @@ export default class SecurityTab extends React.Component {
                     />
                 }
                 describe={describe}
-                updateSection={updateSectionStatus}
+                section={SECTION_PASSWORD}
+                updateSection={this.handleUpdateSection}
             />
         );
     }
 
     createSignInSection = () => {
-        let updateSectionStatus;
         const user = this.props.user;
 
-        if (this.props.activeSection === 'signin') {
+        if (this.props.activeSection === SECTION_SIGNIN) {
             let emailOption;
             let gitlabOption;
             let googleOption;
@@ -760,12 +774,6 @@ export default class SecurityTab extends React.Component {
                 </div>
             );
 
-            updateSectionStatus = function updateSection(e) {
-                this.props.updateSection('');
-                this.setState({serverError: null});
-                e.preventDefault();
-            }.bind(this);
-
             const extraInfo = (
                 <span>
                     <FormattedMessage
@@ -781,14 +789,10 @@ export default class SecurityTab extends React.Component {
                     extraInfo={extraInfo}
                     inputs={inputs}
                     server_error={this.state.serverError}
-                    updateSection={updateSectionStatus}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }
-
-        updateSectionStatus = function updateSection() {
-            this.props.updateSection('signin');
-        }.bind(this);
 
         let describe = (
             <FormattedMessage
@@ -837,15 +841,14 @@ export default class SecurityTab extends React.Component {
             <SettingItemMin
                 title={Utils.localizeMessage('user.settings.security.method', 'Sign-in Method')}
                 describe={describe}
-                updateSection={updateSectionStatus}
+                section={SECTION_SIGNIN}
+                updateSection={this.handleUpdateSection}
             />
         );
     }
 
     createOAuthAppsSection = () => {
-        let updateSectionStatus;
-
-        if (this.props.activeSection === 'apps') {
+        if (this.props.activeSection === SECTION_APPS) {
             let apps;
             if (this.state.authorizedApps && this.state.authorizedApps.length > 0) {
                 apps = this.state.authorizedApps.map((app) => {
@@ -933,12 +936,6 @@ export default class SecurityTab extends React.Component {
                 </div>
             );
 
-            updateSectionStatus = function updateSection(e) {
-                this.props.updateSection('');
-                this.setState({serverError: null});
-                e.preventDefault();
-            }.bind(this);
-
             const title = (
                 <div>
                     <FormattedMessage
@@ -954,7 +951,7 @@ export default class SecurityTab extends React.Component {
                     title={title}
                     inputs={inputs}
                     server_error={this.state.serverError}
-                    updateSection={updateSectionStatus}
+                    updateSection={this.handleUpdateSection}
                     width='full'
                     cancelButtonText={
                         <FormattedMessage
@@ -966,10 +963,6 @@ export default class SecurityTab extends React.Component {
             );
         }
 
-        updateSectionStatus = function updateSection() {
-            this.props.updateSection('apps');
-        }.bind(this);
-
         return (
             <SettingItemMin
                 title={Utils.localizeMessage('user.settings.security.oauthApps', 'OAuth 2.0 Applications')}
@@ -979,7 +972,8 @@ export default class SecurityTab extends React.Component {
                         defaultMessage="Click 'Edit' to manage your OAuth 2.0 Applications"
                     />
                 }
-                updateSection={updateSectionStatus}
+                section={SECTION_APPS}
+                updateSection={this.handleUpdateSection}
             />
         );
     }
@@ -1128,10 +1122,9 @@ export default class SecurityTab extends React.Component {
     }
 
     createTokensSection = () => {
-        let updateSectionStatus;
         let tokenListClass = '';
 
-        if (this.props.activeSection === 'tokens') {
+        if (this.props.activeSection === SECTION_TOKENS) {
             const tokenList = [];
             Object.values(this.props.userAccessTokens).forEach((token) => {
                 if (this.state.newToken && this.state.newToken.id === token.id) {
@@ -1383,12 +1376,6 @@ export default class SecurityTab extends React.Component {
                 </div>
             );
 
-            updateSectionStatus = function resetSection(e) {
-                this.props.updateSection('');
-                this.setState({newToken: null, tokenCreationState: TOKEN_NOT_CREATING, serverError: null, tokenError: ''});
-                e.preventDefault();
-            }.bind(this);
-
             return (
                 <SettingItemMax
                     title={Utils.localizeMessage('user.settings.tokens.title', 'Personal Access Tokens')}
@@ -1396,7 +1383,7 @@ export default class SecurityTab extends React.Component {
                     extraInfo={extraInfo}
                     infoPosition='top'
                     server_error={this.state.serverError}
-                    updateSection={updateSectionStatus}
+                    updateSection={this.handleUpdateSection}
                     width='full'
                     cancelButtonText={
                         <FormattedMessage
@@ -1410,15 +1397,12 @@ export default class SecurityTab extends React.Component {
 
         const describe = Utils.localizeMessage('user.settings.tokens.clickToEdit', "Click 'Edit' to manage your personal access tokens");
 
-        updateSectionStatus = function updateSection() {
-            this.props.updateSection('tokens');
-        }.bind(this);
-
         return (
             <SettingItemMin
                 title={Utils.localizeMessage('user.settings.tokens.title', 'Personal Access Tokens')}
                 describe={describe}
-                updateSection={updateSectionStatus}
+                section={SECTION_TOKENS}
+                updateSection={this.handleUpdateSection}
             />
         );
     }

--- a/components/user_settings/user_settings_sidebar.jsx
+++ b/components/user_settings/user_settings_sidebar.jsx
@@ -11,8 +11,8 @@ import UserStore from 'stores/user_store.jsx';
 
 import Constants from 'utils/constants.jsx';
 
-import SettingItemMax from '../setting_item_max.jsx';
-import SettingItemMin from '../setting_item_min.jsx';
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min.jsx';
 
 export default class SidebarSettingsDisplay extends React.Component {
     constructor(props) {
@@ -48,7 +48,7 @@ export default class SidebarSettingsDisplay extends React.Component {
         this.setState(settings);
     }
 
-    handleSubmit(setting) {
+    handleSubmit = (setting) => {
         const preferences = [];
         const userId = UserStore.getCurrentId();
 
@@ -148,13 +148,11 @@ export default class SidebarSettingsDisplay extends React.Component {
                             </div>
                         </div>
                     ]}
-                    submit={() => this.handleSubmit('close_unused_direct_messages')}
+                    setting={'close_unused_direct_messages'}
+                    submit={this.handleSubmit}
                     saving={this.state.isSaving}
                     server_error={this.state.serverError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
+                    updateSection={this.updateSection}
                 />
             );
         }
@@ -168,7 +166,8 @@ export default class SidebarSettingsDisplay extends React.Component {
                     />
                 }
                 describe={this.renderAutoCloseDMLabel(this.state.settings.close_unused_direct_messages)}
-                updateSection={() => this.props.updateSection('autoCloseDM')}
+                section={'autoCloseDM'}
+                updateSection={this.updateSection}
             />
         );
     }

--- a/components/user_settings/user_settings_theme.jsx
+++ b/components/user_settings/user_settings_theme.jsx
@@ -16,9 +16,9 @@ import UserStore from 'stores/user_store.jsx';
 import {ActionTypes, Constants, Preferences} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-import AppDispatcher from '../../dispatcher/app_dispatcher.jsx';
-import SettingItemMax from '../setting_item_max.jsx';
-import SettingItemMin from '../setting_item_min.jsx';
+import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min.jsx';
 
 import CustomThemeChooser from './custom_theme_chooser.jsx';
 import PremadeThemeChooser from './premade_theme_chooser.jsx';
@@ -111,9 +111,7 @@ export default class ThemeSetting extends React.Component {
         $('.ps-container.modal-body').scrollTop(0);
     }
 
-    submitTheme(e) {
-        e.preventDefault();
-
+    submitTheme() {
         const teamId = this.state.applyToAllTeams ? '' : this.state.teamId;
 
         this.setState({isSaving: true});
@@ -173,6 +171,10 @@ export default class ThemeSetting extends React.Component {
         });
 
         this.props.setEnforceFocus(false);
+    }
+
+    handleUpdateSection = (section) => {
+        this.props.updateSection(section);
     }
 
     render() {
@@ -325,10 +327,7 @@ export default class ThemeSetting extends React.Component {
                     saving={this.state.isSaving}
                     server_error={serverError}
                     width='full'
-                    updateSection={(e) => {
-                        this.props.updateSection('');
-                        e.preventDefault();
-                    }}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         } else {
@@ -346,9 +345,8 @@ export default class ThemeSetting extends React.Component {
                             defaultMessage='Open to manage your theme'
                         />
                     }
-                    updateSection={() => {
-                        this.props.updateSection('theme');
-                    }}
+                    section={'theme'}
+                    updateSection={this.handleUpdateSection}
                 />
             );
         }

--- a/tests/components/__snapshots__/setting_item_max.test.jsx.snap
+++ b/tests/components/__snapshots__/setting_item_max.test.jsx.snap
@@ -1,0 +1,206 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/SettingItemMin should match snapshot 1`] = `
+<ul
+  className="section-max form-horizontal"
+>
+  <li
+    className="col-sm-12 section-title"
+  >
+    title
+  </li>
+  <li
+    className="col-sm-12"
+  >
+    <ul
+      className="setting-list"
+    >
+      <li
+        className="setting-list-item"
+      >
+        input_1
+      </li>
+      <li
+        className="setting-list-item"
+      >
+        <hr />
+        <SaveButton
+          defaultMessage="Save"
+          disabled={false}
+          onClick={[Function]}
+          saving={false}
+          savingMessage="Saving"
+        />
+        <button
+          className="btn btn-sm cursor--pointer style--none"
+          id="titleCancel"
+          onClick={[Function]}
+        >
+          <FormattedMessage
+            defaultMessage="Cancel"
+            id="setting_item_max.cancel"
+            values={Object {}}
+          />
+        </button>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`components/SettingItemMin should match snapshot, on client_error 1`] = `
+<ul
+  className="section-max form-horizontal"
+>
+  <li
+    className="col-sm-12 section-title"
+  >
+    title
+  </li>
+  <li
+    className="col-sm-12"
+  >
+    <ul
+      className="setting-list"
+    >
+      <li
+        className="setting-list-item"
+      >
+        input_1
+      </li>
+      <li
+        className="setting-list-item"
+      >
+        <hr />
+        <div
+          className="form-group"
+        >
+          <label
+            className="col-sm-12 has-error"
+            id="clientError"
+          >
+            client_error
+          </label>
+        </div>
+        <SaveButton
+          defaultMessage="Save"
+          disabled={false}
+          onClick={[Function]}
+          saving={false}
+          savingMessage="Saving"
+        />
+        <button
+          className="btn btn-sm cursor--pointer style--none"
+          id="titleCancel"
+          onClick={[Function]}
+        >
+          <FormattedMessage
+            defaultMessage="Cancel"
+            id="setting_item_max.cancel"
+            values={Object {}}
+          />
+        </button>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`components/SettingItemMin should match snapshot, on server_error 1`] = `
+<ul
+  className="section-max form-horizontal"
+>
+  <li
+    className="col-sm-12 section-title"
+  >
+    title
+  </li>
+  <li
+    className="col-sm-12"
+  >
+    <ul
+      className="setting-list"
+    >
+      <li
+        className="setting-list-item"
+      >
+        input_1
+      </li>
+      <li
+        className="setting-list-item"
+      >
+        <hr />
+        <div
+          className="form-group"
+        >
+          <label
+            className="col-sm-12 has-error"
+            id="serverError"
+          >
+            server_error
+          </label>
+        </div>
+        <SaveButton
+          defaultMessage="Save"
+          disabled={false}
+          onClick={[Function]}
+          saving={false}
+          savingMessage="Saving"
+        />
+        <button
+          className="btn btn-sm cursor--pointer style--none"
+          id="titleCancel"
+          onClick={[Function]}
+        >
+          <FormattedMessage
+            defaultMessage="Cancel"
+            id="setting_item_max.cancel"
+            values={Object {}}
+          />
+        </button>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`components/SettingItemMin should match snapshot, without submit 1`] = `
+<ul
+  className="section-max form-horizontal"
+>
+  <li
+    className="col-sm-12 section-title"
+  >
+    title
+  </li>
+  <li
+    className="col-sm-12"
+  >
+    <ul
+      className="setting-list"
+    >
+      <li
+        className="setting-list-item"
+      >
+        input_1
+      </li>
+      <li
+        className="setting-list-item"
+      >
+        <hr />
+        <button
+          className="btn btn-sm cursor--pointer style--none"
+          id="titleCancel"
+          onClick={[Function]}
+        >
+          <FormattedMessage
+            defaultMessage="Cancel"
+            id="setting_item_max.cancel"
+            values={Object {}}
+          />
+        </button>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;

--- a/tests/components/__snapshots__/setting_item_max.test.jsx.snap
+++ b/tests/components/__snapshots__/setting_item_max.test.jsx.snap
@@ -48,7 +48,7 @@ exports[`components/SettingItemMin should match snapshot 1`] = `
 </ul>
 `;
 
-exports[`components/SettingItemMin should match snapshot, on client_error 1`] = `
+exports[`components/SettingItemMin should match snapshot, on clientError 1`] = `
 <ul
   className="section-max form-horizontal"
 >
@@ -79,7 +79,7 @@ exports[`components/SettingItemMin should match snapshot, on client_error 1`] = 
             className="col-sm-12 has-error"
             id="clientError"
           >
-            client_error
+            clientError
           </label>
         </div>
         <SaveButton
@@ -106,7 +106,7 @@ exports[`components/SettingItemMin should match snapshot, on client_error 1`] = 
 </ul>
 `;
 
-exports[`components/SettingItemMin should match snapshot, on server_error 1`] = `
+exports[`components/SettingItemMin should match snapshot, on serverError 1`] = `
 <ul
   className="section-max form-horizontal"
 >
@@ -137,7 +137,7 @@ exports[`components/SettingItemMin should match snapshot, on server_error 1`] = 
             className="col-sm-12 has-error"
             id="serverError"
           >
-            server_error
+            serverError
           </label>
         </div>
         <SaveButton

--- a/tests/components/__snapshots__/setting_item_min.test.jsx.snap
+++ b/tests/components/__snapshots__/setting_item_min.test.jsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/SettingItemMin should match snapshot 1`] = `
+<ul
+  className="section-min"
+  onClick={[Function]}
+>
+  <li
+    className="col-xs-12 col-sm-9 section-title"
+    id="titleTitle"
+  >
+    title
+  </li>
+  <li
+    className="col-xs-12 col-sm-3 section-edit"
+  >
+    <button
+      className="color--link cursor--pointer style--none text-left"
+      id="titleEdit"
+      onClick={[Function]}
+    >
+      <i
+        className="fa fa-pencil"
+      />
+      <FormattedMessage
+        defaultMessage="Edit"
+        id="setting_item_min.edit"
+        values={Object {}}
+      />
+    </button>
+  </li>
+  <li
+    className="col-xs-12 section-describe"
+    id="titleDesc"
+  >
+    describe
+  </li>
+</ul>
+`;
+
+exports[`components/SettingItemMin should match snapshot, on disableOpen to true 1`] = `
+<ul
+  className="section-min"
+  onClick={[Function]}
+>
+  <li
+    className="col-xs-12 col-sm-9 section-title"
+    id="titleTitle"
+  >
+    title
+  </li>
+</ul>
+`;

--- a/tests/components/__snapshots__/user_settings_display.test.jsx.snap
+++ b/tests/components/__snapshots__/user_settings_display.test.jsx.snap
@@ -64,6 +64,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, cha
             values={Object {}}
           />
         }
+        section="clock"
         title={
           <FormattedMessage
             defaultMessage="Clock Display"
@@ -86,6 +87,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, cha
             values={Object {}}
           />
         }
+        section="linkpreview"
         title={
           <FormattedMessage
             defaultMessage="Website Link Previews"
@@ -108,6 +110,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, cha
             values={Object {}}
           />
         }
+        section="collapse"
         title={
           <FormattedMessage
             defaultMessage="Default appearance of image link previews"
@@ -130,6 +133,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, cha
             values={Object {}}
           />
         }
+        section="message_display"
         title={
           <FormattedMessage
             defaultMessage="Message Display"
@@ -199,6 +203,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, cha
           ]
         }
         saving={false}
+        section=""
         submit={[Function]}
         title={
           <FormattedMessage
@@ -216,6 +221,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, cha
     <div>
       <SettingItemMin
         describe="English"
+        section="languages"
         title={
           <FormattedMessage
             defaultMessage="Language"
@@ -345,6 +351,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, clo
           ]
         }
         saving={false}
+        section=""
         submit={[Function]}
         title={
           <FormattedMessage
@@ -368,6 +375,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, clo
             values={Object {}}
           />
         }
+        section="linkpreview"
         title={
           <FormattedMessage
             defaultMessage="Website Link Previews"
@@ -390,6 +398,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, clo
             values={Object {}}
           />
         }
+        section="collapse"
         title={
           <FormattedMessage
             defaultMessage="Default appearance of image link previews"
@@ -412,6 +421,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, clo
             values={Object {}}
           />
         }
+        section="message_display"
         title={
           <FormattedMessage
             defaultMessage="Message Display"
@@ -434,6 +444,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, clo
             values={Object {}}
           />
         }
+        section="channel_display_mode"
         title={
           <FormattedMessage
             defaultMessage="Channel Display Mode"
@@ -450,6 +461,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, clo
     <div>
       <SettingItemMin
         describe="English"
+        section="languages"
         title={
           <FormattedMessage
             defaultMessage="Language"
@@ -532,6 +544,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, col
             values={Object {}}
           />
         }
+        section="clock"
         title={
           <FormattedMessage
             defaultMessage="Clock Display"
@@ -554,6 +567,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, col
             values={Object {}}
           />
         }
+        section="linkpreview"
         title={
           <FormattedMessage
             defaultMessage="Website Link Previews"
@@ -623,6 +637,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, col
           ]
         }
         saving={false}
+        section=""
         submit={[Function]}
         title={
           <FormattedMessage
@@ -646,6 +661,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, col
             values={Object {}}
           />
         }
+        section="message_display"
         title={
           <FormattedMessage
             defaultMessage="Message Display"
@@ -668,6 +684,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, col
             values={Object {}}
           />
         }
+        section="channel_display_mode"
         title={
           <FormattedMessage
             defaultMessage="Channel Display Mode"
@@ -684,6 +701,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, col
     <div>
       <SettingItemMin
         describe="English"
+        section="languages"
         title={
           <FormattedMessage
             defaultMessage="Language"
@@ -766,6 +784,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lan
             values={Object {}}
           />
         }
+        section="clock"
         title={
           <FormattedMessage
             defaultMessage="Clock Display"
@@ -788,6 +807,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lan
             values={Object {}}
           />
         }
+        section="linkpreview"
         title={
           <FormattedMessage
             defaultMessage="Website Link Previews"
@@ -810,6 +830,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lan
             values={Object {}}
           />
         }
+        section="collapse"
         title={
           <FormattedMessage
             defaultMessage="Default appearance of image link previews"
@@ -832,6 +853,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lan
             values={Object {}}
           />
         }
+        section="message_display"
         title={
           <FormattedMessage
             defaultMessage="Message Display"
@@ -854,6 +876,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lan
             values={Object {}}
           />
         }
+        section="channel_display_mode"
         title={
           <FormattedMessage
             defaultMessage="Channel Display Mode"
@@ -951,6 +974,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
             values={Object {}}
           />
         }
+        section="clock"
         title={
           <FormattedMessage
             defaultMessage="Clock Display"
@@ -973,6 +997,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
             values={Object {}}
           />
         }
+        section="collapse"
         title={
           <FormattedMessage
             defaultMessage="Default appearance of image link previews"
@@ -995,6 +1020,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
             values={Object {}}
           />
         }
+        section="message_display"
         title={
           <FormattedMessage
             defaultMessage="Message Display"
@@ -1017,6 +1043,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
             values={Object {}}
           />
         }
+        section="channel_display_mode"
         title={
           <FormattedMessage
             defaultMessage="Channel Display Mode"
@@ -1033,6 +1060,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
     <div>
       <SettingItemMin
         describe="English"
+        section="languages"
         title={
           <FormattedMessage
             defaultMessage="Language"
@@ -1115,6 +1143,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
             values={Object {}}
           />
         }
+        section="clock"
         title={
           <FormattedMessage
             defaultMessage="Clock Display"
@@ -1184,6 +1213,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
           ]
         }
         saving={false}
+        section=""
         submit={[Function]}
         title={
           <FormattedMessage
@@ -1207,6 +1237,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
             values={Object {}}
           />
         }
+        section="collapse"
         title={
           <FormattedMessage
             defaultMessage="Default appearance of image link previews"
@@ -1229,6 +1260,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
             values={Object {}}
           />
         }
+        section="message_display"
         title={
           <FormattedMessage
             defaultMessage="Message Display"
@@ -1251,6 +1283,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
             values={Object {}}
           />
         }
+        section="channel_display_mode"
         title={
           <FormattedMessage
             defaultMessage="Channel Display Mode"
@@ -1267,6 +1300,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, lin
     <div>
       <SettingItemMin
         describe="English"
+        section="languages"
         title={
           <FormattedMessage
             defaultMessage="Language"
@@ -1349,6 +1383,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, mes
             values={Object {}}
           />
         }
+        section="clock"
         title={
           <FormattedMessage
             defaultMessage="Clock Display"
@@ -1371,6 +1406,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, mes
             values={Object {}}
           />
         }
+        section="linkpreview"
         title={
           <FormattedMessage
             defaultMessage="Website Link Previews"
@@ -1393,6 +1429,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, mes
             values={Object {}}
           />
         }
+        section="collapse"
         title={
           <FormattedMessage
             defaultMessage="Default appearance of image link previews"
@@ -1482,6 +1519,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, mes
           ]
         }
         saving={false}
+        section=""
         submit={[Function]}
         title={
           <FormattedMessage
@@ -1505,6 +1543,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, mes
             values={Object {}}
           />
         }
+        section="channel_display_mode"
         title={
           <FormattedMessage
             defaultMessage="Channel Display Mode"
@@ -1521,6 +1560,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, mes
     <div>
       <SettingItemMin
         describe="English"
+        section="languages"
         title={
           <FormattedMessage
             defaultMessage="Language"
@@ -1603,6 +1643,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, no 
             values={Object {}}
           />
         }
+        section="clock"
         title={
           <FormattedMessage
             defaultMessage="Clock Display"
@@ -1625,6 +1666,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, no 
             values={Object {}}
           />
         }
+        section="linkpreview"
         title={
           <FormattedMessage
             defaultMessage="Website Link Previews"
@@ -1647,6 +1689,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, no 
             values={Object {}}
           />
         }
+        section="collapse"
         title={
           <FormattedMessage
             defaultMessage="Default appearance of image link previews"
@@ -1669,6 +1712,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, no 
             values={Object {}}
           />
         }
+        section="message_display"
         title={
           <FormattedMessage
             defaultMessage="Message Display"
@@ -1691,6 +1735,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, no 
             values={Object {}}
           />
         }
+        section="channel_display_mode"
         title={
           <FormattedMessage
             defaultMessage="Channel Display Mode"
@@ -1707,6 +1752,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, no 
     <div>
       <SettingItemMin
         describe="English"
+        section="languages"
         title={
           <FormattedMessage
             defaultMessage="Language"
@@ -1789,6 +1835,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
             values={Object {}}
           />
         }
+        section="clock"
         title={
           <FormattedMessage
             defaultMessage="Clock Display"
@@ -1811,6 +1858,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
             values={Object {}}
           />
         }
+        section="linkpreview"
         title={
           <FormattedMessage
             defaultMessage="Website Link Previews"
@@ -1833,6 +1881,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
             values={Object {}}
           />
         }
+        section="collapse"
         title={
           <FormattedMessage
             defaultMessage="Default appearance of image link previews"
@@ -1855,6 +1904,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
             values={Object {}}
           />
         }
+        section="message_display"
         title={
           <FormattedMessage
             defaultMessage="Message Display"
@@ -1877,6 +1927,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
             values={Object {}}
           />
         }
+        section="channel_display_mode"
         title={
           <FormattedMessage
             defaultMessage="Channel Display Mode"
@@ -1893,6 +1944,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
     <div>
       <SettingItemMin
         describe="English"
+        section="languages"
         title={
           <FormattedMessage
             defaultMessage="Language"
@@ -1986,6 +2038,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
             values={Object {}}
           />
         }
+        section="clock"
         title={
           <FormattedMessage
             defaultMessage="Clock Display"
@@ -2008,6 +2061,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
             values={Object {}}
           />
         }
+        section="linkpreview"
         title={
           <FormattedMessage
             defaultMessage="Website Link Previews"
@@ -2030,6 +2084,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
             values={Object {}}
           />
         }
+        section="collapse"
         title={
           <FormattedMessage
             defaultMessage="Default appearance of image link previews"
@@ -2052,6 +2107,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
             values={Object {}}
           />
         }
+        section="message_display"
         title={
           <FormattedMessage
             defaultMessage="Message Display"
@@ -2074,6 +2130,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
             values={Object {}}
           />
         }
+        section="channel_display_mode"
         title={
           <FormattedMessage
             defaultMessage="Channel Display Mode"
@@ -2090,6 +2147,7 @@ exports[`components/user_settings/UserSettingsDisplay should match snapshot, the
     <div>
       <SettingItemMin
         describe="English"
+        section="languages"
         title={
           <FormattedMessage
             defaultMessage="Language"

--- a/tests/components/setting_item_max.test.jsx
+++ b/tests/components/setting_item_max.test.jsx
@@ -1,0 +1,120 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import Constants from 'utils/constants.jsx';
+
+import SettingItemMax from 'components/setting_item_max.jsx';
+
+describe('components/SettingItemMin', () => {
+    const baseProps = {
+        inputs: ['input_1'],
+        client_error: '',
+        server_error: '',
+        infoPosition: 'bottom',
+        section: 'section',
+        updateSection: jest.fn(),
+        setting: 'setting',
+        submit: jest.fn(),
+        saving: false,
+        title: 'title',
+        width: 'full'
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <SettingItemMax {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, without submit', () => {
+        const props = {...baseProps, submit: null};
+        const wrapper = shallow(
+            <SettingItemMax {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, on client_error', () => {
+        const props = {...baseProps, client_error: 'client_error'};
+        const wrapper = shallow(
+            <SettingItemMax {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, on server_error', () => {
+        const props = {...baseProps, server_error: 'server_error'};
+        const wrapper = shallow(
+            <SettingItemMax {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should have called updateSection on handleUpdateSection with section', () => {
+        const updateSection = jest.fn();
+        const props = {...baseProps, updateSection};
+        const wrapper = shallow(
+            <SettingItemMax {...props}/>
+        );
+
+        wrapper.instance().handleUpdateSection({preventDefault: jest.fn()});
+        expect(updateSection).toHaveBeenCalled();
+        expect(updateSection).toHaveBeenCalledWith('section');
+    });
+
+    test('should have called updateSection on handleUpdateSection with empty string', () => {
+        const updateSection = jest.fn();
+        const props = {...baseProps, updateSection, section: ''};
+        const wrapper = shallow(
+            <SettingItemMax {...props}/>
+        );
+
+        wrapper.instance().handleUpdateSection({preventDefault: jest.fn()});
+        expect(updateSection).toHaveBeenCalled();
+        expect(updateSection).toHaveBeenCalledWith('');
+    });
+
+    test('should have called submit on handleSubmit with setting', () => {
+        const submit = jest.fn();
+        const props = {...baseProps, submit};
+        const wrapper = shallow(
+            <SettingItemMax {...props}/>
+        );
+
+        wrapper.instance().handleSubmit({preventDefault: jest.fn()});
+        expect(submit).toHaveBeenCalled();
+        expect(submit).toHaveBeenCalledWith('setting');
+    });
+
+    test('should have called submit on handleSubmit with empty string', () => {
+        const submit = jest.fn();
+        const props = {...baseProps, submit, setting: ''};
+        const wrapper = shallow(
+            <SettingItemMax {...props}/>
+        );
+
+        wrapper.instance().handleSubmit({preventDefault: jest.fn()});
+        expect(submit).toHaveBeenCalled();
+        expect(submit).toHaveBeenCalledWith();
+    });
+
+    it('should have called submit on handleSubmit onKeyDown ENTER', () => {
+        const submit = jest.fn();
+        const props = {...baseProps, submit};
+        const wrapper = shallow(
+            <SettingItemMax {...props}/>
+        );
+        const instance = wrapper.instance();
+        instance.onKeyDown({preventDefault: jest.fn(), keyCode: Constants.KeyCodes.ENTER});
+        expect(submit).toHaveBeenCalled();
+        expect(submit).toHaveBeenCalledWith('setting');
+    });
+});

--- a/tests/components/setting_item_max.test.jsx
+++ b/tests/components/setting_item_max.test.jsx
@@ -11,8 +11,8 @@ import SettingItemMax from 'components/setting_item_max.jsx';
 describe('components/SettingItemMin', () => {
     const baseProps = {
         inputs: ['input_1'],
-        client_error: '',
-        server_error: '',
+        clientError: '',
+        serverError: '',
         infoPosition: 'bottom',
         section: 'section',
         updateSection: jest.fn(),
@@ -40,8 +40,8 @@ describe('components/SettingItemMin', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should match snapshot, on client_error', () => {
-        const props = {...baseProps, client_error: 'client_error'};
+    test('should match snapshot, on clientError', () => {
+        const props = {...baseProps, clientError: 'clientError'};
         const wrapper = shallow(
             <SettingItemMax {...props}/>
         );
@@ -49,8 +49,8 @@ describe('components/SettingItemMin', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should match snapshot, on server_error', () => {
-        const props = {...baseProps, server_error: 'server_error'};
+    test('should match snapshot, on serverError', () => {
+        const props = {...baseProps, serverError: 'serverError'};
         const wrapper = shallow(
             <SettingItemMax {...props}/>
         );

--- a/tests/components/setting_item_min.test.jsx
+++ b/tests/components/setting_item_min.test.jsx
@@ -1,0 +1,58 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import SettingItemMin from 'components/setting_item_min.jsx';
+
+describe('components/SettingItemMin', () => {
+    const baseProps = {
+        title: 'title',
+        disableOpen: false,
+        section: 'section',
+        updateSection: jest.fn(),
+        describe: 'describe'
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <SettingItemMin {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, on disableOpen to true', () => {
+        const props = {...baseProps, disableOpen: true};
+        const wrapper = shallow(
+            <SettingItemMin {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should have called updateSection on handleUpdateSection with section', () => {
+        const updateSection = jest.fn();
+        const props = {...baseProps, updateSection};
+        const wrapper = shallow(
+            <SettingItemMin {...props}/>
+        );
+
+        wrapper.instance().handleUpdateSection({preventDefault: jest.fn()});
+        expect(updateSection).toHaveBeenCalled();
+        expect(updateSection).toHaveBeenCalledWith('section');
+    });
+
+    test('should have called updateSection on handleUpdateSection with empty string', () => {
+        const updateSection = jest.fn();
+        const props = {...baseProps, updateSection, section: ''};
+        const wrapper = shallow(
+            <SettingItemMin {...props}/>
+        );
+
+        wrapper.instance().handleUpdateSection({preventDefault: jest.fn()});
+        expect(updateSection).toHaveBeenCalled();
+        expect(updateSection).toHaveBeenCalledWith('');
+    });
+});

--- a/tests/components/user_settings/__snapshots__/email_notification_setting.test.jsx.snap
+++ b/tests/components/user_settings/__snapshots__/email_notification_setting.test.jsx.snap
@@ -101,6 +101,7 @@ exports[`components/user_settings/EmailNotificationSetting should match snapshot
       ]
     }
     saving={false}
+    section=""
     server_error=""
     submit={[Function]}
     title="Email notifications"
@@ -253,6 +254,7 @@ exports[`components/user_settings/EmailNotificationSetting should match snapshot
       values={Object {}}
     />
   }
+  section="email"
   title="Email notifications"
   updateSection={[Function]}
 />
@@ -267,6 +269,7 @@ exports[`components/user_settings/EmailNotificationSetting should match snapshot
       values={Object {}}
     />
   }
+  section="email"
   title="Email notifications"
   updateSection={[Function]}
 />
@@ -285,6 +288,7 @@ exports[`components/user_settings/EmailNotificationSetting should match snapshot
       }
     />
   }
+  section="email"
   title="Email notifications"
   updateSection={[Function]}
 />
@@ -438,6 +442,7 @@ exports[`components/user_settings/EmailNotificationSetting should match snapshot
       ]
     }
     saving={false}
+    section=""
     server_error=""
     submit={[Function]}
     title="Email notifications"
@@ -657,6 +662,7 @@ exports[`components/user_settings/EmailNotificationSetting should match snapshot
     ]
   }
   saving={false}
+  section="email"
   title="Email notifications"
   updateSection={[Function]}
 />
@@ -728,6 +734,7 @@ exports[`components/user_settings/EmailNotificationSetting should match snapshot
     ]
   }
   saving={false}
+  section=""
   server_error="serverError"
   submit={[Function]}
   title="Email notifications"

--- a/tests/components/user_settings/email_notification_setting.test.jsx
+++ b/tests/components/user_settings/email_notification_setting.test.jsx
@@ -139,29 +139,22 @@ describe('components/user_settings/EmailNotificationSetting', () => {
         expect(savePreference).toBeCalledWith('notifications', 'email_interval', '0');
     });
 
-    test('should pass handleExpand', () => {
+    test('should pass handleUpdateSection', () => {
         const newUpdateSection = jest.fn();
-        const props = {...requiredProps, updateSection: newUpdateSection};
-        const wrapper = mountWithIntl(<EmailNotificationSetting {...props}/>);
-
-        wrapper.instance().handleExpand();
-
-        expect(newUpdateSection).toBeCalled();
-        expect(newUpdateSection).toHaveBeenCalledTimes(1);
-        expect(newUpdateSection).toBeCalledWith('email');
-    });
-
-    test('should pass handleCancel', () => {
         const newOnCancel = jest.fn();
-        const props = {...requiredProps, onCancel: newOnCancel};
-        const evt = {preventDefault: jest.fn()};
+        const props = {...requiredProps, updateSection: newUpdateSection, onCancel: newOnCancel};
         const wrapper = mountWithIntl(<EmailNotificationSetting {...props}/>);
 
-        wrapper.instance().handleCancel(evt);
+        wrapper.instance().handleUpdateSection('email');
+        expect(newUpdateSection).toBeCalledWith('email');
+        expect(newUpdateSection).toHaveBeenCalledTimes(1);
+        expect(newOnCancel).not.toBeCalled();
 
+        wrapper.instance().handleUpdateSection();
+        expect(newUpdateSection).toBeCalled();
+        expect(newUpdateSection).toHaveBeenCalledTimes(2);
+        expect(newUpdateSection).toBeCalledWith('');
         expect(newOnCancel).toBeCalled();
-        expect(newOnCancel).toHaveBeenCalledTimes(1);
-        expect(newOnCancel).toBeCalledWith(evt);
     });
 
     test('should pass componentWillReceiveProps', () => {

--- a/tests/components/user_settings/email_notification_setting.test.jsx
+++ b/tests/components/user_settings/email_notification_setting.test.jsx
@@ -133,7 +133,7 @@ describe('components/user_settings/EmailNotificationSetting', () => {
 
         expect(newOnSubmit).toBeCalled();
         expect(newOnSubmit).toHaveBeenCalledTimes(1);
-        expect(newOnSubmit).toBeCalledWith({enableEmail: 'false'});
+        expect(newOnSubmit).toBeCalledWith('false');
 
         expect(savePreference).toHaveBeenCalledTimes(1);
         expect(savePreference).toBeCalledWith('notifications', 'email_interval', '0');


### PR DESCRIPTION
#### Summary
Migrate SettingItemMin and SettingItemMax to pure component, and avoid/replace anonymous inline function on props

(Note: This is the first PR related to anonymous inline function on props)

#### Ticket Link
Jira ticket: [PLT-8296](https://mattermost.atlassian.net/browse/PLT-8296)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

