### PR TITLE
PLT-8334: Radio button selection changes selections on Account Settings > Notifications > Email Notifications while saving

### DIFF
--- a/components/user_settings/email_notification_setting.jsx
+++ b/components/user_settings/email_notification_setting.jsx
@@ -35,7 +35,7 @@ export default class EmailNotificationSetting extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.enableEmail !== this.props.enableEmail || nextProps.emailInterval !== this.props.emailInterval) {
+        if (!nextProps.saving && (nextProps.enableEmail !== this.props.enableEmail || nextProps.emailInterval !== this.props.emailInterval)) {
             this.setState({
                 enableEmail: nextProps.enableEmail,
                 emailInterval: nextProps.emailInterval


### PR DESCRIPTION
#### Summary
The default time span for email notifications is 15 minutes. While in the process of saving, the user settings are in an inconsistent state, so this default is returned, and causes a re-render of the component. Ignored new props while saving to avoid the undesirable re-render.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8334

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed