### PR TITLE
MM-9571- Load all default emojis on emoji picker trigger

### DIFF
--- a/components/emoji_picker/components/emoji_picker_trigger_preload.jsx
+++ b/components/emoji_picker/components/emoji_picker_trigger_preload.jsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class EmojiPickerTriggerPreload extends React.PureComponent {
+    static propTypes = {
+        allEmojis: PropTypes.object
+    };
+    render() {
+        const sections = Object.values(this.props.allEmojis).
+            reduce((result, currentEmoji) => ({
+                ...result,
+                [currentEmoji.category]: {
+                    ...result[currentEmoji.category],
+                    [currentEmoji.batch]: 1
+                }
+            }), {});
+        const divs = [];
+        Object.keys(sections).forEach((section) => {
+            Object.keys(sections[section]).forEach((batch) => {
+                const sectionBatch = `emoji-category-${section}-${batch}`;
+                divs.push(
+                    <div
+                        key={sectionBatch}
+                        className={sectionBatch}
+                    />
+                );
+            });
+        });
+        return (
+            <div className='preload-emojis'>
+                {divs}
+            </div>
+        );
+    }
+}

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -13,6 +13,7 @@ import EmojiPickerCategory from './components/emoji_picker_category';
 import EmojiPickerItem from './components/emoji_picker_item';
 import EmojiPickerCategorySection from './emoji_picker_category_section';
 import EmojiPickerPreview from './components/emoji_picker_preview';
+import EmojiPickerTriggerPreload from './components/emoji_picker_trigger_preload';
 
 const CATEGORY_SEARCH_RESULTS = 'searchResults';
 const EMOJI_HEIGHT = 27;
@@ -98,9 +99,8 @@ const CATEGORIES = {
     }
 };
 
-function getEmojiFilename(emoji) {
-    return emoji.filename || emoji.id;
-}
+const getEmojiFilename = (emoji) =>
+    emoji.filename || emoji.id;
 
 const EMOJIS_PER_PAGE = 200;
 const LOAD_MORE_AT_PIXELS_FROM_BOTTOM = 500;
@@ -584,6 +584,9 @@ export default class EmojiPicker extends React.PureComponent {
                 {this.emojiSearch()}
                 {this.emojiCurrentResults()}
                 <EmojiPickerPreview emoji={this.getCurrentEmojiByCursor(this.state.cursor)}/>
+                <EmojiPickerTriggerPreload
+                    allEmojis={this.state.allEmojis}
+                />
             </div>
         );
     }

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -132,12 +132,12 @@ export default class EmojiPicker extends React.PureComponent {
     constructor(props) {
         super(props);
 
+        this.divHeight = 0;
         this.state = {
             allEmojis: {},
             categories: CATEGORIES,
             filter: '',
             cursor: [0, 0], // categoryIndex, emojiIndex
-            divHeight: 0,
             divTopOffset: 0,
             missingPages: true,
             emojisToShow: EMOJI_TO_LOAD_PER_UPDATE
@@ -159,7 +159,7 @@ export default class EmojiPicker extends React.PureComponent {
         requestAnimationFrame(() => {
             this.searchInput.focus();
         });
-        this.updateState({divHeight: this.emojiPickerContainer.offsetHeight});
+        this.divHeight = this.emojiPickerContainer.offsetHeight;
     }
 
     componentWillUpdate(nextProps, nextState) {
@@ -532,7 +532,7 @@ export default class EmojiPicker extends React.PureComponent {
                     emojiIndex={emojiIndex}
                     containerRef={this.emojiPickerContainer}
                     containerTop={this.state.divTopOffset}
-                    containerBottom={this.state.divTopOffset + this.state.divHeight}
+                    containerBottom={this.state.divTopOffset + this.divHeight}
                 />
             );
         });

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -132,25 +132,18 @@ export default class EmojiPicker extends React.PureComponent {
     constructor(props) {
         super(props);
 
-        this.handleCategoryClick = this.handleCategoryClick.bind(this);
-        this.handleFilterChange = this.handleFilterChange.bind(this);
-        this.handleItemOver = this.handleItemOver.bind(this);
-        this.handleItemClick = this.handleItemClick.bind(this);
-        this.handleKeyDown = this.handleKeyDown.bind(this);
-        this.handleScroll = this.handleScroll.bind(this);
-        this.handleScrollThrottle = throttle(this.handleScroll, EMOJI_LAZY_LOAD_SCROLL_THROTTLE, {leading: false, trailing: true});
-        this.updateCategoryOffset = this.updateCategoryOffset.bind(this);
-
-        this.divHeight = 0;
-        this.missingPages = true;
         this.state = {
             allEmojis: {},
             categories: CATEGORIES,
             filter: '',
             cursor: [0, 0], // categoryIndex, emojiIndex
+            divHeight: 0,
             divTopOffset: 0,
+            missingPages: true,
             emojisToShow: EMOJI_TO_LOAD_PER_UPDATE
         };
+
+        this.handleScrollThrottle = throttle(this.handleScroll, EMOJI_LAZY_LOAD_SCROLL_THROTTLE, {leading: false, trailing: true});
     }
 
     componentWillMount() {
@@ -166,7 +159,7 @@ export default class EmojiPicker extends React.PureComponent {
         requestAnimationFrame(() => {
             this.searchInput.focus();
         });
-        this.divHeight = this.emojiPickerContainer.offsetHeight;
+        this.updateState({divHeight: this.emojiPickerContainer.offsetHeight});
     }
 
     componentWillUpdate(nextProps, nextState) {
@@ -184,7 +177,7 @@ export default class EmojiPicker extends React.PureComponent {
             }
         }
 
-        if (!this.missingPages || !this.emojiPickerContainer) {
+        if (!this.state.missingPages || !this.emojiPickerContainer) {
             return;
         }
 
@@ -211,7 +204,7 @@ export default class EmojiPicker extends React.PureComponent {
         }
 
         if (data.length < EMOJIS_PER_PAGE) {
-            this.missingPages = false;
+            this.setState({missingPages: false});
             return;
         }
 
@@ -228,11 +221,11 @@ export default class EmojiPicker extends React.PureComponent {
         this.searchInput = input;
     };
 
-    handleCategoryClick(categoryName) {
+    handleCategoryClick = (categoryName) => {
         this.emojiPickerContainer.scrollTop = this.state.categories[categoryName].offset;
     }
 
-    handleFilterChange(e) {
+    handleFilterChange = (e) => {
         e.preventDefault();
         const filter = e.target.value.toLowerCase();
 
@@ -246,17 +239,17 @@ export default class EmojiPicker extends React.PureComponent {
         }));
     }
 
-    handleItemOver(categoryIndex, emojiIndex) {
+    handleItemOver = (categoryIndex, emojiIndex) => {
         this.setState({
             cursor: [categoryIndex, emojiIndex]
         });
     }
 
-    handleItemClick(emoji) {
+    handleItemClick = (emoji) => {
         this.props.onEmojiClick(emoji);
     }
 
-    handleKeyDown(e) {
+    handleKeyDown = (e) => {
         switch (e.key) {
         case 'ArrowRight':
             e.preventDefault();
@@ -283,7 +276,7 @@ export default class EmojiPicker extends React.PureComponent {
         }
     }
 
-    handleScroll() {
+    handleScroll = () => {
         this.setState({divTopOffset: this.emojiPickerContainer.scrollTop});
     }
 
@@ -539,13 +532,13 @@ export default class EmojiPicker extends React.PureComponent {
                     emojiIndex={emojiIndex}
                     containerRef={this.emojiPickerContainer}
                     containerTop={this.state.divTopOffset}
-                    containerBottom={this.state.divTopOffset + this.divHeight}
+                    containerBottom={this.state.divTopOffset + this.state.divHeight}
                 />
             );
         });
     };
 
-    updateCategoryOffset(categoryName, offset) {
+    updateCategoryOffset = (categoryName, offset) => {
         if (categoryName !== CATEGORY_SEARCH_RESULTS) {
             this.setState((state) => ({
                 categories: {

--- a/sass/components/_emojisprite.scss
+++ b/sass/components/_emojisprite.scss
@@ -30,6 +30,14 @@
     transform-origin: 0 0;
     width: 64px;
 }
+.preload-emojis {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+}
 .emoji-category-people-1 { background-image: url('../images/emoji-sheets/people-1.png'); }
 .emoji-263a-fe0f { background-position: -0px -0px; }
 .emoji-1f601 { background-position: -64px -0px; }


### PR DESCRIPTION
… opening of emoji-picker

Added visually hidden component at bottom of emoji picker to trigger the loading of all **system** emojis when the emoji picker is first triggered. 

Issue: Clicking a category on the emoji picker displays a blank screen on first time before loading the images.

There still *could* be a small flash of blank images if the sprites haven't downloaded yet.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-684

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)

#### Video of changes, for further clarity
https://www.youtube.com/watch?v=Xfoxkmu8Ymw