### PR TITLE
ICU-686 Fixed channels ignoring mark unread setting

### DIFF
--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -13,19 +13,18 @@ export function checkAndSetMobileView() {
     };
 }
 
-export function keepChanneIdAsUnread(channelId, hadMentions = false) {
-    return (dispatch) => {
-        let data = null;
-        if (channelId) {
-            data = {
-                id: channelId,
-                hadMentions
-            };
+export function keepChannelIdAsUnread(channelId, hadMentions) {
+    return {
+        type: ActionTypes.KEEP_CHANNEL_AS_UNREAD,
+        data: {
+            id: channelId,
+            hadMentions
         }
+    };
+}
 
-        dispatch({
-            type: ActionTypes.KEEP_CHANNEL_AS_UNREAD,
-            data
-        });
+export function clearKeepChannelIdAsUnread() {
+    return {
+        type: ActionTypes.CLEAR_KEEP_CHANNEL_AS_UNREAD
     };
 }

--- a/components/sidebar/index.js
+++ b/components/sidebar/index.js
@@ -10,7 +10,6 @@ import {
     getSortedFavoriteChannelWithUnreadsIds,
     getSortedDirectChannelWithUnreadsIds,
     getCurrentChannel,
-    getMyChannelMemberships,
     getUnreads,
     getSortedUnreadChannelIds,
     getSortedDirectChannelIds,
@@ -69,7 +68,6 @@ function mapStateToProps(state) {
         currentTeammate,
         currentTeam: getCurrentTeam(state),
         currentUser: getCurrentUser(state),
-        memberships: getMyChannelMemberships(state),
         unreads: getUnreads(state),
         isSystemAdmin: isCurrentUserSystemAdmin(state),
         isTeamAdmin: isCurrentUserCurrentTeamAdmin(state)

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -79,11 +79,6 @@ export default class Sidebar extends React.PureComponent {
         currentUser: PropTypes.object.isRequired,
 
         /**
-         * User channels memerships
-         */
-        memberships: PropTypes.object.isRequired,
-
-        /**
          * Number of unread mentions/messages
          */
         unreads: PropTypes.object.isRequired,
@@ -412,10 +407,10 @@ export default class Sidebar extends React.PureComponent {
 
     getDisplayedChannels = (props = this.props) => {
         return props.unreadChannelIds.
-        concat(props.favoriteChannelIds).
-        concat(props.publicChannelIds).
-        concat(props.privateChannelIds).
-        concat(props.directAndGroupChannelIds);
+            concat(props.favoriteChannelIds).
+            concat(props.publicChannelIds).
+            concat(props.privateChannelIds).
+            concat(props.directAndGroupChannelIds);
     };
 
     channelIdIsDisplayedForProps = (props, id) => {
@@ -467,7 +462,6 @@ export default class Sidebar extends React.PureComponent {
                 key={channelId}
                 ref={channelId}
                 channelId={channelId}
-                membership={this.props.memberships[channelId]}
                 active={channelId === this.props.currentChannel.id}
                 currentTeamName={this.props.currentTeam.name}
                 currentUserId={this.props.currentUser.id}

--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -4,16 +4,16 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {getChannelsNameMapInCurrentTeam, makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getChannelsNameMapInCurrentTeam, getMyChannelMemberships, makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getUserIdsInChannels, getUser} from 'mattermost-redux/selectors/entities/users';
 import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {leaveChannel} from 'mattermost-redux/actions/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
-import {keepChanneIdAsUnread} from 'actions/views/channel';
+import {clearKeepChannelIdAsUnread, keepChannelIdAsUnread} from 'actions/views/channel';
 
-import {Constants} from 'utils/constants.jsx';
+import {Constants, NotificationLevels} from 'utils/constants.jsx';
 
 import SidebarChannel from './sidebar_channel.jsx';
 
@@ -21,8 +21,10 @@ function makeMapStateToProps() {
     const getChannel = makeGetChannel();
 
     return (state, ownProps) => {
+        const channelId = ownProps.channelId;
+
         const config = getConfig(state);
-        const channel = getChannel(state, {id: ownProps.channelId}) || {};
+        const channel = getChannel(state, {id: channelId}) || {};
         const tutorialStep = getPreference(state, Constants.Preferences.TUTORIAL_STEP, ownProps.currentUserId, 999);
         const channelsByName = getChannelsNameMapInCurrentTeam(state);
         const memberIds = getUserIdsInChannels(state);
@@ -35,12 +37,21 @@ function makeMapStateToProps() {
             }
         }
 
-        const member = ownProps.membership;
-        const unreadMentions = member ? member.mention_count : 0;
+        const member = getMyChannelMemberships(state)[channelId];
 
-        let unreadMsgs = channel && member ? channel.total_msg_count - member.msg_count : 0;
-        if (unreadMsgs < 0) {
-            unreadMsgs = 0;
+        let unreadMentions = 0;
+        let unreadMsgs = 0;
+        let showUnreadForMsgs = true;
+        if (member) {
+            unreadMentions = member.mention_count;
+
+            if (channel) {
+                unreadMsgs = Math.max(channel.total_msg_count - member.msg_count, 0);
+            }
+
+            if (member.notify_props) {
+                showUnreadForMsgs = member.notify_props.mark_unread !== NotificationLevels.MENTION;
+            }
         }
 
         let teammate = null;
@@ -50,7 +61,7 @@ function makeMapStateToProps() {
 
         return {
             config,
-            channelId: channel.id,
+            channelId,
             channelName: channel.name,
             channelDisplayName: channel.display_name,
             channelType: channel.type,
@@ -62,6 +73,7 @@ function makeMapStateToProps() {
             showTutorialTip: tutorialStep === Constants.TutorialSteps.CHANNEL_POPOVER && config.EnableTutorial === 'true',
             townSquareDisplayName: channelsByName[Constants.DEFAULT_CHANNEL] && channelsByName[Constants.DEFAULT_CHANNEL].display_name,
             offTopicDisplayName: channelsByName[Constants.OFFTOPIC_CHANNEL] && channelsByName[Constants.OFFTOPIC_CHANNEL].display_name,
+            showUnreadForMsgs,
             unreadMsgs,
             unreadMentions,
             membersCount
@@ -72,7 +84,8 @@ function makeMapStateToProps() {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            keepChanneIdAsUnread,
+            clearKeepChannelIdAsUnread,
+            keepChannelIdAsUnread,
             savePreferences,
             leaveChannel
         }, dispatch)

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -216,9 +216,11 @@ export default class SidebarChannel extends React.PureComponent {
                 rowClass += ' has-badge';
 
                 badge = true;
-            } else if (closeHandler) {
-                rowClass += ' has-close';
             }
+        }
+
+        if (closeHandler && !badge) {
+            rowClass += ' has-close';
         }
 
         let tutorialTip = null;

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -67,9 +67,9 @@ export default class SidebarChannel extends React.PureComponent {
         channelTeammateDeletedAt: PropTypes.number,
 
         /**
-         * User's channel membership
+         * Whether or not to mark the channel as unread when it has unread messages and no mentions
          */
-        membership: PropTypes.object,
+        showUnreadForMsgs: PropTypes.bool.isRequired,
 
         /**
          * Number of unread messages
@@ -117,7 +117,8 @@ export default class SidebarChannel extends React.PureComponent {
         membersCount: PropTypes.number.isRequired,
 
         actions: PropTypes.shape({
-            keepChanneIdAsUnread: PropTypes.func.isRequired,
+            clearKeepChannelIdAsUnread: PropTypes.func.isRequired,
+            keepChannelIdAsUnread: PropTypes.func.isRequired,
             savePreferences: PropTypes.func.isRequired,
             leaveChannel: PropTypes.func.isRequired
         }).isRequired
@@ -174,25 +175,22 @@ export default class SidebarChannel extends React.PureComponent {
     }
 
     handleSelectChannel = () => {
-        const {actions, channelId} = this.props;
-        actions.keepChanneIdAsUnread(this.isChannelUnread() ? channelId : null, this.props.unreadMentions > 0);
+        if (this.showChannelAsUnread()) {
+            this.props.actions.keepChannelIdAsUnread(this.props.channelId, this.props.unreadMentions > 0);
+        } else {
+            this.props.actions.clearKeepChannelIdAsUnread(null, false);
+        }
     };
 
-    isChannelUnread = () => {
-        const {membership, unreadMsgs, unreadMentions} = this.props;
-
-        if (membership) {
-            const msgCount = unreadMsgs + unreadMentions;
-            return msgCount > 0 || membership.mention_count > 0;
-        }
-
-        return false;
+    showChannelAsUnread = () => {
+        return this.props.unreadMentions > 0 || (this.props.unreadMsgs > 0 && this.props.showUnreadForMsgs);
     };
 
     render = () => {
         if (!this.props.channelDisplayName || !this.props.channelType) {
-            return (<div/>);
+            return null;
         }
+
         let closeHandler = null;
         if (this.props.channelType === Constants.DM_CHANNEL || this.props.channelType === Constants.GM_CHANNEL) {
             closeHandler = this.handleLeaveDirectChannel;
@@ -210,22 +208,17 @@ export default class SidebarChannel extends React.PureComponent {
         }
 
         let rowClass = 'sidebar-item';
-
-        if (this.isChannelUnread()) {
+        let badge = false;
+        if (this.showChannelAsUnread()) {
             rowClass += ' unread-title';
-        }
 
-        var badge = false;
-        if (this.props.membership && this.props.unreadMentions) {
-            badge = true;
-        }
+            if (this.props.unreadMentions > 0) {
+                rowClass += ' has-badge';
 
-        if (this.props.unreadMentions > 0) {
-            rowClass += ' has-badge';
-        }
-
-        if (closeHandler && !badge) {
-            rowClass += ' has-close';
+                badge = true;
+            } else if (closeHandler) {
+                rowClass += ' has-close';
+            }
         }
 
         let tutorialTip = null;

--- a/reducers/views/channel.js
+++ b/reducers/views/channel.js
@@ -2,7 +2,7 @@
 // See License.txt for license information.
 
 import {combineReducers} from 'redux';
-import {ChannelTypes, PostTypes} from 'mattermost-redux/action_types';
+import {ChannelTypes, PostTypes, UserTypes} from 'mattermost-redux/action_types';
 
 import {ActionTypes, Constants} from 'utils/constants.jsx';
 
@@ -87,6 +87,11 @@ function keepChannelIdAsUnread(state = null, action) {
     switch (action.type) {
     case ActionTypes.KEEP_CHANNEL_AS_UNREAD:
         return action.data;
+    case ActionTypes.CLEAR_KEEP_CHANNEL_AS_UNREAD:
+        return null;
+
+    case UserTypes.LOGOUT_SUCCESS:
+        return null;
     default:
         return state;
     }

--- a/tests/components/sidebar/__snapshots__/sidebar.test.jsx.snap
+++ b/tests/components/sidebar/__snapshots__/sidebar.test.jsx.snap
@@ -105,11 +105,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -117,11 +112,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c2"
-        membership={
-          Object {
-            "name": "Public test 2 membership",
-          }
-        }
       />
       <li>
         <button
@@ -189,11 +179,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -201,11 +186,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c4"
-        membership={
-          Object {
-            "name": "Private test 2 membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -261,11 +241,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -273,11 +248,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c6"
-        membership={
-          Object {
-            "name": "Group message test membership",
-          }
-        }
       />
       <li
         key="more"
@@ -396,11 +366,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -408,11 +373,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -420,11 +380,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -479,11 +434,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -491,11 +441,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c2"
-        membership={
-          Object {
-            "name": "Public test 2 membership",
-          }
-        }
       />
       <li>
         <button
@@ -563,11 +508,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -575,11 +515,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c4"
-        membership={
-          Object {
-            "name": "Private test 2 membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -635,11 +570,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -647,11 +577,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c6"
-        membership={
-          Object {
-            "name": "Group message test membership",
-          }
-        }
       />
       <li
         key="more"
@@ -770,11 +695,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -782,11 +702,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -841,11 +756,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -853,11 +763,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c2"
-        membership={
-          Object {
-            "name": "Public test 2 membership",
-          }
-        }
       />
       <li>
         <button
@@ -925,11 +830,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -937,11 +837,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c4"
-        membership={
-          Object {
-            "name": "Private test 2 membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -997,11 +892,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -1009,11 +899,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c6"
-        membership={
-          Object {
-            "name": "Group message test membership",
-          }
-        }
       />
       <li
         key="more"
@@ -1132,11 +1017,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -1144,11 +1024,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c2"
-        membership={
-          Object {
-            "name": "Public test 2 membership",
-          }
-        }
       />
       <li>
         <button
@@ -1184,11 +1059,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -1196,11 +1066,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c4"
-        membership={
-          Object {
-            "name": "Private test 2 membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -1256,11 +1121,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -1268,11 +1128,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c6"
-        membership={
-          Object {
-            "name": "Group message test membership",
-          }
-        }
       />
       <li
         key="more"
@@ -1431,11 +1286,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -1443,11 +1293,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c2"
-        membership={
-          Object {
-            "name": "Public test 2 membership",
-          }
-        }
       />
       <li>
         <button
@@ -1515,11 +1360,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -1527,11 +1367,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c4"
-        membership={
-          Object {
-            "name": "Private test 2 membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -1587,11 +1422,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -1599,11 +1429,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c6"
-        membership={
-          Object {
-            "name": "Group message test membership",
-          }
-        }
       />
       <li
         key="more"
@@ -1754,11 +1579,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -1766,11 +1586,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c2"
-        membership={
-          Object {
-            "name": "Public test 2 membership",
-          }
-        }
       />
       <li>
         <button
@@ -1838,11 +1653,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -1850,11 +1660,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c4"
-        membership={
-          Object {
-            "name": "Private test 2 membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -1910,11 +1715,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -1922,11 +1722,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c6"
-        membership={
-          Object {
-            "name": "Group message test membership",
-          }
-        }
       />
       <li
         key="more"
@@ -2081,11 +1876,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -2093,11 +1883,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c2"
-        membership={
-          Object {
-            "name": "Public test 2 membership",
-          }
-        }
       />
       <li>
         <button
@@ -2165,11 +1950,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -2177,11 +1957,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c4"
-        membership={
-          Object {
-            "name": "Private test 2 membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -2237,11 +2012,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -2249,11 +2019,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c6"
-        membership={
-          Object {
-            "name": "Group message test membership",
-          }
-        }
       />
       <li
         key="more"
@@ -2404,11 +2169,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -2416,11 +2176,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c2"
-        membership={
-          Object {
-            "name": "Public test 2 membership",
-          }
-        }
       />
       <li>
         <button
@@ -2488,11 +2243,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -2500,11 +2250,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c4"
-        membership={
-          Object {
-            "name": "Private test 2 membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -2560,11 +2305,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -2572,11 +2312,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c6"
-        membership={
-          Object {
-            "name": "Group message test membership",
-          }
-        }
       />
       <li
         key="more"
@@ -2727,11 +2462,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -2739,11 +2469,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c2"
-        membership={
-          Object {
-            "name": "Public test 2 membership",
-          }
-        }
       />
       <li>
         <button
@@ -2811,11 +2536,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -2823,11 +2543,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c4"
-        membership={
-          Object {
-            "name": "Private test 2 membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -2883,11 +2598,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -2895,11 +2605,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c6"
-        membership={
-          Object {
-            "name": "Group message test membership",
-          }
-        }
       />
       <li
         key="more"
@@ -3050,11 +2755,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c1"
-        membership={
-          Object {
-            "name": "Public test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -3062,11 +2762,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c2"
-        membership={
-          Object {
-            "name": "Public test 2 membership",
-          }
-        }
       />
       <li>
         <button
@@ -3134,11 +2829,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c3"
-        membership={
-          Object {
-            "name": "Private test 1 membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -3146,11 +2836,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c4"
-        membership={
-          Object {
-            "name": "Private test 2 membership",
-          }
-        }
       />
     </ul>
     <ul
@@ -3206,11 +2891,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c5"
-        membership={
-          Object {
-            "name": "Direct message test membership",
-          }
-        }
       />
       <Connect(SidebarChannel)
         active={false}
@@ -3218,11 +2898,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         currentTeamName="test-team"
         currentUserId="my-user-id"
         key="c6"
-        membership={
-          Object {
-            "name": "Group message test membership",
-          }
-        }
       />
       <li
         key="more"

--- a/tests/components/sidebar/__snapshots__/sidebar_channel.test.jsx.snap
+++ b/tests/components/sidebar/__snapshots__/sidebar_channel.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/messages/@Channel display name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item"
+    rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -38,7 +38,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/messages/@Channel display name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item"
+    rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -111,7 +111,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/messages/@Channel display name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item"
+    rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -180,7 +180,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/channels/channel-name?fakechannel=%7B%22display_name%22%3A%22Channel%20display%20name%22%2C%22name%22%3A%22channel-name%22%2C%22type%22%3A%22D%22%2C%22id%22%3A%22test-channel-id%22%2C%22status%22%3A%22test%22%2C%22fake%22%3Atrue%7D"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item"
+    rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -226,7 +226,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/channels/channel-name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item"
+    rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -259,7 +259,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/messages/@Channel display name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item"
+    rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="myself"
     unreadMentions={0}
@@ -305,7 +305,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/channels/channel-name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item"
+    rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -351,7 +351,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/channels/channel-name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item"
+    rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}

--- a/tests/components/sidebar/__snapshots__/sidebar_channel.test.jsx.snap
+++ b/tests/components/sidebar/__snapshots__/sidebar_channel.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/messages/@Channel display name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item has-close"
+    rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -38,7 +38,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/messages/@Channel display name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item has-close"
+    rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -111,7 +111,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/messages/@Channel display name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item unread-title has-close"
+    rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -180,7 +180,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/channels/channel-name?fakechannel=%7B%22display_name%22%3A%22Channel%20display%20name%22%2C%22name%22%3A%22channel-name%22%2C%22type%22%3A%22D%22%2C%22id%22%3A%22test-channel-id%22%2C%22status%22%3A%22test%22%2C%22fake%22%3Atrue%7D"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item has-close"
+    rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -226,7 +226,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/channels/channel-name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item has-close"
+    rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -259,7 +259,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/messages/@Channel display name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item has-close"
+    rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="myself"
     unreadMentions={0}
@@ -305,7 +305,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/channels/channel-name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item has-close"
+    rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}
@@ -351,7 +351,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     link="/current-team/channels/channel-name"
     membersCount={8}
     onSelectChannel={[Function]}
-    rowClass="sidebar-item has-close"
+    rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
     unreadMentions={0}

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -27,13 +27,13 @@ import logoWebhook from 'images/webhook_icon.jpg';
 
 import githubCSS from '!!file-loader?name=files/code_themes/[hash].[ext]!highlight.js/styles/github.css';
 
- // eslint-disable-line import/order
+// eslint-disable-line import/order
 import monokaiCSS from '!!file-loader?name=files/code_themes/[hash].[ext]!highlight.js/styles/monokai.css';
 
- // eslint-disable-line import/order
+// eslint-disable-line import/order
 import solarizedDarkCSS from '!!file-loader?name=files/code_themes/[hash].[ext]!highlight.js/styles/solarized-dark.css';
 
- // eslint-disable-line import/order
+// eslint-disable-line import/order
 import solarizedLightCSS from '!!file-loader?name=files/code_themes/[hash].[ext]!highlight.js/styles/solarized-light.css'; // eslint-disable-line import/order
 
 export const PluginSettings = {
@@ -239,6 +239,7 @@ export const ActionTypes = keyMirror({
     POPOVER_MENTION_KEY_CLICK: null,
 
     KEEP_CHANNEL_AS_UNREAD: null,
+    CLEAR_KEEP_CHANNEL_AS_UNREAD: null,
 
     INCREMENT_EMOJI_PICKER_PAGE: null
 });


### PR DESCRIPTION
The reason it wasn't working before was because the channel member's notify_props were being ignored. I also cleaned up a bit of duplication where we were passing in the channel member object, but also the number of unread mentions and messages from that object.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-686