### PR TITLE
PTL-8486 only add slash when required

### DIFF
--- a/components/admin_console/saml_settings.jsx
+++ b/components/admin_console/saml_settings.jsx
@@ -56,7 +56,8 @@ export default class SamlSettings extends AdminSettings {
         const siteUrl = config.ServiceSettings.SiteURL;
         let consumerServiceUrl = settings.AssertionConsumerServiceURL;
         if (siteUrl.length > 0 && consumerServiceUrl.length === 0) {
-            consumerServiceUrl = siteUrl + '/login/sso/saml';
+            const addSlashIfNeeded = siteUrl[siteUrl.length - 1] === '/' ? '' : '/';
+            consumerServiceUrl = `${siteUrl}${addSlashIfNeeded}login/sso/saml`;
         }
 
         return {


### PR DESCRIPTION
#### Summary
consumerServiceUrl was showing two / when the Site Url is written with trailing slash]

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8486

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)