### PR TITLE
[PLT-7615] Fix error title for oauth_missing_code error type, refactor ErrorPage component, add related stateless components and unit tests

### DIFF
--- a/components/error_page/error_link.jsx
+++ b/components/error_page/error_link.jsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+export default function ErrorLink({url, messageId, defaultMessage}) {
+    return (
+        <a
+            href={url}
+            rel='noopener noreferrer'
+            target='_blank'
+        >
+            <FormattedMessage
+                id={messageId}
+                defaultMessage={defaultMessage}
+            />
+        </a>
+    );
+}
+
+ErrorLink.propTypes = {
+    url: PropTypes.string.isRequired,
+    messageId: PropTypes.string.isRequired,
+    defaultMessage: PropTypes.string.isRequired
+};
+
+ErrorLink.defaultProps = {
+    url: '',
+    messageId: '',
+    defaultMessage: ''
+};

--- a/components/error_page/error_message.jsx
+++ b/components/error_page/error_message.jsx
@@ -1,65 +1,20 @@
-// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
-
-import $ from 'jquery';
 
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {Link} from 'react-router';
 
 import {ErrorPageTypes} from 'utils/constants.jsx';
-import * as Utils from 'utils/utils.jsx';
 
-export default class ErrorPage extends React.Component {
-    static propTypes = {
-        location: PropTypes.object.isRequired
-    };
+import ErrorLink from './error_link.jsx';
 
-    componentDidMount() {
-        $('body').attr('class', 'sticky error');
-    }
-
-    componentWillUnmount() {
-        $('body').attr('class', '');
-    }
-
-    renderTitle = () => {
-        switch (this.props.location.query.type) {
+export default function ErrorMessage({type, message, service}) {
+    let errorMessage = null;
+    if (type) {
+        switch (type) {
         case ErrorPageTypes.LOCAL_STORAGE:
-            return (
-                <FormattedMessage
-                    id='error.local_storage.title'
-                    defaultMessage='Cannot Load Mattermost'
-                />
-            );
-        case ErrorPageTypes.PERMALINK_NOT_FOUND:
-            return (
-                <FormattedMessage
-                    id='permalink.error.title'
-                    defaultMessage='Message Not Found'
-                />
-            );
-        case ErrorPageTypes.PAGE_NOT_FOUND:
-            return (
-                <FormattedMessage
-                    id='error.not_found.title'
-                    defaultMessage='Message Not Found'
-                />
-            );
-        }
-
-        if (this.props.location.query.title) {
-            return this.props.location.query.title;
-        }
-
-        return Utils.localizeMessage('error.generic.title', 'Error');
-    }
-
-    renderMessage = () => {
-        switch (this.props.location.query.type) {
-        case ErrorPageTypes.LOCAL_STORAGE:
-            return (
+            errorMessage = (
                 <div>
                     <FormattedMessage
                         id='error.local_storage.message'
@@ -87,8 +42,9 @@ export default class ErrorPage extends React.Component {
                     </ul>
                 </div>
             );
+            break;
         case ErrorPageTypes.PERMALINK_NOT_FOUND:
-            return (
+            errorMessage = (
                 <p>
                     <FormattedMessage
                         id='permalink.error.access'
@@ -96,15 +52,16 @@ export default class ErrorPage extends React.Component {
                     />
                 </p>
             );
+            break;
         case ErrorPageTypes.OAUTH_MISSING_CODE:
-            return (
+            errorMessage = (
                 <div>
                     <p>
                         <FormattedMessage
                             id='error.oauth_missing_code'
                             defaultMessage='The service provider {service} did not provide an authorization code in the redirect URL.'
                             values={{
-                                service: this.props.location.query.service
+                                service
                             }}
                         />
                     </p>
@@ -113,7 +70,13 @@ export default class ErrorPage extends React.Component {
                             id='error.oauth_missing_code.google'
                             defaultMessage='For {link} make sure your administrator enabled the Google+ API.'
                             values={{
-                                link: this.renderLink('https://docs.mattermost.com/deployment/sso-google.html', 'error.oauth_missing_code.google.link', 'Google Apps')
+                                link: (
+                                    <ErrorLink
+                                        url={'https://docs.mattermost.com/deployment/sso-google.html'}
+                                        messageId={'error.oauth_missing_code.google.link'}
+                                        defaultMessage={'Google Apps'}
+                                    />
+                                )
                             }}
                         />
                     </p>
@@ -122,7 +85,13 @@ export default class ErrorPage extends React.Component {
                             id='error.oauth_missing_code.office365'
                             defaultMessage='For {link} make sure the administrator of your Microsoft organization has enabled the Mattermost app.'
                             values={{
-                                link: this.renderLink('https://docs.mattermost.com/deployment/sso-office.html', 'error.oauth_missing_code.office365.link', 'Office 365')
+                                link: (
+                                    <ErrorLink
+                                        url={'https://docs.mattermost.com/deployment/sso-office.html'}
+                                        messageId={'error.oauth_missing_code.office365.link'}
+                                        defaultMessage={'Office 365'}
+                                    />
+                                )
                             }}
                         />
                     </p>
@@ -131,7 +100,13 @@ export default class ErrorPage extends React.Component {
                             id='error.oauth_missing_code.gitlab'
                             defaultMessage='For {link} please make sure you followed the setup instructions.'
                             values={{
-                                link: this.renderLink('https://docs.mattermost.com/deployment/sso-gitlab.html', 'error.oauth_missing_code.gitlab.link', 'GitLab')
+                                link: (
+                                    <ErrorLink
+                                        url={'https://docs.mattermost.com/deployment/sso-gitlab.html'}
+                                        messageId={'error.oauth_missing_code.gitlab.link'}
+                                        defaultMessage={'GitLab'}
+                                    />
+                                )
                             }}
                         />
                     </p>
@@ -140,14 +115,22 @@ export default class ErrorPage extends React.Component {
                             id='error.oauth_missing_code.forum'
                             defaultMessage="If you reviewed the above and are still having trouble with configuration, you may post in our {link} where we'll be happy to help with issues during setup."
                             values={{
-                                link: this.renderLink('https://forum.mattermost.org/c/trouble-shoot', 'error.oauth_missing_code.forum.link', 'Troubleshooting forum')
+                                link: (
+                                    <ErrorLink
+                                        url={'https://forum.mattermost.org/c/trouble-shoot'}
+                                        messageId={'error.oauth_missing_code.forum.link'}
+                                        defaultMessage={'Troubleshooting forum'}
+                                    />
+                                )
                             }}
                         />
                     </p>
                 </div>
             );
+            break;
         case ErrorPageTypes.PAGE_NOT_FOUND:
-            return (
+        default:
+            errorMessage = (
                 <p>
                     <FormattedMessage
                         id='error.not_found.message'
@@ -156,12 +139,14 @@ export default class ErrorPage extends React.Component {
                 </p>
             );
         }
-
-        if (this.props.location.query.message) {
-            return <p>{this.props.location.query.message}</p>;
-        }
-
-        return (
+    } else if (message) {
+        errorMessage = (
+            <p>
+                {message}
+            </p>
+        );
+    } else {
+        errorMessage = (
             <p>
                 <FormattedMessage
                     id='error.generic.message'
@@ -171,43 +156,23 @@ export default class ErrorPage extends React.Component {
         );
     }
 
-    renderLink = (url, id, defaultMessage) => {
-        return (
-            <a
-                href={url}
-                rel='noopener noreferrer'
-                target='_blank'
-            >
-                <FormattedMessage
-                    id={id}
-                    defaultMessage={defaultMessage}
-                />
-            </a>
-        );
-    }
-
-    render() {
-        const title = this.renderTitle();
-        const message = this.renderMessage();
-
-        return (
-            <div className='container-fluid'>
-                <div className='error__container'>
-                    <div className='error__icon'>
-                        <i className='fa fa-exclamation-triangle'/>
-                    </div>
-                    <h2>
-                        {title}
-                    </h2>
-                    {message}
-                    <Link to='/'>
-                        <FormattedMessage
-                            id='error.generic.link'
-                            defaultMessage='Back to Mattermost'
-                        />
-                    </Link>
-                </div>
-            </div>
-        );
-    }
+    return errorMessage;
 }
+
+ErrorMessage.propTypes = {
+
+    /*
+    * Error type
+    */
+    type: PropTypes.string,
+
+    /*
+    * Error message
+    */
+    message: PropTypes.string,
+
+    /*
+    * Service provider
+    */
+    service: PropTypes.string
+};

--- a/components/error_page/error_title.jsx
+++ b/components/error_page/error_title.jsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import {ErrorPageTypes} from 'utils/constants.jsx';
+import * as Utils from 'utils/utils.jsx';
+
+export default function ErrorTitle({type, title}) {
+    let errorTitle = null;
+    if (type) {
+        switch (type) {
+        case ErrorPageTypes.LOCAL_STORAGE:
+            errorTitle = (
+                <FormattedMessage
+                    id='error.local_storage.title'
+                    defaultMessage='Cannot Load Mattermost'
+                />
+            );
+            break;
+        case ErrorPageTypes.PERMALINK_NOT_FOUND:
+            errorTitle = (
+                <FormattedMessage
+                    id='permalink.error.title'
+                    defaultMessage='Message Not Found'
+                />
+            );
+            break;
+        case ErrorPageTypes.OAUTH_MISSING_CODE:
+            errorTitle = (
+                <FormattedMessage
+                    id='error.oauth_missing_code.title'
+                    defaultMessage='Mattermost needs your help'
+                />
+            );
+            break;
+        case ErrorPageTypes.PAGE_NOT_FOUND:
+        default:
+            errorTitle = (
+                <FormattedMessage
+                    id='error.not_found.title'
+                    defaultMessage='Page Not Found'
+                />
+            );
+        }
+    } else if (title) {
+        errorTitle = title;
+    } else {
+        errorTitle = Utils.localizeMessage('error.generic.title', 'Error');
+    }
+
+    return errorTitle;
+}
+
+ErrorTitle.propTypes = {
+
+    /*
+    * Error type
+    */
+    type: PropTypes.string,
+
+    /*
+    * Error title
+    */
+    title: PropTypes.string
+};

--- a/components/error_page/index.jsx
+++ b/components/error_page/index.jsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+import {Link} from 'react-router';
+
+import ErrorTitle from './error_title.jsx';
+import ErrorMessage from './error_message.jsx';
+
+export default class ErrorPage extends React.PureComponent {
+    static propTypes = {
+        location: PropTypes.object.isRequired
+    };
+
+    componentDidMount() {
+        document.body.setAttribute('class', 'sticky error');
+    }
+
+    componentWillUnmount() {
+        document.body.removeAttribute('class');
+    }
+
+    render() {
+        return (
+            <div className='container-fluid'>
+                <div className='error__container'>
+                    <div className='error__icon'>
+                        <i className='fa fa-exclamation-triangle'/>
+                    </div>
+                    <h2>
+                        <ErrorTitle
+                            type={this.props.location.query.type}
+                            title={this.props.location.query.title}
+                        />
+                    </h2>
+                    <ErrorMessage
+                        type={this.props.location.query.type}
+                        message={this.props.location.query.message}
+                        service={this.props.location.query.service}
+                    />
+                    <Link to='/'>
+                        <FormattedMessage
+                            id='error.generic.link'
+                            defaultMessage='Back to Mattermost'
+                        />
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1539,6 +1539,7 @@
   "error.oauth_missing_code.google.link": "Google Apps",
   "error.oauth_missing_code.office365": "For {link} make sure the administrator of your Microsoft organization has enabled the Mattermost app.",
   "error.oauth_missing_code.office365.link": "Office 365",
+  "error.oauth_missing_code.title": "Mattermost needs your help",
   "error_bar.expired": "Enterprise license is expired and some features may be disabled. <a href='{link}' target='_blank'>Please renew</a>.",
   "error_bar.expiring": "Enterprise license expires on {date}. <a href='{link}' target='_blank'>Please renew</a>.",
   "error_bar.past_grace": "Enterprise license is expired and some features may be disabled. Please contact your System Administrator for details.",

--- a/tests/components/error_page/__snapshots__/error_link.test.jsx.snap
+++ b/tests/components/error_page/__snapshots__/error_link.test.jsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/error_page/ErrorLink should match snapshot 1`] = `
+<a
+  href="https://docs.mattermost.com/deployment/sso-gitlab.html"
+  rel="noopener noreferrer"
+  target="_blank"
+>
+  <FormattedMessage
+    defaultMessage="GitLab"
+    id="error.oauth_missing_code.gitlab.link"
+    values={Object {}}
+  />
+</a>
+`;

--- a/tests/components/error_page/__snapshots__/error_message.test.jsx.snap
+++ b/tests/components/error_page/__snapshots__/error_message.test.jsx.snap
@@ -1,0 +1,146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/error_page/ErrorMessage should match snapshot, local_storage type 1`] = `
+<div>
+  <FormattedMessage
+    defaultMessage="Mattermost was unable to load because a setting in your browser prevents the use of its local storage features. To allow Mattermost to load, try the following actions:"
+    id="error.local_storage.message"
+    values={Object {}}
+  />
+  <ul>
+    <li>
+      <FormattedMessage
+        defaultMessage="Enable cookies"
+        id="error.local_storage.help1"
+        values={Object {}}
+      />
+    </li>
+    <li>
+      <FormattedMessage
+        defaultMessage="Turn off private browsing"
+        id="error.local_storage.help2"
+        values={Object {}}
+      />
+    </li>
+    <li>
+      <FormattedMessage
+        defaultMessage="Use a supported browser (IE 11, Chrome 43+, Firefox 38+, Safari 9, Edge)"
+        id="error.local_storage.help3"
+        values={Object {}}
+      />
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`components/error_page/ErrorMessage should match snapshot, no type but with message 1`] = `
+<p>
+  error message
+</p>
+`;
+
+exports[`components/error_page/ErrorMessage should match snapshot, no type nor message 1`] = `
+<p>
+  <FormattedMessage
+    defaultMessage="An error has occurred."
+    id="error.generic.message"
+    values={Object {}}
+  />
+</p>
+`;
+
+exports[`components/error_page/ErrorMessage should match snapshot, oauth_missing_code type 1`] = `
+<div>
+  <p>
+    <FormattedMessage
+      defaultMessage="The service provider {service} did not provide an authorization code in the redirect URL."
+      id="error.oauth_missing_code"
+      values={
+        Object {
+          "service": "Gitlab",
+        }
+      }
+    />
+  </p>
+  <p>
+    <FormattedMessage
+      defaultMessage="For {link} make sure your administrator enabled the Google+ API."
+      id="error.oauth_missing_code.google"
+      values={
+        Object {
+          "link": <ErrorLink
+            defaultMessage="Google Apps"
+            messageId="error.oauth_missing_code.google.link"
+            url="https://docs.mattermost.com/deployment/sso-google.html"
+          />,
+        }
+      }
+    />
+  </p>
+  <p>
+    <FormattedMessage
+      defaultMessage="For {link} make sure the administrator of your Microsoft organization has enabled the Mattermost app."
+      id="error.oauth_missing_code.office365"
+      values={
+        Object {
+          "link": <ErrorLink
+            defaultMessage="Office 365"
+            messageId="error.oauth_missing_code.office365.link"
+            url="https://docs.mattermost.com/deployment/sso-office.html"
+          />,
+        }
+      }
+    />
+  </p>
+  <p>
+    <FormattedMessage
+      defaultMessage="For {link} please make sure you followed the setup instructions."
+      id="error.oauth_missing_code.gitlab"
+      values={
+        Object {
+          "link": <ErrorLink
+            defaultMessage="GitLab"
+            messageId="error.oauth_missing_code.gitlab.link"
+            url="https://docs.mattermost.com/deployment/sso-gitlab.html"
+          />,
+        }
+      }
+    />
+  </p>
+  <p>
+    <FormattedMessage
+      defaultMessage="If you reviewed the above and are still having trouble with configuration, you may post in our {link} where we'll be happy to help with issues during setup."
+      id="error.oauth_missing_code.forum"
+      values={
+        Object {
+          "link": <ErrorLink
+            defaultMessage="Troubleshooting forum"
+            messageId="error.oauth_missing_code.forum.link"
+            url="https://forum.mattermost.org/c/trouble-shoot"
+          />,
+        }
+      }
+    />
+  </p>
+</div>
+`;
+
+exports[`components/error_page/ErrorMessage should match snapshot, page_not_found type 1`] = `
+<p>
+  <FormattedMessage
+    defaultMessage="The page you were trying to reach does not exist"
+    id="error.not_found.message"
+    values={Object {}}
+  />
+</p>
+`;
+
+exports[`components/error_page/ErrorMessage should match snapshot, permalink_not_found type 1`] = `
+<p>
+  <FormattedMessage
+    defaultMessage="Permalink belongs to a deleted message or to a channel to which you do not have access."
+    id="permalink.error.access"
+    values={Object {}}
+  />
+</p>
+`;

--- a/tests/components/error_page/__snapshots__/error_page.test.jsx.snap
+++ b/tests/components/error_page/__snapshots__/error_page.test.jsx.snap
@@ -1,0 +1,201 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/error_page/ErrorPage should match snapshot, local_storage type 1`] = `
+<div
+  className="container-fluid"
+>
+  <div
+    className="error__container"
+  >
+    <div
+      className="error__icon"
+    >
+      <i
+        className="fa fa-exclamation-triangle"
+      />
+    </div>
+    <h2>
+      <ErrorTitle
+        title=""
+        type="local_storage"
+      />
+    </h2>
+    <ErrorMessage
+      message=""
+      service=""
+      type="local_storage"
+    />
+    <Link
+      onlyActiveOnIndex={false}
+      style={Object {}}
+      to="/"
+    >
+      <FormattedMessage
+        defaultMessage="Back to Mattermost"
+        id="error.generic.link"
+        values={Object {}}
+      />
+    </Link>
+  </div>
+</div>
+`;
+
+exports[`components/error_page/ErrorPage should match snapshot, no type but with title 1`] = `
+<div
+  className="container-fluid"
+>
+  <div
+    className="error__container"
+  >
+    <div
+      className="error__icon"
+    >
+      <i
+        className="fa fa-exclamation-triangle"
+      />
+    </div>
+    <h2>
+      <ErrorTitle
+        title="Error Title"
+        type=""
+      />
+    </h2>
+    <ErrorMessage
+      message=""
+      service=""
+      type=""
+    />
+    <Link
+      onlyActiveOnIndex={false}
+      style={Object {}}
+      to="/"
+    >
+      <FormattedMessage
+        defaultMessage="Back to Mattermost"
+        id="error.generic.link"
+        values={Object {}}
+      />
+    </Link>
+  </div>
+</div>
+`;
+
+exports[`components/error_page/ErrorPage should match snapshot, oauth_missing_code type 1`] = `
+<div
+  className="container-fluid"
+>
+  <div
+    className="error__container"
+  >
+    <div
+      className="error__icon"
+    >
+      <i
+        className="fa fa-exclamation-triangle"
+      />
+    </div>
+    <h2>
+      <ErrorTitle
+        title=""
+        type="oauth_missing_code"
+      />
+    </h2>
+    <ErrorMessage
+      message=""
+      service="Gitlab"
+      type="oauth_missing_code"
+    />
+    <Link
+      onlyActiveOnIndex={false}
+      style={Object {}}
+      to="/"
+    >
+      <FormattedMessage
+        defaultMessage="Back to Mattermost"
+        id="error.generic.link"
+        values={Object {}}
+      />
+    </Link>
+  </div>
+</div>
+`;
+
+exports[`components/error_page/ErrorPage should match snapshot, page_not_found type 1`] = `
+<div
+  className="container-fluid"
+>
+  <div
+    className="error__container"
+  >
+    <div
+      className="error__icon"
+    >
+      <i
+        className="fa fa-exclamation-triangle"
+      />
+    </div>
+    <h2>
+      <ErrorTitle
+        title=""
+        type="page_not_found"
+      />
+    </h2>
+    <ErrorMessage
+      message=""
+      service=""
+      type="page_not_found"
+    />
+    <Link
+      onlyActiveOnIndex={false}
+      style={Object {}}
+      to="/"
+    >
+      <FormattedMessage
+        defaultMessage="Back to Mattermost"
+        id="error.generic.link"
+        values={Object {}}
+      />
+    </Link>
+  </div>
+</div>
+`;
+
+exports[`components/error_page/ErrorPage should match snapshot, permalink_not_found type 1`] = `
+<div
+  className="container-fluid"
+>
+  <div
+    className="error__container"
+  >
+    <div
+      className="error__icon"
+    >
+      <i
+        className="fa fa-exclamation-triangle"
+      />
+    </div>
+    <h2>
+      <ErrorTitle
+        title=""
+        type="permalink_not_found"
+      />
+    </h2>
+    <ErrorMessage
+      message=""
+      service=""
+      type="permalink_not_found"
+    />
+    <Link
+      onlyActiveOnIndex={false}
+      style={Object {}}
+      to="/"
+    >
+      <FormattedMessage
+        defaultMessage="Back to Mattermost"
+        id="error.generic.link"
+        values={Object {}}
+      />
+    </Link>
+  </div>
+</div>
+`;

--- a/tests/components/error_page/__snapshots__/error_title.test.jsx.snap
+++ b/tests/components/error_page/__snapshots__/error_title.test.jsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/error_page/ErrorTitle should match snapshot, local_storage type 1`] = `
+<FormattedMessage
+  defaultMessage="Cannot Load Mattermost"
+  id="error.local_storage.title"
+  values={Object {}}
+/>
+`;
+
+exports[`components/error_page/ErrorTitle should match snapshot, no type but with title 1`] = `"error title"`;
+
+exports[`components/error_page/ErrorTitle should match snapshot, no type nor title 1`] = `"Error"`;
+
+exports[`components/error_page/ErrorTitle should match snapshot, oauth_missing_code type 1`] = `
+<FormattedMessage
+  defaultMessage="Mattermost needs your help"
+  id="error.oauth_missing_code.title"
+  values={Object {}}
+/>
+`;
+
+exports[`components/error_page/ErrorTitle should match snapshot, page_not_found type 1`] = `
+<FormattedMessage
+  defaultMessage="Page Not Found"
+  id="error.not_found.title"
+  values={Object {}}
+/>
+`;
+
+exports[`components/error_page/ErrorTitle should match snapshot, permalink_not_found type 1`] = `
+<FormattedMessage
+  defaultMessage="Message Not Found"
+  id="permalink.error.title"
+  values={Object {}}
+/>
+`;

--- a/tests/components/error_page/error_link.test.jsx
+++ b/tests/components/error_page/error_link.test.jsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import ErrorLink from 'components/error_page/error_link.jsx';
+
+describe('components/error_page/ErrorLink', () => {
+    const baseProps = {
+        url: 'https://docs.mattermost.com/deployment/sso-gitlab.html',
+        messageId: 'error.oauth_missing_code.gitlab.link',
+        defaultMessage: 'GitLab'
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <ErrorLink {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/tests/components/error_page/error_message.test.jsx
+++ b/tests/components/error_page/error_message.test.jsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {ErrorPageTypes} from 'utils/constants.jsx';
+
+import ErrorMessage from 'components/error_page/error_message.jsx';
+
+describe('components/error_page/ErrorMessage', () => {
+    const baseProps = {
+        type: ErrorPageTypes.LOCAL_STORAGE,
+        message: '',
+        service: ''
+    };
+
+    test('should match snapshot, local_storage type', () => {
+        const wrapper = shallow(
+            <ErrorMessage {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, permalink_not_found type', () => {
+        const props = {...baseProps, type: ErrorPageTypes.PERMALINK_NOT_FOUND};
+        const wrapper = shallow(
+            <ErrorMessage {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, oauth_missing_code type', () => {
+        const props = {...baseProps, type: ErrorPageTypes.OAUTH_MISSING_CODE, service: 'Gitlab'};
+        const wrapper = shallow(
+            <ErrorMessage {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, page_not_found type', () => {
+        const props = {...baseProps, type: ErrorPageTypes.PAGE_NOT_FOUND};
+        const wrapper = shallow(
+            <ErrorMessage {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, no type but with message', () => {
+        const props = {...baseProps, type: '', message: 'error message'};
+        const wrapper = shallow(
+            <ErrorMessage {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, no type nor message', () => {
+        const props = {...baseProps, type: '', message: ''};
+        const wrapper = shallow(
+            <ErrorMessage {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/tests/components/error_page/error_page.test.jsx
+++ b/tests/components/error_page/error_page.test.jsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {ErrorPageTypes} from 'utils/constants.jsx';
+
+import ErrorPage from 'components/error_page';
+
+describe('components/error_page/ErrorPage', () => {
+    const defaultLocation = {
+        query: {
+            type: ErrorPageTypes.LOCAL_STORAGE,
+            title: '',
+            message: '',
+            service: ''
+        }
+    };
+
+    test('should match snapshot, local_storage type', () => {
+        const wrapper = shallow(
+            <ErrorPage location={defaultLocation}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, permalink_not_found type', () => {
+        const newLocation = {...defaultLocation};
+        newLocation.query.type = ErrorPageTypes.PERMALINK_NOT_FOUND;
+        const wrapper = shallow(
+            <ErrorPage location={newLocation}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, oauth_missing_code type', () => {
+        const newLocation = {...defaultLocation};
+        newLocation.query.type = ErrorPageTypes.OAUTH_MISSING_CODE;
+        newLocation.query.service = 'Gitlab';
+        const wrapper = shallow(
+            <ErrorPage location={newLocation}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, page_not_found type', () => {
+        const newLocation = {...defaultLocation};
+        newLocation.query.type = ErrorPageTypes.PAGE_NOT_FOUND;
+        newLocation.query.service = '';
+
+        const wrapper = shallow(
+            <ErrorPage location={newLocation}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, no type but with title', () => {
+        const newLocation = {...defaultLocation};
+        newLocation.query.type = '';
+        newLocation.query.title = 'Error Title';
+
+        const wrapper = shallow(
+            <ErrorPage location={newLocation}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/tests/components/error_page/error_title.test.jsx
+++ b/tests/components/error_page/error_title.test.jsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {ErrorPageTypes} from 'utils/constants.jsx';
+
+import ErrorTitle from 'components/error_page/error_title.jsx';
+
+describe('components/error_page/ErrorTitle', () => {
+    const baseProps = {
+        type: ErrorPageTypes.LOCAL_STORAGE,
+        title: ''
+    };
+
+    test('should match snapshot, local_storage type', () => {
+        const wrapper = shallow(
+            <ErrorTitle {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, permalink_not_found type', () => {
+        const props = {...baseProps, type: ErrorPageTypes.PERMALINK_NOT_FOUND};
+        const wrapper = shallow(
+            <ErrorTitle {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, oauth_missing_code type', () => {
+        const props = {...baseProps, type: ErrorPageTypes.OAUTH_MISSING_CODE};
+        const wrapper = shallow(
+            <ErrorTitle {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, page_not_found type', () => {
+        const props = {...baseProps, type: ErrorPageTypes.PAGE_NOT_FOUND};
+        const wrapper = shallow(
+            <ErrorTitle {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, no type but with title', () => {
+        const props = {...baseProps, type: '', title: 'error title'};
+        const wrapper = shallow(
+            <ErrorTitle {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, no type nor title', () => {
+        const props = {...baseProps, type: '', title: ''};
+        const wrapper = shallow(
+            <ErrorTitle {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
- Fix error title for oauth_missing_code error type, 
- Refactor ErrorPage component, 
- Add related stateless components,
- Add unit tests

#### Ticket Link
Jira ticket: [PLT-7615](https://mattermost.atlassian.net/browse/PLT-7615)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates

