### PR TITLE
PLT-8455 Fixed tab and alt-tab keyboard navigation for links on login page

### DIFF
--- a/components/header_footer_template/header_footer_template.jsx
+++ b/components/header_footer_template/header_footer_template.jsx
@@ -31,32 +31,17 @@ export default class NotLoggedIn extends React.PureComponent {
     render() {
         const content = [];
 
-        if (this.props.config.HelpLink) {
+        if (this.props.config.AboutLink) {
             content.push(
                 <a
-                    key='help_link'
-                    id='help_link'
-                    className='pull-right footer-link'
+                    key='about_link'
+                    id='about_link'
+                    className='footer-link'
                     target='_blank'
                     rel='noopener noreferrer'
-                    href={this.props.config.HelpLink}
+                    href={this.props.config.AboutLink}
                 >
-                    <FormattedMessage id='web.footer.help'/>
-                </a>
-            );
-        }
-
-        if (this.props.config.TermsOfServiceLink) {
-            content.push(
-                <a
-                    key='terms_link'
-                    id='terms_link'
-                    className='pull-right footer-link'
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    href={this.props.config.TermsOfServiceLink}
-                >
-                    <FormattedMessage id='web.footer.terms'/>
+                    <FormattedMessage id='web.footer.about'/>
                 </a>
             );
         }
@@ -66,7 +51,7 @@ export default class NotLoggedIn extends React.PureComponent {
                 <a
                     key='privacy_link'
                     id='privacy_link'
-                    className='pull-right footer-link'
+                    className='footer-link'
                     target='_blank'
                     rel='noopener noreferrer'
                     href={this.props.config.PrivacyPolicyLink}
@@ -76,17 +61,32 @@ export default class NotLoggedIn extends React.PureComponent {
             );
         }
 
-        if (this.props.config.AboutLink) {
+        if (this.props.config.TermsOfServiceLink) {
             content.push(
                 <a
-                    key='about_link'
-                    id='about_link'
-                    className='pull-right footer-link'
+                    key='terms_link'
+                    id='terms_link'
+                    className='footer-link'
                     target='_blank'
                     rel='noopener noreferrer'
-                    href={this.props.config.AboutLink}
+                    href={this.props.config.TermsOfServiceLink}
                 >
-                    <FormattedMessage id='web.footer.about'/>
+                    <FormattedMessage id='web.footer.terms'/>
+                </a>
+            );
+        }
+
+        if (this.props.config.HelpLink) {
+            content.push(
+                <a
+                    key='help_link'
+                    id='help_link'
+                    className='footer-link'
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    href={this.props.config.HelpLink}
+                >
+                    <FormattedMessage id='web.footer.help'/>
                 </a>
             );
         }
@@ -106,7 +106,9 @@ export default class NotLoggedIn extends React.PureComponent {
                             <span className='pull-right footer-link copyright'>
                                 {`© 2015-${new Date().getFullYear()} Mattermost, Inc.`}
                             </span>
-                            {content}
+                            <span className='pull-right'>
+                                {content}
+                            </span>
                         </div>
                     </div>
                 </div>

--- a/tests/components/__snapshots__/header_footer_template.test.jsx.snap
+++ b/tests/components/__snapshots__/header_footer_template.test.jsx.snap
@@ -34,19 +34,23 @@ exports[`components/HeaderFooterTemplate should match snapshot with about link 1
         >
           © 2015-2017 Mattermost, Inc.
         </span>
-        <a
-          className="pull-right footer-link"
-          href="http://testaboutlink"
-          id="about_link"
-          key="about_link"
-          rel="noopener noreferrer"
-          target="_blank"
+        <span
+          className="pull-right"
         >
-          <FormattedMessage
-            id="web.footer.about"
-            values={Object {}}
-          />
-        </a>
+          <a
+            className="footer-link"
+            href="http://testaboutlink"
+            id="about_link"
+            key="about_link"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              id="web.footer.about"
+              values={Object {}}
+            />
+          </a>
+        </span>
       </div>
     </div>
   </div>
@@ -87,58 +91,62 @@ exports[`components/HeaderFooterTemplate should match snapshot with all links 1`
         >
           © 2015-2017 Mattermost, Inc.
         </span>
-        <a
-          className="pull-right footer-link"
-          href="http://testhelplink"
-          id="help_link"
-          key="help_link"
-          rel="noopener noreferrer"
-          target="_blank"
+        <span
+          className="pull-right"
         >
-          <FormattedMessage
-            id="web.footer.help"
-            values={Object {}}
-          />
-        </a>
-        <a
-          className="pull-right footer-link"
-          href="http://testtermsofservicelink"
-          id="terms_link"
-          key="terms_link"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <FormattedMessage
-            id="web.footer.terms"
-            values={Object {}}
-          />
-        </a>
-        <a
-          className="pull-right footer-link"
-          href="http://testprivacypolicylink"
-          id="privacy_link"
-          key="privacy_link"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <FormattedMessage
-            id="web.footer.privacy"
-            values={Object {}}
-          />
-        </a>
-        <a
-          className="pull-right footer-link"
-          href="http://testaboutlink"
-          id="about_link"
-          key="about_link"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <FormattedMessage
-            id="web.footer.about"
-            values={Object {}}
-          />
-        </a>
+          <a
+            className="footer-link"
+            href="http://testaboutlink"
+            id="about_link"
+            key="about_link"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              id="web.footer.about"
+              values={Object {}}
+            />
+          </a>
+          <a
+            className="footer-link"
+            href="http://testprivacypolicylink"
+            id="privacy_link"
+            key="privacy_link"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              id="web.footer.privacy"
+              values={Object {}}
+            />
+          </a>
+          <a
+            className="footer-link"
+            href="http://testtermsofservicelink"
+            id="terms_link"
+            key="terms_link"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              id="web.footer.terms"
+              values={Object {}}
+            />
+          </a>
+          <a
+            className="footer-link"
+            href="http://testhelplink"
+            id="help_link"
+            key="help_link"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              id="web.footer.help"
+              values={Object {}}
+            />
+          </a>
+        </span>
       </div>
     </div>
   </div>
@@ -182,6 +190,9 @@ exports[`components/HeaderFooterTemplate should match snapshot with children 1`]
         >
           © 2015-2017 Mattermost, Inc.
         </span>
+        <span
+          className="pull-right"
+        />
       </div>
     </div>
   </div>
@@ -222,19 +233,23 @@ exports[`components/HeaderFooterTemplate should match snapshot with help link 1`
         >
           © 2015-2017 Mattermost, Inc.
         </span>
-        <a
-          className="pull-right footer-link"
-          href="http://testhelplink"
-          id="help_link"
-          key="help_link"
-          rel="noopener noreferrer"
-          target="_blank"
+        <span
+          className="pull-right"
         >
-          <FormattedMessage
-            id="web.footer.help"
-            values={Object {}}
-          />
-        </a>
+          <a
+            className="footer-link"
+            href="http://testhelplink"
+            id="help_link"
+            key="help_link"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              id="web.footer.help"
+              values={Object {}}
+            />
+          </a>
+        </span>
       </div>
     </div>
   </div>
@@ -275,19 +290,23 @@ exports[`components/HeaderFooterTemplate should match snapshot with privacy poli
         >
           © 2015-2017 Mattermost, Inc.
         </span>
-        <a
-          className="pull-right footer-link"
-          href="http://testprivacypolicylink"
-          id="privacy_link"
-          key="privacy_link"
-          rel="noopener noreferrer"
-          target="_blank"
+        <span
+          className="pull-right"
         >
-          <FormattedMessage
-            id="web.footer.privacy"
-            values={Object {}}
-          />
-        </a>
+          <a
+            className="footer-link"
+            href="http://testprivacypolicylink"
+            id="privacy_link"
+            key="privacy_link"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              id="web.footer.privacy"
+              values={Object {}}
+            />
+          </a>
+        </span>
       </div>
     </div>
   </div>
@@ -328,19 +347,23 @@ exports[`components/HeaderFooterTemplate should match snapshot with term of serv
         >
           © 2015-2017 Mattermost, Inc.
         </span>
-        <a
-          className="pull-right footer-link"
-          href="http://testtermsofservicelink"
-          id="terms_link"
-          key="terms_link"
-          rel="noopener noreferrer"
-          target="_blank"
+        <span
+          className="pull-right"
         >
-          <FormattedMessage
-            id="web.footer.terms"
-            values={Object {}}
-          />
-        </a>
+          <a
+            className="footer-link"
+            href="http://testtermsofservicelink"
+            id="terms_link"
+            key="terms_link"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <FormattedMessage
+              id="web.footer.terms"
+              values={Object {}}
+            />
+          </a>
+        </span>
       </div>
     </div>
   </div>
@@ -381,6 +404,9 @@ exports[`components/HeaderFooterTemplate should match snapshot without children 
         >
           © 2015-2017 Mattermost, Inc.
         </span>
+        <span
+          className="pull-right"
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### Summary
Currently, tab and alt-tab keyboard navigations are reversed for links on login page (tabbing through page takes you through Help, Terms, Privacy, and then About)

This pull request fixes this issue and the navigation is now About, Privacy, Terms, then Help

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/8046

#### Checklist
- [X] Ran `make check-style` to check for style errors (required for all pull requests)
- [X] Ran `make test` to ensure unit and component tests passed
  