### PR TITLE
ABC-214: fix permalinks to direct messages

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -120,7 +120,7 @@ export async function emitPostFocusEvent(postId) {
     if (data) {
         const channelId = data.posts[data.order[0]].channel_id;
         const channel = ChannelStore.getChannelById(channelId);
-        if (!channel || channel.team_id !== TeamStore.getCurrentId()) {
+        if (!channel) {
             browserHistory.push('/error?type=' + ErrorPageTypes.PERMALINK_NOT_FOUND);
         }
 


### PR DESCRIPTION
#### Summary
This simplifies the changes introduced in ABC-160 to simply check that
the channel exists instead of also checking that the channel team id
matches the current team. The additional check was redundant, since the
set of channels available are already constrained to the current team;
it was also wrong, since direct messages and group messages aren't
actually assigned team ids, leading to the regression in question.

Note that this check (before and even now) only works if you have access
to the two teams in question. If you try to open a malformed permalink
referencing a team for which you don't have access or that doesn't
exist, none of the router code in `<NeedsTeam>` executes (team is null),
and a different path is executed that doesn't try to evaluate the
permalink. Fixing that appears to be non-trivial and out of scope for
this change.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-214

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed