### PR TITLE
ABC-178: polyfill URLSearchParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "reselect": "3.0.1",
     "superagent": "3.8.2",
     "twemoji": "2.5.0",
-    "url-search-params-polyfill": "^2.0.2",
+    "url-search-params-polyfill": "2.0.2",
     "webrtc-adapter": "6.0.4",
     "whatwg-fetch": "2.0.3",
     "xregexp": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "reselect": "3.0.1",
     "superagent": "3.8.2",
     "twemoji": "2.5.0",
+    "url-search-params-polyfill": "^2.0.2",
     "webrtc-adapter": "6.0.4",
     "whatwg-fetch": "2.0.3",
     "xregexp": "4.0.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -129,7 +129,7 @@ var MYSTATS = {
 };
 
 var config = {
-    entry: ['babel-polyfill', 'whatwg-fetch', './root.jsx', 'root.html'],
+    entry: ['babel-polyfill', 'whatwg-fetch', 'url-search-params-polyfill', './root.jsx', 'root.html'],
     output: {
         path: path.join(__dirname, 'dist'),
         publicPath: '/static/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8702,7 +8702,7 @@ url-regex@^3.0.0:
   dependencies:
     ip-regex "^1.0.1"
 
-url-search-params-polyfill@^2.0.2:
+url-search-params-polyfill@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-2.0.2.tgz#45361092f511ae88a19dee3e7b0964634b756fb3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8702,6 +8702,10 @@ url-regex@^3.0.0:
   dependencies:
     ip-regex "^1.0.1"
 
+url-search-params-polyfill@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-2.0.2.tgz#45361092f511ae88a19dee3e7b0964634b756fb3"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
#### Summary
IE11 and the current Edge don't support URLSearchParams, newly
introduced as part of the react-router upgrades. This completely
prevents Mattermost from working. The newest Edge in preview does
support URLSearchParams and renders without issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-178

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed