### PR TITLE
MM-9681: Fix the click in the emoji picker

### DIFF
--- a/components/emoji_picker/components/emoji_picker_item.jsx
+++ b/components/emoji_picker/components/emoji_picker_item.jsx
@@ -90,12 +90,14 @@ export default class EmojiPickerItem extends React.Component {
                     className={itemClassName}
                     ref={this.emojiItemRef}
                 >
-                    <img
-                        src={EmojiStore.getEmojiImageUrl(emoji)}
-                        className={spriteClassName}
-                        onMouseOver={this.handleMouseOver}
-                        onClick={this.handleClick}
-                    />
+                    <div>
+                        <img
+                            src={EmojiStore.getEmojiImageUrl(emoji)}
+                            className={spriteClassName}
+                            onMouseOver={this.handleMouseOver}
+                            onClick={this.handleClick}
+                        />
+                    </div>
                 </div>
             );
         }

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -159,9 +159,9 @@
             vertical-align: middle;
             width: 26px;
             border-radius: 3px;
-            position: relative;;
+            position: relative;
 
-            > div {
+            > div > img {
                 position: relative;
                 top: -21px;
                 left: -21px;


### PR DESCRIPTION
#### Summary
The click in the emoji picker was failing due a problem with the css. This change solves the problem respecting the fix done by original commit.

It was introduced in the #799 PR.

I really :heart: `git bisect`.

#### Ticket Link
[MM-9681](https://mattermost.atlassian.net/browse/MM-9681)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed