### PR TITLE
ABC-176 Remove UI setting for enabling plugin uploads

### DIFF
--- a/components/admin_console/plugin_settings.jsx
+++ b/components/admin_console/plugin_settings.jsx
@@ -19,15 +19,13 @@ export default class PluginSettings extends AdminSettings {
 
     getConfigFromState(config) {
         config.PluginSettings.Enable = this.state.enablePlugins;
-        config.PluginSettings.EnableUploads = this.state.enableUploads;
 
         return config;
     }
 
     getStateFromConfig(config) {
         return {
-            enablePlugins: config.PluginSettings.Enable,
-            enableUploads: config.PluginSettings.EnableUploads
+            enablePlugins: config.PluginSettings.Enable
         };
     }
 
@@ -59,24 +57,6 @@ export default class PluginSettings extends AdminSettings {
                     }
                     value={this.state.enablePlugins}
                     onChange={this.handleChange}
-                />
-                <BooleanSetting
-                    id='enableUploads'
-                    label={
-                        <FormattedMessage
-                            id='admin.plugins.settings.enableUploads'
-                            defaultMessage='Enable Plugin Uploads: '
-                        />
-                    }
-                    helpText={
-                        <FormattedHTMLMessage
-                            id='admin.plugins.settings.enableUploadsDesc'
-                            defaultMessage='When true, enables plugin uploads by System Admins at <strong>Plugins > Management</strong>. If you do not plan to upload a plugin, set to false to control which plugins are installed on your server. See <a href="https://about.mattermost.com/default-plugins-uploads" target="_blank">documentation</a> to learn more.'
-                        />
-                    }
-                    value={this.state.enableUploads}
-                    onChange={this.handleChange}
-                    disabled={!this.state.enablePlugins}
                 />
             </SettingsGroup>
         );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -753,8 +753,6 @@
   "admin.plugin.version": "Version:",
   "admin.plugins.settings.enable": "Enable Plugins: ",
   "admin.plugins.settings.enableDesc": "When true, enables plugins on your Mattermost server. Use plugins to integrate with third-party systems, extend functionality or customize the user interface of your Mattermost server. See <a href=\"https://about.mattermost.com/default-plugins\" target=\"_blank\">documentation</a> to learn more.",
-  "admin.plugins.settings.enableUploads": "Enable Plugin Uploads: ",
-  "admin.plugins.settings.enableUploadsDesc": "When true, enables plugin uploads by System Admins at <strong>Plugins > Management</strong>. If you do not plan to upload a plugin, set to false to control which plugins are installed on your server. See <a href=\"https://about.mattermost.com/default-plugin-uploads\" target=\"_blank\">documentation</a> to learn more.",
   "admin.plugins.settings.title": "Configuration",
   "admin.privacy.showEmailDescription": "When false, hides the email address of members from everyone except System Administrators.",
   "admin.privacy.showEmailTitle": "Show Email Address: ",


### PR DESCRIPTION
#### Summary
Remove UI setting for enabling plugin uploads.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-176

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has server changes (mattermost/mattermost-server#8249)