### PR TITLE
Fix for edit Header modal

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -234,6 +234,10 @@ export default class ChannelHeader extends React.Component {
         this.setState({showEditChannelHeaderModal: false});
     }
 
+    showEditChannelHeaderModal = () => {
+        this.setState({showEditChannelHeaderModal: true});
+    }
+
     handleWebRTCOnClick = (e) => {
         e.preventDefault();
         const dmUserId = this.props.dmUser.id;
@@ -819,7 +823,7 @@ export default class ChannelHeader extends React.Component {
                 editMessage = (
                     <button
                         className='style--none'
-                        onClick={this.showEditChannelPurposeModal}
+                        onClick={this.showEditChannelHeaderModal}
                     >
                         <FormattedMessage
                             id='channel_header.addChannelHeader'


### PR DESCRIPTION
#### Summary
Click on channel description` opens Edit Header instead of edit purpose

#### Ticket Link
[PLT-8599](https://mattermost.atlassian.net/browse/PLT-8599)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
