### PR TITLE
Fix post text box style issue

### DIFF
--- a/components/autosize_textarea.jsx
+++ b/components/autosize_textarea.jsx
@@ -101,6 +101,6 @@ export default class AutosizeTextarea extends React.Component {
 }
 
 const style = {
-    reference: {height: 0, overflow: 'hidden'},
-    container: {height: 'auto', width: '100%'}
+    container: {height: 0, overflow: 'hidden'},
+    reference: {height: 'auto', width: '100%'}
 };


### PR DESCRIPTION
#### Summary
This is a quick fix for the previously submitted patch which mistakenly interchanged styles for `container` and `reference` of post text box.

https://github.com/mattermost/mattermost-webapp/commit/d0de4f01bc9dd08e896ecfdce5baeeb6349a6c03#r26394782

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
