### PR TITLE
PLT-8437: Convert return value to boolean

### DIFF
--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -17,7 +17,7 @@ const getDeactivatedChannel = createSelector(
     (state, channelId) => channelId,
     (users, channelId) => {
         const teammate = getDirectTeammate(channelId);
-        return teammate && teammate.delete_at;
+        return Boolean(teammate && teammate.delete_at);
     }
 );
 


### PR DESCRIPTION
#### Summary
Convert return value to boolean so it doesn't return `undefined` and cause React errors about missing properties.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8437

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
  