### PR TITLE
[ICU-648-2] Fix scroll pop issue when viewing single images except of svg file type

### DIFF
--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -142,28 +142,59 @@
 .file-view--single {
     margin: 5px 0;
 
-    &.loading {
-        height: 400px;
-    }
-
     .file__image-loading {
         min-height: 100px;
     }
 
     .file__image {
-        display: inline-block;
-        position: relative;
+        overflow: hidden;
 
-        &:hover {
-            .file__download {
-                @include opacity(1);
+        .image-container {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+          
+        .image-preload {
+            position: absolute;
+            z-index: 1;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            display: inline-block;
+        }
+          
+        .image-loaded {
+            cursor: 'pointer';
+            position: absolute;
+            z-index: 2;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            opacity: 0;
+            transition: opacity 1s ease;
+
+            display: inline-block;
+            position: relative;
+
+            &:hover {
+                .file__download {
+                    @include opacity(1);
+                }
+            }
+
+            img {
+                @include border-radius(4px);
+                min-height: 75px;
+                min-width: 75px;
             }
         }
-
-        img {
-            @include border-radius(4px);
-            min-height: 75px;
-            min-width: 75px;
+          
+        .image-fade-in {
+            opacity: 1;
         }
     }
 


### PR DESCRIPTION
#### Summary
Fix scroll pop issue when viewing single images except of SVG file type
- computes dimension of images depending on viewing window
- remove progress % loading indicator and just inject the image source on image `onload`. It improves image loading.
 

Note: Currently, SVG don't have height & width file info. Need to address separately (ticket: [ICU-698](https://mattermost.atlassian.net/browse/ICU-698)). 

#### Ticket Link
Jira ticket: [ICU-648](https://mattermost.atlassian.net/browse/ICU-648)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
