### PR TITLE
PLT-8487 Allow .cert extensions for IDP files

### DIFF
--- a/components/admin_console/saml_settings.jsx
+++ b/components/admin_console/saml_settings.jsx
@@ -209,7 +209,7 @@ export default class SamlSettings extends AdminSettings {
                     }
                     uploadingText={Utils.localizeMessage('admin.saml.uploading.certificate', 'Uploading Certificate...')}
                     disabled={!this.state.enable}
-                    fileType='.crt,.cer'
+                    fileType='.crt,.cer,.cert'
                     onSubmit={this.uploadCertificate}
                     error={this.state.idpCertificateFileError}
                 />


### PR DESCRIPTION
#### Summary
Allow .cert extensions for IDP files.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8487