### PR TITLE
Disabling the GlobalRelay support in the interface for 4.8 release

### DIFF
--- a/components/admin_console/message_export_settings.jsx
+++ b/components/admin_console/message_export_settings.jsx
@@ -48,7 +48,7 @@ export default class MessageExportSettings extends AdminSettings {
     renderSettings() {
         const exportFormatOptions = [
             {value: 'actiance', text: Utils.localizeMessage('admin.complianceExport.exportFormat.actiance', 'Actiance XML')},
-            {value: 'globalrelay', text: Utils.localizeMessage('admin.complianceExport.exportFormat.globalrelay', 'GlobalRelay EML')},
+            // {value: 'globalrelay', text: Utils.localizeMessage('admin.complianceExport.exportFormat.globalrelay', 'GlobalRelay EML')},
         ];
 
         // if export format is globalrelay, user must set email address
@@ -94,11 +94,22 @@ export default class MessageExportSettings extends AdminSettings {
 
         return (
             <SettingsGroup>
+                {/*
                 <div className='banner'>
                     <div className='banner__content'>
                         <FormattedHTMLMessage
                             id='admin.complianceExport.description'
                             defaultMessage='This feature supports compliance exports to the Actiance XML and GlobalRelay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\"/admin_console/general/compliance\">Compliance</a> feature.'
+                        />
+                    </div>
+                </div>
+                */}
+
+                <div className='banner'>
+                    <div className='banner__content'>
+                        <FormattedHTMLMessage
+                            id='admin.complianceExport.description_without_globalrelay'
+                            defaultMessage='This feature supports compliance exports to the Actiance XML format, and is currently in beta. Support for GlobalRelay EML and the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\"/admin_console/general/compliance\">Compliance</a> feature.'
                         />
                     </div>
                 </div>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -203,6 +203,7 @@
   "admin.complianceExport.createJob.help": "Initiates a Compliance Export job immediately.",
   "admin.complianceExport.createJob.title": "Run Compliance Export Job Now",
   "admin.complianceExport.description": "This feature supports compliance exports to the Actiance XML and GlobalRelay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\"/admin_console/general/compliance\">Compliance</a> feature.",
+  "admin.complianceExport.description_without_globalrelay": "This feature supports compliance exports to the Actiance XML format, and is currently in beta. Support for GlobalRelay EML and the Mattermost CSV formats is scheduled for a future release, and will replace the existing <a href=\"/admin_console/general/compliance\">Compliance</a> feature.",
   "admin.complianceExport.exportFormat.actiance": "Actiance XML",
   "admin.complianceExport.exportFormat.actiance.description": "Format of the compliance export. Corresponds to the system that you want to import the data into. Compliance Export files will be written to the \"exports\" subdirectory of the configured <a href=\"/admin_console/files/storage\">Local Storage Directory</a>.",
   "admin.complianceExport.exportFormat.globalrelay": "GlobalRelay EML",

--- a/tests/components/admin_console/__snapshots__/message_export_settings.test.jsx.snap
+++ b/tests/components/admin_console/__snapshots__/message_export_settings.test.jsx.snap
@@ -28,8 +28,8 @@ exports[`components/MessageExportSettings should match snapshot, disabled 1`] = 
           className="banner__content"
         >
           <FormattedHTMLMessage
-            defaultMessage="This feature supports compliance exports to the Actiance XML and GlobalRelay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\\\\\\"/admin_console/general/compliance\\\\\\">Compliance</a> feature."
-            id="admin.complianceExport.description"
+            defaultMessage="This feature supports compliance exports to the Actiance XML format, and is currently in beta. Support for GlobalRelay EML and the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\\\\\\"/admin_console/general/compliance\\\\\\">Compliance</a> feature."
+            id="admin.complianceExport.description_without_globalrelay"
             values={Object {}}
           />
         </div>
@@ -117,10 +117,6 @@ exports[`components/MessageExportSettings should match snapshot, disabled 1`] = 
               "text": "Actiance XML",
               "value": "actiance",
             },
-            Object {
-              "text": "GlobalRelay EML",
-              "value": "globalrelay",
-            },
           ]
         }
       />
@@ -200,8 +196,8 @@ exports[`components/MessageExportSettings should match snapshot, enabled, actian
           className="banner__content"
         >
           <FormattedHTMLMessage
-            defaultMessage="This feature supports compliance exports to the Actiance XML and GlobalRelay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\\\\\\"/admin_console/general/compliance\\\\\\">Compliance</a> feature."
-            id="admin.complianceExport.description"
+            defaultMessage="This feature supports compliance exports to the Actiance XML format, and is currently in beta. Support for GlobalRelay EML and the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\\\\\\"/admin_console/general/compliance\\\\\\">Compliance</a> feature."
+            id="admin.complianceExport.description_without_globalrelay"
             values={Object {}}
           />
         </div>
@@ -289,10 +285,6 @@ exports[`components/MessageExportSettings should match snapshot, enabled, actian
               "text": "Actiance XML",
               "value": "actiance",
             },
-            Object {
-              "text": "GlobalRelay EML",
-              "value": "globalrelay",
-            },
           ]
         }
       />
@@ -372,8 +364,8 @@ exports[`components/MessageExportSettings should match snapshot, enabled, global
           className="banner__content"
         >
           <FormattedHTMLMessage
-            defaultMessage="This feature supports compliance exports to the Actiance XML and GlobalRelay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\\\\\\"/admin_console/general/compliance\\\\\\">Compliance</a> feature."
-            id="admin.complianceExport.description"
+            defaultMessage="This feature supports compliance exports to the Actiance XML format, and is currently in beta. Support for GlobalRelay EML and the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\\\\\\"/admin_console/general/compliance\\\\\\">Compliance</a> feature."
+            id="admin.complianceExport.description_without_globalrelay"
             values={Object {}}
           />
         </div>
@@ -460,10 +452,6 @@ exports[`components/MessageExportSettings should match snapshot, enabled, global
             Object {
               "text": "Actiance XML",
               "value": "actiance",
-            },
-            Object {
-              "text": "GlobalRelay EML",
-              "value": "globalrelay",
             },
           ]
         }


### PR DESCRIPTION
#### Summary
The full implementation of the GlobalRelay compliance export is expected to be
in the 4.9 release, so, temporary we disable the configuration in the admin
console.

#### Ticket Link
[MM-9675](https://mattermost.atlassian.net/browse/MM-9675)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed