### PR TITLE
ICU-724 Deal with scroll pop from single image previews

### DIFF
--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -80,6 +80,10 @@ export default class FileAttachmentList extends React.Component {
                     />
                 );
             }
+        } else if (fileCount === 1) {
+            return (
+                <div style={{minHeight: '385px'}}/>
+            );
         }
 
         if (fileInfos && fileInfos.length > 0) {

--- a/components/single_image_view.jsx
+++ b/components/single_image_view.jsx
@@ -103,36 +103,30 @@ export default class SingleImageView extends React.PureComponent {
         this.fileImage = node;
     }
 
-    computeImageDimension() {
+    computeImageHeight = () => {
         const {fileInfo} = this.props;
         const {viewPortWidth} = this.state;
 
-        let previewWidth = fileInfo.width;
         let previewHeight = fileInfo.height;
 
-        if (previewWidth > viewPortWidth) {
+        if (viewPortWidth && fileInfo.width > viewPortWidth) {
             const origRatio = fileInfo.height / fileInfo.width;
-            previewWidth = Math.floor(Math.min(PREVIEW_IMAGE_MAX_WIDTH, fileInfo.width, viewPortWidth));
-            previewHeight = Math.floor(previewWidth * origRatio);
+            previewHeight = Math.floor(fileInfo.width * origRatio);
         }
 
         if (previewHeight > PREVIEW_IMAGE_MAX_HEIGHT) {
             const heightRatio = PREVIEW_IMAGE_MAX_HEIGHT / previewHeight;
             previewHeight = PREVIEW_IMAGE_MAX_HEIGHT;
-            previewWidth = Math.floor(previewWidth * heightRatio);
         }
 
-        return {previewWidth, previewHeight};
+        return previewHeight;
     }
 
     render() {
         const {fileInfo} = this.props;
         const {loaded} = this.state;
 
-        const {
-            previewWidth,
-            previewHeight
-        } = this.computeImageDimension();
+        const previewHeight = this.computeImageHeight();
 
         let minPreviewClass = '';
         if (
@@ -169,8 +163,8 @@ export default class SingleImageView extends React.PureComponent {
         let loadingImagePreview;
 
         let fadeInClass = '';
-        let imageLoadedDimension = {width: previewWidth, height: previewHeight};
-        let imageContainerDimension = {width: previewWidth, height: previewHeight};
+        let imageStyle = {height: previewHeight};
+        const imageContainerStyle = {height: previewHeight};
         if (loaded) {
             viewImageModal = (
                 <ViewImageModal
@@ -181,8 +175,7 @@ export default class SingleImageView extends React.PureComponent {
             );
 
             fadeInClass = 'image-fade-in';
-            imageLoadedDimension = {cursor: 'pointer'};
-            imageContainerDimension = {};
+            imageStyle = {cursor: 'pointer'};
         } else {
             loadingImagePreview = (
                 <LoadingImagePreview
@@ -203,13 +196,15 @@ export default class SingleImageView extends React.PureComponent {
                 >
                     {fileHeader}
                     <div
-                        style={imageContainerDimension}
                         className='image-container'
                     >
-                        <div className={`image-loaded ${fadeInClass}`}>
+                        <div
+                            className={`image-loaded ${fadeInClass}`}
+                            style={imageContainerStyle}
+                        >
                             <img
                                 ref={this.setImageLoadedRef}
-                                style={imageLoadedDimension}
+                                style={imageStyle}
                                 className={`${minPreviewClass} ${svgClass}`}
                                 onClick={this.handleImageClick}
                             />

--- a/components/single_image_view.jsx
+++ b/components/single_image_view.jsx
@@ -12,10 +12,11 @@ import {
     localizeMessage
 } from 'utils/utils';
 
+import {postListScrollChange} from 'actions/global_actions.jsx';
+
 import LoadingImagePreview from 'components/loading_image_preview';
 import ViewImageModal from 'components/view_image.jsx';
 
-const PREVIEW_IMAGE_MAX_WIDTH = 1024;
 const PREVIEW_IMAGE_MAX_HEIGHT = 350;
 const PREVIEW_IMAGE_MIN_DIMENSION = 50;
 
@@ -48,6 +49,9 @@ export default class SingleImageView extends React.PureComponent {
         window.addEventListener('resize', this.handleResize);
         this.setViewPortWidth();
         this.loadImage(this.props.fileInfo);
+
+        // Timeout used to delay execution until after current render cycle
+        setTimeout(postListScrollChange, 0);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -115,7 +119,6 @@ export default class SingleImageView extends React.PureComponent {
         }
 
         if (previewHeight > PREVIEW_IMAGE_MAX_HEIGHT) {
-            const heightRatio = PREVIEW_IMAGE_MAX_HEIGHT / previewHeight;
             previewHeight = PREVIEW_IMAGE_MAX_HEIGHT;
         }
 

--- a/components/single_image_view.jsx
+++ b/components/single_image_view.jsx
@@ -17,6 +17,7 @@ import {postListScrollChange} from 'actions/global_actions.jsx';
 import LoadingImagePreview from 'components/loading_image_preview';
 import ViewImageModal from 'components/view_image.jsx';
 
+const PREVIEW_IMAGE_MAX_WIDTH = 1024;
 const PREVIEW_IMAGE_MAX_HEIGHT = 350;
 const PREVIEW_IMAGE_MIN_DIMENSION = 50;
 
@@ -107,29 +108,33 @@ export default class SingleImageView extends React.PureComponent {
         this.fileImage = node;
     }
 
-    computeImageHeight = () => {
+    computeImageDimensions = () => {
         const {fileInfo} = this.props;
         const {viewPortWidth} = this.state;
 
+        let previewWidth = fileInfo.width;
         let previewHeight = fileInfo.height;
 
-        if (viewPortWidth && fileInfo.width > viewPortWidth) {
+        if (viewPortWidth && previewWidth > viewPortWidth) {
             const origRatio = fileInfo.height / fileInfo.width;
-            previewHeight = Math.floor(fileInfo.width * origRatio);
+            previewWidth = Math.floor(Math.min(PREVIEW_IMAGE_MAX_WIDTH, fileInfo.width, viewPortWidth));
+            previewHeight = Math.floor(previewWidth * origRatio);
         }
 
         if (previewHeight > PREVIEW_IMAGE_MAX_HEIGHT) {
+            const heightRatio = PREVIEW_IMAGE_MAX_HEIGHT / previewHeight;
             previewHeight = PREVIEW_IMAGE_MAX_HEIGHT;
+            previewWidth = Math.floor(previewWidth * heightRatio);
         }
 
-        return previewHeight;
+        return {previewWidth, previewHeight};
     }
 
     render() {
         const {fileInfo} = this.props;
         const {loaded} = this.state;
 
-        const previewHeight = this.computeImageHeight();
+        const {previewHeight, previewWidth} = this.computeImageDimensions();
 
         let minPreviewClass = '';
         if (


### PR DESCRIPTION
#### Summary
There were a few separate issues:
* Viewport width was starting at 0, so our initial height would be 0 even if we had the file height already (fixed by first commit)
* The loading indicator div was not the same height as the final image div, it was off by 10-15 pixels (fixed by first commit)
* In cases where the app was waiting on the file info to load, there was no scrolling of the post list to deal with the scroll pop from these mounting (fixed by second commit)

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-724