### PR TITLE
Fix timezone issue with mockDate

### DIFF
--- a/tests/components/about_build_modal.test.jsx
+++ b/tests/components/about_build_modal.test.jsx
@@ -31,7 +31,7 @@ describe('components/AboutBuildModal', () => {
     });
 
     beforeEach(() => {
-        mockDate('2017-01-01');
+        mockDate('2017-06-01');
 
         config = {
             BuildEnterpriseReady: 'true',

--- a/tests/components/header_footer_template.test.jsx
+++ b/tests/components/header_footer_template.test.jsx
@@ -20,7 +20,7 @@ describe('components/HeaderFooterTemplate', () => {
     }
 
     beforeEach(() => {
-        mockDate('2017-01-01');
+        mockDate('2017-06-01');
 
         const elm = document.createElement('div');
         elm.setAttribute('id', 'root');


### PR DESCRIPTION
#### Summary
The timezone effects the year. i.e. when `getFullYear()` is called on `new Date('2017-01-01')`, it was returning 2016 for my timezone.

#### Ticket Link
No ticket. This was a recent bug I found based on a recent [PR](https://github.com/mattermost/mattermost-webapp/pull/524).

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)