### PR TITLE
ICU-695 - Fixing paragraph spacing for last child

### DIFF
--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -76,6 +76,6 @@ export default class PostMarkdown extends React.PureComponent {
         }
 
         const htmlFormattedText = TextFormatting.formatText(this.props.message, options);
-        return <span>{PostUtils.messageHtmlToComponent(htmlFormattedText, this.props.isRHS)}</span>;
+        return PostUtils.messageHtmlToComponent(htmlFormattedText, this.props.isRHS);
     }
 }

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1012,10 +1012,6 @@
         white-space: pre-wrap;
         width: 100%;
         word-break: break-word;
-
-        &:last-child {
-            display: inline;
-        }
     }
 
     .post__header--info {

--- a/tests/plugins/__snapshots__/post_type.test.jsx.snap
+++ b/tests/plugins/__snapshots__/post_type.test.jsx.snap
@@ -214,15 +214,13 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
             }
             siteURL="http://localhost:8065"
           >
-            <span>
-              <p
-                key="0"
-              >
-                this is some text
-              </p>
-              
+            <p
+              key="0"
+            >
+              this is some text
+            </p>
+            
 
-            </span>
           </PostMarkdown>
         </Connect(PostMarkdown)>
       </span>


### PR DESCRIPTION
This is a response to PR- https://github.com/mattermost/mattermost-webapp/pull/731

I removed the span as I didn't see the need for it, and therefore the `display: inline-block` works again.