### PR TITLE
PLT-8483: Ignore join/leave team messages for unread counts

### DIFF
--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -312,6 +312,8 @@ export const PostTypes = {
     JOIN_LEAVE: 'system_join_leave',
     JOIN_CHANNEL: 'system_join_channel',
     LEAVE_CHANNEL: 'system_leave_channel',
+    JOIN_TEAM: 'system_join_team',
+    LEAVE_TEAM: 'system_leave_team',
     ADD_TO_CHANNEL: 'system_add_to_channel',
     REMOVE_FROM_CHANNEL: 'system_remove_from_channel',
     ADD_REMOVE: 'system_add_remove',
@@ -428,7 +430,7 @@ export const Constants = {
 
     MAX_POST_VISIBILITY: 1000000,
 
-    IGNORE_POST_TYPES: [PostTypes.JOIN_LEAVE, PostTypes.JOIN_CHANNEL, PostTypes.LEAVE_CHANNEL, PostTypes.REMOVE_FROM_CHANNEL, PostTypes.ADD_REMOVE],
+    IGNORE_POST_TYPES: [PostTypes.JOIN_LEAVE, PostTypes.JOIN_TEAM, PostTypes.LEAVE_TEAM, PostTypes.JOIN_CHANNEL, PostTypes.LEAVE_CHANNEL, PostTypes.REMOVE_FROM_CHANNEL, PostTypes.ADD_REMOVE],
 
     PayloadSources: keyMirror({
         SERVER_ACTION: null,


### PR DESCRIPTION
#### Summary
Add join/leave team system messages to the ignored list of messages type to
count as unread messages in channels.

This only solves the frontend part of the problem, the backend part
(mattermost/mattermost-server#8042) is not needed to merge this, but to close
the issue both PRs have to be merged.

#### Ticket Link
[PLT-8483](https://mattermost.atlassian.net/browse/PLT-8483)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed