### PR TITLE
MM-9754 Mark current channel as read from viewed_channel events if window not active

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -573,7 +573,7 @@ function handleReactionRemovedEvent(msg) {
 
 function handleChannelViewedEvent(msg) {
 // Useful for when multiple devices have the app open to different channels
-    if (ChannelStore.getCurrentId() !== msg.data.channel_id &&
+    if ((!window.isActive || ChannelStore.getCurrentId() !== msg.data.channel_id) &&
         UserStore.getCurrentId() === msg.broadcast.user_id) {
         // Mark previous and next channel as read
         ChannelStore.resetCounts([msg.data.channel_id]);


### PR DESCRIPTION
#### Summary
Mark current channel as read from viewed_channel events if window not active. Another part of this ticket is fixed by https://github.com/mattermost/mattermost-redux/pull/422

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9754