### PR TITLE
Remove mm_config and mm_license global state from webapp (PR #3)

### DIFF
--- a/components/channel_view/channel_view.jsx
+++ b/components/channel_view/channel_view.jsx
@@ -12,7 +12,7 @@ import ChannelHeader from 'components/channel_header';
 import CreatePost from 'components/create_post';
 import FileUploadOverlay from 'components/file_upload_overlay.jsx';
 import PostView from 'components/post_view';
-import TutorialView from 'components/tutorial/tutorial_view.jsx';
+import TutorialView from 'components/tutorial';
 import {clearMarks, mark, measure, trackEvent} from 'actions/diagnostics_actions.jsx';
 
 export default class ChannelView extends React.PureComponent {

--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -3,7 +3,8 @@
 
 import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
-import {get} from 'mattermost-redux/selectors/entities/preferences';
+import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {withRouter} from 'react-router-dom';
 
 import {getDirectTeammate} from 'utils/utils.jsx';
@@ -24,10 +25,14 @@ const getDeactivatedChannel = createSelector(
 function mapStateToProps(state) {
     const channelId = state.entities.channels.currentChannelId;
 
+    const config = state.entities.general.config;
+    const enableTutorial = config.EnableTutorial === 'true';
+    const tutorialStep = parseInt(getPreference(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), TutorialSteps.FINISHED), 10);
+
     return {
         channelId,
         deactivatedChannel: getDeactivatedChannel(state, channelId),
-        showTutorial: Number(get(state, Preferences.TUTORIAL_STEP, state.entities.users.currentUserId, 999)) <= TutorialSteps.INTRO_SCREENS && global.window.mm_config.EnableTutorial === 'true'
+        showTutorial: enableTutorial && tutorialStep <= TutorialSteps.INTRO_SCREENS
     };
 }
 

--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
 import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {withRouter} from 'react-router-dom';
 
 import {getDirectTeammate} from 'utils/utils.jsx';
@@ -25,7 +26,7 @@ const getDeactivatedChannel = createSelector(
 function mapStateToProps(state) {
     const channelId = state.entities.channels.currentChannelId;
 
-    const config = state.entities.general.config;
+    const config = getConfig(state);
     const enableTutorial = config.EnableTutorial === 'true';
     const tutorialStep = parseInt(getPreference(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), TutorialSteps.FINISHED), 10);
 

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -12,7 +12,6 @@ import * as GlobalActions from 'actions/global_actions.jsx';
 import {emitEmojiPosted} from 'actions/post_actions.jsx';
 import EmojiStore from 'stores/emoji_store.jsx';
 import Constants, {StoragePrefixes} from 'utils/constants.jsx';
-import * as FileUtils from 'utils/file_utils';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -109,6 +108,11 @@ export default class CreatePost extends React.Component {
         *  Set if the channel is read only.
         */
         readOnlyChannel: PropTypes.bool,
+
+        /**
+         * Whether or not file upload is allowed.
+         */
+        canUploadFiles: PropTypes.bool.isRequired,
 
         actions: PropTypes.shape({
 
@@ -777,7 +781,7 @@ export default class CreatePost extends React.Component {
         }
 
         let attachmentsDisabled = '';
-        if (!FileUtils.canUploadFiles()) {
+        if (!this.props.canUploadFiles) {
             attachmentsDisabled = ' post-create--attachment-disabled';
         }
 

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -31,6 +31,7 @@ import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
 import {makeGetGlobalItem} from 'selectors/storage';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import {Constants, Preferences, StoragePrefixes, TutorialSteps} from 'utils/constants.jsx';
+import {canUploadFiles} from 'utils/file_utils';
 
 import CreatePost from './create_post.jsx';
 
@@ -65,7 +66,8 @@ function mapStateToProps() {
             commentCountForPost: getCommentCountForPost(state, {post}),
             latestReplyablePostId,
             currentUsersLatestPost: getCurrentUsersLatestPost(state),
-            readOnlyChannel: !isCurrentUserSystemAdmin(state) && getConfig(state).ExperimentalTownSquareIsReadOnly === 'true' && currentChannel.name === Constants.DEFAULT_CHANNEL
+            readOnlyChannel: !isCurrentUserSystemAdmin(state) && getConfig(state).ExperimentalTownSquareIsReadOnly === 'true' && currentChannel.name === Constants.DEFAULT_CHANNEL,
+            canUploadFiles: canUploadFiles(state)
         };
     };
 }

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -36,7 +36,7 @@ import {canUploadFiles} from 'utils/file_utils';
 import CreatePost from './create_post.jsx';
 
 function mapStateToProps() {
-    return (state, ownProps) => {
+    return (state) => {
         const config = getConfig(state);
         const currentChannel = getCurrentChannel(state) || {};
         const getDraft = makeGetGlobalItem(StoragePrefixes.DRAFT + currentChannel.id, {
@@ -52,7 +52,6 @@ function mapStateToProps() {
         const enableTutorial = config.EnableTutorial === 'true';
         const tutorialStep = parseInt(get(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), TutorialSteps.FINISHED), 10);
         return {
-            ...ownProps,
             currentTeamId: getCurrentTeamId(state),
             currentChannel,
             currentChannelMembersCount,

--- a/components/do_verify_email/do_verify_email.jsx
+++ b/components/do_verify_email/do_verify_email.jsx
@@ -18,6 +18,11 @@ export default class DoVerifyEmail extends React.PureComponent {
          */
         location: PropTypes.object.isRequired,
 
+        /**
+         * Title of the app or site.
+         */
+        siteName: PropTypes.string,
+
         /*
          * Object with redux action creators
          */
@@ -87,7 +92,7 @@ export default class DoVerifyEmail extends React.PureComponent {
                             src={logoImage}
                         />
                         <div className='signup__content'>
-                            <h1>{global.window.mm_config.SiteName}</h1>
+                            <h1>{this.props.siteName}</h1>
                             <h4 className='color--light'>
                                 <FormattedMessage
                                     id='web.root.signup_info'

--- a/components/do_verify_email/index.js
+++ b/components/do_verify_email/index.js
@@ -7,6 +7,16 @@ import {verifyUserEmail} from 'mattermost-redux/actions/users';
 
 import DoVerifyEmail from './do_verify_email.jsx';
 
+function mapStateToProps(state, ownProps) {
+    const config = state.entities.general.config;
+    const siteName = config.SiteName;
+
+    return {
+        ...ownProps,
+        siteName
+    };
+}
+
 function mapDispatchToProps(dispatch) {
     return {
         actions: {
@@ -15,4 +25,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(null, mapDispatchToProps)(DoVerifyEmail);
+export default connect(mapStateToProps, mapDispatchToProps)(DoVerifyEmail);

--- a/components/do_verify_email/index.js
+++ b/components/do_verify_email/index.js
@@ -4,11 +4,12 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {verifyUserEmail} from 'mattermost-redux/actions/users';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import DoVerifyEmail from './do_verify_email.jsx';
 
 function mapStateToProps(state, ownProps) {
-    const config = state.entities.general.config;
+    const config = getConfig(state);
     const siteName = config.SiteName;
 
     return {

--- a/components/do_verify_email/index.js
+++ b/components/do_verify_email/index.js
@@ -8,12 +8,11 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import DoVerifyEmail from './do_verify_email.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     const config = getConfig(state);
     const siteName = config.SiteName;
 
     return {
-        ...ownProps,
         siteName
     };
 }

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -10,7 +10,6 @@ import 'jquery-dragster/jquery.dragster.js';
 
 import Constants from 'utils/constants.jsx';
 import DelayedAction from 'utils/delayed_action.jsx';
-import {canUploadFiles} from 'utils/file_utils';
 import {
     isIosChrome,
     isMobileApp
@@ -103,7 +102,17 @@ class FileUpload extends React.PureComponent {
         /**
          * Function to be called to upload file
          */
-        uploadFile: PropTypes.func.isRequired
+        uploadFile: PropTypes.func.isRequired,
+
+        /**
+         * The maximum uploaded file size.
+         */
+        maxFileSize: PropTypes.number,
+
+        /**
+         * Whether or not file upload is allowed.
+         */
+        canUploadFiles: PropTypes.bool.isRequired
     };
 
     constructor(props) {
@@ -171,7 +180,7 @@ class FileUpload extends React.PureComponent {
         const clientIds = [];
 
         for (let i = 0; i < sortedFiles.length && numUploads < uploadsRemaining; i++) {
-            if (sortedFiles[i].size > global.mm_config.MaxFileSize) {
+            if (sortedFiles[i].size > this.props.maxFileSize) {
                 tooLargeFiles.push(sortedFiles[i]);
                 continue;
             }
@@ -204,9 +213,9 @@ class FileUpload extends React.PureComponent {
         } else if (tooLargeFiles.length > 1) {
             var tooLargeFilenames = tooLargeFiles.map((file) => file.name).join(', ');
 
-            this.props.onUploadError(formatMessage(holders.filesAbove, {max: (global.mm_config.MaxFileSize / 1048576), filenames: tooLargeFilenames}));
+            this.props.onUploadError(formatMessage(holders.filesAbove, {max: (this.props.maxFileSize / 1048576), filenames: tooLargeFilenames}));
         } else if (tooLargeFiles.length > 0) {
-            this.props.onUploadError(formatMessage(holders.fileAbove, {max: (global.mm_config.MaxFileSize / 1048576), filename: tooLargeFiles[0].name}));
+            this.props.onUploadError(formatMessage(holders.fileAbove, {max: (this.props.maxFileSize / 1048576), filename: tooLargeFiles[0].name}));
         }
     }
 
@@ -221,7 +230,7 @@ class FileUpload extends React.PureComponent {
     }
 
     handleDrop = (e) => {
-        if (!canUploadFiles()) {
+        if (!this.props.canUploadFiles) {
             this.props.onUploadError(localizeMessage('file_upload.disabled', 'File attachments are disabled.'));
             return;
         }
@@ -247,7 +256,7 @@ class FileUpload extends React.PureComponent {
         });
 
         let dragsterActions = {};
-        if (canUploadFiles()) {
+        if (this.props.canUploadFiles) {
             dragsterActions = {
                 enter(dragsterEvent, e) {
                     var files = e.originalEvent.dataTransfer;
@@ -319,7 +328,7 @@ class FileUpload extends React.PureComponent {
         // This looks redundant, but must be done this way due to
         // setState being an asynchronous call
         if (items && items.length > 0) {
-            if (!canUploadFiles()) {
+            if (!this.props.canUploadFiles) {
                 this.props.onUploadError(localizeMessage('file_upload.disabled', 'File attachments are disabled.'));
                 return;
             }
@@ -385,7 +394,7 @@ class FileUpload extends React.PureComponent {
         if (cmdOrCtrlPressed(e) && e.keyCode === Constants.KeyCodes.U) {
             e.preventDefault();
 
-            if (!canUploadFiles()) {
+            if (!this.props.canUploadFiles) {
                 this.props.onUploadError(localizeMessage('file_upload.disabled', 'File attachments are disabled.'));
                 return;
             }
@@ -438,7 +447,7 @@ class FileUpload extends React.PureComponent {
                 ref='input'
                 className={uploadsRemaining <= 0 ? ' btn-file__disabled' : ''}
             >
-                {canUploadFiles() &&
+                {this.props.canUploadFiles &&
                 <div
                     id='fileUploadButton'
                     className='icon icon--attachment'

--- a/components/file_upload/index.js
+++ b/components/file_upload/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {uploadFile} from 'actions/file_actions.jsx';
 import {canUploadFiles} from 'utils/file_utils';
@@ -11,7 +12,7 @@ import {canUploadFiles} from 'utils/file_utils';
 import FileUpload from './file_upload.jsx';
 
 function mapStateToProps(state) {
-    const config = state.entities.general.config;
+    const config = getConfig(state);
     const maxFileSize = parseInt(config.MaxFileSize, 10);
 
     return {

--- a/components/file_upload/index.js
+++ b/components/file_upload/index.js
@@ -6,13 +6,19 @@ import {connect} from 'react-redux';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
 import {uploadFile} from 'actions/file_actions.jsx';
+import {canUploadFiles} from 'utils/file_utils';
 
 import FileUpload from './file_upload.jsx';
 
 function mapStateToProps(state) {
+    const config = state.entities.general.config;
+    const maxFileSize = parseInt(config.MaxFileSize, 10);
+
     return {
         currentChannelId: getCurrentChannelId(state),
-        uploadFile
+        uploadFile,
+        maxFileSize,
+        canUploadFiles: canUploadFiles(state)
     };
 }
 

--- a/components/navbar/index.js
+++ b/components/navbar/index.js
@@ -11,10 +11,14 @@ import {RHSStates} from 'utils/constants.jsx';
 import Navbar from './navbar.jsx';
 
 function mapStateToProps(state) {
+    const config = state.entities.general.config;
+    const enableWebrtc = config.EnableWebrtc === 'true';
+
     const rhsState = getRhsState(state);
 
     return {
-        isPinnedPosts: rhsState === RHSStates.PIN
+        isPinnedPosts: rhsState === RHSStates.PIN,
+        enableWebrtc
     };
 }
 

--- a/components/navbar/index.js
+++ b/components/navbar/index.js
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {closeRightHandSide, updateRhsState, showPinnedPosts} from 'actions/views/rhs';
 import {getRhsState} from 'selectors/rhs';
@@ -11,7 +12,7 @@ import {RHSStates} from 'utils/constants.jsx';
 import Navbar from './navbar.jsx';
 
 function mapStateToProps(state) {
-    const config = state.entities.general.config;
+    const config = getConfig(state);
     const enableWebrtc = config.EnableWebrtc === 'true';
 
     const rhsState = getRhsState(state);

--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -43,6 +43,7 @@ export default class Navbar extends React.Component {
     static propTypes = {
         teamDisplayName: PropTypes.string,
         isPinnedPosts: PropTypes.bool,
+        enableWebrtc: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             closeRightHandSide: PropTypes.func,
             updateRhsState: PropTypes.func,
@@ -283,7 +284,7 @@ export default class Navbar extends React.Component {
     isWebrtcEnabled() {
         const userMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
         const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
-        return global.mm_config.EnableWebrtc === 'true' && userMedia && Utils.isFeatureEnabled(PreReleaseFeatures.WEBRTC_PREVIEW);
+        return this.props.enableWebrtc && userMedia && Utils.isFeatureEnabled(PreReleaseFeatures.WEBRTC_PREVIEW);
     }
 
     initWebrtc = () => {

--- a/components/tutorial/index.jsx
+++ b/components/tutorial/index.jsx
@@ -1,0 +1,31 @@
+import {connect} from 'react-redux';
+import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
+
+import Constants from 'utils/constants.jsx';
+
+import TutorialView from './tutorial_view.jsx';
+
+function mapStateToProps(state, ownProps) {
+    const license = state.entities.general.license;
+    const config = state.entities.general.config;
+
+    const teamChannels = getChannelsNameMapInCurrentTeam(state);
+    const townSquare = teamChannels[Constants.DEFAULT_CHANNEL];
+    const townSquareDisplayName = townSquare ? townSquare.display_name : Constants.DEFAULT_CHANNEL_UI_NAME;
+
+    const appDownloadLink = config.AppDownloadLink;
+    const isLicensed = license.IsLicensed === 'true';
+    const restrictTeamInvite = config.RestrictTeamInvite;
+    const supportEmail = config.SupportEmail;
+
+    return {
+        ...ownProps,
+        townSquareDisplayName,
+        appDownloadLink,
+        isLicensed,
+        restrictTeamInvite,
+        supportEmail
+    };
+}
+
+export default connect(mapStateToProps)(TutorialView);

--- a/components/tutorial/index.jsx
+++ b/components/tutorial/index.jsx
@@ -1,13 +1,14 @@
 import {connect} from 'react-redux';
 import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
+import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import Constants from 'utils/constants.jsx';
 
 import TutorialView from './tutorial_view.jsx';
 
 function mapStateToProps(state, ownProps) {
-    const license = state.entities.general.license;
-    const config = state.entities.general.config;
+    const license = getLicense(state);
+    const config = getConfig(state);
 
     const teamChannels = getChannelsNameMapInCurrentTeam(state);
     const townSquare = teamChannels[Constants.DEFAULT_CHANNEL];

--- a/components/tutorial/index.jsx
+++ b/components/tutorial/index.jsx
@@ -6,7 +6,7 @@ import Constants from 'utils/constants.jsx';
 
 import TutorialView from './tutorial_view.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     const license = getLicense(state);
     const config = getConfig(state);
 
@@ -20,7 +20,6 @@ function mapStateToProps(state, ownProps) {
     const supportEmail = config.SupportEmail;
 
     return {
-        ...ownProps,
         townSquareDisplayName,
         appDownloadLink,
         isLicensed,

--- a/components/tutorial/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens.jsx
@@ -18,23 +18,21 @@ import AppIcons from 'images/appIcons.png';
 const NUM_SCREENS = 3;
 
 export default class TutorialIntroScreens extends React.Component {
-    static get propTypes() {
-        return {
-            townSquare: PropTypes.object,
-            offTopic: PropTypes.object
-        };
-    }
+    static propTypes = {
+        townSquareDisplayName: PropTypes.string.isRequired,
+        appDownloadLink: PropTypes.string,
+        isLicensed: PropTypes.bool.isRequired,
+        restrictTeamInvite: PropTypes.string.isRequired,
+        supportEmail: PropTypes.string.isRequired
+    };
+
     constructor(props) {
         super(props);
 
-        this.handleNext = this.handleNext.bind(this);
-        this.createScreen = this.createScreen.bind(this);
-        this.createCircles = this.createCircles.bind(this);
-        this.skipTutorial = this.skipTutorial.bind(this);
-
         this.state = {currentScreen: 0};
     }
-    handleNext() {
+
+    handleNext = () => {
         switch (this.state.currentScreen) {
         case 0:
             trackEvent('tutorial', 'tutorial_screen_1_welcome_to_mattermost_next');
@@ -60,7 +58,8 @@ export default class TutorialIntroScreens extends React.Component {
             (step + 1).toString()
         );
     }
-    skipTutorial(e) {
+
+    skipTutorial = (e) => {
         e.preventDefault();
 
         switch (this.state.currentScreen) {
@@ -81,7 +80,7 @@ export default class TutorialIntroScreens extends React.Component {
             Constants.TutorialSteps.FINISHED.toString(),
         );
     }
-    createScreen() {
+    createScreen = () => {
         switch (this.state.currentScreen) {
         case 0:
             return this.createScreenOne();
@@ -92,6 +91,7 @@ export default class TutorialIntroScreens extends React.Component {
         }
         return null;
     }
+
     createScreenOne() {
         const circles = this.createCircles();
 
@@ -108,15 +108,16 @@ export default class TutorialIntroScreens extends React.Component {
             </div>
         );
     }
+
     createScreenTwo() {
         const circles = this.createCircles();
 
         let appDownloadLink = null;
         let appDownloadImage = null;
-        if (global.mm_config.AppDownloadLink) {
-            const link = useSafeUrl(global.mm_config.AppDownloadLink);
+        if (this.props.appDownloadLink) {
+            const link = useSafeUrl(this.props.appDownloadLink);
 
-            // not using a FormattedHTMLMessage here since mm_config.AppDownloadLink is configurable and could be used
+            // not using a FormattedHTMLMessage here since appDownloadLink is configurable and could be used
             // to inject HTML if we're not careful
             appDownloadLink = (
                 <FormattedMessage
@@ -169,12 +170,13 @@ export default class TutorialIntroScreens extends React.Component {
             </div>
         );
     }
+
     createScreenThree() {
         const team = TeamStore.getCurrent();
         let inviteModalLink;
         let inviteText;
 
-        if (global.window.mm_license.IsLicensed !== 'true' || global.window.mm_config.RestrictTeamInvite === Constants.PERMISSIONS_ALL) {
+        if (!this.props.isLicensed || this.props.restrictTeamInvite === Constants.PERMISSIONS_ALL) {
             if (team.type === Constants.INVITE_TEAM) {
                 inviteModalLink = (
                     <button
@@ -217,7 +219,7 @@ export default class TutorialIntroScreens extends React.Component {
         const circles = this.createCircles();
 
         let supportInfo = null;
-        if (global.window.mm_config.SupportEmail) {
+        if (this.props.supportEmail) {
             supportInfo = (
                 <p id='supportInfo'>
                     <FormattedMessage
@@ -225,20 +227,15 @@ export default class TutorialIntroScreens extends React.Component {
                         defaultMessage='Need anything, just email us at '
                     />
                     <a
-                        href={'mailto:' + global.window.mm_config.SupportEmail}
+                        href={'mailto:' + this.props.supportEmail}
                         target='_blank'
                         rel='noopener noreferrer'
                     >
-                        {global.window.mm_config.SupportEmail}
+                        {this.props.supportEmail}
                     </a>
                     {'.'}
                 </p>
             );
-        }
-
-        let townSquareDisplayName = Constants.DEFAULT_CHANNEL_UI_NAME;
-        if (this.props.townSquare) {
-            townSquareDisplayName = this.props.townSquare.display_name;
         }
 
         return (
@@ -255,7 +252,7 @@ export default class TutorialIntroScreens extends React.Component {
                     id='tutorial_intro.end'
                     defaultMessage='Click "Next" to enter {channel}. This is the first channel teammates see when they sign up. Use it for posting updates everyone needs to know.'
                     values={{
-                        channel: townSquareDisplayName
+                        channel: this.props.townSquareDisplayName
                     }}
                 />
                 {circles}
@@ -268,7 +265,7 @@ export default class TutorialIntroScreens extends React.Component {
         this.setState({currentScreen: screen});
     }
 
-    createCircles() {
+    createCircles = () => {
         const circles = [];
         for (let i = 0; i < NUM_SCREENS; i++) {
             let className = 'circle';
@@ -294,6 +291,7 @@ export default class TutorialIntroScreens extends React.Component {
             </div>
         );
     }
+
     render() {
         const screen = this.createScreen();
 

--- a/components/tutorial/tutorial_view.jsx
+++ b/components/tutorial/tutorial_view.jsx
@@ -5,40 +5,21 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import ChannelStore from 'stores/channel_store.jsx';
-import Constants from 'utils/constants.jsx';
-
 import TutorialIntroScreens from './tutorial_intro_screens.jsx';
 
 export default class TutorialView extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.handleChannelChange = this.handleChannelChange.bind(this);
-
-        this.state = {
-            townSquare: ChannelStore.getByName(Constants.DEFAULT_CHANNEL)
-        };
-    }
     componentDidMount() {
-        ChannelStore.addChangeListener(this.handleChannelChange);
-
         if (this.props.isRoot) {
             $('body').addClass('app__body');
         }
     }
-    componentWillUnmount() {
-        ChannelStore.removeChangeListener(this.handleChannelChange);
 
+    componentWillUnmount() {
         if (this.props.isRoot) {
             $('body').removeClass('app__body');
         }
     }
-    handleChannelChange() {
-        this.setState({
-            townSquare: ChannelStore.getByName(Constants.DEFAULT_CHANNEL)
-        });
-    }
+
     render() {
         return (
             <div
@@ -46,18 +27,26 @@ export default class TutorialView extends React.Component {
                 className='app__content'
             >
                 <TutorialIntroScreens
-                    townSquare={this.state.townSquare}
-                    handleDone={this.handleDone}
+                    townSquareDisplayName={this.props.townSquareDisplayName}
+                    appDownloadLink={this.props.appDownloadLink}
+                    isLicensed={this.props.isLicensed}
+                    restrictTeamInvite={this.props.restrictTeamInvite}
+                    supportEmail={this.props.supportEmail}
                 />
             </div>
         );
     }
 }
 
-TutorialView.defaultProps = {
-    isRoot: true
+TutorialView.propTypes = {
+    isRoot: PropTypes.bool,
+    townSquareDisplayName: PropTypes.string.isRequired,
+    appDownloadLink: PropTypes.string,
+    isLicensed: PropTypes.bool.isRequired,
+    restrictTeamInvite: PropTypes.string.isRequired,
+    supportEmail: PropTypes.string.isRequired
 };
 
-TutorialView.propTypes = {
-    isRoot: PropTypes.bool
+TutorialView.defaultProps = {
+    isRoot: true
 };

--- a/tests/components/create_post/__snapshots__/create_post.test.jsx.snap
+++ b/tests/components/create_post/__snapshots__/create_post.test.jsx.snap
@@ -220,6 +220,130 @@ exports[`components/create_post should match snapshot for read only channel 1`] 
 </form>
 `;
 
+exports[`components/create_post should match snapshot when file upload disabled 1`] = `
+<form
+  className=""
+  id="create_post"
+  onSubmit={[Function]}
+  role="form"
+>
+  <div
+    className="post-create post-create--attachment-disabled"
+  >
+    <div
+      className="post-create-body"
+    >
+      <div
+        className="post-body__cell"
+      >
+        <Textbox
+          channelId="owsyt8n43jfxjpzh9np93mx1wa"
+          characterLimit={4000}
+          createMessage="Write a message..."
+          disabled={false}
+          emojiEnabled={true}
+          handlePostError={[Function]}
+          id="post_textbox"
+          isRHS={false}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          popoverMentionKeyClick={true}
+          supportsCommands={true}
+          value=""
+        />
+        <span
+          className="post-body__actions"
+        >
+          <Connect(InjectIntl(FileUpload))
+            fileCount={0}
+            getTarget={[Function]}
+            onFileUpload={[Function]}
+            onFileUploadChange={[Function]}
+            onUploadError={[Function]}
+            onUploadStart={[Function]}
+            postType="post"
+          />
+          <span
+            className="emoji-picker__container"
+          >
+            <EmojiPickerOverlay
+              onEmojiClick={[Function]}
+              onHide={[Function]}
+              rightOffset={15}
+              show={false}
+              spaceRequiredAbove={422}
+              spaceRequiredBelow={436}
+              target={[Function]}
+              topOffset={-7}
+            />
+            <EmojiIcon
+              className="icon icon--emoji "
+              id="emojiPickerButton"
+              onClick={[Function]}
+            />
+          </span>
+          <a
+            className="send-button theme disabled"
+            onClick={[Function]}
+          >
+            <i
+              className="fa fa-paper-plane"
+            />
+          </a>
+        </span>
+      </div>
+    </div>
+    <div
+      className="post-create-footer"
+      id="postCreateFooter"
+    >
+      <MsgTyping
+        channelId="owsyt8n43jfxjpzh9np93mx1wa"
+        parentId=""
+      />
+    </div>
+  </div>
+  <PostDeletedModal
+    onHide={[Function]}
+    show={false}
+  />
+  <ConfirmModal
+    confirmButtonClass="btn btn-primary"
+    confirmButtonText={
+      <FormattedMessage
+        defaultMessage="Confirm"
+        id="notify_all.confirm"
+        values={Object {}}
+      />
+    }
+    message={
+      <FormattedMessage
+        defaultMessage="By using @all or @channel you are about to send notifications to {totalMembers} people. Are you sure you want to do this?"
+        id="notify_all.question"
+        values={
+          Object {
+            "totalMembers": 8,
+          }
+        }
+      />
+    }
+    modalClass=""
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    show={false}
+    title={
+      <FormattedMessage
+        defaultMessage="Confirm sending notifications to entire channel"
+        id="notify_all.title.confirm"
+        values={Object {}}
+      />
+    }
+  />
+</form>
+`;
+
 exports[`components/create_post should match snapshot, init 1`] = `
 <form
   className=""

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -87,7 +87,8 @@ function createPost({
     ctrlSend = ctrlSendProp,
     currentUsersLatestPost = currentUsersLatestPostProp,
     commentCountForPost = commentCountForPostProp,
-    readOnlyChannel = false
+    readOnlyChannel = false,
+    canUploadFiles = true
 } = {}) {
     return (
         <CreatePost
@@ -105,6 +106,7 @@ function createPost({
             commentCountForPost={commentCountForPost}
             actions={actions}
             readOnlyChannel={readOnlyChannel}
+            canUploadFiles={canUploadFiles}
         />
     );
 }
@@ -112,7 +114,6 @@ function createPost({
 describe('components/create_post', () => {
     window.mm_config = {
         EnableEmojiPicker: 'true',
-        EnableFileAttachments: 'true',
         EnableConfirmNotificationsToChannel: 'true',
         EnableTutorial: 'true'
     };
@@ -633,6 +634,11 @@ describe('components/create_post', () => {
 
     it('should match snapshot for read only channel', () => {
         const wrapper = shallow(createPost({readOnlyChannel: true}));
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should match snapshot when file upload disabled', () => {
+        const wrapper = shallow(createPost({canUploadFiles: false}));
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/tests/components/do_verify_email.test.jsx
+++ b/tests/components/do_verify_email.test.jsx
@@ -7,16 +7,6 @@ import {shallow} from 'enzyme';
 import DoVerifyEmail from 'components/do_verify_email/do_verify_email.jsx';
 
 describe('components/DoVerifyEmail', () => {
-    global.window.mm_config = {};
-
-    beforeEach(() => {
-        global.window.mm_config.SiteName = 'Mattermost';
-    });
-
-    afterEach(() => {
-        global.window.mm_config = {};
-    });
-
     const requiredProps = {
         location: {
             query: {
@@ -24,6 +14,7 @@ describe('components/DoVerifyEmail', () => {
                 email: 'test@example.com'
             }
         },
+        siteName: 'Mattermost',
         actions: {verifyUserEmail: jest.fn()}
     };
 

--- a/tests/components/file_upload/__snapshots__/file_upload.test.jsx.snap
+++ b/tests/components/file_upload/__snapshots__/file_upload.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`components/FileUpload should match snapshot 1`] = `
 <FileUpload
+  canUploadFiles={true}
   currentChannelId="channel_id"
   fileCount={1}
   getTarget={[Function]}
@@ -30,6 +31,7 @@ exports[`components/FileUpload should match snapshot 1`] = `
       "textComponent": "span",
     }
   }
+  maxFileSize={10}
   onClick={[Function]}
   onFileUpload={[Function]}
   onFileUploadChange={[Function]}

--- a/tests/components/file_upload/file_upload.test.jsx
+++ b/tests/components/file_upload/file_upload.test.jsx
@@ -29,7 +29,6 @@ jest.mock('utils/utils', () => {
 });
 
 describe('components/FileUpload', () => {
-    global.window.mm_config = {};
     const MaxFileSize = 10;
     function emptyFunction() {} //eslint-disable-line no-empty-function
 
@@ -44,17 +43,10 @@ describe('components/FileUpload', () => {
         onUploadError: emptyFunction,
         onUploadStart: emptyFunction,
         postType: 'post',
-        uploadFile: emptyFunction
+        uploadFile: emptyFunction,
+        maxFileSize: MaxFileSize,
+        canUploadFiles: true,
     };
-
-    beforeEach(() => {
-        global.window.mm_config.EnableFileAttachments = 'true';
-        global.window.mm_config.MaxFileSize = MaxFileSize;
-    });
-
-    afterEach(() => {
-        global.window.mm_config = {};
-    });
 
     test('should match snapshot', () => {
         const wrapper = shallowWithIntl(

--- a/tests/components/file_upload/file_upload.test.jsx
+++ b/tests/components/file_upload/file_upload.test.jsx
@@ -45,7 +45,7 @@ describe('components/FileUpload', () => {
         postType: 'post',
         uploadFile: emptyFunction,
         maxFileSize: MaxFileSize,
-        canUploadFiles: true,
+        canUploadFiles: true
     };
 
     test('should match snapshot', () => {

--- a/tests/utils/file_utils.test.jsx
+++ b/tests/utils/file_utils.test.jsx
@@ -3,7 +3,8 @@
 
 import assert from 'assert';
 
-import {trimFilename} from 'utils/file_utils.jsx';
+import {trimFilename, canUploadFiles} from 'utils/file_utils.jsx';
+import * as UserAgent from 'utils/user_agent';
 
 describe('FileUtils.trimFilename', function() {
     it('trimFilename', function() {
@@ -18,5 +19,111 @@ describe('FileUtils.trimFilename', function() {
             'abcdefghijklmnopqrstuvwxyz012345678...',
             'should return trimmed filename'
         );
+    });
+});
+
+describe('FileUtils.canUploadFiles', function() {
+    UserAgent.isMobileApp = jest.fn().mockImplementation(() => false);
+
+    it('is false when file attachments are disabled', function() {
+        const state = {
+            entities: {
+                general: {
+                    license: {
+                        IsLicensed: 'true',
+                        Compliance: 'true'
+                    },
+                    config: {
+                        EnableFileAttachments: 'false',
+                        EnableMobileFileUpload: 'true'
+                    }
+                }
+            }
+        };
+        assert.equal(canUploadFiles(state), false);
+    });
+
+    describe('is true when file attachments are enabled', () => {
+        UserAgent.isMobileApp.mockImplementation(() => false);
+
+        it('and not on mobile', () => {
+            UserAgent.isMobileApp.mockImplementation(() => false);
+
+            const state = {
+                entities: {
+                    general: {
+                        license: {
+                            IsLicensed: 'true',
+                            Compliance: 'true'
+                        },
+                        config: {
+                            EnableFileAttachments: 'true',
+                            EnableMobileFileUpload: 'false'
+                        }
+                    }
+                }
+            };
+            assert.equal(canUploadFiles(state), true);
+        });
+
+        it('and on mobile but no compliance license enabled', function() {
+            UserAgent.isMobileApp.mockImplementation(() => true);
+
+            const state = {
+                entities: {
+                    general: {
+                        license: {
+                            IsLicensed: 'false',
+                            Compliance: 'false'
+                        },
+                        config: {
+                            EnableFileAttachments: 'true',
+                            EnableMobileFileUpload: 'false'
+                        }
+                    }
+                }
+            };
+            assert.equal(canUploadFiles(state), true);
+        });
+
+        it('and on mobile with compliance license enabled but mobile file upload enabled', () => {
+            UserAgent.isMobileApp.mockImplementation(() => true);
+
+            const state = {
+                entities: {
+                    general: {
+                        license: {
+                            IsLicensed: 'true',
+                            Compliance: 'true'
+                        },
+                        config: {
+                            EnableFileAttachments: 'true',
+                            EnableMobileFileUpload: 'true'
+                        }
+                    }
+                }
+            };
+            assert.equal(canUploadFiles(state), true);
+        });
+
+        it('unless on mobile with compliance license enabled and mobile file upload disabled', () => {
+            UserAgent.isMobileApp.mockImplementation(() => true);
+
+            const state = {
+                entities: {
+                    general: {
+                        license: {
+                            IsLicensed: 'true',
+                            Compliance: 'true'
+                        },
+                        config: {
+                            EnableFileAttachments: 'true',
+                            EnableMobileFileUpload: 'false'
+                        }
+                    }
+                }
+            };
+            assert.equal(canUploadFiles(state), false);
+        });
     });
 });

--- a/utils/file_utils.jsx
+++ b/utils/file_utils.jsx
@@ -4,13 +4,21 @@
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent';
 
-export function canUploadFiles() {
-    if (window.mm_config.EnableFileAttachments === 'false') {
+export function canUploadFiles(state) {
+    const license = state.entities.general.license;
+    const config = state.entities.general.config;
+
+    const isLicensed = license && license.IsLicensed === 'true';
+    const compliance = license && license.Compliance === 'true';
+    const enableFileAttachments = config.EnableFileAttachments === 'true';
+    const enableMobileFileUpload = config.EnableMobileFileUpload === 'true';
+
+    if (!enableFileAttachments) {
         return false;
     }
 
-    if (UserAgent.isMobileApp() && window.mm_license.IsLicensed === 'true' && window.mm_license.Compliance === 'true') {
-        return window.mm_config.EnableMobileFileUpload !== 'false';
+    if (UserAgent.isMobileApp() && isLicensed && compliance) {
+        return enableMobileFileUpload;
     }
 
     return true;


### PR DESCRIPTION
#### Summary
This is a subset of the changes in the `MM-8589-remove_mm_global_license` branch, broken up into multiple PRs to facilitate easier review. See any linked PRs for other changes if you're interested. 

These changes, as a whole, move towards removing our dependence on the global `mm_config` and `mm_license` objects. These changes will ultimately facilitate resolving https://mattermost.atlassian.net/browse/MM-8604, allowing us to stop hard refreshing the application whenever someone makes a configuration change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8589

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

### Related PRs
https://github.com/mattermost/mattermost-webapp/pull/816
https://github.com/mattermost/mattermost-webapp/pull/819
https://github.com/mattermost/mattermost-webapp/pull/821
https://github.com/mattermost/mattermost-webapp/pull/822
https://github.com/mattermost/mattermost-webapp/pull/823