### PR TITLE
Removed unused code from ChannelUtils

### DIFF
--- a/utils/channel_utils.jsx
+++ b/utils/channel_utils.jsx
@@ -1,13 +1,11 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import {getGroupOrDirectChannelVisibility} from 'mattermost-redux/selectors/entities/channels';
 import * as ChannelUtilsRedux from 'mattermost-redux/utils/channel_utils';
 
 import ChannelStore from 'stores/channel_store.jsx';
 import LocalizationStore from 'stores/localization_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
-import store from 'stores/redux_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import Constants, {Preferences} from 'utils/constants.jsx';
@@ -19,16 +17,6 @@ export function isFavoriteChannel(channel) {
 
 export function isFavoriteChannelId(channelId) {
     return PreferenceStore.getBool(Preferences.CATEGORY_FAVORITE_CHANNEL, channelId);
-}
-
-// TODO This should use the version from mattermost-redux
-export function isOpenChannel(channel) {
-    return channel.type === Constants.OPEN_CHANNEL;
-}
-
-// TODO This should use the version from mattermost-redux
-export function isPrivateChannel(channel) {
-    return channel.type === Constants.PRIVATE_CHANNEL;
 }
 
 export function sortChannelsByDisplayName(a, b) {
@@ -191,29 +179,6 @@ export function getCountsStateFromStores(team = TeamStore.getCurrent(), teamMemb
     });
 
     return {mentionCount, messageCount};
-}
-
-export function isChannelVisible(channel) {
-    return isOpenChannel(channel) ||
-        isPrivateChannel(channel) ||
-        isDirectChannelVisible(channel) ||
-        isGroupChannelVisible(channel);
-}
-
-function isDirectChannelVisible(channel) {
-    if (!ChannelUtilsRedux.isDirectChannel(channel)) {
-        return false;
-    }
-
-    return getGroupOrDirectChannelVisibility(store.getState(), channel.id);
-}
-
-function isGroupChannelVisible(channel) {
-    if (!ChannelUtilsRedux.isGroupChannel(channel)) {
-        return false;
-    }
-
-    return getGroupOrDirectChannelVisibility(store.getState(), channel.id);
 }
 
 export function findNextUnreadChannelId(curChannelId, allChannelIds, unreadChannelIds, direction) {


### PR DESCRIPTION
Most of this logic is handled by mattermost-redux now