### PR TITLE
ABC-213: focus message box after switching channel

### DIFF
--- a/components/autosize_textarea.jsx
+++ b/components/autosize_textarea.jsx
@@ -80,6 +80,11 @@ export default class AutosizeTextarea extends React.Component {
             value,
             defaultValue,
             placeholder,
+
+            // TODO: The provided `id` is sometimes hard-coded and used to interface with the
+            // component, e.g. `post_textbox`, so it can't be changed. This would ideally be
+            // abstracted to avoid passing in an `id` prop at all, but we intentionally maintain
+            // the old behaviour to address ABC-213.
             id,
             ...otherProps
         } = props;
@@ -96,7 +101,7 @@ export default class AutosizeTextarea extends React.Component {
             <div>
                 <textarea
                     ref='textarea'
-                    id={id + '-textarea'}
+                    id={id}
                     {...heightProps}
                     {...otherProps}
                     placeholder={placeholder}

--- a/tests/components/__snapshots__/autosize_textarea.test.jsx.snap
+++ b/tests/components/__snapshots__/autosize_textarea.test.jsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/AutosizeTextarea should match snapshot, init 1`] = `
+<div>
+  <textarea
+    onChange={[Function]}
+    rows={1}
+  />
+  <div
+    style={
+      Object {
+        "height": 0,
+        "overflow": "hidden",
+      }
+    }
+  >
+    <textarea
+      disabled={true}
+      id="undefined-reference"
+      rows="1"
+      style={
+        Object {
+          "height": "auto",
+          "width": "100%",
+        }
+      }
+    />
+  </div>
+</div>
+`;

--- a/tests/components/autosize_textarea.test.jsx
+++ b/tests/components/autosize_textarea.test.jsx
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import AutosizeTextarea from 'components/autosize_textarea.jsx';
+
+describe('components/AutosizeTextarea', () => {
+    test('should match snapshot, init', () => {
+        const wrapper = shallow(
+            <AutosizeTextarea/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
The changes in PLT-8478 subtly changed the `id` of the AutosizeTextarea
from `post_textbox` to `post_textbox-textarea`. Unfortunately, the
former is hard-coded in a variety of places that trigger the desired
focus behaviour.

Ideally, this would be abstracted (as commented in the code), but for
now the minor portion of this change is reverted with no observable side
effects.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-213

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)