### PR TITLE
configure trim_trailing_whitespace in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 charset = utf-8
 
 [*.go]


### PR DESCRIPTION
#### Summary
Tweak `.editorconfig` to enforce `trim_trailing_whitespace`.