### PR TITLE
[ICU-652] Reset error for new channel creation when switching channel from private to public and vice versa

### DIFF
--- a/components/new_channel_flow.jsx
+++ b/components/new_channel_flow.jsx
@@ -129,11 +129,16 @@ export default class NewChannelFlow extends React.Component {
 
     typeSwitched = (e) => {
         e.preventDefault();
+
+        let channelType = Constants.PRIVATE_CHANNEL;
         if (this.state.channelType === Constants.PRIVATE_CHANNEL) {
-            this.setState({channelType: Constants.OPEN_CHANNEL});
-        } else {
-            this.setState({channelType: Constants.PRIVATE_CHANNEL});
+            channelType = Constants.OPEN_CHANNEL;
         }
+
+        this.setState({
+            channelType,
+            serverError: ''
+        });
     };
 
     urlChangeRequested = (e) => {

--- a/tests/components/new_channel_flow.test.jsx
+++ b/tests/components/new_channel_flow.test.jsx
@@ -91,8 +91,15 @@ describe('components/NewChannelFlow', () => {
             <NewChannelFlow {...baseProps}/>
         );
 
+        wrapper.setState({channelType: Constants.OPEN_CHANNEL, serverError: 'server error'});
         wrapper.instance().typeSwitched({preventDefault: jest.fn()});
         expect(wrapper.state('channelType')).toEqual(Constants.PRIVATE_CHANNEL);
+        expect(wrapper.state('serverError')).toEqual('');
+
+        wrapper.setState({channelType: Constants.PRIVATE_CHANNEL, serverError: 'server error'});
+        wrapper.instance().typeSwitched({preventDefault: jest.fn()});
+        expect(wrapper.state('channelType')).toEqual(Constants.OPEN_CHANNEL);
+        expect(wrapper.state('serverError')).toEqual('');
     });
 
     test('should match state when typeSwitched is called, with state switched from PRIVATE_CHANNEL', () => {


### PR DESCRIPTION
#### Summary
Reset error for new channel creation when switching channel from private to public and vice versa

#### Ticket Link
Jira ticket: [ICU-652](https://mattermost.atlassian.net/browse/ICU-652)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
