### PR TITLE
[XYZ-66] Fix tabIndex going outside modal in NewChannelModal

### DIFF
--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -180,6 +180,7 @@ export default class NewChannelModal extends React.PureComponent {
             <button
                 className='style--none color--link'
                 onClick={this.props.onTypeSwitched}
+                tabIndex='6'
             >
                 <FormattedMessage
                     id='channel_modal.privateGroup2'
@@ -235,8 +236,19 @@ export default class NewChannelModal extends React.PureComponent {
                     bsSize='large'
                     onHide={this.props.onModalDismissed}
                     onExited={this.props.onModalExited}
+                    autoFocus={true}
+                    restoreFocus={true}
                 >
-                    <Modal.Header closeButton={true}>
+                    <Modal.Header>
+                        <button
+                            type='button'
+                            className='close'
+                            onClick={this.props.onModalDismissed}
+                            tabIndex='5'
+                        >
+                            <span aria-hidden='true'>{'×'}</span>
+                            <span className='sr-only'>{'Close'}</span>
+                        </button>
                         <Modal.Title>
                             <FormattedMessage
                                 id='channel_modal.modalTitle'
@@ -279,6 +291,7 @@ export default class NewChannelModal extends React.PureComponent {
                                         <button
                                             className='color--link style--none'
                                             onClick={this.handleOnURLChange}
+                                            tabIndex='7'
                                         >
                                             <FormattedMessage
                                                 id='channel_modal.edit'
@@ -349,7 +362,7 @@ export default class NewChannelModal extends React.PureComponent {
                                         maxLength='1024'
                                         value={this.props.channelData.header}
                                         onChange={this.handleChange}
-                                        tabIndex='2'
+                                        tabIndex='3'
                                     />
                                     <p className='input__help'>
                                         <FormattedMessage
@@ -366,6 +379,8 @@ export default class NewChannelModal extends React.PureComponent {
                                 type='button'
                                 className='btn btn-default'
                                 onClick={this.props.onModalDismissed}
+                                tabIndex='8'
+                                onBlur={() => document.getElementById(`${inputPrefixId}Name`).focus()}
                             >
                                 <FormattedMessage
                                     id='channel_modal.cancel'
@@ -376,7 +391,7 @@ export default class NewChannelModal extends React.PureComponent {
                                 onClick={this.handleSubmit}
                                 type='submit'
                                 className='btn btn-primary'
-                                tabIndex='3'
+                                tabIndex='4'
                             >
                                 <FormattedMessage
                                     id='channel_modal.createNew'

--- a/tests/components/__snapshots__/new_channel_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/new_channel_modal.test.jsx.snap
@@ -31,9 +31,26 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
   >
     <ModalHeader
       bsClass="modal-header"
-      closeButton={true}
+      closeButton={false}
       closeLabel="Close"
     >
+      <button
+        className="close"
+        onClick={[MockFunction]}
+        tabIndex="5"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          ×
+        </span>
+        <span
+          className="sr-only"
+        >
+          Close
+        </span>
+      </button>
       <ModalTitle
         bsClass="modal-title"
         componentClass="h4"
@@ -65,6 +82,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
             <button
               className="style--none color--link"
               onClick={[MockFunction]}
+              tabIndex="6"
             >
               <FormattedMessage
                 defaultMessage="Create a private channel"
@@ -108,6 +126,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
               <button
                 className="color--link style--none"
                 onClick={[Function]}
+                tabIndex="7"
               >
                 <FormattedMessage
                   defaultMessage="Edit"
@@ -203,7 +222,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
               rows="4"
-              tabIndex="2"
+              tabIndex="3"
               value=""
             />
             <p
@@ -224,7 +243,9 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
       >
         <button
           className="btn btn-default"
+          onBlur={[Function]}
           onClick={[MockFunction]}
+          tabIndex="8"
           type="button"
         >
           <FormattedMessage
@@ -236,7 +257,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
         <button
           className="btn btn-primary"
           onClick={[Function]}
-          tabIndex="3"
+          tabIndex="4"
           type="submit"
         >
           <FormattedMessage
@@ -282,9 +303,26 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
   >
     <ModalHeader
       bsClass="modal-header"
-      closeButton={true}
+      closeButton={false}
       closeLabel="Close"
     >
+      <button
+        className="close"
+        onClick={[MockFunction]}
+        tabIndex="5"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          ×
+        </span>
+        <span
+          className="sr-only"
+        >
+          Close
+        </span>
+      </button>
       <ModalTitle
         bsClass="modal-title"
         componentClass="h4"
@@ -316,6 +354,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
             <button
               className="style--none color--link"
               onClick={[MockFunction]}
+              tabIndex="6"
             >
               <FormattedMessage
                 defaultMessage="Create a private channel"
@@ -359,6 +398,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
               <button
                 className="color--link style--none"
                 onClick={[Function]}
+                tabIndex="7"
               >
                 <FormattedMessage
                   defaultMessage="Edit"
@@ -454,7 +494,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
               rows="4"
-              tabIndex="2"
+              tabIndex="3"
               value=""
             />
             <p
@@ -475,7 +515,9 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
       >
         <button
           className="btn btn-default"
+          onBlur={[Function]}
           onClick={[MockFunction]}
+          tabIndex="8"
           type="button"
         >
           <FormattedMessage
@@ -487,7 +529,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
         <button
           className="btn btn-primary"
           onClick={[Function]}
-          tabIndex="3"
+          tabIndex="4"
           type="submit"
         >
           <FormattedMessage
@@ -533,9 +575,26 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
   >
     <ModalHeader
       bsClass="modal-header"
-      closeButton={true}
+      closeButton={false}
       closeLabel="Close"
     >
+      <button
+        className="close"
+        onClick={[MockFunction]}
+        tabIndex="5"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          ×
+        </span>
+        <span
+          className="sr-only"
+        >
+          Close
+        </span>
+      </button>
       <ModalTitle
         bsClass="modal-title"
         componentClass="h4"
@@ -567,6 +626,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
             <button
               className="style--none color--link"
               onClick={[MockFunction]}
+              tabIndex="6"
             >
               <FormattedMessage
                 defaultMessage="Create a private channel"
@@ -619,6 +679,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
               <button
                 className="color--link style--none"
                 onClick={[Function]}
+                tabIndex="7"
               >
                 <FormattedMessage
                   defaultMessage="Edit"
@@ -714,7 +775,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
               rows="4"
-              tabIndex="2"
+              tabIndex="3"
               value=""
             />
             <p
@@ -735,7 +796,9 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
       >
         <button
           className="btn btn-default"
+          onBlur={[Function]}
           onClick={[MockFunction]}
+          tabIndex="8"
           type="button"
         >
           <FormattedMessage
@@ -747,7 +810,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
         <button
           className="btn btn-primary"
           onClick={[Function]}
-          tabIndex="3"
+          tabIndex="4"
           type="submit"
         >
           <FormattedMessage
@@ -793,9 +856,26 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
   >
     <ModalHeader
       bsClass="modal-header"
-      closeButton={true}
+      closeButton={false}
       closeLabel="Close"
     >
+      <button
+        className="close"
+        onClick={[MockFunction]}
+        tabIndex="5"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          ×
+        </span>
+        <span
+          className="sr-only"
+        >
+          Close
+        </span>
+      </button>
       <ModalTitle
         bsClass="modal-title"
         componentClass="h4"
@@ -827,6 +907,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
             <button
               className="style--none color--link"
               onClick={[MockFunction]}
+              tabIndex="6"
             >
               <FormattedMessage
                 defaultMessage="Create a private channel"
@@ -870,6 +951,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
               <button
                 className="color--link style--none"
                 onClick={[Function]}
+                tabIndex="7"
               >
                 <FormattedMessage
                   defaultMessage="Edit"
@@ -965,7 +1047,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
               rows="4"
-              tabIndex="2"
+              tabIndex="3"
               value=""
             />
             <p
@@ -999,7 +1081,9 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
       >
         <button
           className="btn btn-default"
+          onBlur={[Function]}
           onClick={[MockFunction]}
+          tabIndex="8"
           type="button"
         >
           <FormattedMessage
@@ -1011,7 +1095,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
         <button
           className="btn btn-primary"
           onClick={[Function]}
-          tabIndex="3"
+          tabIndex="4"
           type="submit"
         >
           <FormattedMessage
@@ -1057,9 +1141,26 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
   >
     <ModalHeader
       bsClass="modal-header"
-      closeButton={true}
+      closeButton={false}
       closeLabel="Close"
     >
+      <button
+        className="close"
+        onClick={[MockFunction]}
+        tabIndex="5"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          ×
+        </span>
+        <span
+          className="sr-only"
+        >
+          Close
+        </span>
+      </button>
       <ModalTitle
         bsClass="modal-title"
         componentClass="h4"
@@ -1134,6 +1235,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
               <button
                 className="color--link style--none"
                 onClick={[Function]}
+                tabIndex="7"
               >
                 <FormattedMessage
                   defaultMessage="Edit"
@@ -1229,7 +1331,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
               rows="4"
-              tabIndex="2"
+              tabIndex="3"
               value="some header"
             />
             <p
@@ -1250,7 +1352,9 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
       >
         <button
           className="btn btn-default"
+          onBlur={[Function]}
           onClick={[MockFunction]}
+          tabIndex="8"
           type="button"
         >
           <FormattedMessage
@@ -1262,7 +1366,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
         <button
           className="btn btn-primary"
           onClick={[Function]}
-          tabIndex="3"
+          tabIndex="4"
           type="submit"
         >
           <FormattedMessage


### PR DESCRIPTION
#### Summary
* Fix tabIndex going outside NewChannelModal.
Had to add custom close button (exactly identical to the one given by bootstrap) in order to be able to add `tabIndex` on that. Ordered all tabIndexes properly as per the issue description.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/XYZ-66
Github: https://github.com/mattermost/mattermost-server/issues/8157

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes