### PR TITLE
MM-9583: improve malformed pdf behavior

### DIFF
--- a/components/pdf_preview.jsx
+++ b/components/pdf_preview.jsx
@@ -32,6 +32,7 @@ export default class PDFPreview extends React.PureComponent {
 
         this.updateStateFromProps = this.updateStateFromProps.bind(this);
         this.onDocumentLoad = this.onDocumentLoad.bind(this);
+        this.onDocumentLoadError = this.onDocumentLoadError.bind(this);
         this.onPageLoad = this.onPageLoad.bind(this);
         this.renderPDFPage = this.renderPDFPage.bind(this);
 
@@ -97,7 +98,7 @@ export default class PDFPreview extends React.PureComponent {
             success: false,
         });
 
-        PDFJS.getDocument(props.fileUrl).then(this.onDocumentLoad);
+        PDFJS.getDocument(props.fileUrl).then(this.onDocumentLoad, this.onDocumentLoadError);
     }
 
     onDocumentLoad(pdf) {
@@ -106,6 +107,11 @@ export default class PDFPreview extends React.PureComponent {
         for (let i = 1; i <= pdf.numPages; i++) {
             pdf.getPage(i).then(this.onPageLoad);
         }
+    }
+
+    onDocumentLoadError(reason) {
+        console.log('Unable to load PDF preview: ' + reason); //eslint-disable-line no-console
+        this.setState({loading: false, success: false});
     }
 
     onPageLoad(page) {


### PR DESCRIPTION
#### Summary
When the file can't be loaded as a PDF, print a message to the console and fall back to the generic file "preview".

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9583

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed