### PR TITLE
PLT-8562 Close autocomplete after typing command without autocompleting

### DIFF
--- a/actions/integration_actions.jsx
+++ b/actions/integration_actions.jsx
@@ -228,16 +228,14 @@ export function getSuggestedCommands(command, suggestionId, component) {
             // pull out the suggested commands from the returned data
             const terms = matches.map((suggestion) => suggestion.suggestion);
 
-            if (terms.length > 0) {
-                AppDispatcher.handleServerAction({
-                    type: ActionTypes.SUGGESTION_RECEIVED_SUGGESTIONS,
-                    id: suggestionId,
-                    matchedPretext: command,
-                    terms,
-                    items: matches,
-                    component
-                });
-            }
+            AppDispatcher.handleServerAction({
+                type: ActionTypes.SUGGESTION_RECEIVED_SUGGESTIONS,
+                id: suggestionId,
+                matchedPretext: command,
+                terms,
+                items: matches,
+                component
+            });
         }
     ).catch(
         () => {} //eslint-disable-line no-empty-function


### PR DESCRIPTION
There was a fix recently to make the autocomplete results no longer clear repeatedly while typing a slash command, but that meant the autocomplete results stayed visible if you keep typing when they should disappear. This fixes that without re-introducing the original issue

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8562