### PR TITLE
[GH-7996] Fix problem with the last version of webrtc-adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "reselect": "3.0.1",
     "superagent": "3.8.2",
     "twemoji": "2.5.0",
-    "webrtc-adapter": "6.1.0",
+    "webrtc-adapter": "6.0.4",
     "whatwg-fetch": "2.0.3",
     "xregexp": "4.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8926,9 +8926,9 @@ webpack@3.10.0:
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
 
-webrtc-adapter@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-6.1.0.tgz#238ad8c510558798d4dd8978aaf80e2675bbc1ea"
+webrtc-adapter@6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-6.0.4.tgz#fb0b77a742952bd26fe9d8264c872d72c2e8b982"
   dependencies:
     rtcpeerconnection-shim "^1.1.13"
     sdp "^2.3.0"


### PR DESCRIPTION
#### Summary
In firefox, with the about:config setting `media.peerconnections.enabled` equal
to `false`, the application crashes because a webrtc-adapter bug in any version
previous to 6.0.3 and after 6.0.4. This change the version to 6.0.4.

#### Ticket Link
GH ISSUE #7996

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed