### PR TITLE
Icu 734 - Ctrl-U triggers upload box

### DIFF
--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -389,9 +389,8 @@ class FileUpload extends React.PureComponent {
                 this.props.onUploadError(localizeMessage('file_upload.disabled', 'File attachments are disabled.'));
                 return;
             }
-
-            const postTextbox = this.props.postType === 'post' && document.activeElement.id === 'post_textbox-textarea';
-            const commentTextbox = this.props.postType === 'comment' && document.activeElement.id === 'reply_textbox-textarea';
+            const postTextbox = this.props.postType === 'post' && document.activeElement.id === 'post_textbox';
+            const commentTextbox = this.props.postType === 'comment' && document.activeElement.id === 'reply_textbox';
             if (postTextbox || commentTextbox) {
                 $(this.refs.fileInput).focus().trigger('click');
             }


### PR DESCRIPTION
Repro steps:
1. Press CTRL+U (Windows) or CMD+U (Mac)

Observed:
Nothing happens

Expected:
File selector appears

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-734

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)