### PR TITLE
Fixed JavaScript warning and error that I added

### DIFF
--- a/components/autosize_textarea.jsx
+++ b/components/autosize_textarea.jsx
@@ -27,6 +27,14 @@ export default class AutosizeTextarea extends React.Component {
         this.refs.textarea.value = value;
     }
 
+    focus() {
+        this.refs.textarea.focus();
+    }
+
+    blur() {
+        this.refs.textarea.blur();
+    }
+
     componentDidUpdate() {
         this.recalculateSize();
     }

--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -30,7 +30,7 @@ export default class PostMarkdown extends React.PureComponent {
         /*
          * An array of words that can be used to mention a user
          */
-        mentionKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+        mentionKeys: PropTypes.arrayOf(PropTypes.object).isRequired,
 
         /*
          * The post text to be rendered


### PR DESCRIPTION
The warning was due to using incorrect PropTypes, and the error happened when clicking on an autocomplete suggestion