### PR TITLE
Fixed autoFocus issue with delete modal after edit

### DIFF
--- a/components/delete_post_modal.jsx
+++ b/components/delete_post_modal.jsx
@@ -1,11 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import $ from 'jquery';
-
 import React from 'react';
 import {Modal} from 'react-bootstrap';
-import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
 import {deletePost} from 'actions/post_actions.jsx';
@@ -149,9 +146,11 @@ export default class DeletePostModal extends React.Component {
                         />
                     </button>
                     <button
-                        ref={(deletePostBtn) => this.deletePostBtn = deletePostBtn}
+                        ref={(deletePostBtn) => {
+                            this.deletePostBtn = deletePostBtn;
+                        }}
                         type='button'
-                        autoFocus
+                        autoFocus={true}
                         className='btn btn-danger'
                         onClick={this.handleDelete}
                     >

--- a/components/delete_post_modal.jsx
+++ b/components/delete_post_modal.jsx
@@ -42,8 +42,8 @@ export default class DeletePostModal extends React.Component {
     componentDidUpdate(prevProps, prevState) {
         if (this.state.show && !prevState.show) {
             setTimeout(() => {
-                $(ReactDOM.findDOMNode(this.refs.deletePostBtn)).focus();
-            }, 0);
+                this.deletePostBtn.focus();
+            }, 200);
         }
     }
 
@@ -149,8 +149,9 @@ export default class DeletePostModal extends React.Component {
                         />
                     </button>
                     <button
-                        ref='deletePostBtn'
+                        ref={(deletePostBtn) => this.deletePostBtn = deletePostBtn}
                         type='button'
+                        autoFocus
                         className='btn btn-danger'
                         onClick={this.handleDelete}
                     >

--- a/components/delete_post_modal.jsx
+++ b/components/delete_post_modal.jsx
@@ -39,7 +39,9 @@ export default class DeletePostModal extends React.Component {
     componentDidUpdate(prevProps, prevState) {
         if (this.state.show && !prevState.show) {
             setTimeout(() => {
-                this.deletePostBtn.focus();
+                if (this.deletePostBtn) {
+                    this.deletePostBtn.focus();
+                }
             }, 200);
         }
     }


### PR DESCRIPTION
#### Summary
The issue here is a race condition. The problem seems to be that the children elements are being rendered by the parent element. So, at time of render, they are actually not rendered. They have to wait for the `<Modal />` to fully render. So, when autoFocus is being called, they don't actually exist. 
The same issue seems to have always been there, which is why there is a setTimeOut(()=>{}, 0) already there. However, I believe that the transition from one modal to the other is a slightly longer delay, which is causing the autoFocus to fire prematurely. 
The fix I added was simply increasing the SetTimeOut length to 200 milliseconds. The issue with this is that it isn't instantaneous and, yet, is still subject to the same race issue in the future. But it works for now.
I also added the `autoFocus` tag to the button so that React itself also tries to autoFocus the button with it's custom polyfills.

The ref is declared inline so that 
- I don't have to use `ReactDOM.findDOMNode` anymore, for cleaner and preferred code style. Plus it gets rid of jquery dependency.
- and is an inline function because it only needs to be called if the function is actually rendered. Adding it to the class itself causes the function (which will often not be used) to be setup when the page renders. Adding overhead that is probably not needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8511?filter=14100

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed