### PR TITLE
PLT-8478 Added QuickInput component to better handle fast CJK typing on IE

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -298,11 +298,17 @@ export function setEditingPost(postId = '', commentsCount = 0, refocusId = '', t
 
         if (canEditNow) {
             doDispatch({
-                type: ActionTypes.SET_EDITING_POST,
+                type: ActionTypes.SHOW_EDIT_POST_MODAL,
                 data: {postId, commentsCount, refocusId, title}
             }, doGetState);
         }
 
         return {data: canEditNow};
+    };
+}
+
+export function hideEditPostModal() {
+    return {
+        type: ActionTypes.HIDE_EDIT_POST_MODAL
     };
 }

--- a/components/admin_console/user_autocomplete_setting.jsx
+++ b/components/admin_console/user_autocomplete_setting.jsx
@@ -137,7 +137,6 @@ export default class UserAutocompleteSetting extends React.Component {
                         listStyle='bottom'
                         providers={this.userSuggestionProviders}
                         disabled={this.props.disabled}
-                        type='input'
                         requiredCharacters={0}
                         openOnFocus={true}
                     />

--- a/components/autosize_textarea.jsx
+++ b/components/autosize_textarea.jsx
@@ -17,10 +17,6 @@ export default class AutosizeTextarea extends React.Component {
         super(props);
 
         this.height = 0;
-
-        this.state = {
-            referenceValue: this.props.defaultValue
-        };
     }
 
     get value() {
@@ -29,10 +25,6 @@ export default class AutosizeTextarea extends React.Component {
 
     set value(value) {
         this.refs.textarea.value = value;
-
-        this.setState({
-            referenceValue: value
-        });
     }
 
     componentDidUpdate() {
@@ -64,12 +56,6 @@ export default class AutosizeTextarea extends React.Component {
     };
 
     handleChange = (e) => {
-        if (this.props.defaultValue != null) {
-            this.setState({
-                referenceValue: e.target.value
-            });
-        }
-
         if (this.props.onChange) {
             this.props.onChange(e);
         }
@@ -84,6 +70,7 @@ export default class AutosizeTextarea extends React.Component {
 
         const {
             value,
+            defaultValue,
             placeholder,
             id,
             ...otherProps
@@ -97,22 +84,17 @@ export default class AutosizeTextarea extends React.Component {
             heightProps.height = this.height;
         }
 
-        // We need to track the value of the main textbox ourselves if we're using a defaultValue
-        let referenceValue;
-        if (this.props.defaultValue == null) {
-            referenceValue = value;
-        } else {
-            referenceValue = this.state.referenceValue;
-        }
-
         return (
             <div>
                 <textarea
                     ref='textarea'
                     id={id + '-textarea'}
                     {...heightProps}
-                    {...props}
+                    {...otherProps}
+                    placeholder={placeholder}
                     onChange={this.handleChange}
+                    value={value}
+                    defaultValue={defaultValue}
                 />
                 <div style={style.container}>
                     <textarea
@@ -120,10 +102,10 @@ export default class AutosizeTextarea extends React.Component {
                         id={id + '-reference'}
                         style={style.reference}
                         disabled={true}
-                        value={referenceValue}
                         placeholder={placeholder}
                         rows='1'
                         {...otherProps}
+                        value={value || defaultValue}
                     />
                 </div>
             </div>

--- a/components/autosize_textarea.jsx
+++ b/components/autosize_textarea.jsx
@@ -7,14 +7,20 @@ import React from 'react';
 export default class AutosizeTextarea extends React.Component {
     static propTypes = {
         value: PropTypes.string,
+        defaultValue: PropTypes.string,
         placeholder: PropTypes.string,
+        onChange: PropTypes.func,
         onHeightChange: PropTypes.func
-    }
+    };
 
     constructor(props) {
         super(props);
 
         this.height = 0;
+
+        this.state = {
+            referenceValue: this.props.defaultValue
+        };
     }
 
     get value() {
@@ -23,13 +29,17 @@ export default class AutosizeTextarea extends React.Component {
 
     set value(value) {
         this.refs.textarea.value = value;
+
+        this.setState({
+            referenceValue: value
+        });
     }
 
     componentDidUpdate() {
         this.recalculateSize();
     }
 
-    recalculateSize() {
+    recalculateSize = () => {
         const height = this.refs.reference.scrollHeight;
 
         if (height > 0 && height !== this.height) {
@@ -47,11 +57,23 @@ export default class AutosizeTextarea extends React.Component {
                 this.props.onHeightChange(height, parseInt(style.maxHeight, 10));
             }
         }
-    }
+    };
 
-    getDOMNode() {
+    getDOMNode = () => {
         return this.refs.textarea;
-    }
+    };
+
+    handleChange = (e) => {
+        if (this.props.defaultValue != null) {
+            this.setState({
+                referenceValue: e.target.value
+            });
+        }
+
+        if (this.props.onChange) {
+            this.props.onChange(e);
+        }
+    };
 
     render() {
         const props = {...this.props};
@@ -75,6 +97,14 @@ export default class AutosizeTextarea extends React.Component {
             heightProps.height = this.height;
         }
 
+        // We need to track the value of the main textbox ourselves if we're using a defaultValue
+        let referenceValue;
+        if (this.props.defaultValue == null) {
+            referenceValue = value;
+        } else {
+            referenceValue = this.state.referenceValue;
+        }
+
         return (
             <div>
                 <textarea
@@ -82,6 +112,7 @@ export default class AutosizeTextarea extends React.Component {
                     id={id + '-textarea'}
                     {...heightProps}
                     {...props}
+                    onChange={this.handleChange}
                 />
                 <div style={style.container}>
                     <textarea
@@ -89,7 +120,7 @@ export default class AutosizeTextarea extends React.Component {
                         id={id + '-reference'}
                         style={style.reference}
                         disabled={true}
-                        value={value}
+                        value={referenceValue}
                         placeholder={placeholder}
                         rows='1'
                         {...otherProps}

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -2,7 +2,6 @@
 // See License.txt for license information.
 
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
@@ -185,11 +184,11 @@ export default class EditPostModal extends React.PureComponent {
     handleEditKeyPress = (e) => {
         if (!UserAgent.isMobile() && !this.props.ctrlSend && e.which === KeyCodes.ENTER && !e.shiftKey && !e.altKey) {
             e.preventDefault();
-            ReactDOM.findDOMNode(this.refs.editbox).blur();
+            this.refs.editbox.blur();
             this.handleEdit();
         } else if (this.props.ctrlSend && e.ctrlKey && e.which === KeyCodes.ENTER) {
             e.preventDefault();
-            ReactDOM.findDOMNode(this.refs.editbox).blur();
+            this.refs.editbox.blur();
             this.handleEdit();
         }
     }

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -37,12 +37,38 @@ export default class EditPostModal extends React.PureComponent {
         /**
          * Editing post information
          */
-        editingPost: PropTypes.object.isRequired,
+        editingPost: PropTypes.shape({
+
+            /**
+             * The post being edited
+             */
+            post: PropTypes.object,
+
+            /**
+             * The ID of the post being edited
+             */
+            postId: PropTypes.string,
+
+            /**
+             * The ID of a DOM node to focus with the keyboard when this modal closes
+             */
+            refocusId: PropTypes.string,
+
+            /**
+             * Whether or not to show the modal
+             */
+            show: PropTypes.bool.isRequired,
+
+            /**
+             * What to show in the title of the modal as "Edit {title}"
+             */
+            title: PropTypes.string
+        }).isRequired,
 
         actions: PropTypes.shape({
-            editPost: PropTypes.func.isRequired,
             addMessageIntoHistory: PropTypes.func.isRequired,
-            setEditingPost: PropTypes.func.isRequired
+            editPost: PropTypes.func.isRequired,
+            hideEditPostModal: PropTypes.func.isRequired
         }).isRequired
     }
 
@@ -53,19 +79,16 @@ export default class EditPostModal extends React.PureComponent {
             editText: '',
             postError: '',
             errorClass: null,
-            showEmojiPicker: false,
-            hiding: false
+            showEmojiPicker: false
         };
     }
 
-    mustBeShown = () => {
-        if (this.state.hiding) {
-            return false;
+    componentWillUpdate(nextProps) {
+        if (!this.props.editingPost.show && nextProps.editingPost.show) {
+            this.setState({
+                editText: nextProps.editingPost.post.message_source || nextProps.editingPost.post.message
+            });
         }
-        if (!this.props.editingPost || !this.props.editingPost.post) {
-            return false;
-        }
-        return true;
     }
 
     getContainer = () => {
@@ -178,13 +201,7 @@ export default class EditPostModal extends React.PureComponent {
     }
 
     handleHide = () => {
-        this.setState({hiding: true});
-    }
-
-    handleEnter = () => {
-        this.setState({
-            editText: this.props.editingPost.post.message_source || this.props.editingPost.post.message
-        });
+        this.props.actions.hideEditPostModal();
     }
 
     handleEntered = () => {
@@ -198,7 +215,7 @@ export default class EditPostModal extends React.PureComponent {
 
     handleExited = () => {
         const refocusId = this.props.editingPost.refocusId;
-        if (refocusId !== '') {
+        if (refocusId) {
             setTimeout(() => {
                 const element = document.getElementById(refocusId);
                 if (element) {
@@ -206,8 +223,8 @@ export default class EditPostModal extends React.PureComponent {
                 }
             });
         }
-        this.props.actions.setEditingPost();
-        this.setState({editText: '', postError: '', errorClass: null, hiding: false, showEmojiPicker: false});
+
+        this.setState({editText: '', postError: '', errorClass: null, showEmojiPicker: false});
     }
 
     render() {
@@ -242,10 +259,9 @@ export default class EditPostModal extends React.PureComponent {
         return (
             <Modal
                 dialogClassName='edit-modal'
-                show={this.mustBeShown()}
+                show={this.props.editingPost.show}
                 onKeyDown={this.handleKeyDown}
                 onHide={this.handleHide}
-                onEnter={this.handleEnter}
                 onEntered={this.handleEntered}
                 onExit={this.handleExit}
                 onExited={this.handleExited}

--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -8,7 +8,7 @@ import {Preferences} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 
-import {setEditingPost} from 'actions/post_actions';
+import {hideEditPostModal} from 'actions/post_actions';
 import {editPost} from 'actions/views/edit_post_modal';
 import {getEditingPost} from 'selectors/posts';
 
@@ -25,9 +25,9 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            addMessageIntoHistory,
             editPost,
-            setEditingPost,
-            addMessageIntoHistory
+            hideEditPostModal
         }, dispatch)
     };
 }

--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// A component that can be used to make controlled inputs that function properly in certain
+// environments (ie. IE11) where typing quickly would sometimes miss inputs
+export default class QuickInput extends React.PureComponent {
+    static propTypes = {
+
+        /**
+         * An optional React component that will be used instead of an HTML input when rendering
+         */
+        inputComponent: PropTypes.func,
+
+        /**
+         * The string value displayed in this input
+         */
+        value: PropTypes.string.isRequired
+    };
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.value !== this.props.value) {
+            this.refs.input.value = this.props.value;
+        }
+    }
+
+    get value() {
+        return this.refs.input.value;
+    }
+
+    set value(value) {
+        this.refs.input.value = value;
+    }
+
+    getInput = () => {
+        return this.refs.input;
+    };
+
+    render() {
+        const {value, inputComponent, ...props} = this.props;
+
+        return React.createElement(
+            inputComponent || 'input',
+            {
+                ...props,
+                ref: 'input',
+                defaultValue: value
+            }
+        );
+    }
+}

--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -54,7 +54,7 @@ export default class QuickInput extends React.PureComponent {
             {
                 ...props,
                 ref: 'input',
-                defaultValue: value
+                defaultValue: value // Only set the defaultValue since the real one will be updated using componentDidUpdate
             }
         );
     }

--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -34,6 +34,14 @@ export default class QuickInput extends React.PureComponent {
         this.refs.input.value = value;
     }
 
+    focus() {
+        this.refs.input.focus();
+    }
+
+    blur() {
+        this.refs.input.blur();
+    }
+
     getInput = () => {
         return this.refs.input;
     };

--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -316,7 +316,6 @@ export default class QuickSwitchModal extends React.PureComponent {
                     <SuggestionBox
                         ref={this.setSwitchBoxRef}
                         className='form-control focused'
-                        type='input'
                         onChange={this.onChange}
                         value={this.state.text}
                         onKeyDown={this.handleKeyDown}

--- a/components/searchable_channel_list.jsx
+++ b/components/searchable_channel_list.jsx
@@ -7,11 +7,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
+import LoadingScreen from 'components/loading_screen';
+import QuickInput from 'components/quick_input';
 import * as UserAgent from 'utils/user_agent.jsx';
 import {localizeMessage} from 'utils/utils.jsx';
-import loadingGif from 'images/load.gif';
 
-import LoadingScreen from './loading_screen.jsx';
+import loadingGif from 'images/load.gif';
 
 const NEXT_BUTTON_TIMEOUT_MILLISECONDS = 500;
 
@@ -184,7 +185,7 @@ export default class SearchableChannelList extends React.Component {
             <div className='filtered-user-list'>
                 <div className='filter-row'>
                     <div className='col-sm-12'>
-                        <input
+                        <QuickInput
                             id='searchChannelsTextbox'
                             ref='filter'
                             className='form-control filter-textbox'

--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -7,8 +7,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
-import * as Utils from 'utils/utils.jsx';
+import QuickInput from 'components/quick_input';
 import UserList from 'components/user_list.jsx';
+import * as Utils from 'utils/utils.jsx';
 
 const NEXT_BUTTON_TIMEOUT = 500;
 
@@ -211,7 +212,7 @@ export default class SearchableUserList extends React.Component {
         } else {
             filterRow = (
                 <div className='col-xs-12'>
-                    <input
+                    <QuickInput
                         ref='filter'
                         className='form-control filter-textbox'
                         placeholder={Utils.localizeMessage('filtered_user_list.search', 'Search users')}

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -303,7 +303,7 @@ export default class SuggestionBox extends React.Component {
             }
         }
 
-        this.getTextbox().focus();
+        this.refs.input.focus();
 
         for (const provider of this.props.providers) {
             if (provider.handleCompleteWord) {
@@ -356,7 +356,7 @@ export default class SuggestionBox extends React.Component {
     }
 
     blur() {
-        this.getTextbox().blur();
+        this.refs.input.blur();
     }
 
     render() {

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -8,6 +8,7 @@ import * as GlobalActions from 'actions/global_actions.jsx';
 import QuickInput from 'components/quick_input.jsx';
 import SuggestionStore from 'stores/suggestion_store.jsx';
 import Constants from 'utils/constants.jsx';
+import * as Utils from 'utils/utils.jsx';
 
 const KeyCodes = Constants.KeyCodes;
 

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -5,10 +5,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
+import QuickInput from 'components/quick_input.jsx';
 import SuggestionStore from 'stores/suggestion_store.jsx';
 import Constants from 'utils/constants.jsx';
-import * as Utils from 'utils/utils.jsx';
-import AutosizeTextarea from 'components/autosize_textarea.jsx';
 
 const KeyCodes = Constants.KeyCodes;
 
@@ -19,11 +18,6 @@ export default class SuggestionBox extends React.Component {
          * The list component to render, usually SuggestionList
          */
         listComponent: PropTypes.func.isRequired,
-
-        /**
-         * The HTML input box type
-         */
-        type: PropTypes.oneOf(['input', 'textarea', 'search']).isRequired,
 
         /**
          * The value of in the input
@@ -97,7 +91,6 @@ export default class SuggestionBox extends React.Component {
     }
 
     static defaultProps = {
-        type: 'input',
         listStyle: 'top',
         renderDividers: false,
         completeOnTab: true,
@@ -154,17 +147,22 @@ export default class SuggestionBox extends React.Component {
     }
 
     getTextbox() {
-        if (this.props.type === 'textarea' && this.refs.textbox) {
-            const node = this.refs.textbox.getDOMNode();
-            return node;
+        const input = this.refs.input.getInput();
+
+        if (input.getDOMNode) {
+            return input.getDOMNode();
         }
 
-        return this.refs.textbox;
+        return input;
     }
 
     recalculateSize() {
-        if (this.props.type === 'textarea') {
-            this.refs.textbox.recalculateSize();
+        // Pretty hacky way to force an AutosizeTextarea to recalculate its height if that's what
+        // we're rendering as the input
+        const input = this.refs.input.getInput();
+
+        if (input.recalculateSize) {
+            input.recalculateSize();
         }
     }
 
@@ -236,7 +234,7 @@ export default class SuggestionBox extends React.Component {
         let insertText = '@' + mentionKey;
 
         // if the current text does not end with a whitespace, then insert a space
-        if (this.refs.textbox.value && (/[^\s]$/).test(this.refs.textbox.value)) {
+        if (this.props.value && (/[^\s]$/).test(this.props.value)) {
             insertText = ' ' + insertText;
         }
 
@@ -271,12 +269,12 @@ export default class SuggestionBox extends React.Component {
             newValue = prefix + term + ' ' + suffix;
         }
 
-        this.refs.textbox.value = newValue;
+        textbox.value = newValue;
 
         if (this.props.onChange) {
             // fake an input event to send back to parent components
             const e = {
-                target: this.refs.textbox
+                target: textbox
             };
 
             // don't call handleChange or we'll get into an event loop
@@ -358,12 +356,11 @@ export default class SuggestionBox extends React.Component {
     }
 
     blur() {
-        this.refs.textbox.blur();
+        this.getTextbox().blur();
     }
 
     render() {
         const {
-            type,
             listComponent,
             listStyle,
             renderDividers,
@@ -380,52 +377,23 @@ export default class SuggestionBox extends React.Component {
         Reflect.deleteProperty(props, 'requiredCharacters');
         Reflect.deleteProperty(props, 'openOnFocus');
 
-        const childProps = {
-            ref: 'textbox',
-            onBlur: this.handleBlur,
-            onFocus: this.handleFocus,
-            onInput: this.handleChange,
-            onChange() { /* this is only here to suppress warnings about onChange not being implemented for read-write inputs */ },
-            onCompositionStart: this.handleCompositionStart,
-            onCompositionUpdate: this.handleCompositionUpdate,
-            onCompositionEnd: this.handleCompositionEnd,
-            onKeyDown: this.handleKeyDown
-        };
-
-        let textbox = null;
-        if (type === 'input') {
-            textbox = (
-                <input
-                    type='text'
-                    autoComplete='off'
-                    {...props}
-                    {...childProps}
-                />
-            );
-        } else if (type === 'search') {
-            textbox = (
-                <input
-                    type='search'
-                    autoComplete='off'
-                    {...props}
-                    {...childProps}
-                />
-            );
-        } else if (type === 'textarea') {
-            textbox = (
-                <AutosizeTextarea
-                    {...props}
-                    {...childProps}
-                />
-            );
-        }
-
         // This needs to be upper case so React doesn't think it's an html tag
         const SuggestionListComponent = listComponent;
 
         return (
-            <div ref='container'>
-                {textbox}
+            <div>
+                <QuickInput
+                    ref='input'
+                    autoComplete='off'
+                    {...props}
+                    onBlur={this.handleBlur}
+                    onFocus={this.handleFocus}
+                    onInput={this.handleChange}
+                    onCompositionStart={this.handleCompositionStart}
+                    onCompositionUpdate={this.handleCompositionUpdate}
+                    onCompositionEnd={this.handleCompositionEnd}
+                    onKeyDown={this.handleKeyDown}
+                />
                 {this.props.value.length >= this.props.requiredCharacters &&
                     <SuggestionListComponent
                         suggestionId={this.suggestionId}

--- a/components/textbox.jsx
+++ b/components/textbox.jsx
@@ -6,17 +6,17 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
+import AutosizeTextarea from 'components/autosize_textarea.jsx';
 import PostMarkdown from 'components/post_markdown';
+import AtMentionProvider from 'components/suggestion/at_mention_provider.jsx';
+import ChannelMentionProvider from 'components/suggestion/channel_mention_provider.jsx';
+import CommandProvider from 'components/suggestion/command_provider.jsx';
+import EmoticonProvider from 'components/suggestion/emoticon_provider.jsx';
+import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
+import SuggestionList from 'components/suggestion/suggestion_list.jsx';
 import ErrorStore from 'stores/error_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
-
-import AtMentionProvider from './suggestion/at_mention_provider.jsx';
-import ChannelMentionProvider from './suggestion/channel_mention_provider.jsx';
-import CommandProvider from './suggestion/command_provider.jsx';
-import EmoticonProvider from './suggestion/emoticon_provider.jsx';
-import SuggestionBox from './suggestion/suggestion_box.jsx';
-import SuggestionList from './suggestion/suggestion_list.jsx';
 
 const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
@@ -301,7 +301,6 @@ export default class Textbox extends React.Component {
                     id={this.props.id}
                     ref='message'
                     className={textboxClassName}
-                    type='textarea'
                     spellCheck='true'
                     placeholder={this.props.createMessage}
                     onChange={this.handleChange}
@@ -310,6 +309,7 @@ export default class Textbox extends React.Component {
                     onBlur={this.handleBlur}
                     onHeightChange={this.handleHeightChange}
                     style={{visibility: this.state.preview ? 'hidden' : 'visible'}}
+                    inputComponent={AutosizeTextarea}
                     listComponent={SuggestionList}
                     listStyle={this.props.suggestionListStyle}
                     providers={this.suggestionProviders}

--- a/reducers/views/posts.js
+++ b/reducers/views/posts.js
@@ -6,10 +6,22 @@ import {UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes} from 'utils/constants.jsx';
 
-function editingPost(state = '', action) {
+const defaultState = {
+    show: false
+};
+
+function editingPost(state = defaultState, action) {
     switch (action.type) {
-    case ActionTypes.SET_EDITING_POST:
-        return action.data;
+    case ActionTypes.SHOW_EDIT_POST_MODAL:
+        return {
+            ...action.data,
+            show: true
+        };
+    case ActionTypes.HIDE_EDIT_POST_MODAL:
+        return {
+            show: false
+        };
+
     case UserTypes.LOGOUT_SUCCESS:
         return '';
     default:

--- a/tests/components/__snapshots__/edit_post_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/edit_post_modal.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`comoponents/EditPostModal should match with default config 1`] = `
+exports[`components/EditPostModal should match with default config 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -22,7 +22,6 @@ exports[`comoponents/EditPostModal should match with default config 1`] = `
       "remove": [Function],
     }
   }
-  onEnter={[Function]}
   onEntered={[Function]}
   onExit={[Function]}
   onExited={[Function]}
@@ -129,7 +128,7 @@ exports[`comoponents/EditPostModal should match with default config 1`] = `
 </Modal>
 `;
 
-exports[`comoponents/EditPostModal should match without editingPost 1`] = `
+exports[`components/EditPostModal should match without editingPost 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -151,7 +150,6 @@ exports[`comoponents/EditPostModal should match without editingPost 1`] = `
       "remove": [Function],
     }
   }
-  onEnter={[Function]}
   onEntered={[Function]}
   onExit={[Function]}
   onExited={[Function]}
@@ -257,7 +255,7 @@ exports[`comoponents/EditPostModal should match without editingPost 1`] = `
 </Modal>
 `;
 
-exports[`comoponents/EditPostModal should match without emoji picker 1`] = `
+exports[`components/EditPostModal should match without emoji picker 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -279,7 +277,6 @@ exports[`comoponents/EditPostModal should match without emoji picker 1`] = `
       "remove": [Function],
     }
   }
-  onEnter={[Function]}
   onEntered={[Function]}
   onExit={[Function]}
   onExited={[Function]}
@@ -366,7 +363,7 @@ exports[`comoponents/EditPostModal should match without emoji picker 1`] = `
 </Modal>
 `;
 
-exports[`comoponents/EditPostModal should show emojis on emojis click 1`] = `
+exports[`components/EditPostModal should show emojis on emojis click 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -388,7 +385,6 @@ exports[`comoponents/EditPostModal should show emojis on emojis click 1`] = `
       "remove": [Function],
     }
   }
-  onEnter={[Function]}
   onEntered={[Function]}
   onExit={[Function]}
   onExited={[Function]}
@@ -495,7 +491,7 @@ exports[`comoponents/EditPostModal should show emojis on emojis click 1`] = `
 </Modal>
 `;
 
-exports[`comoponents/EditPostModal should show errors when it is set in the state 1`] = `
+exports[`components/EditPostModal should show errors when it is set in the state 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -517,7 +513,6 @@ exports[`comoponents/EditPostModal should show errors when it is set in the stat
       "remove": [Function],
     }
   }
-  onEnter={[Function]}
   onEntered={[Function]}
   onExit={[Function]}
   onExited={[Function]}

--- a/tests/redux/actions/posts.test.js
+++ b/tests/redux/actions/posts.test.js
@@ -14,23 +14,41 @@ describe('Actions.Posts', () => {
 
     it('setEditingPost', async () => {
         await Actions.setEditingPost('123', 0, 'test', 'title')(store.dispatch, store.getState);
+
         assert.deepEqual(
             store.getState().views.posts.editingPost,
             {
                 postId: '123',
                 commentsCount: 0,
                 refocusId: 'test',
+                show: true,
                 title: 'title'
             }
         );
+
         await Actions.setEditingPost('456', 3, 'test2', 'title2')(store.dispatch, store.getState);
+
         assert.deepEqual(
             store.getState().views.posts.editingPost,
             {
                 postId: '456',
                 commentsCount: 3,
                 refocusId: 'test2',
+                show: true,
                 title: 'title2'
+            }
+        );
+    });
+
+    it('hideEditPostModal', async () => {
+        await Actions.setEditingPost('123', 0, 'test', 'title')(store.dispatch, store.getState);
+
+        await store.dispatch(Actions.hideEditPostModal(), store.getState);
+
+        assert.deepEqual(
+            store.getState().views.posts.editingPost,
+            {
+                show: false
             }
         );
     });

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -101,7 +101,6 @@ export const ActionTypes = keyMirror({
     RECEIVED_FOCUSED_POST: null,
     RECEIVED_POST: null,
     RECEIVED_EDIT_POST: null,
-    SET_EDITING_POST: null,
     EDIT_POST: null,
     SELECT_POST: null,
     RECEIVED_POST_SELECTED: null,
@@ -214,6 +213,8 @@ export const ActionTypes = keyMirror({
     TOGGLE_CHANNEL_PURPOSE_UPDATE_MODAL: null,
     TOGGLE_CHANNEL_NAME_UPDATE_MODAL: null,
     TOGGLE_LEAVE_PRIVATE_CHANNEL_MODAL: null,
+    SHOW_EDIT_POST_MODAL: null,
+    HIDE_EDIT_POST_MODAL: null,
 
     SUGGESTION_PRETEXT_CHANGED: null,
     SUGGESTION_RECEIVED_SUGGESTIONS: null,


### PR DESCRIPTION
This is an improvement to typing in languages that allow character composition on IE since it would frequently miss letters before when typing quickly. As a particularly bad example, this is what it looks like using a keyboard macro to type "한글이 찰 입력되는지 테스트" ("test Hangul input") into the channel switcher on pre-release
![prerelease-channel-switch-slow](https://user-images.githubusercontent.com/3277310/35046944-7b93a50a-fb66-11e7-99eb-8a8f1f0815f6.gif)
And this is on my local instance with the fixes applied
![local-channel-switch-slow](https://user-images.githubusercontent.com/3277310/35046985-96dbbfaa-fb66-11e7-99a8-7fd54b56034a.gif)

The big change here is that the post textboxes, the edit post modal, the channel switcher, and the channel/user lists in the web app will now use a new QuickInput component that manually updates the value of the `<input/>` instead of passing in a `value` prop. I also had to make some changes to the AutosizeTextarea and EditPostModal to make this work.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8478

#### Checklist
- Has UI changes
- Touches critical sections of the codebase (auth, posting, etc.)
