### PR TITLE
Minor update to GlobalRelay email setting help text

### DIFF
--- a/components/admin_console/message_export_settings.jsx
+++ b/components/admin_console/message_export_settings.jsx
@@ -68,7 +68,7 @@ export default class MessageExportSettings extends AdminSettings {
                     helpText={
                         <FormattedHTMLMessage
                             id='admin.complianceExport.globalRelayEmailAddress.description'
-                            defaultMessage='The email address that your GlobalRelay instance monitors for incoming Compliance Exports'
+                            defaultMessage='The email address that your GlobalRelay server monitors for incoming Compliance Exports.'
                         />
                     }
                     value={this.state.globalRelayEmailAddress === null ? '' : this.state.globalRelayEmailAddress}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -211,7 +211,7 @@
   "admin.complianceExport.exportJobStartTime.example": "E.g.: \"02:00\"",
   "admin.complianceExport.exportJobStartTime.title": "Compliance Export time:",
   "admin.complianceExport.globalRelayEmailAddress.title": "GlobalRelay Email Address:",
-  "admin.complianceExport.globalRelayEmailAddress.description": "The email address that your GlobalRelay instance monitors for incoming Compliance Exports",
+  "admin.complianceExport.globalRelayEmailAddress.description": "The email address that your GlobalRelay server monitors for incoming Compliance Exports.",
   "admin.complianceExport.globalRelayEmailAddress.example": "E.g.: \"globalrelay@mattermost.com\"",
   "admin.complianceExport.title": "Compliance Export (Beta)",
   "admin.compliance_reports.desc": "Job Name:",

--- a/tests/components/admin_console/__snapshots__/message_export_settings.test.jsx.snap
+++ b/tests/components/admin_console/__snapshots__/message_export_settings.test.jsx.snap
@@ -472,7 +472,7 @@ exports[`components/MessageExportSettings should match snapshot, enabled, global
         disabled={false}
         helpText={
           <FormattedHTMLMessage
-            defaultMessage="The email address that your GlobalRelay instance monitors for incoming Compliance Exports"
+            defaultMessage="The email address that your GlobalRelay server monitors for incoming Compliance Exports."
             id="admin.complianceExport.globalRelayEmailAddress.description"
             values={Object {}}
           />


### PR DESCRIPTION
- Adds missing period
- Changes `instance` to `server` for consistency with other settings text, e.g. Elasticsearch