### PR TITLE
MM-9628: fix broken channel switching

### DIFF
--- a/components/channel_layout/center_channel/center_channel.jsx
+++ b/components/channel_layout/center_channel/center_channel.jsx
@@ -11,16 +11,18 @@ import ChannelIdentifierRouter from 'components/channel_layout/channel_identifie
 
 export default class CenterChannel extends React.PureComponent {
     static propTypes = {
-        params: PropTypes.object,
+        match: PropTypes.object.isRequired,
+        location: PropTypes.object.isRequired,
         lastChannelPath: PropTypes.string.isRequired
     };
 
-    constructor(params) {
-        super(params);
+    constructor(props) {
+        super(props);
         this.state = {
             returnTo: ''
         };
     }
+
     componentWillReceiveProps(nextProps) {
         if (this.props.location.pathname !== nextProps.location.pathname && nextProps.location.pathname.includes('/pl/')) {
             this.setState({returnTo: this.props.location.pathname});
@@ -29,7 +31,7 @@ export default class CenterChannel extends React.PureComponent {
 
     render() {
         const {lastChannelPath} = this.props;
-        const url = this.props.params.match.url;
+        const url = this.props.match.url;
         return (
             <div
                 id='inner-wrap-webrtc'

--- a/components/channel_layout/center_channel/index.js
+++ b/components/channel_layout/center_channel/index.js
@@ -25,7 +25,7 @@ const getLastChannelPath = (state, teamName) => {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-    lastChannelPath: `${ownProps.params.match.url}/channels/${getLastChannelPath(state, ownProps.params.match.params.team)}`
+    lastChannelPath: `${ownProps.match.url}/channels/${getLastChannelPath(state, ownProps.match.params.team)}`
 });
 
 export default connect(mapStateToProps)(CenterChannel);

--- a/components/channel_layout/channel_controller.jsx
+++ b/components/channel_layout/channel_controller.jsx
@@ -36,6 +36,7 @@ export default class ChannelController extends React.Component {
         pathName: PropTypes.string.isRequired,
         teamType: PropTypes.string.isRequired
     };
+
     shouldComponentUpdate(nextProps) {
         return this.props.teamType !== nextProps.teamType || this.props.pathName !== nextProps.pathName;
     }
@@ -52,15 +53,7 @@ export default class ChannelController extends React.Component {
                     <WebrtcSidebar/>
                     <Route component={TeamSidebar}/>
                     <Route component={Sidebar}/>
-
-                    <Route
-                        render={(params) => (
-                            <CenterChannel
-                                params={params}
-                            />
-                        )}
-                    />
-
+                    <Route component={CenterChannel}/>
                     <Pluggable pluggableName='Root'/>
                     <UserSettingsModal/>
                     <GetPostLinkModal/>


### PR DESCRIPTION
#### Summary
A recent refactor of the center channel component grouped the implicit
router parameters as a `params` prop, but then failed to utilize this
everywhere. For simplicity, I've eliminataed the `params` prop and just
declared the expected incoming parameters directly on `props`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9628

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed