### PR TITLE
[PLT-8464] Remove PostTypes.ADD_TO_CHANNEL from IGNORE_POST_TYPES to prompt mention  when user is added to channel/team

### DIFF
--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -428,7 +428,7 @@ export const Constants = {
 
     MAX_POST_VISIBILITY: 1000000,
 
-    IGNORE_POST_TYPES: [PostTypes.JOIN_LEAVE, PostTypes.JOIN_CHANNEL, PostTypes.LEAVE_CHANNEL, PostTypes.REMOVE_FROM_CHANNEL, PostTypes.ADD_TO_CHANNEL, PostTypes.ADD_REMOVE],
+    IGNORE_POST_TYPES: [PostTypes.JOIN_LEAVE, PostTypes.JOIN_CHANNEL, PostTypes.LEAVE_CHANNEL, PostTypes.REMOVE_FROM_CHANNEL, PostTypes.ADD_REMOVE],
 
     PayloadSources: keyMirror({
         SERVER_ACTION: null,


### PR DESCRIPTION
#### Summary
Remove PostTypes.ADD_TO_CHANNEL from IGNORE_POST_TYPES to prompt mention when user is added to channel/team

If above is correct solution, I'll submit similar patch to mattermost-redux https://github.com/mattermost/mattermost-redux/blob/master/src/constants/posts.js#L31

#### Ticket Link
Jira ticket: [PLT-8464](https://mattermost.atlassian.net/browse/PLT-8464)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
