### PR TITLE
ABC-193: Add webapp commit hash to "about" modal

### DIFF
--- a/components/about_build_modal/about_build_modal.jsx
+++ b/components/about_build_modal/about_build_modal.jsx
@@ -33,7 +33,12 @@ export default class AboutBuildModal extends React.PureComponent {
         /**
          * Global license object
          */
-        license: PropTypes.object.isRequired
+        license: PropTypes.object.isRequired,
+
+        /**
+         * Webapp build hash override. By default, webpack sets this (so it must be overridden in tests).
+         */
+        webappBuildHash: PropTypes.string
     };
 
     constructor(props) {
@@ -214,7 +219,7 @@ export default class AboutBuildModal extends React.PureComponent {
                                 id='about.hashwebapp'
                                 defaultMessage='Webapp Build Hash:'
                             />
-                            &nbsp;{/* global __COMMIT_HASH__ */ __COMMIT_HASH__}
+                            &nbsp;{/* global COMMIT_HASH */ this.props.webappBuildHash || (typeof COMMIT_HASH === 'undefined' ? '' : COMMIT_HASH)}
                         </p>
                         <p>
                             <FormattedMessage

--- a/components/about_build_modal/about_build_modal.jsx
+++ b/components/about_build_modal/about_build_modal.jsx
@@ -209,6 +209,12 @@ export default class AboutBuildModal extends React.PureComponent {
                                 defaultMessage='EE Build Hash:'
                             />
                             &nbsp;{config.BuildHashEnterprise}
+                            <br/>
+                            <FormattedMessage
+                                id='about.hashwebapp'
+                                defaultMessage='Webapp Build Hash:'
+                            />
+                            &nbsp;{/* global __COMMIT_HASH__ */ __COMMIT_HASH__}
                         </p>
                         <p>
                             <FormattedMessage

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,6 +8,7 @@
   "about.enterpriseEditione1": "Enterprise Edition",
   "about.hash": "Build Hash:",
   "about.hashee": "EE Build Hash:",
+  "about.hashwebapp": "Webapp Build Hash:",
   "about.licensed": "Licensed to:",
   "about.notice": "Mattermost is made possible by the open source software used in our <a href=\"https://about.mattermost.com/platform-notice-txt/\" target='_blank'>platform</a>, <a href=\"https://about.mattermost.com/desktop-notice-txt/\" target='_blank'>desktop</a> and <a href=\"https://about.mattermost.com/mobile-notice-txt/\" target='_blank'>mobile</a> apps.",
   "about.number": "Build Number:",

--- a/tests/components/__snapshots__/about_build_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/about_build_modal.test.jsx.snap
@@ -162,6 +162,14 @@ exports[`components/AboutBuildModal should hide the build number if it is the sa
           values={Object {}}
         />
          
+        <br />
+        <FormattedMessage
+          defaultMessage="Webapp Build Hash:"
+          id="about.hashwebapp"
+          values={Object {}}
+        />
+         
+        0a1b2c3d4f
       </p>
       <p>
         <FormattedMessage
@@ -351,6 +359,14 @@ exports[`components/AboutBuildModal should match snapshot for enterprise edition
         />
          
         0123456789abcdef
+        <br />
+        <FormattedMessage
+          defaultMessage="Webapp Build Hash:"
+          id="about.hashwebapp"
+          values={Object {}}
+        />
+         
+        0a1b2c3d4f
       </p>
       <p>
         <FormattedMessage
@@ -528,6 +544,14 @@ exports[`components/AboutBuildModal should match snapshot for team edition 1`] =
           values={Object {}}
         />
          
+        <br />
+        <FormattedMessage
+          defaultMessage="Webapp Build Hash:"
+          id="about.hashwebapp"
+          values={Object {}}
+        />
+         
+        0a1b2c3d4f
       </p>
       <p>
         <FormattedMessage
@@ -705,6 +729,14 @@ exports[`components/AboutBuildModal should show the build number if it is the di
           values={Object {}}
         />
          
+        <br />
+        <FormattedMessage
+          defaultMessage="Webapp Build Hash:"
+          id="about.hashwebapp"
+          values={Object {}}
+        />
+         
+        0a1b2c3d4f
       </p>
       <p>
         <FormattedMessage

--- a/tests/components/about_build_modal.test.jsx
+++ b/tests/components/about_build_modal.test.jsx
@@ -101,6 +101,7 @@ describe('components/AboutBuildModal', () => {
             <AboutBuildModal
                 config={config}
                 license={license}
+                webappBuildHash='0a1b2c3d4f'
                 show={true}
                 onModalDismissed={onHide}
             />
@@ -116,6 +117,7 @@ describe('components/AboutBuildModal', () => {
         const allProps = {
             show,
             onModalDismissed,
+            webappBuildHash: '0a1b2c3d4f',
             ...props
         };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -255,7 +255,7 @@ var config = {
             children: true
         }),
         new webpack.DefinePlugin({
-            __COMMIT_HASH__: JSON.stringify(childProcess.execSync('git rev-parse HEAD').toString())
+            COMMIT_HASH: JSON.stringify(childProcess.execSync('git rev-parse HEAD').toString())
         }),
         extractCSS,
         extractSCSS

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const childProcess = require('child_process');
 const path = require('path');
 
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -252,6 +253,9 @@ var config = {
         new webpack.optimize.CommonsChunkPlugin({
             minChunks: 2,
             children: true
+        }),
+        new webpack.DefinePlugin({
+            __COMMIT_HASH__: JSON.stringify(childProcess.execSync('git rev-parse HEAD').toString())
         }),
         extractCSS,
         extractSCSS


### PR DESCRIPTION
#### Summary
<img width="612" alt="screen shot 2018-02-07 at 6 17 10 pm" src="https://user-images.githubusercontent.com/1731074/35948917-8f0e2130-0c34-11e8-8a4f-79e48e252b48.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-193

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates