### PR TITLE
PLT-8517: Fix for scrolling reply textarea into view when obstructed …

### DIFF
--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -15,6 +15,7 @@ import WebrtcStore from 'stores/webrtc_store.jsx';
 import Constants from 'utils/constants.jsx';
 import DelayedAction from 'utils/delayed_action.jsx';
 import * as Utils from 'utils/utils.jsx';
+import * as UserAgent from 'utils/user_agent.jsx';
 
 import CreateComment from 'components/create_comment';
 import DateSeparator from 'components/post_view/date_separator.jsx';
@@ -196,6 +197,10 @@ export default class RhsThread extends React.Component {
             windowWidth: Utils.windowWidth(),
             windowHeight: Utils.windowHeight()
         });
+
+        if (UserAgent.isMobile() && document.activeElement.id === 'reply_textbox') {
+            this.scrollToBottom();
+        }
     }
 
     onPreferenceChange = () => {


### PR DESCRIPTION
…by mobile keyboard.

#### Summary
Scrolls the view to the bottom of the page in mobile when a screen resize happens and the reply textarea is in focus.

#### Ticket Link
[PLT-8517](https://mattermost.atlassian.net/browse/PLT-8517)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed