### PR TITLE
Fix JS error on actions.emitCLoseRightHandSide

### DIFF
--- a/components/search_results_item/index.js
+++ b/components/search_results_item/index.js
@@ -8,7 +8,7 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import {closeRightHandSide} from 'actions/views/rhs';
 
-import SelectResultsItem from './search_results_item.jsx';
+import SearchResultsItem from './search_results_item.jsx';
 
 function mapStateToProps(state) {
     return {
@@ -24,4 +24,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SelectResultsItem);
+export default connect(mapStateToProps, mapDispatchToProps)(SearchResultsItem);

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -96,7 +96,7 @@ export default class SearchResultsItem extends React.PureComponent {
         *  Function used for closing LHS
         */
         actions: PropTypes.shape({
-            emitCloseRightHandSide: PropTypes.func.isRequired
+            closeRightHandSide: PropTypes.func.isRequired
         }).isRequired
     };
 
@@ -135,7 +135,7 @@ export default class SearchResultsItem extends React.PureComponent {
 
     handleJumpClick = () => {
         if (Utils.isMobile()) {
-            this.props.actions.emitCloseRightHandSide();
+            this.props.actions.closeRightHandSide();
         }
 
         this.shrinkSidebar();

--- a/tests/components/search_results_item.test.jsx
+++ b/tests/components/search_results_item.test.jsx
@@ -87,7 +87,7 @@ describe('components/search_results_item', () => {
             status: 'hello',
             onSelect: mockFunc,
             actions: {
-                emitCloseRightHandSide: mockFunc
+                closeRightHandSide: mockFunc
             }
         };
     });


### PR DESCRIPTION
#### Summary
This is a quick fix to Javascript error when opening RHS.

![screen shot 2017-12-22 at 6 22 20 pm](https://user-images.githubusercontent.com/5334504/34295182-dd970456-e746-11e7-8db5-2d4f8d3ce517.png)


#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
