### PR TITLE
ABC-168 Update initial scrolling on post list

### DIFF
--- a/components/loading_screen.jsx
+++ b/components/loading_screen.jsx
@@ -6,10 +6,22 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
 export default class LoadingScreen extends React.Component {
+    static propTypes = {
+        position: PropTypes.oneOf(['absolute', 'fixed', 'relative', 'static', 'inherit']),
+        style: PropTypes.object,
+        message: PropTypes.node
+    }
+
+    static defaultProps = {
+        position: 'relative',
+        style: {}
+    }
+
     constructor(props) {
         super(props);
         this.state = {};
     }
+
     render() {
         let message = (
             <FormattedMessage
@@ -25,7 +37,7 @@ export default class LoadingScreen extends React.Component {
         return (
             <div
                 className='loading-screen'
-                style={{position: this.props.position}}
+                style={{position: this.props.position, ...this.props.style}}
             >
                 <div className='loading__content'>
                     <h3>
@@ -39,11 +51,3 @@ export default class LoadingScreen extends React.Component {
         );
     }
 }
-
-LoadingScreen.defaultProps = {
-    position: 'relative'
-};
-LoadingScreen.propTypes = {
-    position: PropTypes.oneOf(['absolute', 'fixed', 'relative', 'static', 'inherit']),
-    message: PropTypes.node
-};

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -542,6 +542,8 @@ export default class PostList extends React.PureComponent {
                     />
                 </div>
             );
+        } else if (this.state.isDoingInitialLoad) {
+            topRow = <LoadingScreen style={{height: '0px'}}/>;
         } else {
             topRow = (
                 <button

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -126,6 +126,8 @@ export default class PostList extends React.PureComponent {
         GlobalEventEmitter.addListener(EventTypes.POST_LIST_SCROLL_CHANGE, this.handleResize);
 
         window.addEventListener('resize', this.handleResize);
+
+        this.initialScroll();
     }
 
     componentWillUnmount() {
@@ -192,6 +194,8 @@ export default class PostList extends React.PureComponent {
             return;
         }
 
+        this.initialScroll();
+
         // Scroll to focused post on first load
         const focusedPost = this.refs[this.props.focusedPostId];
         if (focusedPost && this.props.posts) {
@@ -203,21 +207,6 @@ export default class PostList extends React.PureComponent {
             } else if (this.previousScrollHeight !== postList.scrollHeight && posts[0].id === prevPosts[0].id) {
                 postList.scrollTop = this.previousScrollTop + (postList.scrollHeight - this.previousScrollHeight);
             }
-            return;
-        }
-
-        // Scroll to new message indicator or bottom on first load
-        const messageSeparator = this.refs.newMessageSeparator;
-        if (messageSeparator && !this.hasScrolledToNewMessageSeparator) {
-            const element = ReactDOM.findDOMNode(messageSeparator);
-            element.scrollIntoView();
-            if (!this.checkBottom()) {
-                this.setUnreadsBelow(posts, this.props.currentUserId);
-            }
-            return;
-        } else if (postList && !this.hasScrolledToNewMessageSeparator) {
-            postList.scrollTop = postList.scrollHeight;
-            this.atBottom = true;
             return;
         }
 
@@ -250,6 +239,30 @@ export default class PostList extends React.PureComponent {
             if (this.previousScrollHeight !== postList.scrollHeight && posts[0].id === prevPosts[0].id) {
                 postList.scrollTop = this.previousScrollTop + (postList.scrollHeight - this.previousScrollHeight);
             }
+        }
+    }
+
+    // Scroll to new message indicator or bottom on first load
+    initialScroll = () => {
+        const postList = this.refs.postlist;
+        const posts = this.props.posts;
+        if (this.hasScrolledToNewMessageSeparator || !postList || !posts) {
+            return;
+        }
+
+        const messageSeparator = this.refs.newMessageSeparator;
+        if (messageSeparator) {
+            messageSeparator.scrollIntoView();
+            if (!this.checkBottom()) {
+                this.setUnreadsBelow(posts, this.props.currentUserId);
+            }
+        } else {
+            postList.scrollTop = postList.scrollHeight;
+            this.atBottom = true;
+        }
+
+        if (posts.length >= POSTS_PER_PAGE) {
+            this.hasScrolledToNewMessageSeparator = true;
         }
     }
 
@@ -323,6 +336,12 @@ export default class PostList extends React.PureComponent {
         } else {
             const result = await this.props.actions.getPosts(channelId, 0, POSTS_PER_PAGE);
             posts = result.data;
+
+            if (!this.checkBottom()) {
+                const postsArray = posts.order.map((id) => posts.posts[id]);
+                this.setUnreadsBelow(postsArray, this.props.currentUserId);
+            }
+
             this.hasScrolledToNewMessageSeparator = true;
         }
 

--- a/tests/components/__snapshots__/access_history_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/access_history_modal.test.jsx.snap
@@ -114,6 +114,7 @@ exports[`components/AccessHistoryModal should match snapshot when no audits exis
   >
     <LoadingScreen
       position="relative"
+      style={Object {}}
     />
   </ModalBody>
 </Modal>

--- a/tests/components/__snapshots__/activity_log_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/activity_log_modal.test.jsx.snap
@@ -125,6 +125,7 @@ exports[`components/ActivityLogModal should match snapshot 2`] = `
     </p>
     <LoadingScreen
       position="relative"
+      style={Object {}}
     />
   </ModalBody>
 </Modal>

--- a/tests/components/__snapshots__/do_verify_email.test.jsx.snap
+++ b/tests/components/__snapshots__/do_verify_email.test.jsx.snap
@@ -3,5 +3,6 @@
 exports[`components/DoVerifyEmail should match snapshot 1`] = `
 <LoadingScreen
   position="relative"
+  style={Object {}}
 />
 `;

--- a/tests/components/integrations/__snapshots__/edit_command.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/edit_command.test.jsx.snap
@@ -110,11 +110,13 @@ exports[`components/integrations/EditCommand should match snapshot 1`] = `
 exports[`components/integrations/EditCommand should match snapshot when EnableCommands is false 1`] = `
 <LoadingScreen
   position="relative"
+  style={Object {}}
 />
 `;
 
 exports[`components/integrations/EditCommand should match snapshot, loading 1`] = `
 <LoadingScreen
   position="relative"
+  style={Object {}}
 />
 `;

--- a/tests/components/integrations/__snapshots__/edit_incoming_webhook.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/edit_incoming_webhook.test.jsx.snap
@@ -102,6 +102,7 @@ exports[`components/integrations/EditIncomingWebhook should have called submitHo
 exports[`components/integrations/EditIncomingWebhook should not call getIncomingHook 1`] = `
 <LoadingScreen
   position="relative"
+  style={Object {}}
 />
 `;
 
@@ -141,5 +142,6 @@ exports[`components/integrations/EditIncomingWebhook should show AbstractIncomin
 exports[`components/integrations/EditIncomingWebhook should show Loading screen when no hook is provided 1`] = `
 <LoadingScreen
   position="relative"
+  style={Object {}}
 />
 `;

--- a/tests/components/integrations/__snapshots__/edit_oauth_app.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/edit_oauth_app.test.jsx.snap
@@ -182,6 +182,7 @@ exports[`components/integrations/EditOAuthApp should match snapshot when EnableO
 exports[`components/integrations/EditOAuthApp should match snapshot, loading 1`] = `
 <LoadingScreen
   position="relative"
+  style={Object {}}
 />
 `;
 

--- a/tests/components/integrations/__snapshots__/edit_outgoing_webhook.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/edit_outgoing_webhook.test.jsx.snap
@@ -192,5 +192,6 @@ exports[`components/integrations/EditOutgoingWebhook should match snapshot when 
 exports[`components/integrations/EditOutgoingWebhook should match snapshot, loading 1`] = `
 <LoadingScreen
   position="relative"
+  style={Object {}}
 />
 `;


### PR DESCRIPTION
#### Summary
This should hopefully fix the scrolling/flicker issues when switching to a channel. I'm going to have to ask for QA's and/or the PMs' help with testing this to check all the corner cases. These are the possibilities to consider, switching to a channel:

* You have zero posts for and has no unreads
* You have zero posts for and has unreads (two cases here, scrolled to bottom or scrolled off bottom to new message indicator)
* You have some posts for but you haven't loaded the channel before (same two cases as above)
* You have some posts for but missing some newer messages from a disconnected WS (same two cases as above)
* You have loaded before and has no unreads
* You have loaded before and has unreads that you have from the WS (same two cases as above)
* You have loaded before and has unreads that you're missing from a disconnected WS (same two cases as above)
* All the above cases except with a slow connection

I've included the ability to manually disconnect the websocket by opening the dev console and entering `close();` to help with testing. To reconnect, just refresh the page.
![screen shot 2018-01-25 at 9 46 01 am](https://user-images.githubusercontent.com/2672098/35394177-068f88dc-01b5-11e8-9f17-86a3604ede30.png)


I've tried all these cases myself and it seems to work well but I might have missed something.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-168