### PR TITLE
PLT-8374 Fix warning from statistic count component

### DIFF
--- a/components/analytics/statistic_count.jsx
+++ b/components/analytics/statistic_count.jsx
@@ -39,7 +39,7 @@ export default class StatisticCount extends React.PureComponent {
                         {this.props.title}
                         <i className={'fa ' + this.props.icon}/>
                     </div>
-                    <div className='content'>{this.props.count == null ? loading : this.props.count}</div>
+                    <div className='content'>{isNaN(this.props.count) ? loading : this.props.count}</div>
                 </div>
             </div>
         );


### PR DESCRIPTION
#### Summary
Fix warning from statistic count component by using `isNaN()` over null checking.
#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8374