### PR TITLE
Allow .pem extensions for SAML IDP files

### DIFF
--- a/components/admin_console/saml_settings.jsx
+++ b/components/admin_console/saml_settings.jsx
@@ -209,7 +209,7 @@ export default class SamlSettings extends AdminSettings {
                     }
                     uploadingText={Utils.localizeMessage('admin.saml.uploading.certificate', 'Uploading Certificate...')}
                     disabled={!this.state.enable}
-                    fileType='.crt,.cer,.cert'
+                    fileType='.crt,.cer,.cert,.pem'
                     onSubmit={this.uploadCertificate}
                     error={this.state.idpCertificateFileError}
                 />


### PR DESCRIPTION
#### Summary
Allow .pem extensions for SAML IDP files

#### Ticket Link
https://github.com/mattermost/desktop/issues/497

