### PR TITLE
ICU-695 - Fixing paragraph spacing for last child

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1011,6 +1011,12 @@
 
         &:last-child {
             display: inline;
+
+            &:before {
+                content: '';
+                display: block;
+                height: 0.5em;
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
ICU-695 - Fixing paragraph spacing for last child

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-695

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
