### PR TITLE
Quick fix: JS error on showPublicLink of ViewImagePopoverBar

### DIFF
--- a/components/view_image_popover_bar.jsx
+++ b/components/view_image_popover_bar.jsx
@@ -38,7 +38,7 @@ export default class ViewImagePopoverBar extends React.PureComponent {
         /**
          * Set whether to show "Get Public Link"
          */
-        showPublicLink: PropTypes.func,
+        showPublicLink: PropTypes.bool,
 
         /**
          * Function to call when click on "Get Public Link"


### PR DESCRIPTION
#### Summary
Quick fix: JS error on showPublicLink of ViewImagePopoverBar

![image pasted at 2018-1-18 11-15](https://user-images.githubusercontent.com/5334504/35104061-b3816c3a-fca2-11e7-9da4-9c56e09d67f0.png)


#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
