### PR TITLE
[PLT-8515] Fix incorrect channel notification settings when switching teams

### DIFF
--- a/components/channel_notifications_modal.jsx
+++ b/components/channel_notifications_modal.jsx
@@ -11,6 +11,7 @@ import {FormattedMessage} from 'react-intl';
 import {updateChannelNotifyProps} from 'actions/channel_actions.jsx';
 
 import {NotificationLevels} from 'utils/constants.jsx';
+import * as Utils from 'utils/utils.jsx';
 
 import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min.jsx';
@@ -39,6 +40,24 @@ export default class ChannelNotificationsModal extends React.Component {
             unreadLevel: props.channelMember.notify_props.mark_unread,
             pushLevel: props.channelMember.notify_props.push || NotificationLevels.DEFAULT
         };
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (!Utils.areObjectsEqual(this.props.channelMember.notify_props, nextProps.channelMember.notify_props)) {
+            this.setState({
+                notifyLevel: nextProps.channelMember.notify_props.desktop,
+                unreadLevel: nextProps.channelMember.notify_props.mark_unread,
+                pushLevel: nextProps.channelMember.notify_props.push || NotificationLevels.DEFAULT
+            });
+        }
+    }
+
+    handleOnHide = () => {
+        this.setState({
+            activeSection: ''
+        });
+
+        this.props.onHide();
     }
 
     updateSection(section) {
@@ -604,8 +623,8 @@ export default class ChannelNotificationsModal extends React.Component {
             <Modal
                 show={this.props.show}
                 dialogClassName='settings-modal settings-modal--tabless'
-                onHide={this.props.onHide}
-                onExited={this.props.onHide}
+                onHide={this.handleOnHide}
+                onExited={this.handleOnHide}
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>


### PR DESCRIPTION
(Not yet confirmed 

#### Summary
- Fix incorrect channel notification settings when switching teams
- Reset active section whenever channel notification modal is closed or hidden (this is not part of a ticket but good to fix here in my opinion)

#### Ticket Link
Jira ticket: [PLT-8515](https://mattermost.atlassian.net/browse/PLT-8515)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed

