### PR TITLE
[MM-9710] Add flex to file-preview (loading) so it will not collapse when container is combined with loaded and loading files

### DIFF
--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -16,16 +16,14 @@
 
 .file-preview {
     @include clearfix;
+    flex-shrink: 0;
+    flex-wrap: nowrap;
     border: 1px solid $light-gray;
     display: inline-block;
     height: 100px;
-    margin: 0 0 0 10px;
+    margin-right: 10px;
     position: relative;
     width: 120px;
-
-    &:first-child {
-        margin-left: 0;
-    }
 
     .spinner {
         height: 32px;


### PR DESCRIPTION
#### Summary
Add flex styles to file-preview (loading) so it will not collapse when container is combined with loaded and loading files

#### Ticket Link
Jira ticket: [MM-9710](https://mattermost.atlassian.net/browse/MM-9710)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
