### PR TITLE
[PLT-8535] Fix CTRL/CMD+UP on RHS by updating state.draft when new prop is received

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -156,6 +156,10 @@ export default class CreateComment extends React.PureComponent {
         if (newProps.rootId !== this.props.rootId) {
             this.setState({draft: {...newProps.draft, uploadsInProgress: []}});
         }
+
+        if (!Utils.areObjectsEqual(this.props.draft, newProps.draft)) {
+            this.setState({draft: newProps.draft});
+        }
     }
 
     componentDidUpdate(prevProps, prevState) {

--- a/tests/components/create_comment/create_comment.test.jsx
+++ b/tests/components/create_comment/create_comment.test.jsx
@@ -487,4 +487,38 @@ describe('components/CreateComment', () => {
         );
         expect(wrapper.state().draft.uploadsInProgress).toEqual([4, 6]);
     });
+
+    test('should match draft state on componentWillReceiveProps with new draft', () => {
+        const draft = {
+            message: 'Test message',
+            uploadsInProgress: [],
+            fileInfos: [{}, {}, {}]
+        };
+
+        const wrapper = shallow(
+            <CreateComment {...baseProps}/>
+        );
+        expect(wrapper.state('draft')).toEqual(draft);
+
+        const newDraft = {...draft, message: 'Test message edited'};
+        wrapper.setProps({draft: newDraft});
+        expect(wrapper.state('draft')).toEqual(newDraft);
+    });
+
+    test('should match draft state on componentWillReceiveProps with new rootId', () => {
+        const draft = {
+            message: 'Test message',
+            uploadsInProgress: [4, 5, 6],
+            fileInfos: [{id: 1}, {id: 2}, {id: 3}]
+        };
+
+        const wrapper = shallow(
+            <CreateComment {...baseProps}/>
+        );
+        wrapper.setState({draft});
+        expect(wrapper.state('draft')).toEqual(draft);
+
+        wrapper.setProps({rootId: 'new_root_id'});
+        expect(wrapper.state('draft')).toEqual({...draft, uploadsInProgress: [], fileInfos: [{}, {}, {}]});
+    });
 });


### PR DESCRIPTION
#### Summary
Fix CTRL/CMD+UP on RHS by updating state.draft when new prop is received

#### Ticket Link
Jira ticket: [PLT-8535](https://mattermost.atlassian.net/browse/PLT-8535)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
