### PR TITLE
PLT-8399: Fix race condition on persistStore initialization

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -75,68 +75,66 @@ export default function configureStore(initialState) {
             const localforage = extendPrototype(localForage);
             var storage = localforage;
             const KEY_PREFIX = "reduxPersist:";
-            const persistor = persistStore(store, {storage, keyPrefix: KEY_PREFIX, ...options}, () => {
-                store.dispatch({
-                    type: General.STORE_REHYDRATION_COMPLETE,
-                    complete: true
+            localforage.ready(() => {
+                const persistor = persistStore(store, {storage, keyPrefix: KEY_PREFIX, ...options}, () => {
+                    store.dispatch({
+                        type: General.STORE_REHYDRATION_COMPLETE,
+                        complete: true
+                    });
+                });
+
+                localforage.configObservables({
+                    crossTabNotification: true,
+                });
+                var observable = localforage.newObservable({
+                    crossTabNotification: true,
+                    changeDetection: true
+                });
+                var restoredState = {}
+                localforage.iterate((value, key) => {
+                    if(key && key.indexOf(KEY_PREFIX+"storage:") === 0){
+                        const keyspace = key.substr((KEY_PREFIX+"storage:").length);
+                        restoredState[keyspace] = value;
+                    }
+                }).then(() => {
+                    storageRehydrate(restoredState)(store.dispatch, persistor);
+                });
+                observable.subscribe({
+                    next: (args) => {
+                        if(args.key && args.key.indexOf(KEY_PREFIX+"storage:") === 0 && args.oldValue === null){
+                            const keyspace = args.key.substr((KEY_PREFIX+"storage:").length);
+
+                            var statePartial = {};
+                            statePartial[keyspace] = args.newValue;
+                            storageRehydrate(statePartial)(store.dispatch, persistor);
+                        }
+                    }
+                });
+
+                let purging = false;
+
+                // check to see if the logout request was successful
+                store.subscribe(() => {
+                    const state = store.getState();
+                    if (state.requests.users.logout.status === RequestStatus.SUCCESS && !purging) {
+                        purging = true;
+
+                        persistor.purge().then(() => {
+                            document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+                            window.location.href = '/';
+
+                            store.dispatch({
+                                type: General.OFFLINE_STORE_RESET,
+                                data: Object.assign({}, reduxInitialState, initialState)
+                            });
+
+                            setTimeout(() => {
+                                purging = false;
+                            }, 500);
+                        })
+                    }
                 });
             });
-            if (localforage === storage) {
-                localforage.ready(() => {
-                    localforage.configObservables({
-                        crossTabNotification: true,
-                    });
-                    var observable = localforage.newObservable({
-                        crossTabNotification: true,
-                        changeDetection: true
-                    });
-                    var restoredState = {}
-                    localforage.iterate((value, key) => {
-                        if(key && key.indexOf(KEY_PREFIX+"storage:") === 0){
-                            const keyspace = key.substr((KEY_PREFIX+"storage:").length);
-                            restoredState[keyspace] = value;
-                        }
-                    }).then(() => {
-                        storageRehydrate(restoredState)(store.dispatch, persistor);
-                    });
-                    observable.subscribe({
-                        next: (args) => {
-                            if(args.key && args.key.indexOf(KEY_PREFIX+"storage:") === 0 && args.oldValue === null){
-                                const keyspace = args.key.substr((KEY_PREFIX+"storage:").length);
-
-                                var statePartial = {};
-                                statePartial[keyspace] = args.newValue;
-                                storageRehydrate(statePartial)(store.dispatch, persistor);
-                            }
-                        }
-                    })
-                })
-            }
-            let purging = false;
-
-            // check to see if the logout request was successful
-            store.subscribe(() => {
-                const state = store.getState();
-                if (state.requests.users.logout.status === RequestStatus.SUCCESS && !purging) {
-                    purging = true;
-
-                    persistor.purge().then(() => {
-                        document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-                        window.location.href = '/';
-
-                        store.dispatch({
-                            type: General.OFFLINE_STORE_RESET,
-                            data: Object.assign({}, reduxInitialState, initialState)
-                        });
-
-                        setTimeout(() => {
-                            purging = false;
-                        }, 500);
-                    })
-                }
-            });
-
-            return persistor;
         },
         persistOptions: {
             autoRehydrate: {

--- a/tests/components/about_build_modal.test.jsx
+++ b/tests/components/about_build_modal.test.jsx
@@ -12,6 +12,16 @@ import AboutBuildModal from 'components/about_build_modal/about_build_modal.jsx'
 describe('components/AboutBuildModal', () => {
     let config = null;
     let license = null;
+    const RealDate = Date;
+
+    function mockDate(date) {
+        global.Date = class extends RealDate {
+            constructor() {
+                super();
+                return new RealDate(date);
+            }
+        };
+    }
 
     afterEach(() => {
         config = null;
@@ -19,6 +29,8 @@ describe('components/AboutBuildModal', () => {
     });
 
     beforeEach(() => {
+        mockDate('2017-06-01');
+
         config = {
             BuildEnterpriseReady: 'true',
             Version: '3.6.0',

--- a/tests/components/header_footer_template.test.jsx
+++ b/tests/components/header_footer_template.test.jsx
@@ -8,7 +8,20 @@ import {shallow} from 'enzyme';
 import NotLoggedIn from 'components/header_footer_template/header_footer_template.jsx';
 
 describe('components/HeaderFooterTemplate', () => {
+    const RealDate = Date;
+
+    function mockDate(date) {
+        global.Date = class extends RealDate {
+            constructor() {
+                super();
+                return new RealDate(date);
+            }
+        };
+    }
+
     beforeEach(() => {
+        mockDate('2017-06-01');
+
         const elm = document.createElement('div');
         elm.setAttribute('id', 'root');
         document.body.appendChild(elm);


### PR DESCRIPTION
#### Summary
Fix the race condition on persistStore initialization when localForage is not ready.

Backport of the PR #531 to 4.5.

Some snapshots are failing because the change of the year (I think is not a good place to fix it here).

Besides, the styles wasn't checked in the .js files for version 4.5 so I didn't change the code for style fixes.

I assign it to @jwilander and @enahum because they were who approved the #531 PR.

#### Ticket Link
[PLT-8399](https://mattermost.atlassian.net/browse/PLT-8399)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed