### PR TITLE
Fix FF in mobile view

### DIFF
--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -48,7 +48,10 @@ export default class SearchBar extends React.Component {
     componentDidMount() {
         if (Utils.isMobile()) {
             setTimeout(() => {
-                document.querySelector('.app__body .sidebar--menu').classList.remove('visible');
+                const element = document.querySelector('.app__body .sidebar--menu');
+                if (element) {
+                    element.classList.remove('visible');
+                }
             });
         }
     }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -829,7 +829,11 @@ export function changeCss(className, classValue) {
     if (className.indexOf('@media') >= 0) {
         mediaQuery = '}';
     }
-    styleSheet.insertRule(className + '{' + classValue + '}' + mediaQuery, styleSheet.cssRules.length);
+    try {
+        styleSheet.insertRule(className + '{' + classValue + '}' + mediaQuery, styleSheet.cssRules.length);
+    } catch (e) {
+        // do nothing
+    }
 }
 
 export function updateCodeTheme(userTheme) {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -832,7 +832,7 @@ export function changeCss(className, classValue) {
     try {
         styleSheet.insertRule(className + '{' + classValue + '}' + mediaQuery, styleSheet.cssRules.length);
     } catch (e) {
-        // do nothing
+        console.error(e); // eslint-disable-line no-console
     }
 }
 


### PR DESCRIPTION
#### Summary
When opening the webapp in mobile view on Firefox (57) the page wasn't being rendered at all, two issues where found:

1. When mounting the search_bar component the element `'.app__body .sidebar--menu'` returns null
2. the util to `changeCss` received a className that was not supported by `styleSheet.insertRule`

Note: Without this PR I cannot complete my RC tests as the webapp does not render at all.
