### PR TITLE
[ICU-720] Clear imageContainerStyle on image load

### DIFF
--- a/components/single_image_view.jsx
+++ b/components/single_image_view.jsx
@@ -17,9 +17,10 @@ import {postListScrollChange} from 'actions/global_actions.jsx';
 import LoadingImagePreview from 'components/loading_image_preview';
 import ViewImageModal from 'components/view_image.jsx';
 
-const PREVIEW_IMAGE_MAX_WIDTH = 1024;
-const PREVIEW_IMAGE_MAX_HEIGHT = 350;
-const PREVIEW_IMAGE_MIN_DIMENSION = 50;
+// Size in px multiply by 100
+const PREVIEW_IMAGE_MAX_WIDTH = 102400;
+const PREVIEW_IMAGE_MAX_HEIGHT = 35000;
+const PREVIEW_IMAGE_MIN_DIMENSION = 5000;
 
 export default class SingleImageView extends React.PureComponent {
     static propTypes = {
@@ -110,21 +111,21 @@ export default class SingleImageView extends React.PureComponent {
 
     computeImageDimensions = () => {
         const {fileInfo} = this.props;
-        const {viewPortWidth} = this.state;
+        const viewPortWidth = this.state.viewPortWidth * 100;
 
-        let previewWidth = fileInfo.width;
-        let previewHeight = fileInfo.height;
+        let previewWidth = fileInfo.width * 100;
+        let previewHeight = fileInfo.height * 100;
 
         if (viewPortWidth && previewWidth > viewPortWidth) {
             const origRatio = fileInfo.height / fileInfo.width;
-            previewWidth = Math.floor(Math.min(PREVIEW_IMAGE_MAX_WIDTH, fileInfo.width, viewPortWidth));
-            previewHeight = Math.floor(previewWidth * origRatio);
+            previewWidth = Math.min(PREVIEW_IMAGE_MAX_WIDTH, fileInfo.width * 100, viewPortWidth);
+            previewHeight = previewWidth * origRatio;
         }
 
         if (previewHeight > PREVIEW_IMAGE_MAX_HEIGHT) {
             const heightRatio = PREVIEW_IMAGE_MAX_HEIGHT / previewHeight;
             previewHeight = PREVIEW_IMAGE_MAX_HEIGHT;
-            previewWidth = Math.floor(previewWidth * heightRatio);
+            previewWidth *= heightRatio;
         }
 
         return {previewWidth, previewHeight};
@@ -171,8 +172,8 @@ export default class SingleImageView extends React.PureComponent {
         let loadingImagePreview;
 
         let fadeInClass = '';
-        let imageStyle = {height: previewHeight};
-        let imageContainerStyle = {height: previewHeight};
+        let imageStyle = {height: previewHeight / 100};
+        let imageContainerStyle = {height: previewHeight / 100};
         if (loaded) {
             viewImageModal = (
                 <ViewImageModal

--- a/components/single_image_view.jsx
+++ b/components/single_image_view.jsx
@@ -172,7 +172,7 @@ export default class SingleImageView extends React.PureComponent {
 
         let fadeInClass = '';
         let imageStyle = {height: previewHeight};
-        const imageContainerStyle = {height: previewHeight};
+        let imageContainerStyle = {height: previewHeight};
         if (loaded) {
             viewImageModal = (
                 <ViewImageModal
@@ -184,6 +184,7 @@ export default class SingleImageView extends React.PureComponent {
 
             fadeInClass = 'image-fade-in';
             imageStyle = {cursor: 'pointer'};
+            imageContainerStyle = {};
         } else {
             loadingImagePreview = (
                 <LoadingImagePreview

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -173,7 +173,7 @@
             cursor: 'pointer';
             display: inline-block;
             left: 0;
-            max-height: 360px;
+            max-height: 350px;
             max-width: 100%;
             opacity: 0;
             overflow: hidden;


### PR DESCRIPTION
#### Summary
Clear `imageContainerStyle` on image load
- This is to prevent fix height at center view whenever RHS is expanded.

#### Ticket Link
Jira ticket: [ICU-720](https://mattermost.atlassian.net/browse/ICU-720)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed

