### PR TITLE
Mm 9607- Fix regression that removed error message

### DIFF
--- a/components/select_team/components/select_team_item.jsx
+++ b/components/select_team/components/select_team_item.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
-import {Link} from 'react-router-dom';
 
 import TeamInfoIcon from 'components/svg/team_info_icon';
 import * as Utils from 'utils/utils.jsx';
@@ -16,7 +15,8 @@ export default class SelectTeamItem extends React.PureComponent {
         loading: PropTypes.bool.isRequired
     };
 
-    handleTeamClick = () => {
+    handleTeamClick = (e) => {
+        e.preventDefault();
         this.props.onTeamClick(this.props.team);
     }
 
@@ -32,8 +32,8 @@ export default class SelectTeamItem extends React.PureComponent {
             );
         }
 
-        var descriptionTooltip = '';
-        var showDescriptionTooltip = '';
+        let descriptionTooltip = '';
+        let showDescriptionTooltip = '';
         if (this.props.team.description) {
             descriptionTooltip = (
                 <Tooltip id='team-description__tooltip'>
@@ -59,14 +59,14 @@ export default class SelectTeamItem extends React.PureComponent {
         return (
             <div className='signup-team-dir'>
                 {showDescriptionTooltip}
-                <Link
-                    to={`/${this.props.team.name}/channels/town-square`}
+                <a
+                    href='#'
                     id={Utils.createSafeId(this.props.team.display_name)}
                     onClick={this.handleTeamClick}
                 >
                     <span className='signup-team-dir__name'>{this.props.team.display_name}</span>
                     {icon}
-                </Link>
+                </a>
             </div>
         );
     }

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -28,11 +28,11 @@ export default class SelectTeam extends React.Component {
 
     constructor(props) {
         super(props);
-
-        const state = this.getStateFromStores(false);
-        state.loadingTeamId = '';
-        state.error = null;
-        this.state = state;
+        this.state = {
+            ...this.getStateFromStores(false),
+            loadingTeamId: '',
+            error: null
+        };
     }
 
     componentDidMount() {


### PR DESCRIPTION
Regression: Found while testing https://mattermost.atlassian.net/browse/MM-8757. If a team is at its max users, and I click to join it from the team selection page, I should see an error message that the team is at its maximum (see screenshot from previous version).

#### Summary
Issue was that route was getting pre-maturely updated, which was causing the unmounting and remounting of the select_team component, which made it lose state and not display error message

Fix was to remove `Link` tag and simply use a a tag with no href.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9607

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)