### PR TITLE
Fix JS errors on draft - post or comment

### DIFF
--- a/actions/views/create_comment.jsx
+++ b/actions/views/create_comment.jsx
@@ -20,7 +20,8 @@ import * as GlobalActions from 'actions/global_actions.jsx';
 import * as ChannelActions from 'actions/channel_actions.jsx';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import {EmojiMap} from 'stores/emoji_store.jsx';
-import {makeGetCommentDraft} from 'selectors/rhs';
+import {getPostDraft} from 'selectors/rhs';
+
 import * as Utils from 'utils/utils.jsx';
 import {Constants, StoragePrefixes} from 'utils/constants.jsx';
 
@@ -39,11 +40,9 @@ export function updateCommentDraft(rootId, draft) {
 
 export function makeOnMoveHistoryIndex(rootId, direction) {
     const getMessageInHistory = makeGetMessageInHistoryItem(Posts.MESSAGE_TYPES.COMMENT);
-    const getCommentDraft = makeGetCommentDraft(rootId);
 
     return () => (dispatch, getState) => {
-        const draft = getCommentDraft(getState());
-
+        const draft = getPostDraft(getState(), StoragePrefixes.COMMENT_DRAFT, rootId);
         if (draft.message !== '' && draft.message !== getMessageInHistory(getState())) {
             return;
         }
@@ -124,10 +123,8 @@ export function submitCommand(channelId, rootId, draft) {
 }
 
 export function makeOnSubmit(channelId, rootId, latestPostId) {
-    const getCommentDraft = makeGetCommentDraft(rootId);
-
     return () => async (dispatch, getState) => {
-        const draft = getCommentDraft(getState());
+        const draft = getPostDraft(getState(), StoragePrefixes.COMMENT_DRAFT, rootId);
         const {message} = draft;
 
         dispatch(addMessageIntoHistory(message));

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -11,7 +11,7 @@ import {makeGetMessageInHistoryItem} from 'mattermost-redux/selectors/entities/p
 import {resetCreatePostRequest, resetHistoryIndex} from 'mattermost-redux/actions/posts';
 import {Preferences, Posts} from 'mattermost-redux/constants';
 
-import {Constants} from 'utils/constants.jsx';
+import {Constants, StoragePrefixes} from 'utils/constants.jsx';
 
 import {
     clearCommentDraftUploads,
@@ -20,18 +20,16 @@ import {
     makeOnSubmit,
     makeOnEditLatestPost,
 } from 'actions/views/create_comment';
-import {makeGetCommentDraft} from 'selectors/rhs';
+import {getPostDraft} from 'selectors/rhs';
 
 import CreateComment from './create_comment.jsx';
 
 function mapStateToProps(state, ownProps) {
     const err = state.requests.posts.createPost.error || {};
 
-    const getCommentDraft = makeGetCommentDraft(ownProps.rootId);
-
-    const draft = getCommentDraft(state);
-
+    const draft = getPostDraft(state, StoragePrefixes.COMMENT_DRAFT, ownProps.rootId);
     const enableAddButton = draft.message.trim().length !== 0 || draft.fileInfos.length !== 0;
+
     const channelMembersCount = getAllChannelStats(state)[ownProps.channelId] ? getAllChannelStats(state)[ownProps.channelId].member_count : 1;
     const messageInHistory = makeGetMessageInHistoryItem(Posts.MESSAGE_TYPES.COMMENT)(state);
 

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -28,7 +28,7 @@ import {Posts} from 'mattermost-redux/constants';
 import {emitUserPostedEvent, postListScrollChange} from 'actions/global_actions.jsx';
 import {createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
-import {makeGetGlobalItem} from 'selectors/storage';
+import {getPostDraft} from 'selectors/rhs';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import {Constants, Preferences, StoragePrefixes, TutorialSteps} from 'utils/constants.jsx';
 import {canUploadFiles} from 'utils/file_utils';
@@ -39,11 +39,7 @@ function mapStateToProps() {
     return (state) => {
         const config = getConfig(state);
         const currentChannel = getCurrentChannel(state) || {};
-        const getDraft = makeGetGlobalItem(StoragePrefixes.DRAFT + currentChannel.id, {
-            message: '',
-            uploadsInProgress: [],
-            fileInfos: [],
-        });
+        const draft = getPostDraft(state, StoragePrefixes.DRAFT, currentChannel.id);
         const recentPostIdInChannel = getMostRecentPostIdInChannel(state, currentChannel.id);
         const post = getPost(state, recentPostIdInChannel);
         const getCommentCountForPost = makeGetCommentCountForPost();
@@ -63,7 +59,7 @@ function mapStateToProps() {
             fullWidthTextBox: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
             showTutorialTip: enableTutorial && tutorialStep === TutorialSteps.POST_POPOVER,
             messageInHistoryItem: makeGetMessageInHistoryItem(Posts.MESSAGE_TYPES.POST)(state),
-            draft: getDraft(state),
+            draft,
             recentPostIdInChannel,
             commentCountForPost: getCommentCountForPost(state, {post}),
             latestReplyablePostId,

--- a/selectors/rhs.jsx
+++ b/selectors/rhs.jsx
@@ -67,9 +67,19 @@ export function getIsSearchingPinnedPost(state) {
     return state.views.rhs.isSearchingPinnedPost;
 }
 
-export function makeGetCommentDraft(rootId) {
-    const defaultValue = {message: '', fileInfos: [], uploadsInProgress: []};
-    return makeGetGlobalItem(`${StoragePrefixes.COMMENT_DRAFT}${rootId}`, defaultValue);
+export function getPostDraft(state, prefixId, suffixId) {
+    const defaultDraft = {message: '', fileInfos: [], uploadsInProgress: []};
+    const draft = makeGetGlobalItem(prefixId + suffixId, defaultDraft)(state);
+
+    if (
+        typeof draft.message !== 'undefined' &&
+        typeof draft.uploadsInProgress !== 'undefined' &&
+        typeof draft.fileInfos !== 'undefined'
+    ) {
+        return draft;
+    }
+
+    return defaultDraft;
 }
 
 export function makeGetPostsEmbedVisibleObj() {


### PR DESCRIPTION
#### Summary
(Note: This is not included on approved fixes for v4.8 but would recommend to get in. ~~This might be related to https://mattermost.atlassian.net/browse/MM-9710 which unfortunately I couldn't repro on my local dev machine.~~)

Quick fix for JS errors:
- The prop draft.message is marked as required in CreatePost, but its value is undefined
- Uncaught TypeError: Cannot read property 'trim' of undefined at CreatePost.handleEnableSendButton
![screen shot 2018-03-10 at 12 27 35 am](https://user-images.githubusercontent.com/5334504/37224192-b3928af0-240d-11e8-8fb0-baed5ea72c5b.png)
![screen shot 2018-03-10 at 12 26 42 am](https://user-images.githubusercontent.com/5334504/37224193-b3c348ca-240d-11e8-8791-e9275a5c8d7b.png)

Post on prerelease: https://pre-release.mattermost.com/core/pl/6atd8qhthbdh7fir1ocqrz9ffa

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
