### PR TITLE
[ICU-699] Single view image improvement

### DIFF
--- a/components/single_image_view.jsx
+++ b/components/single_image_view.jsx
@@ -8,13 +8,10 @@ import {getFilePreviewUrl, getFileUrl} from 'mattermost-redux/utils/file_utils';
 
 import {FileTypes} from 'utils/constants.jsx';
 import {
-    fileSizeToString,
     getFileType,
     localizeMessage
 } from 'utils/utils';
-import {canDownloadFiles} from 'utils/file_utils';
 
-import DownloadIcon from 'components/svg/download_icon';
 import LoadingImagePreview from 'components/loading_image_preview';
 import ViewImageModal from 'components/view_image.jsx';
 
@@ -142,16 +139,11 @@ export default class SingleImageView extends React.PureComponent {
                     className='file-details__name'
                     onClick={this.handleImageClick}
                 >
-                    {fileInfo.name.toUpperCase()}
-                </span>
-                <span className='file-details__extension'>
-                    {`${fileInfo.extension.toUpperCase()}  ${fileSizeToString(fileInfo.size)}`}
+                    {fileInfo.name}
                 </span>
             </div>
         );
 
-        const fileUrl = getFileUrl(fileInfo.id);
-        const canDownload = canDownloadFiles();
         const fileType = getFileType(fileInfo.extension);
         let svgClass = '';
         if (fileType === FileTypes.SVG) {
@@ -161,7 +153,6 @@ export default class SingleImageView extends React.PureComponent {
         const loading = localizeMessage('view_image.loading', 'Loading');
 
         let viewImageModal;
-        let downloadIcon;
         let loadingImagePreview;
 
         let fadeInClass = '';
@@ -179,20 +170,6 @@ export default class SingleImageView extends React.PureComponent {
             fadeInClass = 'image-fade-in';
             imageLoadedDimension = {cursor: 'pointer'};
             imageContainerDimension = {};
-
-            if (canDownload) {
-                downloadIcon = (
-                    <a
-                        href={fileUrl}
-                        download={fileInfo.name}
-                        className='file__download'
-                        target='_blank'
-                        rel='noopener noreferrer'
-                    >
-                        <DownloadIcon/>
-                    </a>
-                );
-            }
         } else {
             loadingImagePreview = (
                 <LoadingImagePreview
@@ -223,7 +200,6 @@ export default class SingleImageView extends React.PureComponent {
                                 className={svgClass}
                                 onClick={this.handleImageClick}
                             />
-                            {downloadIcon}
                         </div>
                         <div className='image-preload'>
                             {loadingImagePreview}

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -180,16 +180,10 @@
             display: inline-block;
             position: relative;
 
-            &:hover {
-                .file__download {
-                    @include opacity(1);
-                }
-            }
-
             img {
                 @include border-radius(4px);
-                min-height: 75px;
-                min-width: 75px;
+                min-height: 50px;
+                min-width: 50px;
             }
         }
           
@@ -207,24 +201,6 @@
     .file-details__name:hover {
         cursor: pointer;
         text-decoration: underline;
-    }
-
-    .file-details__extension {
-        display: block;
-        font-size: 12px;
-        margin-bottom: 5px;
-    }
-
-    .file__download {
-        @include single-transition(all, .25s);
-        @include border-radius(50%);
-        @include opacity(0);
-        background: rgba($black, .5);
-        bottom: 20px;
-        height: 40px;
-        position: absolute;
-        right: 20px;
-        width: 40px;
     }
 }
 


### PR DESCRIPTION
#### Summary
Fix the following for single view image:
1. Remove size and image type from title
2. Title should not upper case (keep case of uploaded file)
3. Title should be same font size as normal text but bolded
4. Reduce minimum height and width to 50 pixels
5. Remove download button on single

[UPDATE - end result]
![screen shot 2018-02-06 at 9 38 00 pm](https://user-images.githubusercontent.com/5334504/35862278-15ec5316-0b86-11e8-9319-e3ec22e84ae5.png)

After clicking the single image or its filename, image download is available at image modal, like:
![screen shot 2018-02-06 at 9 39 16 pm](https://user-images.githubusercontent.com/5334504/35862359-57f5cf08-0b86-11e8-8ccc-22a8c1ffecd4.png)


#### Ticket Link
Jira ticket: [ICU-699](https://mattermost.atlassian.net/browse/ICU-699)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
