### PR TITLE
ICU-732 Made system emojis always take precedence over custom ones

### DIFF
--- a/components/suggestion/emoticon_provider.jsx
+++ b/components/suggestion/emoticon_provider.jsx
@@ -104,6 +104,11 @@ export default class EmoticonProvider {
                 }
             } else if (name.indexOf(partialName) !== -1) {
                 // This is a custom emoji so it only has one name
+                if (EmojiStore.hasSystemEmoji(name)) {
+                    // System emojis take precedence over custom ones
+                    continue;
+                }
+
                 matched.push({name, emoji});
             }
         }


### PR DESCRIPTION
When we added new system emojis a while back, it became possible to have a custom emoji with the same name as a system one. This causes some undefined behaviour when sorting the emoji autocomplete, so just don't even bother looking at custom emojis with the same name as a system one.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-732
