### PR TITLE
Ea78c752 regression fix

### DIFF
--- a/components/team_general_tab.jsx
+++ b/components/team_general_tab.jsx
@@ -507,7 +507,6 @@ class GeneralTab extends React.Component {
                     />
                 );
             }
-
             descriptionSection = (
                 <SettingItemMin
                     title={Utils.localizeMessage('general_tab.teamDescription', 'Team Description')}

--- a/components/team_general_tab.jsx
+++ b/components/team_general_tab.jsx
@@ -381,6 +381,7 @@ class GeneralTab extends React.Component {
                     title={Utils.localizeMessage('general_tab.codeTitle', 'Invite Code')}
                     describe={Utils.localizeMessage('general_tab.codeDesc', "Click 'Edit' to regenerate Invite Code.")}
                     updateSection={this.handleUpdateSection}
+                    section={'invite_id'}
                 />
             );
         }
@@ -441,6 +442,7 @@ class GeneralTab extends React.Component {
                     title={Utils.localizeMessage('general_tab.teamName', 'Team Name')}
                     describe={describe}
                     updateSection={this.handleUpdateSection}
+                    section={'name'}
                 />
             );
         }
@@ -511,6 +513,7 @@ class GeneralTab extends React.Component {
                     title={Utils.localizeMessage('general_tab.teamDescription', 'Team Description')}
                     describe={describemsg}
                     updateSection={this.handleUpdateSection}
+                    section={'description'}
                 />
             );
         }


### PR DESCRIPTION
#### Summary
A regression was introduced that does not allow users to expand Team Setting's sections. This fixes that by adding the section prop.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)