### PR TITLE
Remove mm_config and mm_license global state from webapp, phase 2 (PR #1)

### DIFF
--- a/components/at_mention/at_mention.jsx
+++ b/components/at_mention/at_mention.jsx
@@ -7,7 +7,7 @@ import {OverlayTrigger} from 'react-bootstrap';
 import {Client4} from 'mattermost-redux/client';
 
 import Pluggable from 'plugins/pluggable';
-import ProfilePopover from 'components/profile_popover.jsx';
+import ProfilePopover from 'components/profile_popover';
 
 export default class AtMention extends React.PureComponent {
     static propTypes = {

--- a/components/error_page/error_page.jsx
+++ b/components/error_page/error_page.jsx
@@ -1,0 +1,99 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import crypto from 'crypto';
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+import {Link} from 'react-router-dom';
+
+import {ErrorPageTypes} from 'utils/constants.jsx';
+
+import ErrorTitle from './error_title.jsx';
+import ErrorMessage from './error_message.jsx';
+
+export default class ErrorPage extends React.PureComponent {
+    static propTypes = {
+        location: PropTypes.object.isRequired,
+        asymmetricSigningPublicKey: PropTypes.string,
+        siteName: PropTypes.string,
+    };
+
+    componentDidMount() {
+        document.body.setAttribute('class', 'sticky error');
+    }
+
+    componentWillUnmount() {
+        document.body.removeAttribute('class');
+    }
+
+    render() {
+        const params = new URLSearchParams(this.props.location.search);
+        const signature = params.get('s');
+
+        var trustParams = false;
+        if (signature) {
+            params.delete('s');
+
+            const key = this.props.asymmetricSigningPublicKey;
+            const keyPEM = '-----BEGIN PUBLIC KEY-----\n' + key + '\n-----END PUBLIC KEY-----';
+
+            const verify = crypto.createVerify('sha256');
+            verify.update('/error?' + params.toString());
+            trustParams = verify.verify(keyPEM, signature, 'base64');
+        }
+
+        const type = params.get('type');
+        const title = (trustParams && params.get('title')) || '';
+        const message = (trustParams && params.get('message')) || '';
+        const service = (trustParams && params.get('service')) || '';
+        const returnTo = (trustParams && params.get('returnTo')) || '';
+
+        let backButton;
+        if (type === ErrorPageTypes.PERMALINK_NOT_FOUND && returnTo) {
+            backButton = (
+                <Link to={returnTo}>
+                    <FormattedMessage
+                        id='error.generic.link'
+                        defaultMessage='Back to Mattermost'
+                    />
+                </Link>
+            );
+        } else {
+            backButton = (
+                <Link to='/'>
+                    <FormattedMessage
+                        id='error.generic.link'
+                        defaultMessage='Back to {siteName}'
+                        values={{
+                            siteName: this.props.siteName,
+                        }}
+                    />
+                </Link>
+            );
+        }
+
+        return (
+            <div className='container-fluid'>
+                <div className='error__container'>
+                    <div className='error__icon'>
+                        <i className='fa fa-exclamation-triangle'/>
+                    </div>
+                    <h2>
+                        <ErrorTitle
+                            type={type}
+                            title={title}
+                        />
+                    </h2>
+                    <ErrorMessage
+                        type={type}
+                        message={message}
+                        service={service}
+                    />
+                    {backButton}
+                </div>
+            </div>
+        );
+    }
+}

--- a/components/error_page/index.jsx
+++ b/components/error_page/index.jsx
@@ -1,97 +1,18 @@
-// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import crypto from 'crypto';
+import {connect} from 'react-redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
-import PropTypes from 'prop-types';
-import React from 'react';
-import {FormattedMessage} from 'react-intl';
-import {Link} from 'react-router-dom';
+import ErrorPage from './error_page.jsx';
 
-import {ErrorPageTypes} from 'utils/constants.jsx';
+function mapStateToProps(state) {
+    const config = getConfig(state);
 
-import ErrorTitle from './error_title.jsx';
-import ErrorMessage from './error_message.jsx';
-
-export default class ErrorPage extends React.PureComponent {
-    static propTypes = {
-        location: PropTypes.object.isRequired,
+    return {
+        siteName: config.SiteName,
+        asymmetricSigningPublicKey: config.AsymmetricSigningPublicKey,
     };
-
-    componentDidMount() {
-        document.body.setAttribute('class', 'sticky error');
-    }
-
-    componentWillUnmount() {
-        document.body.removeAttribute('class');
-    }
-
-    render() {
-        const params = new URLSearchParams(this.props.location.search);
-        const signature = params.get('s');
-
-        var trustParams = false;
-        if (signature) {
-            params.delete('s');
-
-            const key = window.mm_config.AsymmetricSigningPublicKey;
-            const keyPEM = '-----BEGIN PUBLIC KEY-----\n' + key + '\n-----END PUBLIC KEY-----';
-
-            const verify = crypto.createVerify('sha256');
-            verify.update('/error?' + params.toString());
-            trustParams = verify.verify(keyPEM, signature, 'base64');
-        }
-
-        const type = params.get('type');
-        const title = (trustParams && params.get('title')) || '';
-        const message = (trustParams && params.get('message')) || '';
-        const service = (trustParams && params.get('service')) || '';
-        const returnTo = (trustParams && params.get('returnTo')) || '';
-
-        let backButton;
-        if (type === ErrorPageTypes.PERMALINK_NOT_FOUND && returnTo) {
-            backButton = (
-                <Link to={returnTo}>
-                    <FormattedMessage
-                        id='error.generic.link'
-                        defaultMessage='Back to Mattermost'
-                    />
-                </Link>
-            );
-        } else {
-            backButton = (
-                <Link to='/'>
-                    <FormattedMessage
-                        id='error.generic.link'
-                        defaultMessage='Back to {siteName}'
-                        values={{
-                            siteName: global.window.mm_config.SiteName,
-                        }}
-                    />
-                </Link>
-            );
-        }
-
-        return (
-            <div className='container-fluid'>
-                <div className='error__container'>
-                    <div className='error__icon'>
-                        <i className='fa fa-exclamation-triangle'/>
-                    </div>
-                    <h2>
-                        <ErrorTitle
-                            type={type}
-                            title={title}
-                        />
-                    </h2>
-                    <ErrorMessage
-                        type={type}
-                        message={message}
-                        service={service}
-                    />
-                    {backButton}
-                </div>
-            </div>
-        );
-    }
 }
+
+export default connect(mapStateToProps)(ErrorPage);

--- a/components/profile_picture.jsx
+++ b/components/profile_picture.jsx
@@ -7,7 +7,7 @@ import {OverlayTrigger} from 'react-bootstrap';
 
 import Pluggable from 'plugins/pluggable';
 
-import ProfilePopover from './profile_popover.jsx';
+import ProfilePopover from './profile_popover';
 import StatusIcon from './status_icon.jsx';
 
 export default class ProfilePicture extends React.PureComponent {

--- a/components/profile_popover/index.js
+++ b/components/profile_popover/index.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import ProfilePopover from './profile_popover.jsx';
+
+function mapStateToProps(state, ownProps) {
+    const config = state.entities.general.config;
+
+    const showEmailAddress = config.showEmailAddress === 'true';
+    const enableWebrtc = config.EnableWebrtc === 'true';
+
+    return {
+        ...ownProps,
+        showEmailAddress,
+        enableWebrtc,
+    };
+}
+
+export default connect(mapStateToProps)(ProfilePopover);

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -66,6 +66,16 @@ class ProfilePopover extends React.Component {
          */
         hasMention: PropTypes.bool,
 
+        /**
+         * Whether or not to reveal the email address associated with the user.
+         */
+        showEmailAddress: PropTypes.bool.isRequired,
+
+        /**
+         * Whether or not WebRtc is enabled.
+         */
+        enableWebrtc: PropTypes.bool.isRequired,
+
         ...Popover.propTypes,
     }
 
@@ -194,11 +204,13 @@ class ProfilePopover extends React.Component {
         delete popoverProps.isRHS;
         delete popoverProps.hasMention;
         delete popoverProps.dispatch;
+        delete popoverProps.showEmailAddress;
+        delete popoverProps.enableWebrtc;
 
         let webrtc;
         const userMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 
-        const webrtcEnabled = global.mm_config.EnableWebrtc === 'true' && userMedia && Utils.isFeatureEnabled(PreReleaseFeatures.WEBRTC_PREVIEW);
+        const webrtcEnabled = this.props.enableWebrtc && userMedia && Utils.isFeatureEnabled(PreReleaseFeatures.WEBRTC_PREVIEW);
 
         if (webrtcEnabled && this.props.user.id !== this.state.currentUserId) {
             const isOnline = this.props.status !== UserStatuses.OFFLINE;
@@ -282,6 +294,7 @@ class ProfilePopover extends React.Component {
                     delayShow={Constants.WEBRTC_TIME_DELAY}
                     placement='top'
                     overlay={<Tooltip id='positionTooltip'>{position}</Tooltip>}
+                    key='user-popover-position'
                 >
                     <div
                         className='overflow--ellipsis text-nowrap padding-bottom'
@@ -293,7 +306,7 @@ class ProfilePopover extends React.Component {
         }
 
         const email = this.props.user.email;
-        if (global.window.mm_config.ShowEmailAddress === 'true' || UserStore.isSystemAdminForCurrentUser() || this.props.user === UserStore.getCurrentUser()) {
+        if (this.props.showEmailAddress || UserStore.isSystemAdminForCurrentUser() || this.props.user === UserStore.getCurrentUser()) {
             dataContent.push(
                 <div
                     data-toggle='tooltip'

--- a/components/select_team/index.js
+++ b/components/select_team/index.js
@@ -4,13 +4,22 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getTeams} from 'mattermost-redux/actions/teams';
+import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {withRouter} from 'react-router-dom';
 
 import SelectTeam from './select_team.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
+    const license = getLicense(state);
+    const config = getConfig(state);
+
     return {
-        ...ownProps,
+        isLicensed: license.IsLicensed === 'true',
+        customBrand: license.CustomBrand === 'true',
+        enableCustomBrand: config.EnableCustomBrand === 'true',
+        customDescriptionText: config.CustomDescriptionText,
+        enableTeamCreation: config.EnableTeamCreation === 'true',
+        siteName: config.SiteName,
     };
 }
 

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -21,6 +21,12 @@ import SelectTeamItem from './components/select_team_item.jsx';
 
 export default class SelectTeam extends React.Component {
     static propTypes = {
+        isLicensed: PropTypes.bool.isRequired,
+        customBrand: PropTypes.bool.isRequired,
+        enableCustomBrand: PropTypes.bool.isRequired,
+        customDescriptionText: PropTypes.string,
+        enableTeamCreation: PropTypes.bool.isRequired,
+        siteName: PropTypes.string,
         actions: PropTypes.shape({
             getTeams: PropTypes.func.isRequired,
         }).isRequired,
@@ -130,7 +136,7 @@ export default class SelectTeam extends React.Component {
                 }
             }
 
-            if (openTeamContents.length === 0 && (global.window.mm_config.EnableTeamCreation === 'true' || isSystemAdmin)) {
+            if (openTeamContents.length === 0 && (this.props.enableTeamCreation || isSystemAdmin)) {
                 openTeamContents = (
                     <div className='signup-team-dir-err'>
                         <div>
@@ -174,7 +180,7 @@ export default class SelectTeam extends React.Component {
         }
 
         let teamHelp = null;
-        if (isSystemAdmin && (global.window.mm_config.EnableTeamCreation === 'false')) {
+        if (isSystemAdmin && !this.props.enableTeamCreation) {
             teamHelp = (
                 <FormattedMessage
                     id='login.createTeamAdminOnly'
@@ -184,7 +190,7 @@ export default class SelectTeam extends React.Component {
         }
 
         let teamSignUp;
-        if (isSystemAdmin || global.window.mm_config.EnableTeamCreation === 'true') {
+        if (isSystemAdmin || this.props.enableTeamCreation) {
             teamSignUp = (
                 <div className='margin--extra'>
                     <Link
@@ -221,8 +227,8 @@ export default class SelectTeam extends React.Component {
         }
 
         let description = null;
-        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && global.window.mm_config.EnableCustomBrand === 'true') {
-            description = global.window.mm_config.CustomDescriptionText;
+        if (this.props.isLicensed && this.props.customBrand && this.props.enableCustomBrand) {
+            description = this.props.customDescriptionText;
         } else {
             description = (
                 <FormattedMessage
@@ -260,7 +266,7 @@ export default class SelectTeam extends React.Component {
                             className='signup-team-logo'
                             src={logoImage}
                         />
-                        <h1>{global.window.mm_config.SiteName}</h1>
+                        <h1>{this.props.siteName}</h1>
                         <h4 className='color--light'>
                             {description}
                         </h4>

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -6,6 +6,7 @@ import {Client4} from 'mattermost-redux/client';
 import {Preferences} from 'mattermost-redux/constants';
 import {getChannelsInCurrentTeam, getGroupChannels, getMyChannelMemberships} from 'mattermost-redux/selectors/entities/channels';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, searchProfiles, getUserIdsInChannels, getUser} from 'mattermost-redux/selectors/entities/users';
 
@@ -162,13 +163,15 @@ export default class SwitchChannelProvider extends Provider {
     }
 
     async fetchUsersAndChannels(channelPrefix, suggestionId) {
-        const teamId = getCurrentTeamId(getState());
+        const state = getState();
+        const teamId = getCurrentTeamId(state);
         if (!teamId) {
             return;
         }
 
+        const config = getConfig(state);
         let usersAsync;
-        if (global.window.mm_config.RestrictDirectMessage === 'team') {
+        if (config.RestrictDirectMessage === 'team') {
             usersAsync = Client4.autocompleteUsers(channelPrefix, teamId, '');
         } else {
             usersAsync = Client4.autocompleteUsers(channelPrefix, '', '');
@@ -192,8 +195,8 @@ export default class SwitchChannelProvider extends Provider {
             return;
         }
 
-        const users = Object.assign([], searchProfiles(getState(), channelPrefix, true)).concat(usersFromServer.users);
-        const channels = getChannelsInCurrentTeam(getState()).concat(getGroupChannels(getState())).concat(channelsFromServer);
+        const users = Object.assign([], searchProfiles(state, channelPrefix, true)).concat(usersFromServer.users);
+        const channels = getChannelsInCurrentTeam(state).concat(getGroupChannels(state)).concat(channelsFromServer);
         this.formatChannelsAndDispatch(channelPrefix, suggestionId, channels, users);
     }
 

--- a/components/user_profile.jsx
+++ b/components/user_profile.jsx
@@ -8,7 +8,7 @@ import {OverlayTrigger} from 'react-bootstrap';
 import Pluggable from 'plugins/pluggable';
 import * as Utils from 'utils/utils.jsx';
 
-import ProfilePopover from './profile_popover.jsx';
+import ProfilePopover from './profile_popover';
 
 export default class UserProfile extends React.Component {
     constructor(props) {

--- a/tests/components/__snapshots__/profile_picture.test.jsx.snap
+++ b/tests/components/__snapshots__/profile_picture.test.jsx.snap
@@ -41,7 +41,7 @@ exports[`components/ProfilePicture should match snapshot, user specified 1`] = `
   defaultOverlayShown={false}
   overlay={
     <Connect(Pluggable)>
-      <ProfilePopover
+      <Connect(ProfilePopover)
         hasMention={false}
         hide={[Function]}
         isBusy={true}
@@ -83,7 +83,7 @@ exports[`components/ProfilePicture should match snapshot, user specified, overri
   defaultOverlayShown={false}
   overlay={
     <Connect(Pluggable)>
-      <ProfilePopover
+      <Connect(ProfilePopover)
         hasMention={true}
         hide={[Function]}
         isBusy={true}

--- a/tests/plugins/__snapshots__/pluggable.test.jsx.snap
+++ b/tests/plugins/__snapshots__/pluggable.test.jsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`plugins/Pluggable should match snapshot with no overridden component 1`] = `
-<Pluggable
-  components={Object {}}
+<Provider
   intl={
     Object {
       "defaultFormats": Object {},
@@ -28,216 +27,170 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
       "textComponent": "span",
     }
   }
-  theme={Object {}}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
 >
-  <ProfilePopover
-    hasMention={false}
-    intl={
-      Object {
-        "defaultFormats": Object {},
-        "defaultLocale": "en",
-        "formatDate": [Function],
-        "formatHTMLMessage": [Function],
-        "formatMessage": [Function],
-        "formatNumber": [Function],
-        "formatPlural": [Function],
-        "formatRelative": [Function],
-        "formatTime": [Function],
-        "formats": Object {},
-        "formatters": Object {
-          "getDateTimeFormat": [Function],
-          "getMessageFormat": [Function],
-          "getNumberFormat": [Function],
-          "getPluralFormat": [Function],
-          "getRelativeFormat": [Function],
-        },
-        "locale": "en",
-        "messages": Object {},
-        "now": [Function],
-        "textComponent": "span",
-      }
-    }
-    isRHS={false}
-    src="src"
+  <Pluggable
+    components={Object {}}
     theme={Object {}}
-    user={
-      Object {
-        "name": "name",
-      }
-    }
   >
-    <Popover
-      bsClass="popover"
-      id="user-profile-popover"
-      intl={
+    <Connect(ProfilePopover)
+      src="src"
+      theme={Object {}}
+      user={
         Object {
-          "defaultFormats": Object {},
-          "defaultLocale": "en",
-          "formatDate": [Function],
-          "formatHTMLMessage": [Function],
-          "formatMessage": [Function],
-          "formatNumber": [Function],
-          "formatPlural": [Function],
-          "formatRelative": [Function],
-          "formatTime": [Function],
-          "formats": Object {},
-          "formatters": Object {
-            "getDateTimeFormat": [Function],
-            "getMessageFormat": [Function],
-            "getNumberFormat": [Function],
-            "getPluralFormat": [Function],
-            "getRelativeFormat": [Function],
-          },
-          "locale": "en",
-          "messages": Object {},
-          "now": [Function],
-          "textComponent": "span",
+          "name": "name",
         }
       }
-      placement="right"
-      theme={Object {}}
-      title="@undefined"
     >
-      <div
-        className="popover right"
-        id="user-profile-popover"
-        intl={
-          Object {
-            "defaultFormats": Object {},
-            "defaultLocale": "en",
-            "formatDate": [Function],
-            "formatHTMLMessage": [Function],
-            "formatMessage": [Function],
-            "formatNumber": [Function],
-            "formatPlural": [Function],
-            "formatRelative": [Function],
-            "formatTime": [Function],
-            "formats": Object {},
-            "formatters": Object {
-              "getDateTimeFormat": [Function],
-              "getMessageFormat": [Function],
-              "getNumberFormat": [Function],
-              "getPluralFormat": [Function],
-              "getRelativeFormat": [Function],
-            },
-            "locale": "en",
-            "messages": Object {},
-            "now": [Function],
-            "textComponent": "span",
-          }
-        }
-        role="tooltip"
-        style={
-          Object {
-            "display": "block",
-            "left": undefined,
-            "top": undefined,
-          }
-        }
+      <ProfilePopover
+        dispatch={[Function]}
+        enableWebrtc={true}
+        hasMention={false}
+        isRHS={false}
+        showEmailAddress={false}
+        src="src"
         theme={Object {}}
-      >
-        <div
-          className="arrow"
-          style={
-            Object {
-              "left": undefined,
-              "top": undefined,
-            }
+        user={
+          Object {
+            "name": "name",
           }
-        />
-        <h3
-          className="popover-title"
+        }
+      >
+        <Popover
+          bsClass="popover"
+          id="user-profile-popover"
+          placement="right"
+          theme={Object {}}
+          title="@undefined"
         >
-          @undefined
-        </h3>
-        <div
-          className="popover-content"
-        >
-          <img
-            alt="user profile image"
-            className="user-popover__image"
-            height="128"
-            key="user-popover-image"
-            src="src"
-            width="128"
-          />
           <div
-            data-toggle="tooltip"
-            key="user-popover-email"
+            className="popover right"
+            id="user-profile-popover"
+            role="tooltip"
+            style={
+              Object {
+                "display": "block",
+                "left": undefined,
+                "top": undefined,
+              }
+            }
+            theme={Object {}}
           >
-            <a
-              className="text-nowrap text-lowercase user-popover__email"
-              href="mailto:undefined"
+            <div
+              className="arrow"
+              style={
+                Object {
+                  "left": undefined,
+                  "top": undefined,
+                }
+              }
             />
-          </div>
-          <div
-            className="popover__row first"
-            data-toggle="tooltip"
-            key="user-popover-dm"
-          >
-            <a
-              className="text-nowrap text-lowercase user-popover__email"
-              href="#"
-              onClick={[Function]}
+            <h3
+              className="popover-title"
             >
-              <i
-                className="fa fa-paper-plane"
+              @undefined
+            </h3>
+            <div
+              className="popover-content"
+            >
+              <img
+                alt="user profile image"
+                className="user-popover__image"
+                height="128"
+                key="user-popover-image"
+                src="src"
+                width="128"
               />
-              <FormattedMessage
-                defaultMessage="Send Message"
-                id="user_profile.send.dm"
-                values={Object {}}
+              <div
+                className="popover__row first"
+                data-toggle="tooltip"
+                key="user-popover-dm"
               >
-                <span>
-                  Send Message
-                </span>
-              </FormattedMessage>
-            </a>
+                <a
+                  className="text-nowrap text-lowercase user-popover__email"
+                  href="#"
+                  onClick={[Function]}
+                >
+                  <i
+                    className="fa fa-paper-plane"
+                  />
+                  <FormattedMessage
+                    defaultMessage="Send Message"
+                    id="user_profile.send.dm"
+                    values={Object {}}
+                  >
+                    <span>
+                      Send Message
+                    </span>
+                  </FormattedMessage>
+                </a>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
-    </Popover>
-  </ProfilePopover>
-</Pluggable>
+        </Popover>
+      </ProfilePopover>
+    </Connect(ProfilePopover)>
+  </Pluggable>
+</Provider>
 `;
 
 exports[`plugins/Pluggable should match snapshot with overridden component 1`] = `
-<Pluggable
-  components={
+<Provider
+  store={
     Object {
-      "ProfilePopover": Object {
-        "component": [Function],
-      },
-    }
-  }
-  theme={
-    Object {
-      "id": "theme_id",
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
     }
   }
 >
-  <ProfilePopoverPlugin
-    hasMention={false}
-    isRHS={false}
-    src="src"
+  <Pluggable
+    components={
+      Object {
+        "ProfilePopover": Object {
+          "component": [Function],
+        },
+      }
+    }
     theme={
       Object {
         "id": "theme_id",
       }
     }
-    user={
-      Object {
-        "name": "name",
-      }
-    }
   >
-    <span
-      id="pluginId"
+    <ProfilePopoverPlugin
+      src="src"
+      theme={
+        Object {
+          "id": "theme_id",
+        }
+      }
+      user={
+        Object {
+          "name": "name",
+        }
+      }
     >
-      ProfilePopoverPlugin
-    </span>
-  </ProfilePopoverPlugin>
-</Pluggable>
+      <span
+        id="pluginId"
+      >
+        ProfilePopoverPlugin
+      </span>
+    </ProfilePopoverPlugin>
+  </Pluggable>
+</Provider>
 `;
 
 exports[`plugins/Pluggable should match snapshot with overridden component with pluggableName 1`] = `
@@ -282,7 +235,6 @@ exports[`plugins/Pluggable should match snapshot with overridden component with 
   }
 >
   <ProfilePopoverPlugin
-    hasMention={false}
     intl={
       Object {
         "defaultFormats": Object {},
@@ -308,7 +260,6 @@ exports[`plugins/Pluggable should match snapshot with overridden component with 
         "textComponent": "span",
       }
     }
-    isRHS={false}
     src="src"
     theme={
       Object {

--- a/tests/plugins/pluggable.test.jsx
+++ b/tests/plugins/pluggable.test.jsx
@@ -3,10 +3,12 @@
 
 import React from 'react';
 import {mount, shallow} from 'enzyme';
+import configureStore from 'redux-mock-store';
+import {Provider} from 'react-redux';
 
 import Pluggable from 'plugins/pluggable/pluggable.jsx';
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
-import ProfilePopover from 'components/profile_popover.jsx';
+import ProfilePopover from 'components/profile_popover';
 
 class ProfilePopoverPlugin extends React.PureComponent {
     render() {
@@ -15,39 +17,48 @@ class ProfilePopoverPlugin extends React.PureComponent {
 }
 
 describe('plugins/Pluggable', () => {
-    beforeEach(() => {
-        window.mm_config = {
-            EnableWebrtc: 'true',
-            ShowEmailAddress: 'true',
-        };
+    const mockStore = configureStore();
+    const store = mockStore({
+        entities: {
+            general: {
+                config: {
+                    EnableWebrtc: 'true',
+                    ShowEmailAddress: 'true',
+                },
+            },
+        },
     });
 
     test('should match snapshot with no overridden component', () => {
         const wrapper = mountWithIntl(
-            <Pluggable
-                components={{}}
-                theme={{}}
-            >
-                <ProfilePopover
-                    user={{name: 'name'}}
-                    src='src'
-                />
-            </Pluggable>
+            <Provider store={store}>
+                <Pluggable
+                    components={{}}
+                    theme={{}}
+                >
+                    <ProfilePopover
+                        user={{name: 'name'}}
+                        src='src'
+                    />
+                </Pluggable>
+            </Provider>
         );
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot with overridden component', () => {
         const wrapper = mount(
-            <Pluggable
-                components={{ProfilePopover: {component: ProfilePopoverPlugin}}}
-                theme={{id: 'theme_id'}}
-            >
-                <ProfilePopover
-                    user={{name: 'name'}}
-                    src='src'
-                />
-            </Pluggable>
+            <Provider store={store}>
+                <Pluggable
+                    components={{ProfilePopover: {component: ProfilePopoverPlugin}}}
+                    theme={{id: 'theme_id'}}
+                >
+                    <ProfilePopover
+                        user={{name: 'name'}}
+                        src='src'
+                    />
+                </Pluggable>
+            </Provider>
         );
 
         expect(wrapper).toMatchSnapshot();


### PR DESCRIPTION
#### Summary
This is a subset of the changes in the `MM-9635-remove_mm_global_license_config` branch, broken up into multiple PRs to facilitate easier review. See any linked PRs for other changes if you're interested. 

This is phase two of the changes that remove our dependence on the global `mm_config` and `mm_license` objects. The last PR to follow this series will remove the exports altogether. These changes will ultimately facilitate resolving https://mattermost.atlassian.net/browse/MM-8604, allowing us to stop hard refreshing the application whenever someone makes a configuration change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9635

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

### Related PRs
https://github.com/mattermost/mattermost-webapp/pull/863
https://github.com/mattermost/mattermost-webapp/pull/865
https://github.com/mattermost/mattermost-webapp/pull/866