### PR TITLE
GH-8402: Invalid latex code, break the entire app (Fixed)

### DIFF
--- a/components/latex_block.jsx
+++ b/components/latex_block.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
 
 export default class LatexBlock extends React.Component {
     static propTypes = {
@@ -34,14 +35,26 @@ export default class LatexBlock extends React.Component {
             );
         }
 
-        const html = this.state.katex.renderToString(this.props.content, {throwOnError: false, displayMode: true});
+        try {
+            const html = this.state.katex.renderToString(this.props.content, {throwOnError: false, displayMode: true});
 
-        return (
-            <div
-                className='post-body--code tex'
-                dangerouslySetInnerHTML={{__html: html}}
-            />
-        );
+            return (
+                <div
+                    className='post-body--code tex'
+                    dangerouslySetInnerHTML={{__html: html}}
+                />
+            );
+        } catch (e) {
+            return (
+                <div
+                    className='post-body--code tex'
+                >
+                    <FormattedMessage
+                        id='katex.error'
+                        defaultMessage='Error: Invalid Latex code'
+                    />
+                </div>
+            );
+        }
     }
 }
-

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3015,5 +3015,6 @@
   "webrtc.unmute_audio": "Unmute microphone",
   "webrtc.unpause_video": "Turn on camera",
   "webrtc.unsupported": "{username} client does not support video calls.",
-  "youtube_video.notFound": "Video not found"
+  "youtube_video.notFound": "Video not found",
+  "katex.error": "Error: Invalid Latex code"
 }


### PR DESCRIPTION
#### Summary
**This is a backport of #894 PR to release-4.8 branch.**

When you introduce invalid latex code in mattermost, the Katex library throws
an exception, so the entire webapp is broken. This PR manage that. The expected
behavior is that `throwOnError = false` prevent the exceptions, but it only
works for certain type of error managed by Katex, other parse errors are thrown
anyway.

#### Ticket Link
GH ticket mattermost/mattermost-server#8402
[MM-9718](https://mattermost.atlassian.net/browse/MM-9718)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [X] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates