### PR TITLE
Wraps JS Performance API.

### DIFF
--- a/actions/diagnostics_actions.jsx
+++ b/actions/diagnostics_actions.jsx
@@ -22,3 +22,62 @@ export function trackEvent(category, event, props) {
         global.window.analytics.track('event', properties, options);
     }
 }
+
+/**
+ * Takes an array of string names of performance markers and invokes
+ * performance.clearMarkers on each.
+ * @param   {array} names of markers to clear
+ *
+ */
+export function clearMarks(names) {
+    if (!global.mm_config.EnableDeveloper === 'true') {
+        return;
+    }
+    names.forEach((name) => performance.clearMarks(name));
+}
+
+export function mark(name) {
+    if (!global.mm_config.EnableDeveloper === 'true') {
+        return;
+    }
+    performance.mark(name);
+}
+
+/**
+ * Takes the names of two markers and invokes performance.measure on
+ * them. The measured duration (ms) and the string name of the measure is
+ * are returned.
+ *
+ * @param   {string} name1 the first marker
+ * @param   {string} name2 the second marker
+ *
+ * @returns {[number, string]} Either the measured duration (ms) and the string name
+ * of the measure are returned or -1 and and empty string is returned if
+ * in dev. mode or one of the marker can't be found.
+ *
+ */
+export function measure(name1, name2) {
+    if (!global.mm_config.EnableDeveloper === 'true') {
+        return [-1, ''];
+    }
+
+    // Check for existence of entry name to avoid DOMException
+    const performanceEntries = performance.getEntries();
+    if (![name1, name2].every((name) => performanceEntries.find((item) => item.name === name))) {
+        return [-1, ''];
+    }
+
+    const displayPrefix = '🐐 Mattermost: ';
+    const measurementName = `${displayPrefix}${name1} - ${name2}`;
+    performance.measure(measurementName, name1, name2);
+    const lastDuration = mostRecentDurationByEntryName(measurementName);
+
+    // Clean up the measures we created
+    performance.clearMeasures(measurementName);
+    return [lastDuration, measurementName];
+}
+
+function mostRecentDurationByEntryName(entryName) {
+    const entriesWithName = performance.getEntriesByName(entryName);
+    return entriesWithName.map((item) => item.duration)[entriesWithName.length - 1];
+}

--- a/components/channel_view/channel_view.jsx
+++ b/components/channel_view/channel_view.jsx
@@ -15,6 +15,7 @@ import CreatePost from 'components/create_post';
 import FileUploadOverlay from 'components/file_upload_overlay.jsx';
 import PostView from 'components/post_view';
 import TutorialView from 'components/tutorial/tutorial_view.jsx';
+import {clearMarks, mark, measure, trackEvent} from 'actions/diagnostics_actions.jsx';
 
 export default class ChannelView extends React.PureComponent {
     static propTypes = {
@@ -68,6 +69,28 @@ export default class ChannelView extends React.PureComponent {
 
     getChannelView = () => {
         return this.refs.channelView;
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.channelId !== this.props.channelId) {
+            mark('ChannelView#componentDidUpdate');
+
+            const [dur1] = measure('SidebarChannelLink#click', 'ChannelView#componentDidUpdate');
+            const [dur2] = measure('TeamLink#click', 'ChannelView#componentDidUpdate');
+
+            clearMarks([
+                'SidebarChannelLink#click',
+                'ChannelView#componentDidUpdate',
+                'TeamLink#click'
+            ]);
+
+            if (dur1 !== -1) {
+                trackEvent('performance', 'channel_switch', {duration: Math.round(dur1)});
+            }
+            if (dur2 !== -1) {
+                trackEvent('performance', 'team_switch', {duration: Math.round(dur2)});
+            }
+        }
     }
 
     render() {

--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -13,7 +13,7 @@ import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getChannelsByCategory} from 'mattermost-redux/selectors/entities/channels';
 
 import * as ChannelActions from 'actions/channel_actions.jsx';
-import {trackEvent} from 'actions/diagnostics_actions.jsx';
+import {mark, trackEvent} from 'actions/diagnostics_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
@@ -727,6 +727,7 @@ export default class Sidebar extends React.Component {
     }
 
     trackChannelSelectedEvent = () => {
+        mark('SidebarChannelLink#click');
         trackEvent('ui', 'ui_channel_selected');
     }
 

--- a/components/team_sidebar/components/team_button.jsx
+++ b/components/team_sidebar/components/team_button.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {Link} from 'react-router';
 
-import {trackEvent} from 'actions/diagnostics_actions.jsx';
+import {mark, trackEvent} from 'actions/diagnostics_actions.jsx';
 import {switchTeams} from 'actions/team_actions.jsx';
 
 import Constants from 'utils/constants.jsx';
@@ -24,6 +24,7 @@ export default class TeamButton extends React.Component {
 
     handleSwitch(e) {
         e.preventDefault();
+        mark('TeamLink#click');
         trackEvent('ui', 'ui_team_sidebar_switch_team');
         switchTeams(this.props.url);
     }

--- a/root.jsx
+++ b/root.jsx
@@ -14,6 +14,7 @@ import * as Websockets from 'actions/websocket_actions.jsx';
 import {loadMeAndConfig} from 'actions/user_actions.jsx';
 import PersistGate from 'components/persist_gate';
 import ChannelStore from 'stores/channel_store.jsx';
+import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import * as I18n from 'i18n/i18n.jsx';
 import {initializePlugins} from 'plugins';
 
@@ -130,7 +131,43 @@ function renderRootComponent() {
     document.getElementById('root'));
 }
 
+function trackLoadTime() {
+    // Must be wrapped in setTimeout because loadEventEnd property is 0
+    // until onload is complete, also time added because analytics
+    // code isn't loaded until a subsequent window event has fired.
+    const tenSeconds = 10000;
+    setTimeout(() => {
+        const {loadEventEnd, navigationStart} = window.performance.timing;
+        const pageLoadTime = loadEventEnd - navigationStart;
+        trackEvent('performance', 'page_load', {duration: pageLoadTime});
+    }, tenSeconds);
+}
+
+/**
+ * Adds a function to be invoked onload appended to any existing onload
+ * event handlers.
+ *
+ * @param   {function} fn onload event handler
+ *
+ */
+function appendOnLoadEvent(fn) {
+    if (window.attachEvent) {
+        window.attachEvent('onload', fn);
+    } else if (window.onload) {
+        const curronload = window.onload;
+        window.onload = (evt) => {
+            curronload(evt);
+            fn(evt);
+        };
+    } else {
+        window.onload = fn;
+    }
+}
+
 global.window.setup_root = () => {
+    // Append trackLoadTime function to any exisitng onload events
+    appendOnLoadEvent(trackLoadTime);
+
     // Do the pre-render setup and call renderRootComponent when done
     preRenderSetup(renderRootComponent);
 };


### PR DESCRIPTION
#### Summary
Adds pattern for using [JS Performance API](https://developer.mozilla.org/en-US/docs/Web/API/Performance) and tracks:

- channel switching (dev mode)
- team switching (dev mode)
- page load

The information appears in the Chrome performance tab and also is sent to Segment under the 'performance' category.

#### Ticket Link
n/a

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed

<img width="1680" alt="screen shot 2017-12-21 at 1 48 42 pm" src="https://user-images.githubusercontent.com/1149597/34270426-2d80bf12-e656-11e7-9d2d-4976831864ba.png">
<img width="1680" alt="screen shot 2017-12-21 at 1 48 13 pm" src="https://user-images.githubusercontent.com/1149597/34270428-2d915ad4-e656-11e7-96cd-24ac5e3217c4.png">
<img width="1680" alt="screen shot 2017-12-21 at 2 06 12 pm" src="https://user-images.githubusercontent.com/1149597/34270948-2d566bc0-e658-11e7-9730-20a06358e156.png">
<img width="1680" alt="screen shot 2017-12-21 at 2 06 10 pm" src="https://user-images.githubusercontent.com/1149597/34270949-2d66026a-e658-11e7-8033-c67a278801eb.png">
<img width="1680" alt="screen shot 2017-12-21 at 2 06 05 pm" src="https://user-images.githubusercontent.com/1149597/34270950-2d724cc8-e658-11e7-9728-2145da9e693b.png">
