### PR TITLE
[PLT-1260] Refactor TeamSettingsModal to use React-Bootstrap

### DIFF
--- a/components/sidebar_header_dropdown.jsx
+++ b/components/sidebar_header_dropdown.jsx
@@ -23,6 +23,7 @@ import * as Utils from 'utils/utils.jsx';
 import AboutBuildModal from 'components/about_build_modal';
 import AddUsersToTeam from 'components/add_users_to_team';
 import TeamMembersModal from 'components/team_members_modal';
+import TeamSettingsModal from 'components/team_settings_modal.jsx';
 
 import SidebarHeaderDropdownButton from './sidebar_header_dropdown_button.jsx';
 
@@ -65,6 +66,7 @@ export default class SidebarHeaderDropdown extends React.Component {
             teamListings: TeamStore.getTeamListings(),
             showAboutModal: false,
             showDropdown: false,
+            showTeamSettingsModal: false,
             showTeamMembersModal: false,
             showAddUsersToTeamModal: false
         };
@@ -147,6 +149,21 @@ export default class SidebarHeaderDropdown extends React.Component {
         this.setState({showDropdown: false});
 
         GlobalActions.showGetTeamInviteLinkModal();
+    }
+
+    showTeamSettingsModal = (e) => {
+        e.preventDefault();
+
+        this.setState({
+            showDropdown: false,
+            showTeamSettingsModal: true
+        });
+    }
+
+    hideTeamSettingsModal = () => {
+        this.setState({
+            showTeamSettingsModal: false
+        });
     }
 
     showTeamMembersModal(e) {
@@ -299,9 +316,7 @@ export default class SidebarHeaderDropdown extends React.Component {
                     <button
                         className='style--none'
                         id='teamSettings'
-                        data-toggle='modal'
-                        data-target='#team_settings'
-                        onClick={this.toggleDropdown}
+                        onClick={this.showTeamSettingsModal}
                     >
                         <FormattedMessage
                             id='navbar_dropdown.teamSettings'
@@ -643,6 +658,10 @@ export default class SidebarHeaderDropdown extends React.Component {
                     {logoutDivider}
                     {logout}
                     {teamMembersModal}
+                    <TeamSettingsModal
+                        show={this.state.showTeamSettingsModal}
+                        onModalDismissed={this.hideTeamSettingsModal}
+                    />
                     <AboutBuildModal
                         show={this.state.showAboutModal}
                         onModalDismissed={this.aboutModalDismissed}

--- a/components/sidebar_right_menu/sidebar_right_menu.jsx
+++ b/components/sidebar_right_menu/sidebar_right_menu.jsx
@@ -28,6 +28,7 @@ import AddUsersToTeam from 'components/add_users_to_team';
 import LeaveTeamIcon from 'components/svg/leave_team_icon';
 import TeamMembersModal from 'components/team_members_modal';
 import ToggleModalButton from 'components/toggle_modal_button.jsx';
+import TeamSettingsModal from 'components/team_settings_modal.jsx';
 import {createMenuTip} from 'components/tutorial/tutorial_tip.jsx';
 
 export default class SidebarRightMenu extends React.Component {
@@ -48,7 +49,8 @@ export default class SidebarRightMenu extends React.Component {
         this.state = {
             ...this.getStateFromStores(),
             showAboutModal: false,
-            showAddUsersToTeamModal: false
+            showAddUsersToTeamModal: false,
+            showTeamSettingsModal: false
         };
     }
 
@@ -90,6 +92,19 @@ export default class SidebarRightMenu extends React.Component {
         this.setState({
             showAddUsersToTeamModal: false
         });
+    }
+
+    showTeamSettingsModal = (e) => {
+        e.preventDefault();
+
+        this.setState({
+            showTeamSettingsModal: true,
+            showDropdown: false
+        });
+    }
+
+    hideTeamSettingsModal = () => {
+        this.setState({showTeamSettingsModal: false});
     }
 
     getFlagged = (e) => {
@@ -319,8 +334,7 @@ export default class SidebarRightMenu extends React.Component {
                 <li>
                     <a
                         href='#'
-                        data-toggle='modal'
-                        data-target='#team_settings'
+                        onClick={this.showTeamSettingsModal}
                     >
                         <i className='icon fa fa-globe'/>
                         <FormattedMessage
@@ -555,6 +569,10 @@ export default class SidebarRightMenu extends React.Component {
                 <AboutBuildModal
                     show={this.state.showAboutModal}
                     onModalDismissed={this.aboutModalDismissed}
+                />
+                <TeamSettingsModal
+                    show={this.state.showTeamSettingsModal}
+                    onModalDismissed={this.hideTeamSettingsModal}
                 />
                 {addUsersToTeamModal}
             </div>

--- a/components/team_general_tab.jsx
+++ b/components/team_general_tab.jsx
@@ -526,17 +526,19 @@ class GeneralTab extends React.Component {
                         className='close'
                         data-dismiss='modal'
                         aria-label='Close'
+                        onClick={this.props.closeModal}
                     >
-                        <span aria-hidden='true'>
-                            {'×'}
-                        </span>
+                        <span aria-hidden='true'>{'×'}</span>
                     </button>
                     <h4
                         className='modal-title'
                         ref='title'
                     >
                         <div className='modal-back'>
-                            <i className='fa fa-angle-left'/>
+                            <i
+                                className='fa fa-angle-left'
+                                onClick={this.props.collapseModal}
+                            />
                         </div>
                         <FormattedMessage
                             id='general_tab.title'
@@ -572,7 +574,9 @@ class GeneralTab extends React.Component {
 GeneralTab.propTypes = {
     updateSection: PropTypes.func.isRequired,
     team: PropTypes.object.isRequired,
-    activeSection: PropTypes.string.isRequired
+    activeSection: PropTypes.string.isRequired,
+    closeModal: PropTypes.func.isRequired,
+    collapseModal: PropTypes.func.isRequired
 };
 
 export default GeneralTab;

--- a/components/team_import_tab.jsx
+++ b/components/team_import_tab.jsx
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
 
 import * as utils from 'utils/utils.jsx';
@@ -183,6 +184,7 @@ class TeamImportTab extends React.Component {
                         className='close'
                         data-dismiss='modal'
                         aria-label='Close'
+                        onClick={this.props.closeModal}
                     >
                         <span aria-hidden='true'>{'×'}</span>
                     </button>
@@ -191,7 +193,10 @@ class TeamImportTab extends React.Component {
                         ref='title'
                     >
                         <div className='modal-back'>
-                            <i className='fa fa-angle-left'/>
+                            <i
+                                className='fa fa-angle-left'
+                                onClick={this.props.collapseModal}
+                            />
                         </div>
                         <FormattedMessage
                             id='team_import_tab.import'
@@ -220,7 +225,9 @@ class TeamImportTab extends React.Component {
 }
 
 TeamImportTab.propTypes = {
-    intl: intlShape.isRequired
+    intl: intlShape.isRequired,
+    closeModal: PropTypes.func.isRequired,
+    collapseModal: PropTypes.func.isRequired
 };
 
 export default injectIntl(TeamImportTab);

--- a/components/team_settings.jsx
+++ b/components/team_settings.jsx
@@ -19,24 +19,29 @@ export default class TeamSettings extends React.Component {
 
         this.state = {team: TeamStore.getCurrent()};
     }
+
     componentDidMount() {
         TeamStore.addChangeListener(this.onChange);
     }
+
     componentWillUnmount() {
         TeamStore.removeChangeListener(this.onChange);
     }
+
     onChange() {
-        var team = TeamStore.getCurrent();
+        const team = TeamStore.getCurrent();
 
         if (!Utils.areObjectsEqual(this.state.team, team)) {
             this.setState({team});
         }
     }
+
     render() {
         if (!this.state.team) {
             return null;
         }
-        var result;
+
+        let result;
         switch (this.props.activeTab) {
         case 'general':
             result = (
@@ -45,6 +50,8 @@ export default class TeamSettings extends React.Component {
                         team={this.state.team}
                         activeSection={this.props.activeSection}
                         updateSection={this.props.updateSection}
+                        closeModal={this.props.closeModal}
+                        collapseModal={this.props.collapseModal}
                     />
                 </div>
             );
@@ -56,6 +63,8 @@ export default class TeamSettings extends React.Component {
                         team={this.state.team}
                         activeSection={this.props.activeSection}
                         updateSection={this.props.updateSection}
+                        closeModal={this.props.closeModal}
+                        collapseModal={this.props.collapseModal}
                     />
                 </div>
             );
@@ -66,6 +75,7 @@ export default class TeamSettings extends React.Component {
             );
             break;
         }
+
         return result;
     }
 }
@@ -78,5 +88,7 @@ TeamSettings.defaultProps = {
 TeamSettings.propTypes = {
     activeTab: PropTypes.string.isRequired,
     activeSection: PropTypes.string.isRequired,
-    updateSection: PropTypes.func.isRequired
+    updateSection: PropTypes.func.isRequired,
+    closeModal: PropTypes.func.isRequired,
+    collapseModal: PropTypes.func.isRequired
 };

--- a/components/team_settings_modal.jsx
+++ b/components/team_settings_modal.jsx
@@ -4,7 +4,9 @@
 import $ from 'jquery';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
+import {Modal} from 'react-bootstrap';
 import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
 
 import * as Utils from 'utils/utils.jsx';
@@ -27,43 +29,54 @@ class TeamSettingsModal extends React.Component {
     constructor(props) {
         super(props);
 
-        this.updateTab = this.updateTab.bind(this);
-        this.updateSection = this.updateSection.bind(this);
-
         this.state = {
             activeTab: 'general',
             activeSection: ''
         };
     }
+
     componentDidMount() {
-        const modal = $(ReactDOM.findDOMNode(this.refs.modal));
-
-        modal.on('click', '.modal-back', function handleBackClick() {
-            $(this).closest('.modal-dialog').removeClass('display--content');
-            $(this).closest('.modal-dialog').find('.settings-table .nav li.active').removeClass('active');
-        });
-        modal.on('click', '.modal-header .close', () => {
-            setTimeout(() => {
-                $('.modal-dialog.display--content').removeClass('display--content');
-            }, 500);
-        });
-
         if (!Utils.isMobile()) {
             $('.settings-modal .settings-content').perfectScrollbar();
         }
     }
-    updateTab(tab) {
-        this.setState({activeTab: tab, activeSection: ''});
+
+    updateTab = (tab) => {
+        this.setState({
+            activeTab: tab,
+            activeSection: ''
+        });
+
         if (!Utils.isMobile()) {
             $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
         }
     }
-    updateSection(section) {
+
+    updateSection = (section) => {
         if ($('.section-max').length) {
             $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
         }
+
         this.setState({activeSection: section});
     }
+
+    closeModal = () => {
+        this.props.onModalDismissed();
+    }
+
+    collapseModal = () => {
+        $(ReactDOM.findDOMNode(this.refs.modalBody)).closest('.modal-dialog').removeClass('display--content');
+
+        this.setState({
+            active_tab: '',
+            active_section: ''
+        });
+    }
+
+    handleHide = () => {
+        this.props.onModalDismissed();
+    }
+
     render() {
         const {formatMessage} = this.props.intl;
         const tabs = [];
@@ -71,64 +84,49 @@ class TeamSettingsModal extends React.Component {
         tabs.push({name: 'import', uiName: formatMessage(holders.importTab), icon: 'icon fa fa-upload'});
 
         return (
-            <div
-                className='modal fade'
-                ref='modal'
-                id='team_settings'
-                role='dialog'
-                tabIndex='-1'
-                aria-hidden='true'
+            <Modal
+                dialogClassName='settings-modal settings-modal--action'
+                show={this.props.show}
+                onHide={this.handleHide}
+                onExited={this.handleHide}
             >
-                <div className='modal-dialog settings-modal'>
-                    <div className='modal-content'>
-                        <div className='modal-header'>
-                            <button
-                                type='button'
-                                className='close'
-                                data-dismiss='modal'
-                                aria-label='Close'
-                            >
-                                <span aria-hidden='true'>
-                                    {'×'}
-                                </span>
-                            </button>
-                            <h4
-                                className='modal-title'
-                                ref='title'
-                            >
-                                <FormattedMessage
-                                    id='team_settings_modal.title'
-                                    defaultMessage='Team Settings'
-                                />
-                            </h4>
+                <Modal.Header closeButton={true}>
+                    <Modal.Title>
+                        <FormattedMessage
+                            id='team_settings_modal.title'
+                            defaultMessage='Team Settings'
+                        />
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body ref='modalBody'>
+                    <div className='settings-table'>
+                        <div className='settings-links'>
+                            <SettingsSidebar
+                                tabs={tabs}
+                                activeTab={this.state.activeTab}
+                                updateTab={this.updateTab}
+                            />
                         </div>
-                        <div className='modal-body settings-modal__body'>
-                            <div className='settings-table'>
-                                <div className='settings-links'>
-                                    <SettingsSidebar
-                                        tabs={tabs}
-                                        activeTab={this.state.activeTab}
-                                        updateTab={this.updateTab}
-                                    />
-                                </div>
-                                <div className='settings-content minimize-settings'>
-                                    <TeamSettings
-                                        activeTab={this.state.activeTab}
-                                        activeSection={this.state.activeSection}
-                                        updateSection={this.updateSection}
-                                    />
-                                </div>
-                            </div>
+                        <div className='settings-content minimize-settings'>
+                            <TeamSettings
+                                activeTab={this.state.activeTab}
+                                activeSection={this.state.activeSection}
+                                updateSection={this.updateSection}
+                                closeModal={this.closeModal}
+                                collapseModal={this.collapseModal}
+                            />
                         </div>
                     </div>
-                </div>
-            </div>
+                </Modal.Body>
+            </Modal>
         );
     }
 }
 
 TeamSettingsModal.propTypes = {
-    intl: intlShape.isRequired
+    intl: intlShape.isRequired,
+    show: PropTypes.bool,
+    onModalDismissed: PropTypes.func
 };
 
 export default injectIntl(TeamSettingsModal);


### PR DESCRIPTION
#### Summary
Refactored the `TeamSettingsModal` to be a `React-Bootstrap` modal like all other ones rather than a plain Bootstrap modal. `jQuery` usage has also been removed except for the `PerfectScrollbar`. For triggering the modal, I followed the logic used for other modals such as `AboutBuildModal` and `AddUsersToTeamModal`.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7985
https://mattermost.atlassian.net/browse/PLT-1260

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed