### PR TITLE
PLT-7690: fix undefined user reference

### DIFF
--- a/components/profile_picture.jsx
+++ b/components/profile_picture.jsx
@@ -72,7 +72,7 @@ export default class ProfilePicture extends React.PureComponent {
             <span className='status-wrapper'>
                 <img
                     className='more-modal__image'
-                    alt={`${this.props.user.username || 'user'} profile image`}
+                    alt={'user profile image'}
                     width={this.props.width}
                     height={this.props.width}
                     src={this.props.src}

--- a/tests/components/__snapshots__/profile_picture.test.jsx.snap
+++ b/tests/components/__snapshots__/profile_picture.test.jsx.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/ProfilePicture should match snapshot, no user specified, default props 1`] = `
+<span
+  className="status-wrapper"
+>
+  <img
+    alt="user profile image"
+    className="more-modal__image"
+    height="36"
+    src="http://example.com/image.png"
+    width="36"
+  />
+  <StatusIcon
+    className=""
+    status="away"
+  />
+</span>
+`;
+
+exports[`components/ProfilePicture should match snapshot, no user specified, overridden props 1`] = `
+<span
+  className="status-wrapper"
+>
+  <img
+    alt="user profile image"
+    className="more-modal__image"
+    height="48"
+    src="http://example.com/image.png"
+    width="48"
+  />
+  <StatusIcon
+    className=""
+    status="away"
+  />
+</span>
+`;
+
+exports[`components/ProfilePicture should match snapshot, user specified 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  overlay={
+    <Connect(Pluggable)>
+      <ProfilePopover
+        hasMention={false}
+        hide={[Function]}
+        isBusy={true}
+        isRHS={false}
+        src="http://example.com/image.png"
+        status="away"
+        user={
+          Object {
+            "username": "username",
+          }
+        }
+      />
+    </Connect(Pluggable)>
+  }
+  placement="right"
+  rootClose={true}
+  trigger="click"
+>
+  <span
+    className="status-wrapper"
+  >
+    <img
+      alt="username profile image"
+      className="more-modal__image"
+      height="36"
+      src="http://example.com/image.png"
+      width="36"
+    />
+    <StatusIcon
+      className=""
+      status="away"
+    />
+  </span>
+</OverlayTrigger>
+`;
+
+exports[`components/ProfilePicture should match snapshot, user specified, overridden props 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  overlay={
+    <Connect(Pluggable)>
+      <ProfilePopover
+        hasMention={true}
+        hide={[Function]}
+        isBusy={true}
+        isRHS={true}
+        src="http://example.com/image.png"
+        status="away"
+        user={
+          Object {
+            "username": "username",
+          }
+        }
+      />
+    </Connect(Pluggable)>
+  }
+  placement="right"
+  rootClose={true}
+  trigger="click"
+>
+  <span
+    className="status-wrapper"
+  >
+    <img
+      alt="username profile image"
+      className="more-modal__image"
+      height="48"
+      src="http://example.com/image.png"
+      width="48"
+    />
+    <StatusIcon
+      className=""
+      status="away"
+    />
+  </span>
+</OverlayTrigger>
+`;

--- a/tests/components/profile_picture.test.jsx
+++ b/tests/components/profile_picture.test.jsx
@@ -1,0 +1,71 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import ProfilePicture from 'components/profile_picture.jsx';
+
+describe('components/ProfilePicture', () => {
+    const baseProps = {
+        src: 'http://example.com/image.png',
+        status: 'away',
+        isBusy: true
+    };
+
+    test('should match snapshot, no user specified, default props', () => {
+        const props = baseProps;
+        const wrapper = shallow(
+            <ProfilePicture {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, no user specified, overridden props', () => {
+        const props = {
+            ...baseProps,
+            width: '48',
+            height: '48',
+            isRHS: true,
+            hasMention: true
+        };
+        const wrapper = shallow(
+            <ProfilePicture {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, user specified', () => {
+        const props = {
+            ...baseProps,
+            user: {
+                username: 'username'
+            }
+        };
+        const wrapper = shallow(
+            <ProfilePicture {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, user specified, overridden props', () => {
+        const props = {
+            ...baseProps,
+            user: {
+                username: 'username'
+            },
+            width: '48',
+            height: '48',
+            isRHS: true,
+            hasMention: true
+        };
+        const wrapper = shallow(
+            <ProfilePicture {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
This addresses an attempt to dereference an undefined `this.props.user`, introduced by https://github.com/mattermost/mattermost-webapp/pull/742.

#### Ticket Link
Original ticket was https://mattermost.atlassian.net/browse/PLT-7690. Not filing new ticket for this issue.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)