### PR TITLE
ABC-216: fix tutorial progression

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -26,7 +26,6 @@ import EmojiIcon from 'components/svg/emoji_icon';
 import Textbox from 'components/textbox.jsx';
 import TutorialTip from 'components/tutorial/tutorial_tip.jsx';
 
-const TutorialSteps = Constants.TutorialSteps;
 const KeyCodes = Constants.KeyCodes;
 
 export default class CreatePost extends React.Component {
@@ -70,7 +69,7 @@ export default class CreatePost extends React.Component {
         /**
         *  Data used for deciding if tutorial tip is to be shown
         */
-        showTutorialTip: PropTypes.string,
+        showTutorialTip: PropTypes.bool.isRequired,
 
         /**
         *  Data used populating message state when triggered by shortcuts
@@ -757,7 +756,7 @@ export default class CreatePost extends React.Component {
         }
 
         let tutorialTip = null;
-        if (parseInt(showTutorialTip, 10) === TutorialSteps.POST_POPOVER && global.window.mm_config.EnableTutorial === 'true') {
+        if (showTutorialTip) {
             tutorialTip = this.createTutorialTip();
         }
 

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentChannel, getCurrentChannelStats} from 'mattermost-redux/selectors/entities/channels';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {get, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {
@@ -29,12 +30,13 @@ import {createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
 import {makeGetGlobalItem} from 'selectors/storage';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
-import {Preferences, StoragePrefixes} from 'utils/constants.jsx';
+import {Preferences, StoragePrefixes, TutorialSteps} from 'utils/constants.jsx';
 
 import CreatePost from './create_post.jsx';
 
 function mapStateToProps() {
     return (state, ownProps) => {
+        const config = getConfig(state);
         const currentChannel = getCurrentChannel(state) || {};
         const getDraft = makeGetGlobalItem(StoragePrefixes.DRAFT + currentChannel.id, {
             message: '',
@@ -46,6 +48,8 @@ function mapStateToProps() {
         const getCommentCountForPost = makeGetCommentCountForPost();
         const latestReplyablePostId = getLatestReplyablePostId(state);
         const currentChannelMembersCount = getCurrentChannelStats(state) ? getCurrentChannelStats(state).member_count : 1;
+        const enableTutorial = config.EnableTutorial === 'true';
+        const tutorialStep = parseInt(get(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), TutorialSteps.FINISHED), 10);
         return {
             ...ownProps,
             currentTeamId: getCurrentTeamId(state),
@@ -54,7 +58,7 @@ function mapStateToProps() {
             currentUserId: getCurrentUserId(state),
             ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
             fullWidthTextBox: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
-            showTutorialTip: get(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), 999),
+            showTutorialTip: enableTutorial && tutorialStep === TutorialSteps.POST_POPOVER,
             messageInHistoryItem: makeGetMessageInHistoryItem(Posts.MESSAGE_TYPES.POST)(state),
             draft: getDraft(state),
             recentPostIdInChannel,

--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -25,7 +25,9 @@ function makeMapStateToProps() {
 
         const config = getConfig(state);
         const channel = getChannel(state, {id: channelId}) || {};
-        const tutorialStep = getPreference(state, Constants.Preferences.TUTORIAL_STEP, ownProps.currentUserId, 999);
+
+        const enableTutorial = config.EnableTutorial === 'true';
+        const tutorialStep = parseInt(getPreference(state, Constants.Preferences.TUTORIAL_STEP, ownProps.currentUserId, Constants.TutorialSteps.FINISHED), 10);
         const channelsByName = getChannelsNameMapInCurrentTeam(state);
         const memberIds = getUserIdsInChannels(state);
 
@@ -71,7 +73,7 @@ function makeMapStateToProps() {
             channelTeammateId: teammate && teammate.id,
             channelTeammateUsername: teammate && teammate.username,
             channelTeammateDeletedAt: teammate && teammate.delete_at,
-            showTutorialTip: tutorialStep === Constants.TutorialSteps.CHANNEL_POPOVER && config.EnableTutorial === 'true',
+            showTutorialTip: enableTutorial && tutorialStep === Constants.TutorialSteps.CHANNEL_POPOVER,
             townSquareDisplayName: channelsByName[Constants.DEFAULT_CHANNEL] && channelsByName[Constants.DEFAULT_CHANNEL].display_name,
             offTopicDisplayName: channelsByName[Constants.OFFTOPIC_CHANNEL] && channelsByName[Constants.OFFTOPIC_CHANNEL].display_name,
             showUnreadForMsgs,

--- a/components/sidebar_header.jsx
+++ b/components/sidebar_header.jsx
@@ -39,7 +39,7 @@ export default class SidebarHeader extends React.Component {
         if (!this.props.currentUser) {
             return {};
         }
-        const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, this.props.currentUser.id, 999);
+        const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, this.props.currentUser.id, TutorialSteps.FINISHED);
         const showTutorialTip = tutorialStep === TutorialSteps.MENU_POPOVER && !Utils.isMobile() && global.window.mm_config.EnableTutorial === 'true';
 
         return {showTutorialTip};

--- a/components/sidebar_right_menu/index.js
+++ b/components/sidebar_right_menu/index.js
@@ -3,18 +3,27 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {showMentions, showFlaggedPosts, closeRightHandSide} from 'actions/views/rhs';
 import {getRhsState} from 'selectors/rhs';
-import {RHSStates} from 'utils/constants.jsx';
+import {RHSStates, Preferences, TutorialSteps} from 'utils/constants.jsx';
+import {isMobile} from 'utils/utils.jsx';
 
 import SidebarRightMenu from './sidebar_right_menu.jsx';
 
 function mapStateToProps(state) {
+    const config = getConfig(state);
     const rhsState = getRhsState(state);
 
+    const enableTutorial = config.EnableTutorial === 'true';
+    const tutorialStep = parseInt(get(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), TutorialSteps.FINISHED), 10);
+
     return {
-        isMentionSearch: rhsState === RHSStates.MENTION
+        isMentionSearch: rhsState === RHSStates.MENTION,
+        showTutorialTip: enableTutorial && isMobile() && tutorialStep === TutorialSteps.MENU_POPOVER
     };
 }
 

--- a/components/sidebar_right_menu/sidebar_right_menu.jsx
+++ b/components/sidebar_right_menu/sidebar_right_menu.jsx
@@ -13,8 +13,6 @@ import UserStore from 'stores/user_store.jsx';
 import WebrtcStore from 'stores/webrtc_store.jsx';
 import {
     Constants,
-    Preferences,
-    TutorialSteps,
     WebrtcActionTypes
 } from 'utils/constants.jsx';
 import {useSafeUrl} from 'utils/url.jsx';
@@ -33,6 +31,7 @@ export default class SidebarRightMenu extends React.Component {
         teamType: PropTypes.string,
         teamDisplayName: PropTypes.string,
         isMentionSearch: PropTypes.bool,
+        showTutorialTip: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             showMentions: PropTypes.func,
             showFlaggedPosts: PropTypes.func,
@@ -111,13 +110,10 @@ export default class SidebarRightMenu extends React.Component {
     }
 
     getStateFromStores = () => {
-        const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), 999);
-
         return {
             currentUser: UserStore.getCurrentUser(),
             teamMembers: TeamStore.getMyTeamMembers(),
-            teamListings: TeamStore.getTeamListings(),
-            showTutorialTip: tutorialStep === TutorialSteps.MENU_POPOVER && Utils.isMobile() && global.window.mm_config.EnableTutorial === 'true'
+            teamListings: TeamStore.getTeamListings()
         };
     }
 
@@ -422,7 +418,7 @@ export default class SidebarRightMenu extends React.Component {
         }
 
         let tutorialTip = null;
-        if (this.state.showTutorialTip) {
+        if (this.props.showTutorialTip) {
             tutorialTip = createMenuTip((e) => e.preventDefault(), true);
             this.closeLeftSidebar();
             this.openRightSidebar();

--- a/components/tutorial/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens.jsx
@@ -263,10 +263,9 @@ export default class TutorialIntroScreens extends React.Component {
         );
     }
 
-    handleCircleClick = (e) => {
+    handleCircleClick = (e, screen) => {
         e.preventDefault();
-        const currentScreen = e.currentTarget.getAttribute('data-screen');
-        this.setState({currentScreen});
+        this.setState({currentScreen: screen});
     }
 
     createCircles() {
@@ -284,7 +283,7 @@ export default class TutorialIntroScreens extends React.Component {
                     key={'circle' + i}
                     className={className}
                     data-screen={i}
-                    onClick={this.handleCircleClick}
+                    onClick={(e) => this.handleCircleClick(e, i)}
                 />
             );
         }

--- a/components/tutorial/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens.jsx
@@ -78,7 +78,7 @@ export default class TutorialIntroScreens extends React.Component {
         savePreference(
             Preferences.TUTORIAL_STEP,
             UserStore.getCurrentId(),
-            '999'
+            Constants.TutorialSteps.FINISHED.toString(),
         );
     }
     createScreen() {

--- a/components/tutorial/tutorial_tip.jsx
+++ b/components/tutorial/tutorial_tip.jsx
@@ -16,31 +16,28 @@ import tutorialGif from 'images/tutorialTip.gif';
 import tutorialGifWhite from 'images/tutorialTipWhite.gif';
 
 const Preferences = Constants.Preferences;
+const TutorialSteps = Constants.TutorialSteps;
 
 export default class TutorialTip extends React.Component {
     constructor(props) {
         super(props);
 
         this.handleNext = this.handleNext.bind(this);
-        this.toggle = this.toggle.bind(this);
+        this.show = this.show.bind(this);
+        this.hide = this.hide.bind(this);
         this.skipTutorial = this.skipTutorial.bind(this);
 
         this.state = {currentScreen: 0, show: false};
     }
-    toggle() {
-        const show = !this.state.show;
-        this.setState({show});
 
-        if (!show && this.state.currentScreen >= this.props.screens.length - 1) {
-            const step = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), 0);
-
-            savePreference(
-                Preferences.TUTORIAL_STEP,
-                UserStore.getCurrentId(),
-                (step + 1).toString()
-            );
-        }
+    show() {
+        this.setState({show: true});
     }
+
+    hide() {
+        this.setState({show: false});
+    }
+
     handleNext() {
         if (this.state.currentScreen < this.props.screens.length - 1) {
             this.setState({currentScreen: this.state.currentScreen + 1});
@@ -64,8 +61,16 @@ export default class TutorialTip extends React.Component {
         }
 
         this.closeRightSidebar();
-        this.toggle();
+        this.hide();
+
+        const step = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), 0);
+        savePreference(
+            Preferences.TUTORIAL_STEP,
+            UserStore.getCurrentId(),
+            (step + 1).toString()
+        );
     }
+
     closeRightSidebar() {
         if (Utils.isMobile()) {
             setTimeout(() => {
@@ -74,6 +79,7 @@ export default class TutorialTip extends React.Component {
             });
         }
     }
+
     skipTutorial(e) {
         e.preventDefault();
 
@@ -89,7 +95,7 @@ export default class TutorialTip extends React.Component {
         savePreference(
             Preferences.TUTORIAL_STEP,
             UserStore.getCurrentId(),
-            '999'
+            TutorialSteps.FINISHED.toString()
         );
     }
 
@@ -145,13 +151,13 @@ export default class TutorialTip extends React.Component {
             <div
                 id='tipButton'
                 className={'tip-div ' + this.props.overlayClass}
-                onClick={this.toggle}
+                onClick={this.show}
             >
                 <img
                     className='tip-button'
                     src={tutorialGifImage}
                     width='35'
-                    onClick={this.toggle}
+                    onClick={this.show}
                     ref='target'
                 />
 
@@ -165,7 +171,7 @@ export default class TutorialTip extends React.Component {
                     placement={this.props.placement}
                     show={this.state.show}
                     rootClose={true}
-                    onHide={this.toggle}
+                    onHide={this.hide}
                     target={this.getTarget}
                 >
                     <div className={'tip-overlay ' + this.props.overlayClass}>

--- a/components/tutorial/tutorial_tip.jsx
+++ b/components/tutorial/tutorial_tip.jsx
@@ -22,23 +22,18 @@ export default class TutorialTip extends React.Component {
     constructor(props) {
         super(props);
 
-        this.handleNext = this.handleNext.bind(this);
-        this.show = this.show.bind(this);
-        this.hide = this.hide.bind(this);
-        this.skipTutorial = this.skipTutorial.bind(this);
-
         this.state = {currentScreen: 0, show: false};
     }
 
-    show() {
+    show = () => {
         this.setState({show: true});
     }
 
-    hide() {
+    hide = () => {
         this.setState({show: false});
     }
 
-    handleNext() {
+    handleNext = () => {
         if (this.state.currentScreen < this.props.screens.length - 1) {
             this.setState({currentScreen: this.state.currentScreen + 1});
             return;
@@ -80,7 +75,7 @@ export default class TutorialTip extends React.Component {
         }
     }
 
-    skipTutorial(e) {
+    skipTutorial = (e) => {
         e.preventDefault();
 
         if (this.props.diagnosticsTag) {

--- a/components/tutorial/tutorial_tip.jsx
+++ b/components/tutorial/tutorial_tip.jsx
@@ -99,10 +99,9 @@ export default class TutorialTip extends React.Component {
         );
     }
 
-    handleCircleClick = (e) => {
+    handleCircleClick = (e, screen) => {
         e.preventDefault();
-        const currentScreen = e.currentTarget.getAttribute('data-screen');
-        this.setState({currentScreen});
+        this.setState({currentScreen: screen});
     }
 
     getTarget = () => {
@@ -136,7 +135,7 @@ export default class TutorialTip extends React.Component {
                         key={'dotactive' + i}
                         className={className}
                         data-screen={i}
-                        onClick={this.handleCircleClick}
+                        onClick={(e) => this.handleCircleClick(e, i)}
                     />
                 );
             }

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -38,7 +38,7 @@ jest.mock('actions/post_actions.jsx', () => ({
 const KeyCodes = Constants.KeyCodes;
 const currentTeamIdProp = 'r7rws4y7ppgszym3pdd5kaibfa';
 const currentUserIdProp = 'zaktnt8bpbgu8mb6ez9k64r7sa';
-const showTutorialTipProp = '999';
+const showTutorialTipProp = false;
 const fullWidthTextBoxProp = true;
 const recentPostIdInChannelProp = 'a';
 const latestReplyablePostIdProp = 'a';
@@ -599,7 +599,7 @@ describe('components/create_post', () => {
 
     it('Show tutorial', () => {
         const wrapper = shallow(createPost({
-            showTutorialTip: '1'
+            showTutorialTip: true
         }));
         expect(wrapper.find('TutorialTip').length).toBe(1);
     });

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -327,7 +327,8 @@ export const TutorialSteps = {
     INTRO_SCREENS: 0,
     POST_POPOVER: 1,
     CHANNEL_POPOVER: 2,
-    MENU_POPOVER: 3
+    MENU_POPOVER: 3,
+    FINISHED: 999
 };
 
 export const PostTypes = {


### PR DESCRIPTION
#### Summary
This change fixes a `===` comparison between a string an integer to
allow the second tutorial step to display. It also fixes the trigger
that increments the tutorial step to only fire on an explicit "next"
instead of twice on a click because of multiple registered event
handlers. This also means that the tutorial no longer advances on an
"escape", but requires being explicitly skipped or completed.

As part of the clean up, unify most handling of the tutorial step
preference constants.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-216

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)