### PR TITLE
Remove mm_config and mm_license global state from webapp, phase 2 (PR #5)

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -35,8 +35,6 @@ export async function loadMe() {
 export async function loadMeAndConfig(callback) {
     const {data: config} = await getClientConfig()(store.dispatch, store.getState);
 
-    global.window.mm_config = config;
-
     const promises = [];
 
     if (document.cookie.indexOf('MMUSERID=') > -1) {
@@ -59,13 +57,7 @@ export async function loadMeAndConfig(callback) {
         promises.push(loadMe());
     }
 
-    promises.push(
-        getLicenseConfig()(store.dispatch, store.getState).then(
-            ({data: license}) => {
-                global.window.mm_license = license;
-            }
-        )
-    );
+    promises.push(getLicenseConfig()(store.dispatch, store.getState));
 
     Promise.all(promises).then(callback);
 }

--- a/components/admin_console/reset_password_modal/index.js
+++ b/components/admin_console/reset_password_modal/index.js
@@ -2,23 +2,19 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
-import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
 import {getPasswordConfig} from 'utils/utils.jsx';
 
-import ClaimController from './claim_controller.jsx';
+import ResetPasswordModal from './reset_password_modal.jsx';
 
 function mapStateToProps(state) {
     const license = getLicense(state);
     const config = getConfig(state);
-    const siteName = config.SiteName;
-    const ldapLoginFieldName = config.LdapLoginFieldName;
 
     return {
-        siteName,
-        ldapLoginFieldName,
         passwordConfig: getPasswordConfig(license, config),
     };
 }
 
-export default connect(mapStateToProps)(ClaimController);
+export default connect(mapStateToProps)(ResetPasswordModal);

--- a/components/admin_console/reset_password_modal/reset_password_modal.jsx
+++ b/components/admin_console/reset_password_modal/reset_password_modal.jsx
@@ -16,6 +16,7 @@ export default class ResetPasswordModal extends React.Component {
         show: PropTypes.bool.isRequired,
         onModalSubmit: PropTypes.func,
         onModalDismissed: PropTypes.func,
+        passwordConfig: PropTypes.object,
     };
 
     static defaultProps = {
@@ -61,7 +62,7 @@ export default class ResetPasswordModal extends React.Component {
 
         const password = this.refs.password.value;
 
-        const passwordErr = Utils.isValidPassword(password, Utils.getPasswordConfig());
+        const passwordErr = Utils.isValidPassword(password, this.props.passwordConfig);
         if (passwordErr) {
             this.setState({serverErrorNewPass: passwordErr});
             return;

--- a/components/admin_console/system_users/system_users_list.jsx
+++ b/components/admin_console/system_users/system_users_list.jsx
@@ -12,7 +12,7 @@ import * as Utils from 'utils/utils.jsx';
 import ManageRolesModal from 'components/admin_console/manage_roles_modal';
 import ManageTeamsModal from 'components/admin_console/manage_teams_modal/manage_teams_modal.jsx';
 import ManageTokensModal from 'components/admin_console/manage_tokens_modal';
-import ResetPasswordModal from 'components/admin_console/reset_password_modal.jsx';
+import ResetPasswordModal from 'components/admin_console/reset_password_modal';
 import SearchableUserList from 'components/searchable_user_list/searchable_user_list.jsx';
 import UserListRowWithError from 'components/user_list_row_with_error.jsx';
 

--- a/components/claim/claim_controller.jsx
+++ b/components/claim/claim_controller.jsx
@@ -37,6 +37,7 @@ export default class ClaimController extends React.Component {
                                             currentType={currentType}
                                             email={email}
                                             siteName={this.props.siteName}
+                                            passwordConfig={this.props.passwordConfig}
                                         />
                                 )}
                                 />
@@ -58,6 +59,7 @@ export default class ClaimController extends React.Component {
                                             {...props}
                                             siteName={this.props.siteName}
                                             email={email}
+                                            passwordConfig={this.props.passwordConfig}
                                         />
                                 )}
                                 />
@@ -85,4 +87,5 @@ ClaimController.propTypes = {
     location: PropTypes.object.isRequired,
     siteName: PropTypes.string,
     ldapLoginFieldName: PropTypes.string,
+    passwordConfig: PropTypes.object,
 };

--- a/components/claim/components/ldap_to_email.jsx
+++ b/components/claim/components/ldap_to_email.jsx
@@ -48,7 +48,7 @@ export default class LDAPToEmail extends React.Component {
             return;
         }
 
-        const passwordErr = Utils.isValidPassword(password, Utils.getPasswordConfig());
+        const passwordErr = Utils.isValidPassword(password, this.props.passwordConfig);
         if (passwordErr !== '') {
             this.setState({
                 passwordError: passwordErr,
@@ -242,4 +242,5 @@ export default class LDAPToEmail extends React.Component {
 
 LDAPToEmail.propTypes = {
     email: PropTypes.string,
+    passwordConfig: PropTypes.object,
 };

--- a/components/claim/components/oauth_to_email.jsx
+++ b/components/claim/components/oauth_to_email.jsx
@@ -30,7 +30,7 @@ export default class OAuthToEmail extends React.Component {
             return;
         }
 
-        const passwordErr = Utils.isValidPassword(password, Utils.getPasswordConfig());
+        const passwordErr = Utils.isValidPassword(password, this.props.passwordConfig);
         if (passwordErr !== '') {
             this.setState({
                 error: passwordErr,
@@ -141,4 +141,5 @@ OAuthToEmail.propTypes = {
     currentType: PropTypes.string,
     email: PropTypes.string,
     siteName: PropTypes.string,
+    passwordConfig: PropTypes.object,
 };

--- a/components/signup/signup_email/index.js
+++ b/components/signup/signup_email/index.js
@@ -4,6 +4,8 @@
 import {connect} from 'react-redux';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
+import {getPasswordConfig} from 'utils/utils.jsx';
+
 import SignupEmail from './signup_email.jsx';
 
 function mapStateToProps(state) {
@@ -28,6 +30,7 @@ function mapStateToProps(state) {
         customBrand,
         enableCustomBrand,
         customDescriptionText,
+        passwordConfig: getPasswordConfig(license, config),
     };
 }
 

--- a/components/signup/signup_email/signup_email.jsx
+++ b/components/signup/signup_email/signup_email.jsx
@@ -30,6 +30,7 @@ export default class SignupEmail extends React.Component {
             customBrand: PropTypes.bool.isRequired,
             enableCustomBrand: PropTypes.bool.isRequired,
             customDescriptionText: PropTypes.string,
+            passwordConfig: PropTypes.object,
         };
     }
 
@@ -213,7 +214,7 @@ export default class SignupEmail extends React.Component {
         }
 
         const providedPassword = this.refs.password.value;
-        const pwdError = Utils.isValidPassword(providedPassword, Utils.getPasswordConfig());
+        const pwdError = Utils.isValidPassword(providedPassword, this.props.passwordConfig);
         if (pwdError) {
             this.setState({
                 nameError: '',

--- a/components/user_settings/security/index.js
+++ b/components/user_settings/security/index.js
@@ -7,6 +7,8 @@ import {clearUserAccessTokens, createUserAccessToken, getMe, getUserAccessTokens
 import * as UserUtils from 'mattermost-redux/utils/user_utils';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
+import {getPasswordConfig} from 'utils/utils.jsx';
+
 import SecurityTab from './user_settings_security.jsx';
 
 function mapStateToProps(state, ownProps) {
@@ -45,6 +47,7 @@ function mapStateToProps(state, ownProps) {
         enableSaml,
         enableSignUpWithOffice365,
         experimentalEnableAuthenticationTransfer,
+        passwordConfig: getPasswordConfig(license, config),
     };
 }
 

--- a/components/user_settings/security/user_settings_security.jsx
+++ b/components/user_settings/security/user_settings_security.jsx
@@ -87,6 +87,8 @@ export default class SecurityTab extends React.Component {
         // Whether or not the experimental authentication transfer is enabled.
         experimentalEnableAuthenticationTransfer: PropTypes.bool,
 
+        passwordConfig: PropTypes.object,
+
         actions: PropTypes.shape({
             getMe: PropTypes.func.isRequired,
 
@@ -172,7 +174,7 @@ export default class SecurityTab extends React.Component {
             return;
         }
 
-        const passwordErr = Utils.isValidPassword(newPassword, Utils.getPasswordConfig());
+        const passwordErr = Utils.isValidPassword(newPassword, this.props.passwordConfig);
         if (passwordErr !== '') {
             this.setState({
                 passwordError: passwordErr,

--- a/tests/components/change_url_modal.test.jsx
+++ b/tests/components/change_url_modal.test.jsx
@@ -9,18 +9,6 @@ import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 import ChangeURLModal from 'components/change_url_modal/change_url_modal';
 
 describe('components/ChangeURLModal', () => {
-    global.window.mm_license = {};
-    global.window.mm_config = {};
-
-    beforeEach(() => {
-        global.window.mm_license.IsLicensed = 'false';
-    });
-
-    afterEach(() => {
-        global.window.mm_license = {};
-        global.window.mm_config = {};
-    });
-
     const baseProps = {
         show: true,
         onDataChanged: jest.fn(),

--- a/tests/components/dot_menu/dot_menu.test.jsx
+++ b/tests/components/dot_menu/dot_menu.test.jsx
@@ -24,16 +24,6 @@ jest.mock('utils/post_utils', () => {
 });
 
 describe('components/dot_menu/DotMenu', () => {
-    global.window.mm_license = {};
-
-    beforeEach(() => {
-        global.window.mm_license.IsLicensed = 'false';
-    });
-
-    afterEach(() => {
-        global.window.mm_license = {};
-    });
-
     const baseProps = {
         idPrefix: Constants.CENTER,
         idCount: -1,

--- a/tests/components/dot_menu/dot_menu_empty.test.jsx
+++ b/tests/components/dot_menu/dot_menu_empty.test.jsx
@@ -22,16 +22,6 @@ jest.mock('utils/post_utils', () => {
 });
 
 describe('components/dot_menu/DotMenu returning empty ("")', () => {
-    global.window.mm_license = {};
-
-    beforeEach(() => {
-        global.window.mm_license.IsLicensed = 'false';
-    });
-
-    afterEach(() => {
-        global.window.mm_license = {};
-    });
-
     test('should match snapshot, return empty ("") on Center', () => {
         const baseProps = {
             idPrefix: Constants.CENTER,

--- a/tests/components/dot_menu/dot_menu_mobile.test.jsx
+++ b/tests/components/dot_menu/dot_menu_mobile.test.jsx
@@ -22,16 +22,6 @@ jest.mock('utils/post_utils', () => {
 });
 
 describe('components/dot_menu/DotMenu on mobile view', () => {
-    global.window.mm_license = {};
-
-    beforeEach(() => {
-        global.window.mm_license.IsLicensed = 'false';
-    });
-
-    afterEach(() => {
-        global.window.mm_license = {};
-    });
-
     test('should match snapshot', () => {
         const baseProps = {
             idPrefix: Constants.CENTER,

--- a/tests/components/navbar/navbar.test.jsx
+++ b/tests/components/navbar/navbar.test.jsx
@@ -24,19 +24,6 @@ describe('components/navbar/Navbar', () => {
         currentUser: {id: 'current_user_id'},
     };
 
-    global.window.mm_license = {};
-    global.window.mm_config = {};
-
-    beforeEach(() => {
-        global.window.mm_license.IsLicensed = 'true';
-        global.window.mm_config.EnableWebrtc = 'true';
-    });
-
-    afterEach(() => {
-        global.window.mm_license = {};
-        global.window.mm_config = {};
-    });
-
     test('should match snapshot, invalid state', () => {
         const wrapper = shallow(
             <Navbar {...baseProps}/>
@@ -55,7 +42,6 @@ describe('components/navbar/Navbar', () => {
     });
 
     test('should match snapshot, if not licensed', () => {
-        global.window.mm_license.IsLicensed = 'false';
         const wrapper = shallow(
             <Navbar
                 {...baseProps}
@@ -68,7 +54,6 @@ describe('components/navbar/Navbar', () => {
     });
 
     test('should match snapshot, if enabled WebRTC and DM channel', () => {
-        global.window.mm_config.EnableWebrtc = 'true';
         const wrapper = shallow(
             <Navbar
                 {...baseProps}
@@ -82,7 +67,6 @@ describe('components/navbar/Navbar', () => {
     });
 
     test('should match snapshot, if WebRTC is not enabled', () => {
-        global.window.mm_config.EnableWebrtc = 'false';
         const wrapper = shallow(
             <Navbar
                 {...baseProps}

--- a/tests/components/new_channel_flow.test.jsx
+++ b/tests/components/new_channel_flow.test.jsx
@@ -14,18 +14,6 @@ import NewChannelFlow, {
 } from 'components/new_channel_flow';
 
 describe('components/NewChannelFlow', () => {
-    global.window.mm_license = {};
-    global.window.mm_config = {};
-
-    beforeEach(() => {
-        global.window.mm_license.IsLicensed = 'false';
-    });
-
-    afterEach(() => {
-        global.window.mm_license = {};
-        global.window.mm_config = {};
-    });
-
     const baseProps = {
         show: true,
         channelType: Constants.OPEN_CHANNEL,

--- a/tests/components/popover_list_members.test.jsx
+++ b/tests/components/popover_list_members.test.jsx
@@ -14,7 +14,6 @@ jest.mock('actions/channel_actions.jsx', () => ({
 }));
 
 describe('components/PopoverListMembers', () => {
-    global.window.mm_config = {};
     const channel = {
         id: 'channel_id',
         name: 'channel-name',
@@ -37,16 +36,6 @@ describe('components/PopoverListMembers', () => {
         currentUserId: 'current_user_id',
         actions,
     };
-
-    global.window.mm_license = {};
-
-    beforeEach(() => {
-        global.window.mm_license.IsLicensed = 'false';
-    });
-
-    afterEach(() => {
-        global.window.mm_license = {};
-    });
 
     test('should match snapshot', () => {
         const wrapper = shallow(

--- a/tests/components/post_view/reaction.test.jsx
+++ b/tests/components/post_view/reaction.test.jsx
@@ -12,16 +12,6 @@ jest.mock('actions/post_actions.jsx', () => ({
 }));
 
 describe('components/post_view/Reaction', () => {
-    global.window.mm_config = {};
-
-    beforeEach(() => {
-        global.window.mm_config.TeammateNameDisplay = 'username';
-    });
-
-    afterEach(() => {
-        global.window.mm_config = {};
-    });
-
     const post = {id: 'post_id_1'};
     const profiles = [{id: 'user_id_2', username: 'username_2'}];
     const reactions = [{user_id: 'user_id_2'}, {user_id: 'user_id_3'}];

--- a/tests/components/rename_channel_modal.test.jsx
+++ b/tests/components/rename_channel_modal.test.jsx
@@ -8,7 +8,6 @@ import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import RenameChannelModal from 'components/rename_channel_modal/rename_channel_modal.jsx';
 
 describe('components/RenameChannelModal', () => {
-    global.window.mm_config = {};
     const channel = {
         id: 'fake-id',
         name: 'fake-channel',

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1381,16 +1381,16 @@ export function canCreateCustomEmoji(user) {
     return true;
 }
 
-export function getPasswordConfig() {
+export function getPasswordConfig(license, config) {
     return {
-        isEnterprise: global.window.mm_config.BuildEnterpriseReady === 'true',
-        isLicensed: global.window.mm_license.IsLicensed === 'true',
-        isPasswordRequirements: global.window.mm_license.PasswordRequirements === 'true',
-        minimumLength: parseInt(global.window.mm_config.PasswordMinimumLength, 10),
-        requireLowercase: global.window.mm_config.PasswordRequireLowercase === 'true',
-        requireUppercase: global.window.mm_config.PasswordRequireUppercase === 'true',
-        requireNumber: global.window.mm_config.PasswordRequireNumber === 'true',
-        requireSymbol: global.window.mm_config.PasswordRequireSymbol === 'true',
+        isEnterprise: config.BuildEnterpriseReady === 'true',
+        isLicensed: license.IsLicensed === 'true',
+        isPasswordRequirements: license.PasswordRequirements === 'true',
+        minimumLength: parseInt(config.PasswordMinimumLength, 10),
+        requireLowercase: config.PasswordRequireLowercase === 'true',
+        requireUppercase: config.PasswordRequireUppercase === 'true',
+        requireNumber: config.PasswordRequireNumber === 'true',
+        requireSymbol: config.PasswordRequireSymbol === 'true',
     };
 }
 


### PR DESCRIPTION
#### Summary
This is the final PR in a series of changes from the `MM-9635-remove_mm_global_license_config` branch, broken up into multiple PRs to facilitate easier review. See any linked PRs for other changes if you're interested. 

This is phase two of the changes that remove our dependence on the global `mm_config` and `mm_license` objects. This PR removes the exports altogether. These changes will ultimately facilitate resolving https://mattermost.atlassian.net/browse/MM-8604, allowing us to stop hard refreshing the application whenever someone makes a configuration change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9635

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

### Related PRs
https://github.com/mattermost/mattermost-webapp/pull/862
https://github.com/mattermost/mattermost-webapp/pull/863
https://github.com/mattermost/mattermost-webapp/pull/865
https://github.com/mattermost/mattermost-webapp/pull/866