### PR TITLE
MM-9734 Fix permalink view loading from search results

### DIFF
--- a/components/permalink_view.jsx
+++ b/components/permalink_view.jsx
@@ -30,12 +30,11 @@ export default class PermalinkView extends React.PureComponent {
         this.doPermalinkEvent(props);
     }
 
-    doPermalinkEvent(props) {
+    async doPermalinkEvent(props) {
         this.setState({valid: false});
         const postId = props.match.params.postid;
-        GlobalActions.emitPostFocusEvent(postId, this.props.returnTo).then(() => {
-            this.setState({...this.getStateFromStores(props), valid: true});
-        });
+        await GlobalActions.emitPostFocusEvent(postId, this.props.returnTo);
+        this.setState({...this.getStateFromStores(props), valid: true});
     }
 
     getStateFromStores(props) {

--- a/components/permalink_view.jsx
+++ b/components/permalink_view.jsx
@@ -25,15 +25,17 @@ export default class PermalinkView extends React.PureComponent {
         this.isStateValid = this.isStateValid.bind(this);
         this.updateState = this.updateState.bind(this);
         this.doPermalinkEvent = this.doPermalinkEvent.bind(this);
+        this.state = {valid: false};
 
         this.doPermalinkEvent(props);
-
-        this.state = this.getStateFromStores(props);
     }
 
     doPermalinkEvent(props) {
+        this.setState({valid: false});
         const postId = props.match.params.postid;
-        GlobalActions.emitPostFocusEvent(postId, this.props.returnTo);
+        GlobalActions.emitPostFocusEvent(postId, this.props.returnTo).then(() => {
+            this.setState({...this.getStateFromStores(props), valid: true});
+        });
     }
 
     getStateFromStores(props) {
@@ -52,7 +54,7 @@ export default class PermalinkView extends React.PureComponent {
     }
 
     isStateValid() {
-        return this.state.channelId !== '' && this.state.teamName;
+        return this.state.valid && this.state.channelId !== '' && this.state.teamName;
     }
 
     updateState() {
@@ -75,7 +77,6 @@ export default class PermalinkView extends React.PureComponent {
 
     componentWillReceiveProps(nextProps) {
         this.doPermalinkEvent(nextProps);
-        this.setState(this.getStateFromStores(nextProps));
     }
 
     render() {


### PR DESCRIPTION
Fixes posts not loading around selected posts due to wrong assumption that ChannelStore.getCurrent() can be used to get channel id for post, before emitPostFocusEvent has finished loading.
It works fine when you boot to a permalink, but doesn't work correctly if you switch channel view to permalink view.
This caused surrounding posts to be requested but with wrong channel id, and empty results were returned.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9734
