### PR TITLE
MM-9654 Updated channel routing to better handle 26 character long character names

### DIFF
--- a/components/channel_identifier_router.jsx
+++ b/components/channel_identifier_router.jsx
@@ -25,6 +25,14 @@ function onChannelByIdentifierEnter({match, history}) {
     const {path, identifier} = match.params;
 
     if (path === 'channels') {
+        // It's hard to tell an ID apart from a channel name of the same length, so check first if
+        // the identifier matches a channel that we have
+        const channel = ChannelStore.getByName(identifier);
+        if (channel) {
+            goToChannelByChannelName(match, history);
+            return;
+        }
+
         if (identifier.length === LENGTH_OF_ID) {
             goToChannelByChannelId(match, history);
         } else if (identifier.length === LENGTH_OF_GROUP_ID) {
@@ -35,14 +43,14 @@ function onChannelByIdentifierEnter({match, history}) {
             goToChannelByChannelName(match, history);
         }
     } else if (path === 'messages') {
-        if (identifier.length === LENGTH_OF_ID) {
-            goToDirectChannelByUserId(match, history);
-        } else if (identifier.length === LENGTH_OF_GROUP_ID) {
-            goToGroupChannelByGroupId(match, history);
-        } else if (identifier.indexOf('@') === 0) {
+        if (identifier.indexOf('@') === 0) {
             goToDirectChannelByUsername(match, history);
         } else if (identifier.indexOf('@') > 0) {
             goToDirectChannelByEmail(match, history);
+        } else if (identifier.length === LENGTH_OF_ID) {
+            goToDirectChannelByUserId(match, history);
+        } else if (identifier.length === LENGTH_OF_GROUP_ID) {
+            goToGroupChannelByGroupId(match, history);
         } else {
             handleError(match, history);
         }


### PR DESCRIPTION
This fixes some conflicts that arose from https://github.com/mattermost/mattermost-webapp/pull/189.

1. When going to `/messages/<identifier>`, we now check for an @ sign for emails/username before checking length of the identifier like we used to
2. When going to `/channels/<identifier>` with an identifier that is 26 or 40 characters long, we check to see if we have a channel with that name before assuming that the identifier is a channel or group ID so that we can once again view channels with a 26 or 40 character long name. 

    Note that this will however cause problems with ID-based routing if someone creates a channel with a name matching a channel ID, but it's impossible to completely prevent conflicts without completely changing the routing behaviour.

    It also means that you will be unable to join 26 character public channels by going to `/channels/<name>`, but I think that's also acceptable given that's already an exception case since we usually prevent you from creating channels with names longer than 22 characters


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9654

#### Checklist
- Touches critical sections of the codebase (auth, posting, etc.)
