### PR TITLE
MM-8534: Fix insecure image loading by post author

### DIFF
--- a/components/post_markdown/index.js
+++ b/components/post_markdown/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
 import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserMentionKeys} from 'mattermost-redux/selectors/entities/users';
 
@@ -23,11 +24,14 @@ const getChannelNamesMap = createSelector(
 );
 
 function mapStateToProps(state) {
+    const config = getConfig(state);
+
     return {
         channelNamesMap: getChannelNamesMap(state),
         mentionKeys: getCurrentUserMentionKeys(state),
         siteURL: getSiteURL(),
         team: getCurrentTeam(state),
+        hasImageProxy: config.HasImageProxy === 'true',
     };
 }
 

--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -52,6 +52,10 @@ export default class PostMarkdown extends React.PureComponent {
          */
         team: PropTypes.object.isRequired,
 
+        /**
+         * If an image proxy is enabled.
+         */
+        hasImageProxy: PropTypes.bool.isRequired,
     };
 
     static defaultProps = {
@@ -66,6 +70,9 @@ export default class PostMarkdown extends React.PureComponent {
             atMentions: true,
             channelNamesMap: this.props.channelNamesMap,
             team: this.props.team,
+
+            // Proxy images if we have an image proxy and the server hasn't already rewritten the post's image URLs.
+            proxyImages: this.props.hasImageProxy && (!this.props.post || !this.props.post.message_source || this.props.post.message === this.props.post.message_source),
         }, this.props.options);
 
         if (this.props.post) {

--- a/tests/plugins/__snapshots__/post_type.test.jsx.snap
+++ b/tests/plugins/__snapshots__/post_type.test.jsx.snap
@@ -202,6 +202,7 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
           <PostMarkdown
             channelNamesMap={Object {}}
             dispatch={[Function]}
+            hasImageProxy={false}
             isRHS={false}
             mentionKeys={Array []}
             message="this is some text"

--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -3,6 +3,7 @@
 
 import marked from 'marked';
 
+import * as PostUtils from 'utils/post_utils.jsx';
 import * as SyntaxHighlighting from 'utils/syntax_highlighting.jsx';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 import {isUrlSafe} from 'utils/url.jsx';
@@ -119,6 +120,7 @@ export default class Renderer extends marked.Renderer {
                 }
             }
         }
+        src = PostUtils.getImageSrc(src, this.formattingOptions.proxyImages);
         let out = '<img src="' + src + '" alt="' + text + '"';
         if (title) {
             out += ' title="' + title + '"';

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -32,6 +32,7 @@ const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-
 // - channelNamesMap - An object mapping channel display names to channels. If provided, ~channel mentions will be replaced with
 //      links to the relevant channel.
 // - team - The current team.
+// - proxyImages - If specified, images are proxied. Defaults to false.
 export function formatText(text, inputOptions) {
     if (!text || typeof text !== 'string') {
         return '';


### PR DESCRIPTION
#### Summary
This ensures that post previews and predictive posts proxy images.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8534

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed