### PR TITLE
[MM-9055] Fix sidebar unread above indicator

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -221,8 +221,13 @@ export default class Sidebar extends React.PureComponent {
     }
 
     setFirstAndLastUnreadChannels() {
+        const {
+            currentChannel,
+            unreadChannelIds,
+        } = this.props;
+
         this.getDisplayedChannels().map((channelId) => {
-            if (channelId !== this.props.currentChannel.id && this.props.unreadChannelIds.includes(channelId)) {
+            if (channelId !== currentChannel.id && unreadChannelIds.includes(channelId)) {
                 if (!this.firstUnreadChannel) {
                     this.firstUnreadChannel = channelId;
                 }
@@ -404,8 +409,15 @@ export default class Sidebar extends React.PureComponent {
     }
 
     getDisplayedChannels = (props = this.props) => {
-        return props.unreadChannelIds.
-            concat(props.favoriteChannelIds).
+        if (props.showUnreadSection) {
+            return props.unreadChannelIds.
+                concat(props.favoriteChannelIds).
+                concat(props.publicChannelIds).
+                concat(props.privateChannelIds).
+                concat(props.directAndGroupChannelIds);
+        }
+
+        return props.favoriteChannelIds.
             concat(props.publicChannelIds).
             concat(props.privateChannelIds).
             concat(props.directAndGroupChannelIds);


### PR DESCRIPTION
#### Summary
Fixes the "Unread Message above" indicator in the sidebar

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9055

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
