### PR TITLE
[GH-7996] Fix problem with the version of webrtc-adapter (4.5 version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "superagent": "3.8.1",
     "twemoji": "2.5.0",
     "velocity-animate": "1.5.0",
-    "webrtc-adapter": "6.0.2",
+    "webrtc-adapter": "6.0.3",
     "whatwg-fetch": "2.0.3",
     "xregexp": "3.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9016,9 +9016,9 @@ webpack@3.8.1:
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
 
-webrtc-adapter@6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-6.0.2.tgz#765f99c163e46046a758fec457f7859c90a19487"
+webrtc-adapter@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-6.0.3.tgz#850ab1649099922086c2c038c87c10c46d0c42cc"
   dependencies:
     rtcpeerconnection-shim "^1.1.13"
     sdp "^2.3.0"


### PR DESCRIPTION
#### Summary
This is a PR to the release-4.5 branch for the 4.5.2 version.

In firefox, with the about:config setting `media.peerconnections.enabled` equal
to `false`, the application crashes because a webrtc-adapter bug in any version
previous to 6.0.3 and after 6.0.4. This change the version to 6.0.3.

#### Ticket Link
GH ISSUE mattermost/mattermost-server#7996

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed