### PR TITLE
ABC-93 Support for loading emojis asynchronously in posts

### DIFF
--- a/components/post_emoji/index.jsx
+++ b/components/post_emoji/index.jsx
@@ -1,0 +1,32 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import EmojiStore from 'stores/emoji_store.jsx';
+import {getEmojiMap} from 'selectors/emojis';
+
+import PostEmoji from './post_emoji.jsx';
+
+function mapStateToProps(state, ownProps) {
+    const emojiMap = getEmojiMap(state);
+    const emoji = emojiMap.get(ownProps.name);
+
+    let imageUrl = '';
+    let displayTextOnly = false;
+    if (emoji) {
+        imageUrl = EmojiStore.getEmojiImageUrl(emoji);
+    } else {
+        displayTextOnly = state.entities.emojis.nonExistentEmoji.has(ownProps.name) ||
+            getConfig(state).EnableCustomEmojis !== 'true';
+    }
+
+    return {
+        imageUrl,
+        displayTextOnly
+    };
+}
+
+export default connect(mapStateToProps)(PostEmoji);

--- a/components/post_emoji/index.jsx
+++ b/components/post_emoji/index.jsx
@@ -20,7 +20,7 @@ function mapStateToProps(state, ownProps) {
         imageUrl = EmojiStore.getEmojiImageUrl(emoji);
     } else {
         displayTextOnly = state.entities.emojis.nonExistentEmoji.has(ownProps.name) ||
-            getConfig(state).EnableCustomEmojis !== 'true';
+            getConfig(state).EnableCustomEmoji !== 'true';
     }
 
     return {

--- a/components/post_emoji/post_emoji.jsx
+++ b/components/post_emoji/post_emoji.jsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class PostEmoji extends React.PureComponent {
+    static propTypes = {
+
+        /*
+         * Emoji name.
+         */
+        name: PropTypes.string.isRequired,
+
+        /*
+         * Emoji image URL.
+         */
+        imageUrl: PropTypes.string.isRequired,
+
+        /*
+         * Set to display the emoji text instead of the image.
+         */
+        displayTextOnly: PropTypes.bool.isRequired
+    };
+
+    static defaultProps = {
+        name: '',
+        imageUrl: '',
+        displayTextOnly: false
+    }
+
+    render() {
+        const emojiText = ':' + this.props.name + ':';
+
+        if (this.props.displayTextOnly) {
+            return emojiText;
+        }
+
+        return (
+            <span
+                alt={emojiText}
+                className='emoticon'
+                title={emojiText}
+                style={{backgroundImage: 'url(' + this.props.imageUrl + ')'}}
+            />
+        );
+    }
+}

--- a/components/post_markdown/index.js
+++ b/components/post_markdown/index.js
@@ -7,7 +7,6 @@ import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entiti
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserMentionKeys} from 'mattermost-redux/selectors/entities/users';
 
-import {getEmojiMap} from 'selectors/emojis';
 import {getSiteURL} from 'utils/url.jsx';
 
 import PostMarkdown from './post_markdown';
@@ -26,7 +25,6 @@ const getChannelNamesMap = createSelector(
 function mapStateToProps(state) {
     return {
         channelNamesMap: getChannelNamesMap(state),
-        emojis: getEmojiMap(state),
         mentionKeys: getCurrentUserMentionKeys(state),
         siteURL: getSiteURL(),
         team: getCurrentTeam(state)

--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -18,11 +18,6 @@ export default class PostMarkdown extends React.PureComponent {
         channelNamesMap: PropTypes.object.isRequired,
 
         /*
-         * An object mapping emoji names to emojis including both custom and system emojis
-         */
-        emojis: PropTypes.object.isRequired,
-
-        /*
          * Whether or not this text is part of the RHS
          */
         isRHS: PropTypes.bool,
@@ -66,7 +61,6 @@ export default class PostMarkdown extends React.PureComponent {
 
     render() {
         const options = Object.assign({
-            emojis: this.props.emojis,
             siteURL: this.props.siteURL,
             mentionKeys: this.props.mentionKeys,
             atMentions: true,

--- a/components/root.jsx
+++ b/components/root.jsx
@@ -10,8 +10,10 @@ import {IntlProvider} from 'react-intl';
 import FastClick from 'fastclick';
 import {Route, Switch, Redirect} from 'react-router-dom';
 import {getClientConfig, getLicenseConfig, setUrl} from 'mattermost-redux/actions/general';
+import {setSystemEmojis} from 'mattermost-redux/actions/emojis';
 import {Client4} from 'mattermost-redux/client';
 
+import {EmojiIndicesByAlias} from 'utils/emoji.jsx';
 import {trackLoadTime} from 'actions/diagnostics_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import BrowserStore from 'stores/browser_store.jsx';
@@ -87,6 +89,7 @@ export default class Root extends React.Component {
 
         // Redux
         setUrl(window.location.origin);
+        setSystemEmojis(EmojiIndicesByAlias);
 
         // Force logout of all tabs if one tab is logged out
         $(window).bind('storage', (e) => {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "localforage": "1.5.6",
     "localforage-observable": "1.4.0",
     "marked": "mattermost/marked#802e981ade71149a497cbe79d12b8a3f82f7657e",
-    "mattermost-redux": "mattermost/mattermost-redux#ed1d042770aa5fe805949da62a508f607452a746",
+    "mattermost-redux": "mattermost/mattermost-redux",
     "pdfjs-dist": "2.0.290",
     "perfect-scrollbar": "0.8.1",
     "prop-types": "15.6.0",

--- a/tests/plugins/__snapshots__/post_type.test.jsx.snap
+++ b/tests/plugins/__snapshots__/post_type.test.jsx.snap
@@ -202,12 +202,6 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
           <PostMarkdown
             channelNamesMap={Object {}}
             dispatch={[Function]}
-            emojis={
-              EmojiMap {
-                "customEmojis": Map {},
-                "customEmojisArray": Array [],
-              }
-            }
             isRHS={false}
             mentionKeys={Array []}
             message="this is some text"

--- a/tests/utils/emoticons.test.jsx
+++ b/tests/utils/emoticons.test.jsx
@@ -27,10 +27,5 @@ describe('Emoticons', () => {
             expect(Emoticons.handleEmoticons('asdf:goat:asdf:dash:asdf', new Map(), emojis)).
                 toEqual('asdf$MM_EMOTICON0asdf$MM_EMOTICON1asdf');
         });
-
-        test('shouldn\'t replace invalid emoticons', () => {
-            expect(Emoticons.handleEmoticons(':asdf: :goat : : dash:', new Map(), emojis)).
-                toEqual(':asdf: :goat : : dash:');
-        });
     });
 });

--- a/tests/utils/emoticons.test.jsx
+++ b/tests/utils/emoticons.test.jsx
@@ -1,31 +1,33 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import EmojiStore from 'stores/emoji_store.jsx';
 import * as Emoticons from 'utils/emoticons.jsx';
 
 describe('Emoticons', () => {
     describe('handleEmoticons', () => {
-        const emojis = EmojiStore.getEmojis();
-
         test('should replace emoticons with tokens', () => {
-            expect(Emoticons.handleEmoticons(':goat: :dash:', new Map(), emojis)).
+            expect(Emoticons.handleEmoticons(':goat: :dash:', new Map())).
                 toEqual('$MM_EMOTICON0 $MM_EMOTICON1');
         });
 
         test('should replace emoticons not separated by whitespace', () => {
-            expect(Emoticons.handleEmoticons(':goat::dash:', new Map(), emojis)).
+            expect(Emoticons.handleEmoticons(':goat::dash:', new Map())).
                 toEqual('$MM_EMOTICON0$MM_EMOTICON1');
         });
 
         test('should replace emoticons separated by punctuation', () => {
-            expect(Emoticons.handleEmoticons('/:goat:..:dash:)', new Map(), emojis)).
+            expect(Emoticons.handleEmoticons('/:goat:..:dash:)', new Map())).
                 toEqual('/$MM_EMOTICON0..$MM_EMOTICON1)');
         });
 
         test('should replace emoticons separated by text', () => {
-            expect(Emoticons.handleEmoticons('asdf:goat:asdf:dash:asdf', new Map(), emojis)).
+            expect(Emoticons.handleEmoticons('asdf:goat:asdf:dash:asdf', new Map())).
                 toEqual('asdf$MM_EMOTICON0asdf$MM_EMOTICON1asdf');
+        });
+
+        test('shouldn\'t replace invalid emoticons', () => {
+            expect(Emoticons.handleEmoticons(':goat : : dash:', new Map())).
+                toEqual(':goat : : dash:');
         });
     });
 });

--- a/tests/utils/formatting_hashtags.test.jsx
+++ b/tests/utils/formatting_hashtags.test.jsx
@@ -185,7 +185,7 @@ describe('TextFormatting.Hashtags', function() {
 
         assert.equal(
             TextFormatting.formatText('#:mattermost:').trim(),
-            '<p>#<span alt=":mattermost:" class="emoticon" title=":mattermost:" style="background-image:url(/static/emoji/mattermost.png)"></span></p>'
+            '<p>#<span data-emoticon="mattermost">:mattermost:</span></p>'
         );
 
         assert.equal(

--- a/utils/emoticons.jsx
+++ b/utils/emoticons.jsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import EmojiStore from 'stores/emoji_store.jsx';
-
 export const emoticonPatterns = {
     slightly_smiling_face: /(^|\s)(:-?\))(?=$|\s)/g, // :)
     wink: /(^|\s)(;-?\))(?=$|\s)/g, // ;)
@@ -28,26 +26,19 @@ export const emoticonPatterns = {
 
 export const EMOJI_PATTERN = /(:([a-zA-Z0-9_-]+):)/g;
 
-export function handleEmoticons(text, tokens, emojis) {
+export function handleEmoticons(text, tokens) {
     let output = text;
 
     function replaceEmoticonWithToken(fullMatch, prefix, matchText, name) {
         const index = tokens.size;
         const alias = `$MM_EMOTICON${index}`;
 
-        if (emojis.has(name)) {
-            const path = EmojiStore.getEmojiImageUrl(emojis.get(name));
+        tokens.set(alias, {
+            value: `<span data-emoticon="${name}">${matchText}</span>`,
+            originalText: fullMatch
+        });
 
-            // we have an image path so we found a matching emoticon
-            tokens.set(alias, {
-                value: `<span alt="${matchText}" class="emoticon" title="${matchText}" style="background-image:url(${path})"></span>`,
-                originalText: fullMatch
-            });
-
-            return prefix + alias;
-        }
-
-        return fullMatch;
+        return prefix + alias;
     }
 
     // match named emoticons like :goat:

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -10,6 +10,7 @@ import UserStore from 'stores/user_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import AtMention from 'components/at_mention';
+import PostEmoji from 'components/post_emoji';
 import MarkdownImage from 'components/markdown_image';
 import LatexBlock from 'components/latex_block';
 
@@ -137,7 +138,8 @@ export function removeCode(text) {
 
 export function postMessageHtmlToComponent(html, isRHS) {
     const parser = new Parser();
-    const attrib = 'data-mention';
+    const mentionAttrib = 'data-mention';
+    const emojiAttrib = 'data-emoticon';
     const processNodeDefinitions = new ProcessNodeDefinitions(React);
 
     function isValidNode() {
@@ -147,9 +149,9 @@ export function postMessageHtmlToComponent(html, isRHS) {
     const processingInstructions = [
         {
             replaceChildren: true,
-            shouldProcessNode: (node) => node.attribs && node.attribs[attrib],
+            shouldProcessNode: (node) => node.attribs && node.attribs[mentionAttrib],
             processNode: (node) => {
-                const mentionName = node.attribs[attrib];
+                const mentionName = node.attribs[mentionAttrib];
                 const callAtMention = (
                     <AtMention
                         mentionName={mentionName}
@@ -158,6 +160,19 @@ export function postMessageHtmlToComponent(html, isRHS) {
                     />
                 );
                 return callAtMention;
+            }
+        },
+        {
+            replaceChildren: true,
+            shouldProcessNode: (node) => node.attribs && node.attribs[emojiAttrib],
+            processNode: (node) => {
+                const emojiName = node.attribs[emojiAttrib];
+                const callPostEmoji = (
+                    <PostEmoji
+                        name={emojiName}
+                    />
+                );
+                return callPostEmoji;
             }
         },
         {

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -24,7 +24,7 @@ const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-
 // - mentionHighlight - Specifies whether or not to highlight mentions of the current user. Defaults to true.
 // - mentionKeys - A list of mention keys for the current user to highlight.
 // - singleline - Specifies whether or not to remove newlines. Defaults to false.
-// - emoticons - Enables emoticon parsing. Defaults to true.
+// - emoticons - Enables emoticon parsing with a data-emoticon attribute. Defaults to true.
 // - markdown - Enables markdown parsing. Defaults to true.
 // - siteURL - The origin of this Mattermost instance. If provided, links to channels and posts will be replaced with internal
 //     links that can be handled by a special click handler.
@@ -77,7 +77,7 @@ export function doFormatText(text, options) {
     output = autolinkHashtags(output, tokens);
 
     if (!('emoticons' in options) || options.emoticon) {
-        output = Emoticons.handleEmoticons(output, tokens, options.emojis || EmojiStore.getEmojis());
+        output = Emoticons.handleEmoticons(output, tokens);
     }
 
     if (options.searchPatterns) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5566,7 +5566,7 @@ math-expression-evaluator@^1.2.14:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz#b357fa1ca9faefb8e48d10c14ef2bcb2d9f0a7c9"
 
-mattermost-redux@mattermost/mattermost-redux#58adb9a71cf5b3d1b753f33295da81372702cd45:
+mattermost-redux@mattermost/mattermost-redux:
   version "1.1.0"
   resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/ed1d042770aa5fe805949da62a508f607452a746"
   dependencies:


### PR DESCRIPTION
#### Summary
Support for loading emojis asynchronously in posts.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-93

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has redux changes (mattermost/mattermost-redux#379)
- [x] Has UI changes