### PR TITLE
User lock file to get yarn dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test: .yarninstall ## Runs tests
 .yarninstall: package.json
 	@echo Getting dependencies using yarn
 
-	yarn install
+	yarn install --pure-lockfile
 	cd node_modules/mattermost-redux; npm run build
 
 	touch $@


### PR DESCRIPTION
This will use whatever commits are in the yarn.lock file so it should fix the problem we are having with mattermost-redux