### PR TITLE
[PLT-8397] Add loading animation to RHS when flagged posts list is loading

### DIFF
--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -104,11 +104,13 @@ export function getFlaggedPosts() {
         await PostActions.getProfilesAndStatusesForPosts(result.posts, dispatch, getState);
 
         dispatch(receivedSearchPosts(teamId, result));
+        dispatch({type: ActionTypes.SEARCH_FLAGGED_POSTS_SUCCESS});
     };
 }
 
 export function showFlaggedPosts() {
     return (dispatch) => {
+        dispatch({type: ActionTypes.SEARCH_FLAGGED_POSTS_REQUEST});
         dispatch(getFlaggedPosts());
         dispatch(updateSearchTerms(''));
         dispatch(updateRhsState(RHSStates.FLAG));

--- a/components/search_bar/index.jsx
+++ b/components/search_bar/index.jsx
@@ -12,7 +12,7 @@ import {
     closeRightHandSide
 } from 'actions/views/rhs';
 
-import {getRhsState, getSearchTerms, getIsSearching} from 'selectors/rhs';
+import {getRhsState, getSearchTerms, getIsSearchingTerm} from 'selectors/rhs';
 
 import {RHSStates} from 'utils/constants.jsx';
 
@@ -22,7 +22,7 @@ function mapStateToProps(state) {
     const rhsState = getRhsState(state);
 
     return {
-        isSearching: getIsSearching(state),
+        isSearchingTerm: getIsSearchingTerm(state),
         searchTerms: getSearchTerms(state),
         isMentionSearch: rhsState === RHSStates.MENTION,
         isFlaggedPosts: rhsState === RHSStates.FLAG

--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -18,7 +18,7 @@ const {KeyCodes} = Constants;
 
 export default class SearchBar extends React.Component {
     static propTypes = {
-        isSearching: PropTypes.bool,
+        isSearchingTerm: PropTypes.bool,
         searchTerms: PropTypes.string,
         isMentionSearch: PropTypes.bool,
         isFlaggedPosts: PropTypes.bool,
@@ -167,9 +167,9 @@ export default class SearchBar extends React.Component {
         const searchIcon = Constants.SEARCH_ICON_SVG;
         const mentionsIcon = Constants.MENTIONS_ICON_SVG;
 
-        var isSearching = null;
-        if (this.props.isSearching) {
-            isSearching = <span className={'fa fa-spin fa-spinner'}/>;
+        var isSearchingTerm = null;
+        if (this.props.isSearchingTerm) {
+            isSearchingTerm = <span className={'fa fa-spin fa-spinner'}/>;
         }
 
         let helpClass = 'search-help-popover';
@@ -250,7 +250,7 @@ export default class SearchBar extends React.Component {
         }
 
         let clearClass = 'sidebar__search-clear';
-        if (!this.props.isSearching && this.props.searchTerms && this.props.searchTerms.trim() !== '') {
+        if (!this.props.isSearchingTerm && this.props.searchTerms && this.props.searchTerms.trim() !== '') {
             clearClass += ' visible';
         }
 
@@ -313,7 +313,7 @@ export default class SearchBar extends React.Component {
                                 {'×'}
                             </span>
                         </div>
-                        {isSearching}
+                        {isSearchingTerm}
                         {this.renderHintPopover(helpClass)}
                     </form>
                 </div>

--- a/components/search_results/index.jsx
+++ b/components/search_results/index.jsx
@@ -9,7 +9,7 @@ import * as PreferenceSelectors from 'mattermost-redux/selectors/entities/prefer
 
 import {selectPostFromRightHandSideSearch} from 'actions/views/rhs';
 
-import {getSearchTerms, getIsSearching} from 'selectors/rhs';
+import {getSearchTerms, getIsSearchingTerm, getIsSearchingFlaggedPost} from 'selectors/rhs';
 
 import {Preferences} from 'utils/constants.jsx';
 
@@ -64,7 +64,8 @@ function makeMapStateToProps() {
             channels,
             searchTerms: getSearchTerms(state),
             isFlaggedByPostId,
-            loading: getIsSearching(state),
+            isSearchingTerm: getIsSearchingTerm(state),
+            isSearchingFlaggedPost: getIsSearchingFlaggedPost(state),
             compactDisplay: PreferenceSelectors.get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.MESSAGE_DISPLAY, Preferences.MESSAGE_DISPLAY_DEFAULT) === Preferences.MESSAGE_DISPLAY_COMPACT
         };
     };

--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -47,7 +47,8 @@ export default class SearchResults extends React.PureComponent {
         channels: PropTypes.object,
         searchTerms: PropTypes.string,
         isFlaggedByPostId: PropTypes.object,
-        loading: PropTypes.bool,
+        isSearchingTerm: PropTypes.bool,
+        isSearchingFlaggedPost: PropTypes.bool,
         compactDisplay: PropTypes.bool,
         useMilitaryTime: PropTypes.bool.isRequired,
         toggleSize: PropTypes.func,
@@ -126,7 +127,7 @@ export default class SearchResults extends React.PureComponent {
 
         let ctls = null;
 
-        if (this.props.loading) {
+        if (this.props.isSearchingTerm || this.props.isSearchingFlaggedPost) {
             ctls =
             (
                 <div className='sidebar--right__subheader'>
@@ -380,7 +381,7 @@ export default class SearchResults extends React.PureComponent {
                     isFlaggedPosts={this.props.isFlaggedPosts}
                     isPinnedPosts={this.props.isPinnedPosts}
                     channelDisplayName={this.props.channelDisplayName}
-                    isLoading={this.props.loading}
+                    isLoading={this.props.isSearchingTerm}
                 />
                 <Scrollbars
                     autoHide={true}

--- a/reducers/views/rhs.js
+++ b/reducers/views/rhs.js
@@ -69,12 +69,23 @@ function searchTerms(state = '', action) {
     }
 }
 
-function isSearching(state = false, action) {
+function isSearchingTerm(state = false, action) {
     switch (action.type) {
     case SearchTypes.SEARCH_POSTS_REQUEST:
         return true;
     case SearchTypes.SEARCH_POSTS_FAILURE:
     case SearchTypes.SEARCH_POSTS_SUCCESS:
+        return false;
+    default:
+        return state;
+    }
+}
+
+function isSearchingFlaggedPost(state = false, action) {
+    switch (action.type) {
+    case ActionTypes.SEARCH_FLAGGED_POSTS_REQUEST:
+        return true;
+    case ActionTypes.SEARCH_FLAGGED_POSTS_SUCCESS:
         return false;
     default:
         return state;
@@ -87,5 +98,6 @@ export default combineReducers({
     previousRhsState,
     rhsState,
     searchTerms,
-    isSearching
+    isSearchingTerm,
+    isSearchingFlaggedPost
 });

--- a/selectors/rhs.jsx
+++ b/selectors/rhs.jsx
@@ -55,8 +55,12 @@ export function getSearchTerms(state) {
     return state.views.rhs.searchTerms;
 }
 
-export function getIsSearching(state) {
-    return state.views.rhs.isSearching;
+export function getIsSearchingTerm(state) {
+    return state.views.rhs.isSearchingTerm;
+}
+
+export function getIsSearchingFlaggedPost(state) {
+    return state.views.rhs.isSearchingFlaggedPost;
 }
 
 export function makeGetCommentDraft(rootId) {

--- a/tests/redux/actions/views/rhs.test.js
+++ b/tests/redux/actions/views/rhs.test.js
@@ -237,6 +237,7 @@ describe('rhs view actions', () => {
             const result = await Client4.getFlaggedPosts(currentUserId, '', currentTeamId);
             await PostActions.getProfilesAndStatusesForPosts(result.posts, compareStore.dispatch, compareStore.getState);
             compareStore.dispatch(receivedSearchResultsAction(currentTeamId, result));
+            compareStore.dispatch({type: ActionTypes.SEARCH_FLAGGED_POSTS_SUCCESS});
 
             expect(store.getActions()).toEqual(compareStore.getActions());
         });
@@ -247,6 +248,7 @@ describe('rhs view actions', () => {
             store.dispatch(showFlaggedPosts());
 
             const compareStore = mockStore(initialState);
+            compareStore.dispatch({type: ActionTypes.SEARCH_FLAGGED_POSTS_REQUEST});
             compareStore.dispatch(getFlaggedPosts());
             compareStore.dispatch(updateSearchTerms(''));
             compareStore.dispatch(updateRhsState(RHSStates.FLAG));

--- a/tests/redux/reducers/views/rhs.test.js
+++ b/tests/redux/reducers/views/rhs.test.js
@@ -14,7 +14,8 @@ describe('Reducers.RHS', () => {
         previousRhsState: null,
         rhsState: null,
         searchTerms: '',
-        isSearching: false
+        isSearchingTerm: false,
+        isSearchingFlaggedPost: false
     };
 
     test('Initial state', () => {
@@ -26,7 +27,7 @@ describe('Reducers.RHS', () => {
         expect(nextState).toEqual(initialState);
     });
 
-    test(ActionTypes.UPDATE_RHS_STATE, () => {
+    test('should match RHS state to pin', () => {
         const nextState = rhsReducer(
             {},
             {
@@ -61,7 +62,7 @@ describe('Reducers.RHS', () => {
         });
     });
 
-    test(PostTypes.SEARCH_POSTS_REQUEST, () => {
+    test('should match isSearchingTerm state to true', () => {
         const nextState = rhsReducer(
             {},
             {
@@ -71,14 +72,14 @@ describe('Reducers.RHS', () => {
 
         expect(nextState).toEqual({
             ...initialState,
-            isSearching: true
+            isSearchingTerm: true
         });
     });
 
-    test(PostTypes.SEARCH_POSTS_FAILURE, () => {
+    test('should match isSearchingTerm state to false', () => {
         const nextState = rhsReducer(
             {
-                isSearching: true
+                isSearchingTerm: true
             },
             {
                 type: SearchTypes.SEARCH_POSTS_FAILURE
@@ -87,14 +88,14 @@ describe('Reducers.RHS', () => {
 
         expect(nextState).toEqual({
             ...initialState,
-            isSearching: false
+            isSearchingTerm: false
         });
     });
 
-    test(PostTypes.SEARCH_POSTS_SUCCESS, () => {
+    test('should match isSearchingTerm state to false', () => {
         const nextState = rhsReducer(
             {
-                isSearching: true
+                isSearchingTerm: true
             },
             {
                 type: SearchTypes.SEARCH_POSTS_SUCCESS
@@ -103,11 +104,39 @@ describe('Reducers.RHS', () => {
 
         expect(nextState).toEqual({
             ...initialState,
-            isSearching: false
+            isSearchingTerm: false
         });
     });
 
-    test(ActionTypes.UPDATE_RHS_SEARCH_TERMS, () => {
+    test('should match isSearchingFlaggedPost state to true', () => {
+        const nextState = rhsReducer(
+            {},
+            {
+                type: ActionTypes.SEARCH_FLAGGED_POSTS_REQUEST
+            }
+        );
+
+        expect(nextState).toEqual({
+            ...initialState,
+            isSearchingFlaggedPost: true
+        });
+    });
+
+    test('should match isSearchingFlaggedPost state to false', () => {
+        const nextState = rhsReducer(
+            {},
+            {
+                type: ActionTypes.SEARCH_FLAGGED_POSTS_SUCCESS
+            }
+        );
+
+        expect(nextState).toEqual({
+            ...initialState,
+            isSearchingFlaggedPost: false
+        });
+    });
+
+    test('should match searchTerms state', () => {
         const nextState = rhsReducer(
             {},
             {
@@ -122,7 +151,7 @@ describe('Reducers.RHS', () => {
         });
     });
 
-    test(ActionTypes.SELECT_POST, () => {
+    test('should match select_post state', () => {
         const nextState1 = rhsReducer(
             {},
             {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -109,6 +109,9 @@ export const ActionTypes = keyMirror({
     UPDATE_RHS_STATE: null,
     UPDATE_RHS_SEARCH_TERMS: null,
 
+    SEARCH_FLAGGED_POSTS_REQUEST: null,
+    SEARCH_FLAGGED_POSTS_SUCCESS: null,
+
     RECEIVED_PROFILES: null,
     RECEIVED_PROFILES_IN_TEAM: null,
     RECEIVED_PROFILES_NOT_IN_TEAM: null,


### PR DESCRIPTION
#### Summary
Add loading animation to RHS when flagged posts list is loading
- add loading indicator to search results but not on search bar

![dec-21-2017 19-45-29](https://user-images.githubusercontent.com/5334504/34254587-b35fbd14-e687-11e7-90cd-c7d56382c10e.gif)

#### Ticket Link
Jira ticket: [PLT-8397](https://mattermost.atlassian.net/browse/PLT-8397)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
