### PR TITLE
Disable Select Team button in Team sidebar when ExperimentalPrimaryTe…

### DIFF
--- a/components/team_sidebar/team_sidebar_controller.jsx
+++ b/components/team_sidebar/team_sidebar_controller.jsx
@@ -145,7 +145,7 @@ export default class TeamSidebar extends React.Component {
                 );
             });
 
-        if (moreTeams) {
+        if (moreTeams && !global.mm_config.ExperimentalPrimaryTeam) {
             teams.push(
                 <TeamButton
                     btnClass='team-btn__add'
@@ -161,7 +161,7 @@ export default class TeamSidebar extends React.Component {
                     content={<i className='fa fa-plus'/>}
                 />
             );
-        } else if (global.window.mm_config.EnableTeamCreation === 'true' || isSystemAdmin) {
+        } else if (global.mm_config.EnableTeamCreation === 'true' || isSystemAdmin) {
             teams.push(
                 <TeamButton
                     btnClass='team-btn__add'


### PR DESCRIPTION
#### Summary
This change completes PR `Allow default team to be configured`:
https://github.com/mattermost/mattermost-webapp/pull/334/files

It hides the ability to `select team` from the team sidebar if there's a ExperimetalPrimaryTeam value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes