### PR TITLE
Remove ownProps duplication and make connect functions consistent

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -17,7 +17,7 @@
       other entities that control, are controlled by, or are under common
       control with that entity. For the purposes of this definition,
       "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or 
+      direction or management of such entity, whether by contract or
       otherwise, or (ii) ownership of fifty percent (50%) or more of the
       outstanding shares, or (iii) beneficial ownership of such entity.
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -17,7 +17,7 @@
       other entities that control, are controlled by, or are under common
       control with that entity. For the purposes of this definition,
       "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
+      direction or management of such entity, whether by contract or 
       otherwise, or (ii) ownership of fifty percent (50%) or more of the
       outstanding shares, or (iii) beneficial ownership of such entity.
 

--- a/components/about_build_modal/index.js
+++ b/components/about_build_modal/index.js
@@ -6,12 +6,9 @@ import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general
 
 import AboutBuildModal from './about_build_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        config: getConfig(state),
-        license: getLicense(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    config: getConfig(state),
+    license: getLicense(state)
+});
 
 export default connect(mapStateToProps)(AboutBuildModal);

--- a/components/access_history_modal/index.js
+++ b/components/access_history_modal/index.js
@@ -7,18 +7,10 @@ import {getUserAudits} from 'mattermost-redux/actions/users';
 
 import AccessHistoryModal from './access_history_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getUserAudits
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getUserAudits
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(AccessHistoryModal);
+export default connect(null, mapDispatchToProps)(AccessHistoryModal);

--- a/components/activity_log_modal/index.js
+++ b/components/activity_log_modal/index.js
@@ -7,19 +7,11 @@ import {getSessions, revokeSession} from 'mattermost-redux/actions/users';
 
 import ActivityLogModal from './activity_log_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getSessions,
+        revokeSession
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getSessions,
-            revokeSession
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ActivityLogModal);
+export default connect(null, mapDispatchToProps)(ActivityLogModal);

--- a/components/add_users_to_team/index.js
+++ b/components/add_users_to_team/index.js
@@ -7,18 +7,10 @@ import {getProfilesNotInTeam} from 'mattermost-redux/actions/users';
 
 import AddUsersToTeam from './add_users_to_team.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getProfilesNotInTeam
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getProfilesNotInTeam
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(AddUsersToTeam);
+export default connect(null, mapDispatchToProps)(AddUsersToTeam);

--- a/components/admin_console/admin_navbar_dropdown/index.js
+++ b/components/admin_console/admin_navbar_dropdown/index.js
@@ -9,18 +9,14 @@ import {getNavigationBlocked} from 'selectors/views/admin';
 
 import AdminNavbarDropdown from './admin_navbar_dropdown.jsx';
 
-function mapStateToProps(state) {
-    return {
-        navigationBlocked: getNavigationBlocked(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    navigationBlocked: getNavigationBlocked(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            deferNavigation
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        deferNavigation
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(AdminNavbarDropdown);

--- a/components/admin_console/admin_sidebar/index.js
+++ b/components/admin_console/admin_sidebar/index.js
@@ -7,20 +7,15 @@ import {getPlugins} from 'mattermost-redux/actions/admin';
 
 import AdminSidebar from './admin_sidebar.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        config: state.entities.admin.config,
-        plugins: state.entities.admin.plugins
-    };
-}
+const mapStateToProps = (state) => ({
+    config: state.entities.admin.config,
+    plugins: state.entities.admin.plugins
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getPlugins
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getPlugins
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {pure: false})(AdminSidebar);

--- a/components/admin_console/audits/index.js
+++ b/components/admin_console/audits/index.js
@@ -8,19 +8,14 @@ import * as Selectors from 'mattermost-redux/selectors/entities/admin';
 
 import Audits from './audits.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        audits: Object.values(Selectors.getAudits(state))
-    };
-}
+const mapStateToProps = (state) => ({
+    audits: Object.values(Selectors.getAudits(state))
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getAudits
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getAudits
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(Audits);

--- a/components/admin_console/blockable_link/index.js
+++ b/components/admin_console/blockable_link/index.js
@@ -9,18 +9,14 @@ import {getNavigationBlocked} from 'selectors/views/admin';
 
 import BlockableLink from './blockable_link.jsx';
 
-function mapStateToProps(state) {
-    return {
-        blocked: getNavigationBlocked(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    blocked: getNavigationBlocked(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            deferNavigation
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        deferNavigation
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(BlockableLink);

--- a/components/admin_console/compliance_reports/index.js
+++ b/components/admin_console/compliance_reports/index.js
@@ -8,7 +8,7 @@ import {getComplianceReports as selectComplianceReports, getConfig} from 'matter
 
 import ComplianceReports from './compliance_reports.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state) => {
     let enabled = false;
     const config = getConfig(state);
     if (config && config.ComplianceSettings) {
@@ -26,20 +26,17 @@ function mapStateToProps(state, ownProps) {
     });
 
     return {
-        ...ownProps,
         enabled,
         reports,
         serverError
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getComplianceReports,
-            createComplianceReport
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getComplianceReports,
+        createComplianceReport
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(ComplianceReports);

--- a/components/admin_console/custom_plugin_settings/index.js
+++ b/components/admin_console/custom_plugin_settings/index.js
@@ -5,12 +5,12 @@ import {connect} from 'react-redux';
 
 import CustomPluginSettings from './custom_plugin_settings.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const pluginId = ownProps.match.params.plugin_id;
 
     return {
         plugin: state.entities.admin.plugins[pluginId]
     };
-}
+};
 
 export default connect(mapStateToProps)(CustomPluginSettings);

--- a/components/admin_console/index.js
+++ b/components/admin_console/index.js
@@ -12,25 +12,20 @@ import {getNavigationBlocked, showNavigationPrompt} from 'selectors/views/admin'
 
 import AdminConsole from './admin_console.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        config: Selectors.getConfig(state),
-        navigationBlocked: getNavigationBlocked(state),
-        showNavigationPrompt: showNavigationPrompt(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    config: Selectors.getConfig(state),
+    navigationBlocked: getNavigationBlocked(state),
+    showNavigationPrompt: showNavigationPrompt(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getConfig,
-            setNavigationBlocked,
-            deferNavigation,
-            cancelNavigation,
-            confirmNavigation
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getConfig,
+        setNavigationBlocked,
+        deferNavigation,
+        cancelNavigation,
+        confirmNavigation
+    }, dispatch)
+});
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(AdminConsole));

--- a/components/admin_console/jobs/index.jsx
+++ b/components/admin_console/jobs/index.jsx
@@ -8,19 +8,14 @@ import * as Selectors from 'mattermost-redux/selectors/entities/jobs';
 
 import Table from './table.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        jobs: Selectors.makeGetJobsByType(ownProps.jobType)(state)
-    };
-}
+const mapStateToProps = (state, ownProps) => ({
+    jobs: Selectors.makeGetJobsByType(ownProps.jobType)(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getJobsByType
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getJobsByType
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(Table);

--- a/components/admin_console/manage_roles_modal/index.js
+++ b/components/admin_console/manage_roles_modal/index.js
@@ -7,19 +7,14 @@ import {updateUserRoles} from 'mattermost-redux/actions/users';
 
 import ManageRolesModal from './manage_roles_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        userAccessTokensEnabled: state.entities.admin.config.ServiceSettings.EnableUserAccessTokens
-    };
-}
+const mapStateToProps = (state) => ({
+    userAccessTokensEnabled: state.entities.admin.config.ServiceSettings.EnableUserAccessTokens
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            updateUserRoles
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        updateUserRoles
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(ManageRolesModal);

--- a/components/admin_console/manage_tokens_modal/index.js
+++ b/components/admin_console/manage_tokens_modal/index.js
@@ -7,21 +7,18 @@ import {getUserAccessTokensForUser} from 'mattermost-redux/actions/users';
 
 import ManageTokensModal from './manage_tokens_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const userId = ownProps.user ? ownProps.user.id : '';
 
     return {
-        ...ownProps,
         userAccessTokens: state.entities.admin.userAccessTokens[userId]
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getUserAccessTokensForUser
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getUserAccessTokensForUser
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(ManageTokensModal);

--- a/components/admin_console/manage_tokens_modal/index.js
+++ b/components/admin_console/manage_tokens_modal/index.js
@@ -13,7 +13,7 @@ const mapStateToProps = (state, ownProps) => {
     return {
         userAccessTokens: state.entities.admin.userAccessTokens[userId]
     };
-}
+};
 
 const mapDispatchToProps = (dispatch) => ({
     actions: bindActionCreators({

--- a/components/admin_console/plugin_management/index.js
+++ b/components/admin_console/plugin_management/index.js
@@ -7,23 +7,18 @@ import {getPlugins, removePlugin, uploadPlugin, activatePlugin, deactivatePlugin
 
 import PluginManagement from './plugin_management.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        plugins: state.entities.admin.plugins
-    };
-}
+const mapStateToProps = (state) => ({
+    plugins: state.entities.admin.plugins
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            uploadPlugin,
-            removePlugin,
-            getPlugins,
-            activatePlugin,
-            deactivatePlugin
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        uploadPlugin,
+        removePlugin,
+        getPlugins,
+        activatePlugin,
+        deactivatePlugin
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(PluginManagement);

--- a/components/admin_console/revoke_token_button/index.js
+++ b/components/admin_console/revoke_token_button/index.js
@@ -7,18 +7,10 @@ import {revokeUserAccessToken} from 'mattermost-redux/actions/users';
 
 import RevokeTokenButton from './revoke_token_button.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        revokeUserAccessToken
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            revokeUserAccessToken
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(RevokeTokenButton);
+export default connect(null, mapDispatchToProps)(RevokeTokenButton);

--- a/components/admin_console/server_logs/index.js
+++ b/components/admin_console/server_logs/index.js
@@ -8,19 +8,14 @@ import * as Selectors from 'mattermost-redux/selectors/entities/admin';
 
 import Logs from './logs.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        logs: Selectors.getLogs(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    logs: Selectors.getLogs(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getLogs
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getLogs
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(Logs);

--- a/components/admin_console/system_users/index.js
+++ b/components/admin_console/system_users/index.js
@@ -9,22 +9,17 @@ import {getTeamsList} from 'mattermost-redux/selectors/entities/teams';
 
 import SystemUsers from './system_users.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        teams: getTeamsList(state),
-        ...ownProps
-    };
-}
+const mapStateToProps = (state) => ({
+    teams: getTeamsList(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getTeams,
-            getTeamStats,
-            getUser,
-            getUserAccessToken
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getTeams,
+        getTeamStats,
+        getUser,
+        getUserAccessToken
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(SystemUsers);

--- a/components/analytics/team_analytics/index.js
+++ b/components/analytics/team_analytics/index.js
@@ -13,24 +13,21 @@ import TeamAnalytics from './team_analytics.jsx';
 
 const LAST_ANALYTICS_TEAM = 'last_analytics_team';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state) => {
     const teams = getTeamsList(state);
     const teamId = BrowserStore.getGlobalItem(LAST_ANALYTICS_TEAM, teams.length > 0 ? teams[0].id : '');
 
     return {
         initialTeam: state.entities.teams.teams[teamId],
-        teams,
-        ...ownProps
+        teams
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getTeams,
-            getProfilesInTeam
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getTeams,
+        getProfilesInTeam
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(TeamAnalytics);

--- a/components/announcement_bar/index.js
+++ b/components/announcement_bar/index.js
@@ -6,11 +6,8 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import AnnouncementBar from './announcement_bar.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        isLoggedIn: Boolean(getCurrentUserId(state))
-    };
-}
+const mapStateToProps = (state) => ({
+    isLoggedIn: Boolean(getCurrentUserId(state))
+});
 
 export default connect(mapStateToProps)(AnnouncementBar);

--- a/components/at_mention/index.jsx
+++ b/components/at_mention/index.jsx
@@ -6,11 +6,9 @@ import {getCurrentUserId, getUsersByUsername} from 'mattermost-redux/selectors/e
 
 import AtMention from './at_mention.jsx';
 
-function mapStateToProps(state) {
-    return {
-        currentUserId: getCurrentUserId(state),
-        usersByUsername: getUsersByUsername(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    currentUserId: getCurrentUserId(state),
+    usersByUsername: getUsersByUsername(state)
+});
 
 export default connect(mapStateToProps)(AtMention);

--- a/components/backstage/index.js
+++ b/components/backstage/index.js
@@ -11,7 +11,7 @@ import {isSystemAdmin, isAdmin as isTeamAdmin} from 'utils/utils.jsx';
 
 import BackstageController from './backstage_controller.jsx';
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const user = getCurrentUser(state);
     const team = getCurrentTeam(state);
     const teamMember = getCurrentTeamMembership(state);
@@ -30,6 +30,6 @@ function mapStateToProps(state) {
         team,
         isAdmin
     };
-}
+};
 
 export default withRouter(connect(mapStateToProps)(BackstageController));

--- a/components/change_url_modal/index.js
+++ b/components/change_url_modal/index.js
@@ -8,12 +8,12 @@ import {getSiteURL} from 'utils/url';
 
 import ChangeURLModal from './change_url_modal';
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const currentTeam = getCurrentTeam(state);
     const currentTeamURL = `${getSiteURL()}/${currentTeam.name}`;
     return {
         currentTeamURL
     };
-}
+};
 
 export default connect(mapStateToProps)(ChangeURLModal);

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -20,7 +20,7 @@ import {getRhsState} from 'selectors/rhs';
 
 import ChannelHeader from './channel_header.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const channel = getChannel(state, ownProps.channelId) || {};
     const prefs = state.entities.preferences.myPreferences;
     const user = getCurrentUser(state);
@@ -45,22 +45,20 @@ function mapStateToProps(state, ownProps) {
         enableFormatting: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true),
         rhsState: getRhsState(state)
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            leaveChannel,
-            favoriteChannel,
-            unfavoriteChannel,
-            showFlaggedPosts,
-            showPinnedPosts,
-            showMentions,
-            closeRightHandSide,
-            openModal,
-            getCustomEmojisInText
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        leaveChannel,
+        favoriteChannel,
+        unfavoriteChannel,
+        showFlaggedPosts,
+        showPinnedPosts,
+        showMentions,
+        closeRightHandSide,
+        openModal,
+        getCustomEmojisInText
+    }, dispatch)
+});
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ChannelHeader));

--- a/components/channel_info_modal/index.js
+++ b/components/channel_info_modal/index.js
@@ -6,11 +6,8 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import ChannelInfoModal from './channel_info_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        currentTeam: getCurrentTeam(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    currentTeam: getCurrentTeam(state)
+});
 
 export default connect(mapStateToProps)(ChannelInfoModal);

--- a/components/channel_invite_modal/index.js
+++ b/components/channel_invite_modal/index.js
@@ -8,19 +8,11 @@ import {getProfilesNotInChannel} from 'mattermost-redux/actions/users';
 
 import ChannelInviteModal from './channel_invite_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getProfilesNotInChannel,
+        getTeamStats
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getProfilesNotInChannel,
-            getTeamStats
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ChannelInviteModal);
+export default connect(null, mapDispatchToProps)(ChannelInviteModal);

--- a/components/channel_members_dropdown/index.js
+++ b/components/channel_members_dropdown/index.js
@@ -7,18 +7,10 @@ import {getChannelStats} from 'mattermost-redux/actions/channels';
 
 import ChannelMembersDropdown from './channel_members_dropdown.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getChannelStats
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getChannelStats
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ChannelMembersDropdown);
+export default connect(null, mapDispatchToProps)(ChannelMembersDropdown);

--- a/components/channel_members_modal/index.js
+++ b/components/channel_members_modal/index.js
@@ -6,10 +6,8 @@ import {canManageChannelMembers} from 'mattermost-redux/selectors/entities/chann
 
 import ChannelMembersModal from './channel_members_modal.jsx';
 
-function mapStateToProps(state) {
-    return {
-        canManageChannelMembers: canManageChannelMembers(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    canManageChannelMembers: canManageChannelMembers(state)
+});
 
 export default connect(mapStateToProps)(ChannelMembersModal);

--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -21,7 +21,7 @@ const getDeactivatedChannel = createSelector(
     }
 );
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const channelId = state.entities.channels.currentChannelId;
 
     return {
@@ -29,6 +29,6 @@ function mapStateToProps(state) {
         deactivatedChannel: getDeactivatedChannel(state, channelId),
         showTutorial: Number(get(state, Preferences.TUTORIAL_STEP, state.entities.users.currentUserId, 999)) <= TutorialSteps.INTRO_SCREENS && global.window.mm_config.EnableTutorial === 'true'
     };
-}
+};
 
 export default withRouter(connect(mapStateToProps)(ChannelView));

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -24,7 +24,7 @@ import {makeGetCommentDraft} from 'selectors/rhs';
 
 import CreateComment from './create_comment.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const err = state.requests.posts.createPost.error || {};
 
     const getCommentDraft = makeGetCommentDraft(ownProps.rootId);
@@ -46,7 +46,7 @@ function mapStateToProps(state, ownProps) {
         createPostErrorId: err.server_error_id,
         readOnlyChannel: !isCurrentUserSystemAdmin(state) && getConfig(state).ExperimentalTownSquareIsReadOnly === 'true' && channel.name === Constants.DEFAULT_CHANNEL
     };
-}
+};
 
 function makeOnUpdateCommentDraft(rootId) {
     return (draft) => updateCommentDraft(rootId, draft);

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -35,7 +35,7 @@ import {Constants, Preferences, StoragePrefixes, TutorialSteps} from 'utils/cons
 import CreatePost from './create_post.jsx';
 
 function mapStateToProps() {
-    return (state, ownProps) => {
+    return (state) => {
         const config = getConfig(state);
         const currentChannel = getCurrentChannel(state) || {};
         const getDraft = makeGetGlobalItem(StoragePrefixes.DRAFT + currentChannel.id, {
@@ -51,7 +51,7 @@ function mapStateToProps() {
         const enableTutorial = config.EnableTutorial === 'true';
         const tutorialStep = parseInt(get(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), TutorialSteps.FINISHED), 10);
         return {
-                currentTeamId: getCurrentTeamId(state),
+            currentTeamId: getCurrentTeamId(state),
             currentChannel,
             currentChannelMembersCount,
             currentUserId: getCurrentUserId(state),

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -51,8 +51,7 @@ function mapStateToProps() {
         const enableTutorial = config.EnableTutorial === 'true';
         const tutorialStep = parseInt(get(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), TutorialSteps.FINISHED), 10);
         return {
-            ...ownProps,
-            currentTeamId: getCurrentTeamId(state),
+                currentTeamId: getCurrentTeamId(state),
             currentChannel,
             currentChannelMembersCount,
             currentUserId: getCurrentUserId(state),
@@ -78,21 +77,19 @@ function onSubmitPost(post, fileInfos) {
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            addMessageIntoHistory,
-            onSubmitPost,
-            moveHistoryIndexBack,
-            moveHistoryIndexForward,
-            addReaction,
-            removeReaction,
-            setDraft: setGlobalItem,
-            clearDraftUploads: actionOnGlobalItemsWithPrefix,
-            selectPostFromRightHandSideSearchByPostId,
-            setEditingPost
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        addMessageIntoHistory,
+        onSubmitPost,
+        moveHistoryIndexBack,
+        moveHistoryIndexForward,
+        addReaction,
+        removeReaction,
+        setDraft: setGlobalItem,
+        clearDraftUploads: actionOnGlobalItemsWithPrefix,
+        selectPostFromRightHandSideSearchByPostId,
+        setEditingPost
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(CreatePost);

--- a/components/delete_channel_modal/index.js
+++ b/components/delete_channel_modal/index.js
@@ -8,19 +8,14 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import DeleteChannelModal from './delete_channel_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        currentTeamDetails: getCurrentTeam(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    currentTeamDetails: getCurrentTeam(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            deleteChannel
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        deleteChannel
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(DeleteChannelModal);

--- a/components/do_verify_email/index.js
+++ b/components/do_verify_email/index.js
@@ -7,12 +7,10 @@ import {verifyUserEmail} from 'mattermost-redux/actions/users';
 
 import DoVerifyEmail from './do_verify_email.jsx';
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: {
-            verifyUserEmail: bindActionCreators(verifyUserEmail, dispatch)
-        }
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: {
+        verifyUserEmail: bindActionCreators(verifyUserEmail, dispatch)
+    }
+});
 
 export default connect(null, mapDispatchToProps)(DoVerifyEmail);

--- a/components/dot_menu/index.js
+++ b/components/dot_menu/index.js
@@ -9,20 +9,14 @@ import {pinPost, unpinPost, setEditingPost} from 'actions/post_actions.jsx';
 
 import DotMenu from './dot_menu.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return ownProps;
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        flagPost,
+        unflagPost,
+        setEditingPost,
+        pinPost,
+        unpinPost
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            flagPost,
-            unflagPost,
-            setEditingPost,
-            pinPost,
-            unpinPost
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(DotMenu);
+export default connect(null, mapDispatchToProps)(DotMenu);

--- a/components/edit_channel_header_modal/index.js
+++ b/components/edit_channel_header_modal/index.js
@@ -25,13 +25,11 @@ const mapStateToProps = createSelector(
     }),
 );
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: {
-            patchChannel: bindActionCreators(patchChannel, dispatch)
-        }
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: {
+        patchChannel: bindActionCreators(patchChannel, dispatch)
+    }
+});
 
 export default connect(
     mapStateToProps,

--- a/components/edit_channel_purpose_modal/index.js
+++ b/components/edit_channel_purpose_modal/index.js
@@ -20,13 +20,11 @@ const mapStateToProps = createSelector(
     (ctrlSend, requestInfo) => ({ctrlSend, ...requestInfo})
 );
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: {
-            patchChannel: bindActionCreators(patchChannel, dispatch)
-        }
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: {
+        patchChannel: bindActionCreators(patchChannel, dispatch)
+    }
+});
 
 export default connect(
     mapStateToProps,

--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -14,22 +14,18 @@ import {getEditingPost} from 'selectors/posts';
 
 import EditPostModal from './edit_post_modal.jsx';
 
-function mapStateToProps(state) {
-    return {
-        ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
-        config: getConfig(state),
-        editingPost: getEditingPost(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
+    config: getConfig(state),
+    editingPost: getEditingPost(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            addMessageIntoHistory,
-            editPost,
-            hideEditPostModal
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        addMessageIntoHistory,
+        editPost,
+        hideEditPostModal
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditPostModal);

--- a/components/emoji/emoji_list/index.js
+++ b/components/emoji/emoji_list/index.js
@@ -10,19 +10,15 @@ import {getCustomEmojis, searchCustomEmojis} from 'mattermost-redux/actions/emoj
 
 import EmojiList from './emoji_list.jsx';
 
-function mapStateToProps(state) {
-    return {
-        emojiIds: getCustomEmojiIdsSortedByName(state) || []
-    };
-}
+const mapStateToProps = (state) => ({
+    emojiIds: getCustomEmojiIdsSortedByName(state) || []
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getCustomEmojis,
-            searchCustomEmojis
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getCustomEmojis,
+        searchCustomEmojis
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(EmojiList);

--- a/components/emoji/emoji_list_item/index.js
+++ b/components/emoji/emoji_list_item/index.js
@@ -12,7 +12,7 @@ import {displayUsernameForUser} from 'utils/utils.jsx';
 
 import EmojiListItem from './emoji_list_item.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const emoji = state.entities.emojis.customEmoji[ownProps.emojiId];
     const creator = getUser(state, emoji.creator_id) || {};
 
@@ -23,14 +23,12 @@ function mapStateToProps(state, ownProps) {
         currentUserId: getCurrentUserId(state),
         isSystemAdmin: isCurrentUserSystemAdmin(state)
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            deleteCustomEmoji
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        deleteCustomEmoji
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(EmojiListItem);

--- a/components/emoji/index.js
+++ b/components/emoji/index.js
@@ -7,7 +7,7 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import EmojiPage from './emoji_page.jsx';
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const team = getCurrentTeam(state) || {};
 
     return {
@@ -15,6 +15,6 @@ function mapStateToProps(state) {
         teamDisplayName: team.display_name,
         siteName: state.entities.general.config.SiteName
     };
-}
+};
 
 export default connect(mapStateToProps)(EmojiPage);

--- a/components/emoji_picker/index.js
+++ b/components/emoji_picker/index.js
@@ -11,22 +11,18 @@ import {getEmojiMap} from 'selectors/emojis';
 
 import EmojiPicker from './emoji_picker.jsx';
 
-function mapStateToProps(state) {
-    return {
-        customEmojisEnabled: state.entities.general.config.EnableCustomEmoji === 'true',
-        customEmojiPage: state.views.emoji.emojiPickerCustomPage,
-        emojiMap: getEmojiMap(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    customEmojisEnabled: state.entities.general.config.EnableCustomEmoji === 'true',
+    customEmojiPage: state.views.emoji.emojiPickerCustomPage,
+    emojiMap: getEmojiMap(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getCustomEmojis,
-            searchCustomEmojis,
-            incrementEmojiPickerPage
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getCustomEmojis,
+        searchCustomEmojis,
+        incrementEmojiPickerPage
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(EmojiPicker);

--- a/components/file_attachment_list/index.js
+++ b/components/file_attachment_list/index.js
@@ -8,9 +8,9 @@ import {makeGetFilesForPost} from 'mattermost-redux/selectors/entities/files';
 
 import FileAttachmentList from './file_attachment_list.jsx';
 
-function makeMapStateToProps() {
+const makeMapStateToProps = () => {
     const selectFilesForPost = makeGetFilesForPost();
-    return function mapStateToProps(state, ownProps) {
+    return (state, ownProps) => {
         const postId = ownProps.post ? ownProps.post.id : '';
         const fileInfos = selectFilesForPost(state, postId);
 
@@ -26,7 +26,7 @@ function makeMapStateToProps() {
             fileCount
         };
     };
-}
+};
 
 const mapDispatchToProps = (dispatch) => ({
     actions: bindActionCreators({

--- a/components/file_attachment_list/index.js
+++ b/components/file_attachment_list/index.js
@@ -22,19 +22,16 @@ function makeMapStateToProps() {
         }
 
         return {
-            ...ownProps,
             fileInfos,
             fileCount
         };
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getMissingFilesForPost
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getMissingFilesForPost
+    }, dispatch)
+});
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(FileAttachmentList);

--- a/components/file_upload/index.js
+++ b/components/file_upload/index.js
@@ -9,12 +9,9 @@ import {uploadFile} from 'actions/file_actions.jsx';
 
 import FileUpload from './file_upload.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        currentChannelId: getCurrentChannelId(state),
-        uploadFile
-    };
-}
+const mapStateToProps = (state) => ({
+    currentChannelId: getCurrentChannelId(state),
+    uploadFile
+});
 
 export default connect(mapStateToProps)(FileUpload);

--- a/components/get_post_link_modal/index.js
+++ b/components/get_post_link_modal/index.js
@@ -8,13 +8,12 @@ import {getSiteURL} from 'utils/url.jsx';
 
 import GetPostLinkModal from './get_post_link_modal';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state) => {
     const currentTeam = getCurrentTeam(state) || {};
     const currentTeamUrl = `${getSiteURL()}/${currentTeam.name}`;
     return {
-        ...ownProps,
         currentTeamUrl
     };
-}
+};
 
 export default connect(mapStateToProps)(GetPostLinkModal);

--- a/components/get_public_link_modal/index.js
+++ b/components/get_public_link_modal/index.js
@@ -5,19 +5,14 @@ import * as Selectors from 'mattermost-redux/selectors/entities/files';
 
 import GetPublicLinkModal from './get_public_link_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        link: Selectors.getFilePublicLink(state).link
-    };
-}
+const mapStateToProps = (state) => ({
+    link: Selectors.getFilePublicLink(state).link
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getFilePublicLink
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getFilePublicLink
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(GetPublicLinkModal);

--- a/components/get_team_invite_link_modal/index.js
+++ b/components/get_team_invite_link_modal/index.js
@@ -4,12 +4,9 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import GetTeamInviteLinkModal from './get_team_invite_link_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        currentTeam: getCurrentTeam(state),
-        config: getConfig(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    currentTeam: getCurrentTeam(state),
+    config: getConfig(state)
+});
 
 export default connect(mapStateToProps)(GetTeamInviteLinkModal);

--- a/components/header_footer_template/index.js
+++ b/components/header_footer_template/index.js
@@ -6,11 +6,8 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import NotLoggedIn from './header_footer_template.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        config: getConfig(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    config: getConfig(state)
+});
 
 export default connect(mapStateToProps)(NotLoggedIn);

--- a/components/integrations/components/add_command/index.js
+++ b/components/integrations/components/add_command/index.js
@@ -7,18 +7,10 @@ import {addCommand} from 'mattermost-redux/actions/integrations';
 
 import AddCommand from './add_command.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        addCommand
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            addCommand
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(AddCommand);
+export default connect(null, mapDispatchToProps)(AddCommand);

--- a/components/integrations/components/add_incoming_webhook/index.js
+++ b/components/integrations/components/add_incoming_webhook/index.js
@@ -7,25 +7,22 @@ import {createIncomingHook} from 'mattermost-redux/actions/integrations';
 
 import AddIncomingWebhook from './add_incoming_webhook.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state) => {
     const config = state.entities.general.config;
     const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
     const enablePostIconOverride = config.EnablePostIconOverride === 'true';
 
     return {
-        ...ownProps,
         createIncomingHookRequest: state.requests.integrations.createIncomingHook,
         enablePostUsernameOverride,
         enablePostIconOverride
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            createIncomingHook
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        createIncomingHook
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(AddIncomingWebhook);

--- a/components/integrations/components/add_oauth_app/index.js
+++ b/components/integrations/components/add_oauth_app/index.js
@@ -8,20 +8,15 @@ import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/user
 
 import AddOAuthApp from './add_oauth_app.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        addOAuthAppRequest: state.requests.integrations.addOAuthApp,
-        isSystemAdmin: isCurrentUserSystemAdmin(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    addOAuthAppRequest: state.requests.integrations.addOAuthApp,
+    isSystemAdmin: isCurrentUserSystemAdmin(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            addOAuthApp
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        addOAuthApp
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(AddOAuthApp);

--- a/components/integrations/components/add_outgoing_webhook/index.js
+++ b/components/integrations/components/add_outgoing_webhook/index.js
@@ -7,19 +7,14 @@ import {createOutgoingHook} from 'mattermost-redux/actions/integrations';
 
 import AddOutgoingWebhook from './add_outgoing_webhook.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        createOutgoingHookRequest: state.requests.integrations.createOutgoingHook
-    };
-}
+const mapStateToProps = (state) => ({
+    createOutgoingHookRequest: state.requests.integrations.createOutgoingHook
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            createOutgoingHook
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        createOutgoingHook
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(AddOutgoingWebhook);

--- a/components/integrations/components/commands_container/index.js
+++ b/components/integrations/components/commands_container/index.js
@@ -9,20 +9,15 @@ import {getUsers} from 'mattermost-redux/selectors/entities/users';
 
 import CommandsContainer from './commands_container.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        commands: Object.values(getCommands(state)),
-        users: getUsers(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    commands: Object.values(getCommands(state)),
+    users: getUsers(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getCustomTeamCommands
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getCustomTeamCommands
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(CommandsContainer);

--- a/components/integrations/components/confirm_integration/index.js
+++ b/components/integrations/components/confirm_integration/index.js
@@ -6,11 +6,8 @@ import {getCommands} from 'mattermost-redux/selectors/entities/integrations';
 
 import ConfirmIntegration from './confirm_integration.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        commands: getCommands(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    commands: getCommands(state)
+});
 
 export default connect(mapStateToProps)(ConfirmIntegration);

--- a/components/integrations/components/edit_command/index.js
+++ b/components/integrations/components/edit_command/index.js
@@ -8,23 +8,20 @@ import {getCommands} from 'mattermost-redux/selectors/entities/integrations';
 
 import EditCommand from './edit_command.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const commandId = (new URLSearchParams(ownProps.location.search)).get('id');
 
     return {
-        ...ownProps,
         commandId,
         commands: getCommands(state)
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getCustomTeamCommands,
-            editCommand
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getCustomTeamCommands,
+        editCommand
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditCommand);

--- a/components/integrations/components/edit_incoming_webhook/index.js
+++ b/components/integrations/components/edit_incoming_webhook/index.js
@@ -7,7 +7,7 @@ import {getIncomingHook, updateIncomingHook} from 'mattermost-redux/actions/inte
 
 import EditIncomingWebhook from './edit_incoming_webhook.jsx';
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, ownProps) => {
     const config = state.entities.general.config;
     const enableIncomingWebhooks = config.EnableIncomingWebhooks === 'true';
     const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';

--- a/components/integrations/components/edit_incoming_webhook/index.js
+++ b/components/integrations/components/edit_incoming_webhook/index.js
@@ -7,7 +7,7 @@ import {getIncomingHook, updateIncomingHook} from 'mattermost-redux/actions/inte
 
 import EditIncomingWebhook from './edit_incoming_webhook.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state) => {
     const config = state.entities.general.config;
     const enableIncomingWebhooks = config.EnableIncomingWebhooks === 'true';
     const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
@@ -15,7 +15,6 @@ function mapStateToProps(state, ownProps) {
     const hookId = (new URLSearchParams(ownProps.location.search)).get('id');
 
     return {
-        ...ownProps,
         hookId,
         hook: state.entities.integrations.incomingHooks[hookId],
         updateIncomingHookRequest: state.requests.integrations.updateIncomingHook,
@@ -23,15 +22,13 @@ function mapStateToProps(state, ownProps) {
         enablePostUsernameOverride,
         enablePostIconOverride
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            updateIncomingHook,
-            getIncomingHook
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        updateIncomingHook,
+        getIncomingHook
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditIncomingWebhook);

--- a/components/integrations/components/edit_oauth_app/index.js
+++ b/components/integrations/components/edit_oauth_app/index.js
@@ -8,24 +8,21 @@ import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/user
 
 import EditOAuthApp from './edit_oauth_app.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const oauthAppId = (new URLSearchParams(ownProps.location.search)).get('id');
 
     return {
-        ...ownProps,
         isSystemAdmin: isCurrentUserSystemAdmin(state),
         oauthAppId,
         oauthApp: state.entities.integrations.oauthApps[oauthAppId]
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getOAuthApp,
-            editOAuthApp
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getOAuthApp,
+        editOAuthApp
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditOAuthApp);

--- a/components/integrations/components/edit_outgoing_webhook/index.js
+++ b/components/integrations/components/edit_outgoing_webhook/index.js
@@ -7,24 +7,21 @@ import {getOutgoingHook, updateOutgoingHook} from 'mattermost-redux/actions/inte
 
 import EditOutgoingWebhook from './edit_outgoing_webhook.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const hookId = (new URLSearchParams(ownProps.location.search)).get('id');
 
     return {
-        ...ownProps,
         hookId,
         hook: state.entities.integrations.outgoingHooks[hookId],
         updateOutgoingHookRequest: state.requests.integrations.createOutgoingHook
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            updateOutgoingHook,
-            getOutgoingHook
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        updateOutgoingHook,
+        getOutgoingHook
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditOutgoingWebhook);

--- a/components/integrations/components/installed_commands/index.js
+++ b/components/integrations/components/installed_commands/index.js
@@ -7,19 +7,11 @@ import {deleteCommand, regenCommandToken} from 'mattermost-redux/actions/integra
 
 import InstalledCommands from './installed_commands.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        regenCommandToken,
+        deleteCommand
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            regenCommandToken,
-            deleteCommand
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(InstalledCommands);
+export default connect(null, mapDispatchToProps)(InstalledCommands);

--- a/components/integrations/components/installed_incoming_webhooks/index.js
+++ b/components/integrations/components/installed_incoming_webhooks/index.js
@@ -11,7 +11,7 @@ import {getUsers} from 'mattermost-redux/selectors/entities/users';
 
 import InstalledIncomingWebhooks from './installed_incoming_webhooks.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state) => {
     const teamId = getCurrentTeamId(state);
     const incomingHooks = getIncomingHooks(state);
     const incomingWebhooks = Object.keys(incomingHooks).
@@ -19,21 +19,18 @@ function mapStateToProps(state, ownProps) {
         filter((incomingWebhook) => incomingWebhook.team_id === teamId);
 
     return {
-        ...ownProps,
         incomingWebhooks,
         channels: getAllChannels(state),
         users: getUsers(state),
         teamId
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getIncomingHooks: Actions.getIncomingHooks,
-            removeIncomingHook: Actions.removeIncomingHook
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getIncomingHooks: Actions.getIncomingHooks,
+        removeIncomingHook: Actions.removeIncomingHook
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(InstalledIncomingWebhooks);

--- a/components/integrations/components/installed_oauth_apps/index.js
+++ b/components/integrations/components/installed_oauth_apps/index.js
@@ -9,23 +9,18 @@ import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/user
 
 import InstalledOAuthApps from './installed_oauth_apps.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        oauthApps: getOAuthApps(state),
-        isSystemAdmin: isCurrentUserSystemAdmin(state),
-        regenOAuthAppSecretRequest: state.requests.integrations.updateOAuthApp
-    };
-}
+const mapStateToProps = (state) => ({
+    oauthApps: getOAuthApps(state),
+    isSystemAdmin: isCurrentUserSystemAdmin(state),
+    regenOAuthAppSecretRequest: state.requests.integrations.updateOAuthApp
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getOAuthApps: Actions.getOAuthApps,
-            regenOAuthAppSecret: Actions.regenOAuthAppSecret,
-            deleteOAuthApp: Actions.deleteOAuthApp
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getOAuthApps: Actions.getOAuthApps,
+        regenOAuthAppSecret: Actions.regenOAuthAppSecret,
+        deleteOAuthApp: Actions.deleteOAuthApp
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(InstalledOAuthApps);

--- a/components/integrations/components/installed_outgoing_webhooks/index.js
+++ b/components/integrations/components/installed_outgoing_webhooks/index.js
@@ -8,7 +8,7 @@ import {getUsers} from 'mattermost-redux/selectors/entities/users';
 
 import InstalledOutgoingWebhook from './installed_outgoing_webhooks.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state) => {
     const teamId = getCurrentTeamId(state);
     const outgoingHooks = getOutgoingHooks(state);
     const outgoingWebhooks = Object.keys(outgoingHooks).
@@ -16,22 +16,19 @@ function mapStateToProps(state, ownProps) {
         filter((outgoingWebhook) => outgoingWebhook.team_id === teamId);
 
     return {
-        ...ownProps,
         outgoingWebhooks,
         channels: getAllChannels(state),
         users: getUsers(state),
         teamId
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getOutgoingHooks: Actions.getOutgoingHooks,
-            removeOutgoingHook: Actions.removeOutgoingHook,
-            regenOutgoingHookToken: Actions.regenOutgoingHookToken
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getOutgoingHooks: Actions.getOutgoingHooks,
+        removeOutgoingHook: Actions.removeOutgoingHook,
+        regenOutgoingHookToken: Actions.regenOutgoingHookToken
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(InstalledOutgoingWebhook);

--- a/components/member_list_channel/index.js
+++ b/components/member_list_channel/index.js
@@ -7,12 +7,10 @@ import {getChannelStats} from 'mattermost-redux/actions/channels';
 
 import MemberListChannel from './member_list_channel.jsx';
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getChannelStats
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getChannelStats
+    }, dispatch)
+});
 
 export default connect(null, mapDispatchToProps)(MemberListChannel);

--- a/components/member_list_team/index.js
+++ b/components/member_list_team/index.js
@@ -7,18 +7,10 @@ import {getTeamStats} from 'mattermost-redux/actions/teams';
 
 import MemberListTeam from './member_list_team.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getTeamStats
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getTeamStats
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(MemberListTeam);
+export default connect(null, mapDispatchToProps)(MemberListTeam);

--- a/components/modal_controller/index.js
+++ b/components/modal_controller/index.js
@@ -8,19 +8,14 @@ import {closeModal} from 'actions/views/modals';
 
 import ModalController from './modal_controller.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        modals: state.views.modals
-    };
-}
+const mapStateToProps = (state) => ({
+    modals: state.views.modals
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            closeModal
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        closeModal
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(ModalController);

--- a/components/more_channels/index.js
+++ b/components/more_channels/index.js
@@ -7,18 +7,10 @@ import {getChannels} from 'mattermost-redux/actions/channels';
 
 import MoreChannels from './more_channels.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getChannels
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getChannels
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(MoreChannels);
+export default connect(null, mapDispatchToProps)(MoreChannels);

--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -8,20 +8,15 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import MoreDirectChannels from './more_direct_channels.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        currentUserId: getCurrentUserId(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    currentUserId: getCurrentUserId(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getProfiles,
-            getProfilesInTeam
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getProfiles,
+        getProfilesInTeam
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(MoreDirectChannels);

--- a/components/navbar/index.js
+++ b/components/navbar/index.js
@@ -10,22 +10,20 @@ import {RHSStates} from 'utils/constants.jsx';
 
 import Navbar from './navbar.jsx';
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const rhsState = getRhsState(state);
 
     return {
         isPinnedPosts: rhsState === RHSStates.PIN
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            closeRightHandSide,
-            updateRhsState,
-            showPinnedPosts
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        closeRightHandSide,
+        updateRhsState,
+        showPinnedPosts
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(Navbar);

--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -28,7 +28,7 @@ import ChannelMembersModal from 'components/channel_members_modal';
 import ChannelNotificationsModal from 'components/channel_notifications_modal/channel_notifications_modal.jsx';
 import DeleteChannelModal from 'components/delete_channel_modal';
 import NotifyCounts from 'components/notify_counts.jsx';
-import QuickSwitchModal from 'components/quick_switch_modal';
+import QuickSwitchModal from 'components/quick_switch_modal/quick_switch_modal';
 import RenameChannelModal from 'components/rename_channel_modal';
 import StatusIcon from 'components/status_icon.jsx';
 import MenuIcon from 'components/svg/menu_icon';

--- a/components/needs_team/index.js
+++ b/components/needs_team/index.js
@@ -10,22 +10,18 @@ import {withRouter} from 'react-router-dom';
 
 import NeedsTeam from './needs_team.jsx';
 
-function mapStateToProps(state) {
-    return {
-        theme: getTheme(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    theme: getTheme(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            fetchMyChannelsAndMembers,
-            getMyTeamUnreads,
-            viewChannel,
-            markChannelAsRead,
-            getMyChannelMembers
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        fetchMyChannelsAndMembers,
+        getMyTeamUnreads,
+        viewChannel,
+        markChannelAsRead,
+        getMyChannelMembers
+    }, dispatch)
+});
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(NeedsTeam));

--- a/components/new_channel_modal/index.js
+++ b/components/new_channel_modal/index.js
@@ -9,13 +9,10 @@ import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/user
 
 import NewChannelModal from './new_channel_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
-        isTeamAdmin: isCurrentUserCurrentTeamAdmin(state),
-        isSystemAdmin: isCurrentUserSystemAdmin(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
+    isTeamAdmin: isCurrentUserCurrentTeamAdmin(state),
+    isSystemAdmin: isCurrentUserSystemAdmin(state)
+});
 
 export default connect(mapStateToProps)(NewChannelModal);

--- a/components/persist_gate/index.js
+++ b/components/persist_gate/index.js
@@ -5,10 +5,8 @@ import {connect} from 'react-redux';
 
 import PersistGate from './persist_gate';
 
-function mapStateToProps(state) {
-    return {
-        initialized: state.storage.initialized
-    };
-}
+const mapStateToProps = (state) => ({
+    initialized: state.storage.initialized
+});
 
 export default connect(mapStateToProps)(PersistGate);

--- a/components/popover_list_members/index.js
+++ b/components/popover_list_members/index.js
@@ -9,10 +9,10 @@ import {getCurrentUserId, makeGetProfilesInChannel} from 'mattermost-redux/selec
 
 import PopoverListMembers from './popover_list_members.jsx';
 
-function makeMapStateToProps() {
+const makeMapStateToProps = () => {
     const doGetProfilesInChannel = makeGetProfilesInChannel();
 
-    return function mapStateToProps(state, ownProps) {
+    return (state, ownProps) => {
         const stats = getAllChannelStats(state)[ownProps.channel.id] || {};
         const members = doGetProfilesInChannel(state, ownProps.channel.id, true);
 
@@ -22,7 +22,7 @@ function makeMapStateToProps() {
             currentUserId: getCurrentUserId(state)
         };
     };
-}
+};
 
 const mapDispatchToProps = (dispatch) => ({
     actions: bindActionCreators({

--- a/components/popover_list_members/index.js
+++ b/components/popover_list_members/index.js
@@ -17,7 +17,6 @@ function makeMapStateToProps() {
         const members = doGetProfilesInChannel(state, ownProps.channel.id, true);
 
         return {
-            ...ownProps,
             memberCount: stats.member_count,
             members,
             currentUserId: getCurrentUserId(state)
@@ -25,12 +24,10 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getProfilesInChannel
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getProfilesInChannel
+    }, dispatch)
+});
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(PopoverListMembers);

--- a/components/post_emoji/index.jsx
+++ b/components/post_emoji/index.jsx
@@ -11,7 +11,7 @@ import {getEmojiMap} from 'selectors/emojis';
 
 import PostEmoji from './post_emoji.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const emojiMap = getEmojiMap(state);
     const emoji = emojiMap.get(ownProps.name);
 
@@ -29,6 +29,6 @@ function mapStateToProps(state, ownProps) {
         imageUrl,
         displayTextOnly
     };
-}
+};
 
 export default connect(mapStateToProps)(PostEmoji);

--- a/components/post_markdown/index.js
+++ b/components/post_markdown/index.js
@@ -22,13 +22,11 @@ const getChannelNamesMap = createSelector(
     }
 );
 
-function mapStateToProps(state) {
-    return {
-        channelNamesMap: getChannelNamesMap(state),
-        mentionKeys: getCurrentUserMentionKeys(state),
-        siteURL: getSiteURL(),
-        team: getCurrentTeam(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    channelNamesMap: getChannelNamesMap(state),
+    mentionKeys: getCurrentUserMentionKeys(state),
+    siteURL: getSiteURL(),
+    team: getCurrentTeam(state)
+});
 
 export default connect(mapStateToProps)(PostMarkdown);

--- a/components/post_view/commented_on_files_message/index.js
+++ b/components/post_view/commented_on_files_message/index.js
@@ -18,18 +18,15 @@ function makeMapStateToProps() {
         }
 
         return {
-            ...ownProps,
             fileInfos
         };
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getFilesForPost
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getFilesForPost
+    }, dispatch)
+});
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(CommentedOnFilesMessage);

--- a/components/post_view/commented_on_files_message/index.js
+++ b/components/post_view/commented_on_files_message/index.js
@@ -8,10 +8,10 @@ import {makeGetFilesForPost} from 'mattermost-redux/selectors/entities/files';
 
 import CommentedOnFilesMessage from './commented_on_files_message.jsx';
 
-function makeMapStateToProps() {
+const makeMapStateToProps = () => {
     const selectFileInfosForPost = makeGetFilesForPost();
 
-    return function mapStateToProps(state, ownProps) {
+    return (state, ownProps) => {
         let fileInfos;
         if (ownProps.parentPostId) {
             fileInfos = selectFileInfosForPost(state, ownProps.parentPostId);
@@ -21,7 +21,7 @@ function makeMapStateToProps() {
             fileInfos
         };
     };
-}
+};
 
 const mapDispatchToProps = (dispatch) => ({
     actions: bindActionCreators({

--- a/components/post_view/failed_post_options/index.js
+++ b/components/post_view/failed_post_options/index.js
@@ -7,18 +7,10 @@ import {removePost} from 'mattermost-redux/actions/posts';
 
 import FailedPostOptions from './failed_post_options.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        removePost
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            removePost
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(FailedPostOptions);
+export default connect(null, mapDispatchToProps)(FailedPostOptions);

--- a/components/post_view/index.js
+++ b/components/post_view/index.js
@@ -15,11 +15,11 @@ import {Preferences} from 'utils/constants.jsx';
 
 import PostList from './post_list.jsx';
 
-function makeMapStateToProps() {
+const makeMapStateToProps = () => {
     const getPostsInChannel = makeGetPostsInChannel();
     const getPostsAroundPost = makeGetPostsAroundPost();
 
-    return function mapStateToProps(state, ownProps) {
+    return (state, ownProps) => {
         let posts;
         if (ownProps.focusedPostId) {
             posts = getPostsAroundPost(state, ownProps.focusedPostId, ownProps.channelId);
@@ -38,7 +38,7 @@ function makeMapStateToProps() {
             fullWidth: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN
         };
     };
-}
+};
 
 const mapDispatchToProps = (dispatch) => ({
     actions: bindActionCreators({

--- a/components/post_view/index.js
+++ b/components/post_view/index.js
@@ -40,17 +40,15 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getPosts,
-            getPostsBefore,
-            getPostsAfter,
-            getPostThread,
-            increasePostVisibility,
-            checkAndSetMobileView
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getPosts,
+        getPostsBefore,
+        getPostsAfter,
+        getPostThread,
+        increasePostVisibility,
+        checkAndSetMobileView
+    }, dispatch)
+});
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(PostList);

--- a/components/post_view/post/index.js
+++ b/components/post_view/post/index.js
@@ -10,7 +10,7 @@ import {Preferences} from 'utils/constants.jsx';
 
 import Post from './post.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const detailedPost = ownProps.post || {};
 
     return {
@@ -28,6 +28,6 @@ function mapStateToProps(state, ownProps) {
         center: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_CENTERED,
         compactDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.MESSAGE_DISPLAY, Preferences.MESSAGE_DISPLAY_DEFAULT) === Preferences.MESSAGE_DISPLAY_COMPACT
     };
-}
+};
 
 export default connect(mapStateToProps)(Post);

--- a/components/post_view/post_add_channel_member/index.js
+++ b/components/post_view/post_add_channel_member/index.js
@@ -12,25 +12,22 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import PostAddChannelMember from './post_add_channel_member.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state) => {
     const currentChannelId = getCurrentChannelId(state);
 
     return {
-        ...ownProps,
         team: getCurrentTeam(state),
         channel: getChannel(state, currentChannelId),
         currentUser: getCurrentUser(state)
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            addChannelMember,
-            getPost,
-            removePost
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        addChannelMember,
+        getPost,
+        removePost
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(PostAddChannelMember);

--- a/components/post_view/post_attachment_opengraph/index.js
+++ b/components/post_view/post_attachment_opengraph/index.js
@@ -9,20 +9,15 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import PostAttachmentOpenGraph from './post_attachment_opengraph.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        openGraphData: getOpenGraphMetadataForUrl(state, ownProps.link),
-        currentUser: getCurrentUser(state)
-    };
-}
+const mapStateToProps = (state, ownProps) => ({
+    openGraphData: getOpenGraphMetadataForUrl(state, ownProps.link),
+    currentUser: getCurrentUser(state)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getOpenGraphMetadata
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getOpenGraphMetadata
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(PostAttachmentOpenGraph);

--- a/components/post_view/post_body/index.js
+++ b/components/post_view/post_body/index.js
@@ -11,7 +11,7 @@ import {Preferences, StoragePrefixes} from 'utils/constants.jsx';
 
 import PostBody from './post_body.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     let parentPost;
     let parentPostUser;
     const previewCollapsed = get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.COLLAPSE_DISPLAY, Preferences.COLLAPSE_DISPLAY_DEFAULT);
@@ -22,7 +22,6 @@ function mapStateToProps(state, ownProps) {
     }
 
     return {
-        ...ownProps,
         parentPost,
         parentPostUser,
         pluginPostTypes: state.plugins.postTypes,
@@ -30,6 +29,6 @@ function mapStateToProps(state, ownProps) {
         previewEnabled: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, true),
         isEmbedVisible
     };
-}
+};
 
 export default connect(mapStateToProps)(PostBody);

--- a/components/post_view/post_header/index.js
+++ b/components/post_view/post_header/index.js
@@ -7,11 +7,8 @@ import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import PostHeader from './post_header.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        displayNameType: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, 'name_format', 'false')
-    };
-}
+const mapStateToProps = (state) => ({
+    displayNameType: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, 'name_format', 'false')
+});
 
 export default connect(mapStateToProps)(PostHeader);

--- a/components/post_view/post_info/index.js
+++ b/components/post_view/post_info/index.js
@@ -10,22 +10,17 @@ import {Preferences} from 'utils/constants.jsx';
 
 import PostInfo from './post_info.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        useMilitaryTime: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false),
-        isFlagged: get(state, Preferences.CATEGORY_FLAGGED_POST, ownProps.post.id, null) != null,
-        isMobile: state.views.channel.mobileView
-    };
-}
+const mapStateToProps = (state, ownProps) => ({
+    useMilitaryTime: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false),
+    isFlagged: get(state, Preferences.CATEGORY_FLAGGED_POST, ownProps.post.id, null) != null,
+    isMobile: state.views.channel.mobileView
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            removePost,
-            addReaction
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        removePost,
+        addReaction
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(PostInfo);

--- a/components/post_view/post_message_view/index.js
+++ b/components/post_view/post_message_view/index.js
@@ -7,12 +7,10 @@ import {getTheme, getBool} from 'mattermost-redux/selectors/entities/preferences
 
 import PostMessageView from './post_message_view.jsx';
 
-function mapStateToProps(state) {
-    return {
-        enableFormatting: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true),
-        pluginPostTypes: state.plugins.postTypes,
-        theme: getTheme(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    enableFormatting: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true),
+    pluginPostTypes: state.plugins.postTypes,
+    theme: getTheme(state)
+});
 
 export default connect(mapStateToProps)(PostMessageView);

--- a/components/post_view/post_time.jsx
+++ b/components/post_view/post_time.jsx
@@ -39,7 +39,6 @@ export default class PostTime extends React.PureComponent {
 
     constructor(props) {
         super(props);
-
         this.state = {
             currentTeamDisplayName: TeamStore.getCurrent().name
         };

--- a/components/post_view/reaction/index.js
+++ b/components/post_view/reaction/index.js
@@ -30,8 +30,7 @@ function makeMapStateToProps() {
         }
 
         return {
-            ...ownProps,
-            profiles,
+                profiles,
             otherUsersCount: ownProps.reactions.length - profiles.length,
             currentUserId: getCurrentUserId(state),
             reactionCount: ownProps.reactions.length,
@@ -40,14 +39,12 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            addReaction,
-            removeReaction,
-            getMissingProfilesByIds
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        addReaction,
+        removeReaction,
+        getMissingProfilesByIds
+    }, dispatch)
+});
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(Reaction);

--- a/components/post_view/reaction/index.js
+++ b/components/post_view/reaction/index.js
@@ -12,10 +12,10 @@ import * as Emoji from 'utils/emoji.jsx';
 
 import Reaction from './reaction.jsx';
 
-function makeMapStateToProps() {
+const makeMapStateToProps = () => {
     const getProfilesForReactions = makeGetProfilesForReactions();
 
-    return function mapStateToProps(state, ownProps) {
+    return (state, ownProps) => {
         const profiles = getProfilesForReactions(state, ownProps.reactions);
         let emoji;
         if (Emoji.EmojiIndicesByAlias.has(ownProps.emojiName)) {
@@ -30,14 +30,14 @@ function makeMapStateToProps() {
         }
 
         return {
-                profiles,
+            profiles,
             otherUsersCount: ownProps.reactions.length - profiles.length,
             currentUserId: getCurrentUserId(state),
             reactionCount: ownProps.reactions.length,
             emojiImageUrl
         };
     };
-}
+};
 
 const mapDispatchToProps = (dispatch) => ({
     actions: bindActionCreators({

--- a/components/post_view/reaction_list/index.js
+++ b/components/post_view/reaction_list/index.js
@@ -9,16 +9,16 @@ import {makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts
 
 import ReactionList from './reaction_list.jsx';
 
-function makeMapStateToProps() {
+const makeMapStateToProps = () => {
     const getReactionsForPost = makeGetReactionsForPost();
 
-    return function mapStateToProps(state, ownProps) {
+    return (state, ownProps) => {
         return {
             reactions: getReactionsForPost(state, ownProps.post.id),
             emojis: getCustomEmojisByName(state)
         };
     };
-}
+};
 
 const mapDispatchToProps = (dispatch) => ({
     actions: bindActionCreators({

--- a/components/post_view/reaction_list/index.js
+++ b/components/post_view/reaction_list/index.js
@@ -14,20 +14,17 @@ function makeMapStateToProps() {
 
     return function mapStateToProps(state, ownProps) {
         return {
-            ...ownProps,
             reactions: getReactionsForPost(state, ownProps.post.id),
             emojis: getCustomEmojisByName(state)
         };
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getReactionsForPost: Actions.getReactionsForPost,
-            addReaction: Actions.addReaction
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getReactionsForPost: Actions.getReactionsForPost,
+        addReaction: Actions.addReaction
+    }, dispatch)
+});
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(ReactionList);

--- a/components/quick_switch_modal/index.js
+++ b/components/quick_switch_modal/index.js
@@ -1,15 +1,6 @@
 // Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import {connect} from 'react-redux';
-
 import QuickSwitchModal from './quick_switch_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        showTeamSwitcher: false
-    };
-}
-
-export default connect(mapStateToProps)(QuickSwitchModal);
+export default QuickSwitchModal;

--- a/components/quick_switch_modal/index.js
+++ b/components/quick_switch_modal/index.js
@@ -1,6 +1,0 @@
-// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
-// See License.txt for license information.
-
-import QuickSwitchModal from './quick_switch_modal.jsx';
-
-export default QuickSwitchModal;

--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -48,7 +48,8 @@ export default class QuickSwitchModal extends React.PureComponent {
     }
 
     static defaultProps = {
-        initialMode: CHANNEL_MODE
+        initialMode: CHANNEL_MODE,
+        showTeamSwitcher: false
     }
 
     constructor(props) {

--- a/components/rename_channel_modal/index.js
+++ b/components/rename_channel_modal/index.js
@@ -24,12 +24,10 @@ const mapStateToProps = createSelector(
     (teamInfo) => ({...teamInfo})
 );
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: {
-            updateChannel: bindActionCreators(UpdateChannel, dispatch)
-        }
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: {
+        updateChannel: bindActionCreators(UpdateChannel, dispatch)
+    }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(RenameChannelModal);

--- a/components/reset_status_modal/index.js
+++ b/components/reset_status_modal/index.js
@@ -12,22 +12,19 @@ import {autoResetStatus} from 'actions/user_actions.jsx';
 
 import ResetStatusModal from './reset_status_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state) => {
     const {currentUserId} = state.entities.users;
     return {
-        ...ownProps,
         autoResetPref: get(state, Preferences.CATEGORY_AUTO_RESET_MANUAL_STATUS, currentUserId, '')
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            autoResetStatus,
-            setStatus,
-            savePreferences
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        autoResetStatus,
+        setStatus,
+        savePreferences
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(ResetStatusModal);

--- a/components/rhs_header_post/index.js
+++ b/components/rhs_header_post/index.js
@@ -14,16 +14,14 @@ import {
 
 import RhsHeaderPost from './rhs_header_post.jsx';
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            showSearchResults,
-            showMentions,
-            showFlaggedPosts,
-            showPinnedPosts,
-            closeRightHandSide
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        showSearchResults,
+        showMentions,
+        showFlaggedPosts,
+        showPinnedPosts,
+        closeRightHandSide
+    }, dispatch)
+});
 
 export default connect(null, mapDispatchToProps)(RhsHeaderPost);

--- a/components/rhs_thread/index.js
+++ b/components/rhs_thread/index.js
@@ -13,11 +13,11 @@ import {getSelectedPost, makeGetPostsEmbedVisibleObj} from 'selectors/rhs.jsx';
 
 import RhsThread from './rhs_thread.jsx';
 
-function makeMapStateToProps() {
+const makeMapStateToProps = () => {
     const getPostsForThread = makeGetPostsForThread();
     const getPostsEmbedVisibleObj = makeGetPostsEmbedVisibleObj();
 
-    return function mapStateToProps(state) {
+    return (state) => {
         const selected = getSelectedPost(state);
 
         let channel = null;
@@ -39,7 +39,7 @@ function makeMapStateToProps() {
             previewEnabled: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, Preferences.LINK_PREVIEW_DISPLAY_DEFAULT)
         };
     };
-}
+};
 
 const mapDispatchToProps = (dispatch) => ({
     actions: bindActionCreators({

--- a/components/rhs_thread/index.js
+++ b/components/rhs_thread/index.js
@@ -41,12 +41,10 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            removePost
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        removePost
+    }, dispatch)
+});
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(RhsThread);

--- a/components/search_bar/index.jsx
+++ b/components/search_bar/index.jsx
@@ -16,7 +16,7 @@ import {RHSStates} from 'utils/constants.jsx';
 
 import SearchBar from './search_bar.jsx';
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const rhsState = getRhsState(state);
 
     return {
@@ -25,18 +25,16 @@ function mapStateToProps(state) {
         isMentionSearch: rhsState === RHSStates.MENTION,
         isFlaggedPosts: rhsState === RHSStates.FLAG
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            updateSearchTerms,
-            showSearchResults,
-            showMentions,
-            showFlaggedPosts,
-            closeRightHandSide
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        updateSearchTerms,
+        showSearchResults,
+        showMentions,
+        showFlaggedPosts,
+        closeRightHandSide
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(SearchBar);

--- a/components/search_results/index.jsx
+++ b/components/search_results/index.jsx
@@ -19,14 +19,14 @@ import SearchResults from './search_results.jsx';
 
 const getCategory = PreferenceSelectors.makeGetCategory();
 
-function makeMapStateToProps() {
+const makeMapStateToProps = () => {
     let results;
     let posts;
     let channels;
     let flaggedPosts;
     let isFlaggedByPostId;
 
-    return function mapStateToProps(state) {
+    return (state) => {
         const newResults = getSearchResults(state);
 
         // Cache posts and channels
@@ -72,7 +72,7 @@ function makeMapStateToProps() {
             compactDisplay: PreferenceSelectors.get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.MESSAGE_DISPLAY, Preferences.MESSAGE_DISPLAY_DEFAULT) === Preferences.MESSAGE_DISPLAY_COMPACT
         };
     };
-}
+};
 
 const mapDispatchToProps = {
     selectPost: selectPostFromRightHandSideSearch

--- a/components/search_results_header/index.jsx
+++ b/components/search_results_header/index.jsx
@@ -8,12 +8,10 @@ import {closeRightHandSide} from 'actions/views/rhs';
 
 import SearchResultsHeader from './search_results_header.jsx';
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            closeRightHandSide
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        closeRightHandSide
+    }, dispatch)
+});
 
 export default connect(null, mapDispatchToProps)(SearchResultsHeader);

--- a/components/search_results_item/index.js
+++ b/components/search_results_item/index.js
@@ -10,20 +10,18 @@ import {closeRightHandSide} from 'actions/views/rhs';
 
 import SearchResultsItem from './search_results_item.jsx';
 
-function mapStateToProps() {
+const mapStateToProps = (state, ownProps) => {
     const getCommentCountForPost = makeGetCommentCountForPost();
-    return (state, ownProps) => ({
+    return {
         currentTeamName: getCurrentTeam(state).name,
         commentCountForPost: getCommentCountForPost(state, {post: ownProps.post})
-    });
-}
-
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            closeRightHandSide
-        }, dispatch)
     };
-}
+};
+
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        closeRightHandSide
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(SearchResultsItem);

--- a/components/select_team/index.js
+++ b/components/select_team/index.js
@@ -8,18 +8,10 @@ import {withRouter} from 'react-router-dom';
 
 import SelectTeam from './select_team.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getTeams
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getTeams
-        }, dispatch)
-    };
-}
-
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(SelectTeam));
+export default withRouter(connect(null, mapDispatchToProps)(SelectTeam));

--- a/components/sidebar/index.js
+++ b/components/sidebar/index.js
@@ -28,7 +28,7 @@ import {GroupUnreadChannels} from 'utils/constants.jsx';
 
 import Sidebar from './sidebar.jsx';
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const config = getConfig(state);
     const currentChannel = getCurrentChannel(state);
     const currentTeammate = currentChannel && currentChannel.teammate_id && getCurrentChannel(state, currentChannel.teammate_id);
@@ -74,14 +74,12 @@ function mapStateToProps(state) {
         isSystemAdmin: isCurrentUserSystemAdmin(state),
         isTeamAdmin: isCurrentUserCurrentTeamAdmin(state)
     };
-}
+};
 
-function mapDispatchToProps() {
-    return {
-        actions: {
-            goToChannelById
-        }
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: {
+        goToChannelById
+    }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(Sidebar);

--- a/components/sidebar/index.js
+++ b/components/sidebar/index.js
@@ -76,7 +76,7 @@ const mapStateToProps = (state) => {
     };
 };
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = () => ({
     actions: {
         goToChannelById
     }

--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -82,13 +82,11 @@ function makeMapStateToProps() {
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            savePreferences,
-            leaveChannel
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        savePreferences,
+        leaveChannel
+    }, dispatch)
+});
 
 export default connect(makeMapStateToProps, mapDispatchToProps, null, {withRef: true})(SidebarChannel);

--- a/components/sidebar_right/index.js
+++ b/components/sidebar_right/index.js
@@ -14,7 +14,7 @@ import {RHSStates} from 'utils/constants.jsx';
 
 import SidebarRight from './sidebar_right.jsx';
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const rhsState = getRhsState(state);
 
     const channelId = getSelectedChannelId(state);
@@ -44,15 +44,13 @@ function mapStateToProps(state) {
         isFlaggedPosts: rhsState === RHSStates.FLAG,
         isPinnedPosts: rhsState === RHSStates.PIN
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getPinnedPosts,
-            getFlaggedPosts
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getPinnedPosts,
+        getFlaggedPosts
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(SidebarRight);

--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -36,8 +36,6 @@ export default class SidebarRight extends React.Component {
     constructor(props) {
         super(props);
 
-        this.plScrolledToBottom = true;
-
         this.state = {
             expanded: false,
             useMilitaryTime: PreferenceStore.getBool(Constants.Preferences.CATEGORY_DISPLAY_SETTINGS, Constants.Preferences.USE_MILITARY_TIME, false)

--- a/components/sidebar_right_menu/index.js
+++ b/components/sidebar_right_menu/index.js
@@ -14,7 +14,7 @@ import {isMobile} from 'utils/utils.jsx';
 
 import SidebarRightMenu from './sidebar_right_menu.jsx';
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const config = getConfig(state);
     const rhsState = getRhsState(state);
 
@@ -25,16 +25,14 @@ function mapStateToProps(state) {
         isMentionSearch: rhsState === RHSStates.MENTION,
         showTutorialTip: enableTutorial && isMobile() && tutorialStep === TutorialSteps.MENU_POPOVER
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            showMentions,
-            showFlaggedPosts,
-            closeRightHandSide
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        showMentions,
+        showFlaggedPosts,
+        closeRightHandSide
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(SidebarRightMenu);

--- a/components/status_dropdown/index.jsx
+++ b/components/status_dropdown/index.jsx
@@ -9,7 +9,7 @@ import {getCurrentUser, getStatusForUserId} from 'mattermost-redux/selectors/ent
 
 import StatusDropdown from 'components/status_dropdown/status_dropdown.jsx';
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const currentUser = getCurrentUser(state);
 
     if (!currentUser) {
@@ -22,14 +22,12 @@ function mapStateToProps(state) {
         profilePicture: Client4.getProfilePictureUrl(userId, currentUser.last_picture_update),
         status: getStatusForUserId(state, userId)
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            setStatus
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        setStatus
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(StatusDropdown);

--- a/components/team_members_dropdown/index.js
+++ b/components/team_members_dropdown/index.js
@@ -9,20 +9,12 @@ import {getUser} from 'mattermost-redux/actions/users';
 
 import TeamMembersDropdown from './team_members_dropdown.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getUser,
+        getTeamStats,
+        getChannelStats
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getUser,
-            getTeamStats,
-            getChannelStats
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(TeamMembersDropdown);
+export default connect(null, mapDispatchToProps)(TeamMembersDropdown);

--- a/components/team_members_modal/index.js
+++ b/components/team_members_modal/index.js
@@ -6,11 +6,8 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import TeamMembersModal from './team_members_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        currentTeam: getCurrentTeam(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    currentTeam: getCurrentTeam(state)
+});
 
 export default connect(mapStateToProps)(TeamMembersModal);

--- a/components/team_sidebar/index.js
+++ b/components/team_sidebar/index.js
@@ -8,18 +8,10 @@ import {withRouter} from 'react-router-dom';
 
 import TeamSidebar from './team_sidebar_controller.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getTeams
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getTeams
-        }, dispatch)
-    };
-}
-
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TeamSidebar));
+export default withRouter(connect(null, mapDispatchToProps)(TeamSidebar));

--- a/components/toggle_modal_button_redux/index.js
+++ b/components/toggle_modal_button_redux/index.js
@@ -8,12 +8,10 @@ import {openModal} from 'actions/views/modals';
 
 import ModalToggleButtonRedux from './toggle_modal_button_redux.jsx';
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            openModal
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        openModal
+    }, dispatch)
+});
 
 export default connect(null, mapDispatchToProps)(ModalToggleButtonRedux);

--- a/components/user_settings/user_settings_general/index.js
+++ b/components/user_settings/user_settings_general/index.js
@@ -7,18 +7,10 @@ import {getMe} from 'mattermost-redux/actions/users';
 
 import UserSettingsGeneralTab from './user_settings_general.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getMe
+    }, dispatch)
+});
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getMe
-        }, dispatch)
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(UserSettingsGeneralTab);
+export default connect(null, mapDispatchToProps)(UserSettingsGeneralTab);

--- a/components/user_settings/user_settings_security/index.js
+++ b/components/user_settings/user_settings_security/index.js
@@ -8,29 +8,26 @@ import * as UserUtils from 'mattermost-redux/utils/user_utils';
 
 import SecurityTab from './user_settings_security.jsx';
 
-function mapStateToProps(state, ownProps) {
+const mapStateToProps = (state, ownProps) => {
     const tokensEnabled = state.entities.general.config.EnableUserAccessTokens === 'true';
     const userHasTokenRole = UserUtils.hasUserAccessTokenRole(ownProps.user.roles) || UserUtils.isSystemAdmin(ownProps.user.roles);
 
     return {
-        ...ownProps,
         userAccessTokens: state.entities.users.myUserAccessTokens,
         canUseAccessTokens: tokensEnabled && userHasTokenRole
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getMe,
-            getUserAccessTokensForUser,
-            createUserAccessToken,
-            revokeUserAccessToken,
-            enableUserAccessToken,
-            disableUserAccessToken,
-            clearUserAccessTokens
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        getMe,
+        getUserAccessTokensForUser,
+        createUserAccessToken,
+        revokeUserAccessToken,
+        enableUserAccessToken,
+        disableUserAccessToken,
+        clearUserAccessTokens
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(SecurityTab);

--- a/components/user_settings/user_settings_sidebar/index.js
+++ b/components/user_settings/user_settings_sidebar/index.js
@@ -17,7 +17,7 @@ import {GroupUnreadChannels} from 'utils/constants.jsx';
 
 import UserSettingsSidebar from './user_settings_sidebar.jsx';
 
-function mapStateToProps(state) {
+const mapStateToProps = (state) => {
     const config = getConfig(state);
 
     return {
@@ -37,14 +37,12 @@ function mapStateToProps(state) {
         showUnreadOption: config.ExperimentalGroupUnreadChannels !== GroupUnreadChannels.DISABLED,
         user: getCurrentUser(state)
     };
-}
+};
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            savePreferences
-        }, dispatch)
-    };
-}
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({
+        savePreferences
+    }, dispatch)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserSettingsSidebar);

--- a/components/youtube_video/index.js
+++ b/components/youtube_video/index.js
@@ -6,11 +6,8 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 
 import YoutubeVideo from './youtube_video.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        currentChannelId: getCurrentChannelId(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    currentChannelId: getCurrentChannelId(state)
+});
 
 export default connect(mapStateToProps)(YoutubeVideo);

--- a/plugins/pluggable/index.js
+++ b/plugins/pluggable/index.js
@@ -6,12 +6,9 @@ import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import Pluggable from './pluggable.jsx';
 
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        components: state.plugins.components,
-        theme: getTheme(state)
-    };
-}
+const mapStateToProps = (state) => ({
+    components: state.plugins.components,
+    theme: getTheme(state)
+});
 
 export default connect(mapStateToProps)(Pluggable);

--- a/tests/components/navbar/__snapshots__/navbar.test.jsx.snap
+++ b/tests/components/navbar/__snapshots__/navbar.test.jsx.snap
@@ -339,10 +339,11 @@ exports[`components/navbar/Navbar should match snapshot, for private channel 1`]
     onHide={[Function]}
     show={false}
   />
-  <Connect(QuickSwitchModal)
+  <QuickSwitchModal
     initialMode="channel"
     onHide={[Function]}
     show={false}
+    showTeamSwitcher={false}
   />
 </div>
 `;
@@ -686,10 +687,11 @@ exports[`components/navbar/Navbar should match snapshot, if WebRTC is not enable
     onHide={[Function]}
     show={false}
   />
-  <Connect(QuickSwitchModal)
+  <QuickSwitchModal
     initialMode="channel"
     onHide={[Function]}
     show={false}
+    showTeamSwitcher={false}
   />
 </div>
 `;
@@ -869,10 +871,11 @@ exports[`components/navbar/Navbar should match snapshot, if enabled WebRTC and D
     onHide={[Function]}
     show={false}
   />
-  <Connect(QuickSwitchModal)
+  <QuickSwitchModal
     initialMode="channel"
     onHide={[Function]}
     show={false}
+    showTeamSwitcher={false}
   />
 </div>
 `;
@@ -1216,10 +1219,11 @@ exports[`components/navbar/Navbar should match snapshot, if not licensed 1`] = `
     onHide={[Function]}
     show={false}
   />
-  <Connect(QuickSwitchModal)
+  <QuickSwitchModal
     initialMode="channel"
     onHide={[Function]}
     show={false}
+    showTeamSwitcher={false}
   />
 </div>
 `;
@@ -1565,10 +1569,11 @@ exports[`components/navbar/Navbar should match snapshot, valid state 1`] = `
     onHide={[Function]}
     show={false}
   />
-  <Connect(QuickSwitchModal)
+  <QuickSwitchModal
     initialMode="channel"
     onHide={[Function]}
     show={false}
+    showTeamSwitcher={false}
   />
 </div>
 `;


### PR DESCRIPTION
This is a refactor to update all redux connect files to 
- use arrow functions
- to remove `ownProps`
- and fix other minor inconsitencies

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Touches critical sections of the codebase (auth, posting, etc.)
