### PR TITLE
MM-9677 Fixed being unable to go to DMs/GMs using old routes

### DIFF
--- a/components/channel_identifier_router.jsx
+++ b/components/channel_identifier_router.jsx
@@ -48,7 +48,7 @@ function onChannelByIdentifierEnter({match, history}) {
         } else if (identifier.indexOf('@') > 0) {
             goToDirectChannelByEmail(match, history);
         } else if (identifier.length === LENGTH_OF_ID) {
-            goToDirectChannelByUserId(match, history);
+            goToDirectChannelByUserId(match, history, identifier);
         } else if (identifier.length === LENGTH_OF_GROUP_ID) {
             goToGroupChannelByGroupId(match, history);
         } else {
@@ -72,8 +72,7 @@ async function goToChannelByChannelId(match, history) {
     }
 
     if (channel.type === Constants.DM_CHANNEL) {
-        const user = UserStore.get(Utils.getUserIdFromChannelId(channel.name));
-        history.replace(`/${team}/messages/@${user.name}`);
+        goToDirectChannelByUserId(match, history, Utils.getUserIdFromChannelId(channel.name));
     } else if (channel.type === Constants.GM_CHANNEL) {
         history.replace(`/${team}/messages/${channel.name}`);
     } else {
@@ -96,8 +95,7 @@ async function goToChannelByChannelName(match, history) {
     }
 
     if (channel.type === Constants.DM_CHANNEL) {
-        const user = UserStore.get(Utils.getUserIdFromChannelId(channel.name));
-        history.replace(`/${team}/messages/@${user.name}`);
+        goToDirectChannelByUserIds(match, history);
     } else if (channel.type === Constants.GM_CHANNEL) {
         history.replace(`/${team}/messages/${channel.name}`);
     } else {
@@ -128,9 +126,8 @@ async function goToDirectChannelByUsername(match, history) {
     );
 }
 
-async function goToDirectChannelByUserId(match, history) {
-    const {team, identifier} = match.params;
-    const userId = identifier.toLowerCase();
+async function goToDirectChannelByUserId(match, history, userId) {
+    const {team} = match.params;
 
     let user = UserStore.getProfile(userId);
     if (!user) {

--- a/components/channel_identifier_router.jsx
+++ b/components/channel_identifier_router.jsx
@@ -25,16 +25,14 @@ function onChannelByIdentifierEnter({match, history}) {
     const {path, identifier} = match.params;
 
     if (path === 'channels') {
-        // It's hard to tell an ID apart from a channel name of the same length, so check first if
-        // the identifier matches a channel that we have
-        const channel = ChannelStore.getByName(identifier);
-        if (channel) {
-            goToChannelByChannelName(match, history);
-            return;
-        }
-
         if (identifier.length === LENGTH_OF_ID) {
-            goToChannelByChannelId(match, history);
+            // It's hard to tell an ID apart from a channel name of the same length, so check first if
+            // the identifier matches a channel that we have
+            if (ChannelStore.getByName(identifier)) {
+                goToChannelByChannelName(match, history);
+            } else {
+                goToChannelByChannelId(match, history);
+            }
         } else if (identifier.length === LENGTH_OF_GROUP_ID) {
             goToGroupChannelByGroupId(match, history);
         } else if (identifier.length === LENGTH_OF_USER_ID_PAIR) {


### PR DESCRIPTION
For GM channels (`<mattermost>/<team>/channels/<GM channel name>`), my last PR broke the logic to switch to GM channels because it was calling `goToChannelByChannelName` for a GM channel which only rewrites the URL to the `/messages` version of the route without actually setting the selected channel ID.

For DM channels (`<mattermost>/<team>/messages/<user ID 1>__<user ID 2>`), it would attempt to get the username of the other user while rewriting the URL, but that would error out if it didn't already have the user in the store, so we needed to explicitly request it.

I think we should look at reorganizing this logic to
1. Separate the channel switching and URL rewriting behaviour since there's definitely code paths like the one we were going through with the GM channels where the URL is changed, but no channel is actually set. I don't think you can hit those code paths in normal use though
2. Add unit tests. That'll be easier if we split out those two behaviours

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9677

#### Checklist
- Touches critical sections of the codebase (auth, posting, etc.)
