### PR TITLE
More robust sidebar rendering

### DIFF
--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -17,7 +17,7 @@ import SidebarChannel from './sidebar_channel.jsx';
 
 function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
-    const channel = getChannel(state, ownProps.channelId);
+    const channel = getChannel(state, ownProps.channelId) || {};
     const tutorialStep = getPreference(state, Constants.Preferences.TUTORIAL_STEP, ownProps.currentUserId, 999);
     const channelsByName = getChannelsNameMapInCurrentTeam(state);
     const memberIds = getUserIdsInChannels(state);

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -174,6 +174,9 @@ export default class SidebarChannel extends React.PureComponent {
     }
 
     render = () => {
+        if (!this.props.channelDisplayName || !this.props.channelType) {
+            return null;
+        }
         let closeHandler = null;
         if (this.props.channelType === Constants.DM_CHANNEL || this.props.channelType === Constants.GM_CHANNEL) {
             closeHandler = this.handleLeaveDirectChannel;


### PR DESCRIPTION
#### Summary
Add some checks for render the sidebar channels only if it is possible to render it (not loaded channels do not fail).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed