### PR TITLE
ABC-241: fix oauth to email landing page

### DIFF
--- a/components/claim/claim_controller.jsx
+++ b/components/claim/claim_controller.jsx
@@ -47,7 +47,7 @@ export default class ClaimController extends React.Component {
                                 )}
                                 />
                                 <Route
-                                    path={`${this.props.match.url}/email_to_oath`}
+                                    path={`${this.props.match.url}/email_to_oauth`}
                                     render={(props) => (
                                         <EmailToOauth
                                             {...this.state}

--- a/components/claim/claim_controller.jsx
+++ b/components/claim/claim_controller.jsx
@@ -22,7 +22,7 @@ export default class ClaimController extends React.Component {
         this.setState({
             email: (new URLSearchParams(this.props.location.search)).get('email'),
             newType: (new URLSearchParams(this.props.location.search)).get('new_type'),
-            oldType: (new URLSearchParams(this.props.location.search)).get('old_type')
+            currentType: (new URLSearchParams(this.props.location.search)).get('old_type')
         });
     }
     render() {


### PR DESCRIPTION
#### Summary
The react-router changes broke the binding between the `old_type` query
string parameter and the `currentType` prop type expected by the oauth
to email landing page. This fixes that mapping.

A better solution would be to pass this explicitly to the component. I'm
reworking these in `master` and will tackle that improvement there
instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-241

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed