### PR TITLE
[PLT-8383] Fix for markdown lists

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1335,6 +1335,7 @@
 
             p {
                 margin-bottom: 0;
+                display: initial;
             }
 
             li {

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1330,7 +1330,8 @@
             font-size: 13.5px;
             margin-bottom: .11em;
             margin-top: 3px;
-            padding-left: 20px;
+            padding-left: 5px;
+            list-style-position: inside;
 
             p {
                 margin-bottom: 0;


### PR DESCRIPTION
#### Summary
Fix markdown lists to have list-styles-positions to be inside the post

#### Ticket Link
[PLT-8383](https://github.com/mattermost/mattermost-server/issues/8024)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
