### PR TITLE
MM-9605: Permalinks to public channels don't join the channels if not in them

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -124,10 +124,6 @@ export async function emitPostFocusEvent(postId, returnTo = '') {
     if (data) {
         const channelId = data.posts[data.order[0]].channel_id;
         const channel = ChannelStore.getChannelById(channelId);
-        if (!channel) {
-            browserHistory.push(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=${returnTo}`);
-            return;
-        }
 
         if (channel && channel.type === Constants.DM_CHANNEL) {
             loadNewDMIfNeeded(channel.id);


### PR DESCRIPTION
#### Summary
Removed the null check on channel. Unfortunately, this will cause [MM-8564](https://mattermost.atlassian.net/browse/MM-8564) to regress, but it seems like the less important bug, since it is only triggered by somebody using an invalid permalink url. There's a [big long discussion about this](https://pre-release.mattermost.com/core/pl/dj1en7cu5bbkjg5rmiqo9xdjpa) on pre-release.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9605

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed