### PR TITLE
PLT-8509 Fix many places where components error when missing props

### DIFF
--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -21,7 +21,7 @@ import CreatePost from './create_post.jsx';
 
 function mapStateToProps() {
     return (state, ownProps) => {
-        const currentChannel = getCurrentChannel(state);
+        const currentChannel = getCurrentChannel(state) || {};
         const getDraft = makeGetGlobalItem(StoragePrefixes.DRAFT + currentChannel.id, {
             message: '',
             uploadsInProgress: [],

--- a/components/get_post_link_modal/index.js
+++ b/components/get_post_link_modal/index.js
@@ -10,7 +10,7 @@ import {getSiteURL} from 'utils/url.jsx';
 import GetPostLinkModal from './get_post_link_modal';
 
 function mapStateToProps(state, ownProps) {
-    const currentTeam = getCurrentTeam(state);
+    const currentTeam = getCurrentTeam(state) || {};
     const currentTeamUrl = `${getSiteURL()}/${currentTeam.name}`;
     return {
         ...ownProps,

--- a/components/get_team_invite_link_modal/get_team_invite_link_modal.jsx
+++ b/components/get_team_invite_link_modal/get_team_invite_link_modal.jsx
@@ -26,6 +26,10 @@ export default class GetTeamInviteLinkModal extends React.PureComponent {
         config: PropTypes.object.isRequired
     }
 
+    static defaultProps = {
+        currentTeam: {}
+    }
+
     constructor(props) {
         super(props);
         this.state = {

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -199,13 +199,15 @@ export default class NeedsTeam extends React.Component {
             );
         }
 
+        const teamType = this.state.team ? this.state.team.type : '';
+
         return (
             <div className='channel-view'>
                 <AnnouncementBar/>
                 <WebrtcNotification/>
                 <div className='container-fluid'>
                     <SidebarRight/>
-                    <SidebarRightMenu teamType={this.state.team.type}/>
+                    <SidebarRightMenu teamType={teamType}/>
                     <WebrtcSidebar/>
                     {content}
 

--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -146,7 +146,7 @@ export default class Sidebar extends React.Component {
         }
 
         // reset the scrollbar upon switching teams
-        if (this.state.currentTeam !== prevState.currentTeam) {
+        if (this.refs.container && this.state.currentTeam !== prevState.currentTeam) {
             this.refs.container.scrollTop = 0;
             $('.nav-pills__container').perfectScrollbar('update');
         }
@@ -190,7 +190,7 @@ export default class Sidebar extends React.Component {
     }
 
     onChange = () => {
-        if (this.state.currentTeam.id !== TeamStore.getCurrentId()) {
+        if (this.state.currentTeam && this.state.currentTeam.id !== TeamStore.getCurrentId()) {
             ChannelStore.clear();
         }
         this.setState(this.getStateFromStores());

--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -145,9 +145,8 @@ export default class SidebarRight extends React.Component {
             expandedClass = 'sidebar--right--expanded';
         }
 
-        var currentId = this.props.currentUser.id;
         var searchForm = null;
-        if (currentId) {
+        if (this.props.currentUser) {
             searchForm = <SearchBox isFocus={this.props.searchVisible && Utils.isMobile()}/>;
         }
 

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -12,14 +12,16 @@ import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
 
 function mapStateToProps(state) {
     const currentUser = getCurrentUser(state);
+
+    if (!currentUser) {
+        return {};
+    }
+
     const userId = currentUser.id;
-    const lastPicUpdate = currentUser.last_picture_update;
-    const profilePicture = Client4.getProfilePictureUrl(userId, lastPicUpdate);
-    const status = getStatusForUserId(state, currentUser.id);
     return {
         userId,
-        profilePicture,
-        status
+        profilePicture: Client4.getProfilePictureUrl(userId, currentUser.last_picture_update),
+        status: getStatusForUserId(state, userId)
     };
 }
 

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -23,6 +23,12 @@ export default class StatusDropdown extends React.Component {
         }).isRequired
     }
 
+    static defaultProps = {
+        userId: '',
+        profilePicture: '',
+        status: UserStatuses.OFFLINE
+    }
+
     state = {
         showDropdown: false
     }


### PR DESCRIPTION
#### Summary
When mattermost-redux receives a 401 from the server, it moves to log out the user and causes the redux store to be emptied. Unfortunately many of our components are a bit fragile and will break if some of their props (usually current user/team/channel) are not set. Those two previous facts combined with revoking your current session created a race between JS errors from these fragile components and the bit of code pushing the browser to the login page.

This PR should patch the components that were breaking in this situation. Ideally all of our components would be more robust and be able to handle rendering when missing any prop but this is a start

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8509