### PR TITLE
Remove duplicate keys on constants

### DIFF
--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -318,8 +318,6 @@ export const PostTypes = {
     JOIN_TEAM: 'system_join_team',
     LEAVE_TEAM: 'system_leave_team',
     ADD_TO_CHANNEL: 'system_add_to_channel',
-    JOIN_TEAM: 'system_join_team',
-    LEAVE_TEAM: 'system_leave_team',
     ADD_TO_TEAM: 'system_add_to_team',
     REMOVE_FROM_CHANNEL: 'system_remove_from_channel',
     ADD_REMOVE: 'system_add_remove',


### PR DESCRIPTION
#### Summary
Remove duplicate keys on constants (might be due to bad merge)
- JOIN_TEAM
- LEAVE_TEAM

#### Ticket Link
None, only quick fix

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
