### PR TITLE
ABC-215 Prevent posting in town-square when set to read only

### DIFF
--- a/components/autosize_textarea.jsx
+++ b/components/autosize_textarea.jsx
@@ -118,7 +118,7 @@ export default class AutosizeTextarea extends React.Component {
                         placeholder={placeholder}
                         rows='1'
                         {...otherProps}
-                        value={value || defaultValue}
+                        value={value || defaultValue || placeholder}
                     />
                 </div>
             </div>

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -112,7 +112,12 @@ export default class CreateComment extends React.PureComponent {
         /**
          * Reset state of createPost request
          */
-        resetCreatePostRequest: PropTypes.func.isRequired
+        resetCreatePostRequest: PropTypes.func.isRequired,
+
+        /**
+         * Set if channel is read only
+         */
+        readOnlyChannel: PropTypes.bool
     }
 
     constructor(props) {
@@ -464,6 +469,7 @@ export default class CreateComment extends React.PureComponent {
 
     render() {
         const {draft} = this.state;
+        const {readOnlyChannel} = this.props;
 
         const notifyAllTitle = (
             <FormattedMessage
@@ -505,7 +511,7 @@ export default class CreateComment extends React.PureComponent {
         }
 
         let preview = null;
-        if (draft.fileInfos.length > 0 || draft.uploadsInProgress.length > 0) {
+        if (!readOnlyChannel && (draft.fileInfos.length > 0 || draft.uploadsInProgress.length > 0)) {
             preview = (
                 <FilePreview
                     fileInfos={draft.fileInfos}
@@ -540,21 +546,24 @@ export default class CreateComment extends React.PureComponent {
             addButtonClass += ' disabled';
         }
 
-        const fileUpload = (
-            <FileUpload
-                ref='fileUpload'
-                fileCount={this.getFileCount()}
-                getTarget={this.getFileUploadTarget}
-                onFileUploadChange={this.handleFileUploadChange}
-                onUploadStart={this.handleUploadStart}
-                onFileUpload={this.handleFileUploadComplete}
-                onUploadError={this.handleUploadError}
-                postType='comment'
-            />
-        );
+        let fileUpload;
+        if (!readOnlyChannel) {
+            fileUpload = (
+                <FileUpload
+                    ref='fileUpload'
+                    fileCount={this.getFileCount()}
+                    getTarget={this.getFileUploadTarget}
+                    onFileUploadChange={this.handleFileUploadChange}
+                    onUploadStart={this.handleUploadStart}
+                    onFileUpload={this.handleFileUploadComplete}
+                    onUploadError={this.handleUploadError}
+                    postType='comment'
+                />
+            );
+        }
 
         let emojiPicker = null;
-        if (window.mm_config.EnableEmojiPicker === 'true') {
+        if (window.mm_config.EnableEmojiPicker === 'true' && !readOnlyChannel) {
             emojiPicker = (
                 <span className='emoji-picker__container'>
                     <EmojiPickerOverlay
@@ -574,6 +583,13 @@ export default class CreateComment extends React.PureComponent {
             );
         }
 
+        let createMessage;
+        if (readOnlyChannel) {
+            createMessage = Utils.localizeMessage('create_post.read_only', 'This channel is read-only. Only members with permission can post here.');
+        } else {
+            createMessage = Utils.localizeMessage('create_comment.addComment', 'Add a comment...');
+        }
+
         return (
             <form onSubmit={this.handleSubmit}>
                 <div className='post-create'>
@@ -587,9 +603,9 @@ export default class CreateComment extends React.PureComponent {
                                 onKeyPress={this.commentMsgKeyPress}
                                 onKeyDown={this.handleKeyDown}
                                 handlePostError={this.handlePostError}
-                                value={draft.message}
+                                value={readOnlyChannel ? '' : draft.message}
                                 onBlur={this.handleBlur}
-                                createMessage={Utils.localizeMessage('create_comment.addComment', 'Add a comment...')}
+                                createMessage={createMessage}
                                 emojiEnabled={window.mm_config.EnableEmojiPicker === 'true'}
                                 initialText=''
                                 channelId={this.props.channelId}
@@ -597,6 +613,7 @@ export default class CreateComment extends React.PureComponent {
                                 popoverMentionKeyClick={true}
                                 id='reply_textbox'
                                 ref='textbox'
+                                disabled={readOnlyChannel}
                             />
                             <span
                                 ref='createCommentControls'

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -3,10 +3,14 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
 import {resetCreatePostRequest, resetHistoryIndex} from 'mattermost-redux/actions/posts';
 import {Preferences, Posts} from 'mattermost-redux/constants';
+
+import {Constants} from 'utils/constants.jsx';
 
 import {
     clearCommentDraftUploads,
@@ -29,12 +33,15 @@ function mapStateToProps(state, ownProps) {
     const enableAddButton = draft.message.trim().length !== 0 || draft.fileInfos.length !== 0;
     const channelMembersCount = getAllChannelStats(state)[ownProps.channelId] ? getAllChannelStats(state)[ownProps.channelId].member_count : 1;
 
+    const channel = state.entities.channels.channels[ownProps.channelId] || {};
+
     return {
         draft,
         enableAddButton,
         channelMembersCount,
         ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
-        createPostErrorId: err.server_error_id
+        createPostErrorId: err.server_error_id,
+        readOnlyChannel: !isCurrentUserSystemAdmin(state) && getConfig(state).ExperimentalTownSquareIsReadOnly === 'true' && channel.name === Constants.DEFAULT_CHANNEL
     };
 }
 

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -3,10 +3,11 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentChannel, getCurrentChannelStats} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {get, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {
     getCurrentUsersLatestPost,
@@ -30,7 +31,7 @@ import {createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
 import {makeGetGlobalItem} from 'selectors/storage';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
-import {Preferences, StoragePrefixes, TutorialSteps} from 'utils/constants.jsx';
+import {Constants,Preferences, StoragePrefixes, TutorialSteps} from 'utils/constants.jsx';
 
 import CreatePost from './create_post.jsx';
 
@@ -64,7 +65,8 @@ function mapStateToProps() {
             recentPostIdInChannel,
             commentCountForPost: getCommentCountForPost(state, {post}),
             latestReplyablePostId,
-            currentUsersLatestPost: getCurrentUsersLatestPost(state)
+            currentUsersLatestPost: getCurrentUsersLatestPost(state),
+            readOnlyChannel: !isCurrentUserSystemAdmin(state) && getConfig(state).ExperimentalTownSquareIsReadOnly === 'true' && currentChannel.name === Constants.DEFAULT_CHANNEL
         };
     };
 }

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -6,7 +6,6 @@ import {bindActionCreators} from 'redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentChannel, getCurrentChannelStats} from 'mattermost-redux/selectors/entities/channels';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserId, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {get, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {
@@ -31,7 +30,7 @@ import {createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
 import {makeGetGlobalItem} from 'selectors/storage';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
-import {Constants,Preferences, StoragePrefixes, TutorialSteps} from 'utils/constants.jsx';
+import {Constants, Preferences, StoragePrefixes, TutorialSteps} from 'utils/constants.jsx';
 
 import CreatePost from './create_post.jsx';
 

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -88,7 +88,12 @@ export default class SuggestionBox extends React.Component {
         /**
          * If true, the suggestion box is opened on focus, default to false
          */
-        openOnFocus: PropTypes.bool
+        openOnFocus: PropTypes.bool,
+
+        /**
+         * If true, the suggestion box is disabled
+         */
+        disabled: PropTypes.bool
     }
 
     static defaultProps = {

--- a/components/textbox.jsx
+++ b/components/textbox.jsx
@@ -37,7 +37,8 @@ export default class Textbox extends React.Component {
         emojiEnabled: PropTypes.bool,
         isRHS: PropTypes.bool,
         popoverMentionKeyClick: PropTypes.bool,
-        characterLimit: PropTypes.number
+        characterLimit: PropTypes.number,
+        disabled: PropTypes.bool
     };
 
     static defaultProps = {
@@ -321,6 +322,7 @@ export default class Textbox extends React.Component {
                     renderDividers={true}
                     isRHS={this.props.isRHS}
                     popoverMentionKeyClick={this.props.popoverMentionKeyClick}
+                    disabled={this.props.disabled}
                 />
                 {preview}
                 <div className={'help__text ' + helpTextClass}>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1436,6 +1436,7 @@
   "create_comment.commentTitle": "Comment",
   "create_comment.file": "File uploading",
   "create_comment.files": "Files uploading",
+  "create_post.read_only": "This channel is read-only. Only members with permission can post here.",
   "create_post.comment": "Comment",
   "create_post.deactivated": "You are viewing an archived channel with a deactivated user.",
   "create_post.error_message": "Your message is too long. Character count: {length}/{limit}",

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -422,6 +422,10 @@
         &.textbox-preview-area {
             overflow-y: auto;
         }
+
+        @include input-placeholder {
+            color: inherit;
+        }
     }
 
     .emoji-picker {

--- a/tests/components/create_comment/__snapshots__/create_comment.test.jsx.snap
+++ b/tests/components/create_comment/__snapshots__/create_comment.test.jsx.snap
@@ -1,5 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/CreateComment should match snapshot read only channel 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <div
+    className="post-create"
+  >
+    <div
+      className="post-create-body comment-create-body"
+      id=""
+    >
+      <div
+        className="post-body__cell"
+      >
+        <Textbox
+          channelId="g6139tbospd18cmxroesdk3kkc"
+          characterLimit={4000}
+          createMessage="This channel is read-only. Only members with permission can post here."
+          disabled={true}
+          emojiEnabled={true}
+          handlePostError={[Function]}
+          id="reply_textbox"
+          initialText=""
+          isRHS={true}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          popoverMentionKeyClick={true}
+          supportsCommands={true}
+          value=""
+        />
+        <span
+          className="post-body__actions"
+        />
+      </div>
+    </div>
+    <MsgTyping
+      channelId="g6139tbospd18cmxroesdk3kkc"
+      parentId=""
+    />
+    <div
+      className="post-create-footer"
+    >
+      <input
+        className="btn btn-primary comment-btn pull-right"
+        onClick={[Function]}
+        type="button"
+        value="Add Comment"
+      />
+    </div>
+  </div>
+  <PostDeletedModal
+    onHide={[Function]}
+    show={false}
+  />
+  <ConfirmModal
+    confirmButtonClass="btn btn-primary"
+    confirmButtonText={
+      <FormattedMessage
+        defaultMessage="Confirm"
+        id="notify_all.confirm"
+        values={Object {}}
+      />
+    }
+    message={
+      <FormattedMessage
+        defaultMessage="By using @all or @channel you are about to send notifications to {totalMembers} people. Are you sure you want to do this?"
+        id="notify_all.question"
+        values={
+          Object {
+            "totalMembers": 2,
+          }
+        }
+      />
+    }
+    modalClass=""
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    show={false}
+    title={
+      <FormattedMessage
+        defaultMessage="Confirm sending notifications to entire channel"
+        id="notify_all.title.confirm"
+        values={Object {}}
+      />
+    }
+  />
+</form>
+`;
+
 exports[`components/CreateComment should match snapshot, comment with message 1`] = `
 <form
   onSubmit={[Function]}
@@ -18,6 +109,7 @@ exports[`components/CreateComment should match snapshot, comment with message 1`
           channelId="g6139tbospd18cmxroesdk3kkc"
           characterLimit={4000}
           createMessage="Add a comment..."
+          disabled={false}
           emojiEnabled={true}
           handlePostError={[Function]}
           id="reply_textbox"
@@ -137,6 +229,7 @@ exports[`components/CreateComment should match snapshot, empty comment 1`] = `
           channelId="g6139tbospd18cmxroesdk3kkc"
           characterLimit={4000}
           createMessage="Add a comment..."
+          disabled={false}
           emojiEnabled={true}
           handlePostError={[Function]}
           id="reply_textbox"
@@ -256,6 +349,7 @@ exports[`components/CreateComment should match snapshot, non-empty message and u
           channelId="g6139tbospd18cmxroesdk3kkc"
           characterLimit={4000}
           createMessage="Add a comment..."
+          disabled={false}
           emojiEnabled={true}
           handlePostError={[Function]}
           id="reply_textbox"

--- a/tests/components/create_comment/create_comment.test.jsx
+++ b/tests/components/create_comment/create_comment.test.jsx
@@ -46,7 +46,8 @@ describe('components/CreateComment', () => {
         onMoveHistoryIndexBack: jest.fn(),
         onMoveHistoryIndexForward: jest.fn(),
         onEditLatestPost: jest.fn(),
-        resetCreatePostRequest: jest.fn()
+        resetCreatePostRequest: jest.fn(),
+        readOnlyChannel: false
     };
 
     test('should match snapshot, empty comment', () => {
@@ -519,5 +520,14 @@ describe('components/CreateComment', () => {
 
         wrapper.setProps({rootId: 'new_root_id'});
         expect(wrapper.state('draft')).toEqual({...draft, uploadsInProgress: [], fileInfos: [{}, {}, {}]});
+    });
+
+    test('should match snapshot read only channel', () => {
+        const props = {...baseProps, readOnlyChannel: true};
+        const wrapper = shallow(
+            <CreateComment {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
     });
 });

--- a/tests/components/create_post/__snapshots__/create_post.test.jsx.snap
+++ b/tests/components/create_post/__snapshots__/create_post.test.jsx.snap
@@ -20,6 +20,7 @@ exports[`components/create_post should match snapshot for center textbox 1`] = `
           channelId="owsyt8n43jfxjpzh9np93mx1wa"
           characterLimit={4000}
           createMessage="Write a message..."
+          disabled={false}
           emojiEnabled={true}
           handlePostError={[Function]}
           id="post_textbox"
@@ -123,6 +124,102 @@ exports[`components/create_post should match snapshot for center textbox 1`] = `
 </form>
 `;
 
+exports[`components/create_post should match snapshot for read only channel 1`] = `
+<form
+  className=""
+  id="create_post"
+  onSubmit={[Function]}
+  role="form"
+>
+  <div
+    className="post-create"
+  >
+    <div
+      className="post-create-body"
+    >
+      <div
+        className="post-body__cell"
+      >
+        <Textbox
+          channelId="owsyt8n43jfxjpzh9np93mx1wa"
+          characterLimit={4000}
+          createMessage="This channel is read-only. Only members with permission can post here."
+          disabled={true}
+          emojiEnabled={true}
+          handlePostError={[Function]}
+          id="post_textbox"
+          isRHS={false}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          popoverMentionKeyClick={true}
+          supportsCommands={true}
+          value=""
+        />
+        <span
+          className="post-body__actions"
+        >
+          <a
+            className="send-button theme disabled"
+            onClick={[Function]}
+          >
+            <i
+              className="fa fa-paper-plane"
+            />
+          </a>
+        </span>
+      </div>
+    </div>
+    <div
+      className="post-create-footer"
+      id="postCreateFooter"
+    >
+      <MsgTyping
+        channelId="owsyt8n43jfxjpzh9np93mx1wa"
+        parentId=""
+      />
+    </div>
+  </div>
+  <PostDeletedModal
+    onHide={[Function]}
+    show={false}
+  />
+  <ConfirmModal
+    confirmButtonClass="btn btn-primary"
+    confirmButtonText={
+      <FormattedMessage
+        defaultMessage="Confirm"
+        id="notify_all.confirm"
+        values={Object {}}
+      />
+    }
+    message={
+      <FormattedMessage
+        defaultMessage="By using @all or @channel you are about to send notifications to {totalMembers} people. Are you sure you want to do this?"
+        id="notify_all.question"
+        values={
+          Object {
+            "totalMembers": 8,
+          }
+        }
+      />
+    }
+    modalClass=""
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    show={false}
+    title={
+      <FormattedMessage
+        defaultMessage="Confirm sending notifications to entire channel"
+        id="notify_all.title.confirm"
+        values={Object {}}
+      />
+    }
+  />
+</form>
+`;
+
 exports[`components/create_post should match snapshot, init 1`] = `
 <form
   className=""
@@ -143,6 +240,7 @@ exports[`components/create_post should match snapshot, init 1`] = `
           channelId="owsyt8n43jfxjpzh9np93mx1wa"
           characterLimit={4000}
           createMessage="Write a message..."
+          disabled={false}
           emojiEnabled={true}
           handlePostError={[Function]}
           id="post_textbox"

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -86,7 +86,8 @@ function createPost({
     actions = actionsProp,
     ctrlSend = ctrlSendProp,
     currentUsersLatestPost = currentUsersLatestPostProp,
-    commentCountForPost = commentCountForPostProp
+    commentCountForPost = commentCountForPostProp,
+    readOnlyChannel = false
 } = {}) {
     return (
         <CreatePost
@@ -103,6 +104,7 @@ function createPost({
             currentUsersLatestPost={currentUsersLatestPost}
             commentCountForPost={commentCountForPost}
             actions={actions}
+            readOnlyChannel={readOnlyChannel}
         />
     );
 }
@@ -628,5 +630,10 @@ describe('components/create_post', () => {
         expect(onSubmitPost).toHaveBeenCalledTimes(1);
         expect(onSubmitPost.mock.calls[0][0]).toEqual(post);
         expect(onSubmitPost.mock.calls[0][1]).toEqual([]);
+    });
+
+    it('should match snapshot for read only channel', () => {
+        const wrapper = shallow(createPost({readOnlyChannel: true}));
+        expect(wrapper).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Summary
Instead of just fixing the bug (which would have been very hacky), I instead prevented users from posting in town square when it was marked as read only.

The user is prevented from writing in the textbox, any previous drafts will not show up (but are still saved for if town square is not read only in the future), and the file upload and emoji picker buttons are disabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-215

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
