### PR TITLE
Fixed messageHtmlToComponent returning undefined

### DIFF
--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -141,6 +141,10 @@ export function containsAtChannel(text) {
  * - latex - If specified, latex is replaced with the LatexBlock component. Defaults to true.
  */
 export function messageHtmlToComponent(html, isRHS, options = {}) {
+    if (!html) {
+        return null;
+    }
+
     const parser = new Parser();
     const processNodeDefinitions = new ProcessNodeDefinitions(React);
 


### PR DESCRIPTION
The `html-to-react` parser returns undefined for some reason if you give it an empty string. I'm also going to cherry-pick this into the release branch if https://github.com/mattermost/mattermost-webapp/pull/754 is accepted for 4.7
