### PR TITLE
[PLT-7803] Have shift+up switch keyboard focus to RHS if it's already…

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -509,6 +509,13 @@ export function postListScrollChange(forceScrollToBottom = false) {
     });
 }
 
+export function focusRhs() {
+    AppDispatcher.handleViewAction({
+        type: EventTypes.FOCUS_RHS,
+        value: null
+    });
+}
+
 export function emitPopoverMentionKeyClick(isRHS, mentionKey) {
     AppDispatcher.handleViewAction({
         type: ActionTypes.POPOVER_MENTION_KEY_CLICK,

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -8,6 +8,8 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
+import GlobalEventEmitter from 'utils/global_event_emitter.jsx';
+import EventTypes from 'utils/event_types.jsx';
 
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
@@ -130,6 +132,7 @@ export default class CreateComment extends React.PureComponent {
         this.props.clearCommentDraftUploads();
         this.props.onResetHistoryIndex();
         this.setState({draft: {...this.props.draft, uploadsInProgress: []}});
+        GlobalEventEmitter.addListener(EventTypes.FOCUS_RHS, this.onPostPinnedChange)
     }
 
     componentDidMount() {
@@ -138,6 +141,7 @@ export default class CreateComment extends React.PureComponent {
 
     componentWillUnmount() {
         this.props.resetCreatePostRequest();
+        GlobalEventEmitter.removeListener(EventTypes.FOCUS_RHS, this.onPostPinnedChange)
     }
 
     componentWillReceiveProps(newProps) {
@@ -153,10 +157,10 @@ export default class CreateComment extends React.PureComponent {
         if (prevState.draft.uploadsInProgress.length < this.state.draft.uploadsInProgress.length) {
             this.scrollToBottom();
         }
+    }
 
-        if (prevProps.rootId !== this.props.rootId) {
-            this.focusTextbox();
-        }
+    onPostPinnedChange = () => {
+        this.focusTextbox();
     }
 
     toggleEmojiPicker = () => {

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import {Posts} from 'mattermost-redux/constants';
 
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
+import * as GlobalActions from 'actions/global_actions.jsx';
 
 import Constants from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
@@ -118,6 +119,7 @@ export default class Post extends React.PureComponent {
             postId: Utils.getRootId(post),
             channelId: post.channel_id
         });
+        GlobalActions.focusRhs()
     }
 
     handleDropdownOpened = (opened) => {

--- a/utils/event_types.jsx
+++ b/utils/event_types.jsx
@@ -4,5 +4,6 @@
 import keyMirror from 'key-mirror';
 
 export default keyMirror({
-    POST_LIST_SCROLL_CHANGE: null
+    POST_LIST_SCROLL_CHANGE: null,
+    FOCUS_RHS: null
 });

--- a/utils/global_event_emitter.jsx
+++ b/utils/global_event_emitter.jsx
@@ -20,6 +20,9 @@ class GlobalEventEmitterClass extends EventEmitter {
         case EventTypes.POST_LIST_SCROLL_CHANGE:
             this.emit(type, value, args);
             break;
+        case EventTypes.FOCUS_RHS:
+            this.emit(type, value, args);
+            break;
         }
     }
 }


### PR DESCRIPTION
… open to the current thread #7580

#### Summary
When the RHS window is already open viewing a post thread, using the Shift+Up keyboard shortcut when focused on an empty post creation text field will now focus on the RHS text field. Before this commit, nothing happened when using Shift+Up if the RHS was already open.

Added a new event to the global event emitter (instead of use Post Store).

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7580

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
- [x] Touches critical sections of the codebase (auth, posting, etc.)
