### PR TITLE
[webapp-perf] Reduce post mounting time to speed up channel switching

### DIFF
--- a/components/common/comment_icon.jsx
+++ b/components/common/comment_icon.jsx
@@ -51,7 +51,7 @@ export default class CommentIcon extends React.PureComponent {
         return (
             <button
                 id={id}
-                className={iconStyle + ' color--link style--none ' + selectorId + props.extraClass}
+                className={iconStyle + ' color--link style--none ' + selectorId + this.props.extraClass}
                 onClick={this.props.handleCommentClick}
             >
                 <ReplyIcon className='comment-icon'/>

--- a/components/common/comment_icon.jsx
+++ b/components/common/comment_icon.jsx
@@ -15,14 +15,16 @@ export default class CommentIcon extends React.PureComponent {
         handleCommentClick: PropTypes.func.isRequired,
         searchStyle: PropTypes.string,
         commentCount: PropTypes.number,
-        id: PropTypes.string
+        id: PropTypes.string,
+        extraClass: PropTypes.string
     };
 
     static defaultProps = {
         idCount: -1,
         searchStyle: '',
         commentCount: 0,
-        id: ''
+        id: '',
+        extraClass: ''
     };
 
     render() {
@@ -49,7 +51,7 @@ export default class CommentIcon extends React.PureComponent {
         return (
             <button
                 id={id}
-                className={iconStyle + ' color--link style--none ' + selectorId}
+                className={iconStyle + ' color--link style--none ' + selectorId + props.extraClass}
                 onClick={this.props.handleCommentClick}
             >
                 <ReplyIcon className='comment-icon'/>

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -100,8 +100,14 @@ export default class Post extends React.PureComponent {
         super(props);
 
         this.state = {
-            dropdownOpened: false
+            dropdownOpened: false,
+            hover: false,
+            sameRoot: this.hasSameRoot(props)
         };
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({sameRoot: this.hasSameRoot(nextProps)});
     }
 
     handleCommentClick = (e) => {
@@ -125,6 +131,20 @@ export default class Post extends React.PureComponent {
         });
     }
 
+    hasSameRoot = (props) => {
+        const post = props.post;
+
+        if (props.isFirstReply) {
+            return false;
+        } else if (!post.root_id && !props.previousPostIsComment && props.consecutivePostByUser) {
+            return true;
+        } else if (post.root_id) {
+            return true;
+        }
+
+        return false;
+    }
+
     getClassName = (post, isSystemMessage, fromWebhook) => {
         let className = 'post';
 
@@ -137,11 +157,7 @@ export default class Post extends React.PureComponent {
         }
 
         let rootUser = '';
-        if (this.props.isFirstReply) {
-            rootUser = 'other--root';
-        } else if (!post.root_id && !this.props.previousPostIsComment && this.props.consecutivePostByUser) {
-            rootUser = 'same--root';
-        } else if (post.root_id) {
+        if (this.state.sameRoot) {
             rootUser = 'same--root';
         } else {
             rootUser = 'other--root';
@@ -193,6 +209,14 @@ export default class Post extends React.PureComponent {
         this.domNode = node;
     }
 
+    setHover = () => {
+        this.setState({hover: true});
+    }
+
+    unsetHover = () => {
+        this.setState({hover: false});
+    }
+
     render() {
         const post = this.props.post || {};
 
@@ -204,58 +228,64 @@ export default class Post extends React.PureComponent {
             status = null;
         }
 
-        let profilePic = (
-            <ProfilePicture
-                src={PostUtils.getProfilePicSrcForPost(post, this.props.user)}
-                status={status}
-                user={this.props.user}
-                isBusy={this.props.isBusy}
-                hasMention={true}
-            />
-        );
-
-        if (fromWebhook) {
+        let profilePic;
+        const hideProfilePicture = this.state.sameRoot && this.props.consecutivePostByUser;
+        if (!hideProfilePicture) {
             profilePic = (
                 <ProfilePicture
                     src={PostUtils.getProfilePicSrcForPost(post, this.props.user)}
+                    status={status}
+                    user={this.props.user}
+                    isBusy={this.props.isBusy}
+                    hasMention={true}
                 />
             );
-        } else if (PostUtils.isSystemMessage(post)) {
-            profilePic = (
-                <MattermostLogo className='icon'/>
-            );
+
+            if (fromWebhook) {
+                profilePic = (
+                    <ProfilePicture
+                        src={PostUtils.getProfilePicSrcForPost(post, this.props.user)}
+                    />
+                );
+            } else if (PostUtils.isSystemMessage(post)) {
+                profilePic = (
+                    <MattermostLogo className='icon'/>
+                );
+            }
+
+            if (this.props.compactDisplay) {
+                if (fromWebhook) {
+                    profilePic = (
+                        <ProfilePicture
+                            src=''
+                            status={status}
+                            isBusy={this.props.isBusy}
+                            user={this.props.user}
+                        />
+                    );
+                } else {
+                    profilePic = (
+                        <ProfilePicture
+                            src=''
+                            status={status}
+                        />
+                    );
+                }
+            }
         }
+
+        const profilePicContainer = <div className='post__img'>{profilePic}</div>;
 
         let centerClass = '';
         if (this.props.center) {
             centerClass = 'center';
         }
 
-        if (this.props.compactDisplay) {
-            if (fromWebhook) {
-                profilePic = (
-                    <ProfilePicture
-                        src=''
-                        status={status}
-                        isBusy={this.props.isBusy}
-                        user={this.props.user}
-                    />
-                );
-            } else {
-                profilePic = (
-                    <ProfilePicture
-                        src=''
-                        status={status}
-                    />
-                );
-            }
-        }
-
-        const profilePicContainer = (<div className='post__img'>{profilePic}</div>);
-
         return (
             <div
                 ref={this.getRef}
+                onMouseEnter={this.setHover}
+                onMouseLeave={this.unsetHover}
             >
                 <div
                     id={'post_' + post.id}
@@ -274,9 +304,11 @@ export default class Post extends React.PureComponent {
                                 status={this.props.status}
                                 isBusy={this.props.isBusy}
                                 lastPostCount={this.props.lastPostCount}
+                                isFirstReply={this.props.isFirstReply}
                                 replyCount={this.props.replyCount}
-                                consecutivePostByUser={this.props.consecutivePostByUser}
+                                showTimeWithoutHover={!hideProfilePicture}
                                 getPostList={this.props.getPostList}
+                                hover={this.state.hover}
                             />
                             <PostBody
                                 post={post}

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -316,6 +316,7 @@ export default class Post extends React.PureComponent {
                                 compactDisplay={this.props.compactDisplay}
                                 lastPostCount={this.props.lastPostCount}
                                 isCommentMention={this.props.isCommentMention}
+                                isFirstReply={this.props.isFirstReply}
                             />
                         </div>
                     </div>

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -229,7 +229,7 @@ export default class Post extends React.PureComponent {
         }
 
         let profilePic;
-        const hideProfilePicture = this.state.sameRoot && this.props.consecutivePostByUser;
+        const hideProfilePicture = this.state.sameRoot && this.props.consecutivePostByUser && (!post.root_id && this.props.replyCount === 0);
         if (!hideProfilePicture) {
             profilePic = (
                 <ProfilePicture

--- a/components/post_view/post_body/post_body.jsx
+++ b/components/post_view/post_body/post_body.jsx
@@ -58,6 +58,11 @@ export default class PostBody extends React.PureComponent {
         isCommentMention: PropTypes.bool,
 
         /**
+         * Set to render a preview of the parent post above this reply
+         */
+        isFirstReply: PropTypes.bool,
+
+        /**
          * Set to collapse image and video previews
          */
         previewCollapsed: PropTypes.string,
@@ -124,7 +129,7 @@ export default class PostBody extends React.PureComponent {
         let comment = '';
         let postClass = '';
         const isEphemeral = Utils.isPostEphemeral(post);
-        if (parentPost && !isEphemeral) {
+        if (this.props.isFirstReply && parentPost && !isEphemeral) {
             const profile = this.props.parentPostUser;
 
             let apostrophe = '';

--- a/components/post_view/post_header/post_header.jsx
+++ b/components/post_view/post_header/post_header.jsx
@@ -40,11 +40,6 @@ export default class PostHeader extends React.PureComponent {
         compactDisplay: PropTypes.bool,
 
         /*
-         * Set to render the post time when not hovering
-         */
-        showTimeWithoutHover: PropTypes.bool,
-
-        /*
          * The method for displaying the post creator's name
          */
         displayNameType: PropTypes.string,
@@ -79,7 +74,15 @@ export default class PostHeader extends React.PureComponent {
          */
         getPostList: PropTypes.func.isRequired,
 
-        hover: PropTypes.bool.isRequired
+        /**
+         * Set to mark post as being hovered over
+         */
+        hover: PropTypes.bool.isRequired,
+
+        /*
+         * Set to render the post time when not hovering
+         */
+        showTimeWithoutHover: PropTypes.bool
     }
 
     constructor(props) {

--- a/components/post_view/post_header/post_header.jsx
+++ b/components/post_view/post_header/post_header.jsx
@@ -40,9 +40,9 @@ export default class PostHeader extends React.PureComponent {
         compactDisplay: PropTypes.bool,
 
         /*
-         * Set to render the post as if it was part of the previous post
+         * Set to render the post time when not hovering
          */
-        consecutivePostByUser: PropTypes.bool,
+        showTimeWithoutHover: PropTypes.bool,
 
         /*
          * The method for displaying the post creator's name
@@ -64,6 +64,11 @@ export default class PostHeader extends React.PureComponent {
          */
         replyCount: PropTypes.number,
 
+        /**
+         * Set to indicate that this is previous post was not a reply to the same thread
+         */
+        isFirstReply: PropTypes.bool,
+
         /*
          * Post identifiers for selenium tests
          */
@@ -72,7 +77,9 @@ export default class PostHeader extends React.PureComponent {
         /**
          * Function to get the post list HTML element
          */
-        getPostList: PropTypes.func.isRequired
+        getPostList: PropTypes.func.isRequired,
+
+        hover: PropTypes.bool.isRequired
     }
 
     constructor(props) {
@@ -148,8 +155,10 @@ export default class PostHeader extends React.PureComponent {
                         compactDisplay={this.props.compactDisplay}
                         lastPostCount={this.props.lastPostCount}
                         replyCount={this.props.replyCount}
-                        consecutivePostByUser={this.props.consecutivePostByUser}
+                        isFirstReply={this.props.isFirstReply}
+                        showTimeWithoutHover={this.props.showTimeWithoutHover}
                         getPostList={this.props.getPostList}
+                        hover={this.props.hover}
                     />
                 </div>
             </div>

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -54,6 +54,11 @@ export default class PostInfo extends React.PureComponent {
          */
         replyCount: PropTypes.number,
 
+        /**
+         * Set to indicate that this is previous post was not a reply to the same thread
+         */
+        isFirstReply: PropTypes.bool,
+
         /*
          * Post identifiers for selenium tests
          */
@@ -68,6 +73,9 @@ export default class PostInfo extends React.PureComponent {
          * Function to get the post list HTML element
          */
         getPostList: PropTypes.func.isRequired,
+
+        hover: PropTypes.bool.isRequired,
+        showTimeWithoutHover: PropTypes.bool.isRequired,
 
         actions: PropTypes.shape({
 
@@ -136,32 +144,28 @@ export default class PostInfo extends React.PureComponent {
         return this.refs.dotMenu;
     };
 
-    render() {
-        const post = this.props.post;
-
-        let idCount = -1;
-        if (this.props.lastPostCount >= 0 && this.props.lastPostCount < Constants.TEST_ID_COUNT) {
-            idCount = this.props.lastPostCount;
+    buildOptions = (post, isSystemMessage, idCount) => {
+        if (!PostUtils.shouldShowDotMenu(post)) {
+            return null;
         }
 
-        const isEphemeral = Utils.isPostEphemeral(post);
-        const isSystemMessage = PostUtils.isSystemMessage(post);
+        let comments;
+        let react;
 
-        let comments = null;
-        let react = null;
-        let flagIcon = null;
-        if (!isEphemeral && !post.failed && !isSystemMessage) {
-            comments = (
-                <CommentIcon
-                    idPrefix='commentIcon'
-                    idCount={idCount}
-                    handleCommentClick={this.props.handleCommentClick}
-                    commentCount={this.props.replyCount}
-                    id={post.channel_id + '_' + post.id}
-                />
-            );
+        if (!isSystemMessage) {
+            if (this.props.hover || (!post.root_id && this.props.replyCount) || this.props.isFirstReply) {
+                comments = (
+                    <CommentIcon
+                        idPrefix='commentIcon'
+                        idCount={idCount}
+                        handleCommentClick={this.props.handleCommentClick}
+                        commentCount={this.props.replyCount}
+                        id={post.channel_id + '_' + post.id}
+                    />
+                );
+            }
 
-            if (window.mm_config.EnableEmojiPicker === 'true') {
+            if (this.props.hover && window.mm_config.EnableEmojiPicker === 'true') {
                 react = (
                     <span>
                         <EmojiPickerOverlay
@@ -182,7 +186,48 @@ export default class PostInfo extends React.PureComponent {
 
                 );
             }
+        }
 
+        let dotMenu;
+        if (this.props.hover) {
+            dotMenu = (
+                <DotMenu
+                    idPrefix={Constants.CENTER}
+                    idCount={idCount}
+                    post={post}
+                    commentCount={this.props.replyCount}
+                    isFlagged={this.props.isFlagged}
+                    handleCommentClick={this.props.handleCommentClick}
+                    handleDropdownOpened={this.props.handleDropdownOpened}
+                />
+            );
+        }
+
+        return (
+            <div
+                ref='dotMenu'
+                className='col col__reply'
+            >
+                {dotMenu}
+                {react}
+                {comments}
+            </div>
+        );
+    }
+
+    render() {
+        const post = this.props.post;
+
+        let idCount = -1;
+        if (this.props.lastPostCount >= 0 && this.props.lastPostCount < Constants.TEST_ID_COUNT) {
+            idCount = this.props.lastPostCount;
+        }
+
+        const isEphemeral = Utils.isPostEphemeral(post);
+        const isSystemMessage = PostUtils.isSystemMessage(post);
+
+        let flagIcon;
+        if (!isEphemeral && !post.failed && !isSystemMessage && (this.props.hover || this.props.isFlagged)) {
             flagIcon = (
                 <PostFlagIcon
                     idPrefix='centerPostFlag'
@@ -202,30 +247,7 @@ export default class PostInfo extends React.PureComponent {
                 </div>
             );
         } else if (!post.failed) {
-            const dotMenu = (
-                <DotMenu
-                    idPrefix={Constants.CENTER}
-                    idCount={idCount}
-                    post={this.props.post}
-                    commentCount={this.props.replyCount}
-                    isFlagged={this.props.isFlagged}
-                    handleCommentClick={this.props.handleCommentClick}
-                    handleDropdownOpened={this.props.handleDropdownOpened}
-                />
-            );
-
-            if (PostUtils.shouldShowDotMenu(this.props.post)) {
-                options = (
-                    <div
-                        ref='dotMenu'
-                        className='col col__reply'
-                    >
-                        {dotMenu}
-                        {react}
-                        {comments}
-                    </div>
-                );
-            }
+            options = this.buildOptions(post, isSystemMessage, idCount);
         }
 
         let visibleMessage;
@@ -252,22 +274,28 @@ export default class PostInfo extends React.PureComponent {
             );
         }
 
-        // timestamp should not be a permalink if the post has been deleted, is ephemeral message, or is pending
-        const isPermalink = !(isEphemeral ||
-            Posts.POST_DELETED === this.props.post.state ||
-            ReduxPostUtils.isPostPendingOrFailed(this.props.post));
+        let postTime;
+        if (this.props.hover || this.props.showTimeWithoutHover) {
+            // timestamp should not be a permalink if the post has been deleted, is ephemeral message, or is pending
+            const isPermalink = !(isEphemeral ||
+                Posts.POST_DELETED === this.props.post.state ||
+                ReduxPostUtils.isPostPendingOrFailed(this.props.post));
+
+            postTime = (
+                <PostTime
+                    isPermalink={isPermalink}
+                    eventTime={post.create_at}
+                    useMilitaryTime={this.props.useMilitaryTime}
+                    postId={post.id}
+                />
+            );
+        }
 
         return (
             <div className='post__header--info'>
                 <div className='col'>
-                    <PostTime
-                        isPermalink={isPermalink}
-                        eventTime={post.create_at}
-                        useMilitaryTime={this.props.useMilitaryTime}
-                        postId={post.id}
-                    />
+                    {postTime}
                     {pinnedBadge}
-                    {this.state.showEmojiPicker}
                     {flagIcon}
                     {visibleMessage}
                 </div>

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -74,7 +74,14 @@ export default class PostInfo extends React.PureComponent {
          */
         getPostList: PropTypes.func.isRequired,
 
+        /**
+         * Set to mark post as being hovered over
+         */
         hover: PropTypes.bool.isRequired,
+
+        /**
+         * Set to render the post time when not hovering
+         */
         showTimeWithoutHover: PropTypes.bool.isRequired,
 
         actions: PropTypes.shape({
@@ -161,6 +168,7 @@ export default class PostInfo extends React.PureComponent {
                         handleCommentClick={this.props.handleCommentClick}
                         commentCount={this.props.replyCount}
                         id={post.channel_id + '_' + post.id}
+                        extraClass='pull-right'
                     />
                 );
             }

--- a/tests/components/__snapshots__/search_results_item.test.jsx.snap
+++ b/tests/components/__snapshots__/search_results_item.test.jsx.snap
@@ -148,6 +148,7 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
             />
             <CommentIcon
               commentCount={0}
+              extraClass=""
               handleCommentClick={[Function]}
               id=""
               idCount={-1}
@@ -324,6 +325,7 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
             />
             <CommentIcon
               commentCount={0}
+              extraClass=""
               handleCommentClick={[Function]}
               id=""
               idCount={-1}

--- a/tests/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
+++ b/tests/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
@@ -6,81 +6,10 @@ exports[`components/post_view/PostInfo hideEmojiPicker, should have called props
 >
   <div
     className="col"
-  >
-    <PostTime
-      eventTime={1502715365009}
-      isPermalink={true}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-      useMilitaryTime={false}
-    />
-    <PostFlagIcon
-      idCount={-1}
-      idPrefix="centerPostFlag"
-      isEphemeral={false}
-      isFlagged={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-    />
-  </div>
+  />
   <div
     className="col col__reply"
-  >
-    <Connect(DotMenu)
-      commentCount={0}
-      handleCommentClick={[Function]}
-      handleDropdownOpened={[Function]}
-      idCount={-1}
-      idPrefix="center"
-      isFlagged={false}
-      post={
-        Object {
-          "channel_id": "g6139tbospd18cmxroesdk3kkc",
-          "create_at": 1502715365009,
-          "delete_at": 0,
-          "edit_at": 1502715372443,
-          "hashtags": "",
-          "id": "e584uzbwwpny9kengqayx5ayzw",
-          "is_pinned": false,
-          "message": "post message",
-          "original_id": "",
-          "parent_id": "",
-          "pending_post_id": "",
-          "props": Object {},
-          "root_id": "",
-          "type": "",
-          "update_at": 1502715372443,
-          "user_id": "b4pfxi8sn78y8yq7phzxxfor7h",
-        }
-      }
-    />
-    <span>
-      <EmojiPickerOverlay
-        container={[Function]}
-        onEmojiClick={[Function]}
-        onHide={[Function]}
-        rightOffset={7}
-        show={false}
-        spaceRequiredAbove={422}
-        spaceRequiredBelow={436}
-        target={[Function]}
-      />
-      <button
-        className="reacticon__container color--link style--none"
-        onClick={[Function]}
-      >
-        <EmojiIcon
-          className="icon icon--emoji"
-        />
-      </button>
-    </span>
-    <CommentIcon
-      commentCount={0}
-      handleCommentClick={[Function]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
-      idCount={-1}
-      idPrefix="commentIcon"
-      searchStyle=""
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -90,81 +19,10 @@ exports[`components/post_view/PostInfo reactEmojiClick, should have called props
 >
   <div
     className="col"
-  >
-    <PostTime
-      eventTime={1502715365009}
-      isPermalink={true}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-      useMilitaryTime={false}
-    />
-    <PostFlagIcon
-      idCount={-1}
-      idPrefix="centerPostFlag"
-      isEphemeral={false}
-      isFlagged={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-    />
-  </div>
+  />
   <div
     className="col col__reply"
-  >
-    <Connect(DotMenu)
-      commentCount={0}
-      handleCommentClick={[Function]}
-      handleDropdownOpened={[Function]}
-      idCount={-1}
-      idPrefix="center"
-      isFlagged={false}
-      post={
-        Object {
-          "channel_id": "g6139tbospd18cmxroesdk3kkc",
-          "create_at": 1502715365009,
-          "delete_at": 0,
-          "edit_at": 1502715372443,
-          "hashtags": "",
-          "id": "e584uzbwwpny9kengqayx5ayzw",
-          "is_pinned": false,
-          "message": "post message",
-          "original_id": "",
-          "parent_id": "",
-          "pending_post_id": "",
-          "props": Object {},
-          "root_id": "",
-          "type": "",
-          "update_at": 1502715372443,
-          "user_id": "b4pfxi8sn78y8yq7phzxxfor7h",
-        }
-      }
-    />
-    <span>
-      <EmojiPickerOverlay
-        container={[Function]}
-        onEmojiClick={[Function]}
-        onHide={[Function]}
-        rightOffset={7}
-        show={false}
-        spaceRequiredAbove={422}
-        spaceRequiredBelow={436}
-        target={[Function]}
-      />
-      <button
-        className="reacticon__container color--link style--none"
-        onClick={[Function]}
-      >
-        <EmojiIcon
-          className="icon icon--emoji"
-        />
-      </button>
-    </span>
-    <CommentIcon
-      commentCount={0}
-      handleCommentClick={[Function]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
-      idCount={-1}
-      idPrefix="commentIcon"
-      searchStyle=""
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -174,81 +32,10 @@ exports[`components/post_view/PostInfo removePost, should have called props.acti
 >
   <div
     className="col"
-  >
-    <PostTime
-      eventTime={1502715365009}
-      isPermalink={true}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-      useMilitaryTime={false}
-    />
-    <PostFlagIcon
-      idCount={-1}
-      idPrefix="centerPostFlag"
-      isEphemeral={false}
-      isFlagged={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-    />
-  </div>
+  />
   <div
     className="col col__reply"
-  >
-    <Connect(DotMenu)
-      commentCount={0}
-      handleCommentClick={[Function]}
-      handleDropdownOpened={[Function]}
-      idCount={-1}
-      idPrefix="center"
-      isFlagged={false}
-      post={
-        Object {
-          "channel_id": "g6139tbospd18cmxroesdk3kkc",
-          "create_at": 1502715365009,
-          "delete_at": 0,
-          "edit_at": 1502715372443,
-          "hashtags": "",
-          "id": "e584uzbwwpny9kengqayx5ayzw",
-          "is_pinned": false,
-          "message": "post message",
-          "original_id": "",
-          "parent_id": "",
-          "pending_post_id": "",
-          "props": Object {},
-          "root_id": "",
-          "type": "",
-          "update_at": 1502715372443,
-          "user_id": "b4pfxi8sn78y8yq7phzxxfor7h",
-        }
-      }
-    />
-    <span>
-      <EmojiPickerOverlay
-        container={[Function]}
-        onEmojiClick={[Function]}
-        onHide={[Function]}
-        rightOffset={7}
-        show={false}
-        spaceRequiredAbove={422}
-        spaceRequiredBelow={436}
-        target={[Function]}
-      />
-      <button
-        className="reacticon__container color--link style--none"
-        onClick={[Function]}
-      >
-        <EmojiIcon
-          className="icon icon--emoji"
-        />
-      </button>
-    </span>
-    <CommentIcon
-      commentCount={0}
-      handleCommentClick={[Function]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
-      idCount={-1}
-      idPrefix="commentIcon"
-      searchStyle=""
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -258,61 +45,10 @@ exports[`components/post_view/PostInfo should match snapshot 1`] = `
 >
   <div
     className="col"
-  >
-    <PostTime
-      eventTime={1502715365009}
-      isPermalink={true}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-      useMilitaryTime={false}
-    />
-    <PostFlagIcon
-      idCount={-1}
-      idPrefix="centerPostFlag"
-      isEphemeral={false}
-      isFlagged={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-    />
-  </div>
+  />
   <div
     className="col col__reply"
-  >
-    <Connect(DotMenu)
-      commentCount={0}
-      handleCommentClick={[Function]}
-      handleDropdownOpened={[Function]}
-      idCount={-1}
-      idPrefix="center"
-      isFlagged={false}
-      post={
-        Object {
-          "channel_id": "g6139tbospd18cmxroesdk3kkc",
-          "create_at": 1502715365009,
-          "delete_at": 0,
-          "edit_at": 1502715372443,
-          "hashtags": "",
-          "id": "e584uzbwwpny9kengqayx5ayzw",
-          "is_pinned": false,
-          "message": "post message",
-          "original_id": "",
-          "parent_id": "",
-          "pending_post_id": "",
-          "props": Object {},
-          "root_id": "",
-          "type": "",
-          "update_at": 1502715372443,
-          "user_id": "b4pfxi8sn78y8yq7phzxxfor7h",
-        }
-      }
-    />
-    <CommentIcon
-      commentCount={0}
-      handleCommentClick={[Function]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
-      idCount={-1}
-      idPrefix="commentIcon"
-      searchStyle=""
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -322,61 +58,10 @@ exports[`components/post_view/PostInfo should match snapshot, compact display 1`
 >
   <div
     className="col"
-  >
-    <PostTime
-      eventTime={1502715365009}
-      isPermalink={true}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-      useMilitaryTime={false}
-    />
-    <PostFlagIcon
-      idCount={-1}
-      idPrefix="centerPostFlag"
-      isEphemeral={false}
-      isFlagged={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-    />
-  </div>
+  />
   <div
     className="col col__reply"
-  >
-    <Connect(DotMenu)
-      commentCount={0}
-      handleCommentClick={[Function]}
-      handleDropdownOpened={[Function]}
-      idCount={-1}
-      idPrefix="center"
-      isFlagged={false}
-      post={
-        Object {
-          "channel_id": "g6139tbospd18cmxroesdk3kkc",
-          "create_at": 1502715365009,
-          "delete_at": 0,
-          "edit_at": 1502715372443,
-          "hashtags": "",
-          "id": "e584uzbwwpny9kengqayx5ayzw",
-          "is_pinned": false,
-          "message": "post message",
-          "original_id": "",
-          "parent_id": "",
-          "pending_post_id": "",
-          "props": Object {},
-          "root_id": "",
-          "type": "",
-          "update_at": 1502715372443,
-          "user_id": "b4pfxi8sn78y8yq7phzxxfor7h",
-        }
-      }
-    />
-    <CommentIcon
-      commentCount={0}
-      handleCommentClick={[Function]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
-      idCount={-1}
-      idPrefix="commentIcon"
-      searchStyle=""
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -386,81 +71,10 @@ exports[`components/post_view/PostInfo should match snapshot, enable emoji picke
 >
   <div
     className="col"
-  >
-    <PostTime
-      eventTime={1502715365009}
-      isPermalink={true}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-      useMilitaryTime={false}
-    />
-    <PostFlagIcon
-      idCount={-1}
-      idPrefix="centerPostFlag"
-      isEphemeral={false}
-      isFlagged={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-    />
-  </div>
+  />
   <div
     className="col col__reply"
-  >
-    <Connect(DotMenu)
-      commentCount={0}
-      handleCommentClick={[Function]}
-      handleDropdownOpened={[Function]}
-      idCount={-1}
-      idPrefix="center"
-      isFlagged={false}
-      post={
-        Object {
-          "channel_id": "g6139tbospd18cmxroesdk3kkc",
-          "create_at": 1502715365009,
-          "delete_at": 0,
-          "edit_at": 1502715372443,
-          "hashtags": "",
-          "id": "e584uzbwwpny9kengqayx5ayzw",
-          "is_pinned": false,
-          "message": "post message",
-          "original_id": "",
-          "parent_id": "",
-          "pending_post_id": "",
-          "props": Object {},
-          "root_id": "",
-          "type": "",
-          "update_at": 1502715372443,
-          "user_id": "b4pfxi8sn78y8yq7phzxxfor7h",
-        }
-      }
-    />
-    <span>
-      <EmojiPickerOverlay
-        container={[Function]}
-        onEmojiClick={[Function]}
-        onHide={[Function]}
-        rightOffset={7}
-        show={false}
-        spaceRequiredAbove={422}
-        spaceRequiredBelow={436}
-        target={[Function]}
-      />
-      <button
-        className="reacticon__container color--link style--none"
-        onClick={[Function]}
-      >
-        <EmojiIcon
-          className="icon icon--emoji"
-        />
-      </button>
-    </span>
-    <CommentIcon
-      commentCount={0}
-      handleCommentClick={[Function]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
-      idCount={-1}
-      idPrefix="commentIcon"
-      searchStyle=""
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -470,14 +84,7 @@ exports[`components/post_view/PostInfo should match snapshot, ephemeral deleted 
 >
   <div
     className="col"
-  >
-    <PostTime
-      eventTime={1502715365009}
-      isPermalink={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-      useMilitaryTime={false}
-    />
-  </div>
+  />
   <div
     className="col col__remove"
   >
@@ -499,12 +106,6 @@ exports[`components/post_view/PostInfo should match snapshot, ephemeral post 1`]
   <div
     className="col"
   >
-    <PostTime
-      eventTime={1502715365009}
-      isPermalink={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-      useMilitaryTime={false}
-    />
     <span
       className="post__visibility"
     >
@@ -536,6 +137,27 @@ exports[`components/post_view/PostInfo should match snapshot, flagged post 1`] =
   <div
     className="col"
   >
+    <PostFlagIcon
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+    />
+  </div>
+  <div
+    className="col col__reply"
+  />
+</div>
+`;
+
+exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
+<div
+  className="post__header--info"
+>
+  <div
+    className="col"
+  >
     <PostTime
       eventTime={1502715365009}
       isPermalink={true}
@@ -546,7 +168,7 @@ exports[`components/post_view/PostInfo should match snapshot, flagged post 1`] =
       idCount={-1}
       idPrefix="centerPostFlag"
       isEphemeral={false}
-      isFlagged={true}
+      isFlagged={false}
       postId="e584uzbwwpny9kengqayx5ayzw"
     />
   </div>
@@ -559,7 +181,7 @@ exports[`components/post_view/PostInfo should match snapshot, flagged post 1`] =
       handleDropdownOpened={[Function]}
       idCount={-1}
       idPrefix="center"
-      isFlagged={true}
+      isFlagged={false}
       post={
         Object {
           "channel_id": "g6139tbospd18cmxroesdk3kkc",
@@ -583,6 +205,7 @@ exports[`components/post_view/PostInfo should match snapshot, flagged post 1`] =
     />
     <CommentIcon
       commentCount={0}
+      extraClass="pull-right"
       handleCommentClick={[Function]}
       id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
       idCount={-1}
@@ -599,61 +222,10 @@ exports[`components/post_view/PostInfo should match snapshot, military time 1`] 
 >
   <div
     className="col"
-  >
-    <PostTime
-      eventTime={1502715365009}
-      isPermalink={true}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-      useMilitaryTime={true}
-    />
-    <PostFlagIcon
-      idCount={-1}
-      idPrefix="centerPostFlag"
-      isEphemeral={false}
-      isFlagged={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-    />
-  </div>
+  />
   <div
     className="col col__reply"
-  >
-    <Connect(DotMenu)
-      commentCount={0}
-      handleCommentClick={[Function]}
-      handleDropdownOpened={[Function]}
-      idCount={-1}
-      idPrefix="center"
-      isFlagged={false}
-      post={
-        Object {
-          "channel_id": "g6139tbospd18cmxroesdk3kkc",
-          "create_at": 1502715365009,
-          "delete_at": 0,
-          "edit_at": 1502715372443,
-          "hashtags": "",
-          "id": "e584uzbwwpny9kengqayx5ayzw",
-          "is_pinned": false,
-          "message": "post message",
-          "original_id": "",
-          "parent_id": "",
-          "pending_post_id": "",
-          "props": Object {},
-          "root_id": "",
-          "type": "",
-          "update_at": 1502715372443,
-          "user_id": "b4pfxi8sn78y8yq7phzxxfor7h",
-        }
-      }
-    />
-    <CommentIcon
-      commentCount={0}
-      handleCommentClick={[Function]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
-      idCount={-1}
-      idPrefix="commentIcon"
-      searchStyle=""
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -664,12 +236,6 @@ exports[`components/post_view/PostInfo should match snapshot, pinned post 1`] = 
   <div
     className="col"
   >
-    <PostTime
-      eventTime={1502715365009}
-      isPermalink={true}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-      useMilitaryTime={false}
-    />
     <span
       className="post__pinned-badge"
     >
@@ -679,58 +245,14 @@ exports[`components/post_view/PostInfo should match snapshot, pinned post 1`] = 
         values={Object {}}
       />
     </span>
-    <PostFlagIcon
-      idCount={-1}
-      idPrefix="centerPostFlag"
-      isEphemeral={false}
-      isFlagged={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-    />
   </div>
   <div
     className="col col__reply"
-  >
-    <Connect(DotMenu)
-      commentCount={0}
-      handleCommentClick={[Function]}
-      handleDropdownOpened={[Function]}
-      idCount={-1}
-      idPrefix="center"
-      isFlagged={false}
-      post={
-        Object {
-          "channel_id": "g6139tbospd18cmxroesdk3kkc",
-          "create_at": 1502715365009,
-          "delete_at": 0,
-          "edit_at": 1502715372443,
-          "hashtags": "",
-          "id": "e584uzbwwpny9kengqayx5ayzw",
-          "is_pinned": true,
-          "message": "post message",
-          "original_id": "",
-          "parent_id": "",
-          "pending_post_id": "",
-          "props": Object {},
-          "root_id": "",
-          "type": "",
-          "update_at": 1502715372443,
-          "user_id": "b4pfxi8sn78y8yq7phzxxfor7h",
-        }
-      }
-    />
-    <CommentIcon
-      commentCount={0}
-      handleCommentClick={[Function]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
-      idCount={-1}
-      idPrefix="commentIcon"
-      searchStyle=""
-    />
-  </div>
+  />
 </div>
 `;
 
-exports[`components/post_view/PostInfo toggleEmojiPicker, should have called props.handleDropdownOpened 1`] = `
+exports[`components/post_view/PostInfo should match snapshot, showTimeWithoutHover 1`] = `
 <div
   className="post__header--info"
 >
@@ -743,73 +265,22 @@ exports[`components/post_view/PostInfo toggleEmojiPicker, should have called pro
       postId="e584uzbwwpny9kengqayx5ayzw"
       useMilitaryTime={false}
     />
-    <PostFlagIcon
-      idCount={-1}
-      idPrefix="centerPostFlag"
-      isEphemeral={false}
-      isFlagged={false}
-      postId="e584uzbwwpny9kengqayx5ayzw"
-    />
   </div>
   <div
     className="col col__reply"
-  >
-    <Connect(DotMenu)
-      commentCount={0}
-      handleCommentClick={[Function]}
-      handleDropdownOpened={[Function]}
-      idCount={-1}
-      idPrefix="center"
-      isFlagged={false}
-      post={
-        Object {
-          "channel_id": "g6139tbospd18cmxroesdk3kkc",
-          "create_at": 1502715365009,
-          "delete_at": 0,
-          "edit_at": 1502715372443,
-          "hashtags": "",
-          "id": "e584uzbwwpny9kengqayx5ayzw",
-          "is_pinned": false,
-          "message": "post message",
-          "original_id": "",
-          "parent_id": "",
-          "pending_post_id": "",
-          "props": Object {},
-          "root_id": "",
-          "type": "",
-          "update_at": 1502715372443,
-          "user_id": "b4pfxi8sn78y8yq7phzxxfor7h",
-        }
-      }
-    />
-    <span>
-      <EmojiPickerOverlay
-        container={[Function]}
-        onEmojiClick={[Function]}
-        onHide={[Function]}
-        rightOffset={7}
-        show={false}
-        spaceRequiredAbove={422}
-        spaceRequiredBelow={436}
-        target={[Function]}
-      />
-      <button
-        className="reacticon__container color--link style--none"
-        onClick={[Function]}
-      >
-        <EmojiIcon
-          className="icon icon--emoji"
-        />
-      </button>
-    </span>
-    <CommentIcon
-      commentCount={0}
-      handleCommentClick={[Function]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
-      idCount={-1}
-      idPrefix="commentIcon"
-      searchStyle=""
-    />
-  </div>
+  />
+</div>
+`;
+
+exports[`components/post_view/PostInfo toggleEmojiPicker, should have called props.handleDropdownOpened 1`] = `
+<div
+  className="post__header--info"
+>
+  <div
+    className="col"
+  />
+  <div
+    className="col col__reply"
+  />
 </div>
 `;

--- a/tests/components/post_view/post_info/post_info.test.jsx
+++ b/tests/components/post_view/post_info/post_info.test.jsx
@@ -43,6 +43,8 @@ describe('components/post_view/PostInfo', () => {
         getPostList: jest.fn(),
         useMilitaryTime: false,
         isFlagged: false,
+        hover: false,
+        showTimeWithoutHover: false,
         actions: {
             removePost: jest.fn(),
             addReaction: jest.fn()
@@ -176,5 +178,19 @@ describe('components/post_view/PostInfo', () => {
         expect(addReaction).toBeCalledWith(post.id, emoji.name);
         expect(handleDropdownOpened).toHaveBeenCalledTimes(1);
         expect(handleDropdownOpened).toBeCalledWith(false);
+    });
+
+    test('should match snapshot, hover', () => {
+        const props = {...requiredProps, hover: true};
+
+        const wrapper = shallow(<PostInfo {...props}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, showTimeWithoutHover', () => {
+        const props = {...requiredProps, showTimeWithoutHover: true};
+
+        const wrapper = shallow(<PostInfo {...props}/>);
+        expect(wrapper).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Summary
A while ago I profiled channel switching and discovered that the mounting time for posts was a big factor in the performance of channel switching. Here's a more recent profile (using 4x CPU slowdown) showing this:

![screen shot 2017-12-21 at 10 59 50 am](https://user-images.githubusercontent.com/2672098/34264546-431a1ebe-e641-11e7-9dc8-9f5cd9e0d4b7.png)

From that profile, the mounting of the posts is totalling about 1.33s, with each post taking around 40-60ms each. Looking a bit deeper, the PostHeader component is causing the majority of that (averaging around 65% depending on the post), the ProfilePicture takes up a small slice (5% or so) and the PostBody takes up the rest.

![screen shot 2017-12-21 at 11 00 16 am](https://user-images.githubusercontent.com/2672098/34264766-e81239b0-e641-11e7-96a6-3f0e1dd95e6d.png)

So first, I took a look at what we're doing in PostHeader (and its immediate child PostInfo) to see if there's anything we could remove or speed up.

The first thing I found was that we were mounting the DotMenu, EmojiPicker and CommentIcon components for every single post but we would only show them when a user hovers over the post. To get around this I added onMouseEnter and onMouseLeave event handlers to each post and started using a `hover` prop that would prevent rendering of these components until the user hovered over the relevant post. We were also doing something very similar for the PostTime and FlagIcon components, so I applied a similar solution for those. Did some more profiling, and that seemed to help a good amount.

Next I looked at the ProfilePicture component and surprise surprise we were mounting this for every Post component even if we were hiding it with CSS. To fix that, I just mimicked the CSS rules for when to show the profile picture and only mounted it when it was going to be shown to the user.

Finally, I looked a bit at PostBody. The only easy win in here was that for posts that were comments/replies we were always mounting the "User commented on..." messages even when we were hiding them with CSS. Applied a similar solution as I had just used above and now they only get mounted when necessary. This helped a bit, but only for replies. The vast majority of the mounting time in the PostBody component was coming from the PostMarkdown component.

The end result is a decent improvement in mounting times:
![screen shot 2017-12-21 at 11 01 20 am](https://user-images.githubusercontent.com/2672098/34265507-101bf868-e644-11e7-9b48-018030de289f.png)

From about 1.33s to 753ms which gives an approximate 43% improvement. Of course the improvement will vary depending on the content of posts in the channel. For my profiling I used a channel full of variety of different posts from multiple users.

I'll probably spend some more time looking to see if I can squeeze some more improvements out of these components but I figured this was a decent first step.