### PR TITLE
[PLT-8536] Call PostActions.createPost wrapper function instead of createPost from mattermost-redux

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -9,7 +9,7 @@ import {Posts} from 'mattermost-redux/constants';
 
 import * as ChannelActions from 'actions/channel_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
-import {emitEmojiPosted} from 'actions/post_actions.jsx';
+import {createPost, emitEmojiPosted} from 'actions/post_actions.jsx';
 import EmojiStore from 'stores/emoji_store.jsx';
 import Constants, {StoragePrefixes} from 'utils/constants.jsx';
 import * as FileUtils from 'utils/file_utils';
@@ -363,15 +363,10 @@ export default class CreatePost extends React.Component {
         post.parent_id = this.state.parentId;
 
         GlobalActions.emitUserPostedEvent(post);
-        this.props.actions.createPost(post, this.props.draft.fileInfos).then(() => GlobalActions.postListScrollChange(true)).catch((err) => {
-            if (err.id === 'api.post.create_post.root_id.app_error') {
-                // this should never actually happen since you can't reply from this textbox
-                this.showPostDeletedModal();
-            }
 
-            this.setState({
-                submitting: false
-            });
+        createPost(post, this.props.draft.fileInfos);
+        this.setState({
+            submitting: false
         });
     }
 

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -125,11 +125,6 @@ export default class CreatePost extends React.Component {
             moveHistoryIndexForward: PropTypes.func.isRequired,
 
             /**
-            *  func called for posting message
-            */
-            createPost: PropTypes.func.isRequired,
-
-            /**
             *  func called for adding a reaction
             */
             addReaction: PropTypes.func.isRequired,
@@ -364,9 +359,11 @@ export default class CreatePost extends React.Component {
 
         GlobalActions.emitUserPostedEvent(post);
 
-        createPost(post, this.props.draft.fileInfos);
-        this.setState({
-            submitting: false
+        createPost(post, this.props.draft.fileInfos, () => {
+            GlobalActions.postListScrollChange(true);
+            this.setState({
+                submitting: false
+            });
         });
     }
 

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -8,7 +8,7 @@ import {getCurrentChannel, getCurrentChannelStats} from 'mattermost-redux/select
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {get, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {makeGetMessageInHistoryItem, getPost, getMostRecentPostIdInChannel, makeGetCommentCountForPost, getLatestReplyablePostId, getCurrentUsersLatestPost} from 'mattermost-redux/selectors/entities/posts';
-import {addMessageIntoHistory, moveHistoryIndexBack, moveHistoryIndexForward, createPost, createPostImmediately, addReaction, removeReaction} from 'mattermost-redux/actions/posts';
+import {addMessageIntoHistory, moveHistoryIndexBack, moveHistoryIndexForward, addReaction, removeReaction} from 'mattermost-redux/actions/posts';
 import {Posts} from 'mattermost-redux/constants';
 
 import {setEditingPost} from 'actions/post_actions.jsx';
@@ -16,7 +16,6 @@ import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
 import {makeGetGlobalItem} from 'selectors/storage';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import {Preferences, StoragePrefixes} from 'utils/constants.jsx';
-import * as UserAgent from 'utils/user_agent';
 
 import CreatePost from './create_post.jsx';
 
@@ -53,17 +52,11 @@ function mapStateToProps() {
 }
 
 function mapDispatchToProps(dispatch) {
-    var createPostTemp = createPost;
-    if (UserAgent.isIosClassic()) {
-        createPostTemp = createPostImmediately;
-    }
-
     return {
         actions: bindActionCreators({
             addMessageIntoHistory,
             moveHistoryIndexBack,
             moveHistoryIndexForward,
-            createPost: createPostTemp,
             addReaction,
             removeReaction,
             setDraft: setGlobalItem,

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -20,7 +20,8 @@ jest.mock('actions/global_actions.jsx', () => ({
     showChannelHeaderUpdateModal: jest.fn(),
     showChannelPurposeUpdateModal: jest.fn(),
     showChannelNameUpdateModal: jest.fn(),
-    toggleShortcutsModal: jest.fn()
+    toggleShortcutsModal: jest.fn(),
+    postListScrollChange: jest.fn()
 }));
 
 jest.mock('react-dom', () => ({
@@ -625,6 +626,7 @@ describe('components/create_post', () => {
         expect(GlobalActions.emitUserPostedEvent).toHaveBeenCalledWith(post);
 
         expect(PostActions.createPost).toHaveBeenCalledTimes(1);
-        expect(PostActions.createPost).toHaveBeenCalledWith(post, []);
+        expect(PostActions.createPost.mock.calls[0][0]).toEqual(post);
+        expect(PostActions.createPost.mock.calls[0][1]).toEqual([]);
     });
 });

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+
 import React from 'react';
 
 import {shallow} from 'enzyme';
@@ -11,6 +12,7 @@ import Constants, {StoragePrefixes} from 'utils/constants.jsx';
 import CreatePost from 'components/create_post/create_post.jsx';
 import * as Utils from 'utils/utils.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
+import * as PostActions from 'actions/post_actions.jsx';
 
 jest.mock('actions/global_actions.jsx', () => ({
     emitLocalUserTypingEvent: jest.fn(),
@@ -28,7 +30,12 @@ jest.mock('react-dom', () => ({
 }));
 
 jest.mock('actions/post_actions.jsx', () => ({
-    emitEmojiPosted: jest.fn()
+    emitEmojiPosted: jest.fn(),
+    createPost: jest.fn(() => {
+        return new Promise((resolve) => {
+            process.nextTick(() => resolve());
+        });
+    })
 }));
 
 const KeyCodes = Constants.KeyCodes;
@@ -60,7 +67,6 @@ const actionsProp = {
     addMessageIntoHistory: emptyFunction,
     moveHistoryIndexBack: emptyFunction,
     moveHistoryIndexForward: emptyFunction,
-    createPost: emptyFunction,
     addReaction: emptyFunction,
     removeReaction: emptyFunction,
     clearDraftUploads: emptyFunction,
@@ -217,22 +223,7 @@ describe('components/create_post', () => {
     });
 
     it('onSubmit test for @all', () => {
-        const createPostAction = jest.fn(
-            () => {
-                return new Promise((resolve) => {
-                    process.nextTick(() => resolve());
-                });
-            }
-        );
-
-        const wrapper = shallow(
-            createPost({
-                actions: {
-                    ...actionsProp,
-                    createPost: createPostAction
-                }
-            })
-        );
+        const wrapper = shallow(createPost());
 
         wrapper.setState({
             message: 'test @all'
@@ -359,22 +350,7 @@ describe('components/create_post', () => {
     });
 
     it('check for postError state on handlePostError callback', () => {
-        const createPostAction = jest.fn(
-            () => {
-                return new Promise((resolve) => {
-                    process.nextTick(() => resolve());
-                });
-            }
-        );
-
-        const wrapper = shallow(
-            createPost({
-                actions: {
-                    ...actionsProp,
-                    createPost: createPostAction
-                }
-            })
-        );
+        const wrapper = shallow(createPost());
         const textBox = wrapper.find('#post_textbox');
         const form = wrapper.find('#create_post');
 
@@ -638,5 +614,17 @@ describe('components/create_post', () => {
 
         instance.hidePostDeletedModal();
         expect(wrapper.state('showPostDeletedModal')).toBe(false);
+    });
+
+    it('Should have called PostActions.createPost on sendMessage', () => {
+        const wrapper = shallow(createPost());
+        const post = {message: 'message', file_ids: []};
+        wrapper.instance().sendMessage(post);
+
+        expect(GlobalActions.emitUserPostedEvent).toHaveBeenCalledTimes(1);
+        expect(GlobalActions.emitUserPostedEvent).toHaveBeenCalledWith(post);
+
+        expect(PostActions.createPost).toHaveBeenCalledTimes(1);
+        expect(PostActions.createPost).toHaveBeenCalledWith(post, []);
     });
 });


### PR DESCRIPTION
#### Summary
Issue - Regression: Emoji posted in center channel doesn't appear in Recently Used in emoji picker.

Solved by calling PostActions.createPost wrapper function instead of createPost from mattermost-redux
- such function includes createPost from mattermost-redux
- adding emoji to recent emojis, if present
- immediate post creation on IOS classic 

#### Ticket Link
Jira ticket: [PLT-8536](https://mattermost.atlassian.net/browse/PLT-8536)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
