### PR TITLE
MM-9601 Remove duplicate view channel calls on app focus and channel switch

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -8,8 +8,7 @@ import {
     getMyChannelMember,
     joinChannel,
     markChannelAsRead,
-    selectChannel,
-    viewChannel
+    selectChannel
 } from 'mattermost-redux/actions/channels';
 import {getPostThread} from 'mattermost-redux/actions/posts';
 import {removeUserFromTeam} from 'mattermost-redux/actions/teams';
@@ -58,7 +57,6 @@ export function emitChannelClickEvent(channel) {
 
         getMyChannelMemberPromise.then(() => {
             getChannelStats(chan.id)(dispatch, getState);
-            viewChannel(chan.id, oldChannelId)(dispatch, getState);
 
             // Mark previous and next channel as read
             dispatch(markChannelAsRead(chan.id, oldChannelId));

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -135,11 +135,10 @@ export default class NeedsTeam extends React.Component {
         // Set up tracking for whether the window is active
         window.isActive = true;
         $(window).on('focus', async () => {
-            this.props.actions.markChannelAsRead(ChannelStore.getCurrentId());
+            await this.props.actions.markChannelAsRead(ChannelStore.getCurrentId());
             ChannelStore.emitChange();
             window.isActive = true;
 
-            await this.props.actions.viewChannel(ChannelStore.getCurrentId());
             if (new Date().getTime() - this.blurTime > UNREAD_CHECK_TIME_MILLISECONDS) {
                 this.props.actions.getMyChannelMembers(TeamStore.getCurrentId()).then(loadProfilesForSidebar);
             }


### PR DESCRIPTION
#### Summary
#689 introduced mattermost-redux actions (markChannelAsRead) that already contained view channel requests, so we started getting duplicates.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9601