### PR TITLE
open the main menu during tutorial; fix JS error

### DIFF
--- a/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
+++ b/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
@@ -44,6 +44,8 @@ export default class SidebarHeaderDropdown extends React.Component {
         helpLink: PropTypes.string,
         reportAProblemLink: PropTypes.string,
         restrictTeamInvite: PropTypes.string,
+        showDropdown: PropTypes.bool.isRequired,
+        onToggleDropdown: PropTypes.func.isRequired,
     };
 
     static defaultProps = {
@@ -52,8 +54,6 @@ export default class SidebarHeaderDropdown extends React.Component {
 
     constructor(props) {
         super(props);
-
-        this.toggleDropdown = this.toggleDropdown.bind(this);
 
         this.handleAboutModal = this.handleAboutModal.bind(this);
         this.aboutModalDismissed = this.aboutModalDismissed.bind(this);
@@ -76,7 +76,6 @@ export default class SidebarHeaderDropdown extends React.Component {
             teamMembers: TeamStore.getMyTeamMembers(),
             teamListings: TeamStore.getTeamListings(),
             showAboutModal: false,
-            showDropdown: false,
             showTeamSettingsModal: false,
             showTeamMembersModal: false,
             showAddUsersToTeamModal: false,
@@ -90,9 +89,9 @@ export default class SidebarHeaderDropdown extends React.Component {
         }
     }
 
-    toggleDropdown(val) {
+    toggleDropdown = (val) => {
         if (typeof (val) === 'boolean') {
-            this.setState({showDropdown: val});
+            this.props.onToggleDropdown(val);
             return;
         }
 
@@ -100,7 +99,7 @@ export default class SidebarHeaderDropdown extends React.Component {
             val.preventDefault();
         }
 
-        this.setState({showDropdown: !this.state.showDropdown});
+        this.props.onToggleDropdown();
     }
 
     handleAboutModal(e) {
@@ -108,8 +107,8 @@ export default class SidebarHeaderDropdown extends React.Component {
 
         this.setState({
             showAboutModal: true,
-            showDropdown: false,
         });
+        this.props.onToggleDropdown(false);
     }
 
     aboutModalDismissed() {
@@ -119,14 +118,14 @@ export default class SidebarHeaderDropdown extends React.Component {
     showAccountSettingsModal(e) {
         e.preventDefault();
 
-        this.setState({showDropdown: false});
+        this.props.onToggleDropdown(false);
 
         GlobalActions.showAccountSettingsModal();
     }
 
     toggleShortcutsModal(e) {
         e.preventDefault();
-        this.setState({showDropdown: false});
+        this.props.onToggleDropdown(false);
 
         GlobalActions.toggleShortcutsModal();
     }
@@ -136,8 +135,8 @@ export default class SidebarHeaderDropdown extends React.Component {
 
         this.setState({
             showAddUsersToTeamModal: true,
-            showDropdown: false,
         });
+        this.props.onToggleDropdown(false);
     }
 
     hideAddUsersToTeamModal() {
@@ -149,7 +148,7 @@ export default class SidebarHeaderDropdown extends React.Component {
     showInviteMemberModal(e) {
         e.preventDefault();
 
-        this.setState({showDropdown: false});
+        this.props.onToggleDropdown(false);
 
         GlobalActions.showInviteMemberModal();
     }
@@ -157,7 +156,7 @@ export default class SidebarHeaderDropdown extends React.Component {
     showGetTeamInviteLinkModal(e) {
         e.preventDefault();
 
-        this.setState({showDropdown: false});
+        this.props.onToggleDropdown(false);
 
         GlobalActions.showGetTeamInviteLinkModal();
     }
@@ -166,9 +165,9 @@ export default class SidebarHeaderDropdown extends React.Component {
         e.preventDefault();
 
         this.setState({
-            showDropdown: false,
             showTeamSettingsModal: true,
         });
+        this.props.onToggleDropdown(false);
     }
 
     hideTeamSettingsModal = () => {
@@ -199,8 +198,8 @@ export default class SidebarHeaderDropdown extends React.Component {
         this.setState({
             teamMembers: TeamStore.getMyTeamMembers(),
             teamListings: TeamStore.getTeamListings(),
-            showDropdown: false,
         });
+        this.props.onToggleDropdown(false);
     }
 
     componentWillUnmount() {
@@ -635,7 +634,7 @@ export default class SidebarHeaderDropdown extends React.Component {
         return (
             <Dropdown
                 id='sidebar-header-dropdown'
-                open={this.state.showDropdown}
+                open={this.props.showDropdown}
                 onToggle={this.toggleDropdown}
                 className='sidebar-header-dropdown'
                 pullRight={true}

--- a/components/sidebar/header/sidebar_header.jsx
+++ b/components/sidebar/header/sidebar_header.jsx
@@ -48,17 +48,31 @@ export default class SidebarHeader extends React.Component {
     getStateFromStores = () => {
         const preferences = this.getPreferences();
         const isMobile = Utils.isMobile();
-        return {...preferences, isMobile};
+        return {
+            ...preferences,
+            isMobile,
+            showDropdown: false,
+        };
     }
 
     onPreferenceChange = () => {
         this.setState(this.getPreferences());
     }
 
-    toggleDropdown = (e) => {
-        e.preventDefault();
+    toggleDropdown = (toggle) => {
+        if (typeof (toggle) === 'boolean') {
+            this.setState({
+                showDropdown: toggle,
+            });
+        } else {
+            this.setState({
+                showDropdown: !this.state.showDropdown,
+            });
+        }
+    }
 
-        this.refs.dropdown.toggleDropdown();
+    showDropdown = () => {
+        this.toggleDropdown(true);
     }
 
     renderStatusDropdown = () => {
@@ -75,7 +89,7 @@ export default class SidebarHeader extends React.Component {
 
         let tutorialTip = null;
         if (this.state.showTutorialTip) {
-            tutorialTip = createMenuTip(this.toggleDropdown);
+            tutorialTip = createMenuTip(this.showDropdown);
         }
 
         let teamNameWithToolTip = null;
@@ -127,11 +141,12 @@ export default class SidebarHeader extends React.Component {
                 </div>
                 <div id='sidebarDropdownMenuContainer'>
                     <SidebarHeaderDropdown
-                        ref='dropdown'
                         teamType={this.props.teamType}
                         teamDisplayName={this.props.teamDisplayName}
                         teamName={this.props.teamName}
                         currentUser={this.props.currentUser}
+                        showDropdown={this.state.showDropdown}
+                        onToggleDropdown={this.toggleDropdown}
                     />
                 </div>
                 {statusDropdown}


### PR DESCRIPTION
#### Summary
This was a minor regression after connecting the sidebar header dropdown
to Redux: the ref no longer pointed directly at the
`SidebarHeaderDropdown` component, and the `toggleDropdown` function could
no longer be invoked.

Mutating the child state this way was prone to errors in the first
place, so now the `showDropdown` state is hoisted into the `SidebarHeader`
instead for direct manipulation, and then passed back down as props.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9762

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed