### PR TITLE
PLT-8454 Re-added flow for creating channel with only non-Latin characters

### DIFF
--- a/components/new_channel_flow.jsx
+++ b/components/new_channel_flow.jsx
@@ -16,8 +16,9 @@ import Constants from 'utils/constants';
 import NewChannelModal from 'components/new_channel_modal';
 import ChangeURLModal from 'components/change_url_modal';
 
-export default class NewChannelFlow extends React.Component {
+const SHOW_EDIT_URL_THEN_COMPLETE = 3;
 
+export default class NewChannelFlow extends React.Component {
     static propTypes = {
 
         /**
@@ -75,6 +76,11 @@ export default class NewChannelFlow extends React.Component {
             return;
         }
 
+        if (this.state.channelName < 2) {
+            this.setState({flowState: SHOW_EDIT_URL_THEN_COMPLETE});
+            return;
+        }
+
         const channel = {
             team_id: TeamStore.getCurrentId(),
             name: this.state.channelName,
@@ -94,11 +100,21 @@ export default class NewChannelFlow extends React.Component {
                 this.props.onModalDismissed();
             },
             (err) => {
-                if (err.id === 'store.sql_channel.update.exists.app_error') {
+                if (err.id === 'model.channel.is_valid.2_or_more.app_error') {
+                    this.setState({
+                        flowState: SHOW_EDIT_URL_THEN_COMPLETE,
+                        serverError: (
+                            <FormattedMessage
+                                id='channel_flow.handleTooShort'
+                                defaultMessage='Channel URL must be 2 or more lowercase alphanumeric characters'
+                            />
+                        )
+                    });
+                } else if (err.id === 'store.sql_channel.update.exists.app_error') {
                     this.setState({serverError: Utils.localizeMessage('channel_flow.alreadyExist', 'A channel with that URL already exists')});
-                    return;
+                } else {
+                    this.setState({serverError: err.message});
                 }
-                this.setState({serverError: err.message});
             }
         );
     }
@@ -122,7 +138,11 @@ export default class NewChannelFlow extends React.Component {
         this.setState({flowState: Constants.SHOW_EDIT_URL});
     }
     urlChangeSubmitted = (newURL) => {
-        this.setState({flowState: Constants.SHOW_NEW_CHANNEL, serverError: null, channelName: newURL, nameModified: true});
+        if (this.state.flowState === SHOW_EDIT_URL_THEN_COMPLETE) {
+            this.setState({channelName: newURL, nameModified: true}, this.onSubmit);
+        } else {
+            this.setState({flowState: Constants.SHOW_NEW_CHANNEL, serverError: null, channelName: newURL, nameModified: true});
+        }
     }
     urlChangeDismissed = () => {
         this.setState({flowState: Constants.SHOW_NEW_CHANNEL});
@@ -170,6 +190,21 @@ export default class NewChannelFlow extends React.Component {
                     />
                 );
                 changeURLSubmitButtonText = changeURLTitle;
+                break;
+            case SHOW_EDIT_URL_THEN_COMPLETE:
+                showChangeURLModal = true;
+                changeURLTitle = (
+                    <FormattedMessage
+                        id='channel_flow.set_url_title'
+                        defaultMessage='Set Channel URL'
+                    />
+                );
+                changeURLSubmitButtonText = (
+                    <FormattedMessage
+                        id='channel_flow.create'
+                        defaultMessage='Create Channel'
+                    />
+                );
                 break;
             }
         }

--- a/components/new_channel_flow.jsx
+++ b/components/new_channel_flow.jsx
@@ -37,12 +37,12 @@ export default class NewChannelFlow extends React.Component {
         * Function to call when modal is dimissed
         */
         onModalDismissed: PropTypes.func.isRequired
-    }
+    };
 
     static defaultProps = {
         show: false,
         channelType: Constants.OPEN_CHANNEL
-    }
+    };
 
     constructor(props) {
         super(props);
@@ -57,6 +57,7 @@ export default class NewChannelFlow extends React.Component {
             nameModified: false
         };
     }
+
     componentWillReceiveProps(nextProps) {
         // If we are being shown, grab channel type from props and clear
         if (nextProps.show === true && this.props.show === false) {
@@ -72,6 +73,7 @@ export default class NewChannelFlow extends React.Component {
             });
         }
     }
+
     onSubmit = () => {
         if (!this.state.channelDisplayName) {
             this.setState({serverError: Utils.localizeMessage('channel_flow.invalidName', 'Invalid Channel Name')});
@@ -119,12 +121,14 @@ export default class NewChannelFlow extends React.Component {
                 }
             }
         );
-    }
+    };
+
     onModalExited = () => {
         if (this.doOnModalExited) {
             this.doOnModalExited();
         }
-    }
+    };
+
     typeSwitched = (e) => {
         e.preventDefault();
         if (this.state.channelType === Constants.PRIVATE_CHANNEL) {
@@ -132,23 +136,27 @@ export default class NewChannelFlow extends React.Component {
         } else {
             this.setState({channelType: Constants.PRIVATE_CHANNEL});
         }
-    }
+    };
+
     urlChangeRequested = (e) => {
         if (e) {
             e.preventDefault();
         }
         this.setState({flowState: SHOW_EDIT_URL});
-    }
+    };
+
     urlChangeSubmitted = (newURL) => {
         if (this.state.flowState === SHOW_EDIT_URL_THEN_COMPLETE) {
             this.setState({channelName: newURL, nameModified: true}, this.onSubmit);
         } else {
             this.setState({flowState: SHOW_NEW_CHANNEL, serverError: null, channelName: newURL, nameModified: true});
         }
-    }
+    };
+
     urlChangeDismissed = () => {
         this.setState({flowState: SHOW_NEW_CHANNEL});
-    }
+    };
+
     channelDataChanged = (data) => {
         this.setState({
             channelDisplayName: data.displayName,
@@ -158,7 +166,8 @@ export default class NewChannelFlow extends React.Component {
         if (!this.state.nameModified) {
             this.setState({channelName: cleanUpUrlable(data.displayName.trim())});
         }
-    }
+    };
+
     render() {
         const channelData = {
             name: this.state.channelName,

--- a/components/new_channel_flow.jsx
+++ b/components/new_channel_flow.jsx
@@ -76,7 +76,7 @@ export default class NewChannelFlow extends React.Component {
             return;
         }
 
-        if (this.state.channelName < 2) {
+        if (this.state.channelName.length < 2) {
             this.setState({flowState: SHOW_EDIT_URL_THEN_COMPLETE});
             return;
         }

--- a/components/new_channel_flow.jsx
+++ b/components/new_channel_flow.jsx
@@ -16,7 +16,9 @@ import Constants from 'utils/constants';
 import NewChannelModal from 'components/new_channel_modal';
 import ChangeURLModal from 'components/change_url_modal';
 
-const SHOW_EDIT_URL_THEN_COMPLETE = 3;
+export const SHOW_NEW_CHANNEL = 1;
+export const SHOW_EDIT_URL = 2;
+export const SHOW_EDIT_URL_THEN_COMPLETE = 3;
 
 export default class NewChannelFlow extends React.Component {
     static propTypes = {
@@ -47,7 +49,7 @@ export default class NewChannelFlow extends React.Component {
         this.state = {
             serverError: '',
             channelType: props.channelType || Constants.OPEN_CHANNEL,
-            flowState: Constants.SHOW_NEW_CHANNEL,
+            flowState: SHOW_NEW_CHANNEL,
             channelDisplayName: '',
             channelName: '',
             channelPurpose: '',
@@ -61,7 +63,7 @@ export default class NewChannelFlow extends React.Component {
             this.setState({
                 serverError: '',
                 channelType: nextProps.channelType,
-                flowState: Constants.SHOW_NEW_CHANNEL,
+                flowState: SHOW_NEW_CHANNEL,
                 channelDisplayName: '',
                 channelName: '',
                 channelPurpose: '',
@@ -135,17 +137,17 @@ export default class NewChannelFlow extends React.Component {
         if (e) {
             e.preventDefault();
         }
-        this.setState({flowState: Constants.SHOW_EDIT_URL});
+        this.setState({flowState: SHOW_EDIT_URL});
     }
     urlChangeSubmitted = (newURL) => {
         if (this.state.flowState === SHOW_EDIT_URL_THEN_COMPLETE) {
             this.setState({channelName: newURL, nameModified: true}, this.onSubmit);
         } else {
-            this.setState({flowState: Constants.SHOW_NEW_CHANNEL, serverError: null, channelName: newURL, nameModified: true});
+            this.setState({flowState: SHOW_NEW_CHANNEL, serverError: null, channelName: newURL, nameModified: true});
         }
     }
     urlChangeDismissed = () => {
-        this.setState({flowState: Constants.SHOW_NEW_CHANNEL});
+        this.setState({flowState: SHOW_NEW_CHANNEL});
     }
     channelDataChanged = (data) => {
         this.setState({
@@ -174,14 +176,14 @@ export default class NewChannelFlow extends React.Component {
         // Only listen to flow state if we are being shown
         if (this.props.show) {
             switch (this.state.flowState) {
-            case Constants.SHOW_NEW_CHANNEL:
+            case SHOW_NEW_CHANNEL:
                 if (this.state.channelType === Constants.OPEN_CHANNEL) {
                     showChannelModal = true;
                 } else {
                     showGroupModal = true;
                 }
                 break;
-            case Constants.SHOW_EDIT_URL:
+            case SHOW_EDIT_URL:
                 showChangeURLModal = true;
                 changeURLTitle = (
                     <FormattedMessage

--- a/tests/components/new_channel_flow.test.jsx
+++ b/tests/components/new_channel_flow.test.jsx
@@ -8,7 +8,11 @@ import * as Utils from 'utils/utils';
 import Constants from 'utils/constants';
 import * as actions from 'actions/channel_actions';
 
-import NewChannelFlow from 'components/new_channel_flow';
+import NewChannelFlow, {
+    SHOW_NEW_CHANNEL,
+    SHOW_EDIT_URL,
+    SHOW_EDIT_URL_THEN_COMPLETE
+} from 'components/new_channel_flow';
 
 describe('components/NewChannelFlow', () => {
     global.window.mm_license = {};
@@ -54,7 +58,7 @@ describe('components/NewChannelFlow', () => {
         );
         wrapper.instance().urlChangeDismissed();
 
-        expect(wrapper.state('flowState')).toEqual(Constants.SHOW_NEW_CHANNEL);
+        expect(wrapper.state('flowState')).toEqual(SHOW_NEW_CHANNEL);
     });
 
     test('should match state when urlChangeSubmitted is called', () => {
@@ -64,7 +68,7 @@ describe('components/NewChannelFlow', () => {
         const newUrl = 'example.com';
         wrapper.instance().urlChangeSubmitted(newUrl);
 
-        expect(wrapper.state('flowState')).toEqual(Constants.SHOW_NEW_CHANNEL);
+        expect(wrapper.state('flowState')).toEqual(SHOW_NEW_CHANNEL);
         expect(wrapper.state('serverError')).toEqual(null);
         expect(wrapper.state('channelName')).toEqual(newUrl);
         expect(wrapper.state('nameModified')).toEqual(true);
@@ -76,7 +80,7 @@ describe('components/NewChannelFlow', () => {
         );
 
         wrapper.instance().urlChangeRequested({preventDefault: jest.fn()});
-        expect(wrapper.state('flowState')).toEqual(Constants.SHOW_EDIT_URL);
+        expect(wrapper.state('flowState')).toEqual(SHOW_EDIT_URL);
     });
 
     test('should match state when typeSwitched is called, with state switched from OPEN_CHANNEL', () => {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -547,8 +547,6 @@ export const Constants = {
     PRIVATE_CHANNEL: 'P',
     INVITE_TEAM: 'I',
     OPEN_TEAM: 'O',
-    SHOW_NEW_CHANNEL: 1,
-    SHOW_EDIT_URL: 2,
     MAX_POST_LEN: 4000,
     EMOJI_SIZE: 16,
     THEMES: {


### PR DESCRIPTION
The part of the channel creation flow was removed that's meant to show the URL modal when creating a channel with only non-Latin characters in the display name, so I re-added that along with some unit tests and some minor cosmetic refactoring.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8454

#### Checklist
- Added or updated unit tests (required for all new features)