### PR TITLE
Remove mm_config and mm_license global state from webapp (PR #1)

### DIFF
--- a/components/claim/claim_controller.jsx
+++ b/components/claim/claim_controller.jsx
@@ -7,17 +7,12 @@ import {Route, Switch} from 'react-router-dom';
 
 import logoImage from 'images/logo.png';
 import BackButton from 'components/common/back_button.jsx';
-import OauthToEmail from 'components/claim/components/oauth_to_email';
-import EmailToOauth from 'components/claim/components/email_to_oauth';
-import LdapToEmail from 'components/claim/components/ldap_to_email';
-import EmailToLdap from 'components/claim/components/email_to_ldap';
+import OAuthToEmail from 'components/claim/components/oauth_to_email';
+import EmailToOAuth from 'components/claim/components/email_to_oauth';
+import LDAPToEmail from 'components/claim/components/ldap_to_email';
+import EmailToLDAP from 'components/claim/components/email_to_ldap';
 
 export default class ClaimController extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {};
-    }
     componentWillMount() {
         this.setState({
             email: (new URLSearchParams(this.props.location.search)).get('email'),
@@ -25,6 +20,7 @@ export default class ClaimController extends React.Component {
             currentType: (new URLSearchParams(this.props.location.search)).get('old_type')
         });
     }
+
     render() {
         return (
             <div>
@@ -40,36 +36,41 @@ export default class ClaimController extends React.Component {
                                 <Route
                                     path={`${this.props.match.url}/oauth_to_email`}
                                     render={(props) => (
-                                        <OauthToEmail
+                                        <OAuthToEmail
                                             {...this.state}
                                             {...props}
+                                            siteName={this.props.siteName}
                                         />
                                 )}
                                 />
                                 <Route
                                     path={`${this.props.match.url}/email_to_oauth`}
                                     render={(props) => (
-                                        <EmailToOauth
+                                        <EmailToOAuth
                                             {...this.state}
                                             {...props}
+                                            siteName={this.props.siteName}
                                         />
                                 )}
                                 />
                                 <Route
                                     path={`${this.props.match.url}/ldap_to_email`}
                                     render={(props) => (
-                                        <LdapToEmail
+                                        <LDAPToEmail
                                             {...this.state}
                                             {...props}
+                                            siteName={this.props.siteName}
                                         />
                                 )}
                                 />
                                 <Route
                                     path={`${this.props.match.url}/email_to_ldap`}
                                     render={(props) => (
-                                        <EmailToLdap
+                                        <EmailToLDAP
                                             {...this.state}
                                             {...props}
+                                            siteName={this.props.siteName}
+                                            ldapLoginFieldName={this.props.ldapLoginFieldName}
                                         />
                                 )}
                                 />
@@ -82,9 +83,8 @@ export default class ClaimController extends React.Component {
     }
 }
 
-ClaimController.defaultProps = {
-};
 ClaimController.propTypes = {
     location: PropTypes.object.isRequired,
-    children: PropTypes.node
+    siteName: PropTypes.string,
+    ldapLoginFieldName: PropTypes.string
 };

--- a/components/claim/claim_controller.jsx
+++ b/components/claim/claim_controller.jsx
@@ -13,15 +13,11 @@ import LDAPToEmail from 'components/claim/components/ldap_to_email';
 import EmailToLDAP from 'components/claim/components/email_to_ldap';
 
 export default class ClaimController extends React.Component {
-    componentWillMount() {
-        this.setState({
-            email: (new URLSearchParams(this.props.location.search)).get('email'),
-            newType: (new URLSearchParams(this.props.location.search)).get('new_type'),
-            currentType: (new URLSearchParams(this.props.location.search)).get('old_type')
-        });
-    }
-
     render() {
+        const email = (new URLSearchParams(this.props.location.search)).get('email');
+        const newType = (new URLSearchParams(this.props.location.search)).get('new_type');
+        const currentType = (new URLSearchParams(this.props.location.search)).get('old_type');
+
         return (
             <div>
                 <BackButton/>
@@ -37,8 +33,9 @@ export default class ClaimController extends React.Component {
                                     path={`${this.props.match.url}/oauth_to_email`}
                                     render={(props) => (
                                         <OAuthToEmail
-                                            {...this.state}
                                             {...props}
+                                            currentType={currentType}
+                                            email={email}
                                             siteName={this.props.siteName}
                                         />
                                 )}
@@ -47,8 +44,9 @@ export default class ClaimController extends React.Component {
                                     path={`${this.props.match.url}/email_to_oauth`}
                                     render={(props) => (
                                         <EmailToOAuth
-                                            {...this.state}
                                             {...props}
+                                            newType={newType}
+                                            email={email}
                                             siteName={this.props.siteName}
                                         />
                                 )}
@@ -57,9 +55,9 @@ export default class ClaimController extends React.Component {
                                     path={`${this.props.match.url}/ldap_to_email`}
                                     render={(props) => (
                                         <LDAPToEmail
-                                            {...this.state}
                                             {...props}
                                             siteName={this.props.siteName}
+                                            email={email}
                                         />
                                 )}
                                 />
@@ -67,8 +65,8 @@ export default class ClaimController extends React.Component {
                                     path={`${this.props.match.url}/email_to_ldap`}
                                     render={(props) => (
                                         <EmailToLDAP
-                                            {...this.state}
                                             {...props}
+                                            email={email}
                                             siteName={this.props.siteName}
                                             ldapLoginFieldName={this.props.ldapLoginFieldName}
                                         />

--- a/components/claim/components/email_to_ldap.jsx
+++ b/components/claim/components/email_to_ldap.jsx
@@ -139,18 +139,13 @@ export default class EmailToLDAP extends React.Component {
         }
 
         let loginPlaceholder;
-        if (global.window.mm_config.LdapLoginFieldName) {
-            loginPlaceholder = global.window.mm_config.LdapLoginFieldName;
+        if (this.props.ldapLoginFieldName) {
+            loginPlaceholder = this.props.ldapLoginFieldName;
         } else {
             loginPlaceholder = Utils.localizeMessage('claim.email_to_ldap.ldapId', 'AD/LDAP ID');
         }
 
-        let passwordPlaceholder;
-        if (global.window.mm_config.LdapPasswordFieldName) {
-            passwordPlaceholder = global.window.mm_config.LdapPasswordFieldName;
-        } else {
-            passwordPlaceholder = Utils.localizeMessage('claim.email_to_ldap.ldapPwd', 'AD/LDAP Password');
-        }
+        const passwordPlaceholder = Utils.localizeMessage('claim.email_to_ldap.ldapPwd', 'AD/LDAP Password');
 
         let content;
         if (this.state.showMfa) {
@@ -184,7 +179,7 @@ export default class EmailToLDAP extends React.Component {
                             id='claim.email_to_ldap.enterPwd'
                             defaultMessage='Enter the password for your {site} email account'
                             values={{
-                                site: global.window.mm_config.SiteName
+                                site: this.props.siteName
                             }}
                         />
                     </p>
@@ -263,10 +258,10 @@ export default class EmailToLDAP extends React.Component {
     }
 }
 
-EmailToLDAP.defaultProps = {
-};
 EmailToLDAP.propTypes = {
-    email: PropTypes.string
+    email: PropTypes.string,
+    siteName: PropTypes.string,
+    ldapLoginFieldName: PropTypes.string
 };
 
 const style = {

--- a/components/claim/components/email_to_oauth.jsx
+++ b/components/claim/components/email_to_oauth.jsx
@@ -119,7 +119,7 @@ export default class EmailToOAuth extends React.Component {
                             id='claim.email_to_oauth.enterPwd'
                             defaultMessage='Enter the password for your {site} account'
                             values={{
-                                site: global.window.mm_config.SiteName
+                                site: this.props.siteName
                             }}
                         />
                     </p>
@@ -167,9 +167,8 @@ export default class EmailToOAuth extends React.Component {
     }
 }
 
-EmailToOAuth.defaultProps = {
-};
 EmailToOAuth.propTypes = {
     newType: PropTypes.string,
-    email: PropTypes.string
+    email: PropTypes.string,
+    siteName: PropTypes.string
 };

--- a/components/claim/components/ldap_to_email.jsx
+++ b/components/claim/components/ldap_to_email.jsx
@@ -138,12 +138,7 @@ export default class LDAPToEmail extends React.Component {
             confimClass += ' has-error';
         }
 
-        let passwordPlaceholder;
-        if (global.window.mm_config.LdapPasswordFieldName) {
-            passwordPlaceholder = global.window.mm_config.LdapPasswordFieldName;
-        } else {
-            passwordPlaceholder = Utils.localizeMessage('claim.ldap_to_email.ldapPwd', 'AD/LDAP Password');
-        }
+        const passwordPlaceholder = Utils.localizeMessage('claim.ldap_to_email.ldapPwd', 'AD/LDAP Password');
 
         let content;
         if (this.state.showMfa) {
@@ -245,8 +240,6 @@ export default class LDAPToEmail extends React.Component {
     }
 }
 
-LDAPToEmail.defaultProps = {
-};
 LDAPToEmail.propTypes = {
     email: PropTypes.string
 };

--- a/components/claim/components/oauth_to_email.jsx
+++ b/components/claim/components/oauth_to_email.jsx
@@ -94,7 +94,7 @@ export default class OAuthToEmail extends React.Component {
                             id='claim.oauth_to_email.enterNewPwd'
                             defaultMessage='Enter a new password for your {site} email account'
                             values={{
-                                site: global.window.mm_config.SiteName
+                                site: this.props.siteName
                             }}
                         />
                     </p>
@@ -137,9 +137,8 @@ export default class OAuthToEmail extends React.Component {
     }
 }
 
-OAuthToEmail.defaultProps = {
-};
 OAuthToEmail.propTypes = {
     currentType: PropTypes.string,
-    email: PropTypes.string
+    email: PropTypes.string,
+    siteName: PropTypes.string
 };

--- a/components/claim/index.js
+++ b/components/claim/index.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import ClaimController from './claim_controller.jsx';
+
+function mapStateToProps(state, ownProps) {
+    const config = state.entities.general.config;
+    const siteName = config.SiteName;
+    const ldapLoginFieldName = config.LdapLoginFieldName;
+
+    return {
+        ...ownProps,
+        siteName,
+        ldapLoginFieldName
+    };
+}
+
+export default connect(mapStateToProps)(ClaimController);

--- a/components/claim/index.js
+++ b/components/claim/index.js
@@ -2,11 +2,12 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import ClaimController from './claim_controller.jsx';
 
 function mapStateToProps(state) {
-    const config = state.entities.general.config;
+    const config = getConfig(state);
     const siteName = config.SiteName;
     const ldapLoginFieldName = config.LdapLoginFieldName;
 

--- a/components/claim/index.js
+++ b/components/claim/index.js
@@ -5,13 +5,12 @@ import {connect} from 'react-redux';
 
 import ClaimController from './claim_controller.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     const config = state.entities.general.config;
     const siteName = config.SiteName;
     const ldapLoginFieldName = config.LdapLoginFieldName;
 
     return {
-        ...ownProps,
         siteName,
         ldapLoginFieldName
     };

--- a/components/root.jsx
+++ b/components/root.jsx
@@ -209,7 +209,7 @@ export default class Root extends React.Component {
 
     redirectIfNecessary(props) {
         if (props.location.pathname === '/') {
-            if (UserStore.getNoAccounts()) {
+            if (global.mm_config.NoAccounts === 'true') {
                 this.props.history.push('/signup_user_complete');
             } else if (UserStore.getCurrentUser()) {
                 GlobalActions.redirectUserToDefaultTeam();

--- a/components/root.jsx
+++ b/components/root.jsx
@@ -41,7 +41,7 @@ import loadSignupEmail from 'bundle-loader?lazy!components/signup/components/sig
 import loadSignupLdap from 'bundle-loader?lazy!components/signup/components/signup_ldap';
 import loadShouldVerifyEmail from 'bundle-loader?lazy!components/should_verify_email';
 import loadDoVerifyEmail from 'bundle-loader?lazy!components/do_verify_email';
-import loadClaimController from 'bundle-loader?lazy!components/claim/claim_controller';
+import loadClaimController from 'bundle-loader?lazy!components/claim';
 import loadHelpController from 'bundle-loader?lazy!components/help/help_controller';
 import loadGetIosApp from 'bundle-loader?lazy!components/get_ios_app';
 import loadGetAndroidApp from 'bundle-loader?lazy!components/get_android_app/get_android_app';

--- a/components/signup/signup_controller.jsx
+++ b/components/signup/signup_controller.jsx
@@ -46,7 +46,7 @@ export default class SignupController extends React.Component {
                 loading = true;
             } else if (hash && !UserStore.getCurrentUser()) {
                 usedBefore = BrowserStore.getGlobalItem(hash);
-            } else if (!inviteId && global.window.mm_config.EnableOpenServer !== 'true' && !UserStore.getNoAccounts()) {
+            } else if (!inviteId && global.window.mm_config.EnableOpenServer !== 'true' && global.window.mm_config.NoAccounts !== 'true') {
                 noOpenServerError = true;
                 serverError = (
                     <FormattedMessage

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -45,6 +45,8 @@ import trLocaleData from 'react-intl/locale-data/tr';
 import ruLocaleData from 'react-intl/locale-data/ru';
 import zhLocaleData from 'react-intl/locale-data/zh';
 
+import store from 'stores/redux_store.jsx';
+
 // should match the values in model/config.go
 const languages = {
     de: {
@@ -133,34 +135,17 @@ const languages = {
     }
 };
 
-let availableLanguages = null;
-
-function setAvailableLanguages() {
-    let available;
-    availableLanguages = {};
-
-    if (global.window.mm_config.AvailableLocales) {
-        available = global.window.mm_config.AvailableLocales.split(',');
-    } else {
-        available = Object.keys(languages);
-    }
-
-    available.forEach((l) => {
-        if (languages[l]) {
-            availableLanguages[l] = languages[l];
-        }
-    });
-}
-
 export function getAllLanguages() {
     return languages;
 }
 
 export function getLanguages() {
-    if (!availableLanguages) {
-        setAvailableLanguages();
+    const config = store.getState().entities.general.config;
+    if (!config.AvailableLocales) {
+        return getAllLanguages();
     }
-    return availableLanguages;
+
+    return config.AvailableLocales.split(',').filter((l) => languages[l]).map((l) => languages[l]);
 }
 
 export function getLanguageInfo(locale) {

--- a/stores/user_store.jsx
+++ b/stores/user_store.jsx
@@ -29,7 +29,6 @@ class UserStoreClass extends EventEmitter {
     constructor() {
         super();
 
-        this.noAccounts = false;
         this.entities = {};
 
         store.subscribe(() => {
@@ -458,14 +457,6 @@ class UserStoreClass extends EventEmitter {
 
     getStatus(id) {
         return this.getStatuses()[id] || UserStatuses.OFFLINE;
-    }
-
-    getNoAccounts() {
-        return global.window.mm_config.NoAccounts === 'true';
-    }
-
-    setNoAccounts(noAccounts) {
-        this.noAccounts = noAccounts;
     }
 
     isSystemAdminForCurrentUser() {


### PR DESCRIPTION
#### Summary
This is a subset of the changes in the `MM-8589-remove_mm_global_license` branch, broken up into multiple PRs to facilitate easier review. See any linked PRs for other changes if you're interested. 

These changes, as a whole, move towards removing our dependence on the global `mm_config` and `mm_license` objects. These changes will ultimately facilitate resolving https://mattermost.atlassian.net/browse/MM-8604, allowing us to stop hard refreshing the application whenever someone makes a configuration change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8589

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

### Related PRs
https://github.com/mattermost/mattermost-webapp/pull/819
https://github.com/mattermost/mattermost-webapp/pull/820
https://github.com/mattermost/mattermost-webapp/pull/821
https://github.com/mattermost/mattermost-webapp/pull/822
https://github.com/mattermost/mattermost-webapp/pull/823