### PR TITLE
XYZ-75: Migrates EnableOnlyAdminIntegrations config in system console to set role permissions.

### DIFF
--- a/components/admin_console/admin_console.jsx
+++ b/components/admin_console/admin_console.jsx
@@ -17,7 +17,7 @@ import ConfigurationSettings from 'components/admin_console/configuration_settin
 import ConnectionSettings from 'components/admin_console/connection_settings.jsx';
 import CustomBrandSettings from 'components/admin_console/custom_brand_settings.jsx';
 import CustomEmojiSettings from 'components/admin_console/custom_emoji_settings.jsx';
-import CustomIntegrationsSettings from 'components/admin_console/custom_integrations_settings.jsx';
+import CustomIntegrationsSettings from 'components/admin_console/custom_integrations_settings';
 import DataRetentionSettings from 'components/admin_console/data_retention_settings.jsx';
 import DatabaseSettings from 'components/admin_console/database_settings.jsx';
 import DeveloperSettings from 'components/admin_console/developer_settings.jsx';

--- a/components/admin_console/custom_integrations_settings/custom_integrations_settings.jsx
+++ b/components/admin_console/custom_integrations_settings/custom_integrations_settings.jsx
@@ -3,21 +3,27 @@
 
 import React from 'react';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
 
-import AdminSettings from './admin_settings.jsx';
-import BooleanSetting from './boolean_setting.jsx';
-import SettingsGroup from './settings_group.jsx';
+import AdminSettings from '.././admin_settings.jsx';
+import BooleanSetting from '.././boolean_setting.jsx';
+import SettingsGroup from '.././settings_group.jsx';
 
 export default class WebhookSettings extends AdminSettings {
-    constructor(props) {
-        super(props);
+    static propTypes = {
+        roles: PropTypes.object.isRequired,
+        rolesRequest: PropTypes.object.isRequired,
+        actions: PropTypes.shape({
+            loadRolesIfNeeded: PropTypes.func.isRequired,
+            editRole: PropTypes.func.isRequired
+        }).isRequired
+    };
 
-        this.getConfigFromState = this.getConfigFromState.bind(this);
+    // constructor(props) {
+    //     super(props);
+    // }
 
-        this.renderSettings = this.renderSettings.bind(this);
-    }
-
-    getConfigFromState(config) {
+    getConfigFromState = (config) => {
         config.ServiceSettings.EnableIncomingWebhooks = this.state.enableIncomingWebhooks;
         config.ServiceSettings.EnableOutgoingWebhooks = this.state.enableOutgoingWebhooks;
         config.ServiceSettings.EnableCommands = this.state.enableCommands;
@@ -28,7 +34,7 @@ export default class WebhookSettings extends AdminSettings {
         config.ServiceSettings.EnableUserAccessTokens = this.state.enableUserAccessTokens;
 
         return config;
-    }
+    };
 
     getStateFromConfig(config) {
         return {
@@ -52,7 +58,7 @@ export default class WebhookSettings extends AdminSettings {
         );
     }
 
-    renderSettings() {
+    renderSettings = () => {
         return (
             <SettingsGroup>
                 <BooleanSetting
@@ -193,5 +199,5 @@ export default class WebhookSettings extends AdminSettings {
                 />
             </SettingsGroup>
         );
-    }
+    };
 }

--- a/components/admin_console/custom_integrations_settings/index.jsx
+++ b/components/admin_console/custom_integrations_settings/index.jsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {loadRolesIfNeeded, editRole} from 'mattermost-redux/actions/roles';
+
+import {getRoles} from 'mattermost-redux/selectors/entities/roles';
+
+import WebhookSettings from './custom_integrations_settings.jsx';
+
+function mapStateToProps(state) {
+    return {
+        roles: getRoles(state),
+        rolesRequest: state.requests.roles.getRolesByNames
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            loadRolesIfNeeded,
+            editRole
+        }, dispatch)
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(WebhookSettings);

--- a/components/admin_console/policy_settings/policy_settings.jsx
+++ b/components/admin_console/policy_settings/policy_settings.jsx
@@ -25,6 +25,8 @@ import LoadingScreen from 'components/loading_screen.jsx';
 
 export default class PolicySettings extends AdminSettings {
     static propTypes = {
+        roles: PropTypes.object.isRequired,
+        rolesRequest: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             loadRolesIfNeeded: PropTypes.func.isRequired,
             editRole: PropTypes.func.isRequired
@@ -33,10 +35,6 @@ export default class PolicySettings extends AdminSettings {
 
     constructor(props) {
         super(props);
-
-        this.getConfigFromState = this.getConfigFromState.bind(this);
-
-        this.renderSettings = this.renderSettings.bind(this);
 
         this.roleBasedPolicies = {
             allowEditPost: '',
@@ -114,7 +112,7 @@ export default class PolicySettings extends AdminSettings {
         }
     };
 
-    getConfigFromState(config) {
+    getConfigFromState = (config) => {
         config.ServiceSettings.PostEditTimeLimit = this.state.postEditTimeLimit ? this.parseIntNonZero(this.state.postEditTimeLimit, Constants.UNSET_POST_EDIT_TIME_LIMIT) : Constants.UNSET_POST_EDIT_TIME_LIMIT;
         config.AnnouncementSettings.EnableBanner = this.state.enableBanner;
         config.AnnouncementSettings.BannerText = this.state.bannerText;
@@ -122,7 +120,7 @@ export default class PolicySettings extends AdminSettings {
         config.AnnouncementSettings.BannerTextColor = this.state.bannerTextColor;
         config.AnnouncementSettings.AllowBannerDismissal = this.state.allowBannerDismissal;
         return config;
-    }
+    };
 
     getStateFromConfig(config) {
         return {
@@ -144,7 +142,7 @@ export default class PolicySettings extends AdminSettings {
         );
     }
 
-    renderSettings() {
+    renderSettings = () => {
         if (!this.state.loaded) {
             return <LoadingScreen/>;
         }
@@ -479,5 +477,5 @@ export default class PolicySettings extends AdminSettings {
                 />
             </SettingsGroup>
         );
-    }
+    };
 }

--- a/routes/route_admin_console.jsx
+++ b/routes/route_admin_console.jsx
@@ -14,7 +14,7 @@ import ConfigurationSettings from 'components/admin_console/configuration_settin
 import ConnectionSettings from 'components/admin_console/connection_settings.jsx';
 import CustomBrandSettings from 'components/admin_console/custom_brand_settings.jsx';
 import CustomEmojiSettings from 'components/admin_console/custom_emoji_settings.jsx';
-import CustomIntegrationsSettings from 'components/admin_console/custom_integrations_settings.jsx';
+import CustomIntegrationsSettings from 'components/admin_console/custom_integrations_settings';
 import DataRetentionSettings from 'components/admin_console/data_retention_settings.jsx';
 import DatabaseSettings from 'components/admin_console/database_settings.jsx';
 import DeveloperSettings from 'components/admin_console/developer_settings.jsx';

--- a/tests/components/integrations/installed_oauth_apps.test.jsx
+++ b/tests/components/integrations/installed_oauth_apps.test.jsx
@@ -81,7 +81,6 @@ describe('components/integrations/InstalledOAuthApps', () => {
         expect(wrapper.find(BackstageList).props().addLink).toEqual('/test/integrations/oauth2-apps/add');
         expect(wrapper.find(BackstageList).props().addText).toEqual('Add OAuth 2.0 Application');
 
-        global.window.mm_config = {EnableOnlyAdminIntegrations: 'true'};
         wrapper.setProps({canManageOauth: false});
         expect(wrapper.find(BackstageList).props().addLink).toBeFalsy();
         expect(wrapper.find(BackstageList).props().addText).toBeFalsy();

--- a/utils/policy_roles_adapter.js
+++ b/utils/policy_roles_adapter.js
@@ -67,22 +67,16 @@ const MAPPING = {
     restrictPostDelete: {
         all: [
             {roleName: 'channel_user', permission: Permissions.DELETE_POST, shouldHave: true},
-            {roleName: 'channel_admin', permission: Permissions.DELETE_POST, shouldHave: false},
-            {roleName: 'channel_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: false},
             {roleName: 'team_admin', permission: Permissions.DELETE_POST, shouldHave: true},
             {roleName: 'team_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: true}
         ],
         team_admin: [
             {roleName: 'channel_user', permission: Permissions.DELETE_POST, shouldHave: false},
-            {roleName: 'channel_admin', permission: Permissions.DELETE_POST, shouldHave: false},
-            {roleName: 'channel_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: false},
             {roleName: 'team_admin', permission: Permissions.DELETE_POST, shouldHave: true},
             {roleName: 'team_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: true}
         ],
         system_admin: [
             {roleName: 'channel_user', permission: Permissions.DELETE_POST, shouldHave: false},
-            {roleName: 'channel_admin', permission: Permissions.DELETE_POST, shouldHave: false},
-            {roleName: 'channel_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: false},
             {roleName: 'team_admin', permission: Permissions.DELETE_POST, shouldHave: false},
             {roleName: 'team_admin', permission: Permissions.DELETE_OTHERS_POSTS, shouldHave: false}
         ]
@@ -91,6 +85,19 @@ const MAPPING = {
     enableTeamCreation: {
         true: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: true}],
         false: [{roleName: 'system_user', permission: Permissions.CREATE_TEAM, shouldHave: false}]
+    },
+
+    enableOnlyAdminIntegrations: {
+        true: [
+            {roleName: 'team_user', permission: Permissions.MANAGE_WEBHOOKS, shouldHave: false},
+            {roleName: 'team_user', permission: Permissions.MANAGE_SLASH_COMMANDS, shouldHave: false},
+            {roleName: 'system_user', permission: Permissions.MANAGE_OAUTH, shouldHave: false}
+        ],
+        false: [
+            {roleName: 'team_user', permission: Permissions.MANAGE_WEBHOOKS, shouldHave: true},
+            {roleName: 'team_user', permission: Permissions.MANAGE_SLASH_COMMANDS, shouldHave: true},
+            {roleName: 'system_user', permission: Permissions.MANAGE_OAUTH, shouldHave: true}
+        ]
     }
 };
 


### PR DESCRIPTION
#### Summary
* Updates the "Restrict managing integrations to Admins" input on System Console -> Custom Integrations page to change permissions assignments behind the scenes.
* Removes a few unnecessary policy mappings that were the same value for each policy input.
* Adds a few tweaks to the policy react component to remove `bind` and add some missing props validations.

#### Ticket Link
[XYZ-75](https://mattermost.atlassian.net/browse/XYZ-75)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed