### PR TITLE
fix rightsidebar not hiding properly

### DIFF
--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -99,7 +99,7 @@ export default class SidebarRight extends React.Component {
         WebrtcStore.emitRhsChanged(isOpen);
 
         const wasOpen = prevProps.searchVisible || prevProps.postRightVisible;
-        if ((isOpen && !wasOpen) || (!isOpen && wasOpen)) {
+        if (isOpen !== wasOpen) {
             this.doStrangeThings();
         }
         if (isOpen && !wasOpen) {

--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -99,9 +99,10 @@ export default class SidebarRight extends React.Component {
         WebrtcStore.emitRhsChanged(isOpen);
 
         const wasOpen = prevProps.searchVisible || prevProps.postRightVisible;
-
-        if (isOpen && !wasOpen) {
+        if ((isOpen && !wasOpen) || (!isOpen && wasOpen)) {
             this.doStrangeThings();
+        }
+        if (isOpen && !wasOpen) {
             setTimeout(() => postListScrollChange(), 0);
         }
     }


### PR DESCRIPTION
I betcha wouldn't believe that touching the jquery `doStrangeThings` section broke something.

It wouldn't close anymore. I updated the logic to fire when it opens and when it closes. But *only* then.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)