### PR TITLE
MM-8777: Highlighting usernames on exact mention

### DIFF
--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -371,7 +371,7 @@ function parseSearchTerms(searchTerm) {
         }
 
         // capture at mentions differently from the server so we can highlight them with the preceeding at sign
-        captured = (/^@\w+\b/).exec(termString);
+        captured = (/^@[a-z0-9.-_]+\b/).exec(termString);
         if (captured) {
             termString = termString.substring(captured[0].length);
 


### PR DESCRIPTION
#### Summary
When you have a username with ., - or _, wasn't well managed by the
highlighting library. I improved the regular expression on maching usernames
after the @ sign. And adding the highlight of the not @ signed version of the
username.

I'm not if here I'm breaking other expected behaviors.

#### Ticket Link
[MM-8777](https://mattermost.atlassian.net/browse/MM-8777)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed