### PR TITLE
MM-8593 Add announcement bar for sysadmins when APIv3 is enabled, other minor clean-up

### DIFF
--- a/components/announcement_bar/announcement_bar.jsx
+++ b/components/announcement_bar/announcement_bar.jsx
@@ -38,6 +38,7 @@ export default class AnnouncementBar extends React.PureComponent {
         bannerColor: PropTypes.string,
         bannerTextColor: PropTypes.string,
         enableSignUpWithGitLab: PropTypes.bool.isRequired,
+        enableAPIv3: PropTypes.bool.isRequired,
     }
 
     constructor(props) {
@@ -69,6 +70,9 @@ export default class AnnouncementBar extends React.PureComponent {
                 return;
             } else if (!this.props.sendEmailNotifications) {
                 ErrorStore.storeLastError({notification: true, message: ErrorBarTypes.PREVIEW_MODE});
+                return;
+            } else if (isSystemAdmin && this.props.enableAPIv3) {
+                ErrorStore.storeLastError({notification: true, message: ErrorBarTypes.APIV3_ENABLED});
                 return;
             }
         }
@@ -240,6 +244,13 @@ export default class AnnouncementBar extends React.PureComponent {
                 <FormattedMessage
                     id={ErrorBarTypes.PREVIEW_MODE}
                     defaultMessage='Preview Mode: Email notifications have not been configured'
+                />
+            );
+        } else if (message === ErrorBarTypes.APIV3_ENABLED) {
+            message = (
+                <FormattedHTMLMessage
+                    id={ErrorBarTypes.APIV3_ENABLED}
+                    defaultMessage='Warning: API version 3 is enabled even though it is deprecated and scheduled to be removed. <a href="https://api.mattermost.com/#tag/APIv3-Deprecation" target="_blank">Learn more</a>.'
                 />
             );
         } else if (message === ErrorBarTypes.LICENSE_EXPIRING) {

--- a/components/announcement_bar/announcement_bar.jsx
+++ b/components/announcement_bar/announcement_bar.jsx
@@ -250,7 +250,7 @@ export default class AnnouncementBar extends React.PureComponent {
             message = (
                 <FormattedHTMLMessage
                     id={ErrorBarTypes.APIV3_ENABLED}
-                    defaultMessage='Warning: API version 3 is enabled even though it is deprecated and scheduled to be removed. <a href="https://api.mattermost.com/#tag/APIv3-Deprecation" target="_blank">Learn more</a>.'
+                    defaultMessage='API version 3 is deprecated and scheduled for removal. <a href="https://api.mattermost.com/#tag/APIv3-Deprecation" target="_blank">Learn how to migrate to APIv4</a>.'
                 />
             );
         } else if (message === ErrorBarTypes.LICENSE_EXPIRING) {

--- a/components/announcement_bar/index.js
+++ b/components/announcement_bar/index.js
@@ -20,6 +20,7 @@ function mapStateToProps(state) {
     const bannerColor = config.BannerColor;
     const bannerTextColor = config.BannerTextColor;
     const enableSignUpWithGitLab = config.EnableSignUpWithGitLab === 'true';
+    const enableAPIv3 = config.EnableAPIv3 === 'true';
 
     return {
         isLoggedIn: Boolean(getCurrentUserId(state)),
@@ -32,6 +33,7 @@ function mapStateToProps(state) {
         bannerColor,
         bannerTextColor,
         enableSignUpWithGitLab,
+        enableAPIv3,
     };
 }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1574,6 +1574,7 @@
   "error_bar.expiring": "Enterprise license expires on {date}. <a href='{link}' target='_blank'>Please renew</a>.",
   "error_bar.past_grace": "Enterprise license is expired and some features may be disabled. Please contact your System Administrator for details.",
   "error_bar.preview_mode": "Preview Mode: Email notifications have not been configured",
+  "error_bar.apiv3_enabled": "Warning: API version 3 is enabled even though it is deprecated and scheduled to be removed. <a href=\"https://api.mattermost.com/#tag/APIv3-Deprecation\" target=\"_blank\">Learn more</a>.",
   "error_bar.site_url": "Please configure your {docsLink} in the {link}.",
   "error_bar.site_url.docsLink": "Site URL",
   "error_bar.site_url.link": "System Console",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1574,7 +1574,7 @@
   "error_bar.expiring": "Enterprise license expires on {date}. <a href='{link}' target='_blank'>Please renew</a>.",
   "error_bar.past_grace": "Enterprise license is expired and some features may be disabled. Please contact your System Administrator for details.",
   "error_bar.preview_mode": "Preview Mode: Email notifications have not been configured",
-  "error_bar.apiv3_enabled": "Warning: API version 3 is enabled even though it is deprecated and scheduled to be removed. <a href=\"https://api.mattermost.com/#tag/APIv3-Deprecation\" target=\"_blank\">Learn more</a>.",
+  "error_bar.apiv3_enabled": "API version 3 is deprecated and scheduled for removal. <a href=\"https://api.mattermost.com/#tag/APIv3-Deprecation\" target=\"_blank\">Learn how to migrate to APIv4</a>.",
   "error_bar.site_url": "Please configure your {docsLink} in the {link}.",
   "error_bar.site_url.docsLink": "Site URL",
   "error_bar.site_url.link": "System Console",

--- a/root.jsx
+++ b/root.jsx
@@ -27,7 +27,7 @@ function preRenderSetup(callwhendone) {
         l.message = 'msg: ' + msg + ' row: ' + line + ' col: ' + column + ' stack: ' + stack + ' url: ' + url;
 
         const req = new XMLHttpRequest();
-        req.open('POST', '/api/v3/general/log_client');
+        req.open('POST', '/api/v4/logs');
         req.setRequestHeader('Content-Type', 'application/json');
         req.send(JSON.stringify(l));
 

--- a/tests/helpers/client-test-helper.jsx
+++ b/tests/helpers/client-test-helper.jsx
@@ -63,7 +63,7 @@ class TestHelperClass {
 
     createWebSocketClient(token) {
         var ws = new WebSocketClient();
-        ws.initialize('http://localhost:8065/api/v3/users/websocket', token);
+        ws.initialize('http://localhost:8065/api/v4/websocket', token);
         return ws;
     }
 

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -424,6 +424,7 @@ export const ErrorBarTypes = {
     LICENSE_PAST_GRACE: 'error_bar.past_grace',
     PREVIEW_MODE: 'error_bar.preview_mode',
     SITE_URL: 'error_bar.site_url',
+    APIV3_ENABLED: 'error_bar.apiv3_enabled',
     WEBSOCKET_PORT_ERROR: 'channel_loader.socketError',
 };
 


### PR DESCRIPTION
#### Summary
Add announcement bar for sysadmins when APIv3 is enabled. Removed any last references to v3 from the webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8593

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has server changes (mattermost/mattermost-server#8353)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
