### PR TITLE
[PLT-8488] Change height of header to accommodate only one line

### DIFF
--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -232,7 +232,7 @@
     }
 
     .channel-header__description {
-        height: 24px;
+        height: 21px;
         margin-bottom: 3px;
         margin-top: 3px;
         overflow: hidden;


### PR DESCRIPTION
#### Summary
Fixes channel header to display only one line and lets it overflow by hiding the rest.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8488

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
