### PR TITLE
[PLT-8475] Add confirm modal to @all/@channel metions in the RHS comments

### DIFF
--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
 import {resetCreatePostRequest, resetHistoryIndex} from 'mattermost-redux/actions/posts';
 import {Preferences, Posts} from 'mattermost-redux/constants';
 
@@ -27,10 +28,12 @@ function mapStateToProps(state, ownProps) {
     const draft = getCommentDraft(state);
 
     const enableAddButton = draft.message.trim().length !== 0 || draft.fileInfos.length !== 0;
+    const channelMembersCount = getAllChannelStats(state)[ownProps.channelId] ? getAllChannelStats(state)[ownProps.channelId].member_count : 1;
 
     return {
         draft,
         enableAddButton,
+        channelMembersCount,
         ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
         createPostErrorId: err.server_error_id
     };

--- a/tests/components/create_comment/__snapshots__/create_comment.test.jsx.snap
+++ b/tests/components/create_comment/__snapshots__/create_comment.test.jsx.snap
@@ -85,6 +85,38 @@ exports[`components/CreateComment should match snapshot, comment with message 1`
     onHide={[Function]}
     show={false}
   />
+  <ConfirmModal
+    confirmButtonClass="btn btn-primary"
+    confirmButtonText={
+      <FormattedMessage
+        defaultMessage="Confirm"
+        id="notify_all.confirm"
+        values={Object {}}
+      />
+    }
+    message={
+      <FormattedMessage
+        defaultMessage="By using @all or @channel you are about to send notifications to {totalMembers} people. Are you sure you want to do this?"
+        id="notify_all.question"
+        values={
+          Object {
+            "totalMembers": 2,
+          }
+        }
+      />
+    }
+    modalClass=""
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    show={false}
+    title={
+      <FormattedMessage
+        defaultMessage="Confirm sending notifications to entire channel"
+        id="notify_all.title.confirm"
+        values={Object {}}
+      />
+    }
+  />
 </form>
 `;
 
@@ -172,6 +204,38 @@ exports[`components/CreateComment should match snapshot, empty comment 1`] = `
   <PostDeletedModal
     onHide={[Function]}
     show={false}
+  />
+  <ConfirmModal
+    confirmButtonClass="btn btn-primary"
+    confirmButtonText={
+      <FormattedMessage
+        defaultMessage="Confirm"
+        id="notify_all.confirm"
+        values={Object {}}
+      />
+    }
+    message={
+      <FormattedMessage
+        defaultMessage="By using @all or @channel you are about to send notifications to {totalMembers} people. Are you sure you want to do this?"
+        id="notify_all.question"
+        values={
+          Object {
+            "totalMembers": 2,
+          }
+        }
+      />
+    }
+    modalClass=""
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    show={false}
+    title={
+      <FormattedMessage
+        defaultMessage="Confirm sending notifications to entire channel"
+        id="notify_all.title.confirm"
+        values={Object {}}
+      />
+    }
   />
 </form>
 `;
@@ -284,6 +348,38 @@ exports[`components/CreateComment should match snapshot, non-empty message and u
   <PostDeletedModal
     onHide={[Function]}
     show={false}
+  />
+  <ConfirmModal
+    confirmButtonClass="btn btn-primary"
+    confirmButtonText={
+      <FormattedMessage
+        defaultMessage="Confirm"
+        id="notify_all.confirm"
+        values={Object {}}
+      />
+    }
+    message={
+      <FormattedMessage
+        defaultMessage="By using @all or @channel you are about to send notifications to {totalMembers} people. Are you sure you want to do this?"
+        id="notify_all.question"
+        values={
+          Object {
+            "totalMembers": 2,
+          }
+        }
+      />
+    }
+    modalClass=""
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    show={false}
+    title={
+      <FormattedMessage
+        defaultMessage="Confirm sending notifications to entire channel"
+        id="notify_all.title.confirm"
+        values={Object {}}
+      />
+    }
   />
 </form>
 `;


### PR DESCRIPTION
#### Summary
Add the confirm modal to send `@all`/`@channel` mentions in the RHS comments.

#### Ticket Link
[PLT-8475](https://mattermost.atlassian.net/browse/PLT-8475)

##### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests