### PR TITLE
PLT-8265 Only pull channel/team data on reconnect if on a team

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -90,10 +90,14 @@ export function reconnect(includeWebSocket = true) {
     }
 
     loadPluginsIfNecessary();
-    loadChannelsForCurrentUser();
-    getPosts(ChannelStore.getCurrentId())(dispatch, getState);
-    StatusActions.loadStatusesForChannelAndSidebar();
-    TeamActions.getMyTeamUnreads()(dispatch, getState);
+
+    const currentTeamId = getState().entities.teams.currentTeamId;
+    if (currentTeamId) {
+        loadChannelsForCurrentUser();
+        getPosts(ChannelStore.getCurrentId())(dispatch, getState);
+        StatusActions.loadStatusesForChannelAndSidebar();
+        TeamActions.getMyTeamUnreads()(dispatch, getState);
+    }
 
     ErrorStore.clearLastError();
     ErrorStore.emitChange();


### PR DESCRIPTION
#### Summary
Fixes making bad requests when reconnecting on the system console and other non-team pages. This is really just a quick fix for the issue, fixing the core problem would be to change the pattern for all our actions to not make these requests when some required data is missing. That's a ton more work than this ticket merits though.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8265