### PR TITLE
Icu 737- Properly populate header field when creating modal

### DIFF
--- a/components/new_channel_flow.jsx
+++ b/components/new_channel_flow.jsx
@@ -175,7 +175,8 @@ export default class NewChannelFlow extends React.Component {
         const channelData = {
             name: this.state.channelName,
             displayName: this.state.channelDisplayName,
-            purpose: this.state.channelPurpose
+            purpose: this.state.channelPurpose,
+            header: this.state.channelHeader
         };
 
         let showChannelModal = false;

--- a/tests/components/__snapshots__/new_channel_flow.test.jsx.snap
+++ b/tests/components/__snapshots__/new_channel_flow.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`components/NewChannelFlow should match snapshot, with base props 1`] = 
     channelData={
       Object {
         "displayName": "",
+        "header": "",
         "name": "",
         "purpose": "",
       }
@@ -24,6 +25,7 @@ exports[`components/NewChannelFlow should match snapshot, with base props 1`] = 
     channelData={
       Object {
         "displayName": "",
+        "header": "",
         "name": "",
         "purpose": "",
       }


### PR DESCRIPTION
#### Summary
In create channel modal, purpose field is cleared after editing channel URL

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-737

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)