### PR TITLE
MM-8882 Don't show WebRTC icon in non-DM channels in mobile view

### DIFF
--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -325,7 +325,8 @@ export default class Navbar extends React.Component {
     }
 
     generateWebrtcIcon() {
-        if (!this.isWebrtcEnabled()) {
+        const channel = this.state.channel || {};
+        if (!this.isWebrtcEnabled() || channel.type !== Constants.DM_CHANNEL) {
             return null;
         }
 


### PR DESCRIPTION
#### Summary
Don't show WebRTC icon in non-DM channels in mobile view.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8882