### PR TITLE
MM-9586 Only update value of certain textboxes after a delay

### DIFF
--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -10,6 +10,12 @@ export default class QuickInput extends React.PureComponent {
     static propTypes = {
 
         /**
+         * Whether to delay updating the value of the textbox from props. Should only be used
+         * on textboxes that to properly compose CJK characters as the user types.
+         */
+        delayInputUpdate: PropTypes.bool,
+
+        /**
          * An optional React component that will be used instead of an HTML input when rendering
          */
         inputComponent: PropTypes.func,
@@ -20,11 +26,19 @@ export default class QuickInput extends React.PureComponent {
         value: PropTypes.string.isRequired,
     };
 
+    static defaultProps = {
+        delayInputUpdate: false,
+    };
+
     componentDidUpdate(prevProps) {
         if (prevProps.value !== this.props.value) {
-            requestAnimationFrame(() => {
+            if (this.props.delayInputUpdate) {
+                requestAnimationFrame(() => {
+                    this.refs.input.value = this.props.value;
+                });
+            } else {
                 this.refs.input.value = this.props.value;
-            });
+            }
         }
     }
 
@@ -50,6 +64,8 @@ export default class QuickInput extends React.PureComponent {
 
     render() {
         const {value, inputComponent, ...props} = this.props;
+
+        Reflect.deleteProperty(props, 'delayInputUpdate');
 
         return React.createElement(
             inputComponent || 'input',

--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -326,6 +326,7 @@ export default class QuickSwitchModal extends React.PureComponent {
                         listStyle='bottom'
                         completeOnTab={false}
                         renderDividers={renderDividers}
+                        delayInputUpdate={true}
                     />
                 </Modal.Body>
             </Modal>

--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -296,6 +296,7 @@ export default class SearchBar extends React.Component {
                             providers={this.suggestionProviders}
                             type='search'
                             autoFocus={this.props.isFocus && this.props.searchTerms === ''}
+                            delayInputUpdate={true}
                         />
                         <div
                             id='searchClearButton'


### PR DESCRIPTION
This is a followup for my last PR because the previous one made it so that typing in the post textbox and hitting enter repeatedly could cause the existing message to remaining in the textbox as you typed. This'll only use the new behaviour for textboxes that had the bug mentioned in the ticket

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9586
