### PR TITLE
ABC-105 Only expose redux store globally in dev builds

### DIFF
--- a/stores/redux_store.jsx
+++ b/stores/redux_store.jsx
@@ -14,6 +14,8 @@ export function bindActionToRedux(action, ...args) {
     };
 }
 
-window.store = store;
+if (process.env.NODE_ENV !== 'production') { //eslint-disable-line no-process-env
+    window.store = store;
+}
 
 export default store;


### PR DESCRIPTION
#### Summary
Only expose redux store globally in dev builds.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-105

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)