### PR TITLE
MM-8042: Accepts ⌘+enter to comment (et al)

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -300,7 +300,7 @@ export default class CreateComment extends React.PureComponent {
     }
 
     commentMsgKeyPress = (e) => {
-        if (!UserAgent.isMobile() && ((this.props.ctrlSend && e.ctrlKey) || !this.props.ctrlSend)) {
+        if (!UserAgent.isMobile() && ((this.props.ctrlSend && Utils.cmdOrCtrlPressed(e)) || !this.props.ctrlSend)) {
             if (e.which === KeyCodes.ENTER && !e.shiftKey && !e.altKey) {
                 e.preventDefault();
                 this.refs.textbox.blur();
@@ -330,7 +330,7 @@ export default class CreateComment extends React.PureComponent {
     }
 
     handleKeyDown = (e) => {
-        if (this.props.ctrlSend && e.keyCode === KeyCodes.ENTER && e.ctrlKey) {
+        if (this.props.ctrlSend && e.keyCode === KeyCodes.ENTER && Utils.cmdOrCtrlPressed(e)) {
             this.commentMsgKeyPress(e);
             return;
         }
@@ -338,12 +338,12 @@ export default class CreateComment extends React.PureComponent {
         const {draft} = this.state;
         const {message} = draft;
 
-        if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && e.keyCode === KeyCodes.UP && message === '') {
+        if (!Utils.cmdOrCtrlPressed(e) && !e.altKey && !e.shiftKey && e.keyCode === KeyCodes.UP && message === '') {
             e.preventDefault();
             this.props.onEditLatestPost();
         }
 
-        if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey) {
+        if ((Utils.cmdOrCtrlPressed(e)) && !e.altKey && !e.shiftKey) {
             if (e.keyCode === Constants.KeyCodes.UP) {
                 e.preventDefault();
                 this.props.onMoveHistoryIndexBack();

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -418,7 +418,7 @@ export default class CreatePost extends React.Component {
     }
 
     postMsgKeyPress = (e) => {
-        const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
+        const ctrlOrMetaKeyPressed = Utils.cmdOrCtrlPressed(e);
         if (!UserAgent.isMobile() && ((this.props.ctrlSend && ctrlOrMetaKeyPressed) || !this.props.ctrlSend)) {
             if (e.which === KeyCodes.ENTER && !e.shiftKey && !e.altKey) {
                 e.preventDefault();
@@ -557,7 +557,7 @@ export default class CreatePost extends React.Component {
     }
 
     showShortcuts(e) {
-        if ((e.ctrlKey || e.metaKey) && e.keyCode === KeyCodes.FORWARD_SLASH) {
+        if ((Utils.cmdOrCtrlPressed(e)) && e.keyCode === KeyCodes.FORWARD_SLASH) {
             e.preventDefault();
 
             GlobalActions.toggleShortcutsModal();
@@ -587,7 +587,7 @@ export default class CreatePost extends React.Component {
     }
 
     handleKeyDown = (e) => {
-        const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
+        const ctrlOrMetaKeyPressed = Utils.cmdOrCtrlPressed(e);
         const messageIsEmpty = this.state.message.length === 0;
         const draftMessageIsEmpty = this.props.draft.message.length === 0;
         const ctrlEnterKeyCombo = this.props.ctrlSend && e.keyCode === KeyCodes.ENTER && ctrlOrMetaKeyPressed;

--- a/components/edit_channel_header_modal/edit_channel_header_modal.jsx
+++ b/components/edit_channel_header_modal/edit_channel_header_modal.jsx
@@ -117,14 +117,14 @@ class EditChannelHeaderModal extends React.PureComponent {
 
     handleKeyDown = (e) => {
         const {ctrlSend} = this.props;
-        if (ctrlSend && e.keyCode === KeyCodes.ENTER && e.ctrlKey === true) {
+        if (ctrlSend && e.keyCode === KeyCodes.ENTER && Utils.cmdOrCtrlPressed(e)) {
             this.handleKeyPress(e);
         }
     }
 
     handleKeyPress = (e) => {
         const {ctrlSend} = this.props;
-        if (!UserAgent.isMobile() && ((ctrlSend && e.ctrlKey) || !ctrlSend)) {
+        if (!UserAgent.isMobile() && ((ctrlSend && Utils.cmdOrCtrlPressed(e)) || !ctrlSend)) {
             if (e.which === KeyCodes.ENTER && !e.shiftKey && !e.altKey) {
                 e.preventDefault();
                 ReactDOM.findDOMNode(this.refs.editChannelHeaderTextbox).blur();

--- a/components/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx
+++ b/components/edit_channel_purpose_modal/edit_channel_purpose_modal.jsx
@@ -104,7 +104,7 @@ export default class EditChannelPurposeModal extends React.Component {
     handleKeyDown = (e) => {
         const {ctrlSend} = this.props;
 
-        if (ctrlSend && e.keyCode === Constants.KeyCodes.ENTER && e.ctrlKey) {
+        if (ctrlSend && e.keyCode === Constants.KeyCodes.ENTER && Utils.cmdOrCtrlPressed(e)) {
             e.preventDefault();
             this.handleSave(e);
         } else if (!ctrlSend && e.keyCode === Constants.KeyCodes.ENTER && !e.shiftKey && !e.altKey) {

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -186,7 +186,7 @@ export default class EditPostModal extends React.PureComponent {
             e.preventDefault();
             this.refs.editbox.blur();
             this.handleEdit();
-        } else if (this.props.ctrlSend && e.ctrlKey && e.which === KeyCodes.ENTER) {
+        } else if (this.props.ctrlSend && Utils.cmdOrCtrlPressed(e) && e.which === KeyCodes.ENTER) {
             e.preventDefault();
             this.refs.editbox.blur();
             this.handleEdit();
@@ -194,7 +194,7 @@ export default class EditPostModal extends React.PureComponent {
     }
 
     handleKeyDown = (e) => {
-        if (this.props.ctrlSend && e.keyCode === KeyCodes.ENTER && e.ctrlKey === true) {
+        if (this.props.ctrlSend && e.keyCode === KeyCodes.ENTER && Utils.cmdOrCtrlPressed(e)) {
             this.handleEdit();
         }
     }

--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -106,7 +106,7 @@ export default class NewChannelModal extends React.PureComponent {
     }
 
     onEnterKeyDown = (e) => {
-        if (this.props.ctrlSend && e.keyCode === Constants.KeyCodes.ENTER && e.ctrlKey) {
+        if (this.props.ctrlSend && e.keyCode === Constants.KeyCodes.ENTER && Utils.cmdOrCtrlPressed(e)) {
             this.handleSubmit(e);
         } else if (!this.props.ctrlSend && e.keyCode === Constants.KeyCodes.ENTER && !e.shiftKey && !e.altKey) {
             this.handleSubmit(e);

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1464,7 +1464,7 @@ export function handleFormattedTextClick(e) {
     } else if (linkAttribute) {
         const MIDDLE_MOUSE_BUTTON = 1;
 
-        if (!(e.button === MIDDLE_MOUSE_BUTTON || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) {
+        if (!(e.button === MIDDLE_MOUSE_BUTTON || e.altKey || cmdOrCtrlPressed(e) || e.shiftKey)) {
             e.preventDefault();
 
             const urlparse = document.createElement('a');


### PR DESCRIPTION
#### Summary
Adds ability to post comments with ⌘+enter (the original ticket). Also adds support for using ⌘ key in all places that control is supported in key combinations.

#### Ticket Link
[MM-8042](https://mattermost.atlassian.net/browse/MM-8042)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed