### PR TITLE
PLT-8302 - Displaying gifv files correctly

### DIFF
--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -14,6 +14,7 @@ import * as PostUtils from 'utils/post_utils.jsx';
 import PostAttachmentList from '../post_attachment_list.jsx';
 import PostAttachmentOpenGraph from '../post_attachment_opengraph';
 import PostImage from '../post_image';
+import PostMp4 from '../post_mp4';
 
 export default class PostBodyAdditionalContent extends React.PureComponent {
     static propTypes = {
@@ -130,6 +131,15 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         }
     }
 
+    isLinkGifv(link) {
+        const regex = /.+\/(.+\.(gifv))(?:\?.*)?$/i;
+        const match = link.match(regex);
+        if (match && match[1]) {
+            return true;
+        }
+        return false;
+    }
+
     isLinkImage(link) {
         const regex = /.+\/(.+\.(?:jpg|gif|bmp|png|jpeg))(?:\?.*)?$/i;
         const match = link.match(regex);
@@ -147,6 +157,10 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         }
 
         if (YoutubeVideo.isYoutubeLink(link)) {
+            return true;
+        }
+
+        if (this.isLinkGifv(link)) {
             return true;
         }
 
@@ -188,6 +202,18 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
                     link={link}
                     show={this.props.isEmbedVisible}
                     onLinkLoaded={this.handleLinkLoaded}
+                />
+            );
+        }
+
+        if (this.isLinkGifv(link)) {
+            return (
+                <PostMp4
+                    channelId={this.props.post.channel_id}
+                    link={link}
+                    onLinkLoadError={this.handleLinkLoadError}
+                    onLinkLoaded={this.handleLinkLoaded}
+                    handleImageClick={this.handleImageClick}
                 />
             );
         }

--- a/components/post_view/post_mp4/index.js
+++ b/components/post_view/post_mp4/index.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import PostMp4 from './post_mp4.jsx';
+
+function mapStateToProps(state) {
+    const config = getConfig(state);
+    const hasImageProxy = config.HasImageProxy === 'true';
+
+    return {
+        hasImageProxy
+    };
+}
+
+export default connect(mapStateToProps)(PostMp4);

--- a/components/post_view/post_mp4/post_mp4.jsx
+++ b/components/post_view/post_mp4/post_mp4.jsx
@@ -1,0 +1,132 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {postListScrollChange} from 'actions/global_actions.jsx';
+import * as PostUtils from 'utils/post_utils.jsx';
+
+export default class PostImageEmbed extends React.PureComponent {
+    static propTypes = {
+
+        /**
+         * The link to load the image from
+         */
+        link: PropTypes.string.isRequired,
+
+        /**
+         * Function to call when image is loaded
+         */
+        onLinkLoaded: PropTypes.func,
+
+        /**
+         * The function to call if image load fails
+         */
+        onLinkLoadError: PropTypes.func,
+
+        /**
+         * The function to call if image is clicked
+         */
+        handleImageClick: PropTypes.func,
+
+        /**
+         * If an image proxy is enabled.
+         */
+        hasImageProxy: PropTypes.bool.isRequired
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.handleLoadComplete = this.handleLoadComplete.bind(this);
+        this.handleLoadError = this.handleLoadError.bind(this);
+
+        this.state = {
+            loaded: false,
+            errored: false
+        };
+    }
+
+    componentWillMount() {
+        this.loadVideo(PostUtils.changeToMp4Src(this.props.link, this.props.hasImageProxy));
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.link !== this.props.link) {
+            this.setState({
+                loaded: false,
+                errored: false
+            });
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (!this.state.loaded && prevProps.link !== this.props.link) {
+            this.loadVideo(PostUtils.changeToMp4Src(this.props.link, this.props.hasImageProxy));
+        }
+    }
+
+    loadVideo(src) {
+        const video = document.createElement('video');
+        video.onerror = this.handleLoadError;
+        video.load = this.handleLoadComplete;
+        video.src = src;
+        video.load();
+    }
+
+    handleLoadComplete() {
+        this.setState({
+            loaded: true,
+            errored: false
+        });
+
+        postListScrollChange();
+
+        if (this.props.onLinkLoaded) {
+            this.props.onLinkLoaded();
+        }
+    }
+
+    handleLoadError() {
+        this.setState({
+            errored: true,
+            loaded: true
+        });
+        if (this.props.onLinkLoadError) {
+            this.props.onLinkLoadError();
+        }
+    }
+
+    onImageClick = (e) => {
+        e.preventDefault();
+        this.props.handleImageClick();
+    };
+
+    render() {
+        if (this.state.errored || !this.state.loaded) {
+            // scroll pop could be improved with a placeholder when !this.state.loaded
+            return null;
+        }
+        return (
+            <div
+                className='post__embed-container'
+            >
+                <video
+                    poster={PostUtils.changeToJPGSrc(this.props.link, this.props.hasImageProxy)}
+                    preload='auto'
+                    autoPlay='autoPlay'
+                    muted='true'
+                    loop='true'
+                    onClick={this.onImageClick}
+                    className='img-div cursor--pointer'
+                >
+                    <source
+                        src={PostUtils.changeToMp4Src(this.props.link, this.props.hasImageProxy)}
+                        type='video/mp4'
+                    />
+                </video>
+            </div>
+        );
+    }
+}

--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -17,7 +17,6 @@ export default class Renderer extends marked.Renderer {
 
         this.formattingOptions = formattingOptions;
     }
-
     code(code, language) {
         let usedLanguage = language || '';
         usedLanguage = usedLanguage.toLowerCase();
@@ -119,18 +118,41 @@ export default class Renderer extends marked.Renderer {
                 }
             }
         }
-        let out = '<img src="' + src + '" alt="' + text + '"';
-        if (title) {
-            out += ' title="' + title + '"';
+
+        //After looking into the mark package, there appears to be no in-line level render function in marked.js
+        //to render a video. Since we just want to render gifv files like we do gifs, we can check if
+        //the URL src is a gifv, then render it in a <video> HTML5 element rather than an <img> element without
+        //having to touch the mark package. There is some DRY issues here, but I am not sure how to overcome that.
+        const regex = /.+\/(.+\.(gifv))(?:\?.*)?$/i;
+        const match = src.match(regex);
+        let out = '';
+
+        if (match) {
+            const jpgSrc = src.substr(0, src.lastIndexOf('.gifv')) + '.jpg';
+            const mp4Src = src.substr(0, src.lastIndexOf('.gifv')) + '.mp4';
+            out = '<video poster="' + jpgSrc + '" preload="auto" autoplay="autoplay" muted="muted" loop="loop"';
+
+            if (dimensions.length > 0) {
+                out += ' width="' + dimensions[0] + '"';
+            }
+            if (dimensions.length > 1) {
+                out += ' height="' + dimensions[1] + '"';
+            }
+            out += '><source src="' + mp4Src + '" type="video/mp4"></video>';
+        } else {
+            out = '<img src="' + src + '" alt="' + text + '"';
+            if (title) {
+                out += ' title="' + title + '"';
+            }
+            if (dimensions.length > 0) {
+                out += ' width="' + dimensions[0] + '"';
+            }
+            if (dimensions.length > 1) {
+                out += ' height="' + dimensions[1] + '"';
+            }
+            out += ' class="markdown-inline-img"';
+            out += this.options.xhtml ? '/>' : '>';
         }
-        if (dimensions.length > 0) {
-            out += ' width="' + dimensions[0] + '"';
-        }
-        if (dimensions.length > 1) {
-            out += ' height="' + dimensions[1] + '"';
-        }
-        out += ' class="markdown-inline-img"';
-        out += this.options.xhtml ? '/>' : '>';
         return out;
     }
 

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -49,6 +49,22 @@ export function getImageSrc(src, hasImageProxy) {
     return src;
 }
 
+export function changeToMp4Src(src, hasImageProxy) {
+    if (hasImageProxy) {
+        return Client4.getBaseRoute() + '/image?url=' + encodeURIComponent(src);
+    }
+    const mp4Ext = src.substr(0, src.lastIndexOf('.gifv')) + '.mp4';
+    return mp4Ext;
+}
+
+export function changeToJPGSrc(src, hasImageProxy) {
+    if (hasImageProxy) {
+        return Client4.getBaseRoute() + '/image?url=' + encodeURIComponent(src);
+    }
+    const jpgExt = src.substr(0, src.lastIndexOf('.gifv')) + '.jpg';
+    return jpgExt;
+}
+
 export function getProfilePicSrcForPost(post, user) {
     let src = '';
     if (user && user.id === post.user_id) {
@@ -136,7 +152,6 @@ export function containsAtChannel(text) {
     }
 
     const mentionableText = formatWithRenderer(text, new MentionableRenderer());
-
     return (/\B@(all|channel)\b/i).test(mentionableText);
 }
 


### PR DESCRIPTION
### Summary

Renders .gifv urls to a video html element as opposed to previously where they were rendered into an <img> html element.

### Directories/Files Changed (All in mattermost-webapp)

**`components/post_view/post_mp4`**: Created a new component which will display the gifv link. Since it is a video, we display it in a <video> HTML element. Added error handling for video by created an HTML5 video element, and then adding the onerror and onload functions to the video which will be called appropriated after video.load() has been executed. gifv links now appear in a preview in the chat. Have to apply this rendering to \![](*.gifv) next.

**`utils/markdown/renderer.jsx`**: Had to add functionality to image(href, title, text) function. Basically the mark package lacks ability to render a video element and just detects for images when user tries to unfurl an image with \![](URL). So instead of changing the mark package to include a video() function I applied to string regex check to see if the user is trying to post a gifv file. If there is a match, then we render a <video> HTML element rather then an image element which will not display gifv as wanted.

**`components/post_view/post_body_additional_content/post_body_additional_content.jsx`**: Added a isLinkGifv(link) function which checks if the URL is a gifv address. I used the same regex matching used for determining if the URL is a gif, jpg, bmp etc. If the link is a gifv, I render the PostMp4 component and return it.

**`utils/post_utils.jsx`**: Added a changeMp4Src and a changeJPGSrc function which takes in a src URL and returns the URL with the gifv extension replaced with .mp4 or jpg which are used in the <video> HTML element.

### Ticket Link
PLT-8302 - https://github.com/mattermost/mattermost-server/issues/8302

### Checklist
**Apologizes for any items I missed in the checklist, please let me know if I need to include more!**
- [X] Ran `make check-style` to check for style errors (required for all pull requests)
- [X] Ran `make test` to ensure unit and component tests passed
- [X] Touches critical sections of the codebase (auth, posting, etc.)