### PR TITLE
XYZ-62: Character count enforced for previous message when moving to a new channel

### DIFF
--- a/components/textbox.jsx
+++ b/components/textbox.jsx
@@ -138,6 +138,9 @@ export default class Textbox extends React.Component {
 
         textbox.focus();
         Utils.placeCaretAtEnd(textbox);
+
+        // reset character count warning
+        this.checkMessageLength(textbox.value);
     }
 
     blur = () => {

--- a/tests/components/__snapshots__/textbox.test.jsx.snap
+++ b/tests/components/__snapshots__/textbox.test.jsx.snap
@@ -1,0 +1,251 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/TextBox should match snapshot with required props 1`] = `
+<div
+  className="textarea-wrapper"
+>
+  <SuggestionBox
+    className="form-control custom-textarea"
+    completeOnTab={true}
+    id="someid"
+    inputComponent={[Function]}
+    isRHS={false}
+    listComponent={[Function]}
+    listStyle="top"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onHeightChange={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    openOnFocus={false}
+    placeholder="placeholder text"
+    popoverMentionKeyClick={false}
+    providers={
+      Array [
+        AtMentionProvider {
+          "channelId": undefined,
+          "disableDispatches": false,
+          "latestComplete": true,
+          "latestPrefix": "",
+        },
+        ChannelMentionProvider {
+          "disableDispatches": false,
+          "lastCompletedWord": "",
+          "lastPrefixWithNoResults": "",
+          "latestComplete": true,
+          "latestPrefix": "",
+        },
+        EmoticonProvider {},
+      ]
+    }
+    renderDividers={true}
+    requiredCharacters={1}
+    spellCheck="true"
+    style={
+      Object {
+        "visibility": "visible",
+      }
+    }
+    value="some test text"
+  />
+  <div
+    className="help__text "
+  >
+    <div
+      className="help__format-text"
+      id="helpText"
+      style={
+        Object {
+          "opacity": "0.45",
+          "visibility": "visible",
+        }
+      }
+    >
+      <b>
+        <FormattedMessage
+          defaultMessage="**bold**"
+          id="textbox.bold"
+          values={Object {}}
+        />
+      </b>
+      <i>
+        <FormattedMessage
+          defaultMessage="_italic_"
+          id="textbox.italic"
+          values={Object {}}
+        />
+      </i>
+      <span>
+        ~~
+        <strike>
+          <FormattedMessage
+            defaultMessage="strike"
+            id="textbox.strike"
+            values={Object {}}
+          />
+        </strike>
+        ~~ 
+      </span>
+      <span>
+        <FormattedMessage
+          defaultMessage="\`inline code\`"
+          id="textbox.inlinecode"
+          values={Object {}}
+        />
+      </span>
+      <span>
+        <FormattedMessage
+          defaultMessage="\`\`\`preformatted\`\`\`"
+          id="textbox.preformatted"
+          values={Object {}}
+        />
+      </span>
+      <span>
+        <FormattedMessage
+          defaultMessage=">quote"
+          id="textbox.quote"
+          values={Object {}}
+        />
+      </span>
+    </div>
+    <a
+      className="textbox-help-link"
+      href="/help/messaging"
+      id="helpTextLink"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <FormattedMessage
+        defaultMessage="Help"
+        id="textbox.help"
+        values={Object {}}
+      />
+    </a>
+  </div>
+</div>
+`;
+
+exports[`components/TextBox should throw error when value is too long 1`] = `
+<div
+  className="textarea-wrapper"
+>
+  <SuggestionBox
+    className="form-control custom-textarea"
+    completeOnTab={true}
+    id="someid"
+    inputComponent={[Function]}
+    isRHS={false}
+    listComponent={[Function]}
+    listStyle="top"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onHeightChange={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    openOnFocus={false}
+    placeholder="placeholder text"
+    popoverMentionKeyClick={false}
+    providers={
+      Array [
+        AtMentionProvider {
+          "channelId": undefined,
+          "disableDispatches": false,
+          "latestComplete": true,
+          "latestPrefix": "",
+        },
+        ChannelMentionProvider {
+          "disableDispatches": false,
+          "lastCompletedWord": "",
+          "lastPrefixWithNoResults": "",
+          "latestComplete": true,
+          "latestPrefix": "",
+        },
+        EmoticonProvider {},
+      ]
+    }
+    renderDividers={true}
+    requiredCharacters={1}
+    spellCheck="true"
+    style={
+      Object {
+        "visibility": "visible",
+      }
+    }
+    value="some test text"
+  />
+  <div
+    className="help__text "
+  >
+    <div
+      className="help__format-text"
+      id="helpText"
+      style={
+        Object {
+          "opacity": "0.45",
+          "visibility": "visible",
+        }
+      }
+    >
+      <b>
+        <FormattedMessage
+          defaultMessage="**bold**"
+          id="textbox.bold"
+          values={Object {}}
+        />
+      </b>
+      <i>
+        <FormattedMessage
+          defaultMessage="_italic_"
+          id="textbox.italic"
+          values={Object {}}
+        />
+      </i>
+      <span>
+        ~~
+        <strike>
+          <FormattedMessage
+            defaultMessage="strike"
+            id="textbox.strike"
+            values={Object {}}
+          />
+        </strike>
+        ~~ 
+      </span>
+      <span>
+        <FormattedMessage
+          defaultMessage="\`inline code\`"
+          id="textbox.inlinecode"
+          values={Object {}}
+        />
+      </span>
+      <span>
+        <FormattedMessage
+          defaultMessage="\`\`\`preformatted\`\`\`"
+          id="textbox.preformatted"
+          values={Object {}}
+        />
+      </span>
+      <span>
+        <FormattedMessage
+          defaultMessage=">quote"
+          id="textbox.quote"
+          values={Object {}}
+        />
+      </span>
+    </div>
+    <a
+      className="textbox-help-link"
+      href="/help/messaging"
+      id="helpTextLink"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <FormattedMessage
+        defaultMessage="Help"
+        id="textbox.help"
+        values={Object {}}
+      />
+    </a>
+  </div>
+</div>
+`;

--- a/tests/components/textbox.test.jsx
+++ b/tests/components/textbox.test.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import * as Utils from 'utils/utils.jsx';
+import TestHelper from 'tests/helpers/client-test-helper';
 
 import Textbox from 'components/textbox.jsx';
 
@@ -46,7 +46,7 @@ describe('components/TextBox', () => {
             />
         );
 
-        wrapper.find('#someid').value = Utils.generateRandomString(4001);
+        wrapper.find('#someid').value = TestHelper.randomString(4001);
         expect(gotError).toEqual(true);
 
         expect(wrapper).toMatchSnapshot();

--- a/tests/components/textbox.test.jsx
+++ b/tests/components/textbox.test.jsx
@@ -2,9 +2,9 @@
 // See License.txt for license information.
 
 import React from 'react';
-import {mount, shallow} from 'enzyme';
+import {shallow} from 'enzyme';
 
-import * as Utils from 'utils/utils.jsx'
+import * as Utils from 'utils/utils.jsx';
 
 import Textbox from 'components/textbox.jsx';
 

--- a/tests/components/textbox.test.jsx
+++ b/tests/components/textbox.test.jsx
@@ -1,0 +1,54 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {mount, shallow} from 'enzyme';
+
+import * as Utils from 'utils/utils.jsx'
+
+import Textbox from 'components/textbox.jsx';
+
+describe('components/TextBox', () => {
+    test('should match snapshot with required props', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        const wrapper = shallow(
+            <Textbox
+                id='someid'
+                value='some test text'
+                onChange={emptyFunction}
+                onKeyPress={emptyFunction}
+                createMessage='placeholder text'
+                supportsCommands={false}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should throw error when value is too long', () => {
+        function emptyFunction() {} //eslint-disable-line no-empty-function
+
+        // this mock function should be called when the textbox value is too long
+        var gotError = false;
+        function handlePostError() {
+            gotError = true;
+        }
+
+        const wrapper = shallow(
+            <Textbox
+                id='someid'
+                value='some test text'
+                onChange={emptyFunction}
+                onKeyPress={emptyFunction}
+                createMessage='placeholder text'
+                supportsCommands={false}
+                handlePostError={handlePostError}
+            />
+        );
+
+        wrapper.find('#someid').value = Utils.generateRandomString(4001);
+        expect(gotError).toEqual(true);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/tests/helpers/client-test-helper.jsx
+++ b/tests/helpers/client-test-helper.jsx
@@ -104,6 +104,17 @@ class TestHelperClass {
         return post;
     }
 
+    randomString = (length) => {
+        var text = '';
+        var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+        for (var i = 0; i < length; i++) {
+            text += possible.charAt(Math.floor(Math.random() * possible.length));
+        }
+
+        return text;
+    }
+
     initBasic = (done, callback, connectWS) => {
         this.basicc = this.createClient();
 

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1554,3 +1554,13 @@ export function copyToClipboard(e, data) {
     document.execCommand('copy');
     document.body.removeChild(textArea);
 }
+
+export function generateRandomString(length) {
+    var text = '';
+    var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+    for (var i = 0; i < length; i++)
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+    return text;
+}

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1559,8 +1559,9 @@ export function generateRandomString(length) {
     var text = '';
     var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
-    for (var i = 0; i < length; i++)
+    for (var i = 0; i < length; i++) {
         text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
 
     return text;
 }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1554,14 +1554,3 @@ export function copyToClipboard(e, data) {
     document.execCommand('copy');
     document.body.removeChild(textArea);
 }
-
-export function generateRandomString(length) {
-    var text = '';
-    var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-
-    for (var i = 0; i < length; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-
-    return text;
-}


### PR DESCRIPTION
#### Summary
Forced a re-check of the character count whenever the text box receives focus. This event fires when the user clicks the mouse to focus the textbox, but also when the user switches channels (in the centre column), and when the user clicks the reply arrow to enter a new thread in the RHS. 

#### Ticket Link
https://mattermost.atlassian.net/browse/XYZ-62

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes