### PR TITLE
[PLT-7607] Use transparent pixel while the user profile isn't loaded

### DIFF
--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1064,7 +1064,8 @@ export const Constants = {
         SHOW_FULLNAME: 'full_name'
     },
     SEARCH_POST: 'searchpost',
-    CHANNEL_ID_LENGTH: 26
+    CHANNEL_ID_LENGTH: 26,
+    TRANSPARENT_PIXEL: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
 };
 
 export default Constants;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1161,7 +1161,7 @@ export function imageURLForUser(userIdOrObject) {
         if (profile) {
             return imageURLForUser(profile);
         }
-        return Client4.getUsersRoute() + '/' + userIdOrObject + '/image?_=0';
+        return Constants.TRANSPARENT_PIXEL;
     }
     return Client4.getUsersRoute() + '/' + userIdOrObject.id + '/image?_=' + (userIdOrObject.last_picture_update || 0);
 }


### PR DESCRIPTION
#### Summary
Using a transparent pixel when the user profile isn't in the store. I
understand here that if the profile isn't in the store is because is loading
it, but in the near future will be in the store. If that is true, the fix have
sense.

#### Ticket Link
[PLT-7607](https://mattermost.atlassian.net/browse/PLT-7607)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
  