### PR TITLE
Fix bug when ExperimentalPrimaryTeam is set lastUrl does not work

### DIFF
--- a/components/login/login_controller.jsx
+++ b/components/login/login_controller.jsx
@@ -61,11 +61,7 @@ export default class LoginController extends React.Component {
     componentDidMount() {
         document.title = global.window.mm_config.SiteName;
         BrowserStore.removeGlobalItem('team');
-        const experimentalPrimaryTeam = global.mm_config.ExperimentalPrimaryTeam;
-        const primaryTeam = TeamStore.getByName(experimentalPrimaryTeam);
-        if (UserStore.getCurrentUser() && primaryTeam) {
-            browserHistory.push(`/${primaryTeam.name}/channels/${Constants.DEFAULT_CHANNEL}`);
-        } else if (UserStore.getCurrentUser()) {
+        if (UserStore.getCurrentUser()) {
             GlobalActions.redirectUserToDefaultTeam();
         }
 

--- a/components/root.jsx
+++ b/components/root.jsx
@@ -20,7 +20,6 @@ import BrowserStore from 'stores/browser_store.jsx';
 import ErrorStore from 'stores/error_store.jsx';
 import LocalizationStore from 'stores/localization_store.jsx';
 import UserStore from 'stores/user_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
 import {loadMeAndConfig} from 'actions/user_actions.jsx';
 import {loadRecentlyUsedCustomEmojis} from 'actions/emoji_actions.jsx';
 import * as I18n from 'i18n/i18n.jsx';
@@ -195,13 +194,9 @@ export default class Root extends React.Component {
     }
 
     redirectIfNecessary(props) {
-        const experimentalPrimaryTeam = global.mm_config.ExperimentalPrimaryTeam;
-        const primaryTeam = TeamStore.getByName(experimentalPrimaryTeam);
         if (props.location.pathname === '/') {
             if (UserStore.getNoAccounts()) {
                 this.props.history.push('/signup_user_complete');
-            } else if (UserStore.getCurrentUser() && primaryTeam) {
-                this.props.history.push(`/${primaryTeam.name}/channels/${Constants.DEFAULT_CHANNEL}`);
             } else if (UserStore.getCurrentUser()) {
                 GlobalActions.redirectUserToDefaultTeam();
             }


### PR DESCRIPTION
#### Summary
There is an issue were last channel is not being stored when you close the window. Every time you start it takes you to `Town Square`. This is caused by the logic added with config `ExperimentalPrimaryTeam`. This PR fixes the issue.
https://github.com/mattermost/mattermost-webapp/pull/334

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has server changes https://github.com/mattermost/mattermost-server/pull/8236

via @dmeza 