### PR TITLE
PLT-8306 Removed completePending/suggestionsPending flags from SuggestionStore

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -275,12 +275,11 @@ export function emitSelectPreviousSuggestion(suggestionId) {
     });
 }
 
-export function emitCompleteWordSuggestion(suggestionId, term = '', override = false) {
+export function emitCompleteWordSuggestion(suggestionId, term = '') {
     AppDispatcher.handleViewAction({
         type: Constants.ActionTypes.SUGGESTION_COMPLETE_WORD,
         id: suggestionId,
-        term,
-        override
+        term
     });
 }
 

--- a/components/suggestion/provider.jsx
+++ b/components/suggestion/provider.jsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import SuggestionStore from 'stores/suggestion_store.jsx';
-
 export default class Provider {
     constructor() {
         this.latestPrefix = '';
@@ -17,9 +15,6 @@ export default class Provider {
     startNewRequest(suggestionId, prefix) {
         this.latestPrefix = prefix;
         this.latestComplete = false;
-
-        // Don't use the dispatcher here since this is only called while handling an event
-        SuggestionStore.setSuggestionsPending(suggestionId, true);
     }
 
     shouldCancelDispatch(prefix) {

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -242,10 +242,10 @@ export default class SuggestionBox extends React.Component {
             insertText = ' ' + insertText;
         }
 
-        this.handleCompleteWord(insertText, '', false);
+        this.addTextAtCaret(insertText, '');
     }
 
-    handleCompleteWord(term, matchedPretext, shouldEmitWordSuggestion = true) {
+    addTextAtCaret(term, matchedPretext) {
         const textbox = this.getTextbox();
         const caret = textbox.selectionEnd;
         const text = this.props.value;
@@ -285,6 +285,17 @@ export default class SuggestionBox extends React.Component {
             this.props.onChange(e);
         }
 
+        // set the caret position after the next rendering
+        window.requestAnimationFrame(() => {
+            if (textbox.value === newValue) {
+                Utils.setCaretPosition(textbox, prefix.length + term.length + 1);
+            }
+        });
+    }
+
+    handleCompleteWord(term, matchedPretext) {
+        this.addTextAtCaret(term, matchedPretext);
+
         if (this.props.onItemSelected) {
             const items = SuggestionStore.getItems(this.suggestionId);
             const terms = SuggestionStore.getTerms(this.suggestionId);
@@ -296,14 +307,7 @@ export default class SuggestionBox extends React.Component {
             }
         }
 
-        textbox.focus();
-
-        // set the caret position after the next rendering
-        window.requestAnimationFrame(() => {
-            if (textbox.value === newValue) {
-                Utils.setCaretPosition(textbox, prefix.length + term.length + 1);
-            }
-        });
+        this.getTextbox().focus();
 
         for (const provider of this.props.providers) {
             if (provider.handleCompleteWord) {
@@ -311,10 +315,7 @@ export default class SuggestionBox extends React.Component {
             }
         }
 
-        // override if user finished typing term before results returned from API
-        if (shouldEmitWordSuggestion) {
-            GlobalActions.emitCompleteWordSuggestion(this.suggestionId, '');
-        }
+        GlobalActions.emitCompleteWordSuggestion(this.suggestionId);
     }
 
     handleKeyDown(e) {

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -313,8 +313,7 @@ export default class SuggestionBox extends React.Component {
 
         // override if user finished typing term before results returned from API
         if (shouldEmitWordSuggestion) {
-            const override = pretext.endsWith(term);
-            GlobalActions.emitCompleteWordSuggestion(this.suggestionId, '', override);
+            GlobalActions.emitCompleteWordSuggestion(this.suggestionId, '');
         }
     }
 

--- a/stores/suggestion_store.jsx
+++ b/stores/suggestion_store.jsx
@@ -239,22 +239,6 @@ class SuggestionStore extends EventEmitter {
         return pretext.endsWith(matchedPretext);
     }
 
-    setSuggestionsPending(id, pending) {
-        this.suggestions.get(id).suggestionsPending = pending;
-    }
-
-    areSuggestionsPending(id) {
-        return this.suggestions.get(id).suggestionsPending;
-    }
-
-    setCompletePending(id, pending) {
-        this.suggestions.get(id).completePending = pending;
-    }
-
-    isCompletePending(id) {
-        return this.suggestions.get(id).completePending;
-    }
-
     completeWord(id, term = '', matchedPretext = '') {
         this.emitCompleteWord(id, term || this.getSelection(id), matchedPretext || this.getSelectedMatchedPretext(id));
 
@@ -292,14 +276,7 @@ class SuggestionStore extends EventEmitter {
             this.addSuggestions(id, other.terms, other.items, other.component, other.matchedPretext);
             this.ensureSelectionExists(id);
 
-            this.setSuggestionsPending(id, false);
-
-            if (this.isCompletePending(id)) {
-                this.setCompletePending(id, false);
-                this.completeWord(id);
-            } else {
-                this.emitSuggestionsChanged(id);
-            }
+            this.emitSuggestionsChanged(id);
             break;
         case ActionTypes.SUGGESTION_CLEAR_SUGGESTIONS:
             this.setPretext(id, '');
@@ -316,11 +293,7 @@ class SuggestionStore extends EventEmitter {
             this.emitSuggestionsChanged(id);
             break;
         case ActionTypes.SUGGESTION_COMPLETE_WORD:
-            if (this.areSuggestionsPending(id) && !other.override) {
-                this.setCompletePending(id, true);
-            } else {
-                this.completeWord(id, other.term, other.matchedPretext);
-            }
+            this.completeWord(id, other.term, other.matchedPretext);
             break;
         case ActionTypes.POPOVER_MENTION_KEY_CLICK:
             this.emitPopoverMentionKeyClick(other.isRHS, other.mentionKey);


### PR DESCRIPTION
These were intended to be a fix to the bizarre behaviour that sometimes happens when the user hit tab or enter while autocomplete results were being loaded, but it didn't end up really helping that. Instead, it resulted in some cases where we didn't store autocomplete suggestions which caused the autocomplete to stop working completely.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8306
