### PR TITLE
PLT-8248: Email Address Validation should Detect and Reject Microsoft Outlook Display Formatted Addresses

### DIFF
--- a/tests/utils/utils.test.jsx
+++ b/tests/utils/utils.test.jsx
@@ -294,3 +294,80 @@ describe('Utils.isValidPassword', function() {
         }
     });
 });
+
+describe('Utils.isEmail', function() {
+   test('', function() {
+       for (const data of [
+           {
+               email: 'prettyandsimple@example.com',
+               valid: true
+           },
+           {
+               email: 'very.common@example.com',
+               valid: true
+           },
+           {
+               email: 'disposable.style.email.with+symbol@example.com',
+               valid: true
+           },
+           {
+               email: 'other.email-with-dash@example.com',
+               valid: true
+           },
+           {
+               email: 'fully-qualified-domain@example.com',
+               valid: true
+           },
+           {
+               email: 'user.name+tag+sorting@example.com',
+               valid: true
+           },
+           {
+               email: 'x@example.com',
+               valid: true
+           },
+           {
+               email: 'example-indeed@strange-example.com',
+               valid: true
+           },
+           {
+               email: 'admin@mailserver1',
+               valid: true
+           },
+           {
+               email: '#!$%&\'*+-/=?^_`{}|~@example.org',
+               valid: true
+           },
+           {
+               email: 'example@s.solutions',
+               valid: true
+           },
+           {
+               // no @ symbol
+               email: 'Abc.example.com',
+               valid: false
+           },
+           {
+               // too many @ symbols
+               email: 'A@b@c@example.com',
+               valid: false
+           },
+           {
+               // outlook format - we don't allow it, because we require user to type entire email when logging in
+               email: '<Jonathan Fritz> jonathan.fritz@mattermost.com',
+               valid: false
+           },
+           {
+               // we don't allow comma-separated lists of addresses
+               email: 'comma@domain.com, separated@domain.com',
+               valid: false
+           },
+           {
+               email: 'comma@domain.com,separated@domain.com',
+               valid: false
+           }
+       ]) {
+           expect(Utils.isEmail(data.email)).toEqual(data.valid);
+       }
+   });
+});

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -26,9 +26,13 @@ import icon50 from 'images/icon50x50.png';
 import iconWS from 'images/icon_WS.png';
 
 export function isEmail(email) {
-    // writing a regex to match all valid email addresses is really, really hard (see http://stackoverflow.com/a/201378)
-    // so we just do a simple check and rely on a verification email to tell if it's a real address
-    return (/^.+@.+$/).test(email);
+    // writing a regex to match all valid email addresses is really, really hard. (see http://stackoverflow.com/a/201378)
+    // this regex ensures:
+    // - at least one character that is not a space, comma, or @ symbol
+    // - followed by a single @ symbol
+    // - followed by at least one character that is not a space, comma, or @ symbol
+    // this prevents <Outlook Style> outlook.style@domain.com addresses and multiple comma-separated addresses from being accepted
+    return (/^[^ ,@]+@[^ ,@]+$/).test(email);
 }
 
 export function isMac() {


### PR DESCRIPTION
#### Summary
Tightened email address validation and added unit tests

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8248

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, posting, etc.)
