### PR TITLE
Fix first/last unread link on channel not loaded yet

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -175,7 +175,7 @@ export default class SidebarChannel extends React.PureComponent {
 
     render = () => {
         if (!this.props.channelDisplayName || !this.props.channelType) {
-            return null;
+            return (<div/>);
         }
         let closeHandler = null;
         if (this.props.channelType === Constants.DM_CHANNEL || this.props.channelType === Constants.GM_CHANNEL) {


### PR DESCRIPTION
#### Summary
When the channel is not loaded and appears as unread may use a reference to a
"null" element, which doesn't work. The fix always return an element on
SidebarChannel (when the data is not yet available too).

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed