### PR TITLE
XYZ-60: Random characters disappear from RHS randomly

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -41,6 +41,11 @@ export default class CreateComment extends React.PureComponent {
         rootId: PropTypes.string.isRequired,
 
         /**
+         * The current history message selected
+         */
+        messageInHistory: PropTypes.string,
+
+        /**
          * The current draft of the comment
          */
         draft: PropTypes.shape({
@@ -154,7 +159,7 @@ export default class CreateComment extends React.PureComponent {
             this.setState({draft: {...newProps.draft, uploadsInProgress: []}});
         }
 
-        if (!Utils.areObjectsEqual(this.props.draft, newProps.draft)) {
+        if (this.props.messageInHistory !== newProps.messageInHistory) {
             this.setState({draft: newProps.draft});
         }
     }

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
+import {makeGetMessageInHistoryItem} from 'mattermost-redux/selectors/entities/posts';
 import {resetCreatePostRequest, resetHistoryIndex} from 'mattermost-redux/actions/posts';
 import {Preferences, Posts} from 'mattermost-redux/constants';
 
@@ -28,9 +29,11 @@ function mapStateToProps(state, ownProps) {
 
     const enableAddButton = draft.message.trim().length !== 0 || draft.fileInfos.length !== 0;
     const channelMembersCount = getAllChannelStats(state)[ownProps.channelId] ? getAllChannelStats(state)[ownProps.channelId].member_count : 1;
+    const messageInHistory = makeGetMessageInHistoryItem(Posts.MESSAGE_TYPES.COMMENT)(state);
 
     return {
         draft,
+        messageInHistory,
         enableAddButton,
         channelMembersCount,
         ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),

--- a/tests/components/create_comment/create_comment.test.jsx
+++ b/tests/components/create_comment/create_comment.test.jsx
@@ -487,7 +487,7 @@ describe('components/CreateComment', () => {
         expect(wrapper.state().draft.uploadsInProgress).toEqual([4, 6]);
     });
 
-    test('should match draft state on componentWillReceiveProps with new draft', () => {
+    test('should match draft state on componentWillReceiveProps with change in messageInHistory', () => {
         const draft = {
             message: 'Test message',
             uploadsInProgress: [],
@@ -500,7 +500,7 @@ describe('components/CreateComment', () => {
         expect(wrapper.state('draft')).toEqual(draft);
 
         const newDraft = {...draft, message: 'Test message edited'};
-        wrapper.setProps({draft: newDraft});
+        wrapper.setProps({draft: newDraft, messageInHistory: 'Test message edited'});
         expect(wrapper.state('draft')).toEqual(newDraft);
     });
 


### PR DESCRIPTION
#### Summary
Sometimes in the RHS a random character is removed while typing. I hope this solve the problem.

Directly related with this PR #624

The problem is that while you are writting the draft is saving and reloading all the time. This way, it only reload the draft data after an history change, which is the expecte behavior.

#### Ticket Link
[XYZ-60](https://mattermost.atlassian.net/browse/XYZ-60)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)