### PR TITLE
ABC-92 Add paging and server search for custom emojis to emoji picker

### DIFF
--- a/actions/emoji_actions.jsx
+++ b/actions/emoji_actions.jsx
@@ -39,6 +39,10 @@ export async function deleteEmoji(emojiId, success, error) {
 
 export function loadRecentlyUsedCustomEmojis() {
     return async (dispatch, getState) => {
+        if (getState().entities.general.config.EnableCustomEmoji !== 'true') {
+            return {data: true};
+        }
+
         const recentEmojis = EmojiStore.getRecentEmojis();
         const emojiMap = getEmojiMap(getState());
         const missingEmojis = recentEmojis.filter((name) => !emojiMap.has(name));

--- a/actions/emoji_actions.jsx
+++ b/actions/emoji_actions.jsx
@@ -3,15 +3,16 @@
 
 import * as EmojiActions from 'mattermost-redux/actions/emojis';
 
+import {getEmojiMap} from 'selectors/emojis';
+
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import store from 'stores/redux_store.jsx';
+import EmojiStore from 'stores/emoji_store.jsx';
+
 import {ActionTypes} from 'utils/constants.jsx';
 
-const dispatch = store.dispatch;
-const getState = store.getState;
-
 export async function addEmoji(emoji, image, success, error) {
-    const {data, error: err} = await EmojiActions.createCustomEmoji(emoji, image)(dispatch, getState);
+    const {data, error: err} = await EmojiActions.createCustomEmoji(emoji, image)(store.dispatch, store.getState);
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -20,7 +21,7 @@ export async function addEmoji(emoji, image, success, error) {
 }
 
 export async function deleteEmoji(emojiId, success, error) {
-    const {data, error: err} = await EmojiActions.deleteCustomEmoji(emojiId)(dispatch, getState);
+    const {data, error: err} = await EmojiActions.deleteCustomEmoji(emojiId)(store.dispatch, store.getState);
     if (data) {
         // Needed to remove recently used emoji
         AppDispatcher.handleServerAction({
@@ -34,4 +35,28 @@ export async function deleteEmoji(emojiId, success, error) {
     } else if (err && error) {
         error({id: err.server_error_id, ...err});
     }
+}
+
+export function loadRecentlyUsedCustomEmojis() {
+    return async (dispatch, getState) => {
+        const recentEmojis = EmojiStore.getRecentEmojis();
+        const emojiMap = getEmojiMap(getState());
+        const missingEmojis = recentEmojis.filter((name) => !emojiMap.has(name));
+
+        missingEmojis.forEach((name) => {
+            EmojiActions.getCustomEmojiByName(name)(dispatch, getState);
+        });
+
+        return {data: true};
+    };
+}
+
+export function incrementEmojiPickerPage() {
+    return async (dispatch) => {
+        dispatch({
+            type: ActionTypes.INCREMENT_EMOJI_PICKER_PAGE
+        });
+
+        return {data: true};
+    };
 }

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -103,6 +103,7 @@ function getEmojiFilename(emoji) {
 }
 
 const EMOJIS_PER_PAGE = 200;
+const LOAD_MORE_AT_PIXELS_FROM_BOTTOM = 500;
 
 export default class EmojiPicker extends React.PureComponent {
     static propTypes = {
@@ -187,7 +188,8 @@ export default class EmojiPicker extends React.PureComponent {
             return;
         }
 
-        if (this.emojiPickerContainer.scrollHeight - nextState.divTopOffset === this.emojiPickerContainer.clientHeight) {
+        const pixelsFromBottom = this.emojiPickerContainer.scrollHeight - nextState.divTopOffset - this.emojiPickerContainer.clientHeight;
+        if (pixelsFromBottom <= LOAD_MORE_AT_PIXELS_FROM_BOTTOM) {
             this.loadMoreCustomEmojis();
         }
     }

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -111,6 +111,7 @@ export default class EmojiPicker extends React.PureComponent {
         topOffset: PropTypes.number,
         placement: PropTypes.oneOf(['top', 'bottom', 'left']),
         onEmojiClick: PropTypes.func.isRequired,
+        customEmojisEnabled: PropTypes.bool,
         emojiMap: PropTypes.object.isRequired,
         customEmojiPage: PropTypes.number.isRequired,
         actions: PropTypes.shape({
@@ -123,7 +124,8 @@ export default class EmojiPicker extends React.PureComponent {
     static defaultProps = {
         rightOffset: 0,
         topOffset: 0,
-        customEmojiPage: 0
+        customEmojiPage: 0,
+        customEmojisEnabled: false
     };
 
     constructor(props) {
@@ -197,6 +199,10 @@ export default class EmojiPicker extends React.PureComponent {
     }
 
     loadMoreCustomEmojis = async () => {
+        if (!this.props.customEmojisEnabled) {
+            return;
+        }
+
         const {data} = await this.props.actions.getCustomEmojis(this.props.customEmojiPage, EMOJIS_PER_PAGE);
         if (!data) {
             return;
@@ -228,7 +234,7 @@ export default class EmojiPicker extends React.PureComponent {
         e.preventDefault();
         const filter = e.target.value.toLowerCase();
 
-        if (filter && filter.trim() !== '') {
+        if (this.props.customEmojisEnabled && filter && filter.trim() !== '') {
             this.props.actions.searchCustomEmojis(filter);
         }
 

--- a/components/emoji_picker/emoji_picker_overlay.jsx
+++ b/components/emoji_picker/emoji_picker_overlay.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Overlay} from 'react-bootstrap';
 
-import EmojiPicker from './emoji_picker.jsx';
+import EmojiPicker from './';
 
 export default class EmojiPickerOverlay extends React.PureComponent {
     static propTypes = {

--- a/components/emoji_picker/index.js
+++ b/components/emoji_picker/index.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {getCustomEmojis, searchCustomEmojis} from 'mattermost-redux/actions/emojis';
+
+import {incrementEmojiPickerPage} from 'actions/emoji_actions.jsx';
+import {getEmojiMap} from 'selectors/emojis';
+
+import EmojiPicker from './emoji_picker.jsx';
+
+function mapStateToProps(state) {
+    return {
+        customEmojiPage: state.views.emoji.emojiPickerCustomPage,
+        emojiMap: getEmojiMap(state)
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getCustomEmojis,
+            searchCustomEmojis,
+            incrementEmojiPickerPage
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(EmojiPicker);

--- a/components/emoji_picker/index.js
+++ b/components/emoji_picker/index.js
@@ -13,6 +13,7 @@ import EmojiPicker from './emoji_picker.jsx';
 
 function mapStateToProps(state) {
     return {
+        customEmojisEnabled: state.entities.general.config.EnableCustomEmoji === 'true',
         customEmojiPage: state.views.emoji.emojiPickerCustomPage,
         emojiMap: getEmojiMap(state)
     };

--- a/components/root.jsx
+++ b/components/root.jsx
@@ -22,6 +22,7 @@ import LocalizationStore from 'stores/localization_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import {loadMeAndConfig} from 'actions/user_actions.jsx';
+import {loadRecentlyUsedCustomEmojis} from 'actions/emoji_actions.jsx';
 import * as I18n from 'i18n/i18n.jsx';
 import {initializePlugins} from 'plugins';
 import Constants, {StoragePrefixes} from 'utils/constants.jsx';
@@ -182,6 +183,8 @@ export default class Root extends React.Component {
         } else {
             I18n.safariFix(afterIntl);
         }
+
+        loadRecentlyUsedCustomEmojis()(store.dispatch, store.getState);
     }
 
     localizationChanged() {

--- a/reducers/views/emoji.js
+++ b/reducers/views/emoji.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {combineReducers} from 'redux';
+import {UserTypes} from 'mattermost-redux/action_types';
+
+import {ActionTypes} from 'utils/constants.jsx';
+
+function emojiPickerCustomPage(state = 0, action) {
+    switch (action.type) {
+    case ActionTypes.INCREMENT_EMOJI_PICKER_PAGE:
+        return state + 1;
+    case UserTypes.LOGOUT_SUCCESS:
+        return 0;
+    default:
+        return state;
+    }
+}
+
+export default combineReducers({
+    emojiPickerCustomPage
+});

--- a/reducers/views/index.js
+++ b/reducers/views/index.js
@@ -8,11 +8,13 @@ import channel from './channel';
 import rhs from './rhs';
 import posts from './posts';
 import modals from './modals';
+import emoji from './emoji';
 
 export default combineReducers({
     admin,
     channel,
     rhs,
     posts,
-    modals
+    modals,
+    emoji
 });

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -238,7 +238,9 @@ export const ActionTypes = keyMirror({
 
     POPOVER_MENTION_KEY_CLICK: null,
 
-    KEEP_CHANNEL_AS_UNREAD: null
+    KEEP_CHANNEL_AS_UNREAD: null,
+
+    INCREMENT_EMOJI_PICKER_PAGE: null
 });
 
 export const WebrtcActionTypes = keyMirror({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5568,7 +5568,7 @@ math-expression-evaluator@^1.2.14:
 
 mattermost-redux@mattermost/mattermost-redux:
   version "1.1.0"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/ed1d042770aa5fe805949da62a508f607452a746"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/bc7d2ba0972a0380b1f9d593be58692df2001c31"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"


### PR DESCRIPTION
#### Summary
Add paging and server search for custom emojis to emoji picker.

@hmhealey @stephenkiers let me know if I should approach this differently. This is my first time in the emoji picker code and it's a bit complex, so if you guys have better ideas on how to do this let me know :)

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-92

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has server changes (mattermost/mattermost-server#8142)
- [x] Has redux changes (mattermost/mattermost-redux#373)
- [x] Has UI changes