### PR TITLE
MM-9586 Fixed CJK typing in the channel switcher/search box on desktop apps

### DIFF
--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -22,7 +22,9 @@ export default class QuickInput extends React.PureComponent {
 
     componentDidUpdate(prevProps) {
         if (prevProps.value !== this.props.value) {
-            this.refs.input.value = this.props.value;
+            requestAnimationFrame(() => {
+                this.refs.input.value = this.props.value;
+            });
         }
     }
 


### PR DESCRIPTION
The fake connected textbox in QuickInput doesn't work in the desktop app if it tries to update the value immediately in `componentDidUpdate`

Tested with English, Japanese, and Korean using:
- Mattermost Desktop App/Windows 10
- Chrome/Windows 10
- IE11/Windows 10
- Edge/Windows 10
- Firefox/Windows 10
- Mattermost Desktop App/Mac
- Safari/Mac

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9586