### PR TITLE
Remove isRequired in teamId for post_info and reaction_list

### DIFF
--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -31,7 +31,7 @@ export default class PostInfo extends React.PureComponent {
         /*
          * The id of the team which belongs the post
          */
-        teamId: PropTypes.string.isRequired,
+        teamId: PropTypes.string,
 
         /*
          * Function called when the comment icon is clicked

--- a/components/post_view/reaction_list/reaction_list.jsx
+++ b/components/post_view/reaction_list/reaction_list.jsx
@@ -28,7 +28,7 @@ export default class ReactionListView extends React.PureComponent {
         /*
          * The id of the team which belongs the post
          */
-        teamId: PropTypes.string.isRequired,
+        teamId: PropTypes.string,
 
         /**
          * The reactions to render


### PR DESCRIPTION
#### Summary
This remove the isRequired because in some cases, in the reload, you can have
the posts information before the channel information, so it can generate an
error.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed