### PR TITLE
introduce webpack-notifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "selenium-standalone": "6.12.0",
     "style-loader": "0.19.1",
     "webpack": "3.10.0",
-    "webpack-node-externals": "1.6.0"
+    "webpack-node-externals": "1.6.0",
+    "webpack-notifier": "^1.5.1"
   },
   "jest": {
     "snapshotSerializers": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,8 +7,10 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const extractCSS = new ExtractTextPlugin('[name].[contentHash].css');
 const extractSCSS = new ExtractTextPlugin('[name].[contentHash].css');
+const WebpackNotifierPlugin = require('webpack-notifier');
 
 const NPM_TARGET = process.env.npm_lifecycle_event; //eslint-disable-line no-process-env
+const WEBPACK_NOTIFY = process.env.WEBPACK_NOTIFY; //eslint-disable-line no-process-env
 
 var DEV = false;
 var FULLMAP = false;
@@ -325,6 +327,10 @@ if (TEST) {
             {from: 'images/warning.png', to: 'images'}
         ])
     );
+}
+
+if (WEBPACK_NOTIFY) {
+    config.plugins.push(new WebpackNotifierPlugin({alwaysNotify: true, excludeWarnings: true}));
 }
 
 module.exports = config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8896,6 +8896,14 @@ webpack-node-externals@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.6.0.tgz#232c62ec6092b100635a3d29d83c1747128df9bd"
 
+webpack-notifier@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/webpack-notifier/-/webpack-notifier-1.5.1.tgz#cf5f6b9a1711f80969bbc4f7bd15d40ea7b18761"
+  dependencies:
+    node-notifier "^5.1.2"
+    object-assign "^4.1.0"
+    strip-ansi "^3.0.1"
+
 webpack-sources@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.1.tgz#c7356436a4d13123be2e2426a05d1dad9cbe65cf"


### PR DESCRIPTION
#### Summary
Since we don't currently have hot reloading enabled, I find it useful to
know when webpack is done rebuilding assets. This optional plugin is
enabled by setting the `WEBPACK_NOTIFY` environment variable, and will
emit notifications using the operating system's default mechanism.

Thoughts?

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)