### PR TITLE
ABC-79: use autocomplete channels endpoint

### DIFF
--- a/actions/channel_actions.jsx
+++ b/actions/channel_actions.jsx
@@ -316,7 +316,7 @@ export async function autocompleteChannels(term, success, error) {
         return;
     }
 
-    const {data, error: err} = await ChannelActions.searchChannels(teamId, term)(dispatch, getState);
+    const {data, error: err} = await ChannelActions.autocompleteChannels(teamId, term)(dispatch, getState);
     if (data && success) {
         success(data);
     } else if (err && error) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "localforage": "1.5.6",
     "localforage-observable": "1.4.0",
     "marked": "mattermost/marked#802e981ade71149a497cbe79d12b8a3f82f7657e",
-    "mattermost-redux": "mattermost/mattermost-redux#58adb9a71cf5b3d1b753f33295da81372702cd45",
+    "mattermost-redux": "mattermost/mattermost-redux#ed1d042770aa5fe805949da62a508f607452a746",
     "pdfjs-dist": "2.0.290",
     "perfect-scrollbar": "0.8.1",
     "prop-types": "15.6.0",


### PR DESCRIPTION
#### Summary
See https://github.com/mattermost/mattermost-server/pull/8163 and https://github.com/mattermost/mattermost-redux/pull/384

Won't work until the other PRs are merged.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-79

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has server changes
- [x] Has redux changes