### PR TITLE
MM-8228 Fix resizing window forcing scroll to bottom

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -125,14 +125,14 @@ export default class PostList extends React.PureComponent {
         this.props.actions.checkAndSetMobileView();
         GlobalEventEmitter.addListener(EventTypes.POST_LIST_SCROLL_CHANGE, this.handleResize);
 
-        window.addEventListener('resize', this.handleResize);
+        window.addEventListener('resize', this.handleWindowResize);
 
         this.initialScroll();
     }
 
     componentWillUnmount() {
         GlobalEventEmitter.removeListener(EventTypes.POST_LIST_SCROLL_CHANGE, this.handleResize);
-        window.removeEventListener('resize', this.handleResize);
+        window.removeEventListener('resize', this.handleWindowResize);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -295,6 +295,10 @@ export default class PostList extends React.PureComponent {
         }
 
         return this.refs.postlist.clientHeight + this.refs.postlist.scrollTop >= this.refs.postlist.scrollHeight - CLOSE_TO_BOTTOM_SCROLL_MARGIN;
+    }
+
+    handleWindowResize = () => {
+        this.handleResize();
     }
 
     handleResize = (forceScrollToBottom) => {


### PR DESCRIPTION
#### Summary
The event handler for resize was passing in the event and we were interpreting that as a force scroll. Just needed a wrapper.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8228

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed