### PR TITLE
Fix currentYear snapshots test failure

### DIFF
--- a/tests/components/__snapshots__/edit_channel_header_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/edit_channel_header_modal.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/edit_channel_header_modal/edit_channel_header_modal edit dirrect message channel 1`] = `
+exports[`components/EditChannelHeaderModal edit dirrect message channel 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -104,7 +104,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal edit dir
 </Modal>
 `;
 
-exports[`components/edit_channel_header_modal/edit_channel_header_modal error with intl message 1`] = `
+exports[`components/EditChannelHeaderModal error with intl message 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -222,7 +222,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal error wi
 </Modal>
 `;
 
-exports[`components/edit_channel_header_modal/edit_channel_header_modal error without intl message 1`] = `
+exports[`components/EditChannelHeaderModal error without intl message 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -340,7 +340,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal error wi
 </Modal>
 `;
 
-exports[`components/edit_channel_header_modal/edit_channel_header_modal hide error message on new request 1`] = `
+exports[`components/EditChannelHeaderModal hide error message on new request 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -448,7 +448,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal hide err
 </Modal>
 `;
 
-exports[`components/edit_channel_header_modal/edit_channel_header_modal should match snapshot, init 1`] = `
+exports[`components/EditChannelHeaderModal should match snapshot, init 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -556,7 +556,7 @@ exports[`components/edit_channel_header_modal/edit_channel_header_modal should m
 </Modal>
 `;
 
-exports[`components/edit_channel_header_modal/edit_channel_header_modal submitted 1`] = `
+exports[`components/EditChannelHeaderModal submitted 1`] = `
 <Modal
   animation={true}
   autoFocus={true}

--- a/tests/components/__snapshots__/edit_channel_purpose_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/edit_channel_purpose_modal.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx clear error on next 1`] = `
+exports[`comoponents/EditChannelPurposeModal clear error on next 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -98,7 +98,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx c
 </Modal>
 `;
 
-exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx match with modal error 1`] = `
+exports[`comoponents/EditChannelPurposeModal match with modal error 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -206,7 +206,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx m
 </Modal>
 `;
 
-exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx match with modal error with fake id 1`] = `
+exports[`comoponents/EditChannelPurposeModal match with modal error with fake id 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -314,7 +314,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx m
 </Modal>
 `;
 
-exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx should match for private channel 1`] = `
+exports[`comoponents/EditChannelPurposeModal should match for private channel 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -412,7 +412,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx s
 </Modal>
 `;
 
-exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx should match on init 1`] = `
+exports[`comoponents/EditChannelPurposeModal should match on init 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -510,7 +510,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx s
 </Modal>
 `;
 
-exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx should match submitted 1`] = `
+exports[`comoponents/EditChannelPurposeModal should match submitted 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -608,7 +608,7 @@ exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx s
 </Modal>
 `;
 
-exports[`comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx should match with display name 1`] = `
+exports[`comoponents/EditChannelPurposeModal should match with display name 1`] = `
 <Modal
   animation={true}
   autoFocus={true}

--- a/tests/components/__snapshots__/edit_post_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/edit_post_modal.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`comoponents/edit_post_modal/edit_post_modal.jsx should match with default config 1`] = `
+exports[`comoponents/EditPostModal should match with default config 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -134,7 +134,7 @@ exports[`comoponents/edit_post_modal/edit_post_modal.jsx should match with defau
 </Modal>
 `;
 
-exports[`comoponents/edit_post_modal/edit_post_modal.jsx should match without editingPost 1`] = `
+exports[`comoponents/EditPostModal should match without editingPost 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -267,7 +267,7 @@ exports[`comoponents/edit_post_modal/edit_post_modal.jsx should match without ed
 </Modal>
 `;
 
-exports[`comoponents/edit_post_modal/edit_post_modal.jsx should match without emoji picker 1`] = `
+exports[`comoponents/EditPostModal should match without emoji picker 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -376,7 +376,7 @@ exports[`comoponents/edit_post_modal/edit_post_modal.jsx should match without em
 </Modal>
 `;
 
-exports[`comoponents/edit_post_modal/edit_post_modal.jsx should show emojis on emojis click 1`] = `
+exports[`comoponents/EditPostModal should show emojis on emojis click 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -510,7 +510,7 @@ exports[`comoponents/edit_post_modal/edit_post_modal.jsx should show emojis on e
 </Modal>
 `;
 
-exports[`comoponents/edit_post_modal/edit_post_modal.jsx should show errors when it is set in the state 1`] = `
+exports[`comoponents/EditPostModal should show errors when it is set in the state 1`] = `
 <Modal
   animation={true}
   autoFocus={true}

--- a/tests/components/__snapshots__/file_info_preview.test.jsx.snap
+++ b/tests/components/__snapshots__/file_info_preview.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/file_info_preview.jsx should match snapshot 1`] = `
+exports[`components/FileInfoPreview should match snapshot 1`] = `
 <div
   className="file-details__container"
 >

--- a/tests/components/__snapshots__/rename_channel_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/rename_channel_modal.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/rename_channel_modal/rename_channel_modal.jsx should match snapshot 1`] = `
+exports[`components/RenameChannelModal should match snapshot 1`] = `
 <Modal
   animation={true}
   autoFocus={true}

--- a/tests/components/__snapshots__/search_results_item.test.jsx.snap
+++ b/tests/components/__snapshots__/search_results_item.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/search_results_item should match snapshot for DM 1`] = `
+exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
 <div
   className="search-item__container"
 >
@@ -207,7 +207,7 @@ exports[`components/search_results_item should match snapshot for DM 1`] = `
 </div>
 `;
 
-exports[`components/search_results_item should match snapshot for channel 1`] = `
+exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
 <div
   className="search-item__container"
 >
@@ -383,7 +383,7 @@ exports[`components/search_results_item should match snapshot for channel 1`] = 
 </div>
 `;
 
-exports[`components/search_results_item should match snapshot for deleted message with attachments by bot 1`] = `
+exports[`components/SearchResultsItem should match snapshot for deleted message with attachments by bot 1`] = `
 <div
   className="search-item__container"
 >

--- a/tests/components/about_build_modal.test.jsx
+++ b/tests/components/about_build_modal.test.jsx
@@ -10,15 +10,29 @@ import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 import AboutBuildModal from 'components/about_build_modal/about_build_modal.jsx';
 
 describe('components/AboutBuildModal', () => {
+    const RealDate = Date;
+
+    function mockDate(date) {
+        global.Date = class extends RealDate {
+            constructor() {
+                super();
+                return new RealDate(date);
+            }
+        };
+    }
+
     let config = null;
     let license = null;
 
     afterEach(() => {
+        global.Date = RealDate;
         config = null;
         license = null;
     });
 
     beforeEach(() => {
+        mockDate('2017-01-01');
+
         config = {
             BuildEnterpriseReady: 'true',
             Version: '3.6.0',

--- a/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/integrations/DotMenu should match snapshot, canDelete 1`] = `
+exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
 <div
   className="dropdown"
   id={null}
@@ -69,7 +69,7 @@ exports[`components/integrations/DotMenu should match snapshot, canDelete 1`] = 
 </div>
 `;
 
-exports[`components/integrations/DotMenu should match snapshot, on Center 1`] = `
+exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
 <div
   className="dropdown"
   id={null}
@@ -127,7 +127,7 @@ exports[`components/integrations/DotMenu should match snapshot, on Center 1`] = 
 </div>
 `;
 
-exports[`components/integrations/DotMenu should match snapshot, on Center 2`] = `
+exports[`components/dot_menu/DotMenu should match snapshot, on Center 2`] = `
 <div
   className="dropdown"
   id="rhsrootDotMenu"
@@ -180,7 +180,7 @@ exports[`components/integrations/DotMenu should match snapshot, on Center 2`] = 
 </div>
 `;
 
-exports[`components/integrations/DotMenu should match snapshot, on Center 3`] = `
+exports[`components/dot_menu/DotMenu should match snapshot, on Center 3`] = `
 <div
   className="dropdown"
   id="rhsrootDotMenu"

--- a/tests/components/dot_menu/__snapshots__/dot_menu_edit.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu_edit.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/integrations/DotMenuEdit should match snapshot, on Center 1`] = `
+exports[`components/dot_menu/DotMenuEdit should match snapshot, on Center 1`] = `
 <li
   id={null}
   key="center"
@@ -19,7 +19,7 @@ exports[`components/integrations/DotMenuEdit should match snapshot, on Center 1`
 </li>
 `;
 
-exports[`components/integrations/DotMenuEdit should match snapshot, on RHS 1`] = `
+exports[`components/dot_menu/DotMenuEdit should match snapshot, on RHS 1`] = `
 <li
   id={null}
   key="rhs"
@@ -38,7 +38,7 @@ exports[`components/integrations/DotMenuEdit should match snapshot, on RHS 1`] =
 </li>
 `;
 
-exports[`components/integrations/DotMenuEdit should match snapshot, on RHS_ROOT 1`] = `
+exports[`components/dot_menu/DotMenuEdit should match snapshot, on RHS_ROOT 1`] = `
 <li
   id="rhsroot"
   key="rhsroot"

--- a/tests/components/dot_menu/__snapshots__/dot_menu_empty.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu_empty.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/integrations/DotMenu returning empty ("") should match snapshot, return empty ("") on Center 1`] = `""`;
+exports[`components/dot_menu/DotMenu returning empty ("") should match snapshot, return empty ("") on Center 1`] = `""`;
 
-exports[`components/integrations/DotMenu returning empty ("") should match snapshot, return empty ("") on RHS while loading a post 1`] = `""`;
+exports[`components/dot_menu/DotMenu returning empty ("") should match snapshot, return empty ("") on RHS while loading a post 1`] = `""`;
 
-exports[`components/integrations/DotMenu returning empty ("") should match snapshot, return empty ("") on RHS with failed post 1`] = `""`;
+exports[`components/dot_menu/DotMenu returning empty ("") should match snapshot, return empty ("") on RHS with failed post 1`] = `""`;

--- a/tests/components/dot_menu/__snapshots__/dot_menu_flag.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu_flag.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/integrations/DotMenuFlag should match snapshot, flagged on RHS 1`] = `
+exports[`components/dot_menu/DotMenuFlag should match snapshot, flagged on RHS 1`] = `
 <li
   key="rhs"
   role="presentation"
@@ -19,7 +19,7 @@ exports[`components/integrations/DotMenuFlag should match snapshot, flagged on R
 </li>
 `;
 
-exports[`components/integrations/DotMenuFlag should match snapshot, on RHS_ROOT 1`] = `
+exports[`components/dot_menu/DotMenuFlag should match snapshot, on RHS_ROOT 1`] = `
 <li
   key="rhsroot"
   role="presentation"
@@ -38,7 +38,7 @@ exports[`components/integrations/DotMenuFlag should match snapshot, on RHS_ROOT 
 </li>
 `;
 
-exports[`components/integrations/DotMenuFlag should match snapshot, unflagged on Center 1`] = `
+exports[`components/dot_menu/DotMenuFlag should match snapshot, unflagged on Center 1`] = `
 <li
   key="center"
   role="presentation"

--- a/tests/components/dot_menu/__snapshots__/dot_menu_item.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu_item.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/integrations/DotMenuItem should match snapshot, on Delete 1`] = `
+exports[`components/dot_menu/DotMenuItem should match snapshot, on Delete 1`] = `
 <li
   id={null}
   key="idPrefixDotMenuDelete"
@@ -20,7 +20,7 @@ exports[`components/integrations/DotMenuItem should match snapshot, on Delete 1`
 </li>
 `;
 
-exports[`components/integrations/DotMenuItem should match snapshot, on Permalink 1`] = `
+exports[`components/dot_menu/DotMenuItem should match snapshot, on Permalink 1`] = `
 <li
   id={null}
   key="idPrefixDotMenuPermalink"
@@ -40,7 +40,7 @@ exports[`components/integrations/DotMenuItem should match snapshot, on Permalink
 </li>
 `;
 
-exports[`components/integrations/DotMenuItem should match snapshot, on Pin - pinned 1`] = `
+exports[`components/dot_menu/DotMenuItem should match snapshot, on Pin - pinned 1`] = `
 <li
   id="idPrefixDotMenuPin5"
   key="idPrefixDotMenuPin"
@@ -60,7 +60,7 @@ exports[`components/integrations/DotMenuItem should match snapshot, on Pin - pin
 </li>
 `;
 
-exports[`components/integrations/DotMenuItem should match snapshot, on Pin - unpinned 1`] = `
+exports[`components/dot_menu/DotMenuItem should match snapshot, on Pin - unpinned 1`] = `
 <li
   id={null}
   key="idPrefixDotMenuPin"
@@ -80,7 +80,7 @@ exports[`components/integrations/DotMenuItem should match snapshot, on Pin - unp
 </li>
 `;
 
-exports[`components/integrations/DotMenuItem should match snapshot, on RHS_ROOT 1`] = `
+exports[`components/dot_menu/DotMenuItem should match snapshot, on RHS_ROOT 1`] = `
 <li
   id="rhsroot"
   key="rhsroot"
@@ -97,7 +97,7 @@ exports[`components/integrations/DotMenuItem should match snapshot, on RHS_ROOT 
 </li>
 `;
 
-exports[`components/integrations/DotMenuItem should match snapshot, on Reply 1`] = `
+exports[`components/dot_menu/DotMenuItem should match snapshot, on Reply 1`] = `
 <li
   id={null}
   key="idPrefixDotMenuReply"

--- a/tests/components/dot_menu/__snapshots__/dot_menu_mobile.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu_mobile.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/integrations/DotMenu on mobile view should match snapshot 1`] = `
+exports[`components/dot_menu/DotMenu on mobile view should match snapshot 1`] = `
 <div
   className="dropdown"
   id={null}

--- a/tests/components/dot_menu/dot_menu.test.jsx
+++ b/tests/components/dot_menu/dot_menu.test.jsx
@@ -24,7 +24,7 @@ jest.mock('utils/post_utils', () => {
     };
 });
 
-describe('components/integrations/DotMenu', () => {
+describe('components/dot_menu/DotMenu', () => {
     global.window.mm_license = {};
 
     beforeEach(() => {

--- a/tests/components/dot_menu/dot_menu_edit.test.jsx
+++ b/tests/components/dot_menu/dot_menu_edit.test.jsx
@@ -8,7 +8,7 @@ import Constants from 'utils/constants.jsx';
 
 import DotMenuEdit from 'components/dot_menu/dot_menu_edit.jsx';
 
-describe('components/integrations/DotMenuEdit', () => {
+describe('components/dot_menu/DotMenuEdit', () => {
     const baseProps = {
         idCount: -1,
         idPrefix: Constants.CENTER,

--- a/tests/components/dot_menu/dot_menu_empty.test.jsx
+++ b/tests/components/dot_menu/dot_menu_empty.test.jsx
@@ -22,7 +22,7 @@ jest.mock('utils/post_utils', () => {
     };
 });
 
-describe('components/integrations/DotMenu returning empty ("")', () => {
+describe('components/dot_menu/DotMenu returning empty ("")', () => {
     global.window.mm_license = {};
 
     beforeEach(() => {

--- a/tests/components/dot_menu/dot_menu_flag.test.jsx
+++ b/tests/components/dot_menu/dot_menu_flag.test.jsx
@@ -8,7 +8,7 @@ import Constants from 'utils/constants.jsx';
 
 import DotMenuFlag from 'components/dot_menu/dot_menu_flag.jsx';
 
-describe('components/integrations/DotMenuFlag', () => {
+describe('components/dot_menu/DotMenuFlag', () => {
     const baseProps = {
         idCount: -1,
         idPrefix: Constants.CENTER,

--- a/tests/components/dot_menu/dot_menu_item.test.jsx
+++ b/tests/components/dot_menu/dot_menu_item.test.jsx
@@ -17,7 +17,7 @@ jest.mock('actions/global_actions.jsx', () => {
     };
 });
 
-describe('components/integrations/DotMenuItem', () => {
+describe('components/dot_menu/DotMenuItem', () => {
     test('should match snapshot, on Reply', () => {
         const props = {
             idPrefix: 'idPrefixDotMenuReply',

--- a/tests/components/dot_menu/dot_menu_mobile.test.jsx
+++ b/tests/components/dot_menu/dot_menu_mobile.test.jsx
@@ -22,7 +22,7 @@ jest.mock('utils/post_utils', () => {
     };
 });
 
-describe('components/integrations/DotMenu on mobile view', () => {
+describe('components/dot_menu/DotMenu on mobile view', () => {
     global.window.mm_license = {};
 
     beforeEach(() => {

--- a/tests/components/edit_channel_header_modal.test.jsx
+++ b/tests/components/edit_channel_header_modal.test.jsx
@@ -18,7 +18,7 @@ jest.mock('react-dom', () => ({
     })
 }));
 
-describe('components/edit_channel_header_modal/edit_channel_header_modal', () => {
+describe('components/EditChannelHeaderModal', () => {
     const channel = {
         id: 'fake-id',
         header: 'Fake Channel'

--- a/tests/components/edit_channel_purpose_modal.test.jsx
+++ b/tests/components/edit_channel_purpose_modal.test.jsx
@@ -5,7 +5,7 @@ import {shallow} from 'enzyme';
 import EditChannelPurposeModal from 'components/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx';
 import Constants from 'utils/constants.jsx';
 
-describe('comoponents/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx', () => {
+describe('comoponents/EditChannelPurposeModal', () => {
     const channel = {
         id: 'fake-id',
         purpose: 'purpose'

--- a/tests/components/edit_post_modal.test.jsx
+++ b/tests/components/edit_post_modal.test.jsx
@@ -53,7 +53,7 @@ function createEditPost({ctrlSend, config, license, editingPost, actions} = {}) 
     );
 }
 
-describe('comoponents/edit_post_modal/edit_post_modal.jsx', () => {
+describe('comoponents/EditPostModal', () => {
     it('should match with default config', () => {
         const wrapper = shallow(createEditPost());
         expect(wrapper).toMatchSnapshot();

--- a/tests/components/file_info_preview.test.jsx
+++ b/tests/components/file_info_preview.test.jsx
@@ -7,7 +7,7 @@ import {shallow} from 'enzyme';
 
 import FileInfoPreview from 'components/file_info_preview.jsx';
 
-describe('components/file_info_preview.jsx', () => {
+describe('components/FileInfoPreview', () => {
     const requiredProps = {
         fileUrl: 'https://pre-release.mattermost.com/api/v4/files/rqir81f7a7ft8m6j6ej7g1txuo',
         fileInfo: {name: 'Test Image', size: 100, extension: 'jpg'}

--- a/tests/components/header_footer_template.test.jsx
+++ b/tests/components/header_footer_template.test.jsx
@@ -8,11 +8,28 @@ import {shallow} from 'enzyme';
 import NotLoggedIn from 'components/header_footer_template/header_footer_template.jsx';
 
 describe('components/HeaderFooterTemplate', () => {
+    const RealDate = Date;
+
+    function mockDate(date) {
+        global.Date = class extends RealDate {
+            constructor() {
+                super();
+                return new RealDate(date);
+            }
+        };
+    }
+
     beforeEach(() => {
+        mockDate('2017-01-01');
+
         const elm = document.createElement('div');
         elm.setAttribute('id', 'root');
         document.body.appendChild(elm);
         document.body.classList.remove('sticky');
+    });
+
+    afterEach(() => {
+        global.Date = RealDate;
     });
 
     test('should match snapshot without children', () => {

--- a/tests/components/integrations/edit_command.test.jsx
+++ b/tests/components/integrations/edit_command.test.jsx
@@ -4,18 +4,17 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
-
 import EditCommand from 'components/integrations/components/edit_command/edit_command.jsx';
 
 describe('components/integrations/EditCommand', () => {
-    const getCustomTeamCommands = jest.genMockFunction().mockImplementation(
+    const getCustomTeamCommands = jest.fn(
         () => {
             return new Promise((resolve) => {
                 process.nextTick(() => resolve());
             });
         }
     );
+
     const commands = {
         r5tpgt4iepf45jt768jz84djic: {
             id: 'r5tpgt4iepf45jt768jz84djic',
@@ -52,7 +51,7 @@ describe('components/integrations/EditCommand', () => {
         commands,
         editCommandRequest,
         actions: {
-            getCustomTeamCommands: jest.fn(),
+            getCustomTeamCommands,
             editCommand: jest.fn()
         }
     };
@@ -63,18 +62,20 @@ describe('components/integrations/EditCommand', () => {
         global.window.mm_config.EnableCommands = 'true';
     });
 
-    beforeEach(() => {
+    afterEach(() => {
         global.window.mm_config = {};
     });
 
     test('should match snapshot', () => {
-        const props = {...baseProps, getCustomTeamCommands};
-        const wrapper = shallowWithIntl(
-            <EditCommand {...props}/>
+        const wrapper = shallow(
+            <EditCommand {...baseProps}/>
         );
 
         wrapper.setState({originalCommand: commands.r5tpgt4iepf45jt768jz84djic});
         expect(wrapper).toMatchSnapshot();
+
+        expect(baseProps.actions.getCustomTeamCommands).toHaveBeenCalled();
+        expect(baseProps.actions.getCustomTeamCommands).toHaveBeenCalledWith(team.id);
     });
 
     test('should match snapshot, loading', () => {
@@ -87,13 +88,17 @@ describe('components/integrations/EditCommand', () => {
 
     test('should match snapshot when EnableCommands is false', () => {
         global.window.mm_config.EnableCommands = 'false';
-        const props = {...baseProps, getCustomTeamCommands};
+        const actions = {
+            getCustomTeamCommands: jest.fn(),
+            editCommand: jest.fn()
+        };
+        const props = {...baseProps, actions};
         const wrapper = shallow(
             <EditCommand {...props}/>
         );
 
         expect(wrapper).toMatchSnapshot();
-        expect(props.actions.getCustomTeamCommands).not.toHaveBeenCalledWith();
+        expect(actions.getCustomTeamCommands).not.toHaveBeenCalled();
     });
 
     test('should have match state when handleConfirmModal is called', () => {

--- a/tests/components/rename_channel_modal.test.jsx
+++ b/tests/components/rename_channel_modal.test.jsx
@@ -8,7 +8,7 @@ import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import RenameChannelModal from 'components/rename_channel_modal/rename_channel_modal.jsx';
 
-describe('components/rename_channel_modal/rename_channel_modal.jsx', () => {
+describe('components/RenameChannelModal', () => {
     global.window.mm_config = {};
     const channel = {
         id: 'fake-id',

--- a/tests/components/search_results_item.test.jsx
+++ b/tests/components/search_results_item.test.jsx
@@ -29,7 +29,7 @@ jest.mock('utils/post_utils.jsx', () => ({
     isEdited: jest.fn().mockReturnValue(true)
 }));
 
-describe('components/search_results_item', () => {
+describe('components/SearchResultsItem', () => {
     let mockFunc;
     let user;
     let post;


### PR DESCRIPTION
#### Summary
Sample snapshots test failures:
```
                  Object {
    -               "currentYear": 2017,
    +               "currentYear": 2018,
                  }


              <span
                className="pull-right footer-link copyright"
              >
    -           © 2015-2017 Mattermost, Inc.
    +           © 2015-2018 Mattermost, Inc.
              </span>
```

Fix currentYear snapshots test failure by:
- mocking up the date at AboutBuildModal and HeaderFooterTemplate components

Also, did small cleanup/update on 
- tests description 
- EditCommand tests

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
