### PR TITLE
PLT-8553 Properly centred status icons

### DIFF
--- a/components/svg/status_away_icon.jsx
+++ b/components/svg/status_away_icon.jsx
@@ -8,6 +8,8 @@ export default class StatusAwayIcon extends React.PureComponent {
         return (
             <span {...this.props}>
                 <svg
+                    width='100%'
+                    height='100%'
                     viewBox='0 0 20 20'
                     style={style}
                 >

--- a/components/svg/status_away_icon.jsx
+++ b/components/svg/status_away_icon.jsx
@@ -8,8 +8,6 @@ export default class StatusAwayIcon extends React.PureComponent {
         return (
             <span {...this.props}>
                 <svg
-                    width='100%'
-                    height='100%'
                     viewBox='0 0 20 20'
                     style={style}
                 >

--- a/components/svg/status_dnd_icon.jsx
+++ b/components/svg/status_dnd_icon.jsx
@@ -8,8 +8,6 @@ export default class StatusDndIcon extends React.PureComponent {
         return (
             <span {...this.props}>
                 <svg
-                    width='13px'
-                    height='13px'
                     viewBox='0 0 20 20'
                     style={style}
                 >

--- a/components/svg/status_dnd_icon.jsx
+++ b/components/svg/status_dnd_icon.jsx
@@ -8,6 +8,8 @@ export default class StatusDndIcon extends React.PureComponent {
         return (
             <span {...this.props}>
                 <svg
+                    width='100%'
+                    height='100%'
                     viewBox='0 0 20 20'
                     style={style}
                 >

--- a/components/svg/status_offline_icon.jsx
+++ b/components/svg/status_offline_icon.jsx
@@ -9,8 +9,6 @@ export default class StatusOfflineIcon extends React.PureComponent {
             <span {...this.props}>
                 <svg
                     className='offline--icon'
-                    width='13px'
-                    height='13px'
                     viewBox='0 0 20 20'
                     style={style}
                 >

--- a/components/svg/status_offline_icon.jsx
+++ b/components/svg/status_offline_icon.jsx
@@ -8,6 +8,8 @@ export default class StatusOfflineIcon extends React.PureComponent {
         return (
             <span {...this.props}>
                 <svg
+                    width='100%'
+                    height='100%'
                     className='offline--icon'
                     viewBox='0 0 20 20'
                     style={style}

--- a/components/svg/status_online_icon.jsx
+++ b/components/svg/status_online_icon.jsx
@@ -8,8 +8,6 @@ export default class StatusOnlineIcon extends React.PureComponent {
         return (
             <span {...this.props}>
                 <svg
-                    width='13px'
-                    height='13px'
                     viewBox='0 0 20 20'
                     style={style}
                 >

--- a/components/svg/status_online_icon.jsx
+++ b/components/svg/status_online_icon.jsx
@@ -8,6 +8,8 @@ export default class StatusOnlineIcon extends React.PureComponent {
         return (
             <span {...this.props}>
                 <svg
+                    width='100%'
+                    height='100%'
                     viewBox='0 0 20 20'
                     style={style}
                 >


### PR DESCRIPTION
I'm proposing this for 4.6 since it's a small fix and it looks kind of ugly right now. This is how it looks with this PR

![image](https://user-images.githubusercontent.com/3277310/34841641-f10bdd96-f6d6-11e7-8bc3-ad9208f3af0c.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8553

#### Checklist
- Has UI changes
