### PR TITLE
[webapp-perf]: Remove deferred calls on onEnter hooks

### DIFF
--- a/actions/views/lhs.js
+++ b/actions/views/lhs.js
@@ -1,0 +1,15 @@
+
+import {fetchMyChannelsAndMembers} from 'mattermost-redux/actions/channels';
+
+import {loadProfilesForSidebar} from 'actions/user_actions.jsx';
+import {loadStatusesForChannelAndSidebar} from 'actions/status_actions.jsx';
+import store from 'stores/redux_store.jsx';
+
+const dispatch = store.dispatch;
+const getState = store.getState;
+
+export async function initTeamChangeActions(teamId) {
+    await fetchMyChannelsAndMembers(teamId)(dispatch, getState);
+    loadStatusesForChannelAndSidebar();
+    loadProfilesForSidebar();
+}

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -11,6 +11,7 @@ import {browserHistory} from 'react-router';
 import {PropTypes} from 'prop-types';
 
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
+import {initTeamChangeActions} from 'actions/views/lhs.js';
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 
 import * as ChannelUtils from 'utils/channel_utils.jsx';
@@ -130,10 +131,18 @@ export default class Sidebar extends React.PureComponent {
     }
 
     componentDidMount() {
+        if (this.props.currentTeam && this.props.currentTeam.id) {
+            initTeamChangeActions(this.props.currentTeam.id);
+        }
         this.updateUnreadIndicators();
-
         document.addEventListener('keydown', this.navigateChannelShortcut);
         document.addEventListener('keydown', this.navigateUnreadChannelShortcut);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (this.props.currentTeam.id !== nextProps.currentTeam.id) {
+            initTeamChangeActions(nextProps.currentTeam.id);
+        }
     }
 
     componentWillUpdate() {

--- a/routes/route_team.jsx
+++ b/routes/route_team.jsx
@@ -1,18 +1,15 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import $ from 'jquery';
-
 import {browserHistory} from 'react-router';
 
-import {fetchMyChannelsAndMembers, joinChannel} from 'mattermost-redux/actions/channels';
+import {joinChannel} from 'mattermost-redux/actions/channels';
 import {getMyTeamUnreads} from 'mattermost-redux/actions/teams';
 import {getUser, getUserByEmail, getUserByUsername} from 'mattermost-redux/actions/users';
 
 import {openDirectChannelToUser} from 'actions/channel_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
-import {loadStatusesForChannelAndSidebar} from 'actions/status_actions.jsx';
-import {loadNewDMIfNeeded, loadNewGMIfNeeded, loadProfilesForSidebar} from 'actions/user_actions.jsx';
+import {loadNewDMIfNeeded, loadNewGMIfNeeded} from 'actions/user_actions.jsx';
 import {reconnect} from 'actions/websocket_actions.jsx';
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import BrowserStore from 'stores/browser_store.jsx';
@@ -119,21 +116,7 @@ function preNeedsTeam(nextState, replace, callback) {
     BrowserStore.setGlobalItem('team', team.id);
     TeamStore.emitChange();
     GlobalActions.emitCloseRightHandSide();
-
-    const d1 = $.Deferred(); //eslint-disable-line new-cap
-
-    fetchMyChannelsAndMembers(team.id)(dispatch, getState).then(
-        () => {
-            loadStatusesForChannelAndSidebar();
-            loadProfilesForSidebar();
-
-            d1.resolve();
-        }
-    );
-
-    $.when(d1).done(() => {
-        callback();
-    });
+    callback();
 }
 
 function selectLastChannel(nextState, replace, callback) {

--- a/tests/redux/actions/views/lhs.test.js
+++ b/tests/redux/actions/views/lhs.test.js
@@ -1,0 +1,18 @@
+
+import {initTeamChangeActions} from 'actions/views/lhs';
+import {loadProfilesForSidebar} from 'actions/user_actions.jsx';
+import {loadStatusesForChannelAndSidebar} from 'actions/status_actions.jsx';
+
+jest.mock('actions/status_actions.jsx', () => ({
+    loadStatusesForChannelAndSidebar: jest.fn()
+}));
+
+jest.mock('actions/user_actions.jsx', () => ({
+    loadProfilesForSidebar: jest.fn()
+}));
+
+it('Check for sidebar init actions', async () => {
+    await initTeamChangeActions();
+    expect(loadStatusesForChannelAndSidebar).toHaveBeenCalled();
+    expect(loadProfilesForSidebar).toHaveBeenCalled();
+});


### PR DESCRIPTION
#### Summary
Remove promises on onEnter hooks
Edit:
Network setting: Fast 3g

Team switch takes about 3 sec for first paint of conversation on master.
![screen shot 2018-01-05 at 2 06 32 am](https://user-images.githubusercontent.com/4973621/34583424-b52f52e4-f1bd-11e7-9c55-6b94a1fdf4b2.png)

With PR it takes about 1.4 sec for first pain of conversation
![screen shot 2018-01-05 at 2 09 19 am](https://user-images.githubusercontent.com/4973621/34583489-eed66762-f1bd-11e7-88a0-dd63775d391b.png)


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed

  