### PR TITLE
[ICU-747/749/752] Fix unexpected opening of keyboard on classic app

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -434,7 +434,7 @@ export default class CreatePost extends React.Component {
     }
 
     handleFileUploadChange = () => {
-        this.focusTextbox(true);
+        this.focusTextbox();
     }
 
     handleUploadStart = (clientIds, channelId) => {

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -377,7 +377,6 @@ describe('components/create_post', () => {
 
         instance.handleFileUploadChange();
         expect(instance.focusTextbox).toBeCalled();
-        expect(instance.focusTextbox).toBeCalledWith(true);
     });
 
     it('check for handleFileUploadStart callbak', () => {


### PR DESCRIPTION
#### Summary
Fix unexpected opening of keyboard on classic app
- `handleFileUploadChange` should not force focus to textbox
- mobile out of focus (or webapp focus) will be handled by `this.focusTextbox` function

#### Ticket Link
Should be for the following Jira tickets:
- [ICU-747](https://mattermost.atlassian.net/browse/ICU-747)
- [ICU-749](https://mattermost.atlassian.net/browse/ICU-749)
- [ICU-752](https://mattermost.atlassian.net/browse/ICU-752)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
