### PR TITLE
ICU-711 Fix help text missing for Channel Notification preferences

### DIFF
--- a/components/channel_notifications_modal/components/extra_info.jsx
+++ b/components/channel_notifications_modal/components/extra_info.jsx
@@ -8,7 +8,8 @@ import {FormattedMessage} from 'react-intl';
 import {NotificationSections} from 'utils/constants.jsx';
 
 export default function ExtraInfo({section}) {
-    if (section === NotificationSections.DESKTOP) {
+    switch (section) {
+    case NotificationSections.DESKTOP:
         return (
             <span>
                 <FormattedMessage
@@ -17,7 +18,7 @@ export default function ExtraInfo({section}) {
                 />
             </span>
         );
-    } else if (section === NotificationSections.PUSH) {
+    case NotificationSections.PUSH:
         return (
             <span>
                 <FormattedMessage
@@ -26,9 +27,18 @@ export default function ExtraInfo({section}) {
                 />
             </span>
         );
+    case NotificationSections.MARK_UNREAD:
+        return (
+            <span>
+                <FormattedMessage
+                    id='channel_notifications.unreadInfo'
+                    defaultMessage='The channel name is bolded in the sidebar when there are unread messages. Selecting "Only for mentions" will bold the channel only when you are mentioned.'
+                />
+            </span>
+        );
+    default:
+        return null;
     }
-
-    return null;
 }
 
 ExtraInfo.propTypes = {

--- a/tests/components/channel_notifications_modal/__snapshots__/extra_info.test.jsx.snap
+++ b/tests/components/channel_notifications_modal/__snapshots__/extra_info.test.jsx.snap
@@ -10,7 +10,15 @@ exports[`components/channel_notifications_modal/ExtraInfo should match snapshot,
 </span>
 `;
 
-exports[`components/channel_notifications_modal/ExtraInfo should match snapshot, on MARK_UNREAD 1`] = `""`;
+exports[`components/channel_notifications_modal/ExtraInfo should match snapshot, on MARK_UNREAD 1`] = `
+<span>
+  <FormattedMessage
+    defaultMessage="The channel name is bolded in the sidebar when there are unread messages. Selecting \\"Only for mentions\\" will bold the channel only when you are mentioned."
+    id="channel_notifications.unreadInfo"
+    values={Object {}}
+  />
+</span>
+`;
 
 exports[`components/channel_notifications_modal/ExtraInfo should match snapshot, on PUSH 1`] = `
 <span>


### PR DESCRIPTION
#### Summary
Help text missing from Channel Notifications > Mark Channel Unread section

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-711

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
