### PR TITLE
Remove mm_config and mm_license global state from webapp (PR #6)

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -23,7 +23,7 @@ import {messageHtmlToComponent} from 'utils/post_utils.jsx';
 import ChannelInfoModal from 'components/channel_info_modal';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import ChannelMembersModal from 'components/channel_members_modal';
-import ChannelNotificationsModal from 'components/channel_notifications_modal/channel_notifications_modal.jsx';
+import ChannelNotificationsModal from 'components/channel_notifications_modal';
 import DeleteChannelModal from 'components/delete_channel_modal';
 import EditChannelHeaderModal from 'components/edit_channel_header_modal';
 import EditChannelPurposeModal from 'components/edit_channel_purpose_modal';

--- a/components/channel_layout/channel_controller.jsx
+++ b/components/channel_layout/channel_controller.jsx
@@ -12,7 +12,7 @@ import EditPostModal from 'components/edit_post_modal';
 import GetPostLinkModal from 'components/get_post_link_modal';
 import GetTeamInviteLinkModal from 'components/get_team_invite_link_modal';
 import GetPublicLinkModal from 'components/get_public_link_modal';
-import InviteMemberModal from 'components/invite_member_modal.jsx';
+import InviteMemberModal from 'components/invite_member_modal';
 import LeaveTeamModal from 'components/leave_team_modal.jsx';
 import LeavePrivateChannelModal from 'components/modals/leave_private_channel_modal.jsx';
 import RemovedFromChannelModal from 'components/removed_from_channel_modal.jsx';

--- a/components/channel_members_dropdown/channel_members_dropdown.jsx
+++ b/components/channel_members_dropdown/channel_members_dropdown.jsx
@@ -6,10 +6,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {makeUserChannelAdmin, makeUserChannelMember, removeUserFromChannel} from 'actions/channel_actions.jsx';
-import ChannelStore from 'stores/channel_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
-import {canManageMembers} from 'utils/channel_utils.jsx';
 import {Constants} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -19,6 +16,9 @@ export default class ChannelMembersDropdown extends React.Component {
         user: PropTypes.object.isRequired,
         teamMember: PropTypes.object.isRequired,
         channelMember: PropTypes.object.isRequired,
+        isLicensed: PropTypes.bool.isRequired,
+        canChangeMemberRoles: PropTypes.bool.isRequired,
+        canRemoveMember: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             getChannelStats: PropTypes.func.isRequired
         }).isRequired
@@ -26,10 +26,6 @@ export default class ChannelMembersDropdown extends React.Component {
 
     constructor(props) {
         super(props);
-
-        this.handleRemoveFromChannel = this.handleRemoveFromChannel.bind(this);
-        this.handleMakeChannelMember = this.handleMakeChannelMember.bind(this);
-        this.handleMakeChannelAdmin = this.handleMakeChannelAdmin.bind(this);
 
         this.state = {
             serverError: null,
@@ -39,7 +35,7 @@ export default class ChannelMembersDropdown extends React.Component {
         };
     }
 
-    handleRemoveFromChannel() {
+    handleRemoveFromChannel = () => {
         if (this.state.removing) {
             return;
         }
@@ -61,7 +57,7 @@ export default class ChannelMembersDropdown extends React.Component {
         );
     }
 
-    handleMakeChannelMember() {
+    handleMakeChannelMember = () => {
         makeUserChannelMember(
             this.props.channel.id,
             this.props.user.id,
@@ -74,7 +70,7 @@ export default class ChannelMembersDropdown extends React.Component {
         );
     }
 
-    handleMakeChannelAdmin() {
+    handleMakeChannelAdmin = () => {
         makeUserChannelAdmin(
             this.props.channel.id,
             this.props.user.id,
@@ -87,26 +83,8 @@ export default class ChannelMembersDropdown extends React.Component {
         );
     }
 
-    // Checks if the current user has the power to change the roles of this member.
-    canChangeMemberRoles() {
-        if (UserStore.isSystemAdminForCurrentUser()) {
-            return true;
-        } else if (TeamStore.isTeamAdminForCurrentTeam()) {
-            return true;
-        } else if (ChannelStore.isChannelAdminForCurrentChannel()) {
-            return true;
-        }
-
-        return false;
-    }
-
-    // Checks if the current user has the power to remove this member from the channel.
-    canRemoveMember() {
-        return canManageMembers(this.props.channel, ChannelStore.isChannelAdminForCurrentChannel(), TeamStore.isTeamAdminForCurrentTeam(), UserStore.isSystemAdminForCurrentUser());
-    }
-
     render() {
-        const supportsChannelAdmin = global.mm_license.IsLicensed === 'true';
+        const supportsChannelAdmin = this.props.isLicensed;
         const isChannelAdmin = supportsChannelAdmin && Utils.isChannelAdmin(this.props.channelMember.roles);
 
         let serverError = null;
@@ -122,7 +100,7 @@ export default class ChannelMembersDropdown extends React.Component {
             return null;
         }
 
-        if (this.canChangeMemberRoles()) {
+        if (this.props.canChangeMemberRoles) {
             let role = (
                 <FormattedMessage
                     id='channel_members_dropdown.channel_member'
@@ -140,7 +118,7 @@ export default class ChannelMembersDropdown extends React.Component {
             }
 
             let removeFromChannel = null;
-            if (this.canRemoveMember() && this.props.channel.name !== Constants.DEFAULT_CHANNEL) {
+            if (this.props.canRemoveMember && this.props.channel.name !== Constants.DEFAULT_CHANNEL) {
                 removeFromChannel = (
                     <li role='presentation'>
                         <a
@@ -223,7 +201,7 @@ export default class ChannelMembersDropdown extends React.Component {
             }
         }
 
-        if (this.canRemoveMember() && this.props.channel.name !== Constants.DEFAULT_CHANNEL) {
+        if (this.props.canRemoveMember && this.props.channel.name !== Constants.DEFAULT_CHANNEL) {
             return (
                 <button
                     id='removeMember'

--- a/components/channel_members_dropdown/index.js
+++ b/components/channel_members_dropdown/index.js
@@ -5,11 +5,32 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getChannelStats} from 'mattermost-redux/actions/channels';
 
+import UserStore from 'stores/user_store.jsx';
+import TeamStore from 'stores/team_store.jsx';
+import ChannelStore from 'stores/channel_store.jsx';
+import {canManageMembers} from 'utils/channel_utils.jsx';
+
 import ChannelMembersDropdown from './channel_members_dropdown.jsx';
 
 function mapStateToProps(state, ownProps) {
+    const license = state.entities.general.license;
+    const isLicensed = license.IsLicensed === 'true';
+
+    const canChangeMemberRoles = UserStore.isSystemAdminForCurrentUser() ||
+        TeamStore.isTeamAdminForCurrentTeam() ||
+        ChannelStore.isChannelAdminForCurrentChannel();
+    const canRemoveMember = canManageMembers(
+        ownProps.channel,
+        ChannelStore.isChannelAdminForCurrentChannel(),
+        TeamStore.isTeamAdminForCurrentTeam(),
+        UserStore.isSystemAdminForCurrentUser()
+    );
+
     return {
-        ...ownProps
+        ...ownProps,
+        isLicensed,
+        canChangeMemberRoles,
+        canRemoveMember
     };
 }
 

--- a/components/channel_members_dropdown/index.js
+++ b/components/channel_members_dropdown/index.js
@@ -27,7 +27,6 @@ function mapStateToProps(state, ownProps) {
     );
 
     return {
-        ...ownProps,
         isLicensed,
         canChangeMemberRoles,
         canRemoveMember

--- a/components/channel_members_dropdown/index.js
+++ b/components/channel_members_dropdown/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getChannelStats} from 'mattermost-redux/actions/channels';
+import {getLicense} from 'mattermost-redux/selectors/entities/general';
 
 import UserStore from 'stores/user_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
@@ -13,7 +14,7 @@ import {canManageMembers} from 'utils/channel_utils.jsx';
 import ChannelMembersDropdown from './channel_members_dropdown.jsx';
 
 function mapStateToProps(state, ownProps) {
-    const license = state.entities.general.license;
+    const license = getLicense(state);
     const isLicensed = license.IsLicensed === 'true';
 
     const canChangeMemberRoles = UserStore.isSystemAdminForCurrentUser() ||

--- a/components/channel_notifications_modal/channel_notifications_modal.jsx
+++ b/components/channel_notifications_modal/channel_notifications_modal.jsx
@@ -206,7 +206,7 @@ export default class ChannelNotificationsModal extends React.Component {
                                     serverError={this.state.serverError}
                                 />
                                 <div className='divider-light'/>
-                                {global.mm_config.SendPushNotifications !== 'false' &&
+                                {this.props.sendPushNotifications &&
                                 <NotificationSection
                                     section={NotificationSections.PUSH}
                                     expand={this.state.activeSection === NotificationSections.PUSH}
@@ -247,5 +247,6 @@ ChannelNotificationsModal.propTypes = {
     onHide: PropTypes.func.isRequired,
     channel: PropTypes.object.isRequired,
     channelMember: PropTypes.object.isRequired,
-    currentUser: PropTypes.object.isRequired
+    currentUser: PropTypes.object.isRequired,
+    sendPushNotifications: PropTypes.bool.isRequired
 };

--- a/components/channel_notifications_modal/index.js
+++ b/components/channel_notifications_modal/index.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import ChannelNotificationsModal from './channel_notifications_modal.jsx';
+
+function mapStateToProps(state, ownProps) {
+    const config = state.entities.general.config;
+    const sendPushNotifications = config.SendPushNotifications === 'true';
+
+    return {
+        ...ownProps,
+        sendPushNotifications
+    };
+}
+
+export default connect(mapStateToProps)(ChannelNotificationsModal);

--- a/components/channel_notifications_modal/index.js
+++ b/components/channel_notifications_modal/index.js
@@ -5,12 +5,11 @@ import {connect} from 'react-redux';
 
 import ChannelNotificationsModal from './channel_notifications_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     const config = state.entities.general.config;
     const sendPushNotifications = config.SendPushNotifications === 'true';
 
     return {
-        ...ownProps,
         sendPushNotifications
     };
 }

--- a/components/channel_notifications_modal/index.js
+++ b/components/channel_notifications_modal/index.js
@@ -2,11 +2,12 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import ChannelNotificationsModal from './channel_notifications_modal.jsx';
 
 function mapStateToProps(state) {
-    const config = state.entities.general.config;
+    const config = getConfig(state);
     const sendPushNotifications = config.SendPushNotifications === 'true';
 
     return {

--- a/components/invite_member_modal/index.js
+++ b/components/invite_member_modal/index.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import InviteMemberModal from './invite_member_modal.jsx';
+
+function mapStateToProps(state, ownProps) {
+    const config = state.entities.general.config;
+
+    const sendEmailNotifications = config.SendEmailNotifications === 'true';
+    const enableUserCreation = config.EnableUserCreation === 'true';
+
+    return {
+        ...ownProps,
+        sendEmailNotifications,
+        enableUserCreation
+    };
+}
+
+export default connect(mapStateToProps)(InviteMemberModal);

--- a/components/invite_member_modal/index.js
+++ b/components/invite_member_modal/index.js
@@ -5,14 +5,13 @@ import {connect} from 'react-redux';
 
 import InviteMemberModal from './invite_member_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     const config = state.entities.general.config;
 
     const sendEmailNotifications = config.SendEmailNotifications === 'true';
     const enableUserCreation = config.EnableUserCreation === 'true';
 
     return {
-        ...ownProps,
         sendEmailNotifications,
         enableUserCreation
     };

--- a/components/invite_member_modal/index.js
+++ b/components/invite_member_modal/index.js
@@ -2,11 +2,12 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import InviteMemberModal from './invite_member_modal.jsx';
 
 function mapStateToProps(state) {
-    const config = state.entities.general.config;
+    const config = getConfig(state);
 
     const sendEmailNotifications = config.SendEmailNotifications === 'true';
     const enableUserCreation = config.EnableUserCreation === 'true';

--- a/components/invite_member_modal/invite_member_modal.jsx
+++ b/components/invite_member_modal/invite_member_modal.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import ReactDOM from 'react-dom';
 import {defineMessages, FormattedHTMLMessage, FormattedMessage, injectIntl, intlShape} from 'react-intl';
+import PropTypes from 'prop-types';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {inviteMembers} from 'actions/team_actions.jsx';
@@ -15,7 +16,7 @@ import UserStore from 'stores/user_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as utils from 'utils/utils.jsx';
 
-import ConfirmModal from './confirm_modal.jsx';
+import ConfirmModal from 'components/confirm_modal.jsx';
 
 const ActionTypes = Constants.ActionTypes;
 
@@ -50,16 +51,6 @@ class InviteMemberModal extends React.Component {
     constructor(props) {
         super(props);
 
-        this.teamChange = this.teamChange.bind(this);
-        this.handleToggle = this.handleToggle.bind(this);
-        this.handleSubmit = this.handleSubmit.bind(this);
-        this.handleHide = this.handleHide.bind(this);
-        this.addInviteFields = this.addInviteFields.bind(this);
-        this.clearFields = this.clearFields.bind(this);
-        this.removeInviteFields = this.removeInviteFields.bind(this);
-        this.showGetTeamInviteLinkModal = this.showGetTeamInviteLinkModal.bind(this);
-        this.handleKeyDown = this.handleKeyDown.bind(this);
-
         const team = TeamStore.getCurrent();
 
         this.state = {
@@ -69,15 +60,13 @@ class InviteMemberModal extends React.Component {
             emailErrors: {},
             firstNameErrors: {},
             lastNameErrors: {},
-            emailEnabled: global.window.mm_config.SendEmailNotifications === 'true',
-            userCreationEnabled: global.window.mm_config.EnableUserCreation === 'true',
             showConfirmModal: false,
             isSendingEmails: false,
             teamType: team ? team.type : null
         };
     }
 
-    teamChange() {
+    teamChange = () => {
         const team = TeamStore.getCurrent();
         const teamType = team ? team.type : null;
         this.setState({
@@ -95,15 +84,15 @@ class InviteMemberModal extends React.Component {
         TeamStore.removeChangeListener(this.teamChange);
     }
 
-    handleToggle(value) {
+    handleToggle = (value) => {
         this.setState({
             show: value,
             serverError: null
         });
     }
 
-    handleSubmit() {
-        if (!this.state.emailEnabled) {
+    handleSubmit = () => {
+        if (!this.props.sendEmailNotifications) {
             return;
         }
 
@@ -162,7 +151,7 @@ class InviteMemberModal extends React.Component {
         );
     }
 
-    handleHide(requireConfirm) {
+    handleHide = (requireConfirm) => {
         if (requireConfirm) {
             var notEmpty = false;
             for (var i = 0; i < this.state.inviteIds.length; i++) {
@@ -190,14 +179,14 @@ class InviteMemberModal extends React.Component {
         });
     }
 
-    addInviteFields() {
+    addInviteFields = () => {
         var count = this.state.idCount + 1;
         var inviteIds = this.state.inviteIds;
         inviteIds.push(count);
         this.setState({inviteIds, idCount: count});
     }
 
-    clearFields() {
+    clearFields = () => {
         var inviteIds = this.state.inviteIds;
 
         for (var i = 0; i < inviteIds.length; i++) {
@@ -216,7 +205,7 @@ class InviteMemberModal extends React.Component {
         });
     }
 
-    removeInviteFields(index) {
+    removeInviteFields = (index) => {
         var count = this.state.idCount;
         var inviteIds = this.state.inviteIds;
         var i = inviteIds.indexOf(index);
@@ -229,13 +218,13 @@ class InviteMemberModal extends React.Component {
         this.setState({inviteIds, idCount: count});
     }
 
-    showGetTeamInviteLinkModal() {
+    showGetTeamInviteLinkModal = () => {
         this.handleHide(false);
 
         GlobalActions.showGetTeamInviteLinkModal();
     }
 
-    handleKeyDown(e) {
+    handleKeyDown = (e) => {
         if (e.keyCode === Constants.KeyCodes.ENTER) {
             e.preventDefault();
             this.handleSubmit();
@@ -308,7 +297,7 @@ class InviteMemberModal extends React.Component {
                                     ref={'first_name' + index}
                                     placeholder={formatMessage(holders.firstname)}
                                     maxLength='64'
-                                    disabled={!this.state.emailEnabled || !this.state.userCreationEnabled}
+                                    disabled={!this.props.sendEmailNotifications || !this.props.enableUserCreation}
                                     spellCheck='false'
                                 />
                                 {firstNameError}
@@ -323,7 +312,7 @@ class InviteMemberModal extends React.Component {
                                     ref={'last_name' + index}
                                     placeholder={formatMessage(holders.lastname)}
                                     maxLength='64'
-                                    disabled={!this.state.emailEnabled || !this.state.userCreationEnabled}
+                                    disabled={!this.props.sendEmailNotifications || !this.props.enableUserCreation}
                                     spellCheck='false'
                                 />
                                 {lastNameError}
@@ -344,7 +333,7 @@ class InviteMemberModal extends React.Component {
                                 className='form-control'
                                 placeholder='email@domain.com'
                                 maxLength='64'
-                                disabled={!this.state.emailEnabled || !this.state.userCreationEnabled}
+                                disabled={!this.props.sendEmailNotifications || !this.props.enableUserCreation}
                                 spellCheck='false'
                                 autoFocus={true}
                             />
@@ -368,7 +357,7 @@ class InviteMemberModal extends React.Component {
                 defaultChannelName = ChannelStore.getByName(Constants.DEFAULT_CHANNEL).display_name;
             }
 
-            if (this.state.emailEnabled && this.state.userCreationEnabled) {
+            if (this.props.sendEmailNotifications && this.props.enableUserCreation) {
                 content = (
                     <div>
                         {serverError}
@@ -430,7 +419,7 @@ class InviteMemberModal extends React.Component {
                         {sendButtonLabel}
                     </button>
                 );
-            } else if (this.state.userCreationEnabled) {
+            } else if (this.props.enableUserCreation) {
                 var teamInviteLink = null;
                 if (currentUser && this.state.teamType === 'O') {
                     var link = (
@@ -537,7 +526,9 @@ class InviteMemberModal extends React.Component {
 }
 
 InviteMemberModal.propTypes = {
-    intl: intlShape.isRequired
+    intl: intlShape.isRequired,
+    sendEmailNotifications: PropTypes.bool.isRequired,
+    enableUserCreation: PropTypes.bool.isRequired
 };
 
 export default injectIntl(InviteMemberModal);

--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -17,10 +17,14 @@ function mapStateToProps(state, ownProps) {
         currentChannelMembers = getProfilesInCurrentChannel(state);
     }
 
+    const config = state.entities.general.config;
+    const restrictDirectMessage = config.RestrictDirectMessage;
+
     return {
         ...ownProps,
         currentChannelMembers,
-        currentUserId: getCurrentUserId(state)
+        currentUserId: getCurrentUserId(state),
+        restrictDirectMessage
     };
 }
 

--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -21,7 +21,6 @@ function mapStateToProps(state, ownProps) {
     const restrictDirectMessage = config.RestrictDirectMessage;
 
     return {
-        ...ownProps,
         currentChannelMembers,
         currentUserId: getCurrentUserId(state),
         restrictDirectMessage

--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -8,6 +8,7 @@ import {
     getCurrentUserId,
     getProfilesInCurrentChannel
 } from 'mattermost-redux/selectors/entities/users';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import MoreDirectChannels from './more_direct_channels.jsx';
 
@@ -17,7 +18,7 @@ function mapStateToProps(state, ownProps) {
         currentChannelMembers = getProfilesInCurrentChannel(state);
     }
 
-    const config = state.entities.general.config;
+    const config = getConfig(state);
     const restrictDirectMessage = config.RestrictDirectMessage;
 
     return {

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -41,6 +41,11 @@ export default class MoreDirectChannels extends React.Component {
         isExistingChannel: PropTypes.bool.isRequired,
 
         /*
+         * The mode by which direct messages are restricted, if at all.
+         */
+        restrictDirectMessage: PropTypes.string,
+
+        /*
          * Function to call on modal dismissed
          */
         onModalDismissed: PropTypes.func,
@@ -78,7 +83,7 @@ export default class MoreDirectChannels extends React.Component {
 
         this.searchTimeoutId = 0;
         this.term = '';
-        this.listType = global.window.mm_config.RestrictDirectMessage;
+        this.listType = this.props.restrictDirectMessage;
 
         const values = [];
 

--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -24,7 +24,7 @@ import * as Utils from 'utils/utils.jsx';
 import ChannelInfoModal from 'components/channel_info_modal';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import ChannelMembersModal from 'components/channel_members_modal';
-import ChannelNotificationsModal from 'components/channel_notifications_modal/channel_notifications_modal.jsx';
+import ChannelNotificationsModal from 'components/channel_notifications_modal';
 import DeleteChannelModal from 'components/delete_channel_modal';
 import MoreDirectChannels from 'components/more_direct_channels';
 import NotifyCounts from 'components/notify_counts.jsx';

--- a/components/search_results_item/index.js
+++ b/components/search_results_item/index.js
@@ -12,10 +12,17 @@ import SearchResultsItem from './search_results_item.jsx';
 
 function mapStateToProps() {
     const getCommentCountForPost = makeGetCommentCountForPost();
-    return (state, ownProps) => ({
-        currentTeamName: getCurrentTeam(state).name,
-        commentCountForPost: getCommentCountForPost(state, {post: ownProps.post})
-    });
+
+    return (state, ownProps) => {
+        const config = state.entities.general.config;
+        const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
+
+        return {
+            currentTeamName: getCurrentTeam(state).name,
+            commentCountForPost: getCommentCountForPost(state, {post: ownProps.post}),
+            enablePostUsernameOverride
+        };
+    };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/components/search_results_item/index.js
+++ b/components/search_results_item/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {makeGetCommentCountForPost} from 'mattermost-redux/selectors/entities/posts';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {closeRightHandSide} from 'actions/views/rhs';
 
@@ -14,7 +15,7 @@ function mapStateToProps() {
     const getCommentCountForPost = makeGetCommentCountForPost();
 
     return (state, ownProps) => {
-        const config = state.entities.general.config;
+        const config = getConfig(state);
         const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
 
         return {

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -92,6 +92,11 @@ export default class SearchResultsItem extends React.PureComponent {
         commentCountForPost: PropTypes.number,
 
         /**
+         * Whether post username overrides are to be respected.
+         */
+        enablePostUsernameOverride: PropTypes.bool.isRequired,
+
+        /**
         *  Function used for shrinking LHS
         *  on click of jump to message in expanded mode
         */
@@ -200,7 +205,7 @@ export default class SearchResultsItem extends React.PureComponent {
         if (post.props &&
                 post.props.from_webhook &&
                 post.props.override_username &&
-                global.window.mm_config.EnablePostUsernameOverride === 'true') {
+                this.props.enablePostUsernameOverride) {
             overrideUsername = post.props.override_username;
             disableProfilePopover = true;
         }

--- a/components/should_verify_email/index.js
+++ b/components/should_verify_email/index.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import ShouldVerifyEmail from './should_verify_email.jsx';
+
+function mapStateToProps(state, ownProps) {
+    const config = state.entities.general.config;
+    const siteName = config.SiteName;
+
+    return {
+        ...ownProps,
+        siteName
+    };
+}
+
+export default connect(mapStateToProps)(ShouldVerifyEmail);

--- a/components/should_verify_email/index.js
+++ b/components/should_verify_email/index.js
@@ -5,12 +5,11 @@ import {connect} from 'react-redux';
 
 import ShouldVerifyEmail from './should_verify_email.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     const config = state.entities.general.config;
     const siteName = config.SiteName;
 
     return {
-        ...ownProps,
         siteName
     };
 }

--- a/components/should_verify_email/index.js
+++ b/components/should_verify_email/index.js
@@ -2,11 +2,12 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import ShouldVerifyEmail from './should_verify_email.jsx';
 
 function mapStateToProps(state) {
-    const config = state.entities.general.config;
+    const config = getConfig(state);
     const siteName = config.SiteName;
 
     return {

--- a/components/should_verify_email/should_verify_email.jsx
+++ b/components/should_verify_email/should_verify_email.jsx
@@ -12,13 +12,12 @@ export default class ShouldVerifyEmail extends React.Component {
     constructor(props) {
         super(props);
 
-        this.handleResend = this.handleResend.bind(this);
-
         this.state = {
             resendStatus: 'none'
         };
     }
-    handleResend() {
+
+    handleResend = () => {
         const email = (new URLSearchParams(this.props.location.search)).get('email');
 
         this.setState({resendStatus: 'sending'});
@@ -72,7 +71,7 @@ export default class ShouldVerifyEmail extends React.Component {
                                 id='email_verify.almost'
                                 defaultMessage='{siteName}: You are almost done'
                                 values={{
-                                    siteName: global.window.mm_config.SiteName
+                                    siteName: this.props.siteName
                                 }}
                             />
                         </h3>
@@ -101,8 +100,7 @@ export default class ShouldVerifyEmail extends React.Component {
     }
 }
 
-ShouldVerifyEmail.defaultProps = {
-};
 ShouldVerifyEmail.propTypes = {
-    location: PropTypes.object.isRequired
+    location: PropTypes.object.isRequired,
+    siteName: PropTypes.string
 };

--- a/components/team_sidebar/index.js
+++ b/components/team_sidebar/index.js
@@ -9,8 +9,15 @@ import {withRouter} from 'react-router-dom';
 import TeamSidebar from './team_sidebar_controller.jsx';
 
 function mapStateToProps(state, ownProps) {
+    const config = state.entities.general.config;
+
+    const experimentalPrimaryTeam = config.ExperimentalPrimaryTeam;
+    const enableTeamCreation = config.EnableTeamCreation === 'true';
+
     return {
-        ...ownProps
+        ...ownProps,
+        experimentalPrimaryTeam,
+        enableTeamCreation
     };
 }
 

--- a/components/team_sidebar/index.js
+++ b/components/team_sidebar/index.js
@@ -8,14 +8,13 @@ import {withRouter} from 'react-router-dom';
 
 import TeamSidebar from './team_sidebar_controller.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     const config = state.entities.general.config;
 
     const experimentalPrimaryTeam = config.ExperimentalPrimaryTeam;
     const enableTeamCreation = config.EnableTeamCreation === 'true';
 
     return {
-        ...ownProps,
         experimentalPrimaryTeam,
         enableTeamCreation
     };

--- a/components/team_sidebar/index.js
+++ b/components/team_sidebar/index.js
@@ -5,11 +5,12 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getTeams} from 'mattermost-redux/actions/teams';
 import {withRouter} from 'react-router-dom';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import TeamSidebar from './team_sidebar_controller.jsx';
 
 function mapStateToProps(state) {
-    const config = state.entities.general.config;
+    const config = getConfig(state);
 
     const experimentalPrimaryTeam = config.ExperimentalPrimaryTeam;
     const enableTeamCreation = config.EnableTeamCreation === 'true';

--- a/components/team_sidebar/team_sidebar_controller.jsx
+++ b/components/team_sidebar/team_sidebar_controller.jsx
@@ -16,6 +16,8 @@ import TeamButton from './components/team_button.jsx';
 
 export default class TeamSidebar extends React.Component {
     static propTypes = {
+        experimentalPrimaryTeam: PropTypes.string,
+        enableTeamCreation: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             getTeams: PropTypes.func.isRequired
         }).isRequired
@@ -24,15 +26,10 @@ export default class TeamSidebar extends React.Component {
     constructor(props) {
         super(props);
 
-        this.getStateFromStores = this.getStateFromStores.bind(this);
-        this.onChange = this.onChange.bind(this);
-        this.handleResize = this.handleResize.bind(this);
-        this.setStyles = this.setStyles.bind(this);
-
         this.state = this.getStateFromStores();
     }
 
-    getStateFromStores() {
+    getStateFromStores =() => {
         const teamMembers = TeamStore.getMyTeamMembers();
         const currentTeamId = TeamStore.getCurrentId();
 
@@ -74,18 +71,18 @@ export default class TeamSidebar extends React.Component {
         }
     }
 
-    onChange() {
+    onChange = () => {
         this.setState(this.getStateFromStores());
         this.setStyles();
     }
 
-    handleResize() {
+    handleResize = () => {
         const teamMembers = this.state.teamMembers;
         this.setState({show: teamMembers && teamMembers.length > 1});
         this.setStyles();
     }
 
-    setStyles() {
+    setStyles = () => {
         const root = document.querySelector('#root');
 
         if (this.state.show) {
@@ -143,7 +140,7 @@ export default class TeamSidebar extends React.Component {
                 );
             });
 
-        if (moreTeams && !global.mm_config.ExperimentalPrimaryTeam) {
+        if (moreTeams && !this.props.experimentalPrimaryTeam) {
             teams.push(
                 <TeamButton
                     btnClass='team-btn__add'
@@ -159,7 +156,7 @@ export default class TeamSidebar extends React.Component {
                     content={<i className='fa fa-plus'/>}
                 />
             );
-        } else if (global.mm_config.EnableTeamCreation === 'true' || isSystemAdmin) {
+        } else if (this.props.enableTeamCreation || isSystemAdmin) {
             teams.push(
                 <TeamButton
                     btnClass='team-btn__add'

--- a/tests/components/__snapshots__/search_results_item.test.jsx.snap
+++ b/tests/components/__snapshots__/search_results_item.test.jsx.snap
@@ -455,7 +455,7 @@ exports[`components/SearchResultsItem should match snapshot for deleted message 
                 isBusy={false}
                 isRHS={false}
                 overwriteImage=""
-                overwriteName={true}
+                overwriteName="overridden_username"
                 status="hello"
                 user={
                   Object {
@@ -516,7 +516,7 @@ exports[`components/SearchResultsItem should match snapshot for deleted message 
                   "pending_post_id": "",
                   "props": Object {
                     "from_webhook": true,
-                    "override_username": true,
+                    "override_username": "overridden_username",
                   },
                   "root_id": "",
                   "state": "deleted",

--- a/tests/components/navbar/__snapshots__/navbar.test.jsx.snap
+++ b/tests/components/navbar/__snapshots__/navbar.test.jsx.snap
@@ -318,7 +318,7 @@ exports[`components/navbar/Navbar should match snapshot, for private channel 1`]
     onHide={[Function]}
     show={false}
   />
-  <ChannelNotificationsModal
+  <Connect(ChannelNotificationsModal)
     channel={
       Object {
         "display_name": "display_name",
@@ -665,7 +665,7 @@ exports[`components/navbar/Navbar should match snapshot, if WebRTC is not enable
     onHide={[Function]}
     show={false}
   />
-  <ChannelNotificationsModal
+  <Connect(ChannelNotificationsModal)
     channel={
       Object {
         "display_name": "display_name",
@@ -847,7 +847,7 @@ exports[`components/navbar/Navbar should match snapshot, if enabled WebRTC and D
     onHide={[Function]}
     show={false}
   />
-  <ChannelNotificationsModal
+  <Connect(ChannelNotificationsModal)
     channel={
       Object {
         "display_name": "display_name",
@@ -1195,7 +1195,7 @@ exports[`components/navbar/Navbar should match snapshot, if not licensed 1`] = `
     onHide={[Function]}
     show={false}
   />
-  <ChannelNotificationsModal
+  <Connect(ChannelNotificationsModal)
     channel={
       Object {
         "display_name": "display_name",
@@ -1544,7 +1544,7 @@ exports[`components/navbar/Navbar should match snapshot, valid state 1`] = `
     onHide={[Function]}
     show={false}
   />
-  <ChannelNotificationsModal
+  <Connect(ChannelNotificationsModal)
     channel={
       Object {
         "display_name": "display_name",

--- a/tests/components/navbar/navbar.test.jsx
+++ b/tests/components/navbar/navbar.test.jsx
@@ -12,7 +12,9 @@ describe('components/navbar/Navbar', () => {
         isPinnedPosts: true,
         actions: {
             showEditChannelHeaderModal: jest.fn()
-        }
+        },
+        isLicensed: true,
+        enableWebrtc: true
     };
 
     const validState = {
@@ -55,7 +57,10 @@ describe('components/navbar/Navbar', () => {
     test('should match snapshot, if not licensed', () => {
         global.window.mm_license.IsLicensed = 'false';
         const wrapper = shallow(
-            <Navbar {...baseProps}/>
+            <Navbar
+                {...baseProps}
+                isLicensed={false}
+            />
         );
 
         wrapper.setState(validState);
@@ -65,7 +70,10 @@ describe('components/navbar/Navbar', () => {
     test('should match snapshot, if enabled WebRTC and DM channel', () => {
         global.window.mm_config.EnableWebrtc = 'true';
         const wrapper = shallow(
-            <Navbar {...baseProps}/>
+            <Navbar
+                {...baseProps}
+                enableWebrtc={true}
+            />
         );
 
         const newValidState = {...validState, channel: {type: 'D', id: 'channel_id', name: 'user_id_1__user_id_2', display_name: 'display_name'}};
@@ -76,7 +84,10 @@ describe('components/navbar/Navbar', () => {
     test('should match snapshot, if WebRTC is not enabled', () => {
         global.window.mm_config.EnableWebrtc = 'false';
         const wrapper = shallow(
-            <Navbar {...baseProps}/>
+            <Navbar
+                {...baseProps}
+                enableWebrtc={false}
+            />
         );
 
         wrapper.setState(validState);

--- a/tests/components/search_results_item.test.jsx
+++ b/tests/components/search_results_item.test.jsx
@@ -36,8 +36,6 @@ describe('components/SearchResultsItem', () => {
     let defaultProps;
 
     beforeEach(() => {
-        global.window.mm_config = {};
-
         mockFunc = jest.fn();
 
         user = {
@@ -84,6 +82,7 @@ describe('components/SearchResultsItem', () => {
             isFlagged: true,
             isBusy: false,
             status: 'hello',
+            enablePostUsernameOverride: false,
             onSelect: mockFunc,
             actions: {
                 closeRightHandSide: mockFunc
@@ -100,7 +99,6 @@ describe('components/SearchResultsItem', () => {
     });
 
     test('should match snapshot for deleted message with attachments by bot', () => {
-        global.window.mm_config.EnablePostUsernameOverride = 'true';
         const props = {
             ...defaultProps,
             post: {
@@ -109,9 +107,10 @@ describe('components/SearchResultsItem', () => {
                 state: 'deleted',
                 props: {
                     from_webhook: true,
-                    override_username: true
+                    override_username: 'overridden_username'
                 }
-            }
+            },
+            enablePostUsernameOverride: true
         };
 
         const wrapper = shallow(


### PR DESCRIPTION
#### Summary
This is a subset of the changes in the `MM-8589-remove_mm_global_license` branch, broken up into multiple PRs to facilitate easier review. See any linked PRs for other changes if you're interested. 

These changes, as a whole, move towards removing our dependence on the global `mm_config` and `mm_license` objects. These changes will ultimately facilitate resolving https://mattermost.atlassian.net/browse/MM-8604, allowing us to stop hard refreshing the application whenever someone makes a configuration change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8589

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

### Related PRs
https://github.com/mattermost/mattermost-webapp/pull/816
https://github.com/mattermost/mattermost-webapp/pull/819
https://github.com/mattermost/mattermost-webapp/pull/820
https://github.com/mattermost/mattermost-webapp/pull/821
https://github.com/mattermost/mattermost-webapp/pull/822