### PR TITLE
PLT-8352 Handle getting user updated event for logged in user

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -11,6 +11,7 @@ import {getChannelAndMyMember, getChannelStats, viewChannel} from 'mattermost-re
 import {setServerVersion} from 'mattermost-redux/actions/general';
 import {getPosts, getProfilesAndStatusesForPosts} from 'mattermost-redux/actions/posts';
 import * as TeamActions from 'mattermost-redux/actions/teams';
+import {getMe} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
@@ -412,13 +413,11 @@ function handleUserUpdatedEvent(msg) {
     const user = msg.data.user;
 
     if (currentUser.id === user.id) {
-        dispatch({
-            type: UserTypes.RECEIVED_ME,
-            data: {
-                ...currentUser,
-                last_picture_update: user.last_picture_update
-            }
-        });
+        if (user.update_at > currentUser.update_at) {
+            // Need to request me to make sure we don't override with sanitized fields from the
+            // websocket event
+            getMe()(dispatch, getState);
+        }
     } else {
         UserStore.saveProfile(user);
     }


### PR DESCRIPTION
#### Summary
Handle getting user updated event for logged in user by requesting self if update_at is newer than the one we have.

#### Ticket Link
Web app portion of https://mattermost.atlassian.net/browse/PLT-8352

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has server changes (mattermost/mattermost-server#8018)