### PR TITLE
XYZ-23: Use advanced permissions behind policy page.

### DIFF
--- a/components/admin_console/policy_settings/index.jsx
+++ b/components/admin_console/policy_settings/index.jsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {loadRolesIfNeeded, editRole} from 'mattermost-redux/actions/roles';
+
+import {getRoles} from 'mattermost-redux/selectors/entities/roles';
+
+import PolicySettings from './policy_settings.jsx';
+
+function mapStateToProps(state) {
+    return {
+        roles: getRoles(state),
+        rolesRequest: state.requests.roles.getRolesByNames
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            loadRolesIfNeeded,
+            editRole
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PolicySettings);

--- a/components/admin_console/policy_settings/policy_settings.jsx
+++ b/components/admin_console/policy_settings/policy_settings.jsx
@@ -2,63 +2,138 @@
 // See License.txt for license information.
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
+
+import {RequestStatus} from 'mattermost-redux/constants';
 
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-import AdminSettings from './admin_settings.jsx';
-import BooleanSetting from './boolean_setting.jsx';
-import ColorSetting from './color_setting.jsx';
-import DropdownSetting from './dropdown_setting.jsx';
-import PostEditSetting from './post_edit_setting.jsx';
-import RadioSetting from './radio_setting.jsx';
-import SettingsGroup from './settings_group.jsx';
-import TextSetting from './text_setting.jsx';
+import AdminSettings from '../admin_settings.jsx';
+import BooleanSetting from '../boolean_setting.jsx';
+import ColorSetting from '../color_setting.jsx';
+import DropdownSetting from '../dropdown_setting.jsx';
+import PostEditSetting from '../post_edit_setting.jsx';
+import RadioSetting from '../radio_setting.jsx';
+import SettingsGroup from '../settings_group.jsx';
+import TextSetting from '../text_setting.jsx';
+
+import {rolesFromMapping, mappingValueFromRoles} from 'utils/policy_roles_adapter';
+
+import LoadingScreen from 'components/loading_screen.jsx';
 
 export default class PolicySettings extends AdminSettings {
+    static propTypes = {
+        actions: PropTypes.shape({
+            loadRolesIfNeeded: PropTypes.func.isRequired,
+            editRole: PropTypes.func.isRequired
+        }).isRequired
+    };
+
     constructor(props) {
         super(props);
 
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
+
+        this.roleBasedPolicies = {
+            allowEditPost: '',
+            restrictPostDelete: '',
+            restrictTeamInvite: '',
+            restrictPublicChannelCreation: '',
+            restrictPrivateChannelCreation: '',
+            restrictPublicChannelManagement: '',
+            restrictPrivateChannelManagement: '',
+            restrictPublicChannelDeletion: '',
+            restrictPrivateChannelDeletion: '',
+            restrictPrivateChannelManageMembers: ''
+        };
+
+        this.state = {
+            ...this.state, // Brings the state in from the parent class.
+            ...this.roleBasedPolicies,
+            loaded: false
+        };
     }
 
+    loadPoliciesIntoState(props) {
+        if (props.rolesRequest.status === RequestStatus.SUCCESS) {
+            const {roles} = props;
+
+            Object.entries(this.roleBasedPolicies).forEach(([key]) => {
+                this.roleBasedPolicies[key] = mappingValueFromRoles(key, roles);
+            });
+
+            // Adjustment to allowEditPost policy because the roles mapping is the same for 'always' and 'time_limit'
+            if (this.roleBasedPolicies.allowEditPost === Constants.ALLOW_EDIT_POST_ALWAYS && this.state.postEditTimeLimit) {
+                this.roleBasedPolicies.allowEditPost = Constants.ALLOW_EDIT_POST_TIME_LIMIT;
+            }
+
+            this.setState({...this.roleBasedPolicies, loaded: true});
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        // if statement prevents over-invoking every time any props change.
+        if (nextProps.rolesRequest.status === RequestStatus.SUCCESS && this.props.rolesRequest.status !== RequestStatus.SUCCESS) {
+            this.loadPoliciesIntoState(nextProps);
+        }
+    }
+
+    componentWillMount() {
+        this.props.actions.loadRolesIfNeeded(['channel_user', 'team_user', 'channel_admin', 'team_admin', 'system_admin']).then(() => {
+            this.loadPoliciesIntoState(this.props);
+        });
+    }
+
+    handleSubmit = async (e) => {
+        e.preventDefault();
+
+        const stateForAdapter = {...this.state};
+        if (this.state.allowEditPost === Constants.ALLOW_EDIT_POST_TIME_LIMIT) {
+            stateForAdapter.allowEditPost = Constants.ALLOW_EDIT_POST_ALWAYS;
+        } else {
+            // Clear the value if it's not being used in combination with the radio
+            // post time limit radio button. Clearing this is required to derive the
+            // correct policy.
+            this.setState({postEditTimeLimit: null});
+        }
+
+        const updatedRoles = rolesFromMapping(stateForAdapter, this.props.roles);
+        let success = true;
+
+        await Promise.all(Object.values(updatedRoles).map(async (item) => {
+            try {
+                await this.props.actions.editRole(item);
+            } catch (err) {
+                success = false;
+                this.setState({
+                    saving: false,
+                    serverError: err.message
+                });
+            }
+        }));
+
+        if (success) {
+            this.doSubmit();
+        }
+    };
+
     getConfigFromState(config) {
-        config.ServiceSettings.RestrictPostDelete = this.state.restrictPostDelete;
-        config.ServiceSettings.AllowEditPost = this.state.allowEditPost;
-        config.ServiceSettings.PostEditTimeLimit = this.parseIntNonZero(this.state.postEditTimeLimit, Constants.DEFAULT_POST_EDIT_TIME_LIMIT);
-        config.TeamSettings.RestrictTeamInvite = this.state.restrictTeamInvite;
-        config.TeamSettings.RestrictPublicChannelCreation = this.state.restrictPublicChannelCreation;
-        config.TeamSettings.RestrictPrivateChannelCreation = this.state.restrictPrivateChannelCreation;
-        config.TeamSettings.RestrictPublicChannelManagement = this.state.restrictPublicChannelManagement;
-        config.TeamSettings.RestrictPrivateChannelManagement = this.state.restrictPrivateChannelManagement;
-        config.TeamSettings.RestrictPublicChannelDeletion = this.state.restrictPublicChannelDeletion;
-        config.TeamSettings.RestrictPrivateChannelDeletion = this.state.restrictPrivateChannelDeletion;
-        config.TeamSettings.RestrictPrivateChannelManageMembers = this.state.restrictPrivateChannelManageMembers;
+        config.ServiceSettings.PostEditTimeLimit = this.state.postEditTimeLimit ? this.parseIntNonZero(this.state.postEditTimeLimit, Constants.UNSET_POST_EDIT_TIME_LIMIT) : Constants.UNSET_POST_EDIT_TIME_LIMIT;
         config.AnnouncementSettings.EnableBanner = this.state.enableBanner;
         config.AnnouncementSettings.BannerText = this.state.bannerText;
         config.AnnouncementSettings.BannerColor = this.state.bannerColor;
         config.AnnouncementSettings.BannerTextColor = this.state.bannerTextColor;
         config.AnnouncementSettings.AllowBannerDismissal = this.state.allowBannerDismissal;
-
         return config;
     }
 
     getStateFromConfig(config) {
         return {
-            restrictPostDelete: config.ServiceSettings.RestrictPostDelete,
-            allowEditPost: config.ServiceSettings.AllowEditPost,
-            postEditTimeLimit: config.ServiceSettings.PostEditTimeLimit,
-            restrictTeamInvite: config.TeamSettings.RestrictTeamInvite,
-            restrictPublicChannelCreation: config.TeamSettings.RestrictPublicChannelCreation,
-            restrictPrivateChannelCreation: config.TeamSettings.RestrictPrivateChannelCreation,
-            restrictPublicChannelManagement: config.TeamSettings.RestrictPublicChannelManagement,
-            restrictPrivateChannelManagement: config.TeamSettings.RestrictPrivateChannelManagement,
-            restrictPublicChannelDeletion: config.TeamSettings.RestrictPublicChannelDeletion,
-            restrictPrivateChannelDeletion: config.TeamSettings.RestrictPrivateChannelDeletion,
-            restrictPrivateChannelManageMembers: config.TeamSettings.RestrictPrivateChannelManageMembers,
+            postEditTimeLimit: config.ServiceSettings.PostEditTimeLimit === Constants.UNSET_POST_EDIT_TIME_LIMIT ? null : config.ServiceSettings.PostEditTimeLimit,
             enableBanner: config.AnnouncementSettings.EnableBanner,
             bannerText: config.AnnouncementSettings.BannerText,
             bannerColor: config.AnnouncementSettings.BannerColor,
@@ -77,6 +152,9 @@ export default class PolicySettings extends AdminSettings {
     }
 
     renderSettings() {
+        if (!this.state.loaded) {
+            return <LoadingScreen/>;
+        }
         return (
             <SettingsGroup>
                 <DropdownSetting

--- a/components/admin_console/post_edit_setting.jsx
+++ b/components/admin_console/post_edit_setting.jsx
@@ -70,7 +70,7 @@ export default class PostEditSetting extends React.Component {
                         />
                         <input
                             type='text'
-                            value={this.props.timeLimitValue}
+                            value={this.props.timeLimitValue || ''}
                             className='form-control'
                             name={this.props.timeLimitId}
                             onChange={this.handleTimeLimitChange}
@@ -93,7 +93,7 @@ PostEditSetting.propTypes = {
     timeLimitId: PropTypes.string.isRequired,
     label: PropTypes.node.isRequired,
     value: PropTypes.string.isRequired,
-    timeLimitValue: PropTypes.number.isRequired,
+    timeLimitValue: PropTypes.number,
     onChange: PropTypes.func.isRequired,
     disabled: PropTypes.bool,
     helpText: PropTypes.node

--- a/components/admin_console/radio_setting.jsx
+++ b/components/admin_console/radio_setting.jsx
@@ -21,7 +21,10 @@ export default class RadioSetting extends React.Component {
         const options = [];
         for (const {value, text} of this.props.values) {
             options.push(
-                <div className='radio'>
+                <div
+                    className='radio'
+                    key={value}
+                >
                     <label>
                         <input
                             type='radio'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "localforage": "1.5.3",
     "localforage-observable": "1.4.0",
     "marked": "mattermost/marked#802e981ade71149a497cbe79d12b8a3f82f7657e",
-    "mattermost-redux": "mattermost/mattermost-redux#c30ae69432a3ce7d73ba6e36cbe4f02e805ecc0c",
+    "mattermost-redux": "mattermost/mattermost-redux#XYZ-21",
     "pdfjs-dist": "2.0.106",
     "perfect-scrollbar": "0.8.1",
     "prop-types": "15.6.0",

--- a/routes/route_admin_console.jsx
+++ b/routes/route_admin_console.jsx
@@ -38,7 +38,7 @@ import PasswordSettings from 'components/admin_console/password_settings.jsx';
 import PluginSettings from 'components/admin_console/plugin_settings.jsx';
 import PluginManagement from 'components/admin_console/plugin_management';
 import CustomPluginSettings from 'components/admin_console/custom_plugin_settings';
-import PolicySettings from 'components/admin_console/policy_settings.jsx';
+import PolicySettings from 'components/admin_console/policy_settings';
 import PrivacySettings from 'components/admin_console/privacy_settings.jsx';
 import PublicLinkSettings from 'components/admin_console/public_link_settings.jsx';
 import PushSettings from 'components/admin_console/push_settings.jsx';

--- a/tests/utils/policy_roles_adapter.test.jsx
+++ b/tests/utils/policy_roles_adapter.test.jsx
@@ -1,0 +1,307 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {Permissions} from 'mattermost-redux/constants/index';
+
+import {rolesFromMapping, mappingValueFromRoles} from 'utils/policy_roles_adapter';
+
+describe('PolicyRolesAdapter', function() {
+    let roles = {};
+    let policies = {};
+
+    beforeEach(() => {
+        roles = {
+            channel_user: {
+                name: 'channel_user',
+                permissions: [
+                    Permissions.EDIT_POST,
+                    Permissions.DELETE_POST,
+                    Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES,
+                    Permissions.DELETE_PUBLIC_CHANNEL,
+                    Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES,
+                    Permissions.MANAGE_PRIVATE_CHANNEL_MEMBERS,
+                    Permissions.DELETE_PRIVATE_CHANNEL
+                ]
+            },
+            team_user: {
+                name: 'team_user',
+                permissions: [
+                    Permissions.DELETE_PUBLIC_CHANNEL,
+                    Permissions.INVITE_USER,
+                    Permissions.CREATE_PUBLIC_CHANNEL,
+                    Permissions.CREATE_PRIVATE_CHANNEL
+                ]
+            },
+            channel_admin: {
+                name: 'channel_admin',
+                permissions: [
+                    Permissions.MANAGE_CHANNEL_ROLES
+                ]
+            },
+            team_admin: {
+                name: 'team_admin',
+                permissions: [
+                    Permissions.DELETE_POST,
+                    Permissions.DELETE_OTHERS_POSTS
+                ]
+            },
+            system_admin: {
+                name: 'system_admin',
+                permissions: [
+                    Permissions.DELETE_PUBLIC_CHANNEL,
+                    Permissions.INVITE_USER,
+                    Permissions.DELETE_POST,
+                    Permissions.DELETE_OTHERS_POSTS,
+                    Permissions.EDIT_POST
+                ]
+            }
+        };
+        const teamPolicies = {
+            restrictTeamInvite: 'all',
+            restrictPublicChannelCreation: 'all',
+            restrictPrivateChannelCreation: 'all'
+        };
+        const channelPolicies = {
+            restrictPublicChannelManagement: 'all',
+            restrictPublicChannelDeletion: 'all',
+            restrictPrivateChannelManagement: 'all',
+            restrictPrivateChannelManageMembers: 'all',
+            restrictPrivateChannelDeletion: 'all'
+        };
+        const restrictPostDelete = 'all';
+        const allowEditPost = 'always';
+        policies = {
+            ...teamPolicies,
+            ...channelPolicies,
+            restrictPostDelete,
+            allowEditPost
+        };
+    });
+
+    afterEach(() => {
+        roles = {};
+    });
+
+    describe('PolicyRolesAdapter.rolesFromMapping', function() {
+        test('unknown value throws an exception', function() {
+            policies.restrictTeamInvite = 'sometimesmaybe';
+            expect(() => {
+                rolesFromMapping(policies, roles);
+            }).toThrowError(/not present in mapping/i);
+        });
+
+        // // That way you can pass in the whole state if you want.
+        test('ignores unknown keys', function() {
+            policies.blah = 'all';
+            expect(() => {
+                rolesFromMapping(policies, roles);
+            }).not.toThrowError();
+        });
+
+        test('mock data setup', function() {
+            const updatedRoles = rolesFromMapping(policies, roles);
+            expect(Object.values(updatedRoles).length).toEqual(0);
+        });
+
+        describe('teamPolicies', function() {
+            test('all', function() {
+                roles.team_user.permissions = [];
+                const updatedRoles = rolesFromMapping({restrictTeamInvite: 'all'}, roles);
+                expect(Object.values(updatedRoles).length).toEqual(1);
+                expect(updatedRoles.team_user.permissions).toEqual(expect.arrayContaining([Permissions.INVITE_USER]));
+            });
+
+            test('team_admin', function() {
+                const updatedRoles = rolesFromMapping({restrictTeamInvite: 'team_admin'}, roles);
+                expect(Object.values(updatedRoles).length).toEqual(2);
+                expect(updatedRoles.team_user.permissions).not.toEqual(expect.arrayContaining([Permissions.INVITE_USER]));
+                expect(updatedRoles.team_admin.permissions).toEqual(expect.arrayContaining([Permissions.INVITE_USER]));
+            });
+
+            test('system_admin', function() {
+                roles.team_admin.permissions.push(Permissions.INVITE_USER);
+                const updatedRoles = rolesFromMapping({restrictTeamInvite: 'system_admin'}, roles);
+                expect(Object.values(updatedRoles).length).toEqual(2);
+                expect(updatedRoles.team_user.permissions).not.toEqual(expect.arrayContaining([Permissions.INVITE_USER]));
+                expect(updatedRoles.team_admin.permissions).not.toEqual(expect.arrayContaining([Permissions.INVITE_USER]));
+            });
+        });
+
+        describe('channelPolicies', function() {
+            test('all', function() {
+                roles.channel_user.permissions = [];
+                const updatedRoles = rolesFromMapping({restrictPublicChannelManagement: 'all'}, roles);
+                expect(Object.values(updatedRoles).length).toEqual(1);
+                expect(updatedRoles.channel_user.permissions).toEqual(expect.arrayContaining([Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]));
+            });
+
+            test('channel_admin', function() {
+                const updatedRoles = rolesFromMapping({restrictPublicChannelManagement: 'channel_admin'}, roles);
+                expect(Object.values(updatedRoles).length).toEqual(3);
+                expect(updatedRoles.channel_user.permissions).not.toEqual(expect.arrayContaining([Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]));
+                expect(updatedRoles.channel_admin.permissions).toEqual(expect.arrayContaining([Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]));
+                expect(updatedRoles.team_admin.permissions).toEqual(expect.arrayContaining([Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]));
+            });
+
+            test('team_admin', function() {
+                const updatedRoles = rolesFromMapping({restrictPublicChannelManagement: 'team_admin'}, roles);
+                expect(Object.values(updatedRoles).length).toEqual(2);
+                expect(updatedRoles.channel_user.permissions).not.toEqual(expect.arrayContaining([Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]));
+                expect(updatedRoles.team_admin.permissions).toEqual(expect.arrayContaining([Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]));
+            });
+
+            test('system_admin', function() {
+                roles.team_admin.permissions.push(Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES);
+                const updatedRoles = rolesFromMapping({restrictPublicChannelManagement: 'system_admin'}, roles);
+                expect(Object.values(updatedRoles).length).toEqual(2);
+                expect(updatedRoles.channel_user.permissions).not.toEqual(expect.arrayContaining([Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]));
+                expect(updatedRoles.team_admin.permissions).not.toEqual(expect.arrayContaining([Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]));
+            });
+        });
+
+        test('restrictPostDelete updates expected permissions', function() {
+            policies.restrictPostDelete = 'team_admin';
+            let updatedRoles = rolesFromMapping(policies, roles);
+            expect(updatedRoles.channel_user.permissions).not.toEqual(expect.arrayContaining([Permissions.DELETE_POST]));
+            expect(updatedRoles.channel_user.permissions).not.toEqual(expect.arrayContaining([Permissions.DELETE_OTHERS_POSTS]));
+
+            policies.restrictPostDelete = 'system_admin';
+            updatedRoles = rolesFromMapping(policies, roles);
+            expect(updatedRoles.channel_user.permissions).not.toEqual(expect.arrayContaining([Permissions.DELETE_POST]));
+            expect(updatedRoles.channel_user.permissions).not.toEqual(expect.arrayContaining([Permissions.DELETE_OTHERS_POSTS]));
+
+            expect(updatedRoles.team_admin.permissions).not.toEqual(expect.arrayContaining([Permissions.DELETE_POST]));
+            expect(updatedRoles.team_admin.permissions).not.toEqual(expect.arrayContaining([Permissions.DELETE_OTHERS_POSTS]));
+        });
+
+        test('allowEditPost updates expected permissions', function() {
+            policies.allowEditPost = 'never';
+            const updatedRoles = rolesFromMapping(policies, roles);
+            expect(updatedRoles.channel_user.permissions).not.toEqual(expect.arrayContaining([Permissions.EDIT_POST]));
+        });
+
+        test('it only returns the updated roles', function() {
+            const updatedRoles = rolesFromMapping(policies, roles);
+            expect(Object.keys(updatedRoles).length).toEqual(0);
+        });
+    });
+
+    describe('PolicyRolesAdapter.mappingValueFromRoles', function() {
+        describe('team-based', function() {
+            test('returns the expected policy value for a team-based policy', function() {
+                addPermissionToRole(Permissions.INVITE_USER, roles.team_user);
+                let value = mappingValueFromRoles('restrictTeamInvite', roles);
+                expect(value).toEqual('all');
+
+                removePermissionFromRole(Permissions.INVITE_USER, roles.team_user);
+                addPermissionToRole(Permissions.INVITE_USER, roles.team_admin);
+                value = mappingValueFromRoles('restrictTeamInvite', roles);
+                expect(value).toEqual('team_admin');
+
+                removePermissionFromRole(Permissions.INVITE_USER, roles.team_user);
+                removePermissionFromRole(Permissions.INVITE_USER, roles.team_admin);
+                value = mappingValueFromRoles('restrictTeamInvite', roles);
+                expect(value).toEqual('system_admin');
+            });
+        });
+
+        describe('channel-based', function() {
+            test('returns the expected policy value for a team-based policy', function() {
+                addPermissionToRole(Permissions.DELETE_PUBLIC_CHANNEL, roles.channel_user);
+                let value = mappingValueFromRoles('restrictPublicChannelDeletion', roles);
+                expect(value).toEqual('all');
+
+                removePermissionFromRole(Permissions.DELETE_PUBLIC_CHANNEL, roles.channel_user);
+                addPermissionToRole(Permissions.DELETE_PUBLIC_CHANNEL, roles.channel_admin);
+                addPermissionToRole(Permissions.DELETE_PUBLIC_CHANNEL, roles.team_admin);
+                value = mappingValueFromRoles('restrictPublicChannelDeletion', roles);
+                expect(value).toEqual('channel_admin');
+
+                removePermissionFromRole(Permissions.DELETE_PUBLIC_CHANNEL, roles.channel_user);
+                removePermissionFromRole(Permissions.DELETE_PUBLIC_CHANNEL, roles.channel_admin);
+                addPermissionToRole(Permissions.DELETE_PUBLIC_CHANNEL, roles.team_admin);
+                value = mappingValueFromRoles('restrictPublicChannelDeletion', roles);
+                expect(value).toEqual('team_admin');
+
+                removePermissionFromRole(Permissions.DELETE_PUBLIC_CHANNEL, roles.channel_user);
+                removePermissionFromRole(Permissions.DELETE_PUBLIC_CHANNEL, roles.channel_admin);
+                removePermissionFromRole(Permissions.DELETE_PUBLIC_CHANNEL, roles.team_admin);
+                value = mappingValueFromRoles('restrictPublicChannelDeletion', roles);
+                expect(value).toEqual('system_admin');
+            });
+        });
+
+        describe('allowEditPost', function() {
+            test('returns the expected policy value for a team-based policy', function() {
+                addPermissionToRole(Permissions.EDIT_POST, roles.channel_user);
+                addPermissionToRole(Permissions.EDIT_POST, roles.system_admin);
+                let value = mappingValueFromRoles('allowEditPost', roles);
+                expect(value).toEqual('always');
+
+                removePermissionFromRole(Permissions.EDIT_POST, roles.channel_user);
+                removePermissionFromRole(Permissions.EDIT_POST, roles.system_admin);
+                value = mappingValueFromRoles('allowEditPost', roles);
+                expect(value).toEqual('never');
+            });
+        });
+
+        describe('restrictPostDelete', function() {
+            test('returns the expected policy value for a team-based policy', function() {
+                addPermissionToRole(Permissions.DELETE_POST, roles.channel_user);
+                removePermissionFromRole(Permissions.DELETE_POST, roles.channel_admin);
+                removePermissionFromRole(Permissions.DELETE_OTHERS_POSTS, roles.channel_admin);
+                addPermissionToRole(Permissions.DELETE_POST, roles.team_admin);
+                addPermissionToRole(Permissions.DELETE_OTHERS_POSTS, roles.team_admin);
+                let value = mappingValueFromRoles('restrictPostDelete', roles);
+                expect(value).toEqual('all');
+
+                removePermissionFromRole(Permissions.DELETE_POST, roles.channel_user);
+                removePermissionFromRole(Permissions.DELETE_POST, roles.channel_admin);
+                removePermissionFromRole(Permissions.DELETE_OTHERS_POSTS, roles.channel_admin);
+                addPermissionToRole(Permissions.DELETE_POST, roles.team_admin);
+                addPermissionToRole(Permissions.DELETE_OTHERS_POSTS, roles.team_admin);
+                value = mappingValueFromRoles('restrictPostDelete', roles);
+                expect(value).toEqual('team_admin');
+
+                removePermissionFromRole(Permissions.DELETE_POST, roles.channel_user);
+                removePermissionFromRole(Permissions.DELETE_POST, roles.channel_admin);
+                removePermissionFromRole(Permissions.DELETE_OTHERS_POSTS, roles.channel_admin);
+                removePermissionFromRole(Permissions.DELETE_POST, roles.team_admin);
+                removePermissionFromRole(Permissions.DELETE_OTHERS_POSTS, roles.team_admin);
+                value = mappingValueFromRoles('restrictPostDelete', roles);
+                expect(value).toEqual('system_admin');
+            });
+        });
+
+        test('unmet roles condtion throws an exception', function() {
+            addPermissionToRole(Permissions.DELETE_POST, roles.channel_user);
+            addPermissionToRole(Permissions.DELETE_POST, roles.channel_admin);
+            addPermissionToRole(Permissions.DELETE_OTHERS_POSTS, roles.channel_admin);
+            removePermissionFromRole(Permissions.DELETE_POST, roles.team_admin);
+            removePermissionFromRole(Permissions.DELETE_OTHERS_POSTS, roles.team_admin);
+            expect(() => {
+                mappingValueFromRoles('restrictPostDelete', roles);
+            }).toThrowError(/no matching mapping value/i);
+        });
+
+        test('ignores unknown keys', function() {
+            policies.blah = 'all';
+            expect(() => {
+                mappingValueFromRoles('nonExistent', roles);
+            }).toThrowError(/no matching mapping value/i);
+        });
+    });
+});
+
+function addPermissionToRole(permission, role) {
+    if (!role.permissions.includes(permission)) {
+        role.permissions.push(permission);
+    }
+}
+
+function removePermissionFromRole(permission, role) {
+    const permissionIndex = role.permissions.indexOf(permission);
+    if (permissionIndex !== -1) {
+        role.permissions.splice(permissionIndex, 1);
+    }
+}

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1050,7 +1050,7 @@ export const Constants = {
     ALLOW_EDIT_POST_ALWAYS: 'always',
     ALLOW_EDIT_POST_NEVER: 'never',
     ALLOW_EDIT_POST_TIME_LIMIT: 'time_limit',
-    DEFAULT_POST_EDIT_TIME_LIMIT: 300,
+    UNSET_POST_EDIT_TIME_LIMIT: -1,
     MENTION_CHANNELS: 'mention.channels',
     MENTION_MORE_CHANNELS: 'mention.morechannels',
     MENTION_MEMBERS: 'mention.members',

--- a/utils/policy_roles_adapter.js
+++ b/utils/policy_roles_adapter.js
@@ -1,0 +1,217 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {Permissions} from 'mattermost-redux/constants/index';
+
+function teamMapping(permission) {
+    return {
+        all: [
+            {roleName: 'team_user', permission, shouldHave: true}
+        ],
+        team_admin: [
+            {roleName: 'team_user', permission, shouldHave: false},
+            {roleName: 'team_admin', permission, shouldHave: true}
+        ],
+        system_admin: [
+            {roleName: 'team_user', permission, shouldHave: false},
+            {roleName: 'team_admin', permission, shouldHave: false}
+        ]
+    };
+}
+
+function channelMapping(permission) {
+    return {
+        all: [
+            {roleName: 'channel_user', permission, shouldHave: true}
+        ],
+        channel_admin: [
+            {roleName: 'channel_user', permission, shouldHave: false},
+            {roleName: 'channel_admin', permission, shouldHave: true},
+            {roleName: 'team_admin', permission, shouldHave: true}
+        ],
+        team_admin: [
+            {roleName: 'channel_user', permission, shouldHave: false},
+            {roleName: 'channel_admin', permission, shouldHave: false},
+            {roleName: 'team_admin', permission, shouldHave: true}
+        ],
+        system_admin: [
+            {roleName: 'channel_user', permission, shouldHave: false},
+            {roleName: 'channel_admin', permission, shouldHave: false},
+            {roleName: 'team_admin', permission, shouldHave: false}
+        ]
+    };
+}
+
+const MAPPING = {
+    restrictTeamInvite: {...teamMapping(Permissions.INVITE_USER)},
+    restrictPublicChannelCreation: {...teamMapping(Permissions.CREATE_PUBLIC_CHANNEL)},
+    restrictPrivateChannelCreation: {...teamMapping(Permissions.CREATE_PRIVATE_CHANNEL)},
+
+    restrictPublicChannelManagement: {...channelMapping(Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES)},
+    restrictPublicChannelDeletion: {...channelMapping(Permissions.DELETE_PUBLIC_CHANNEL)},
+    restrictPrivateChannelManagement: {...channelMapping(Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES)},
+    restrictPrivateChannelManageMembers: {...channelMapping(Permissions.MANAGE_PRIVATE_CHANNEL_MEMBERS)},
+    restrictPrivateChannelDeletion: {...channelMapping(Permissions.DELETE_PRIVATE_CHANNEL)},
+
+    allowEditPost: {
+        always: [
+            {roleName: 'channel_user', permission: Permissions.EDIT_POST, shouldHave: true},
+            {roleName: 'system_admin', permission: Permissions.EDIT_POST, shouldHave: true}
+        ],
+        never: [
+            {roleName: 'channel_user', permission: Permissions.EDIT_POST, shouldHave: false},
+            {roleName: 'system_admin', permission: Permissions.EDIT_POST, shouldHave: false}
+        ]
+    },
+
+    restrictPostDelete: {
+        all: [
+            {roleName: 'channel_user', permission: Permissions.DELETE_POST, shouldHave: true},
+            {roleName: 'channel_admin', permission: Permissions.DELETE_POST, shouldHave: false},
+            {roleName: 'channel_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: false},
+            {roleName: 'team_admin', permission: Permissions.DELETE_POST, shouldHave: true},
+            {roleName: 'team_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: true}
+        ],
+        team_admin: [
+            {roleName: 'channel_user', permission: Permissions.DELETE_POST, shouldHave: false},
+            {roleName: 'channel_admin', permission: Permissions.DELETE_POST, shouldHave: false},
+            {roleName: 'channel_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: false},
+            {roleName: 'team_admin', permission: Permissions.DELETE_POST, shouldHave: true},
+            {roleName: 'team_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: true}
+        ],
+        system_admin: [
+            {roleName: 'channel_user', permission: Permissions.DELETE_POST, shouldHave: false},
+            {roleName: 'channel_admin', permission: Permissions.DELETE_POST, shouldHave: false},
+            {roleName: 'channel_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: false},
+            {roleName: 'team_admin', permission: Permissions.DELETE_POST, shouldHave: false},
+            {roleName: 'team_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: false}
+        ]
+    }
+};
+
+/**
+ * Get the roles that were changed (but unsaved) for given mapping key/values.
+ *
+ * @param {object} mappingValues key/value to indicate which mapping items to use to update the roles.
+ * @param {object} roles same structure as returned by mattermost-redux `getRoles`.
+ * @return {object} the updated roles (only) in the same structure as returned by mattermost-redux `getRoles`.
+ */
+export function rolesFromMapping(mappingValues, roles) {
+    const rolesClone = JSON.parse(JSON.stringify(roles));
+
+    // Purge roles that aren't present in MAPPING, we don't care about them.
+    purgeNonPertinentRoles(rolesClone);
+
+    Object.entries(MAPPING).forEach(([mappingKey]) => {
+        const value = mappingValues[mappingKey];
+        if (value) {
+            mutateRolesBasedOnMapping(mappingKey, value, rolesClone);
+        }
+    });
+
+    // Purge roles that didn't have permissions changes, we don't care about them.
+    Object.entries(rolesClone).forEach(([roleName, roleClone]) => {
+        const originalPermissionSet = new Set(roles[roleName].permissions);
+        const newPermissionSet = new Set(roleClone.permissions);
+        const difference = [...newPermissionSet].filter((x) => !originalPermissionSet.has(x));
+
+        if (originalPermissionSet.size === newPermissionSet.size && difference.length === 0) {
+            delete rolesClone[roleName];
+        }
+    });
+
+    return rolesClone;
+}
+
+/**
+ * Get the mapping value that matches for a given set of roles.
+ *
+ * @param {string} key to match under in the mapping.
+ * @param {object} roles same structure as returned by mattermost-redux `getRoles`.
+ * @return {string} the value that the roles/permissions assignment match in the mapping.
+ */
+export function mappingValueFromRoles(key, roles) {
+    const iterator = mappingPartIterator(MAPPING[key], roles);
+
+    for (const o of iterator) {
+        if (o.allConditionsAreMet) {
+            return o.value;
+        }
+    }
+
+    throw new Error(`No matching mapping value found for key '${key}' with the given roles.`);
+}
+
+function purgeNonPertinentRoles(roles) {
+    const pertinentRoleNames = roleNamesInMapping();
+
+    Object.entries(roles).forEach(([key]) => {
+        if (!pertinentRoleNames.includes(key)) {
+            delete roles[key];
+        }
+    });
+}
+
+function mutateRolesBasedOnMapping(mappingKey, value, roles) {
+    const roleRules = MAPPING[mappingKey][value];
+
+    if (typeof roleRules === 'undefined') {
+        throw new Error(`Value '${value}' not present in MAPPING for key '${mappingKey}'.`);
+    }
+
+    roleRules.forEach((item) => {
+        const role = roles[item.roleName];
+        if (item.shouldHave) {
+            addPermissionToRole(item.permission, role);
+        } else {
+            removePermissionFromRole(item.permission, role);
+        }
+    });
+}
+
+// Returns a set of the role names present in MAPPING.
+function roleNamesInMapping() {
+    let roleNames = [];
+
+    Object.entries(MAPPING).forEach(([, v1]) => {
+        Object.entries(v1).forEach(([, v2]) => {
+            const names = v2.map((item) => item.roleName); // eslint-disable-line max-nested-callbacks
+            roleNames = roleNames.concat(names);
+        });
+    });
+
+    return [...new Set(roleNames.map((item) => item))];
+}
+
+function* mappingPartIterator(mappingPart, roles) {
+    for (const value in mappingPart) {
+        if (mappingPart.hasOwnProperty(value)) {
+            let allConditionsAreMet = true;
+            const roleRules = mappingPart[value];
+
+            const hasUnmetCondition = roleRules.some((item) => {
+                const role = roles[item.roleName];
+                return (item.shouldHave && !role.permissions.includes(item.permission)) || (!item.shouldHave && role.permissions.includes(item.permission));
+            });
+
+            if (hasUnmetCondition) {
+                allConditionsAreMet = false;
+            }
+
+            yield {value, allConditionsAreMet};
+        }
+    }
+}
+
+function addPermissionToRole(permission, role) {
+    if (!role.permissions.includes(permission)) {
+        role.permissions.push(permission);
+    }
+}
+
+function removePermissionFromRole(permission, role) {
+    const permissionIndex = role.permissions.indexOf(permission);
+    if (permissionIndex !== -1) {
+        role.permissions.splice(permissionIndex, 1);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5271,9 +5271,9 @@ math-expression-evaluator@^1.2.14:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz#b357fa1ca9faefb8e48d10c14ef2bcb2d9f0a7c9"
 
-mattermost-redux@mattermost/mattermost-redux#c30ae69432a3ce7d73ba6e36cbe4f02e805ecc0c:
+mattermost-redux@mattermost/mattermost-redux#XYZ-21:
   version "1.1.0"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/c30ae69432a3ce7d73ba6e36cbe4f02e805ecc0c"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/e2d8585e583cf0c4d70bba1d4209de0bc81bb15d"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"


### PR DESCRIPTION
#### Summary
Uses the policy setting to add/remove permissions from roles. On load it reads the roles and permissions assignments to infer the policy setting.

#### Ticket Link
[XYZ-11](https://mattermost.atlassian.net/browse/XYZ-11)

**DO NOT MERGE**. This PR relies on https://github.com/mattermost/mattermost-redux/pull/360 and https://github.com/mattermost/mattermost-server/pull/8106.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes (very small, yes)
- [x] Touches critical sections of the codebase (auth, posting, etc.)