### PR TITLE
PLT-8550 Clear push notifications URL when switching from HPNS/TPNS to manual

### DIFF
--- a/components/admin_console/push_settings.jsx
+++ b/components/admin_console/push_settings.jsx
@@ -52,6 +52,12 @@ export default class PushSettings extends AdminSettings {
                 this.setState({
                     pushNotificationServer: Constants.MTPNS
                 });
+            } else if (value === PUSH_NOTIFICATIONS_CUSTOM &&
+                (this.state.pushNotificationServerType === PUSH_NOTIFICATIONS_MTPNS ||
+                this.state.pushNotificationServerType === PUSH_NOTIFICATIONS_MHPNS)) {
+                this.setState({
+                    pushNotificationServer: ''
+                });
             }
         }
 


### PR DESCRIPTION
This is a fix for the odd behaviour that occurs when you switch from one of those to manual and then press save. Since it's using one of the predefined URLs, the dropdown switches back to the predefined option, making it look like it didn't save correctly. To get around that, we can clear the URL so that the user would have to re-enter the predefined one to see this happen.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8550

#### Checklist
- Has UI changes