### PR TITLE
ICU-656 Used markdown renderer when searching for at channel in large channels

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -227,7 +227,9 @@ export default class CreateComment extends React.PureComponent {
     handleSubmit = async (e) => {
         e.preventDefault();
 
-        if ((PostUtils.containsAtMention(this.state.draft.message, '@all') || PostUtils.containsAtMention(this.state.draft.message, '@channel')) && this.props.channelMembersCount > Constants.NOTIFY_ALL_MEMBERS && window.mm_config.EnableConfirmNotificationsToChannel === 'true') {
+        if (window.mm_config.EnableConfirmNotificationsToChannel === 'true' &&
+            this.props.channelMembersCount > Constants.NOTIFY_ALL_MEMBERS &&
+            PostUtils.containsAtChannel(this.state.draft.message)) {
             this.showNotifyAllModal();
             return;
         }

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -324,7 +324,9 @@ export default class CreatePost extends React.Component {
     handleSubmit = (e) => {
         const updateChannel = this.props.currentChannel;
 
-        if ((PostUtils.containsAtMention(this.state.message, '@all') || PostUtils.containsAtMention(this.state.message, '@channel')) && this.props.currentChannelMembersCount > Constants.NOTIFY_ALL_MEMBERS && window.mm_config.EnableConfirmNotificationsToChannel === 'true') {
+        if (window.mm_config.EnableConfirmNotificationsToChannel === 'true' &&
+            this.props.currentChannelMembersCount > Constants.NOTIFY_ALL_MEMBERS &&
+            PostUtils.containsAtChannel(this.state.message)) {
             this.showNotifyAllModal();
             return;
         }

--- a/tests/utils/formatting_imgs.test.jsx
+++ b/tests/utils/formatting_imgs.test.jsx
@@ -3,7 +3,7 @@
 
 import assert from 'assert';
 
-import * as Markdown from 'utils/markdown.jsx';
+import * as Markdown from 'utils/markdown';
 
 describe('Markdown.Imgs', function() {
     it('Inline mage', function(done) {

--- a/tests/utils/formatting_links.test.jsx
+++ b/tests/utils/formatting_links.test.jsx
@@ -3,7 +3,7 @@
 
 import assert from 'assert';
 
-import * as Markdown from 'utils/markdown.jsx';
+import * as Markdown from 'utils/markdown';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 
 describe('Markdown.Links', function() {

--- a/tests/utils/post_utils.test.jsx
+++ b/tests/utils/post_utils.test.jsx
@@ -1,167 +1,151 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 import * as PostUtils from 'utils/post_utils.jsx';
 
-describe('PostUtils.containsAtMention', function() {
+describe('PostUtils.containsAtChannel', function() {
     test('should return correct @all (same for @channel)', function() {
         for (const data of [
             {
-                text: undefined, // eslint-disable-line no-undefined
-                key: undefined, // eslint-disable-line no-undefined
-                result: false
-            },
-            {
                 text: '',
-                key: '',
                 result: false
             },
             {
                 text: 'all',
-                key: '@all',
                 result: false
             },
             {
                 text: '@allison',
-                key: '@all',
                 result: false
             },
             {
                 text: '@ALLISON',
-                key: '@all',
                 result: false
             },
             {
                 text: '@all123',
-                key: '@all',
                 result: false
             },
             {
                 text: '123@all',
-                key: '@all',
                 result: false
             },
             {
                 text: 'hey@all',
-                key: '@all',
                 result: false
             },
             {
                 text: 'hey@all.com',
-                key: '@all',
                 result: false
             },
             {
                 text: '@all',
-                key: '@all',
                 result: true
             },
             {
                 text: '@ALL',
-                key: '@all',
                 result: true
             },
             {
                 text: '@all hey',
-                key: '@all',
                 result: true
             },
             {
                 text: 'hey @all',
-                key: '@all',
                 result: true
             },
             {
                 text: 'HEY @ALL',
-                key: '@all',
                 result: true
             },
             {
                 text: 'hey @all!',
-                key: '@all',
                 result: true
             },
             {
                 text: 'hey @all:+1:',
-                key: '@all',
                 result: true
             },
             {
                 text: 'hey @ALL:+1:',
-                key: '@all',
                 result: true
             },
             {
                 text: '`@all`',
-                key: '@all',
                 result: false
             },
             {
                 text: '@someone `@all`',
-                key: '@all',
                 result: false
-            },
-            {
-                text: '@someone `@all`',
-                key: '@someone',
-                result: true
             },
             {
                 text: '``@all``',
-                key: '@all',
                 result: false
             },
             {
                 text: '```@all```',
-                key: '@all',
                 result: false
             },
             {
                 text: '```\n@all\n```',
-                key: '@all',
                 result: false
             },
             {
                 text: '```````\n@all\n```````',
-                key: '@all',
                 result: false
             },
             {
                 text: '```code\n@all\n```',
-                key: '@all',
                 result: false
             },
             {
                 text: '~~~@all~~~',
-                key: '@all',
                 result: true
             },
             {
                 text: '~~~\n@all\n~~~',
-                key: '@all',
                 result: false
             },
             {
                 text: ' /not_cmd @all',
-                key: '@all',
                 result: true
             },
             {
                 text: '/cmd @all',
-                key: '@all',
                 result: false
             },
             {
                 text: '/cmd @all test',
-                key: '@all',
                 result: false
             },
             {
                 text: '/cmd test @all',
-                key: '@all',
                 result: false
+            },
+            {
+                text: '@channel',
+                result: true
+            },
+            {
+                text: '@channel.',
+                result: true
+            },
+            {
+                text: '@channel/test',
+                result: true
+            },
+            {
+                text: 'test/@channel',
+                result: true
+            },
+            {
+                text: '@all/@channel',
+                result: true
             }
         ]) {
-            const containsAtMention = PostUtils.containsAtMention(data.text, data.key);
+            const containsAtChannel = PostUtils.containsAtChannel(data.text);
 
-            expect(containsAtMention).toEqual(data.result);
+            expect(containsAtChannel).toEqual(data.result);
         }
     });
 });

--- a/tests/utils/post_utils.test.jsx
+++ b/tests/utils/post_utils.test.jsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import assert from 'assert';
+
 import * as PostUtils from 'utils/post_utils.jsx';
 
 describe('PostUtils.containsAtChannel', function() {
@@ -141,11 +143,31 @@ describe('PostUtils.containsAtChannel', function() {
             {
                 text: '@all/@channel',
                 result: true
+            },
+            {
+                text: '@cha*nnel*',
+                result: false
+            },
+            {
+                text: '@cha**nnel**',
+                result: false
+            },
+            {
+                text: '*@cha*nnel',
+                result: false
+            },
+            {
+                text: '[@chan](https://google.com)nel',
+                result: false
+            },
+            {
+                text: '@cha![](https://myimage)nnel',
+                result: false
             }
         ]) {
             const containsAtChannel = PostUtils.containsAtChannel(data.text);
 
-            expect(containsAtChannel).toEqual(data.result);
+            assert.equal(containsAtChannel, data.result, data.text);
         }
     });
 });

--- a/utils/markdown/index.js
+++ b/utils/markdown/index.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import marked from 'marked';
+
+import Renderer from './renderer';
+
+export function format(text, options = {}) {
+    return formatWithRenderer(text, new Renderer(null, options));
+}
+
+export function formatWithRenderer(text, renderer) {
+    const markdownOptions = {
+        renderer,
+        sanitize: true,
+        gfm: true,
+        tables: true,
+        mangle: false
+    };
+
+    return marked(text, markdownOptions);
+}

--- a/utils/markdown/mentionable_renderer.jsx
+++ b/utils/markdown/mentionable_renderer.jsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import marked from 'marked';
+
+/** A Markdown renderer that converts a post into plain text that we can search for mentions */
+export default class MentionableRenderer extends marked.Renderer {
+    code() {
+        // Code blocks can't contain mentions
+        return '\n';
+    }
+
+    blockquote(text) {
+        return text + '\n';
+    }
+
+    heading(text) {
+        return text + '\n';
+    }
+
+    hr() {
+        return '\n';
+    }
+
+    list(body) {
+        return body + '\n';
+    }
+
+    listitem(text) {
+        return text + '\n';
+    }
+
+    paragraph(text) {
+        return text + '\n';
+    }
+
+    table(header, body) {
+        return header + '\n' + body;
+    }
+
+    tablerow(content) {
+        return content;
+    }
+
+    tablecell(content) {
+        return content + '\n';
+    }
+
+    strong(text) {
+        return text;
+    }
+
+    em(text) {
+        return text;
+    }
+
+    codespan() {
+        // Code spans can't contain mentions
+        return ' ';
+    }
+
+    br() {
+        return '\n';
+    }
+
+    del(text) {
+        return text;
+    }
+
+    link(href, title, text) {
+        return text;
+    }
+
+    image(href, title, text) {
+        return text;
+    }
+
+    text(text) {
+        return text;
+    }
+}

--- a/utils/markdown/mentionable_renderer.jsx
+++ b/utils/markdown/mentionable_renderer.jsx
@@ -47,11 +47,11 @@ export default class MentionableRenderer extends marked.Renderer {
     }
 
     strong(text) {
-        return text;
+        return ' ' + text + ' ';
     }
 
     em(text) {
-        return text;
+        return ' ' + text + ' ';
     }
 
     codespan() {
@@ -64,15 +64,15 @@ export default class MentionableRenderer extends marked.Renderer {
     }
 
     del(text) {
-        return text;
+        return ' ' + text + ' ';
     }
 
     link(href, title, text) {
-        return text;
+        return ' ' + text + ' ';
     }
 
     image(href, title, text) {
-        return text;
+        return ' ' + text + ' ';
     }
 
     text(text) {

--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -7,7 +7,7 @@ import * as SyntaxHighlighting from 'utils/syntax_highlighting.jsx';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 import {isUrlSafe} from 'utils/url.jsx';
 
-class MattermostMarkdownRenderer extends marked.Renderer {
+export default class Renderer extends marked.Renderer {
     constructor(options, formattingOptions = {}) {
         super(options);
 
@@ -221,18 +221,6 @@ class MattermostMarkdownRenderer extends marked.Renderer {
     text(txt) {
         return TextFormatting.doFormatText(txt, this.formattingOptions);
     }
-}
-
-export function format(text, options = {}) {
-    const markdownOptions = {
-        renderer: new MattermostMarkdownRenderer(null, options),
-        sanitize: true,
-        gfm: true,
-        tables: true,
-        mangle: false
-    };
-
-    return marked(text, markdownOptions);
 }
 
 // Marked helper functions that should probably just be exported

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -4,15 +4,19 @@
 import React from 'react';
 import {Parser, ProcessNodeDefinitions} from 'html-to-react';
 
+import AtMention from 'components/at_mention';
+import LatexBlock from 'components/latex_block';
+import MarkdownImage from 'components/markdown_image';
+import PostEmoji from 'components/post_emoji';
+
 import ChannelStore from 'stores/channel_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
+
 import Constants from 'utils/constants.jsx';
+import {formatWithRenderer} from 'utils/markdown';
+import MentionableRenderer from 'utils/markdown/mentionable_renderer';
 import * as Utils from 'utils/utils.jsx';
-import AtMention from 'components/at_mention';
-import PostEmoji from 'components/post_emoji';
-import MarkdownImage from 'components/markdown_image';
-import LatexBlock from 'components/latex_block';
 
 export function isSystemMessage(post) {
     return Boolean(post.type && (post.type.lastIndexOf(Constants.SYSTEM_MESSAGE_PREFIX) === 0));
@@ -117,23 +121,15 @@ export function shouldShowDotMenu(post) {
     return false;
 }
 
-export function containsAtMention(text, key) {
-    if (!text || !key) {
+export function containsAtChannel(text) {
+    // Don't warn for slash commands
+    if (!text || text.startsWith('/')) {
         return false;
     }
 
-    // This doesn't work for at mentions containing periods or hyphens
-    return !text.startsWith('/') && new RegExp(`\\B${key}\\b`, 'i').test(removeCode(text));
-}
+    const mentionableText = formatWithRenderer(text, new MentionableRenderer());
 
-// Returns a given text string with all Markdown code replaced with whitespace.
-export function removeCode(text) {
-    // These patterns should match the ones in app/notification.go, except JavaScript doesn't
-    // support \z for the end of the text in multiline mode, so we use $(?![\r\n])
-    const codeBlockPattern = /^[^\S\n]*[`~]{3}.*$[\s\S]+?(^[^\S\n]*[`~]{3}$|$(?![\r\n]))/mg;
-    const inlineCodePattern = /`+(?:.+?|.*?(.*?\S.*?\n)*.*?)`+/mg;
-
-    return text.replace(codeBlockPattern, '').replace(inlineCodePattern, ' ');
+    return (/\B@(all|channel)\b/i).test(mentionableText);
 }
 
 export function postMessageHtmlToComponent(html, isRHS) {

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -9,7 +9,7 @@ import EmojiStore from 'stores/emoji_store.jsx';
 
 import Constants from './constants.jsx';
 import * as Emoticons from './emoticons.jsx';
-import * as Markdown from './markdown.jsx';
+import * as Markdown from './markdown';
 
 const punctuation = XRegExp.cache('[^\\pL\\d]');
 


### PR DESCRIPTION
Like the server, we now use the markdown parser to strip out any text that can't trigger mentions before searching for at channel notifications. The regexes we used before had some degenerate cases that would cause the browser to lock up while they were processed, so they had to go.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-656

#### Checklist
- Added or updated unit tests (required for all new features)