### PR TITLE
[PLT-7793] [WIP] Adds Personal Access Tokens Page to System Console

### DIFF
--- a/components/admin_console/admin_sidebar/admin_sidebar.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.jsx
@@ -402,6 +402,15 @@ export default class AdminSidebar extends React.Component {
                                 }
                             />
                             <AdminSidebarSection
+                                name='user_access_tokens'
+                                title={
+                                    <FormattedMessage
+                                        id='admin.sidebar.user_access_tokens'
+                                        defaultMessage='Personal Access Tokens'
+                                    />
+                                 }
+                            />
+                            <AdminSidebarSection
                                 name='logs'
                                 title={
                                     <FormattedMessage

--- a/components/admin_console/system_users/system_users_list.jsx
+++ b/components/admin_console/system_users/system_users_list.jsx
@@ -13,7 +13,7 @@ import ManageRolesModal from 'components/admin_console/manage_roles_modal';
 import ManageTeamsModal from 'components/admin_console/manage_teams_modal/manage_teams_modal.jsx';
 import ManageTokensModal from 'components/admin_console/manage_tokens_modal';
 import ResetPasswordModal from 'components/admin_console/reset_password_modal.jsx';
-import SearchableUserList from 'components/searchable_user_list/searchable_user_list.jsx';
+import SearchableItemList from 'components/searchable_item_list/searchable_item_list.jsx';
 import UserListRowWithError from 'components/user_list_row_with_error.jsx';
 
 import SystemUsersDropdown from './system_users_dropdown.jsx';
@@ -250,8 +250,10 @@ export default class SystemUsersList extends React.Component {
 
         return (
             <div>
-                <SearchableUserList
+                <SearchableItemList
                     {...this.props}
+                    items={this.props.users}
+                    itemsPerPage={this.props.usersPerPage}
                     renderCount={this.renderCount}
                     extraInfo={extraInfo}
                     actions={[SystemUsersDropdown]}

--- a/components/admin_console/user_access_tokens/index.jsx
+++ b/components/admin_console/user_access_tokens/index.jsx
@@ -1,0 +1,3 @@
+import UserAccessTokens from './user_access_tokens';
+
+export default UserAccessTokens;

--- a/components/admin_console/user_access_tokens/user_access_tokens.jsx
+++ b/components/admin_console/user_access_tokens/user_access_tokens.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import {FormattedMessage, FormattedHTMLMessage} from 'react-intl';
 
-import UserAccessTokensList from './user_access_tokens_list';
+import UserAccessTokensContainer from './user_access_tokens_container';
 
 export default class UserAccessTokens extends React.PureComponent {
     static propTypes = {};
@@ -27,8 +27,8 @@ export default class UserAccessTokens extends React.PureComponent {
                     </div>
                 </div>
                 <div className='more-modal__list member-list-holder'>
-                    <UserAccessTokensList
-                        itemsPerPage={10}
+                    <UserAccessTokensContainer
+                        itemsPerPage={30}
                     />
                 </div>
             </div>

--- a/components/admin_console/user_access_tokens/user_access_tokens.jsx
+++ b/components/admin_console/user_access_tokens/user_access_tokens.jsx
@@ -1,0 +1,35 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {FormattedMessage, FormattedHTMLMessage} from 'react-intl';
+
+import UserAccessTokensList from './user_access_tokens_list';
+
+export default class UserAccessTokens extends React.PureComponent {
+    static propTypes = {};
+
+    render() {
+        return (
+            <div className='wrapper--fixed'>
+                <h3 className='admin-console-header'>
+                    <FormattedMessage
+                        id='admin.user_access_tokens.title'
+                        defaultMessage='Personal Access Tokens'
+                    />
+                </h3>
+                <div className='banner'>
+                    <div className='banner__content'>
+                        <FormattedHTMLMessage
+                            id='analytics.user_access_tokens.info'
+                            defaultMessage='Personal access tokens function similarly to session tokens and can be used by integrations to <a href="https://about.mattermost.com/default-api-authentication" target="_blank">interact with this Mattermost server</a>. Learn more about <a href="https://about.mattermost.com/default-user-access-tokens" target="_blank">personal access tokens</a>.'
+                        />
+                    </div>
+                </div>
+                <div className='more-modal__list member-list-holder'>
+                    <UserAccessTokensList/>
+                </div>
+            </div>
+        );
+    }
+}

--- a/components/admin_console/user_access_tokens/user_access_tokens.jsx
+++ b/components/admin_console/user_access_tokens/user_access_tokens.jsx
@@ -27,7 +27,9 @@ export default class UserAccessTokens extends React.PureComponent {
                     </div>
                 </div>
                 <div className='more-modal__list member-list-holder'>
-                    <UserAccessTokensList/>
+                    <UserAccessTokensList
+                        itemsPerPage={10}
+                    />
                 </div>
             </div>
         );

--- a/components/admin_console/user_access_tokens/user_access_tokens_container.jsx
+++ b/components/admin_console/user_access_tokens/user_access_tokens_container.jsx
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import SearchableItemList from '../../searchable_item_list/searchable_item_list';
+
+import UserAccessTokensList from './user_access_tokens_list';
+
+export default class UserAccessTokensContainer extends React.PureComponent {
+    static propTypes = {
+        tokens: PropTypes.arrayOf(PropTypes.object),
+        tokensPerPage: PropTypes.number,
+        total: PropTypes.number,
+        nextPage: PropTypes.func,
+        search: PropTypes.func.isRequired,
+        focusOnMount: PropTypes.bool,
+        renderFilterRow: PropTypes.func,
+        term: PropTypes.string.isRequired,
+        onTermChange: PropTypes.func.isRequired
+    };
+
+    constructor() {
+        super();
+        this.state = {
+            page: 0,
+            showDeleteTokenModal: false,
+            token: null
+        };
+    }
+
+    nextPage = () => {
+        this.setState({page: this.state.page + 1});
+        this.props.nextPage(this.state.page + 1);
+    }
+
+    previousPage = () => {
+        this.setState({page: this.state.page - 1});
+    }
+
+    search = (term) => {
+        this.props.search(term);
+
+        if (term !== '') {
+            this.setState({page: 0});
+        }
+    }
+
+    onDeleteToken = (token) => {
+        this.setState({
+            showDeleteTokenModal: true,
+            token
+        });
+    }
+
+    render() {
+        return (
+            <SearchableItemList
+                listComponent={UserAccessTokensList}
+                items={this.props.tokens}
+            />
+        );
+    }
+}

--- a/components/admin_console/user_access_tokens/user_access_tokens_list.jsx
+++ b/components/admin_console/user_access_tokens/user_access_tokens_list.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default class UserAccessTokensList extends React.PureComponent {
+    render() {
+        return (<div>{'test'}</div>);
+    }
+}

--- a/components/admin_console/user_access_tokens/user_access_tokens_list.jsx
+++ b/components/admin_console/user_access_tokens/user_access_tokens_list.jsx
@@ -1,7 +1,60 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 import React from 'react';
+import PropTypes from 'prop-types';
+
+import SearchableItemList from '../../searchable_item_list/searchable_item_list';
 
 export default class UserAccessTokensList extends React.PureComponent {
+    static propTypes = {
+        tokens: PropTypes.arrayOf(PropTypes.object),
+        tokensPerPage: PropTypes.number,
+        total: PropTypes.number,
+        nextPage: PropTypes.func,
+        search: PropTypes.func.isRequired,
+        focusOnMount: PropTypes.bool,
+        renderFilterRow: PropTypes.func,
+        term: PropTypes.string.isRequired,
+        onTermChange: PropTypes.func.isRequired
+    };
+
+    constructor() {
+        super();
+        this.state = {
+            page: 0,
+            showDeleteTokenModal: false,
+            token: null
+        };
+    }
+
+    nextPage = () => {
+        this.setState({page: this.state.page + 1});
+        this.props.nextPage(this.state.page + 1);
+    }
+
+    previousPage = () => {
+        this.setState({page: this.state.page - 1});
+    }
+
+    search = (term) => {
+        this.props.search(term);
+
+        if (term !== '') {
+            this.setState({page: 0});
+        }
+    }
+
+    onDeleteToken = (token) => {
+        this.setState({
+            showDeleteTokenModal: true,
+            token
+        });
+    }
+
     render() {
-        return (<div>{'test'}</div>);
+        return (
+            <SearchableItemList/>
+        );
     }
 }

--- a/components/admin_console/user_access_tokens/user_access_tokens_list.jsx
+++ b/components/admin_console/user_access_tokens/user_access_tokens_list.jsx
@@ -2,59 +2,9 @@
 // See License.txt for license information.
 
 import React from 'react';
-import PropTypes from 'prop-types';
-
-import SearchableItemList from '../../searchable_item_list/searchable_item_list';
 
 export default class UserAccessTokensList extends React.PureComponent {
-    static propTypes = {
-        tokens: PropTypes.arrayOf(PropTypes.object),
-        tokensPerPage: PropTypes.number,
-        total: PropTypes.number,
-        nextPage: PropTypes.func,
-        search: PropTypes.func.isRequired,
-        focusOnMount: PropTypes.bool,
-        renderFilterRow: PropTypes.func,
-        term: PropTypes.string.isRequired,
-        onTermChange: PropTypes.func.isRequired
-    };
-
-    constructor() {
-        super();
-        this.state = {
-            page: 0,
-            showDeleteTokenModal: false,
-            token: null
-        };
-    }
-
-    nextPage = () => {
-        this.setState({page: this.state.page + 1});
-        this.props.nextPage(this.state.page + 1);
-    }
-
-    previousPage = () => {
-        this.setState({page: this.state.page - 1});
-    }
-
-    search = (term) => {
-        this.props.search(term);
-
-        if (term !== '') {
-            this.setState({page: 0});
-        }
-    }
-
-    onDeleteToken = (token) => {
-        this.setState({
-            showDeleteTokenModal: true,
-            token
-        });
-    }
-
     render() {
-        return (
-            <SearchableItemList/>
-        );
+        return (<div>{'list'}</div>);
     }
 }

--- a/components/member_list_channel/member_list_channel.jsx
+++ b/components/member_list_channel/member_list_channel.jsx
@@ -14,7 +14,7 @@ import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 import ChannelMembersDropdown from 'components/channel_members_dropdown';
-import SearchableUserList from 'components/searchable_user_list/searchable_user_list_container.jsx';
+import SearchableItemList from 'components/searchable_item_list/searchable_item_list_container.jsx';
 
 const USERS_PER_PAGE = 50;
 
@@ -194,9 +194,9 @@ export default class MemberListChannel extends React.Component {
 
     render() {
         return (
-            <SearchableUserList
-                users={this.state.usersToDisplay}
-                usersPerPage={USERS_PER_PAGE}
+            <SearchableItemList
+                items={this.state.usersToDisplay}
+                itemsPerPage={USERS_PER_PAGE}
                 total={this.state.total}
                 nextPage={this.nextPage}
                 search={this.handleSearch}

--- a/components/member_list_team/member_list_team.jsx
+++ b/components/member_list_team/member_list_team.jsx
@@ -11,7 +11,8 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
-import SearchableUserList from 'components/searchable_user_list/searchable_user_list_container.jsx';
+
+import SearchableItemList from 'components/searchable_item_list/searchable_item_list_container.jsx';
 import TeamMembersDropdown from 'components/team_members_dropdown';
 
 const USERS_PER_PAGE = 50;
@@ -147,9 +148,9 @@ export default class MemberListTeam extends React.Component {
         }
 
         return (
-            <SearchableUserList
-                users={usersToDisplay}
-                usersPerPage={USERS_PER_PAGE}
+            <SearchableItemList
+                items={usersToDisplay}
+                itemsPerPage={USERS_PER_PAGE}
                 total={this.state.total}
                 nextPage={this.nextPage}
                 search={this.search}

--- a/components/searchable_item_list/searchable_item_list.jsx
+++ b/components/searchable_item_list/searchable_item_list.jsx
@@ -15,9 +15,9 @@ const NEXT_BUTTON_TIMEOUT = 500;
 
 export default class SearchableItemList extends React.Component {
     static propTypes = {
-        listComponent: PropTypes.element,
         items: PropTypes.arrayOf(PropTypes.object),
         itemsPerPage: PropTypes.number,
+        listComponent: PropTypes.element,
         total: PropTypes.number,
         extraInfo: PropTypes.object,
         nextPage: PropTypes.func.isRequired,
@@ -41,6 +41,7 @@ export default class SearchableItemList extends React.Component {
     static defaultProps = {
         items: [],
         itemsPerPage: 50, // eslint-disable-line no-magic-numbers
+        listComponent: UserList,
         extraInfo: {},
         actions: [],
         actionProps: {},
@@ -166,7 +167,7 @@ export default class SearchableItemList extends React.Component {
     }
 
     render() {
-        const List = this.props.listComponent || UserList;
+        const List = this.props.listComponent;
         let nextButton;
         let previousButton;
         let itemsToDisplay;

--- a/components/searchable_item_list/searchable_item_list.jsx
+++ b/components/searchable_item_list/searchable_item_list.jsx
@@ -15,6 +15,7 @@ const NEXT_BUTTON_TIMEOUT = 500;
 
 export default class SearchableItemList extends React.Component {
     static propTypes = {
+        listComponent: PropTypes.element,
         items: PropTypes.arrayOf(PropTypes.object),
         itemsPerPage: PropTypes.number,
         total: PropTypes.number,
@@ -165,6 +166,7 @@ export default class SearchableItemList extends React.Component {
     }
 
     render() {
+        const List = this.props.listComponent || UserList;
         let nextButton;
         let previousButton;
         let itemsToDisplay;
@@ -238,7 +240,7 @@ export default class SearchableItemList extends React.Component {
                 <div
                     className='more-modal__list'
                 >
-                    <UserList
+                    <List
                         ref='itemList'
                         users={itemsToDisplay}
                         extraInfo={this.props.extraInfo}

--- a/components/searchable_item_list/searchable_item_list.jsx
+++ b/components/searchable_item_list/searchable_item_list.jsx
@@ -2,14 +2,15 @@
 // See License.txt for license information.
 
 import $ from 'jquery';
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
-import QuickInput from 'components/quick_input';
-import UserList from 'components/user_list.jsx';
 import * as Utils from 'utils/utils.jsx';
+
+import UserList from 'components/user_list.jsx';
 
 const NEXT_BUTTON_TIMEOUT = 500;
 
@@ -179,11 +180,7 @@ export default class SearchableItemList extends React.Component {
             const pageEnd = pageStart + this.props.itemsPerPage;
             itemsToDisplay = this.props.items.slice(pageStart, pageEnd);
 
-<<<<<<< HEAD:components/searchable_user_list/searchable_user_list.jsx
-            if (pageEnd < this.props.users.length) {
-=======
-            if (itemsToDisplay.length >= this.props.itemsPerPage) {
->>>>>>> Gerneralize SearchableUserList for better re-use:components/searchable_item_list/searchable_item_list.jsx
+            if (pageEnd < this.props.items.length) {
                 nextButton = (
                     <button
                         className='btn btn-default filter-control filter-control__next'
@@ -219,7 +216,7 @@ export default class SearchableItemList extends React.Component {
         } else {
             filterRow = (
                 <div className='col-xs-12'>
-                    <QuickInput
+                    <input
                         ref='filter'
                         className='form-control filter-textbox'
                         placeholder={Utils.localizeMessage('filtered_user_list.search', 'Search users')}

--- a/components/searchable_item_list/searchable_item_list.jsx
+++ b/components/searchable_item_list/searchable_item_list.jsx
@@ -13,10 +13,10 @@ import * as Utils from 'utils/utils.jsx';
 
 const NEXT_BUTTON_TIMEOUT = 500;
 
-export default class SearchableUserList extends React.Component {
+export default class SearchableItemList extends React.Component {
     static propTypes = {
-        users: PropTypes.arrayOf(PropTypes.object),
-        usersPerPage: PropTypes.number,
+        items: PropTypes.arrayOf(PropTypes.object),
+        itemsPerPage: PropTypes.number,
         total: PropTypes.number,
         extraInfo: PropTypes.object,
         nextPage: PropTypes.func.isRequired,
@@ -38,8 +38,8 @@ export default class SearchableUserList extends React.Component {
     };
 
     static defaultProps = {
-        users: [],
-        usersPerPage: 50, // eslint-disable-line no-magic-numbers
+        items: [],
+        itemsPerPage: 50, // eslint-disable-line no-magic-numbers
         extraInfo: {},
         actions: [],
         actionProps: {},
@@ -72,7 +72,7 @@ export default class SearchableUserList extends React.Component {
 
     componentDidUpdate(prevProps) {
         if (this.props.page !== prevProps.page || this.props.term !== prevProps.term) {
-            this.refs.userList.scrollToTop();
+            this.refs.itemList.scrollToTop();
         }
 
         this.focusSearchBar();
@@ -110,12 +110,12 @@ export default class SearchableUserList extends React.Component {
         this.props.search(e.target.value);
     }
 
-    renderCount(users) {
-        if (!users) {
+    renderCount(items) {
+        if (!items) {
             return null;
         }
 
-        const count = users.length;
+        const count = items.length;
         const total = this.props.total;
         const isSearch = Boolean(this.props.term);
 
@@ -125,8 +125,8 @@ export default class SearchableUserList extends React.Component {
             startCount = -1;
             endCount = -1;
         } else {
-            startCount = this.props.page * this.props.usersPerPage;
-            endCount = Math.min(startCount + this.props.usersPerPage, total);
+            startCount = this.props.page * this.props.itemsPerPage;
+            endCount = Math.min(startCount + this.props.itemsPerPage, total);
         }
 
         if (this.props.renderCount) {
@@ -167,16 +167,20 @@ export default class SearchableUserList extends React.Component {
     render() {
         let nextButton;
         let previousButton;
-        let usersToDisplay;
+        let itemsToDisplay;
 
-        if (this.props.term || !this.props.users) {
-            usersToDisplay = this.props.users;
+        if (this.props.term || !this.props.items) {
+            itemsToDisplay = this.props.items;
         } else if (!this.props.term) {
-            const pageStart = this.props.page * this.props.usersPerPage;
-            const pageEnd = pageStart + this.props.usersPerPage;
-            usersToDisplay = this.props.users.slice(pageStart, pageEnd);
+            const pageStart = this.props.page * this.props.itemsPerPage;
+            const pageEnd = pageStart + this.props.itemsPerPage;
+            itemsToDisplay = this.props.items.slice(pageStart, pageEnd);
 
+<<<<<<< HEAD:components/searchable_user_list/searchable_user_list.jsx
             if (pageEnd < this.props.users.length) {
+=======
+            if (itemsToDisplay.length >= this.props.itemsPerPage) {
+>>>>>>> Gerneralize SearchableUserList for better re-use:components/searchable_item_list/searchable_item_list.jsx
                 nextButton = (
                     <button
                         className='btn btn-default filter-control filter-control__next'
@@ -228,15 +232,15 @@ export default class SearchableUserList extends React.Component {
                 <div className='filter-row'>
                     {filterRow}
                     <div className='col-sm-12'>
-                        <span className='member-count pull-left'>{this.renderCount(usersToDisplay)}</span>
+                        <span className='member-count pull-left'>{this.renderCount(itemsToDisplay)}</span>
                     </div>
                 </div>
                 <div
                     className='more-modal__list'
                 >
                     <UserList
-                        ref='userList'
-                        users={usersToDisplay}
+                        ref='itemList'
+                        users={itemsToDisplay}
                         extraInfo={this.props.extraInfo}
                         actions={this.props.actions}
                         actionProps={this.props.actionProps}

--- a/components/searchable_item_list/searchable_item_list_container.jsx
+++ b/components/searchable_item_list/searchable_item_list_container.jsx
@@ -4,12 +4,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import SearchableUserList from './searchable_user_list.jsx';
+import SearchableItemList from './searchable_item_list.jsx';
 
-export default class SearchableUserListContainer extends React.Component {
+export default class SearchableItemListContainer extends React.Component {
     static propTypes = {
-        users: PropTypes.arrayOf(PropTypes.object),
-        usersPerPage: PropTypes.number,
+        items: PropTypes.arrayOf(PropTypes.object),
+        itemsPerPage: PropTypes.number,
         total: PropTypes.number,
         extraInfo: PropTypes.object,
         nextPage: PropTypes.func.isRequired,
@@ -59,7 +59,7 @@ export default class SearchableUserListContainer extends React.Component {
 
     render() {
         return (
-            <SearchableUserList
+            <SearchableItemList
                 {...this.props}
                 nextPage={this.nextPage}
                 previousPage={this.previousPage}

--- a/tests/components/admin_console/__snapshots__/user_access_token.test.jsx.snap
+++ b/tests/components/admin_console/__snapshots__/user_access_token.test.jsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/admin_console/UserAccessTokens should match snapshot with base props 1`] = `
+<div
+  className="wrapper--fixed"
+>
+  <h3
+    className="admin-console-header"
+  >
+    <FormattedMessage
+      defaultMessage="Personal Access Tokens"
+      id="admin.user_access_tokens.title"
+      values={Object {}}
+    />
+  </h3>
+  <div
+    className="banner"
+  >
+    <div
+      className="banner__content"
+    >
+      <FormattedHTMLMessage
+        defaultMessage="Personal access tokens function similarly to session tokens and can be used by integrations to <a href=\\"https://about.mattermost.com/default-api-authentication\\" target=\\"_blank\\">interact with this Mattermost server</a>. Learn more about <a href=\\"https://about.mattermost.com/default-user-access-tokens\\" target=\\"_blank\\">personal access tokens</a>."
+        id="analytics.user_access_tokens.info"
+        values={Object {}}
+      />
+    </div>
+  </div>
+  <div
+    className="more-modal__list member-list-holder"
+  >
+    <UserAccessTokensList
+      itemsPerPage={10}
+    />
+  </div>
+</div>
+`;

--- a/tests/components/admin_console/__snapshots__/user_access_token.test.jsx.snap
+++ b/tests/components/admin_console/__snapshots__/user_access_token.test.jsx.snap
@@ -29,8 +29,8 @@ exports[`components/admin_console/UserAccessTokens should match snapshot with ba
   <div
     className="more-modal__list member-list-holder"
   >
-    <UserAccessTokensList
-      itemsPerPage={10}
+    <UserAccessTokensContainer
+      itemsPerPage={30}
     />
   </div>
 </div>

--- a/tests/components/admin_console/__snapshots__/user_access_tokens_list.test.jsx.snap
+++ b/tests/components/admin_console/__snapshots__/user_access_tokens_list.test.jsx.snap
@@ -1,14 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/admin_console/UserAccessTokensList should match snapshot with base props 1`] = `
-<SearchableItemList
-  actionProps={Object {}}
-  actionUserProps={Object {}}
-  actions={Array []}
-  extraInfo={Object {}}
-  focusOnMount={false}
-  items={Array []}
-  itemsPerPage={50}
-  showTeamToggle={false}
-/>
+<div>
+  list
+</div>
 `;

--- a/tests/components/admin_console/__snapshots__/user_access_tokens_list.test.jsx.snap
+++ b/tests/components/admin_console/__snapshots__/user_access_tokens_list.test.jsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/admin_console/UserAccessTokensList should match snapshot with base props 1`] = `
+<SearchableItemList
+  actionProps={Object {}}
+  actionUserProps={Object {}}
+  actions={Array []}
+  extraInfo={Object {}}
+  focusOnMount={false}
+  items={Array []}
+  itemsPerPage={50}
+  showTeamToggle={false}
+/>
+`;

--- a/tests/components/admin_console/user_access_token.test.jsx
+++ b/tests/components/admin_console/user_access_token.test.jsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import UserAccessTokens from 'components/admin_console/user_access_tokens/user_access_tokens';
+
+describe('components/admin_console/UserAccessTokens', () => {
+    global.window.mm_license = {};
+    global.window.mm_config = {};
+
+    beforeEach(() => {
+        global.window.mm_license.IsLicensed = 'false';
+    });
+
+    afterEach(() => {
+        global.window.mm_license = {};
+        global.window.mm_config = {};
+    });
+
+    const baseProps = {};
+
+    test('should match snapshot with base props', () => {
+        const wrapper = shallow(
+            <UserAccessTokens {...baseProps}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/tests/components/admin_console/user_access_tokens_list.test.jsx
+++ b/tests/components/admin_console/user_access_tokens_list.test.jsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import UserAccessTokensList from 'components/admin_console/user_access_tokens/user_access_tokens_list';
+
+describe('components/admin_console/UserAccessTokensList', () => {
+    global.window.mm_license = {};
+    global.window.mm_config = {};
+
+    beforeEach(() => {
+        global.window.mm_license.IsLicensed = 'false';
+    });
+
+    afterEach(() => {
+        global.window.mm_license = {};
+        global.window.mm_config = {};
+    });
+
+    const baseProps = {};
+
+    test('should match snapshot with base props', () => {
+        const wrapper = shallow(
+            <UserAccessTokensList {...baseProps}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
## **Still a work in progress...**

#### Summary

Adds a "Personal Access Tokens" page to the System Console and adds it to the System Console's sidebar.

#### PR Links

- [Documentation PR](https://github.com/mattermost/mattermost-api-reference/pull/318)(merged)
- [Webapp PR](https://github.com/mattermost/mattermost-webapp/pull/496)
- [Server PR](https://github.com/mattermost/mattermost-server/pull/8038) (merged)
- [Redux PR](https://github.com/mattermost/mattermost-redux/pull/356) (merged)

#### Ticket Link

- [Jira](https://mattermost.atlassian.net/browse/PLT-7793)
- [Github](https://github.com/mattermost/mattermost-server/issues/7584#issuecomment-352808489)

#### Notes

1. **Personal Access Token** is what we call `UserAccessToken` for the end user. I have taken the liberty to keep calling everything in the code base `UserAccessToken` since if I start using **Personal Access Token** then there is going to be inconsistency everywhere (we are using this naming in the backend, redux, and numerous components). It would make this PR even bigger if I change this naming. It can be done in another PR, if necessary.

2. I generalized `SearchableUserList` and renamed it to `SearchableItemList` so it can be used for more use cases such as this one. It now takes a `prop` called `listComponent` which can be used to specify how the list should be rendered. For example:

```javascript
<SearchableItemList listComponet={UserList} /> // this renders a searchable user list
<SearchableItemList listComponet={UserAccessTokenList} /> // this renders a searchable token list
```

3. To improve scalability I renamed `userAccessTokens` to be `userAccessTokensByUser` which can be used like this `userAccessTokensByUser[userId][tokenId]` and then there is another object called `userAccessTokens` which can be used like this: `userAccessTokens[tokenId]`. They both should stay updated with each other.

#### Checklist
- [x] Back-end: setup Postman to test back-end
- [x] Back-end: routes
- [x] Back-end: tests
- [x] Back-end: [documentation](https://github.com/mattermost/mattermost-api-reference/pull/318)
- [x] Redux: `mapStateToProps` to get tokens
- [x] Redux: rename `userAccessTokens` to `userAccessTokensByUser`
- [x] Redux: make `userAccessTokens` now fetch all the `UserAccessTokens`
- [x] Redux: fix failing tests + new tests
- [x] Webapp: Created sidebar link
- [x] Webapp: Created route
- [x] Webapp: Setup `UserAccessTokens` component
- [x] Webapp: Generalize `SearchableUserListContainer`
- [x] Webapp: Generalize `SearchableUserList` 
- [x] Webapp: Rename `SearchableUserListContainer` and `SearchableUserList` to `SearchableItemList`
- [x] Webapp: Pass a list component via props for better re-use in `SearchableItemList`
- [ ] Webapp: Write `UserAccessTokens` tests
- [ ] Webapp: Delete token modal
- [ ] Webapp: Add UITelemetry
- [ ] Webapp: Update custom integrations help text
- [ ] Webapp: Localization for `filtered_user_list.searchTokens` (contact PM)
- [ ] Fix failing tests
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [x] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, posting, etc.)

  
  
  
  
  
  
  