### PR TITLE
Remove unnecesary trailing comma

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -298,7 +298,7 @@ if (!DEV) {
         })
     );
     config.plugins.push(
-        new webpack.optimize.ModuleConcatenationPlugin(),
+        new webpack.optimize.ModuleConcatenationPlugin()
     );
 }
 


### PR DESCRIPTION
#### Summary
Removed unnecesary trailing comman in the webpack.config.js. It generates errors to Asaad. I didn't reproduce it, but Asaad fix his problem removing this comma.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)