### PR TITLE
[MM-8007] Force focus to textbox when the period since the last blur is greater than the fasterThanHumanWillClick

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -293,7 +293,7 @@ export default class CreateComment extends React.PureComponent {
         }
 
         const fasterThanHumanWillClick = 150;
-        const forceFocus = (Date.now() - this.lastBlurAt < fasterThanHumanWillClick);
+        const forceFocus = (Date.now() - this.lastBlurAt) > fasterThanHumanWillClick;
         this.setState({draft: {...this.props.draft, uploadsInProgress: []}});
         this.focusTextbox(forceFocus);
     }

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -281,6 +281,10 @@ export default class CreateComment extends React.PureComponent {
             return;
         }
 
+        const fasterThanHumanWillClick = 150;
+        const forceFocus = (Date.now() - this.lastBlurAt < fasterThanHumanWillClick);
+        this.focusTextbox(forceFocus);
+
         try {
             await this.props.onSubmit();
 
@@ -292,10 +296,7 @@ export default class CreateComment extends React.PureComponent {
             this.setState({serverError: err.message});
         }
 
-        const fasterThanHumanWillClick = 150;
-        const forceFocus = (Date.now() - this.lastBlurAt) > fasterThanHumanWillClick;
         this.setState({draft: {...this.props.draft, uploadsInProgress: []}});
-        this.focusTextbox(forceFocus);
     }
 
     commentMsgKeyPress = (e) => {

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -321,7 +321,7 @@ export default class CreatePost extends React.Component {
         this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, null);
 
         const fasterThanHumanWillClick = 150;
-        const forceFocus = (Date.now() - this.lastBlurAt) > fasterThanHumanWillClick;
+        const forceFocus = (Date.now() - this.lastBlurAt < fasterThanHumanWillClick);
 
         this.focusTextbox(forceFocus);
     }

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -321,7 +321,7 @@ export default class CreatePost extends React.Component {
         this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, null);
 
         const fasterThanHumanWillClick = 150;
-        const forceFocus = (Date.now() - this.lastBlurAt < fasterThanHumanWillClick);
+        const forceFocus = (Date.now() - this.lastBlurAt) > fasterThanHumanWillClick;
 
         this.focusTextbox(forceFocus);
     }


### PR DESCRIPTION
#### Summary
Force focus to textbox when the period since the last blur is greater than the `fasterThanHumanWillClick`.
Honestly, I don't understand why `less than` currently. In addition, maybe this is no longer applicable nowadays since we have `props.enableAddButton` that enables/disables submit button. 

#### Ticket Link
Jira ticket: [MM-8007](https://mattermost.atlassian.net/browse/MM-8007)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed]
