### PR TITLE
ABC-95 Don't load all custom emojis a second time on page load

### DIFF
--- a/components/logged_in.jsx
+++ b/components/logged_in.jsx
@@ -106,11 +106,6 @@ export default class LoggedIn extends React.Component {
                 e.preventDefault();
             }
         });
-
-        // Get custom emoji from the server
-        if (window.mm_config.EnableCustomEmoji === 'true') {
-            loadEmoji(false);
-        }
     }
 
     componentWillUnmount() {

--- a/components/logged_in.jsx
+++ b/components/logged_in.jsx
@@ -6,7 +6,6 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {loadEmoji} from 'actions/emoji_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import * as WebSocketActions from 'actions/websocket_actions.jsx';
 import 'stores/emoji_store.jsx';


### PR DESCRIPTION
#### Summary
Don't load all custom emojis a second time on page load.

They were already being fetched by [mattermost-redux's loadMe action](https://github.com/mattermost/mattermost-redux/blob/master/src/actions/users.js#L220) which gets called by the [webapp on first load](https://github.com/mattermost/mattermost-webapp/blob/master/root.jsx#L66)

#### Ticket Link
Start of https://mattermost.atlassian.net/browse/ABC-95