### PR TITLE
Add suppport for image links to be previewed

### DIFF
--- a/components/image_preview.jsx
+++ b/components/image_preview.jsx
@@ -9,8 +9,8 @@ import {getFilePreviewUrl, getFileUrl} from 'mattermost-redux/utils/file_utils';
 import {canDownloadFiles} from 'utils/file_utils';
 
 export default function ImagePreview({fileInfo}) {
-    const {has_preview_image: hasPreviewImage, id} = fileInfo;
-    const fileUrl = getFileUrl(id);
+    const {has_preview_image: hasPreviewImage, id, link} = fileInfo;
+    const fileUrl = link || getFileUrl(id);
     const previewUrl = hasPreviewImage ? getFilePreviewUrl(id) : fileUrl;
 
     if (!canDownloadFiles()) {

--- a/components/post_view/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content.jsx
@@ -10,6 +10,7 @@ import * as Utils from 'utils/utils.jsx';
 import {StoragePrefixes} from 'utils/constants.jsx';
 
 import YoutubeVideo from 'components/youtube_video';
+import ViewImageModal from 'components/view_image';
 
 import PostAttachmentList from './post_attachment_list.jsx';
 import PostAttachmentOpenGraph from './post_attachment_opengraph';
@@ -159,6 +160,12 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         });
     }
 
+    handleImageClick = () => {
+        this.setState({
+            showPreviewModal: true
+        });
+    };
+
     generateToggleableEmbed() {
         const link = this.state.link;
         if (!link) {
@@ -183,6 +190,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
                     link={link}
                     onLinkLoadError={this.handleLinkLoadError}
                     onLinkLoaded={this.handleLinkLoaded}
+                    handleImageClick={this.handleImageClick}
                 />
             );
         }
@@ -207,6 +215,33 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         }
 
         return null;
+    }
+
+    renderImagePreview() {
+        const link = this.state.link;
+        if (!link || !this.isLinkImage(link)) {
+            return null;
+        }
+
+        const captureExt = /(?:\.([^.]+))?$/;
+        if (!captureExt || captureExt.length <= 1) {
+            return null;
+        }
+
+        const ext = captureExt.exec(link)[1];
+
+        return (
+            <ViewImageModal
+                show={this.state.showPreviewModal}
+                onModalDismissed={() => this.setState({showPreviewModal: false})}
+                startIndex={0}
+                fileInfos={[{
+                    hasPreviewImage: false,
+                    link,
+                    extension: ext
+                }]}
+            />
+        );
     }
 
     render() {
@@ -250,10 +285,12 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
                     </div>
                 );
             }
+            const imagePreview = this.renderImagePreview();
 
             return (
                 <div>
                     {contents}
+                    {imagePreview}
                 </div>
             );
         }

--- a/components/post_view/post_image.jsx
+++ b/components/post_view/post_image.jsx
@@ -22,7 +22,12 @@ export default class PostImageEmbed extends React.PureComponent {
         /**
          * The function to call if image load fails
          */
-        onLinkLoadError: PropTypes.func
+        onLinkLoadError: PropTypes.func,
+
+        /**
+         * The function to call if image is clicked
+         */
+        handleImageClick: PropTypes.func
     }
 
     constructor(props) {
@@ -86,6 +91,11 @@ export default class PostImageEmbed extends React.PureComponent {
         }
     }
 
+    onImageClick = (e) => {
+        e.preventDefault();
+        this.props.handleImageClick();
+    };
+
     render() {
         if (this.state.errored || !this.state.loaded) {
             return null;
@@ -96,7 +106,8 @@ export default class PostImageEmbed extends React.PureComponent {
                 className='post__embed-container'
             >
                 <img
-                    className='img-div'
+                    onClick={this.onImageClick}
+                    className='img-div cursor--pointer'
                     src={this.props.link}
                 />
             </div>

--- a/components/view_image.jsx
+++ b/components/view_image.jsx
@@ -200,7 +200,8 @@ export default class ViewImageModal extends React.PureComponent {
         }
 
         const fileInfo = this.props.fileInfos[this.state.imageIndex];
-        const fileUrl = getFileUrl(fileInfo.id);
+        const fileName = fileInfo.link || fileInfo.name;
+        const fileUrl = fileInfo.link || getFileUrl(fileInfo.id);
 
         let content;
         if (this.state.loaded[this.state.imageIndex]) {
@@ -314,7 +315,7 @@ export default class ViewImageModal extends React.PureComponent {
                                 show={this.state.showFooter}
                                 fileIndex={this.state.imageIndex}
                                 totalFiles={this.props.fileInfos.length}
-                                filename={fileInfo.name}
+                                filename={fileName}
                                 fileURL={fileUrl}
                                 onGetPublicLink={this.handleGetPublicLink}
                             />

--- a/components/view_image.jsx
+++ b/components/view_image.jsx
@@ -200,6 +200,7 @@ export default class ViewImageModal extends React.PureComponent {
         }
 
         const fileInfo = this.props.fileInfos[this.state.imageIndex];
+        const showPublicLink = !fileInfo.link;
         const fileName = fileInfo.link || fileInfo.name;
         const fileUrl = fileInfo.link || getFileUrl(fileInfo.id);
 
@@ -313,6 +314,7 @@ export default class ViewImageModal extends React.PureComponent {
                             </div>
                             <ViewImagePopoverBar
                                 show={this.state.showFooter}
+                                showPublicLink={showPublicLink}
                                 fileIndex={this.state.imageIndex}
                                 totalFiles={this.props.fileInfos.length}
                                 filename={fileName}

--- a/components/view_image_popover_bar.jsx
+++ b/components/view_image_popover_bar.jsx
@@ -36,6 +36,11 @@ export default class ViewImagePopoverBar extends React.PureComponent {
         fileURL: PropTypes.string.isRequired,
 
         /**
+         * Set whether to show "Get Public Link"
+         */
+        showPublicLink: PropTypes.func,
+
+        /**
          * Function to call when click on "Get Public Link"
          */
         onGetPublicLink: PropTypes.func
@@ -46,12 +51,13 @@ export default class ViewImagePopoverBar extends React.PureComponent {
         fileIndex: 0,
         totalFiles: 0,
         filename: '',
-        fileURL: ''
+        fileURL: '',
+        showPublicLink: true
     };
 
     render() {
         var publicLink = '';
-        if (global.window.mm_config.EnablePublicLink === 'true') {
+        if (global.window.mm_config.EnablePublicLink === 'true' && this.props.showPublicLink) {
             publicLink = (
                 <div>
                     <a

--- a/tests/components/__snapshots__/view_image.test.jsx.snap
+++ b/tests/components/__snapshots__/view_image.test.jsx.snap
@@ -65,6 +65,7 @@ exports[`components/ViewImageModal should match snapshot on onModalShown and onM
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={3}
         />
       </div>
@@ -158,6 +159,7 @@ exports[`components/ViewImageModal should match snapshot on onModalShown and onM
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={3}
         />
       </div>
@@ -252,6 +254,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with AudioVideo
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={1}
         />
       </div>
@@ -326,6 +329,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with AudioVideo
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={1}
         />
       </div>
@@ -400,6 +404,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with CodePrevie
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={1}
         />
       </div>
@@ -474,6 +479,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with FileInfoPr
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={1}
         />
       </div>
@@ -547,6 +553,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with ImagePrevi
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={1}
         />
       </div>
@@ -621,6 +628,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with PDFPreview
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={1}
         />
       </div>
@@ -694,6 +702,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with ViewImageP
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={1}
         />
       </div>
@@ -767,6 +776,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with footer 1`]
           filename=""
           onGetPublicLink={[Function]}
           show={true}
+          showPublicLink={true}
           totalFiles={3}
         />
       </div>
@@ -860,6 +870,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={3}
         />
       </div>
@@ -954,6 +965,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={3}
         />
       </div>
@@ -1048,6 +1060,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={3}
         />
       </div>
@@ -1137,6 +1150,7 @@ exports[`components/ViewImageModal should match snapshot, loading 1`] = `
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={1}
         />
       </div>
@@ -1206,6 +1220,7 @@ exports[`components/ViewImageModal should match snapshot, modal not shown 1`] = 
           filename=""
           onGetPublicLink={[Function]}
           show={false}
+          showPublicLink={true}
           totalFiles={1}
         />
       </div>


### PR DESCRIPTION
#### Summary
Preview link images just like you do with images uploaded from MM.

#### Checklist
- [x] Has UI changes

#### Screenshots

1.
<img width="504" alt="screen shot 2017-12-20 at 4 51 20 pm" src="https://user-images.githubusercontent.com/6182543/34230768-4c996606-e5a7-11e7-872d-7e8e1ead000d.png">

2.
<img width="1693" alt="screen shot 2017-12-20 at 4 51 38 pm" src="https://user-images.githubusercontent.com/6182543/34230813-76c4833e-e5a7-11e7-9a64-fd996037ef25.png">

 
3.
<img width="730" alt="screen shot 2017-12-20 at 4 52 05 pm" src="https://user-images.githubusercontent.com/6182543/34230778-51495580-e5a7-11e7-8eed-ecc1b9d36398.png">

4. download image if desired