### PR TITLE
Remove write access to town square. Hide it when no unread messages.

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -51,7 +51,6 @@ export default class ChannelHeader extends React.Component {
     static propTypes = {
         channel: PropTypes.object.isRequired,
         channelMember: PropTypes.object.isRequired,
-        teamMember: PropTypes.object.isRequired,
         isFavorite: PropTypes.bool,
         isDefault: PropTypes.bool,
         currentUser: PropTypes.object.isRequired,
@@ -59,10 +58,10 @@ export default class ChannelHeader extends React.Component {
         dmUserStatus: PropTypes.object,
         dmUserIsInCall: PropTypes.bool,
         enableFormatting: PropTypes.bool.isRequired,
+        isReadOnly: PropTypes.bool,
         rhsState: PropTypes.oneOf(
             Object.values(RHSStates)
         ),
-        isLicensed: PropTypes.bool.isRequired,
         enableWebrtc: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             leaveChannel: PropTypes.func.isRequired,
@@ -650,71 +649,73 @@ export default class ChannelHeader extends React.Component {
                 );
             }
 
-            dropdownContents.push(
-                <ChannelPermissionGate
-                    channelId={channel.id}
-                    teamId={teamId}
-                    permissions={[isPrivate ? Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES : Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]}
-                    key='set_channel_info_permission'
-                >
-                    <li
-                        key='divider-2'
-                        className='divider'
-                    />
-
-                    <li
-                        key='set_channel_header'
-                        role='presentation'
+            if (!this.props.isReadOnly) {
+                dropdownContents.push(
+                    <ChannelPermissionGate
+                        channelId={channel.id}
+                        teamId={teamId}
+                        permissions={[isPrivate ? Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES : Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]}
+                        key='set_channel_info_permission'
                     >
-                        <ToggleModalButtonRedux
-                            id='channelEditHeader'
-                            role='menuitem'
-                            modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
-                            dialogType={EditChannelHeaderModal}
-                            dialogProps={{channel}}
-                        >
-                            <FormattedMessage
-                                id='channel_header.setHeader'
-                                defaultMessage='Edit Channel Header'
-                            />
-                        </ToggleModalButtonRedux>
-                    </li>
+                        <li
+                            key='divider-2'
+                            className='divider'
+                        />
 
-                    <li
-                        key='set_channel_purpose'
-                        role='presentation'
-                    >
-                        <button
-                            className='style--none'
-                            id='channelEditPurpose'
-                            role='menuitem'
-                            onClick={this.showEditChannelPurposeModal}
+                        <li
+                            key='set_channel_header'
+                            role='presentation'
                         >
-                            <FormattedMessage
-                                id='channel_header.setPurpose'
-                                defaultMessage='Edit Channel Purpose'
-                            />
-                        </button>
-                    </li>
+                            <ToggleModalButtonRedux
+                                id='channelEditHeader'
+                                role='menuitem'
+                                modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
+                                dialogType={EditChannelHeaderModal}
+                                dialogProps={{channel}}
+                            >
+                                <FormattedMessage
+                                    id='channel_header.setHeader'
+                                    defaultMessage='Edit Channel Header'
+                                />
+                            </ToggleModalButtonRedux>
+                        </li>
 
-                    <li
-                        key='rename_channel'
-                        role='presentation'
-                    >
-                        <button
-                            className='style--none'
-                            id='channelRename'
-                            role='menuitem'
-                            onClick={this.showRenameChannelModal}
+                        <li
+                            key='set_channel_purpose'
+                            role='presentation'
                         >
-                            <FormattedMessage
-                                id='channel_header.rename'
-                                defaultMessage='Rename Channel'
-                            />
-                        </button>
-                    </li>
-                </ChannelPermissionGate>
-            );
+                            <button
+                                className='style--none'
+                                id='channelEditPurpose'
+                                role='menuitem'
+                                onClick={this.showEditChannelPurposeModal}
+                            >
+                                <FormattedMessage
+                                    id='channel_header.setPurpose'
+                                    defaultMessage='Edit Channel Purpose'
+                                />
+                            </button>
+                        </li>
+
+                        <li
+                            key='rename_channel'
+                            role='presentation'
+                        >
+                            <button
+                                className='style--none'
+                                id='channelRename'
+                                role='menuitem'
+                                onClick={this.showRenameChannelModal}
+                            >
+                                <FormattedMessage
+                                    id='channel_header.rename'
+                                    defaultMessage='Rename Channel'
+                                />
+                            </button>
+                        </li>
+                    </ChannelPermissionGate>
+                );
+            }
 
             if (!this.props.isDefault) {
                 dropdownContents.push(
@@ -836,25 +837,9 @@ export default class ChannelHeader extends React.Component {
             );
         } else {
             let editMessage;
-            if (isDirect || isGroup) {
-                editMessage = (
-                    <button
-                        className='style--none'
-                        onClick={this.showEditChannelHeaderModal}
-                    >
-                        <FormattedMessage
-                            id='channel_header.addChannelHeader'
-                            defaultMessage='Add a channel description'
-                        />
-                    </button>
-                );
-            } else {
-                editMessage = (
-                    <ChannelPermissionGate
-                        channelId={channel.id}
-                        teamId={teamId}
-                        permissions={[isPrivate ? Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES : Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]}
-                    >
+            if (!this.props.isReadOnly) {
+                if (isDirect || isGroup) {
+                    editMessage = (
                         <button
                             className='style--none'
                             onClick={this.showEditChannelHeaderModal}
@@ -864,8 +849,26 @@ export default class ChannelHeader extends React.Component {
                                 defaultMessage='Add a channel description'
                             />
                         </button>
-                    </ChannelPermissionGate>
-                );
+                    );
+                } else {
+                    editMessage = (
+                        <ChannelPermissionGate
+                            channelId={channel.id}
+                            teamId={teamId}
+                            permissions={[isPrivate ? Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES : Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]}
+                        >
+                            <button
+                                className='style--none'
+                                onClick={this.showEditChannelHeaderModal}
+                            >
+                                <FormattedMessage
+                                    id='channel_header.addChannelHeader'
+                                    defaultMessage='Add a channel description'
+                                />
+                            </button>
+                        </ChannelPermissionGate>
+                    );
+                }
             }
             headerTextContainer = (
                 <div

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 import {favoriteChannel, leaveChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import {getCustomEmojisInText} from 'mattermost-redux/actions/emojis';
 import {General, Preferences} from 'mattermost-redux/constants';
-import {getChannel, getMyChannelMember} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, getMyChannelMember, isCurrentChannelReadOnly} from 'mattermost-redux/selectors/entities/channels';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getMyTeamMember} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser, getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
@@ -56,6 +56,7 @@ function mapStateToProps(state, ownProps) {
         rhsState: getRhsState(state),
         isLicensed: license.IsLicensed === 'true',
         enableWebrtc: config.EnableWebrtc === 'true',
+        isReadOnly: isCurrentChannelReadOnly(state),
     };
 }
 

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -24,6 +24,7 @@ export default class DotMenu extends Component {
         isRHS: PropTypes.bool,
         handleCommentClick: PropTypes.func,
         handleDropdownOpened: PropTypes.func,
+        isReadOnly: PropTypes.bool,
 
         actions: PropTypes.shape({
 
@@ -65,6 +66,7 @@ export default class DotMenu extends Component {
         commentCount: 0,
         isFlagged: false,
         isRHS: false,
+        isReadOnly: false,
     }
 
     constructor(props) {
@@ -167,18 +169,19 @@ export default class DotMenu extends Component {
                     post={this.props.post}
                 />
             );
-
-            dotMenuPin = (
-                <DotMenuItem
-                    idPrefix={idPrefix + 'Pin'}
-                    idCount={this.props.idCount}
-                    post={this.props.post}
-                    actions={{
-                        pinPost: this.props.actions.pinPost,
-                        unpinPost: this.props.actions.unpinPost,
-                    }}
-                />
-            );
+            if (!this.props.isReadOnly) {
+                dotMenuPin = (
+                    <DotMenuItem
+                        idPrefix={idPrefix + 'Pin'}
+                        idCount={this.props.idCount}
+                        post={this.props.post}
+                        actions={{
+                            pinPost: this.props.actions.pinPost,
+                            unpinPost: this.props.actions.unpinPost,
+                        }}
+                    />
+                );
+            }
         }
 
         let dotMenuDelete = null;

--- a/components/post_view/post_body/index.js
+++ b/components/post_view/post_body/index.js
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {isCurrentChannelReadOnly} from 'mattermost-redux/selectors/entities/channels';
 import {get, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -33,6 +34,7 @@ function mapStateToProps(state, ownProps) {
         previewEnabled: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, true),
         isEmbedVisible,
         enablePostUsernameOverride,
+        isReadOnly: isCurrentChannelReadOnly(state),
     };
 }
 

--- a/components/post_view/post_body/post_body.jsx
+++ b/components/post_view/post_body/post_body.jsx
@@ -87,6 +87,15 @@ export default class PostBody extends React.PureComponent {
          * Whether or not the post username can be overridden.
          */
         enablePostUsernameOverride: PropTypes.bool.isRequired,
+
+        /**
+         * Set not to allow edits on post
+         */
+        isReadOnly: PropTypes.bool,
+    }
+
+    static defaultProps = {
+        isReadOnly: false,
     }
 
     constructor(props) {
@@ -275,7 +284,10 @@ export default class PostBody extends React.PureComponent {
                 <div className={`post__body ${mentionHighlightClass} ${ephemeralPostClass}`}>
                     {messageWithAdditionalContent}
                     {fileAttachmentHolder}
-                    <ReactionListContainer post={post}/>
+                    <ReactionListContainer
+                        post={post}
+                        isReadOnly={this.props.isReadOnly}
+                    />
                 </div>
             </div>
         );

--- a/components/post_view/post_info/index.js
+++ b/components/post_view/post_info/index.js
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {addReaction, removePost} from 'mattermost-redux/actions/posts';
-import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, isCurrentChannelReadOnly} from 'mattermost-redux/selectors/entities/channels';
 import {get, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
@@ -25,6 +25,7 @@ function mapStateToProps(state, ownProps) {
         isFlagged: get(state, Preferences.CATEGORY_FLAGGED_POST, ownProps.post.id, null) != null,
         isMobile: state.views.channel.mobileView,
         enableEmojiPicker,
+        isReadOnly: isCurrentChannelReadOnly(state),
     };
 }
 

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -98,6 +98,11 @@ export default class PostInfo extends React.PureComponent {
          */
         enableEmojiPicker: PropTypes.bool.isRequired,
 
+        /**
+         * Set not to allow edits on post
+         */
+        isReadOnly: PropTypes.bool,
+
         actions: PropTypes.shape({
 
             /*
@@ -172,7 +177,7 @@ export default class PostInfo extends React.PureComponent {
             return null;
         }
 
-        const isMobile = this.props.isMobile;
+        const {isMobile, isReadOnly} = this.props;
         const hover = this.props.hover || this.state.showEmojiPicker || this.state.showDotMenu;
 
         let comments;
@@ -193,7 +198,7 @@ export default class PostInfo extends React.PureComponent {
                 );
             }
 
-            if (hover && this.props.enableEmojiPicker) {
+            if (hover && !isReadOnly && this.props.enableEmojiPicker) {
                 react = (
                     <span>
                         <EmojiPickerOverlay
@@ -232,6 +237,7 @@ export default class PostInfo extends React.PureComponent {
                     isFlagged={this.props.isFlagged}
                     handleCommentClick={this.props.handleCommentClick}
                     handleDropdownOpened={this.handleDotMenuOpened}
+                    isReadOnly={isReadOnly}
                 />
             );
         }
@@ -239,7 +245,7 @@ export default class PostInfo extends React.PureComponent {
         return (
             <div
                 ref='dotMenu'
-                className='col col__reply'
+                className={'col col__reply' + (isReadOnly ? ' dot_small' : '')}
             >
                 {dotMenu}
                 {react}

--- a/components/post_view/reaction_list/index.js
+++ b/components/post_view/reaction_list/index.js
@@ -16,7 +16,7 @@ function makeMapStateToProps() {
 
     return function mapStateToProps(state, ownProps) {
         const config = getConfig(state);
-        const enableEmojiPicker = config.EnableEmojiPicker === 'true';
+        const enableEmojiPicker = config.EnableEmojiPicker === 'true' && !ownProps.isReadOnly;
 
         const channel = getChannel(state, ownProps.post.channel_id) || {};
         const teamId = channel.team_id;

--- a/components/rhs_comment/index.js
+++ b/components/rhs_comment/index.js
@@ -2,11 +2,12 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
+import {isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import RhsComment from './rhs_comment.jsx';
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
     const enableEmojiPicker = config.EnableEmojiPicker === 'true';
     const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
@@ -14,6 +15,7 @@ function mapStateToProps(state) {
     return {
         enableEmojiPicker,
         enablePostUsernameOverride,
+        isReadOnly: isChannelReadOnlyById(state, ownProps.post.channel_id),
     };
 }
 

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -47,6 +47,7 @@ export default class RhsComment extends React.Component {
         isEmbedVisible: PropTypes.bool,
         enableEmojiPicker: PropTypes.bool.isRequired,
         enablePostUsernameOverride: PropTypes.bool.isRequired,
+        isReadOnly: PropTypes.bool.isRequired,
     };
 
     constructor(props) {
@@ -206,7 +207,7 @@ export default class RhsComment extends React.Component {
     };
 
     render() {
-        const post = this.props.post;
+        const {post, isReadOnly} = this.props;
 
         let idCount = -1;
         if (this.props.lastPostCount >= 0 && this.props.lastPostCount < Constants.TEST_ID_COUNT) {
@@ -351,7 +352,7 @@ export default class RhsComment extends React.Component {
 
         let react;
 
-        if (!isEphemeral && !post.failed && !isSystemMessage && this.props.enableEmojiPicker) {
+        if (!isReadOnly && !isEphemeral && !post.failed && !isSystemMessage && this.props.enableEmojiPicker) {
             react = (
                 <span>
                     <EmojiPickerOverlay
@@ -396,6 +397,7 @@ export default class RhsComment extends React.Component {
                     post={this.props.post}
                     isFlagged={this.props.isFlagged}
                     handleDropdownOpened={this.handleDropdownOpened}
+                    isReadOnly={isReadOnly}
                 />
             );
 
@@ -479,7 +481,10 @@ export default class RhsComment extends React.Component {
                                 {messageWithAdditionalContent}
                             </div>
                             {fileAttachment}
-                            <ReactionListContainer post={post}/>
+                            <ReactionListContainer
+                                post={post}
+                                isReadOnly={isReadOnly}
+                            />
                         </div>
                     </div>
                 </div>

--- a/components/rhs_root_post/index.js
+++ b/components/rhs_root_post/index.js
@@ -2,11 +2,12 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
+import {isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import RhsRootPost from './rhs_root_post.jsx';
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
     const enableEmojiPicker = config.EnableEmojiPicker === 'true';
     const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
@@ -14,6 +15,7 @@ function mapStateToProps(state) {
     return {
         enableEmojiPicker,
         enablePostUsernameOverride,
+        isReadOnly: isChannelReadOnlyById(state, ownProps.post.channel_id),
     };
 }
 

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -44,6 +44,7 @@ export default class RhsRootPost extends React.Component {
         isEmbedVisible: PropTypes.bool,
         enableEmojiPicker: PropTypes.bool.isRequired,
         enablePostUsernameOverride: PropTypes.bool.isRequired,
+        isReadOnly: PropTypes.bool.isRequired,
     };
 
     static defaultProps = {
@@ -195,8 +196,7 @@ export default class RhsRootPost extends React.Component {
     };
 
     render() {
-        const post = this.props.post;
-        const user = this.props.user;
+        const {post, user, isReadOnly} = this.props;
         var channel = ChannelStore.get(post.channel_id);
 
         const isEphemeral = Utils.isPostEphemeral(post);
@@ -218,7 +218,7 @@ export default class RhsRootPost extends React.Component {
 
         let react;
 
-        if (!isEphemeral && !post.failed && !isSystemMessage && this.props.enableEmojiPicker) {
+        if (!isReadOnly && !isEphemeral && !post.failed && !isSystemMessage && this.props.enableEmojiPicker) {
             react = (
                 <span>
                     <EmojiPickerOverlay
@@ -379,6 +379,7 @@ export default class RhsRootPost extends React.Component {
                 isFlagged={this.props.isFlagged}
                 handleDropdownOpened={this.handleDropdownOpened}
                 commentCount={this.props.commentCount}
+                isReadOnly={isReadOnly}
             />
         );
 
@@ -441,7 +442,10 @@ export default class RhsRootPost extends React.Component {
                                 </PostBodyAdditionalContent>
                             </div>
                             {fileAttachment}
-                            <ReactionListContainer post={post}/>
+                            <ReactionListContainer
+                                post={post}
+                                isReadOnly={isReadOnly}
+                            />
                         </div>
                     </div>
                 </div>

--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -7,11 +7,12 @@ import {bindActionCreators} from 'redux';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {leaveChannel} from 'mattermost-redux/actions/channels';
 
-import {getChannelsNameMapInCurrentTeam, makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getChannelsNameMapInCurrentTeam, makeGetChannel, isChannelReadOnly} from 'mattermost-redux/selectors/entities/channels';
 import {getMyChannelMemberships} from 'mattermost-redux/selectors/entities/common';
 import {getUserIdsInChannels, getUser} from 'mattermost-redux/selectors/entities/users';
 import {getInt, getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {isFavoriteChannel} from 'mattermost-redux/utils/channel_utils';
 
 import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
@@ -77,6 +78,9 @@ function makeMapStateToProps() {
             channelDisplayName = displayUsername(teammate, teammateNameDisplay);
         }
 
+        const shouldHideChannel = isChannelReadOnly(state, channel) && !ownProps.active &&
+            !isFavoriteChannel(state.entities.preferences.myPreferences, channel.id);
+
         return {
             config,
             channelId,
@@ -96,6 +100,7 @@ function makeMapStateToProps() {
             unreadMsgs,
             unreadMentions,
             membersCount,
+            shouldHideChannel,
         };
     };
 }

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -120,6 +120,11 @@ export default class SidebarChannel extends React.PureComponent {
          */
         membersCount: PropTypes.number.isRequired,
 
+        /**
+         * Flag if channel should be hidden in sidebar
+         */
+        shouldHideChannel: PropTypes.bool.isRequired,
+
         actions: PropTypes.shape({
             savePreferences: PropTypes.func.isRequired,
             leaveChannel: PropTypes.func.isRequired,
@@ -179,6 +184,9 @@ export default class SidebarChannel extends React.PureComponent {
 
         let closeHandler = null;
         if (!this.showChannelAsUnread()) {
+            if (this.props.shouldHideChannel) {
+                return '';
+            }
             if (this.props.channelType === Constants.DM_CHANNEL || this.props.channelType === Constants.GM_CHANNEL) {
                 closeHandler = this.handleLeaveDirectChannel;
             } else if (this.props.config.EnableXToLeaveChannelsFromLHS === 'true') {

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1190,6 +1190,10 @@
             top: -4px;
             white-space: normal;
             z-index: 6;
+
+            &.dot_small {
+                min-width: auto !important;
+            }
         }
 
         .col__remove {


### PR DESCRIPTION
#### Summary
Hide edit able elements for Town Square for non admin users when `"ExperimentalTownSquareIsReadOnly": true`.
Hide:
- channel view actions: post textbox, Edit channel header, Edit channel purpose, Rename channel.
- post view actions: reply, pin, emoji, + emoji icon.
Also, hide town square link on the LHS  when there are no unread messages and it is not favorited.

These changes were discussed in the original PRs:
- webapp: https://github.com/mattermost/mattermost-webapp/commit/0a9c047aadafebc9a2d92009c7c5fab72fea3aee
- server: https://github.com/mattermost/mattermost-server/pull/7140
- redux: https://github.com/mattermost/mattermost-redux/pull/222

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Touches critical sections of the codebase (auth, posting, etc.)

cc @jason @dmeza