### PR TITLE
decode encoded filenames

### DIFF
--- a/components/file_attachment/filename_overlay.jsx
+++ b/components/file_attachment/filename_overlay.jsx
@@ -45,7 +45,7 @@ export default class FilenameOverlay extends React.PureComponent {
 
     render() {
         const fileInfo = this.props.fileInfo;
-        const fileName = fileInfo.name;
+        const fileName = decodeURIComponent(fileInfo.name);
         const fileUrl = getFileUrl(fileInfo.id);
 
         let trimmedFilename;


### PR DESCRIPTION
#### Summary
Images uploaded from mobile devices that have non-ASCII characters in their filename are now encoded before upload. This PR simply displays the names properly in UI

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-573
