### PR TITLE
ABC-79: populate channel autocomplete results with local data immediately

### DIFF
--- a/components/suggestion/channel_mention_provider.jsx
+++ b/components/suggestion/channel_mention_provider.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 import {autocompleteChannels} from 'actions/channel_actions.jsx';
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
+import SuggestionStore from 'stores/suggestion_store.jsx';
+
 import {ActionTypes, Constants} from 'utils/constants.jsx';
 
 import Provider from './provider.jsx';
@@ -81,6 +83,47 @@ export default class ChannelMentionProvider extends Provider {
 
         this.startNewRequest(suggestionId, prefix);
 
+        SuggestionStore.clearSuggestions(suggestionId);
+
+        const words = prefix.toLowerCase().split(/\s+/);
+        const wrappedChannelIds = {};
+        const wrappedChannels = [];
+        ChannelStore.getAll().forEach((item) => {
+            if (item.type !== 'O' || item.delete_at > 0) {
+                return;
+            }
+            const nameWords = item.name.toLowerCase().split(/\s+/).concat(item.display_name.toLowerCase().split(/\s+/));
+            var matched = true;
+            for (var j = 0; matched && j < words.length; j++) {
+                if (!words[j]) {
+                    continue;
+                }
+                var wordMatched = false;
+                for (var i = 0; i < nameWords.length; i++) {
+                    if (nameWords[i].startsWith(words[j])) {
+                        wordMatched = true;
+                        break;
+                    }
+                }
+                if (!wordMatched) {
+                    matched = false;
+                    break;
+                }
+            }
+            if (!matched) {
+                return;
+            }
+            wrappedChannelIds[item.id] = true;
+            wrappedChannels.push({
+                type: Constants.MENTION_CHANNELS,
+                channel: item
+            });
+        });
+        const channelMentions = wrappedChannels.map((item) => '~' + item.channel.name);
+        if (channelMentions.length > 0) {
+            SuggestionStore.addSuggestions(suggestionId, channelMentions, wrappedChannels, ChannelMentionSuggestion, captured[2]);
+        }
+
         autocompleteChannels(
             prefix,
             (channels) => {
@@ -93,15 +136,17 @@ export default class ChannelMentionProvider extends Provider {
                 }
 
                 // Wrap channels in an outer object to avoid overwriting the 'type' property.
-                const wrappedChannels = [];
                 const wrappedMoreChannels = [];
                 const moreChannels = [];
                 channels.forEach((item) => {
                     if (ChannelStore.get(item.id)) {
-                        wrappedChannels.push({
-                            type: Constants.MENTION_CHANNELS,
-                            channel: item
-                        });
+                        if (!wrappedChannelIds[item.id]) {
+                            wrappedChannelIds[item.id] = true;
+                            wrappedChannels.push({
+                                type: Constants.MENTION_CHANNELS,
+                                channel: item
+                            });
+                        }
                         return;
                     }
 

--- a/components/suggestion/channel_mention_provider.jsx
+++ b/components/suggestion/channel_mention_provider.jsx
@@ -9,6 +9,7 @@ import ChannelStore from 'stores/channel_store.jsx';
 import SuggestionStore from 'stores/suggestion_store.jsx';
 
 import {ActionTypes, Constants} from 'utils/constants.jsx';
+import * as ChannelUtils from 'utils/channel_utils.jsx';
 
 import Provider from './provider.jsx';
 import Suggestion from './suggestion.jsx';
@@ -87,7 +88,7 @@ export default class ChannelMentionProvider extends Provider {
 
         const words = prefix.toLowerCase().split(/\s+/);
         const wrappedChannelIds = {};
-        const wrappedChannels = [];
+        var wrappedChannels = [];
         ChannelStore.getAll().forEach((item) => {
             if (item.type !== 'O' || item.delete_at > 0) {
                 return;
@@ -119,10 +120,18 @@ export default class ChannelMentionProvider extends Provider {
                 channel: item
             });
         });
+        wrappedChannels = wrappedChannels.sort((a, b) => {
+            return ChannelUtils.sortChannelsByDisplayName(a.channel, b.channel);
+        });
         const channelMentions = wrappedChannels.map((item) => '~' + item.channel.name);
         if (channelMentions.length > 0) {
             SuggestionStore.addSuggestions(suggestionId, channelMentions, wrappedChannels, ChannelMentionSuggestion, captured[2]);
         }
+
+        SuggestionStore.addSuggestions(suggestionId, [''], [{
+            type: Constants.MENTION_MORE_CHANNELS,
+            loading: true
+        }], ChannelMentionSuggestion, captured[2]);
 
         autocompleteChannels(
             prefix,
@@ -158,6 +167,9 @@ export default class ChannelMentionProvider extends Provider {
                     moreChannels.push(item);
                 });
 
+                wrappedChannels = wrappedChannels.sort((a, b) => {
+                    return ChannelUtils.sortChannelsByDisplayName(a.channel, b.channel);
+                });
                 const wrapped = wrappedChannels.concat(wrappedMoreChannels);
                 const mentions = wrapped.map((item) => '~' + item.channel.name);
 


### PR DESCRIPTION
#### Summary
This populates channel autocomplete results with local data immediately. When more channels are returned from the server, they will be added to the results. In addition to improving usability on large servers, this ensures that joined channels are always shown in the autocomplete results.

Discussion: https://pre-release.mattermost.com/core/pl/3nzompitxpfi8do54r1xtb7ooa

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-79

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)