### PR TITLE
Remove mm_config and mm_license global state from webapp, phase 2 (PR #4)

### DIFF
--- a/stores/user_typing_store.jsx
+++ b/stores/user_typing_store.jsx
@@ -3,10 +3,13 @@
 
 import EventEmitter from 'events';
 
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
 import UserStore from 'stores/user_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
+import store from 'stores/redux_store.jsx';
 
 const ActionTypes = Constants.ActionTypes;
 
@@ -59,13 +62,14 @@ class UserTypingStoreClass extends EventEmitter {
         }
 
         // Set the user and a timeout to remove it
+        const config = getConfig(store.getState());
         this.typingUsers[loc][name] = setTimeout(() => {
             Reflect.deleteProperty(this.typingUsers[loc], name);
             if (this.typingUsers[loc] === {}) {
                 Reflect.deleteProperty(this.typingUsers, loc);
             }
             this.emitChange();
-        }, parseInt(window.mm_config.TimeBetweenUserTypingUpdatesMilliseconds, 10));
+        }, parseInt(config.TimeBetweenUserTypingUpdatesMilliseconds, 10));
         this.emitChange();
     }
 

--- a/tests/utils/channel_utils.test.jsx
+++ b/tests/utils/channel_utils.test.jsx
@@ -1,27 +1,58 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+import {GeneralTypes} from 'mattermost-redux/action_types';
 
 import * as Utils from 'utils/channel_utils.jsx';
 import Constants from 'utils/constants.jsx';
+import store from 'stores/redux_store.jsx';
 
 describe('Channel Utils', () => {
+    afterEach(() => {
+        store.dispatch({
+            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            data: {},
+        });
+    });
+
     describe('showDeleteOption', () => {
         test('all users can delete channels on unlicensed instances', () => {
-            global.window.mm_license = {IsLicensed: 'false'};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'false',
+                },
+            });
+
             expect(Utils.showDeleteOptionForCurrentUser(null, true, true, true)).
                 toEqual(true);
         });
 
         test('users cannot delete default channels', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+
             const channel = {name: Constants.DEFAULT_CHANNEL};
             expect(Utils.showDeleteOptionForCurrentUser(channel, true, true, true)).
                 toEqual(false);
         });
 
         test('system admins can delete private channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelDeletion: Constants.PERMISSIONS_SYSTEM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelDeletion: Constants.PERMISSIONS_SYSTEM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -32,8 +63,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins can delete private channels, user is not system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelDeletion: Constants.PERMISSIONS_SYSTEM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelDeletion: Constants.PERMISSIONS_SYSTEM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -44,8 +85,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins can delete public channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelDeletion: Constants.PERMISSIONS_SYSTEM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelDeletion: Constants.PERMISSIONS_SYSTEM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -56,8 +107,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins can delete public channels, user is not system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelDeletion: Constants.PERMISSIONS_SYSTEM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelDeletion: Constants.PERMISSIONS_SYSTEM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -68,8 +129,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can delete private channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -80,8 +151,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can delete private channels, user is not system admin or team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -92,8 +173,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can delete public channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -104,8 +195,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can delete public channels, user is not system admin or team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -116,8 +217,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can delete private channels, user is team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -128,8 +239,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can delete public channels, user is team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelDeletion: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -140,8 +261,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can delete public channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -152,8 +283,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can delete private channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -164,8 +305,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can delete public channels, user is team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -176,8 +327,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can delete private channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -188,8 +349,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can delete public channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -200,8 +371,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can delete private channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -212,8 +393,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can delete public channels, user is not admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -224,8 +415,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can delete private channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelDeletion: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -236,8 +437,18 @@ describe('Channel Utils', () => {
         });
 
         test('any member can delete public channels, user is not admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelDeletion: Constants.PERMISSIONS_ALL};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelDeletion: Constants.PERMISSIONS_ALL,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -248,8 +459,18 @@ describe('Channel Utils', () => {
         });
 
         test('any member can delete private channels, user is not admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelDeletion: Constants.PERMISSIONS_ALL};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelDeletion: Constants.PERMISSIONS_ALL,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -262,14 +483,29 @@ describe('Channel Utils', () => {
 
     describe('showManagementOptions', () => {
         test('all users can manage channel options on unlicensed instances', () => {
-            global.window.mm_license = {IsLicensed: 'false'};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'false',
+                },
+            });
             expect(Utils.showManagementOptions(null, true, true, true)).
                 toEqual(true);
         });
 
         test('system admins can manage channel options in private channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManagement: Constants.PERMISSIONS_SYSTEM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManagement: Constants.PERMISSIONS_SYSTEM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -280,8 +516,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins can manage channel options in private channels, user is not system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManagement: Constants.PERMISSIONS_SYSTEM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManagement: Constants.PERMISSIONS_SYSTEM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -292,8 +538,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins can manage channel options in public channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelManagement: Constants.PERMISSIONS_SYSTEM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelManagement: Constants.PERMISSIONS_SYSTEM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -304,8 +560,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins can manage channel options in public channels, user is not system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelManagement: Constants.PERMISSIONS_SYSTEM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelManagement: Constants.PERMISSIONS_SYSTEM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -316,8 +582,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can manage channel options in private channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -328,8 +604,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can manage channel options in private channels, user is not system admin or team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -340,8 +626,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can manage channel options in public channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -352,8 +648,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can manage channel options in public channels, user is not system admin or team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -364,8 +670,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can manage channel options in private channels, user is team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -376,8 +692,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can manage channel options in public channels, user is team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelManagement: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -388,8 +714,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel options in public channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -400,8 +736,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel options in private channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -412,8 +758,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel options in public channels, user is team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -424,8 +780,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel options in private channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -436,8 +802,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel options in public channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -448,8 +824,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel options in private channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -460,8 +846,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel options in public channels, user is not admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -472,8 +868,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel options in private channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManagement: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -484,8 +890,18 @@ describe('Channel Utils', () => {
         });
 
         test('any member can manage channel options in public channels, user is not admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPublicChannelManagement: Constants.PERMISSIONS_ALL};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPublicChannelManagement: Constants.PERMISSIONS_ALL,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -496,8 +912,18 @@ describe('Channel Utils', () => {
         });
 
         test('any member can manage channel options in private channels, user is not admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManagement: Constants.PERMISSIONS_ALL};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManagement: Constants.PERMISSIONS_ALL,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -691,14 +1117,29 @@ describe('Channel Utils', () => {
 
     describe('canManageMembers', () => {
         test('all users can manage channel members on unlicensed instances', () => {
-            global.window.mm_license = {IsLicensed: 'false'};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'false',
+                },
+            });
             expect(Utils.canManageMembers(null, true, true, true)).
                 toEqual(true);
         });
 
         test('system admins can manage channel members in private channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_SYSTEM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_SYSTEM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -709,8 +1150,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins can manage channel members in private channels, user is not system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_SYSTEM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_SYSTEM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -721,8 +1172,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can manage channel members in private channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -733,8 +1194,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can manage channel members in private channels, user is not system admin or team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -745,8 +1216,18 @@ describe('Channel Utils', () => {
         });
 
         test('system admins or team admins can manage channel members in private channels, user is team admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_TEAM_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_TEAM_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -757,8 +1238,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel members in private channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -769,8 +1260,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel members in private channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -781,8 +1282,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel members in private channels, user is system admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -793,8 +1304,18 @@ describe('Channel Utils', () => {
         });
 
         test('channel, team, and system admins can manage channel members in private channels, user is channel admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_CHANNEL_ADMIN};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_CHANNEL_ADMIN,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',
@@ -805,8 +1326,18 @@ describe('Channel Utils', () => {
         });
 
         test('any member can manage channel members in public channels, user is not admin test', () => {
-            global.window.mm_license = {IsLicensed: 'true'};
-            global.window.mm_config = {RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_ALL};
+            store.dispatch({
+                type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+                data: {
+                    IsLicensed: 'true',
+                },
+            });
+            store.dispatch({
+                type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+                data: {
+                    RestrictPrivateChannelManageMembers: Constants.PERMISSIONS_ALL,
+                },
+            });
 
             const channel = {
                 name: 'fakeChannelName',

--- a/tests/utils/utils.test.jsx
+++ b/tests/utils/utils.test.jsx
@@ -1,18 +1,18 @@
 
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+//
+import {GeneralTypes} from 'mattermost-redux/action_types';
 
 import * as Utils from 'utils/utils.jsx';
+import store from 'stores/redux_store.jsx';
 
 describe('Utils.displayUsernameForUser', function() {
-    global.window.mm_config = {};
-
-    beforeEach(() => {
-        global.window.mm_config.TeammateNameDisplay = 'username';
-    });
-
     afterEach(() => {
-        global.window.mm_config = {};
+        store.dispatch({
+            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            data: {},
+        });
     });
 
     const userA = {username: 'a_user', nickname: 'a_nickname', first_name: 'a_first_name', last_name: ''};
@@ -27,13 +27,26 @@ describe('Utils.displayUsernameForUser', function() {
     const userJ = {username: 'j_user', nickname: '', first_name: 'j_first_name', last_name: ''};
 
     test('Show display name of user with TeammateNameDisplay set to username', function() {
+        store.dispatch({
+            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            data: {
+                TeammateNameDisplay: 'username',
+            },
+        });
+
         [userA, userB, userC, userD, userE, userF, userG, userH, userI, userJ].forEach((user) => {
             expect(Utils.displayUsernameForUser(user)).toEqual(user.username);
         });
     });
 
-    test('Show display name of user with TeammateNameDisplay set to username', function() {
-        global.window.mm_config.TeammateNameDisplay = 'nickname_full_name';
+    test('Show display name of user with TeammateNameDisplay set to nickname_full_name', function() {
+        store.dispatch({
+            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            data: {
+                TeammateNameDisplay: 'nickname_full_name',
+            },
+        });
+
         for (const data of [
             {user: userA, result: userA.nickname},
             {user: userB, result: userB.nickname},
@@ -51,7 +64,13 @@ describe('Utils.displayUsernameForUser', function() {
     });
 
     test('Show display name of user with TeammateNameDisplay set to username', function() {
-        global.window.mm_config.TeammateNameDisplay = 'full_name';
+        store.dispatch({
+            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            data: {
+                TeammateNameDisplay: 'full_name',
+            },
+        });
+
         for (const data of [
             {user: userA, result: userA.first_name},
             {user: userB, result: userB.last_name},
@@ -70,14 +89,11 @@ describe('Utils.displayUsernameForUser', function() {
 });
 
 describe('Utils.sortUsersByStatusAndDisplayName', function() {
-    global.window.mm_config = {};
-
-    beforeEach(() => {
-        global.window.mm_config.TeammateNameDisplay = 'username';
-    });
-
     afterEach(() => {
-        global.window.mm_config = {};
+        store.dispatch({
+            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            data: {},
+        });
     });
 
     const userA = {status: 'dnd', username: 'a_user', nickname: 'ja_nickname', first_name: 'a_first_name', last_name: 'ja_last_name'};
@@ -92,6 +108,13 @@ describe('Utils.sortUsersByStatusAndDisplayName', function() {
     const userJ = {status: 'online', username: 'j_user', nickname: 'aj_nickname', first_name: 'c_first_name', last_name: 'aj_last_name'};
 
     test('Users sort by status and displayname, TeammateNameDisplay set to username', function() {
+        store.dispatch({
+            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            data: {
+                TeammateNameDisplay: 'username',
+            },
+        });
+
         for (const data of [
             {
                 users: [userF, userA, userB, userC, userD, userE],
@@ -114,7 +137,13 @@ describe('Utils.sortUsersByStatusAndDisplayName', function() {
     });
 
     test('Users sort by status and displayname, TeammateNameDisplay set to nickname_full_name', function() {
-        global.window.mm_config.TeammateNameDisplay = 'nickname_full_name';
+        store.dispatch({
+            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            data: {
+                TeammateNameDisplay: 'nickname_full_name',
+            },
+        });
+
         for (const data of [
             {
                 users: [userF, userA, userB, userC, userD, userE],
@@ -137,7 +166,13 @@ describe('Utils.sortUsersByStatusAndDisplayName', function() {
     });
 
     test('Users sort by status and displayname, TeammateNameDisplay set to full_name', function() {
-        global.window.mm_config.TeammateNameDisplay = 'full_name';
+        store.dispatch({
+            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            data: {
+                TeammateNameDisplay: 'full_name',
+            },
+        });
+
         for (const data of [
             {
                 users: [userF, userA, userB, userC, userD, userE],

--- a/tests/utils/utils.test.jsx
+++ b/tests/utils/utils.test.jsx
@@ -10,7 +10,7 @@ import store from 'stores/redux_store.jsx';
 describe('Utils.displayUsernameForUser', function() {
     afterEach(() => {
         store.dispatch({
-            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            type: GeneralTypes.CLIENT_CONFIG_RESET,
             data: {},
         });
     });
@@ -91,7 +91,7 @@ describe('Utils.displayUsernameForUser', function() {
 describe('Utils.sortUsersByStatusAndDisplayName', function() {
     afterEach(() => {
         store.dispatch({
-            type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+            type: GeneralTypes.CLIENT_CONFIG_RESET,
             data: {},
         });
     });

--- a/utils/channel_utils.jsx
+++ b/utils/channel_utils.jsx
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import * as ChannelUtilsRedux from 'mattermost-redux/utils/channel_utils';
+import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import ChannelStore from 'stores/channel_store.jsx';
 import LocalizationStore from 'stores/localization_store.jsx';
@@ -10,6 +11,7 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import Constants, {Preferences} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
+import store from 'stores/redux_store.jsx';
 
 export function isFavoriteChannel(channel) {
     return PreferenceStore.getBool(Preferences.CATEGORY_FAVORITE_CHANNEL, channel.id);
@@ -75,29 +77,32 @@ export function showCreateOption(state, channelType, isTeamAdmin, isSystemAdmin)
 }
 
 export function showManagementOptions(channel, isChannelAdmin, isTeamAdmin, isSystemAdmin) {
-    if (global.window.mm_license.IsLicensed !== 'true') {
+    const license = getLicense(store.getState());
+    const config = getConfig(store.getState());
+
+    if (license.IsLicensed !== 'true') {
         // policies are only enforced in enterprise editions
         return true;
     }
 
     if (channel.type === Constants.OPEN_CHANNEL) {
-        if (global.window.mm_config.RestrictPublicChannelManagement === Constants.PERMISSIONS_CHANNEL_ADMIN && !(isChannelAdmin || isTeamAdmin || isSystemAdmin)) {
+        if (config.RestrictPublicChannelManagement === Constants.PERMISSIONS_CHANNEL_ADMIN && !(isChannelAdmin || isTeamAdmin || isSystemAdmin)) {
             return false;
         }
-        if (global.window.mm_config.RestrictPublicChannelManagement === Constants.PERMISSIONS_TEAM_ADMIN && !(isTeamAdmin || isSystemAdmin)) {
+        if (config.RestrictPublicChannelManagement === Constants.PERMISSIONS_TEAM_ADMIN && !(isTeamAdmin || isSystemAdmin)) {
             return false;
         }
-        if (global.window.mm_config.RestrictPublicChannelManagement === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
+        if (config.RestrictPublicChannelManagement === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
             return false;
         }
     } else if (channel.type === Constants.PRIVATE_CHANNEL) {
-        if (global.window.mm_config.RestrictPrivateChannelManagement === Constants.PERMISSIONS_CHANNEL_ADMIN && !(isChannelAdmin || isTeamAdmin || isSystemAdmin)) {
+        if (config.RestrictPrivateChannelManagement === Constants.PERMISSIONS_CHANNEL_ADMIN && !(isChannelAdmin || isTeamAdmin || isSystemAdmin)) {
             return false;
         }
-        if (global.window.mm_config.RestrictPrivateChannelManagement === Constants.PERMISSIONS_TEAM_ADMIN && !(isTeamAdmin || isSystemAdmin)) {
+        if (config.RestrictPrivateChannelManagement === Constants.PERMISSIONS_TEAM_ADMIN && !(isTeamAdmin || isSystemAdmin)) {
             return false;
         }
-        if (global.window.mm_config.RestrictPrivateChannelManagement === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
+        if (config.RestrictPrivateChannelManagement === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
             return false;
         }
     }
@@ -106,7 +111,10 @@ export function showManagementOptions(channel, isChannelAdmin, isTeamAdmin, isSy
 }
 
 export function showDeleteOptionForCurrentUser(channel, isChannelAdmin, isTeamAdmin, isSystemAdmin) {
-    if (global.window.mm_license.IsLicensed !== 'true') {
+    const license = getLicense(store.getState());
+    const config = getConfig(store.getState());
+
+    if (license.IsLicensed !== 'true') {
         // policies are only enforced in enterprise editions
         return true;
     }
@@ -117,23 +125,23 @@ export function showDeleteOptionForCurrentUser(channel, isChannelAdmin, isTeamAd
     }
 
     if (channel.type === Constants.OPEN_CHANNEL) {
-        if (global.window.mm_config.RestrictPublicChannelDeletion === Constants.PERMISSIONS_CHANNEL_ADMIN && !(isChannelAdmin || isTeamAdmin || isSystemAdmin)) {
+        if (config.RestrictPublicChannelDeletion === Constants.PERMISSIONS_CHANNEL_ADMIN && !(isChannelAdmin || isTeamAdmin || isSystemAdmin)) {
             return false;
         }
-        if (global.window.mm_config.RestrictPublicChannelDeletion === Constants.PERMISSIONS_TEAM_ADMIN && !(isTeamAdmin || isSystemAdmin)) {
+        if (config.RestrictPublicChannelDeletion === Constants.PERMISSIONS_TEAM_ADMIN && !(isTeamAdmin || isSystemAdmin)) {
             return false;
         }
-        if (global.window.mm_config.RestrictPublicChannelDeletion === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
+        if (config.RestrictPublicChannelDeletion === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
             return false;
         }
     } else if (channel.type === Constants.PRIVATE_CHANNEL) {
-        if (global.window.mm_config.RestrictPrivateChannelDeletion === Constants.PERMISSIONS_CHANNEL_ADMIN && !(isChannelAdmin || isTeamAdmin || isSystemAdmin)) {
+        if (config.RestrictPrivateChannelDeletion === Constants.PERMISSIONS_CHANNEL_ADMIN && !(isChannelAdmin || isTeamAdmin || isSystemAdmin)) {
             return false;
         }
-        if (global.window.mm_config.RestrictPrivateChannelDeletion === Constants.PERMISSIONS_TEAM_ADMIN && !(isTeamAdmin || isSystemAdmin)) {
+        if (config.RestrictPrivateChannelDeletion === Constants.PERMISSIONS_TEAM_ADMIN && !(isTeamAdmin || isSystemAdmin)) {
             return false;
         }
-        if (global.window.mm_config.RestrictPrivateChannelDeletion === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
+        if (config.RestrictPrivateChannelDeletion === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
             return false;
         }
     }
@@ -142,18 +150,21 @@ export function showDeleteOptionForCurrentUser(channel, isChannelAdmin, isTeamAd
 }
 
 export function canManageMembers(channel, isChannelAdmin, isTeamAdmin, isSystemAdmin) {
-    if (global.window.mm_license.IsLicensed !== 'true') {
+    const license = getLicense(store.getState());
+    const config = getConfig(store.getState());
+
+    if (license.IsLicensed !== 'true') {
         return true;
     }
 
     if (channel.type === Constants.PRIVATE_CHANNEL) {
-        if (global.window.mm_config.RestrictPrivateChannelManageMembers === Constants.PERMISSIONS_CHANNEL_ADMIN && !(isChannelAdmin || isTeamAdmin || isSystemAdmin)) {
+        if (config.RestrictPrivateChannelManageMembers === Constants.PERMISSIONS_CHANNEL_ADMIN && !(isChannelAdmin || isTeamAdmin || isSystemAdmin)) {
             return false;
         }
-        if (global.window.mm_config.RestrictPrivateChannelManageMembers === Constants.PERMISSIONS_TEAM_ADMIN && !(isTeamAdmin || isSystemAdmin)) {
+        if (config.RestrictPrivateChannelManageMembers === Constants.PERMISSIONS_TEAM_ADMIN && !(isTeamAdmin || isSystemAdmin)) {
             return false;
         }
-        if (global.window.mm_config.RestrictPrivateChannelManageMembers === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
+        if (config.RestrictPrivateChannelManageMembers === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
             return false;
         }
     }

--- a/utils/license_utils.jsx
+++ b/utils/license_utils.jsx
@@ -1,39 +1,46 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+//
+import {getLicense} from 'mattermost-redux/selectors/entities/general';
 
 import LocalizationStore from 'stores/localization_store.jsx';
+import store from 'stores/redux_store.jsx';
 
 const LICENSE_EXPIRY_NOTIFICATION = 1000 * 60 * 60 * 24 * 60; // 60 days
 const LICENSE_GRACE_PERIOD = 1000 * 60 * 60 * 24 * 15; // 15 days
 
 export function isLicenseExpiring() {
-    if (window.mm_license.IsLicensed !== 'true') {
+    const license = getLicense(store.getState());
+    if (license.IsLicensed !== 'true') {
         return false;
     }
 
-    const timeDiff = parseInt(global.window.mm_license.ExpiresAt, 10) - Date.now();
+    const timeDiff = parseInt(license.ExpiresAt, 10) - Date.now();
     return timeDiff <= LICENSE_EXPIRY_NOTIFICATION;
 }
 
 export function isLicenseExpired() {
-    if (window.mm_license.IsLicensed !== 'true') {
+    const license = getLicense(store.getState());
+    if (license.IsLicensed !== 'true') {
         return false;
     }
 
-    const timeDiff = parseInt(global.window.mm_license.ExpiresAt, 10) - Date.now();
+    const timeDiff = parseInt(license.ExpiresAt, 10) - Date.now();
     return timeDiff < 0;
 }
 
 export function isLicensePastGracePeriod() {
-    if (window.mm_license.IsLicensed !== 'true') {
+    const license = getLicense(store.getState());
+    if (license.IsLicensed !== 'true') {
         return false;
     }
 
-    const timeDiff = Date.now() - parseInt(global.window.mm_license.ExpiresAt, 10);
+    const timeDiff = Date.now() - parseInt(license.ExpiresAt, 10);
     return timeDiff > LICENSE_GRACE_PERIOD;
 }
 
 export function displayExpiryDate() {
-    const date = new Date(parseInt(global.window.mm_license.ExpiresAt, 10));
+    const license = getLicense(store.getState());
+    const date = new Date(parseInt(license.ExpiresAt, 10));
     return date.toLocaleString(LocalizationStore.getLocale(), {year: 'numeric', month: 'long', day: 'numeric'});
 }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Client4} from 'mattermost-redux/client';
 import {Posts} from 'mattermost-redux/constants';
+import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {browserHistory} from 'utils/browser_history';
 import {searchForTerm} from 'actions/post_actions';
@@ -20,6 +21,7 @@ import bing from 'images/bing.mp3';
 import icon50 from 'images/icon50x50.png';
 import iconWS from 'images/icon_WS.png';
 import {getSiteURL} from 'utils/url';
+import store from 'stores/redux_store.jsx';
 
 export function isEmail(email) {
     // writing a regex to match all valid email addresses is really, really hard. (see http://stackoverflow.com/a/201378)
@@ -1086,8 +1088,10 @@ export function displayUsername(userId) {
  * Gets the display name of the specified user, respecting the TeammateNameDisplay configuration setting
  */
 export function displayUsernameForUser(user) {
+    const config = getConfig(store.getState());
+
     if (user) {
-        const nameFormat = global.window.mm_config.TeammateNameDisplay;
+        const nameFormat = config.TeammateNameDisplay;
         let name = user.username;
         if (nameFormat === Constants.TEAMMATE_NAME_DISPLAY.SHOW_NICKNAME_FULLNAME && user.nickname && user.nickname !== '') {
             name = user.nickname;
@@ -1343,7 +1347,11 @@ export function mod(a, b) {
 export const REACTION_PATTERN = /^(\+|-):([^:\s]+):\s*$/;
 
 export function canCreateCustomEmoji(user) {
-    if (global.window.mm_license.IsLicensed !== 'true') {
+    const state = store.getState();
+    const license = getLicense(state);
+    const config = getConfig(state);
+
+    if (license.IsLicensed !== 'true') {
         return true;
     }
 
@@ -1352,9 +1360,9 @@ export function canCreateCustomEmoji(user) {
     }
 
     // already checked for system admin for both these cases
-    if (window.mm_config.RestrictCustomEmojiCreation === 'system_admin') {
+    if (config.RestrictCustomEmojiCreation === 'system_admin') {
         return false;
-    } else if (window.mm_config.RestrictCustomEmojiCreation === 'admin') {
+    } else if (config.RestrictCustomEmojiCreation === 'admin') {
         // check whether the user is an admin on any of their teams
         if (TeamStore.isTeamAdminForAnyTeam()) {
             return true;


### PR DESCRIPTION
#### Summary
This is a subset of the changes in the `MM-9635-remove_mm_global_license_config` branch, broken up into multiple PRs to facilitate easier review. See any linked PRs for other changes if you're interested. 

This is phase two of the changes that remove our dependence on the global `mm_config` and `mm_license` objects. The last PR to follow this series will remove the exports altogether. These changes will ultimately facilitate resolving https://mattermost.atlassian.net/browse/MM-8604, allowing us to stop hard refreshing the application whenever someone makes a configuration change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9635

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

### Related PRs
https://github.com/mattermost/mattermost-webapp/pull/862
https://github.com/mattermost/mattermost-webapp/pull/863
https://github.com/mattermost/mattermost-webapp/pull/865