### PR TITLE
[ICU-693] if team exists, then get channel

### DIFF
--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -210,11 +210,12 @@ export default class NeedsTeam extends React.Component {
     toLastChannel = () => {
         let channelName = Constants.DEFAULT_CHANNEL;
         const team = TeamStore.getByName(this.props.match.params.team);
-        const channelId = BrowserStore.getGlobalItem(team.id);
-        const channel = ChannelStore.getChannelById(channelId);
-
-        if (channel) {
-            channelName = channel.name;
+        if (team) {
+            const channelId = BrowserStore.getGlobalItem(team.id);
+            const channel = ChannelStore.getChannelById(channelId);
+            if (channel) {
+                channelName = channel.name;
+            }
         }
         return `${this.props.match.url}/channels/${channelName}`;
     }


### PR DESCRIPTION
#### Summary
Added check that skips getting channelName if the current team is null.

Leaving a team crashes the app with errors `TypeError: Cannot read property 'id' of null` and `needs_team.jsx:214 Uncaught (in promise) TypeError: Cannot read property 'id' of null`.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-693

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
