### PR TITLE
MM-7188: Update unread on server when receive a notification on your channel

### DIFF
--- a/stores/channel_store.jsx
+++ b/stores/channel_store.jsx
@@ -561,14 +561,17 @@ ChannelStore.dispatchToken = AppDispatcher.register((payload) => {
         }
 
         let markAsRead = false;
+        let markAsReadOnServer = false;
         if (post.user_id === UserStore.getCurrentId() && !isSystemMessage(post) && !isFromWebhook(post)) {
             markAsRead = true;
+            markAsReadOnServer = false;
         } else if (action.post.channel_id === ChannelStore.getCurrentId() && window.isActive) {
             markAsRead = true;
+            markAsReadOnServer = true;
         }
 
         if (markAsRead) {
-            dispatch(markChannelAsRead(post.channel_id, null, false));
+            dispatch(markChannelAsRead(post.channel_id, null, markAsReadOnServer));
             dispatch(markChannelAsViewed(post.channel_id));
         } else {
             dispatch(markChannelAsUnread(data.team_id, post.channel_id, data.mentions));


### PR DESCRIPTION
#### Summary
When you receive a notification post in your current channel, you must mark as
read in the client, but in the server too, because this notification must be
mark as unread in mobile devices.

I haven't tested it manually because I haven't a development environment with
push notifications.

#### Ticket Link
[MM-7188](https://mattermost.atlassian.net/browse/MM-7188)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has redux changes (The same fix in mattermost redux, but there is not dependency between PRs mattermost/mattermost-redux#416)