### PR TITLE
Fix dispatch prop warning on popover of profile_popover component

### DIFF
--- a/components/profile_popover.jsx
+++ b/components/profile_popover.jsx
@@ -194,6 +194,7 @@ class ProfilePopover extends React.Component {
         delete popoverProps.hide;
         delete popoverProps.isRHS;
         delete popoverProps.hasMention;
+        delete popoverProps.dispatch;
 
         let webrtc;
         const userMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;


### PR DESCRIPTION
#### Summary
Fixes dispatch prop warning on popover of profile_popover component

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed