### PR TITLE
ICU-703 Don't show close button for unread channels

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -187,13 +187,15 @@ export default class SidebarChannel extends React.PureComponent {
         }
 
         let closeHandler = null;
-        if (this.props.channelType === Constants.DM_CHANNEL || this.props.channelType === Constants.GM_CHANNEL) {
-            closeHandler = this.handleLeaveDirectChannel;
-        } else if (this.props.config.EnableXToLeaveChannelsFromLHS === 'true') {
-            if (this.props.channelType === Constants.OPEN_CHANNEL && this.props.channelName !== Constants.DEFAULT_CHANNEL) {
-                closeHandler = this.handleLeavePublicChannel;
-            } else if (this.props.channelType === Constants.PRIVATE_CHANNEL) {
-                closeHandler = this.handleLeavePrivateChannel;
+        if (!this.showChannelAsUnread()) {
+            if (this.props.channelType === Constants.DM_CHANNEL || this.props.channelType === Constants.GM_CHANNEL) {
+                closeHandler = this.handleLeaveDirectChannel;
+            } else if (this.props.config.EnableXToLeaveChannelsFromLHS === 'true') {
+                if (this.props.channelType === Constants.OPEN_CHANNEL && this.props.channelName !== Constants.DEFAULT_CHANNEL) {
+                    closeHandler = this.handleLeavePublicChannel;
+                } else if (this.props.channelType === Constants.PRIVATE_CHANNEL) {
+                    closeHandler = this.handleLeavePrivateChannel;
+                }
             }
         }
 

--- a/tests/components/sidebar/__snapshots__/sidebar_channel.test.jsx.snap
+++ b/tests/components/sidebar/__snapshots__/sidebar_channel.test.jsx.snap
@@ -81,7 +81,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     channelStatus="test"
     channelType="D"
     displayName="Channel display name"
-    handleClose={[Function]}
+    handleClose={null}
     link="/current-team/messages/@undefined"
     membersCount={8}
     rowClass="sidebar-item unread-title has-badge"


### PR DESCRIPTION
@esethna As I mentioned in the ICU channel, I've removed the X button from unread channels since we don't let you leave a channel that has been marked unread (or if we do, the channel reappears when you refresh the page).

It does look a bit weird when you have the Unread Channels section disabled since you can now have G channels without an X button, but I think that's fine because clicking the X button before just meant the channel reappeared on next refresh. Here's an example with the X button shown for all channels for demonstration purposes
![image](https://user-images.githubusercontent.com/3277310/35871993-af3ecae2-0b33-11e8-9ccc-ac33da125b13.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-703

#### Checklist
- Has UI changes
