### PR TITLE
Disable pull-to-refresh on Android(Chrome)

### DIFF
--- a/sass/base/_structure.scss
+++ b/sass/base/_structure.scss
@@ -13,6 +13,7 @@ body {
     background: $bg--gray;
     position: relative;
     width: 100%;
+    overflow: hidden;
 
     &.error-bar--fixed {
         padding-top: 22px;


### PR DESCRIPTION
Rebased version of #482

#### Summary
When scrolling channel history `Load more messages` button appears, but inertial scroll activates pull-to-refresh feature and page is fully reloaded. This PR disables pull-to-refresh feature to prevent unwanted page refresh

#### Ticket Link
N/A

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
