### PR TITLE
ABC-187: switch post header to onMouseOver

### DIFF
--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -281,7 +281,7 @@ export default class Post extends React.PureComponent {
         return (
             <div
                 ref={this.getRef}
-                onMouseEnter={this.setHover}
+                onMouseOver={this.setHover}
                 onMouseLeave={this.unsetHover}
             >
                 <div


### PR DESCRIPTION
#### Summary
The [...] menu can sometimes appear as a thin white line but devoid of content. See the JIRA link for repro steps.

The underlying issue appears to boil down to a mismatch between the CSS `:hover` state
which assigns the background color to the [...] menu and the
`onMouseEnter` event for the containing post. The latter never fires in
the cases described above, even after the dialog is dismissed, whereas
the CSS state re-evaluates constantly.

Switching to `onMouseOver` keeps the state in sync, with the minor
change that the event now bubbles and could be cancelled (but doesn't
appear to be in this component hierarchy).

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-187

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes