### PR TITLE
XYZ-52: Adapts 'Enable Team Creation' on 'Users and Teams' page to re…

### DIFF
--- a/components/admin_console/admin_console.jsx
+++ b/components/admin_console/admin_console.jsx
@@ -53,7 +53,7 @@ import SessionSettings from 'components/admin_console/session_settings.jsx';
 import SignupSettings from 'components/admin_console/signup_settings.jsx';
 import StorageSettings from 'components/admin_console/storage_settings.jsx';
 import SystemUsers from 'components/admin_console/system_users';
-import UsersAndTeamsSettings from 'components/admin_console/users_and_teams_settings.jsx';
+import UsersAndTeamsSettings from 'components/admin_console/users_and_teams_settings';
 import WebrtcSettings from 'components/admin_console/webrtc_settings.jsx';
 import SystemAnalytics from 'components/analytics/system_analytics.jsx';
 import TeamAnalytics from 'components/analytics/team_analytics';

--- a/components/admin_console/users_and_teams_settings/index.jsx
+++ b/components/admin_console/users_and_teams_settings/index.jsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {loadRolesIfNeeded, editRole} from 'mattermost-redux/actions/roles';
+
+import {getRoles} from 'mattermost-redux/selectors/entities/roles';
+
+import UsersAndTeamsSettings from './users_and_teams_settings.jsx';
+
+function mapStateToProps(state) {
+    return {
+        roles: getRoles(state),
+        rolesRequest: state.requests.roles.getRolesByNames
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            loadRolesIfNeeded,
+            editRole
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(UsersAndTeamsSettings);

--- a/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
+++ b/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
@@ -24,6 +24,8 @@ const RESTRICT_DIRECT_MESSAGE_TEAM = 'team';
 
 export default class UsersAndTeamsSettings extends AdminSettings {
     static propTypes = {
+        roles: PropTypes.object.isRequired,
+        rolesRequest: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             loadRolesIfNeeded: PropTypes.func.isRequired,
             editRole: PropTypes.func.isRequired
@@ -32,10 +34,6 @@ export default class UsersAndTeamsSettings extends AdminSettings {
 
     constructor(props) {
         super(props);
-
-        this.getConfigFromState = this.getConfigFromState.bind(this);
-
-        this.renderSettings = this.renderSettings.bind(this);
 
         this.state = {
             ...this.state, // Brings the state in from the parent class.
@@ -88,7 +86,7 @@ export default class UsersAndTeamsSettings extends AdminSettings {
         }
     }
 
-    getConfigFromState(config) {
+    getConfigFromState = (config) => {
         config.TeamSettings.EnableUserCreation = this.state.enableUserCreation;
         config.TeamSettings.MaxUsersPerTeam = this.parseIntNonZero(this.state.maxUsersPerTeam, Constants.DEFAULT_MAX_USERS_PER_TEAM);
         config.TeamSettings.RestrictCreationToDomains = this.state.restrictCreationToDomains;
@@ -98,7 +96,7 @@ export default class UsersAndTeamsSettings extends AdminSettings {
         config.TeamSettings.MaxNotificationsPerChannel = this.parseIntNonZero(this.state.maxNotificationsPerChannel, Constants.DEFAULT_MAX_NOTIFICATIONS_PER_CHANNEL);
         config.TeamSettings.EnableConfirmNotificationsToChannel = this.state.enableConfirmNotificationsToChannel;
         return config;
-    }
+    };
 
     getStateFromConfig(config) {
         return {
@@ -122,7 +120,7 @@ export default class UsersAndTeamsSettings extends AdminSettings {
         );
     }
 
-    renderSettings() {
+    renderSettings = () => {
         if (!this.state.loaded) {
             return <LoadingScreen/>;
         }
@@ -296,5 +294,5 @@ export default class UsersAndTeamsSettings extends AdminSettings {
                 />
             </SettingsGroup>
         );
-    }
+    };
 }

--- a/routes/route_admin_console.jsx
+++ b/routes/route_admin_console.jsx
@@ -49,7 +49,7 @@ import SessionSettings from 'components/admin_console/session_settings.jsx';
 import SignupSettings from 'components/admin_console/signup_settings.jsx';
 import StorageSettings from 'components/admin_console/storage_settings.jsx';
 import SystemUsers from 'components/admin_console/system_users';
-import UsersAndTeamsSettings from 'components/admin_console/users_and_teams_settings.jsx';
+import UsersAndTeamsSettings from 'components/admin_console/users_and_teams_settings';
 import WebrtcSettings from 'components/admin_console/webrtc_settings.jsx';
 import SystemAnalytics from 'components/analytics/system_analytics.jsx';
 import TeamAnalytics from 'components/analytics/team_analytics';

--- a/tests/utils/policy_roles_adapter.test.jsx
+++ b/tests/utils/policy_roles_adapter.test.jsx
@@ -54,6 +54,12 @@ describe('PolicyRolesAdapter', function() {
                     Permissions.DELETE_OTHERS_POSTS,
                     Permissions.EDIT_POST
                 ]
+            },
+            system_user: {
+                name: 'system_user',
+                permissions: [
+                    Permissions.CREATE_TEAM
+                ]
             }
         };
         const teamPolicies = {

--- a/utils/policy_roles_adapter.js
+++ b/utils/policy_roles_adapter.js
@@ -86,6 +86,11 @@ const MAPPING = {
             {roleName: 'team_admin', permission: Permissions.DELETE_POST, shouldHave: false},
             {roleName: 'team_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: false}
         ]
+    },
+
+    enableTeamCreation: {
+        true: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: true}],
+        false: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: false}]
     }
 };
 


### PR DESCRIPTION
…ad/update permissions.

#### Summary
Similar to the Policy page permissions changes, this change updates a permission on a role based on the value of the radio input labelled "Enable Team Creation" in System Console -> General -> Users and Teams.

#### Ticket Link
[XYZ-52](https://mattermost.atlassian.net/browse/XYZ-52)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)