### PR TITLE
[PLT-8424] Do not show add-user-to-channel ephemeral message at center

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -24,7 +24,7 @@ import UserStore from 'stores/user_store.jsx';
 
 import WebSocketClient from 'client/web_websocket_client.jsx';
 
-import {ActionTypes, Constants, ErrorPageTypes} from 'utils/constants.jsx';
+import {ActionTypes, Constants, ErrorPageTypes, PostTypes} from 'utils/constants.jsx';
 import EventTypes from 'utils/event_types.jsx';
 import {sortTeamsByDisplayName} from 'utils/team_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -330,12 +330,33 @@ export function sendEphemeralPost(message, channelId, parentId) {
         user_id: '0',
         channel_id: channelId || ChannelStore.getCurrentId(),
         message,
-        type: Constants.PostTypes.EPHEMERAL,
+        type: PostTypes.EPHEMERAL,
         create_at: timestamp,
         update_at: timestamp,
         root_id: parentId,
         parent_id: parentId,
         props: {}
+    };
+
+    handleNewPost(post);
+}
+
+export function sendAddToChannelEphemeralPost(user, addedUsername, channelId, postRootId = '') {
+    const timestamp = Utils.getTimestamp();
+    const post = {
+        id: Utils.generateId(),
+        user_id: user.id,
+        channel_id: channelId || ChannelStore.getCurrentId(),
+        message: '',
+        type: PostTypes.EPHEMERAL_ADD_TO_CHANNEL,
+        create_at: timestamp,
+        update_at: timestamp,
+        root_id: postRootId,
+        parent_id: postRootId,
+        props: {
+            username: user.username,
+            addedUsername
+        }
     };
 
     handleNewPost(post);

--- a/components/post_markdown/system_message_helpers.jsx
+++ b/components/post_markdown/system_message_helpers.jsx
@@ -287,6 +287,8 @@ export function renderSystemMessage(post, options) {
         return null;
     } else if (systemMessageRenderers[post.type]) {
         return systemMessageRenderers[post.type](post, options);
+    } else if (post.type === PostTypes.EPHEMERAL_ADD_TO_CHANNEL) {
+        return renderAddToChannelMessage(post, options);
     }
 
     return null;

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -219,20 +219,6 @@ export default class Post extends React.PureComponent {
 
     render() {
         const post = this.props.post || {};
-        const isEphemeral = Utils.isPostEphemeral(post);
-
-        // When user/s is added to channel by clicking @mention links,
-        // add-user-to-channel system message is posted at center while ephemeral message at RHS.
-        // This condition prevents add-user-to-channel ephemeral message at center posts.
-        if (
-            isEphemeral &&
-            post.root_id &&
-            post.props &&
-            post.props.username &&
-            post.props.addedUsername
-        ) {
-            return null;
-        }
 
         const isSystemMessage = PostUtils.isSystemMessage(post);
         const fromWebhook = post && post.props && post.props.from_webhook === 'true';

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -219,6 +219,20 @@ export default class Post extends React.PureComponent {
 
     render() {
         const post = this.props.post || {};
+        const isEphemeral = Utils.isPostEphemeral(post);
+
+        // When user/s is added to channel by clicking @mention links,
+        // add-user-to-channel system message is posted at center while ephemeral message at RHS.
+        // This condition prevents add-user-to-channel ephemeral message at center posts.
+        if (
+            isEphemeral &&
+            post.root_id &&
+            post.props &&
+            post.props.username &&
+            post.props.addedUsername
+        ) {
+            return null;
+        }
 
         const isSystemMessage = PostUtils.isSystemMessage(post);
         const fromWebhook = post && post.props && post.props.from_webhook === 'true';

--- a/components/post_view/post_add_channel_member/index.js
+++ b/components/post_view/post_add_channel_member/index.js
@@ -9,6 +9,7 @@ import {removePost} from 'mattermost-redux/actions/posts';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import PostAddChannelMember from './post_add_channel_member.jsx';
 
@@ -18,7 +19,8 @@ function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
         team: getCurrentTeam(state),
-        channel: getChannel(state, currentChannelId)
+        channel: getChannel(state, currentChannelId),
+        currentUser: getCurrentUser(state)
     };
 }
 

--- a/components/post_view/post_add_channel_member/post_add_channel_member.jsx
+++ b/components/post_view/post_add_channel_member/post_add_channel_member.jsx
@@ -8,6 +8,8 @@ import {browserHistory} from 'react-router';
 
 import store from 'stores/redux_store.jsx';
 
+import {sendAddToChannelEphemeralPost} from 'actions/global_actions.jsx';
+
 import {Constants} from 'utils/constants.jsx';
 
 import AtMention from 'components/at_mention';
@@ -16,6 +18,11 @@ const getState = store.getState;
 
 export default class PostAddChannelMember extends React.PureComponent {
     static propTypes = {
+
+        /*
+        * Current user
+        */
+        currentUser: PropTypes.object.isRequired,
 
         /*
         * Current team
@@ -62,12 +69,13 @@ export default class PostAddChannelMember extends React.PureComponent {
     }
 
     handleAddChannelMember = () => {
-        const {team, channel, postId, userIds} = this.props;
+        const {currentUser, team, channel, postId, userIds, usernames} = this.props;
         const post = this.props.actions.getPost(getState(), postId) || {};
 
         if (post.channel_id === channel.id) {
-            userIds.forEach((userId) => {
-                this.props.actions.addChannelMember(channel.id, userId, post.root_id);
+            userIds.forEach((userId, index) => {
+                this.props.actions.addChannelMember(channel.id, userId);
+                sendAddToChannelEphemeralPost(currentUser, usernames[index], channel.id, post.root_id);
             });
 
             this.props.actions.removePost(post);

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -7,7 +7,7 @@ import ReactDOM from 'react-dom';
 import {FormattedDate, FormattedMessage} from 'react-intl';
 
 import {createChannelIntroMessage} from 'utils/channel_intro_messages.jsx';
-import Constants from 'utils/constants.jsx';
+import Constants, {PostTypes} from 'utils/constants.jsx';
 import DelayedAction from 'utils/delayed_action.jsx';
 import EventTypes from 'utils/event_types.jsx';
 import GlobalEventEmitter from 'utils/global_event_emitter.jsx';
@@ -426,7 +426,10 @@ export default class PostList extends React.PureComponent {
         for (let i = posts.length - 1; i >= 0; i--) {
             const post = posts[i];
 
-            if (post == null) {
+            if (
+                post == null ||
+                post.type === PostTypes.EPHEMERAL_ADD_TO_CHANNEL
+            ) {
                 continue;
             }
 

--- a/tests/components/post_view/post_add_channel_member/post_add_channel_member.test.jsx
+++ b/tests/components/post_view/post_add_channel_member/post_add_channel_member.test.jsx
@@ -8,9 +8,17 @@ import {browserHistory} from 'react-router';
 
 import store from 'stores/redux_store.jsx';
 
+import {sendAddToChannelEphemeralPost} from 'actions/global_actions.jsx';
+
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 
 import PostAddChannelMember from 'components/post_view/post_add_channel_member/post_add_channel_member.jsx';
+
+jest.mock('actions/global_actions.jsx', () => {
+    return {
+        sendAddToChannelEphemeralPost: jest.fn()
+    };
+});
 
 describe('components/post_view/PostAddChannelMember', () => {
     const team = {
@@ -24,6 +32,7 @@ describe('components/post_view/PostAddChannelMember', () => {
     };
 
     const requiredProps = {
+        currentUser: {id: 'current_user_id', username: 'current_username'},
         team,
         channel,
         postId: 'post_id_1',
@@ -83,7 +92,9 @@ describe('components/post_view/PostAddChannelMember', () => {
 
         expect(actions.getPost).toHaveBeenCalledTimes(1);
         expect(actions.addChannelMember).toHaveBeenCalledTimes(1);
-        expect(actions.addChannelMember).toHaveBeenCalledWith(channel.id, requiredProps.userIds[0], post.root_id);
+        expect(actions.addChannelMember).toHaveBeenCalledWith(channel.id, requiredProps.userIds[0]);
+        expect(sendAddToChannelEphemeralPost).toHaveBeenCalledTimes(1);
+        expect(sendAddToChannelEphemeralPost).toHaveBeenCalledWith(props.currentUser, props.usernames[0], channel.id, post.root_id);
         expect(actions.removePost).toHaveBeenCalledTimes(1);
         expect(actions.removePost).toHaveBeenCalledWith(post);
         expect(browserHistory.push).toHaveBeenCalledWith(`/${team.name}/channels/${channel.name}`);

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -327,6 +327,7 @@ export const PostTypes = {
     CHANNEL_DELETED: 'system_channel_deleted',
     FAKE_PARENT_DELETED: 'system_fake_parent_deleted',
     EPHEMERAL: 'system_ephemeral',
+    EPHEMERAL_ADD_TO_CHANNEL: 'system_ephemeral_add_to_channel',
     REMOVE_LINK_PREVIEW: 'remove_link_preview'
 };
 


### PR DESCRIPTION
#### Summary
- Do not show add-user-to-channel ephemeral message at center

When user/s is added to channel by clicking @mention links at RHS, "add-user-to-channel" system message is posted at center while ephemeral message at RHS.

@jasonblais Here is the client-side change preventing both system and ephemeral messages being posted at center. 

![jan-03-2018 23-33-39](https://user-images.githubusercontent.com/5334504/34526834-9e92be02-f0de-11e7-83a0-989cd83cb31b.gif)


#### Ticket Link
Jira ticket: [PLT-8424](https://mattermost.atlassian.net/browse/PLT-8424)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has server changes (https://github.com/mattermost/mattermost-server/pull/8021)
