### PR TITLE
ABC-258: Remove willnorris/imageproxy from sysadmin console

### DIFF
--- a/components/admin_console/storage_settings.jsx
+++ b/components/admin_console/storage_settings.jsx
@@ -149,6 +149,14 @@ export default class StorageSettings extends AdminSettings {
                 );
         }
 
+        const imageProxyTypeValues = [
+            {value: '', text: Utils.localizeMessage('admin.image.proxyTypeNone', 'None')},
+            {value: 'atmos/camo', text: 'atmos/camo'}
+        ];
+        if (this.state.imageProxyType === 'willnorris/imageproxy') {
+            imageProxyTypeValues.push({value: 'willnorris/imageproxy', text: 'willnorris/imageproxy'});
+        }
+
         return (
             <SettingsGroup>
                 <DropdownSetting
@@ -364,11 +372,7 @@ export default class StorageSettings extends AdminSettings {
                 />
                 <DropdownSetting
                     id='imageProxyType'
-                    values={[
-                        {value: '', text: Utils.localizeMessage('admin.image.proxyTypeNone', 'None')},
-                        {value: 'atmos/camo', text: 'atmos/camo'},
-                        {value: 'willnorris/imageproxy', text: 'willnorris/imageproxy'}
-                    ]}
+                    values={imageProxyTypeValues}
                     label={
                         <FormattedMessage
                             id='admin.image.proxyType'
@@ -413,7 +417,7 @@ export default class StorageSettings extends AdminSettings {
                     helpText={
                         <FormattedMessage
                             id='admin.image.proxyOptionsDescription'
-                            defaultMessage='Additional options for basic image adjustments such as resizing, cropping, and rotation. Refer to your image proxy documentation to learn more about what options are supported.'
+                            defaultMessage='Additional options such as the URL signing key. Refer to your image proxy documentation to learn more about what options are supported.'
                         />
                     }
                     value={this.state.imageProxyOptions}

--- a/components/admin_console/storage_settings.jsx
+++ b/components/admin_console/storage_settings.jsx
@@ -149,14 +149,6 @@ export default class StorageSettings extends AdminSettings {
                 );
         }
 
-        const imageProxyTypeValues = [
-            {value: '', text: Utils.localizeMessage('admin.image.proxyTypeNone', 'None')},
-            {value: 'atmos/camo', text: 'atmos/camo'}
-        ];
-        if (this.state.imageProxyType === 'willnorris/imageproxy') {
-            imageProxyTypeValues.push({value: 'willnorris/imageproxy', text: 'willnorris/imageproxy'});
-        }
-
         return (
             <SettingsGroup>
                 <DropdownSetting
@@ -372,7 +364,10 @@ export default class StorageSettings extends AdminSettings {
                 />
                 <DropdownSetting
                     id='imageProxyType'
-                    values={imageProxyTypeValues}
+                    values={[
+                        {value: '', text: Utils.localizeMessage('admin.image.proxyTypeNone', 'None')},
+                        {value: 'atmos/camo', text: 'atmos/camo'}
+                    ]}
                     label={
                         <FormattedMessage
                             id='admin.image.proxyType'

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -520,7 +520,7 @@
   "admin.image.maxFileSizeExample": "50",
   "admin.image.maxFileSizeTitle": "Maximum File Size:",
   "admin.image.proxyOptions": "Image Proxy Options:",
-  "admin.image.proxyOptionsDescription": "Additional options for basic image adjustments such as resizing, cropping, and rotation. Refer to your image proxy documentation to learn more about what options are supported.",
+  "admin.image.proxyOptionsDescription": "Additional options such as the URL signing key. Refer to your image proxy documentation to learn more about what options are supported.",
   "admin.image.proxyType": "Image Proxy Type:",
   "admin.image.proxyTypeDescription": "Configure an image proxy to load all Markdown images through a proxy. The image proxy prevents users from making insecure image requests, provides caching for increased performance, and automates image adjustments such as resizing. See <a href=\"https://about.mattermost.com/default-image-proxy-documentation\">documentation</a> to learn more.",
   "admin.image.proxyTypeNone": "None",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -520,7 +520,7 @@
   "admin.image.maxFileSizeExample": "50",
   "admin.image.maxFileSizeTitle": "Taille maximale de fichier :",
   "admin.image.proxyOptions": "Image Proxy Options:",
-  "admin.image.proxyOptionsDescription": "Additional options for basic image adjustments such as resizing, cropping, and rotation. Refer to your image proxy documentation to learn more about what options are supported.",
+  "admin.image.proxyOptionsDescription": "Additional options such as the URL signing key. Refer to your image proxy documentation to learn more about what options are supported.",
   "admin.image.proxyType": "Image Proxy Type:",
   "admin.image.proxyTypeDescription": "Configure an image proxy to load all Markdown images through a proxy. The image proxy prevents users from making insecure image requests, provides caching for increased performance, and automates image adjustments such as resizing. See <a href=\"https://about.mattermost.com/default-image-proxy-documentation\">documentation</a> to learn more.",
   "admin.image.proxyTypeNone": "Aucun",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -520,7 +520,7 @@
   "admin.image.maxFileSizeExample": "50",
   "admin.image.maxFileSizeTitle": "최대 파일 크기:",
   "admin.image.proxyOptions": "Image Proxy Options:",
-  "admin.image.proxyOptionsDescription": "Additional options for basic image adjustments such as resizing, cropping, and rotation. Refer to your image proxy documentation to learn more about what options are supported.",
+  "admin.image.proxyOptionsDescription": "Additional options such as the URL signing key. Refer to your image proxy documentation to learn more about what options are supported.",
   "admin.image.proxyType": "Image Proxy Type:",
   "admin.image.proxyTypeDescription": "Configure an image proxy to load all Markdown images through a proxy. The image proxy prevents users from making insecure image requests, provides caching for increased performance, and automates image adjustments such as resizing. See <a href=\"https://about.mattermost.com/default-image-proxy-documentation\">documentation</a> to learn more.",
   "admin.image.proxyTypeNone": "None",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -520,7 +520,7 @@
   "admin.image.maxFileSizeExample": "50",
   "admin.image.maxFileSizeTitle": "Maximale bestandsgrootte:",
   "admin.image.proxyOptions": "Image Proxy Options:",
-  "admin.image.proxyOptionsDescription": "Additional options for basic image adjustments such as resizing, cropping, and rotation. Refer to your image proxy documentation to learn more about what options are supported.",
+  "admin.image.proxyOptionsDescription": "Additional options such as the URL signing key. Refer to your image proxy documentation to learn more about what options are supported.",
   "admin.image.proxyType": "Image Proxy Type:",
   "admin.image.proxyTypeDescription": "Configure an image proxy to load all Markdown images through a proxy. The image proxy prevents users from making insecure image requests, provides caching for increased performance, and automates image adjustments such as resizing. See <a href=\"https://about.mattermost.com/default-image-proxy-documentation\">documentation</a> to learn more.",
   "admin.image.proxyTypeNone": "Geen",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -520,7 +520,7 @@
   "admin.image.maxFileSizeExample": "50",
   "admin.image.maxFileSizeTitle": "Maksymalny rozmiar pliku:",
   "admin.image.proxyOptions": "Image Proxy Options:",
-  "admin.image.proxyOptionsDescription": "Additional options for basic image adjustments such as resizing, cropping, and rotation. Refer to your image proxy documentation to learn more about what options are supported.",
+  "admin.image.proxyOptionsDescription": "Additional options such as the URL signing key. Refer to your image proxy documentation to learn more about what options are supported.",
   "admin.image.proxyType": "Image Proxy Type:",
   "admin.image.proxyTypeDescription": "Configure an image proxy to load all Markdown images through a proxy. The image proxy prevents users from making insecure image requests, provides caching for increased performance, and automates image adjustments such as resizing. See <a href=\"https://about.mattermost.com/default-image-proxy-documentation\">documentation</a> to learn more.",
   "admin.image.proxyTypeNone": "Brak",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -520,7 +520,7 @@
   "admin.image.maxFileSizeExample": "50",
   "admin.image.maxFileSizeTitle": "Максимальный размер файла:",
   "admin.image.proxyOptions": "Image Proxy Options:",
-  "admin.image.proxyOptionsDescription": "Additional options for basic image adjustments such as resizing, cropping, and rotation. Refer to your image proxy documentation to learn more about what options are supported.",
+  "admin.image.proxyOptionsDescription": "Additional options such as the URL signing key. Refer to your image proxy documentation to learn more about what options are supported.",
   "admin.image.proxyType": "Image Proxy Type:",
   "admin.image.proxyTypeDescription": "Configure an image proxy to load all Markdown images through a proxy. The image proxy prevents users from making insecure image requests, provides caching for increased performance, and automates image adjustments such as resizing. See <a href=\"https://about.mattermost.com/default-image-proxy-documentation\">documentation</a> to learn more.",
   "admin.image.proxyTypeNone": "Нет",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -520,7 +520,7 @@
   "admin.image.maxFileSizeExample": "50",
   "admin.image.maxFileSizeTitle": "最大文件大小：",
   "admin.image.proxyOptions": "图片代理选项：",
-  "admin.image.proxyOptionsDescription": "Additional options for basic image adjustments such as resizing, cropping, and rotation. Refer to your image proxy documentation to learn more about what options are supported.",
+  "admin.image.proxyOptionsDescription": "Additional options such as the URL signing key. Refer to your image proxy documentation to learn more about what options are supported.",
   "admin.image.proxyType": "图片代理类型：",
   "admin.image.proxyTypeDescription": "Configure an image proxy to load all Markdown images through a proxy. The image proxy prevents users from making insecure image requests, provides caching for increased performance, and automates image adjustments such as resizing. See <a href=\"https://about.mattermost.com/default-image-proxy-documentation\">documentation</a> to learn more.",
   "admin.image.proxyTypeNone": "无",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -520,7 +520,7 @@
   "admin.image.maxFileSizeExample": "50",
   "admin.image.maxFileSizeTitle": "最大檔案大小：",
   "admin.image.proxyOptions": "Image Proxy Options:",
-  "admin.image.proxyOptionsDescription": "Additional options for basic image adjustments such as resizing, cropping, and rotation. Refer to your image proxy documentation to learn more about what options are supported.",
+  "admin.image.proxyOptionsDescription": "Additional options such as the URL signing key. Refer to your image proxy documentation to learn more about what options are supported.",
   "admin.image.proxyType": "Image Proxy Type:",
   "admin.image.proxyTypeDescription": "Configure an image proxy to load all Markdown images through a proxy. The image proxy prevents users from making insecure image requests, provides caching for increased performance, and automates image adjustments such as resizing. See <a href=\"https://about.mattermost.com/default-image-proxy-documentation\">documentation</a> to learn more.",
   "admin.image.proxyTypeNone": "無",


### PR DESCRIPTION
#### Summary
Also changing the options description wording a bit since atmos/camo doesn't do resizing or other image transformations.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-258
See also https://github.com/willnorris/imageproxy/pull/141

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates