### PR TITLE
Make ctrl work wherever cmd works on macOS.

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -53,9 +53,9 @@ export function createSafeId(prop) {
 
 export function cmdOrCtrlPressed(e, allowAlt = false) {
     if (allowAlt) {
-        return (isMac() && e.metaKey) || (!isMac() && e.ctrlKey);
+        return (isMac() && e.metaKey) || e.ctrlKey;
     }
-    return (isMac() && e.metaKey) || (!isMac() && e.ctrlKey && !e.altKey);
+    return (isMac() && e.metaKey) || (e.ctrlKey && !e.altKey);
 }
 
 export function isInRole(roles, inRole) {


### PR DESCRIPTION
#### Summary
Supports ctrl working in all cases where cmd works.

#### Ticket Link
n/a

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed