### PR TITLE
ICU-620 Ensure comparisons are always lowercase

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -185,7 +185,7 @@ export default class EmojiPicker extends React.PureComponent {
 
     handleFilterChange(e) {
         e.preventDefault();
-        const filter = e.target.value;
+        const filter = e.target.value.toLowerCase();
         this.setState(() => ({
             filter,
             cursor: [0, 0]
@@ -297,7 +297,7 @@ export default class EmojiPicker extends React.PureComponent {
         if (this.state.filter) {
             return Object.values(this.state.allEmojis).filter((emoji) => {
                 for (let i = 0; i < emoji.aliases.length; i++) {
-                    if (emoji.aliases[i].includes(this.state.filter)) {
+                    if (emoji.aliases[i].toLowerCase().includes(this.state.filter)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Emoji picker search should not be case-sensitive

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-620

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)