### PR TITLE
Used a fragment to reduce code duplication in sidebar

### DIFF
--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
@@ -49,6 +49,29 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
         if (this.props.badge) {
             badge = <span className='badge'>{this.props.unreadMentions}</span>;
         }
+
+        const content = (
+            <React.Fragment>
+                <SidebarChannelButtonOrLinkIcon
+                    channelId={this.props.channelId}
+                    channelStatus={this.props.channelStatus}
+                    channelType={this.props.channelType}
+                    membersCount={this.props.membersCount}
+                    teammateId={this.props.teammateId}
+                    teammateDeletedAt={this.props.teammateDeletedAt}
+                />
+                <span className='sidebar-item__name'>{this.props.displayName}</span>
+                {badge}
+                <SidebarChannelButtonOrLinkCloseButton
+                    handleClose={this.props.handleClose}
+                    channelId={this.props.channelId}
+                    channelType={this.props.channelType}
+                    teammateId={this.props.teammateId}
+                    badge={this.props.badge}
+                />
+            </React.Fragment>
+        );
+
         let element;
         if (isDesktopApp()) {
             element = (
@@ -60,23 +83,7 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
                         className={'btn btn-link ' + this.props.rowClass}
                         onClick={this.handleClick}
                     >
-                        <SidebarChannelButtonOrLinkIcon
-                            channelId={this.props.channelId}
-                            channelStatus={this.props.channelStatus}
-                            channelType={this.props.channelType}
-                            membersCount={this.props.membersCount}
-                            teammateId={this.props.teammateId}
-                            teammateDeletedAt={this.props.teammateDeletedAt}
-                        />
-                        <span className='sidebar-item__name'>{this.props.displayName}</span>
-                        {badge}
-                        <SidebarChannelButtonOrLinkCloseButton
-                            handleClose={this.props.handleClose}
-                            channelId={this.props.channelId}
-                            channelType={this.props.channelType}
-                            teammateId={this.props.teammateId}
-                            badge={this.props.badge}
-                        />
+                        {content}
                     </button>
                 </CopyUrlContextMenu>
             );
@@ -87,23 +94,7 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
                     className={this.props.rowClass}
                     onClick={this.trackChannelSelectedEvent}
                 >
-                    <SidebarChannelButtonOrLinkIcon
-                        channelId={this.props.channelId}
-                        channelStatus={this.props.channelStatus}
-                        channelType={this.props.channelType}
-                        membersCount={this.props.membersCount}
-                        teammateId={this.props.teammateId}
-                        teammateDeletedAt={this.props.teammateDeletedAt}
-                    />
-                    <span className='sidebar-item__name'>{this.props.displayName}</span>
-                    {badge}
-                    <SidebarChannelButtonOrLinkCloseButton
-                        handleClose={this.props.handleClose}
-                        channelId={this.props.channelId}
-                        channelType={this.props.channelType}
-                        teammateId={this.props.teammateId}
-                        badge={this.props.badge}
-                    />
+                    {content}
                 </Link>
             );
         }

--- a/tests/components/sidebar/__snapshots__/sidebar_channel_button_or_link.test.jsx.snap
+++ b/tests/components/sidebar/__snapshots__/sidebar_channel_button_or_link.test.jsx.snap
@@ -7,31 +7,33 @@ exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOr
   replace={false}
   to="test-link"
 >
-  <SidebarChannelButtonOrLinkIcon
-    channelId="test-channel-id"
-    channelStatus="test"
-    channelType="D"
-    membersCount={3}
-    teammateDeletedAt={1}
-    teammateId="test-teammate-id"
-  />
-  <span
-    className="sidebar-item__name"
-  >
-    test-channel-name
-  </span>
-  <span
-    className="badge"
-  >
-    6
-  </span>
-  <SidebarChannelButtonOrLinkCloseButton
-    badge={true}
-    channelId="test-channel-id"
-    channelType="D"
-    handleClose={[MockFunction]}
-    teammateId="test-teammate-id"
-  />
+  <React.Fragment>
+    <SidebarChannelButtonOrLinkIcon
+      channelId="test-channel-id"
+      channelStatus="test"
+      channelType="D"
+      membersCount={3}
+      teammateDeletedAt={1}
+      teammateId="test-teammate-id"
+    />
+    <span
+      className="sidebar-item__name"
+    >
+      test-channel-name
+    </span>
+    <span
+      className="badge"
+    >
+      6
+    </span>
+    <SidebarChannelButtonOrLinkCloseButton
+      badge={true}
+      channelId="test-channel-id"
+      channelType="D"
+      handleClose={[MockFunction]}
+      teammateId="test-teammate-id"
+    />
+  </React.Fragment>
 </Link>
 `;
 
@@ -42,25 +44,27 @@ exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOr
   replace={false}
   to="test-link"
 >
-  <SidebarChannelButtonOrLinkIcon
-    channelId="test-channel-id"
-    channelStatus="test"
-    channelType="D"
-    membersCount={3}
-    teammateDeletedAt={1}
-    teammateId="test-teammate-id"
-  />
-  <span
-    className="sidebar-item__name"
-  >
-    test-channel-name
-  </span>
-  <SidebarChannelButtonOrLinkCloseButton
-    channelId="test-channel-id"
-    channelType="D"
-    handleClose={[MockFunction]}
-    teammateId="test-teammate-id"
-  />
+  <React.Fragment>
+    <SidebarChannelButtonOrLinkIcon
+      channelId="test-channel-id"
+      channelStatus="test"
+      channelType="D"
+      membersCount={3}
+      teammateDeletedAt={1}
+      teammateId="test-teammate-id"
+    />
+    <span
+      className="sidebar-item__name"
+    >
+      test-channel-name
+    </span>
+    <SidebarChannelButtonOrLinkCloseButton
+      channelId="test-channel-id"
+      channelType="D"
+      handleClose={[MockFunction]}
+      teammateId="test-teammate-id"
+    />
+  </React.Fragment>
 </Link>
 `;
 
@@ -71,31 +75,33 @@ exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOr
   replace={false}
   to="test-link"
 >
-  <SidebarChannelButtonOrLinkIcon
-    channelId="test-channel-id"
-    channelStatus="test"
-    channelType="D"
-    membersCount={3}
-    teammateDeletedAt={1}
-    teammateId="test-teammate-id"
-  />
-  <span
-    className="sidebar-item__name"
-  >
-    test-channel-name
-  </span>
-  <span
-    className="badge"
-  >
-    6
-  </span>
-  <SidebarChannelButtonOrLinkCloseButton
-    badge={true}
-    channelId="test-channel-id"
-    channelType="D"
-    handleClose={[MockFunction]}
-    teammateId="test-teammate-id"
-  />
+  <React.Fragment>
+    <SidebarChannelButtonOrLinkIcon
+      channelId="test-channel-id"
+      channelStatus="test"
+      channelType="D"
+      membersCount={3}
+      teammateDeletedAt={1}
+      teammateId="test-teammate-id"
+    />
+    <span
+      className="sidebar-item__name"
+    >
+      test-channel-name
+    </span>
+    <span
+      className="badge"
+    >
+      6
+    </span>
+    <SidebarChannelButtonOrLinkCloseButton
+      badge={true}
+      channelId="test-channel-id"
+      channelType="D"
+      handleClose={[MockFunction]}
+      teammateId="test-teammate-id"
+    />
+  </React.Fragment>
 </Link>
 `;
 
@@ -106,24 +112,26 @@ exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOr
   replace={false}
   to="test-link"
 >
-  <SidebarChannelButtonOrLinkIcon
-    channelId="test-channel-id"
-    channelStatus="test"
-    channelType="D"
-    membersCount={3}
-    teammateDeletedAt={1}
-    teammateId="test-teammate-id"
-  />
-  <span
-    className="sidebar-item__name"
-  >
-    test-channel-name
-  </span>
-  <SidebarChannelButtonOrLinkCloseButton
-    channelId="test-channel-id"
-    channelType="D"
-    handleClose={[MockFunction]}
-    teammateId="test-teammate-id"
-  />
+  <React.Fragment>
+    <SidebarChannelButtonOrLinkIcon
+      channelId="test-channel-id"
+      channelStatus="test"
+      channelType="D"
+      membersCount={3}
+      teammateDeletedAt={1}
+      teammateId="test-teammate-id"
+    />
+    <span
+      className="sidebar-item__name"
+    >
+      test-channel-name
+    </span>
+    <SidebarChannelButtonOrLinkCloseButton
+      channelId="test-channel-id"
+      channelType="D"
+      handleClose={[MockFunction]}
+      teammateId="test-teammate-id"
+    />
+  </React.Fragment>
 </Link>
 `;


### PR DESCRIPTION
This is a new feature of React that I don't think we've used yet. It lets you render a bunch of components without wrapping it in an extra div or span tag