### PR TITLE
XYZ-111: Checking join rights before join to the team

### DIFF
--- a/components/select_team/components/select_team_item.jsx
+++ b/components/select_team/components/select_team_item.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
-import {Link} from 'react-router-dom';
 
 import TeamInfoIcon from 'components/svg/team_info_icon';
 import * as Utils from 'utils/utils.jsx';
@@ -16,7 +15,8 @@ export default class SelectTeamItem extends React.PureComponent {
         loading: PropTypes.bool.isRequired
     };
 
-    handleTeamClick = () => {
+    handleTeamClick = (e) => {
+        e.preventDefault();
         this.props.onTeamClick(this.props.team);
     }
 
@@ -59,14 +59,14 @@ export default class SelectTeamItem extends React.PureComponent {
         return (
             <div className='signup-team-dir'>
                 {showDescriptionTooltip}
-                <Link
-                    to={`/${this.props.team.name}/channels/town-square`}
+                <a
+                    href='#'
                     id={Utils.createSafeId(this.props.team.display_name)}
                     onClick={this.handleTeamClick}
                 >
                     <span className='signup-team-dir__name'>{this.props.team.display_name}</span>
                     {icon}
-                </Link>
+                </a>
             </div>
         );
     }


### PR DESCRIPTION
#### Summary
Converting the `Link` tag into an `a` tag because the `to` attribute was bypassing the onClick behavior.

#### Ticket Link
[XYZ-111](https://mattermost.atlassian.net/browse/XYZ-111)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [x] Has server changes (https://github.com/mattermost/mattermost-server/pull/8261)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)