### PR TITLE
Fix swith to saml form route

### DIFF
--- a/components/claim/claim_controller.jsx
+++ b/components/claim/claim_controller.jsx
@@ -47,7 +47,7 @@ export default class ClaimController extends React.Component {
                                 )}
                                 />
                                 <Route
-                                    path={`${this.props.match.url}/email_to_oath`}
+                                    path={`${this.props.match.url}/email_to_oauth`}
                                     render={(props) => (
                                         <EmailToOauth
                                             {...this.state}


### PR DESCRIPTION
#### Summary
The email_to_oauth route in claim page had a typo. This is part of the Account Settings > Security > Sign In Method.