### PR TITLE
PLT-8508: switch channel before leaving the channel

### DIFF
--- a/actions/channel_actions.jsx
+++ b/actions/channel_actions.jsx
@@ -368,14 +368,13 @@ export async function getChannelMembersForUserIds(channelId, userIds, success, e
 }
 
 export async function leaveChannel(channelId, success) {
+    const townsquare = ChannelStore.getByName('town-square');
+    browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + townsquare.name);
+
     await ChannelActions.leaveChannel(channelId)(dispatch, getState);
     if (ChannelUtils.isFavoriteChannelId(channelId)) {
         unmarkFavorite(channelId);
     }
-
-    const townsquare = ChannelStore.getByName('town-square');
-    browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + townsquare.name);
-
     if (success) {
         success();
     }


### PR DESCRIPTION
#### Summary
This PR redirects a user to the town square channel before unsubscribing them from the current channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8508
https://github.com/mattermost/mattermost-server/issues/8053

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed