### PR TITLE
Fixed messageHtmlToComponent returning undefined (#755)

### DIFF
--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -141,6 +141,10 @@ export function containsAtChannel(text) {
  * - latex - If specified, latex is replaced with the LatexBlock component. Defaults to true.
  */
 export function messageHtmlToComponent(html, isRHS, options = {}) {
+    if (!html) {
+        return null;
+    }
+
     const parser = new Parser();
     const processNodeDefinitions = new ProcessNodeDefinitions(React);
 


### PR DESCRIPTION
This is a fix for https://github.com/mattermost/mattermost-webapp/pull/754 that I'm submitting separately because it's going backwards (master into 4.7) and doing them together would likely cause merge conflicts
