### PR TITLE
Discard any change to the storage if is older than the current one.

### DIFF
--- a/actions/storage.js
+++ b/actions/storage.js
@@ -10,7 +10,7 @@ export function setItem(name, value) {
         const prefix = getPrefix(state);
         dispatch({
             type: StorageTypes.SET_ITEM,
-            data: {prefix, name, value},
+            data: {prefix, name, value, timestamp: new Date()},
         }, getState);
         return {data: true};
     };
@@ -32,7 +32,7 @@ export function setGlobalItem(name, value) {
     return async (dispatch, getState) => {
         dispatch({
             type: StorageTypes.SET_GLOBAL_ITEM,
-            data: {name, value},
+            data: {name, value, timestamp: new Date()},
         }, getState);
         return {data: true};
     };
@@ -80,13 +80,29 @@ export function actionOnItemsWithPrefix(prefix, action) {
     };
 }
 
-export function storageRehydrate(incoming) {
-    return async (dispatch, persistor) => {
+export function storageRehydrate(incoming, persistor) {
+    return async (dispatch, getState) => {
+        const state = getState();
         persistor.pause();
         Object.keys(incoming).forEach((key) => {
             const storage = {};
             try {
-                storage[key] = JSON.parse(incoming[key]);
+                const value = JSON.parse(incoming[key]);
+                if (typeof state.storage.storage[key] === 'undefined') {
+                    if (typeof value.timestamp === 'undefined') {
+                        storage[key] = {value, timestamp: new Date()};
+                    } else {
+                        storage[key] = value;
+                    }
+                } else if (typeof value.timestamp === 'undefined') {
+                    storage[key] = {value, timestamp: new Date()};
+                } else if (typeof state.storage.storage[key].timestamp === 'undefined') {
+                    storage[key] = value;
+                } else if (value.timestamp > state.storage.storage[key].timestamp) {
+                    storage[key] = value;
+                } else {
+                    return;
+                }
             } catch (err) {
                 if (process.env.NODE_ENV !== 'production') { // eslint-disable-line no-process-env
                     console.warn('Error rehydrating data for key "storage"', err); // eslint-disable-line no-console

--- a/actions/storage.js
+++ b/actions/storage.js
@@ -88,18 +88,20 @@ export function storageRehydrate(incoming, persistor) {
             const storage = {};
             try {
                 const value = JSON.parse(incoming[key]);
-                if (typeof state.storage.storage[key] === 'undefined') {
+                if (value === null) {
+                    storage[key] = {value, timestamp: new Date()};
+                } else if (typeof state.storage.storage[key] === 'undefined') {
                     if (typeof value.timestamp === 'undefined') {
                         storage[key] = {value, timestamp: new Date()};
                     } else {
-                        storage[key] = value;
+                        storage[key] = {value: value.value, timestamp: new Date(value.timestamp)};
                     }
                 } else if (typeof value.timestamp === 'undefined') {
                     storage[key] = {value, timestamp: new Date()};
                 } else if (typeof state.storage.storage[key].timestamp === 'undefined') {
-                    storage[key] = value;
-                } else if (value.timestamp > state.storage.storage[key].timestamp) {
-                    storage[key] = value;
+                    storage[key] = {value: value.value, timestamp: new Date(value.timestamp)};
+                } else if (new Date(value.timestamp) > state.storage.storage[key].timestamp) {
+                    storage[key] = {value: value.value, timestamp: new Date(value.timestamp)};
                 } else {
                     return;
                 }

--- a/reducers/storage.js
+++ b/reducers/storage.js
@@ -11,17 +11,18 @@ function storage(state = {}, action) {
 
     switch (action.type) {
     case StorageTypes.SET_ITEM: {
-        const nextState = {...state};
-        if (!nextState[action.data.prefix + action.data.name] ||
-            !nextState[action.data.prefix + action.data.name].timestamp ||
-            nextState[action.data.prefix + action.data.name].timestamp < action.data.timestamp
+        if (!state[action.data.prefix + action.data.name] ||
+            !state[action.data.prefix + action.data.name].timestamp ||
+            state[action.data.prefix + action.data.name].timestamp < action.data.timestamp
         ) {
+            const nextState = {...state};
             nextState[action.data.prefix + action.data.name] = {
                 timestamp: action.data.timestamp,
                 value: action.data.value,
             };
+            return nextState;
         }
-        return nextState;
+        return state;
     }
     case StorageTypes.REMOVE_ITEM: {
         const nextState = {...state};
@@ -29,17 +30,18 @@ function storage(state = {}, action) {
         return nextState;
     }
     case StorageTypes.SET_GLOBAL_ITEM: {
-        const nextState = {...state};
-        if (!nextState[action.data.name] ||
-            !nextState[action.data.name].timestamp ||
-            nextState[action.data.name].timestamp < action.data.timestamp
+        if (!state[action.data.name] ||
+            !state[action.data.name].timestamp ||
+            state[action.data.name].timestamp < action.data.timestamp
         ) {
+            const nextState = {...state};
             nextState[action.data.name] = {
                 timestamp: action.data.timestamp,
                 value: action.data.value,
             };
+            return nextState;
         }
-        return nextState;
+        return state;
     }
     case StorageTypes.REMOVE_GLOBAL_ITEM: {
         const nextState = {...state};
@@ -59,17 +61,10 @@ function storage(state = {}, action) {
         const nextState = {...state};
         for (key in state) {
             if (key.lastIndexOf(action.data.prefix, 0) === 0) {
-                if (state[key].timestamp) {
-                    nextState[key] = {
-                        timestamp: new Date(),
-                        value: action.data.action(key, state[key].value),
-                    };
-                } else {
-                    nextState[key] = {
-                        timestamp: new Date(),
-                        value: action.data.action(key, state[key]),
-                    };
-                }
+                nextState[key] = {
+                    timestamp: new Date(),
+                    value: action.data.action(key, state[key].value),
+                };
             }
         }
         return nextState;
@@ -81,17 +76,10 @@ function storage(state = {}, action) {
         for (key in state) {
             if (key.lastIndexOf(globalPrefix + action.data.prefix, 0) === 0) {
                 var userkey = key.substring(globalPrefixLen);
-                if (state[key].timestamp) {
-                    nextState[key] = {
-                        timestamp: new Date(),
-                        value: action.data.action(userkey, state[key].value),
-                    };
-                } else {
-                    nextState[key] = {
-                        timestamp: new Date(),
-                        value: action.data.action(userkey, state[key]),
-                    };
-                }
+                nextState[key] = {
+                    timestamp: new Date(),
+                    value: action.data.action(userkey, state[key].value),
+                };
             }
         }
         return nextState;

--- a/reducers/storage.js
+++ b/reducers/storage.js
@@ -7,23 +7,42 @@ import {General} from 'mattermost-redux/constants';
 import {StorageTypes} from 'utils/constants';
 
 function storage(state = {}, action) {
-    const nextState = {...state};
     var key;
 
     switch (action.type) {
     case StorageTypes.SET_ITEM: {
-        nextState[action.data.prefix + action.data.name] = action.data.value;
+        const nextState = {...state};
+        if (!nextState[action.data.prefix + action.data.name] ||
+            !nextState[action.data.prefix + action.data.name].timestamp ||
+            nextState[action.data.prefix + action.data.name].timestamp < action.data.timestamp
+        ) {
+            nextState[action.data.prefix + action.data.name] = {
+                timestamp: action.data.timestamp,
+                value: action.data.value,
+            };
+        }
         return nextState;
     }
     case StorageTypes.REMOVE_ITEM: {
+        const nextState = {...state};
         Reflect.deleteProperty(nextState, action.data.prefix + action.data.name);
         return nextState;
     }
     case StorageTypes.SET_GLOBAL_ITEM: {
-        nextState[action.data.name] = action.data.value;
+        const nextState = {...state};
+        if (!nextState[action.data.name] ||
+            !nextState[action.data.name].timestamp ||
+            nextState[action.data.name].timestamp < action.data.timestamp
+        ) {
+            nextState[action.data.name] = {
+                timestamp: action.data.timestamp,
+                value: action.data.value,
+            };
+        }
         return nextState;
     }
     case StorageTypes.REMOVE_GLOBAL_ITEM: {
+        const nextState = {...state};
         Reflect.deleteProperty(nextState, action.data.name);
         return nextState;
     }
@@ -37,20 +56,42 @@ function storage(state = {}, action) {
         return cleanState;
     }
     case StorageTypes.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX: {
+        const nextState = {...state};
         for (key in state) {
             if (key.lastIndexOf(action.data.prefix, 0) === 0) {
-                nextState[key] = action.data.action(key, state[key]);
+                if (state[key].timestamp) {
+                    nextState[key] = {
+                        timestamp: new Date(),
+                        value: action.data.action(key, state[key].value),
+                    };
+                } else {
+                    nextState[key] = {
+                        timestamp: new Date(),
+                        value: action.data.action(key, state[key]),
+                    };
+                }
             }
         }
         return nextState;
     }
     case StorageTypes.ACTION_ON_ITEMS_WITH_PREFIX: {
+        const nextState = {...state};
         var globalPrefix = action.data.globalPrefix;
         var globalPrefixLen = action.data.globalPrefix.length;
         for (key in state) {
             if (key.lastIndexOf(globalPrefix + action.data.prefix, 0) === 0) {
                 var userkey = key.substring(globalPrefixLen);
-                nextState[key] = action.data.action(userkey, state[key]);
+                if (state[key].timestamp) {
+                    nextState[key] = {
+                        timestamp: new Date(),
+                        value: action.data.action(userkey, state[key].value),
+                    };
+                } else {
+                    nextState[key] = {
+                        timestamp: new Date(),
+                        value: action.data.action(userkey, state[key]),
+                    };
+                }
             }
         }
         return nextState;

--- a/selectors/storage.js
+++ b/selectors/storage.js
@@ -22,12 +22,12 @@ export const makeGetGlobalItem = (name, defaultValue) => {
 };
 
 export const getItemFromStorage = (storage, name, defaultValue) => {
-    if (storage && typeof storage[name] !== 'undefined' && storage[name] !== null) {
-        const data = storage[name];
-        if (typeof data.timestamp !== 'undefined') {
-            return data.value;
-        }
-        return data;
+    if (storage &&
+        typeof storage[name] !== 'undefined' &&
+        storage[name] !== null &&
+        typeof storage[name].value !== 'undefined' &&
+        storage[name].value !== null) {
+        return storage[name].value;
     }
 
     return defaultValue;

--- a/selectors/storage.js
+++ b/selectors/storage.js
@@ -6,11 +6,7 @@ import {getPrefix} from 'utils/storage_utils';
 export const getGlobalItem = (state, name, defaultValue) => {
     const storage = state && state.storage && state.storage.storage;
 
-    if (storage && typeof storage[name] !== 'undefined' && storage[name] !== null) {
-        return storage[name];
-    }
-
-    return defaultValue;
+    return getItemFromStorage(storage, name, defaultValue);
 };
 
 export const makeGetItem = (name, defaultValue) => {
@@ -27,7 +23,11 @@ export const makeGetGlobalItem = (name, defaultValue) => {
 
 export const getItemFromStorage = (storage, name, defaultValue) => {
     if (storage && typeof storage[name] !== 'undefined' && storage[name] !== null) {
-        return storage[name];
+        const data = storage[name];
+        if (typeof data.timestamp !== 'undefined') {
+            return data.value;
+        }
+        return data;
     }
 
     return defaultValue;

--- a/store/index.js
+++ b/store/index.js
@@ -97,7 +97,7 @@ export default function configureStore(initialState) {
                         restoredState[keyspace] = value;
                     }
                 }).then(() => {
-                    storageRehydrate(restoredState)(store.dispatch, persistor);
+                    storageRehydrate(restoredState, persistor)(store.dispatch, store.getState);
                 });
 
                 observable.subscribe({
@@ -107,7 +107,7 @@ export default function configureStore(initialState) {
 
                             var statePartial = {};
                             statePartial[keyspace] = args.newValue;
-                            storageRehydrate(statePartial)(store.dispatch, persistor);
+                            storageRehydrate(statePartial, persistor)(store.dispatch, store.getState);
                         }
                     },
                 });

--- a/tests/redux/actions/storage.test.js
+++ b/tests/redux/actions/storage.test.js
@@ -84,17 +84,31 @@ describe('Actions.Storage', () => {
     });
 
     it('rehydrate', async () => {
+        const RealDate = Date;
+        const now = new Date(1487076708000);
+        global.Date = class extends RealDate {
+            constructor() {
+                super();
+                return new RealDate(now);
+            }
+        };
+
         const persistor = {
             pause: jest.fn(),
             resume: jest.fn(),
         };
         await Actions.storageRehydrate({test: '123'}, persistor)(store.dispatch, store.getState);
         assert.equal(store.getState().storage.storage.test.value, '123');
+        assert.equal(store.getState().storage.storage.test.timestamp.valueOf(), now.valueOf());
         await Actions.storageRehydrate({test: '456'}, persistor)(store.dispatch, store.getState);
         assert.equal(store.getState().storage.storage.test.value, '456');
+        assert.equal(store.getState().storage.storage.test.timestamp.valueOf(), now.valueOf());
         await Actions.storageRehydrate({test2: '789'}, persistor)(store.dispatch, store.getState);
         assert.equal(store.getState().storage.storage.test.value, '456');
+        assert.equal(store.getState().storage.storage.test.timestamp.valueOf(), now.valueOf());
         assert.equal(store.getState().storage.storage.test2.value, '789');
+        assert.equal(store.getState().storage.storage.test2.timestamp.valueOf(), now.valueOf());
+        global.Date = RealDate;
     });
 
     it('rehydrate-with-timestamp', async () => {

--- a/tests/redux/actions/storage.test.js
+++ b/tests/redux/actions/storage.test.js
@@ -14,52 +14,34 @@ describe('Actions.Storage', () => {
 
     it('setItem', async () => {
         await Actions.setItem('test', 'value')(store.dispatch, store.getState);
-        assert.deepEqual(
-            store.getState().storage.storage,
-            {unknown_test: 'value'}
-        );
+        assert.equal(store.getState().storage.storage.unknown_test.value, 'value');
+        assert.notEqual(typeof store.getState().storage.storage.unknown_test.timestamp, 'undefined');
     });
 
     it('removeItem', async () => {
         await Actions.setItem('test1', 'value1')(store.dispatch, store.getState);
         await Actions.setItem('test2', 'value2')(store.dispatch, store.getState);
-        assert.deepEqual(
-            store.getState().storage.storage,
-            {
-                unknown_test1: 'value1',
-                unknown_test2: 'value2',
-            }
-        );
+        assert.equal(store.getState().storage.storage.unknown_test1.value, 'value1');
+        assert.equal(store.getState().storage.storage.unknown_test2.value, 'value2');
         await Actions.removeItem('test1')(store.dispatch, store.getState);
-        assert.deepEqual(
-            store.getState().storage.storage,
-            {unknown_test2: 'value2'}
-        );
+        assert.equal(typeof store.getState().storage.storage.unknown_test1, 'undefined');
+        assert.equal(store.getState().storage.storage.unknown_test2.value, 'value2');
     });
 
     it('setGlobalItem', async () => {
         await Actions.setGlobalItem('test', 'value')(store.dispatch, store.getState);
-        assert.deepEqual(
-            store.getState().storage.storage,
-            {test: 'value'}
-        );
+        assert.equal(store.getState().storage.storage.test.value, 'value');
+        assert.notEqual(typeof store.getState().storage.storage.test.timestamp, 'undefined');
     });
 
     it('removeGlobalItem', async () => {
         await Actions.setGlobalItem('test1', 'value1')(store.dispatch, store.getState);
         await Actions.setGlobalItem('test2', 'value2')(store.dispatch, store.getState);
-        assert.deepEqual(
-            store.getState().storage.storage,
-            {
-                test1: 'value1',
-                test2: 'value2',
-            }
-        );
+        assert.equal(store.getState().storage.storage.test1.value, 'value1');
+        assert.equal(store.getState().storage.storage.test2.value, 'value2');
         await Actions.removeGlobalItem('test1')(store.dispatch, store.getState);
-        assert.deepEqual(
-            store.getState().storage.storage,
-            {test2: 'value2'}
-        );
+        assert.equal(typeof store.getState().storage.storage.test1, 'undefined');
+        assert.equal(store.getState().storage.storage.test2.value, 'value2');
     });
 
     it('actionOnGlobalItemsWithPrefix', async () => {
@@ -97,10 +79,8 @@ describe('Actions.Storage', () => {
         await Actions.setGlobalItem('key', 'value')(store.dispatch, store.getState);
         await Actions.setGlobalItem('excluded', 'not-cleared')(store.dispatch, store.getState);
         await Actions.clear({exclude: ['excluded']})(store.dispatch, store.getState);
-        assert.deepEqual(
-            store.getState().storage.storage,
-            {excluded: 'not-cleared'}
-        );
+        assert.equal(store.getState().storage.storage.excluded.value, 'not-cleared');
+        assert.equal(typeof store.getState().storage.storage.key, 'undefined');
     });
 
     it('rehydrate', async () => {
@@ -108,20 +88,36 @@ describe('Actions.Storage', () => {
             pause: jest.fn(),
             resume: jest.fn(),
         };
-        await Actions.storageRehydrate({test: '123'})(store.dispatch, persistor);
-        assert.deepEqual(
-            store.getState().storage.storage,
-            {test: '123'}
-        );
-        await Actions.storageRehydrate({test: '456'})(store.dispatch, persistor);
-        assert.deepEqual(
-            store.getState().storage.storage,
-            {test: '456'}
-        );
-        await Actions.storageRehydrate({test2: '789'})(store.dispatch, persistor);
-        assert.deepEqual(
-            store.getState().storage.storage,
-            {test: '456', test2: '789'}
-        );
+        await Actions.storageRehydrate({test: '123'}, persistor)(store.dispatch, store.getState);
+        assert.equal(store.getState().storage.storage.test.value, '123');
+        await Actions.storageRehydrate({test: '456'}, persistor)(store.dispatch, store.getState);
+        assert.equal(store.getState().storage.storage.test.value, '456');
+        await Actions.storageRehydrate({test2: '789'}, persistor)(store.dispatch, store.getState);
+        assert.equal(store.getState().storage.storage.test.value, '456');
+        assert.equal(store.getState().storage.storage.test2.value, '789');
+    });
+
+    it('rehydrate-with-timestamp', async () => {
+        const persistor = {
+            pause: jest.fn(),
+            resume: jest.fn(),
+        };
+        await Actions.storageRehydrate({test: JSON.stringify({value: '123', timestamp: 10})}, persistor)(store.dispatch, store.getState);
+        assert.equal(store.getState().storage.storage.test.value, '123');
+        assert.equal(store.getState().storage.storage.test.timestamp, 10);
+
+        await Actions.storageRehydrate({test: JSON.stringify({value: '456', timestamp: 8})}, persistor)(store.dispatch, store.getState);
+        assert.equal(store.getState().storage.storage.test.value, '123');
+        assert.equal(store.getState().storage.storage.test.timestamp, 10);
+
+        await Actions.storageRehydrate({test: JSON.stringify({value: '456', timestamp: 12})}, persistor)(store.dispatch, store.getState);
+        assert.equal(store.getState().storage.storage.test.value, '456');
+        assert.equal(store.getState().storage.storage.test.timestamp, 12);
+
+        await Actions.storageRehydrate({test2: JSON.stringify({value: '789', timestamp: 20})}, persistor)(store.dispatch, store.getState);
+        assert.equal(store.getState().storage.storage.test.value, '456');
+        assert.equal(store.getState().storage.storage.test.timestamp, 12);
+        assert.equal(store.getState().storage.storage.test2.value, '789');
+        assert.equal(store.getState().storage.storage.test2.timestamp, 20);
     });
 });

--- a/tests/redux/actions/storage.test.js
+++ b/tests/redux/actions/storage.test.js
@@ -98,26 +98,33 @@ describe('Actions.Storage', () => {
     });
 
     it('rehydrate-with-timestamp', async () => {
+        const now = new Date();
         const persistor = {
             pause: jest.fn(),
             resume: jest.fn(),
         };
-        await Actions.storageRehydrate({test: JSON.stringify({value: '123', timestamp: 10})}, persistor)(store.dispatch, store.getState);
+        await Actions.storageRehydrate({test: JSON.stringify({value: '123', timestamp: now})}, persistor)(store.dispatch, store.getState);
         assert.equal(store.getState().storage.storage.test.value, '123');
-        assert.equal(store.getState().storage.storage.test.timestamp, 10);
+        assert.equal(store.getState().storage.storage.test.timestamp.valueOf(), now.valueOf());
 
-        await Actions.storageRehydrate({test: JSON.stringify({value: '456', timestamp: 8})}, persistor)(store.dispatch, store.getState);
+        const older = new Date(now);
+        older.setSeconds(now.getSeconds() - 2);
+        await Actions.storageRehydrate({test: JSON.stringify({value: '456', timestamp: older})}, persistor)(store.dispatch, store.getState);
         assert.equal(store.getState().storage.storage.test.value, '123');
-        assert.equal(store.getState().storage.storage.test.timestamp, 10);
+        assert.equal(store.getState().storage.storage.test.timestamp.valueOf(), now.valueOf());
 
-        await Actions.storageRehydrate({test: JSON.stringify({value: '456', timestamp: 12})}, persistor)(store.dispatch, store.getState);
+        const newer = new Date(now);
+        newer.setSeconds(now.getSeconds() + 2);
+        await Actions.storageRehydrate({test: JSON.stringify({value: '456', timestamp: newer})}, persistor)(store.dispatch, store.getState);
         assert.equal(store.getState().storage.storage.test.value, '456');
-        assert.equal(store.getState().storage.storage.test.timestamp, 12);
+        assert.equal(store.getState().storage.storage.test.timestamp.valueOf(), newer.valueOf());
 
-        await Actions.storageRehydrate({test2: JSON.stringify({value: '789', timestamp: 20})}, persistor)(store.dispatch, store.getState);
+        const newest = new Date(now);
+        newest.setSeconds(now.getSeconds() + 10);
+        await Actions.storageRehydrate({test2: JSON.stringify({value: '789', timestamp: newest})}, persistor)(store.dispatch, store.getState);
         assert.equal(store.getState().storage.storage.test.value, '456');
-        assert.equal(store.getState().storage.storage.test.timestamp, 12);
+        assert.equal(store.getState().storage.storage.test.timestamp.valueOf(), newer.valueOf());
         assert.equal(store.getState().storage.storage.test2.value, '789');
-        assert.equal(store.getState().storage.storage.test2.timestamp, 20);
+        assert.equal(store.getState().storage.storage.test2.timestamp.valueOf(), newest.valueOf());
     });
 });

--- a/tests/redux/actions/views/create_comment.test.jsx
+++ b/tests/redux/actions/views/create_comment.test.jsx
@@ -105,9 +105,12 @@ describe('rhs view actions', () => {
         },
         storage: {
             [`${StoragePrefixes.COMMENT_DRAFT}${latestPostId}`]: {
-                message: '',
-                fileInfos: [],
-                uploadsInProgress: [],
+                value: {
+                    message: '',
+                    fileInfos: [],
+                    uploadsInProgress: [],
+                },
+                timestamp: new Date(),
             },
         },
     };
@@ -315,9 +318,12 @@ describe('rhs view actions', () => {
                 storage: {
                     storage: {
                         [`${StoragePrefixes.COMMENT_DRAFT}${latestPostId}`]: {
-                            message: '+:smile:',
-                            fileInfos: [],
-                            uploadsInProgress: [],
+                            value: {
+                                message: '+:smile:',
+                                fileInfos: [],
+                                uploadsInProgress: [],
+                            },
+                            timestamp: new Date(),
                         },
                     },
                 },
@@ -338,9 +344,12 @@ describe('rhs view actions', () => {
                 ...initialState,
                 storage: {
                     [`${StoragePrefixes.COMMENT_DRAFT}${latestPostId}`]: {
-                        message: '/away',
-                        fileInfos: [],
-                        uploadsInProgress: [],
+                        value: {
+                            message: '/away',
+                            fileInfos: [],
+                            uploadsInProgress: [],
+                        },
+                        timestamp: new Date(),
                     },
                 },
             });
@@ -360,9 +369,12 @@ describe('rhs view actions', () => {
                 ...initialState,
                 storage: {
                     [`${StoragePrefixes.COMMENT_DRAFT}${latestPostId}`]: {
-                        message: 'test msg',
-                        fileInfos: [],
-                        uploadsInProgress: [],
+                        value: {
+                            message: 'test msg',
+                            fileInfos: [],
+                            uploadsInProgress: [],
+                        },
+                        timestamp: new Date(),
                     },
                 },
             });

--- a/tests/redux/reducers/storage.test.js
+++ b/tests/redux/reducers/storage.test.js
@@ -7,6 +7,8 @@ import storageReducer from 'reducers/storage';
 import {StorageTypes} from 'utils/constants';
 
 describe('Reducers.Storage', () => {
+    const now = new Date();
+
     it('Storage.SET_ITEM', async () => {
         const nextState = storageReducer(
             {
@@ -18,13 +20,14 @@ describe('Reducers.Storage', () => {
                     name: 'key',
                     prefix: 'user_id_',
                     value: 'value',
+                    timestamp: now,
                 },
             }
         );
         assert.deepEqual(
             nextState.storage,
             {
-                user_id_key: 'value',
+                user_id_key: {value: 'value', timestamp: now},
             }
         );
     });
@@ -39,13 +42,14 @@ describe('Reducers.Storage', () => {
                 data: {
                     name: 'key',
                     value: 'value',
+                    timestamp: now,
                 },
             }
         );
         assert.deepEqual(
             nextState.storage,
             {
-                key: 'value',
+                key: {value: 'value', timestamp: now},
             }
         );
     });

--- a/tests/redux/reducers/storage.test.js
+++ b/tests/redux/reducers/storage.test.js
@@ -130,8 +130,8 @@ describe('Reducers.Storage', () => {
         const nextState = storageReducer(
             {
                 storage: {
-                    key: 'value',
-                    excluded: 'not-cleared',
+                    key: {value: 'value', timestamp: now},
+                    excluded: {value: 'not-cleared', timestamp: now},
                 },
             },
             {
@@ -144,7 +144,7 @@ describe('Reducers.Storage', () => {
         assert.deepEqual(
             nextState.storage,
             {
-                excluded: 'not-cleared',
+                excluded: {value: 'not-cleared', timestamp: now},
             }
         );
     });
@@ -154,9 +154,9 @@ describe('Reducers.Storage', () => {
         storageReducer(
             {
                 storage: {
-                    user_id_prefix_key1: 1,
-                    user_id_prefix_key2: 2,
-                    user_id_not_prefix_key: 3,
+                    user_id_prefix_key1: {value: 1, timestamp: now},
+                    user_id_prefix_key2: {value: 2, timestamp: now},
+                    user_id_not_prefix_key: {value: 3, timestamp: now},
                 },
             },
             {
@@ -179,9 +179,9 @@ describe('Reducers.Storage', () => {
         storageReducer(
             {
                 storage: {
-                    prefix_key1: 1,
-                    prefix_key2: 2,
-                    not_prefix_key: 3,
+                    prefix_key1: {value: 1, timestamp: now},
+                    prefix_key2: {value: 2, timestamp: now},
+                    not_prefix_key: {value: 3, timestamp: now},
                 },
             },
             {

--- a/tests/redux/selectors/rhs.test.js
+++ b/tests/redux/selectors/rhs.test.js
@@ -49,8 +49,8 @@ describe('Selectors.makeGetPostsEmbedVisibleObj', () => {
             },
             storage: {
                 storage: {
-                    [`${StoragePrefixes.EMBED_VISIBLE}c`]: false,
-                    [`${StoragePrefixes.EMBED_VISIBLE}d`]: false,
+                    [`${StoragePrefixes.EMBED_VISIBLE}c`]: {value: false, timestamp: new Date()},
+                    [`${StoragePrefixes.EMBED_VISIBLE}d`]: {value: false, timestamp: new Date()},
                 },
             },
         };
@@ -71,7 +71,7 @@ describe('Selectors.makeGetPostsEmbedVisibleObj', () => {
                 ...state.storage,
                 storage: {
                     ...state.storage.storage,
-                    [`${StoragePrefixes.EMBED_VISIBLE}c`]: null,
+                    [`${StoragePrefixes.EMBED_VISIBLE}c`]: {value: null, timestamp: new Date()},
                 },
             },
         };
@@ -147,7 +147,7 @@ describe('Selectors.makeGetPostsEmbedVisibleObj', () => {
                 ...state.storage,
                 storage: {
                     ...state.storage.storage,
-                    [`${StoragePrefixes.EMBED_VISIBLE}c`]: true,
+                    [`${StoragePrefixes.EMBED_VISIBLE}c`]: {value: true, timestamp: new Date()},
                 },
             },
         };
@@ -176,7 +176,7 @@ describe('Selectors.makeGetPostsEmbedVisibleObj', () => {
                 ...state.storage,
                 storage: {
                     ...state.storage.storage,
-                    [`${StoragePrefixes.EMBED_VISIBLE}d`]: false,
+                    [`${StoragePrefixes.EMBED_VISIBLE}d`]: {value: false, timestamp: new Date()},
                 },
             },
         };

--- a/tests/redux/selectors/storage.test.js
+++ b/tests/redux/selectors/storage.test.js
@@ -20,8 +20,8 @@ describe('Selectors.Storage', () => {
         },
         storage: {
             storage: {
-                'global-item': 'global-item-value',
-                user_id_item: 'item-value',
+                'global-item': {value: 'global-item-value', timestamp: new Date()},
+                user_id_item: {value: 'item-value', timestamp: new Date()},
             },
         },
     };


### PR DESCRIPTION
#### Summary
Added control over overwrites in the localForage. Now all the overwrites of the storage data is checked before overwrite to not be older than the current change.

This change have some degree of backward compatibility because we understand that there is currently some data in the localForage of the user.

#### Ticket Link
[MM-8851](https://mattermost.atlassian.net/browse/MM-8851)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
