### PR TITLE
[PLT-8400] Fix indefinite loading of spinner button at language setting when saving without change

### DIFF
--- a/components/user_settings/manage_languages.jsx
+++ b/components/user_settings/manage_languages.jsx
@@ -28,14 +28,20 @@ export default class ManageLanguage extends React.Component {
     setLanguage(e) {
         this.setState({locale: e.target.value});
     }
+
     changeLanguage(e) {
         e.preventDefault();
 
-        this.submitUser({
-            ...this.props.user,
-            locale: this.state.locale
-        });
+        if (this.props.user.locale === this.state.locale) {
+            this.props.updateSection(e);
+        } else {
+            this.submitUser({
+                ...this.props.user,
+                locale: this.state.locale
+            });
+        }
     }
+
     submitUser(user) {
         this.setState({isSaving: true});
 
@@ -55,6 +61,7 @@ export default class ManageLanguage extends React.Component {
             }
         );
     }
+
     render() {
         let serverError;
         if (this.state.serverError) {


### PR DESCRIPTION
#### Summary
Fix indefinite loading of spinner button at language setting when saving without change, by:
- not spinning
- exiting on language setting max view

#### Ticket Link
Jira ticket: [PLT-8400](https://mattermost.atlassian.net/browse/PLT-8400)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
