### PR TITLE
ICU-687/ICU-688/ICU-689/ICU-690 Fixed channels staying in the UNREADS section after viewing

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -44,7 +44,6 @@ export function emitChannelClickEvent(channel) {
         }
     }
     function switchToChannel(chan) {
-        const channelMember = ChannelStore.getMyMember(chan.id);
         const getMyChannelMemberPromise = getMyChannelMember(chan.id)(dispatch, getState);
         const oldChannelId = ChannelStore.getCurrentId();
 
@@ -63,12 +62,8 @@ export function emitChannelClickEvent(channel) {
 
         AppDispatcher.handleViewAction({
             type: ActionTypes.CLICK_CHANNEL,
-            name: chan.name,
             id: chan.id,
-            team_id: chan.team_id,
-            total_msg_count: chan.total_msg_count,
-            channelMember,
-            prev: oldChannelId
+            team_id: chan.team_id
         });
     }
 

--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -12,19 +12,3 @@ export function checkAndSetMobileView() {
         });
     };
 }
-
-export function keepChannelIdAsUnread(channelId, hadMentions) {
-    return {
-        type: ActionTypes.KEEP_CHANNEL_AS_UNREAD,
-        data: {
-            id: channelId,
-            hadMentions
-        }
-    };
-}
-
-export function clearKeepChannelIdAsUnread() {
-    return {
-        type: ActionTypes.CLEAR_KEEP_CHANNEL_AS_UNREAD
-    };
-}

--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -11,8 +11,6 @@ import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {leaveChannel} from 'mattermost-redux/actions/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
-import {clearKeepChannelIdAsUnread, keepChannelIdAsUnread} from 'actions/views/channel';
-
 import {Constants, NotificationLevels} from 'utils/constants.jsx';
 
 import SidebarChannel from './sidebar_channel.jsx';
@@ -85,8 +83,6 @@ function makeMapStateToProps() {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            clearKeepChannelIdAsUnread,
-            keepChannelIdAsUnread,
             savePreferences,
             leaveChannel
         }, dispatch)

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -183,7 +183,7 @@ export default class SidebarChannel extends React.PureComponent {
 
     render = () => {
         if (!this.props.channelDisplayName || !this.props.channelType) {
-            return null;
+            return (<div/>);
         }
 
         let closeHandler = null;

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -122,8 +122,6 @@ export default class SidebarChannel extends React.PureComponent {
         membersCount: PropTypes.number.isRequired,
 
         actions: PropTypes.shape({
-            clearKeepChannelIdAsUnread: PropTypes.func.isRequired,
-            keepChannelIdAsUnread: PropTypes.func.isRequired,
             savePreferences: PropTypes.func.isRequired,
             leaveChannel: PropTypes.func.isRequired
         }).isRequired
@@ -178,14 +176,6 @@ export default class SidebarChannel extends React.PureComponent {
             browserHistory.push(`/${this.props.currentTeamName}/channels/${Constants.DEFAULT_CHANNEL}`);
         }
     }
-
-    handleSelectChannel = () => {
-        if (this.showChannelAsUnread()) {
-            this.props.actions.keepChannelIdAsUnread(this.props.channelId, this.props.unreadMentions > 0);
-        } else {
-            this.props.actions.clearKeepChannelIdAsUnread(null, false);
-        }
-    };
 
     showChannelAsUnread = () => {
         return this.props.unreadMentions > 0 || (this.props.unreadMsgs > 0 && this.props.showUnreadForMsgs);
@@ -284,7 +274,6 @@ export default class SidebarChannel extends React.PureComponent {
                     membersCount={this.props.membersCount}
                     teammateId={this.props.channelTeammateId}
                     teammateDeletedAt={this.props.channelTeammateDeletedAt}
-                    onSelectChannel={this.handleSelectChannel}
                 />
                 {tutorialTip}
             </li>

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
@@ -29,12 +29,10 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
         membersCount: PropTypes.number.isRequired,
         unreadMentions: PropTypes.number,
         teammateId: PropTypes.string,
-        teammateDeletedAt: PropTypes.number,
-        onSelectChannel: PropTypes.func.isRequired
+        teammateDeletedAt: PropTypes.number
     }
 
     trackChannelSelectedEvent = () => {
-        this.props.onSelectChannel();
         mark('SidebarChannelLink#click');
         trackEvent('ui', 'ui_channel_selected');
     }

--- a/stores/channel_store.jsx
+++ b/stores/channel_store.jsx
@@ -163,11 +163,15 @@ class ChannelStoreClass extends EventEmitter {
     }
 
     setCurrentId(id) {
-        store.dispatch({
+        store.dispatch(batchActions([{
             type: ChannelTypes.SELECT_CHANNEL,
+            data: id
+        }, {
+            type: ActionTypes.SELECT_CHANNEL_WITH_MEMBER,
             data: id,
+            channel: this.getChannelById(id),
             member: this.getMyMember(id)
-        });
+        }]));
     }
 
     resetCounts(ids) {

--- a/tests/components/sidebar/__snapshots__/sidebar_channel.test.jsx.snap
+++ b/tests/components/sidebar/__snapshots__/sidebar_channel.test.jsx.snap
@@ -14,7 +14,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={[Function]}
     link="/current-team/messages/@undefined"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -37,7 +36,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={[Function]}
     link="/current-team/messages/@undefined"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -60,7 +58,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={null}
     link="/current-team/channels/town-square"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -87,7 +84,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={[Function]}
     link="/current-team/messages/@undefined"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item unread-title has-badge"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -110,7 +106,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={[Function]}
     link="/current-team/messages/@undefined"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -133,7 +128,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={null}
     link="/current-team/channels/town-square"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -156,7 +150,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={null}
     link="/current-team/channels/town-square"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -179,7 +172,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={[Function]}
     link="/current-team/channels/channel-name?fakechannel=%7B%22display_name%22%3A%22Channel%20display%20name%22%2C%22name%22%3A%22channel-name%22%2C%22type%22%3A%22D%22%2C%22id%22%3A%22test-channel-id%22%2C%22status%22%3A%22test%22%2C%22fake%22%3Atrue%7D"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -202,7 +194,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={null}
     link="/current-team/channels/channel-name"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -225,7 +216,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={[Function]}
     link="/current-team/channels/channel-name"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -258,7 +248,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={[Function]}
     link="/current-team/messages/@undefined"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="myself"
@@ -281,7 +270,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={null}
     link="/current-team/channels/channel-name"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -304,7 +292,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={[Function]}
     link="/current-team/channels/channel-name"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -327,7 +314,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={null}
     link="/current-team/channels/channel-name"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item"
     teammateDeletedAt={1}
     teammateId="teammate-id"
@@ -350,7 +336,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     handleClose={[Function]}
     link="/current-team/channels/channel-name"
     membersCount={8}
-    onSelectChannel={[Function]}
     rowClass="sidebar-item has-close"
     teammateDeletedAt={1}
     teammateId="teammate-id"

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -238,8 +238,7 @@ export const ActionTypes = keyMirror({
 
     POPOVER_MENTION_KEY_CLICK: null,
 
-    KEEP_CHANNEL_AS_UNREAD: null,
-    CLEAR_KEEP_CHANNEL_AS_UNREAD: null,
+    SELECT_CHANNEL_WITH_MEMBER: null,
 
     INCREMENT_EMOJI_PICKER_PAGE: null
 });


### PR DESCRIPTION
It feels really good to fix 4 bugs with one fix. We were only updating the state that kept track of whether or not the current channel was in the unread section when you actually clicked on the items in the sidebar, so I changed it to trigger whenever you change channels.

As I discussed with Joram, I also changed one of the other reducers to use a new action instead of SELECT_CHANNEL to make it more clear that it needs additional information. At some point, we'll need to think about how this'll work when we start using more of the redux library's actions to switch channels.

This PR is on top of one of my other ones since they touch the same code, so the changes specific to this PR are here: https://github.com/mattermost/mattermost-webapp/compare/icu686...icu687

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-687
https://mattermost.atlassian.net/browse/ICU-688
https://mattermost.atlassian.net/browse/ICU-689
https://mattermost.atlassian.net/browse/ICU-690