### PR TITLE
PLT-8461 Fix JS error when switching teams mid channel switch

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -948,9 +948,10 @@ export function isMobile() {
 }
 
 export function getDirectTeammate(channelId) {
-    var userIds = ChannelStore.get(channelId).name.split('__');
-    var curUserId = UserStore.getCurrentId();
-    var teammate = {};
+    const channel = ChannelStore.get(channelId) || {};
+    const userIds = channel.name.split('__');
+    const curUserId = UserStore.getCurrentId();
+    let teammate = {};
 
     if (userIds.length !== 2 || userIds.indexOf(curUserId) === -1) {
         return teammate;


### PR DESCRIPTION
#### Summary
Fix JS error when switching teams mid channel switch. The problem was sometimes channel could be undefined initially.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8461