### PR TITLE
[webapp-perf]  Fix duplicate calls and redundant actions on team switch

### DIFF
--- a/routes/route_team.jsx
+++ b/routes/route_team.jsx
@@ -83,6 +83,10 @@ const WAKEUP_CHECK_INTERVAL = 30000; // 30 seconds
 const WAKEUP_THRESHOLD = 60000; // 60 seconds
 
 function preNeedsTeam(nextState, replace, callback) {
+    if (nextState.location.action === 'REPLACE') {
+        callback();
+        return;
+    }
     if (RouteUtils.checkIfMFARequired(nextState)) {
         browserHistory.push('/mfa/setup');
         return;


### PR DESCRIPTION
#### Summary
When debugging about some perf improvement on team switch I noticed couple of duplicate calls and redundant actions on main JS exec thread.

On entering team `team pre-needs` are executed and then enters indexRoute which pushes a channel to enter calling `team pre-needs`. 

Network request without PR
![screen shot 2017-12-27 at 4 16 42 pm](https://user-images.githubusercontent.com/4973621/34382218-5a44e136-eb33-11e7-929f-b28c8d005937.png)


Network request with PR
![screen shot 2017-12-27 at 4 19 21 pm](https://user-images.githubusercontent.com/4973621/34382226-679481d4-eb33-11e7-8807-a037921b522f.png)

This PR removes unread and channel duplicate API calls.


There are some perf benefits as well.
Without the PR test case takes about 2.6s for switch(complete paint of conversation in team)
![screen shot 2017-12-27 at 4 24 05 pm](https://user-images.githubusercontent.com/4973621/34382287-d3f49d96-eb33-11e7-9667-9ff9e3507237.png)

With this PR same test case takes about 2s for team switch.
![screen shot 2017-12-27 at 4 32 05 pm](https://user-images.githubusercontent.com/4973621/34382413-b55e7464-eb34-11e7-80f0-0a51ab23682e.png)

You can find the difference between main thread before the `jquery timer call` in the above images.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
