### PR TITLE
ICU-631 Fixed case sensitive mention highlighting

### DIFF
--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -224,24 +224,11 @@ export function showPinnedPosts(channelId) {
 
 export function showMentions() {
     return (dispatch, getState) => {
-        const termKeys = [...getCurrentUserMentionKeys(getState())];
+        const termKeys = getCurrentUserMentionKeys(getState()).filter(({key}) => {
+            return key !== '@channel' && key !== '@all' && key !== '@here';
+        });
 
-        const indexOfChannel = termKeys.indexOf('@channel');
-        if (indexOfChannel !== -1) {
-            termKeys.splice(indexOfChannel, 1);
-        }
-
-        const indexOfAll = termKeys.indexOf('@all');
-        if (indexOfAll !== -1) {
-            termKeys.splice(indexOfAll, 1);
-        }
-
-        const indexOfHere = termKeys.indexOf('@here');
-        if (indexOfHere !== -1) {
-            termKeys.splice(indexOfHere, 1);
-        }
-
-        const terms = termKeys.join(' ').trim() + ' ';
+        const terms = termKeys.map(({key}) => key).join(' ').trim() + ' ';
 
         trackEvent('api', 'api_posts_search_mention');
 

--- a/components/post_markdown/index.js
+++ b/components/post_markdown/index.js
@@ -23,11 +23,11 @@ const getChannelNamesMap = createSelector(
     }
 );
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     return {
         channelNamesMap: getChannelNamesMap(state),
         emojis: getEmojiMap(state),
-        mentionKeys: ownProps.mentionKeys || getCurrentUserMentionKeys(state),
+        mentionKeys: getCurrentUserMentionKeys(state),
         siteURL: getSiteURL(),
         team: getCurrentTeam(state)
     };

--- a/components/post_view/post_message_view/index.js
+++ b/components/post_view/post_message_view/index.js
@@ -4,14 +4,12 @@
 import {connect} from 'react-redux';
 import {Preferences} from 'mattermost-redux/constants';
 import {getTheme, getBool} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentUserMentionKeys} from 'mattermost-redux/selectors/entities/users';
 
 import PostMessageView from './post_message_view.jsx';
 
 function mapStateToProps(state) {
     return {
         enableFormatting: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true),
-        mentionKeys: getCurrentUserMentionKeys(state),
         pluginPostTypes: state.plugins.postTypes,
         theme: getTheme(state)
     };

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -24,11 +24,6 @@ export default class PostMessageView extends React.PureComponent {
         enableFormatting: PropTypes.bool,
 
         /*
-         * An array of words that can be used to mention a user
-         */
-        mentionKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
-
-        /*
          * Options specific to text formatting
          */
         options: PropTypes.object,
@@ -118,7 +113,6 @@ export default class PostMessageView extends React.PureComponent {
                 return (
                     <PluginComponent
                         post={post}
-                        mentionKeys={this.props.mentionKeys}
                         compactDisplay={compactDisplay}
                         isRHS={isRHS}
                         theme={theme}
@@ -149,7 +143,6 @@ export default class PostMessageView extends React.PureComponent {
                     <PostMarkdown
                         message={message}
                         isRHS={isRHS}
-                        mentionKeys={this.props.mentionKeys}
                         options={options}
                         post={post}
                     />

--- a/plugins/docs.json
+++ b/plugins/docs.json
@@ -11,11 +11,6 @@
                 "required": true,
                 "desc": "Post to be displayed"
             },
-            "mentionKeys": {
-                "type": { "name": "array" },
-                "required": false,
-                "desc": "Array of strings representing words to be interpreted as mentions for the logged-in user"
-            },
             "compactDisplay": {
                 "type": { "name": "bool" },
                 "required": false,

--- a/stores/user_store.jsx
+++ b/stores/user_store.jsx
@@ -444,41 +444,6 @@ class UserStoreClass extends EventEmitter {
         return store.getState().entities.users.myAudits;
     }
 
-    getCurrentMentionKeys() {
-        return this.getMentionKeys(this.getCurrentId());
-    }
-
-    getMentionKeys(id) {
-        var user = this.getProfile(id);
-
-        var keys = [];
-
-        if (!user || !user.notify_props) {
-            return keys;
-        }
-
-        if (user.notify_props.mention_keys) {
-            keys = keys.concat(user.notify_props.mention_keys.split(','));
-        }
-
-        if (user.notify_props.first_name === 'true' && user.first_name) {
-            keys.push(user.first_name);
-        }
-
-        if (user.notify_props.channel === 'true') {
-            keys.push('@channel');
-            keys.push('@all');
-            keys.push('@here');
-        }
-
-        const usernameKey = '@' + user.username;
-        if (keys.indexOf(usernameKey) === -1) {
-            keys.push(usernameKey);
-        }
-
-        return keys;
-    }
-
     setStatus(userId, status) {
         const data = [{user_id: userId, status}];
         store.dispatch({

--- a/tests/redux/actions/views/rhs.test.js
+++ b/tests/redux/actions/views/rhs.test.js
@@ -32,7 +32,7 @@ const currentTeamId = '321';
 const currentUserId = 'user123';
 
 const UserSelectors = require('mattermost-redux/selectors/entities/users');
-UserSelectors.getCurrentUserMentionKeys = jest.fn(() => ['@here', '@mattermost', '@channel', '@all']);
+UserSelectors.getCurrentUserMentionKeys = jest.fn(() => [{key: '@here'}, {key: '@mattermost'}, {key: '@channel'}, {key: '@all'}]);
 
 jest.mock('mattermost-redux/actions/posts', () => ({
     getPostThread: (...args) => ({type: 'MOCK_GET_POST_THREAD', args}),

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -252,7 +252,7 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
     // look for any existing tokens which are self mentions and should be highlighted
     var newTokens = new Map();
     for (const [alias, token] of tokens) {
-        if (mentionKeys.indexOf(token.originalText) !== -1) {
+        if (mentionKeys.findIndex((key) => key.key === token.originalText) !== -1) {
             const index = tokens.size + newTokens.size;
             const newAlias = `$MM_SELFMENTION${index}`;
 
@@ -283,11 +283,16 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
     }
 
     for (const mention of mentionKeys) {
-        if (!mention) {
+        if (!mention || !mention.key) {
             continue;
         }
 
-        output = output.replace(new RegExp(`(^|\\W)(${escapeRegex(mention)})\\b`, 'gi'), replaceCurrentMentionWithToken);
+        let flags = 'g';
+        if (!mention.caseSensitive) {
+            flags += 'i';
+        }
+
+        output = output.replace(new RegExp(`(^|\\W)(${escapeRegex(mention.key)})\\b`, flags), replaceCurrentMentionWithToken);
     }
 
     return output;


### PR DESCRIPTION
This, along with my other PR, changes it so that instead of mentionKeys being an array of strings like  `['@user', 'FirstName']`, it'll now be an object including a caseSensitive field like `[{key: '@user'}, {key: 'FirstName', caseSensitive: true}]`.

As discussed earlier, I've removed the mentionKeys prop from post type plugins since they can get it from the store if needed, and this frees us up from having to worry about breaking those plugins as easily in the future.

This PR relies on https://github.com/mattermost/mattermost-redux/pull/375

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-631

#### Checklist
- Has redux changes (please link)
- Has UI changes