### PR TITLE
ABC-181: bind onSubmit in MFA Confirm component

### DIFF
--- a/components/mfa/components/confirm.jsx
+++ b/components/mfa/components/confirm.jsx
@@ -13,6 +13,7 @@ export default class Confirm extends React.Component {
     constructor(props) {
         super(props);
 
+        this.submit = this.submit.bind(this);
         this.onKeyPress = this.onKeyPress.bind(this);
     }
 

--- a/components/mfa/components/confirm.jsx
+++ b/components/mfa/components/confirm.jsx
@@ -10,13 +10,6 @@ import Constants from 'utils/constants.jsx';
 const KeyCodes = Constants.KeyCodes;
 
 export default class Confirm extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.submit = this.submit.bind(this);
-        this.onKeyPress = this.onKeyPress.bind(this);
-    }
-
     componentDidMount() {
         document.body.addEventListener('keydown', this.onKeyPress);
     }
@@ -25,14 +18,14 @@ export default class Confirm extends React.Component {
         document.body.removeEventListener('keydown', this.onKeyPress);
     }
 
-    submit(e) {
+    submit = (e) => {
         e.preventDefault();
         loadMe().then(() => {
             this.props.history.push('/');
         });
     }
 
-    onKeyPress(e) {
+    onKeyPress = (e) => {
         if (e.which === KeyCodes.ENTER) {
             this.submit(e);
         }

--- a/tests/components/mfa/components/__snapshots__/confirm_test.jsx.snap
+++ b/tests/components/mfa/components/__snapshots__/confirm_test.jsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/mfa/components/Confirm should match snapshot 1`] = `
+<div>
+  <form
+    className="form-group"
+    onKeyPress={[Function]}
+    onSubmit={[Function]}
+  >
+    <p>
+      <FormattedHTMLMessage
+        defaultMessage="<strong>Set up complete!</strong>"
+        id="mfa.confirm.complete"
+        values={Object {}}
+      />
+    </p>
+    <p>
+      <FormattedMessage
+        defaultMessage="Your account is now secure. Next time you sign in, you will be asked to enter a code from the Google Authenticator app on your phone."
+        id="mfa.confirm.secure"
+        values={Object {}}
+      />
+    </p>
+    <button
+      className="btn btn-primary"
+      type="submit"
+    >
+      <FormattedMessage
+        defaultMessage="Okay"
+        id="mfa.confirm.okay"
+        values={Object {}}
+      />
+    </button>
+  </form>
+</div>
+`;

--- a/tests/components/mfa/components/confirm_test.jsx
+++ b/tests/components/mfa/components/confirm_test.jsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {loadMe} from 'actions/user_actions.jsx';
+import {browserHistory} from 'utils/browser_history';
+import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+import Confirm from 'components/mfa/components/confirm.jsx';
+import Constants from 'utils/constants.jsx';
+
+jest.mock('actions/user_actions.jsx', () => ({
+    loadMe: jest.fn().mockImplementation(() => Promise.resolve())
+}));
+
+describe('components/mfa/components/Confirm', () => {
+    test('should match snapshot', () => {
+        const wrapper = shallow(<Confirm history={browserHistory}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should submit on form submit', () => {
+        browserHistory.push = jest.fn();
+        const wrapper = mountWithIntl(<Confirm history={browserHistory}/>);
+        wrapper.find('form').simulate('submit');
+
+        return Promise.resolve().then(() => {
+            expect(loadMe).toBeCalled();
+            expect(browserHistory.push).toHaveBeenCalledWith('/');
+        });
+    });
+
+    test('should submit on enter', () => {
+        var map = {};
+        document.body.addEventListener = jest.fn().mockImplementation((event, cb) => {
+            console.log(event);
+            map[event] = cb;
+        });
+
+        browserHistory.push = jest.fn();
+        mountWithIntl(<Confirm history={browserHistory}/>);
+
+        const event = {
+            preventDefault: jest.fn(),
+            which: Constants.KeyCodes.ENTER
+        };
+        map.keydown(event);
+
+        return Promise.resolve().then(() => {
+            expect(loadMe).toBeCalled();
+            expect(browserHistory.push).toHaveBeenCalledWith('/');
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
This fixes a JavaScript exception after completing MFA setup and trying
to click the "Okay" button. The submit handler wasn't bound to `this`.

I scanned the change that introduced this regression, but found no other
instances where this would have been unbound in the function in
question.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-181

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed