### PR TITLE
[PLT-8712] Fix opening attachment preview on compact view

### DIFF
--- a/components/file_attachment.jsx
+++ b/components/file_attachment.jsx
@@ -93,14 +93,15 @@ export default class FileAttachment extends React.PureComponent {
 
     onAttachmentClick = (e) => {
         e.preventDefault();
-        this.props.handleImageClick(this.props.index);
+        if (this.props.handleImageClick) {
+            this.props.handleImageClick(this.props.index);
+        }
     }
 
     render() {
         const {
             compactDisplay,
-            fileInfo,
-            index
+            fileInfo
         } = this.props;
 
         const trimmedFilename = trimFilename(fileInfo.name);
@@ -137,8 +138,8 @@ export default class FileAttachment extends React.PureComponent {
                         fileInfo={fileInfo}
                         compactDisplay={compactDisplay}
                         canDownload={canDownload}
+                        handleImageClick={this.onAttachmentClick}
                         iconClass={'post-image__download'}
-                        index={index}
                     >
                         <DownloadIcon/>
                     </FilenameOverlay>

--- a/components/file_attachment/filename_overlay.jsx
+++ b/components/file_attachment/filename_overlay.jsx
@@ -19,11 +19,6 @@ export default class FilenameOverlay extends React.PureComponent {
         fileInfo: PropTypes.object.isRequired,
 
         /*
-         * The index of this attachment preview in the parent FileAttachmentList
-         */
-        index: PropTypes.number.isRequired,
-
-        /*
          * Handler for when the thumbnail is clicked passed the index above
          */
         handleImageClick: PropTypes.func,
@@ -49,17 +44,13 @@ export default class FilenameOverlay extends React.PureComponent {
         iconClass: PropTypes.string
     };
 
-    onAttachmentClick = (e) => {
-        e.preventDefault();
-        this.props.handleImageClick(this.props.index);
-    }
-
     render() {
         const {
             canDownload,
             children,
             compactDisplay,
             fileInfo,
+            handleImageClick,
             iconClass
         } = this.props;
 
@@ -78,7 +69,7 @@ export default class FilenameOverlay extends React.PureComponent {
                 >
                     <a
                         href='#'
-                        onClick={this.onAttachmentClick}
+                        onClick={handleImageClick}
                         className='post-image__name'
                         rel='noopener noreferrer'
                     >

--- a/tests/components/__snapshots__/file_attachment.test.jsx.snap
+++ b/tests/components/__snapshots__/file_attachment.test.jsx.snap
@@ -61,8 +61,8 @@ exports[`component/FileAttachment should match snapshot, after change from file 
           "width": 600,
         }
       }
+      handleImageClick={[Function]}
       iconClass="post-image__download"
-      index={3}
     >
       <DownloadIcon />
     </FilenameOverlay>
@@ -127,8 +127,8 @@ exports[`component/FileAttachment should match snapshot, file with long name 1`]
           "size": 100,
         }
       }
+      handleImageClick={[Function]}
       iconClass="post-image__download"
-      index={3}
     >
       <DownloadIcon />
     </FilenameOverlay>
@@ -193,8 +193,8 @@ exports[`component/FileAttachment should match snapshot, regular file 1`] = `
           "size": 100,
         }
       }
+      handleImageClick={[Function]}
       iconClass="post-image__download"
-      index={3}
     >
       <DownloadIcon />
     </FilenameOverlay>
@@ -263,8 +263,8 @@ exports[`component/FileAttachment should match snapshot, regular image 1`] = `
           "width": 600,
         }
       }
+      handleImageClick={[Function]}
       iconClass="post-image__download"
-      index={3}
     >
       <DownloadIcon />
     </FilenameOverlay>
@@ -333,8 +333,8 @@ exports[`component/FileAttachment should match snapshot, small image 1`] = `
           "width": 16,
         }
       }
+      handleImageClick={[Function]}
       iconClass="post-image__download"
-      index={3}
     >
       <DownloadIcon />
     </FilenameOverlay>
@@ -403,8 +403,8 @@ exports[`component/FileAttachment should match snapshot, svg image 1`] = `
           "width": 600,
         }
       }
+      handleImageClick={[Function]}
       iconClass="post-image__download"
-      index={3}
     >
       <DownloadIcon />
     </FilenameOverlay>
@@ -462,8 +462,8 @@ exports[`component/FileAttachment should match snapshot, when file is not loaded
           "size": 100,
         }
       }
+      handleImageClick={[Function]}
       iconClass="post-image__download"
-      index={3}
     >
       <DownloadIcon />
     </FilenameOverlay>
@@ -529,8 +529,8 @@ exports[`component/FileAttachment should match snapshot, with compact display 1`
           "size": 100,
         }
       }
+      handleImageClick={[Function]}
       iconClass="post-image__download"
-      index={3}
     >
       <DownloadIcon />
     </FilenameOverlay>

--- a/tests/components/file_attachment/__snapshots__/filename_overlay.test.jsx.snap
+++ b/tests/components/file_attachment/__snapshots__/filename_overlay.test.jsx.snap
@@ -1,0 +1,110 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/file_attachment/FilenameOverlay should match snapshot, compact display 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  delayShow={1000}
+  overlay={
+    <Tooltip
+      bsClass="tooltip"
+      id="file-name__tooltip"
+      placement="right"
+    >
+      test_filename
+    </Tooltip>
+  }
+  placement="top"
+  trigger={
+    Array [
+      "hover",
+      "focus",
+    ]
+  }
+>
+  <a
+    className="post-image__name"
+    href="#"
+    onClick={[MockFunction]}
+    rel="noopener noreferrer"
+  >
+    <AttachmentIcon
+      className="icon"
+    />
+    test_filename
+  </a>
+</OverlayTrigger>
+`;
+
+exports[`components/file_attachment/FilenameOverlay should match snapshot, standard but not downloadable 1`] = `
+<span
+  className="post-image__name"
+>
+  test_filename
+</span>
+`;
+
+exports[`components/file_attachment/FilenameOverlay should match snapshot, standard display 1`] = `
+<a
+  className="post-image__name"
+  download="test_filename"
+  href="/api/v4/files/thumbnail_id"
+  rel="noopener noreferrer"
+  target="_blank"
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={1000}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="file-name__tooltip"
+        placement="right"
+      >
+        Download
+      </Tooltip>
+    }
+    placement="top"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    test_filename
+  </OverlayTrigger>
+</a>
+`;
+
+exports[`components/file_attachment/FilenameOverlay should match snapshot, with Download icon as children 1`] = `
+<a
+  className="post-image__name"
+  download="test_filename"
+  href="/api/v4/files/thumbnail_id"
+  rel="noopener noreferrer"
+  target="_blank"
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={1000}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="file-name__tooltip"
+        placement="right"
+      >
+        Download
+      </Tooltip>
+    }
+    placement="top"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <DownloadIcon />
+  </OverlayTrigger>
+</a>
+`;

--- a/tests/components/file_attachment/filename_overlay.test.jsx
+++ b/tests/components/file_attachment/filename_overlay.test.jsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import FilenameOverlay from 'components/file_attachment/filename_overlay.jsx';
+import DownloadIcon from 'components/svg/download_icon';
+import AttachmentIcon from 'components/svg/attachment_icon';
+
+describe('components/file_attachment/FilenameOverlay', () => {
+    function emptyFunction() {} //eslint-disable-line no-empty-function
+    const fileInfo = {
+        id: 'thumbnail_id',
+        name: 'test_filename',
+        extension: 'jpg',
+        width: 100,
+        height: 80,
+        has_preview_image: true
+    };
+
+    const baseProps = {
+        fileInfo,
+        handleImageClick: emptyFunction,
+        compactDisplay: false,
+        canDownload: true
+    };
+
+    test('should match snapshot, standard display', () => {
+        const wrapper = shallow(
+            <FilenameOverlay {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, compact display', () => {
+        const handleImageClick = jest.fn();
+        const props = {...baseProps, compactDisplay: true, handleImageClick};
+        const wrapper = shallow(
+            <FilenameOverlay {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(AttachmentIcon).exists()).toBe(true);
+
+        wrapper.find('a').first().simulate('click');
+        expect(handleImageClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('should match snapshot, with Download icon as children', () => {
+        const props = {...baseProps, canDownload: true};
+        const wrapper = shallow(
+            <FilenameOverlay {...props}>
+                <DownloadIcon/>
+            </FilenameOverlay>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(DownloadIcon).exists()).toBe(true);
+    });
+
+    test('should match snapshot, standard but not downloadable', () => {
+        const props = {...baseProps, canDownload: false};
+        const wrapper = shallow(
+            <FilenameOverlay {...props}>
+                <DownloadIcon/>
+            </FilenameOverlay>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
Fix opening attachment preview on compact view

Also, removed unnecessary instance function and props in FilenameOverlay.

#### Ticket Link
Jira ticket: [PLT-8712](https://mattermost.atlassian.net/browse/PLT-8712)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
