### PR TITLE
PLT-8551: Remove size requirement from profile picture setting help text

### DIFF
--- a/components/setting_picture.jsx
+++ b/components/setting_picture.jsx
@@ -184,7 +184,7 @@ export default class SettingPicture extends Component {
                         <li className='setting-list-item padding-top x2'>
                             <FormattedMessage
                                 id='setting_picture.help'
-                                defaultMessage='Upload a profile picture in BMP, JPG, JPEG or PNG format, at least {width}px in width and {height}px height.'
+                                defaultMessage='Upload a profile picture in BMP, JPG, JPEG or PNG format.'
                                 values={{
                                     width: Constants.PROFILE_WIDTH,
                                     height: Constants.PROFILE_WIDTH

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2374,7 +2374,7 @@
   "setting_item_max.save": "Save",
   "setting_item_min.edit": "Edit",
   "setting_picture.cancel": "Cancel",
-  "setting_picture.help": "Upload a profile picture in BMP, JPG, JPEG or PNG format, at least {width}px in width and {height}px height.",
+  "setting_picture.help": "Upload a profile picture in BMP, JPG, JPEG or PNG format.",
   "setting_picture.save": "Save",
   "setting_picture.select": "Select",
   "setting_upload.import": "Import",


### PR DESCRIPTION
#### Summary
We don't enforce a minimum profile picture size, so remove the requirement from the setting help text

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8551

#### Checklist
- [X] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
