### PR TITLE
ABC-244: fix team invite link handling

### DIFF
--- a/components/login/login_controller.jsx
+++ b/components/login/login_controller.jsx
@@ -160,9 +160,11 @@ export default class LoginController extends React.Component {
             token,
             () => {
                 // check for query params brought over from signup_user_complete
-                const hash = (new URLSearchParams(this.props.location.search)).get('h');
-                const data = (new URLSearchParams(this.props.location.search)).get('d');
-                const inviteId = (new URLSearchParams(this.props.location.search)).get('id');
+                const params = new URLSearchParams(this.props.location.search);
+                const hash = params.get('h') || '';
+                const data = params.get('d') || '';
+                const inviteId = params.get('id') || '';
+
                 if (inviteId || hash) {
                     addUserToTeamFromInvite(
                         data,

--- a/components/signup/signup_controller.jsx
+++ b/components/signup/signup_controller.jsx
@@ -69,18 +69,9 @@ export default class SignupController extends React.Component {
         BrowserStore.removeGlobalItem('team');
         if (this.props.location.search) {
             const params = new URLSearchParams(this.props.location.search);
-            let hash = params.get('h');
-            if (hash == null) {
-                hash = '';
-            }
-            let data = params.get('d');
-            if (data == null) {
-                data = '';
-            }
-            let inviteId = params.get('id');
-            if (inviteId == null) {
-                inviteId = '';
-            }
+            const hash = params.get('h') || '';
+            const data = params.get('d') || '';
+            const inviteId = params.get('id') || '';
 
             const userLoggedIn = UserStore.getCurrentUser() != null;
 


### PR DESCRIPTION
#### Summary
The `hash` and `data` parameters, being `null`, were cast to strings
downstream in mattermost-redux as part of `buildQueryString`, resulting
in a value of `"null"` being passed up instead of the expected empty
string. The server correctly rejected the hash as invalid.

This change copies the more correct handling from the sign up controller.
Perhaps an even better solution would be to update `buildQueryString` in
mattermost-redux to check `null` parameters and send up empty strings
automatically, however that's probably not the change we want near the
end of a release. I'll propose the change in `master` separately
instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-244

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed