### PR TITLE
[MM-9771] Cursor focus doesn't return to comment box on the RHS after editing a message on the RHS by removing all of the text in the comment

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -287,7 +287,7 @@ export function doPostAction(postId, actionId) {
     PostActions.doPostAction(postId, actionId)(dispatch, getState);
 }
 
-export function setEditingPost(postId = '', commentsCount = 0, refocusId = '', title = '') {
+export function setEditingPost(postId = '', commentsCount = 0, refocusId = '', title = '', isRHS = false) {
     return async (doDispatch, doGetState) => {
         const state = doGetState();
 
@@ -311,7 +311,7 @@ export function setEditingPost(postId = '', commentsCount = 0, refocusId = '', t
         if (canEditNow) {
             doDispatch({
                 type: ActionTypes.SHOW_EDIT_POST_MODAL,
-                data: {postId, commentsCount, refocusId, title},
+                data: {postId, commentsCount, refocusId, title, isRHS},
             }, doGetState);
         }
 

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -59,6 +59,7 @@ export default class DotMenu extends Component {
         post: {},
         commentCount: 0,
         isFlagged: false,
+        isRHS: false,
     }
 
     constructor(props) {
@@ -193,6 +194,7 @@ export default class DotMenu extends Component {
             dotMenuEdit = (
                 <DotMenuEdit
                     idPrefix={idPrefix + 'Edit'}
+                    isRHS={this.props.isRHS}
                     idCount={this.props.idCount}
                     post={this.props.post}
                     type={type}

--- a/components/dot_menu/dot_menu_edit.jsx
+++ b/components/dot_menu/dot_menu_edit.jsx
@@ -23,7 +23,8 @@ export default function DotMenuEdit(props) {
             props.post.id,
             props.commentsCount,
             props.idPrefix.indexOf(Constants.CENTER) === 0 ? 'post_textbox' : 'reply_textbox',
-            props.idPrefix.indexOf(Constants.CENTER) === 0 ? props.type : Utils.localizeMessage('rhs_comment.comment', 'Comment')
+            props.idPrefix.indexOf(Constants.CENTER) === 0 ? props.type : Utils.localizeMessage('rhs_comment.comment', 'Comment'),
+            props.isRHS
         );
     }
 
@@ -48,6 +49,7 @@ export default function DotMenuEdit(props) {
 
 DotMenuEdit.propTypes = {
     idPrefix: PropTypes.string.isRequired,
+    isRHS: PropTypes.bool,
     idCount: PropTypes.number,
     post: PropTypes.object,
     type: PropTypes.string,

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -62,6 +62,11 @@ export default class EditPostModal extends React.PureComponent {
              * What to show in the title of the modal as "Edit {title}"
              */
             title: PropTypes.string,
+
+            /**
+             * Whether or not the modal was open from RHS
+             */
+            isRHS: PropTypes.bool,
         }).isRequired,
 
         actions: PropTypes.shape({
@@ -160,7 +165,7 @@ export default class EditPostModal extends React.PureComponent {
         const hasAttachment = editingPost.post.file_ids && editingPost.post.file_ids.length > 0;
         if (updatedPost.message.trim().length === 0 && !hasAttachment) {
             this.handleHide(false);
-            GlobalActions.showDeletePostModal(Selectors.getPost(getState(), editingPost.postId), editingPost.commentsCount);
+            GlobalActions.showDeletePostModal(Selectors.getPost(getState(), editingPost.postId), editingPost.commentsCount, editingPost.isRHS);
             return;
         }
 

--- a/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
@@ -56,6 +56,7 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
           commentCount={0}
           idCount={-1}
           idPrefix="centerDotMenuDelete"
+          isRHS={false}
           post={
             Object {
               "id": "post_id_1",

--- a/tests/components/dot_menu/dot_menu.test.jsx
+++ b/tests/components/dot_menu/dot_menu.test.jsx
@@ -29,6 +29,7 @@ describe('components/dot_menu/DotMenu', () => {
         idCount: -1,
         post: {id: 'post_id_1', is_pinned: false},
         isFlagged: false,
+        isRHS: false,
         handleCommentClick: jest.fn(),
         handleDropdownOpened: jest.fn(),
         actions: {

--- a/tests/components/dot_menu/dot_menu_edit.test.jsx
+++ b/tests/components/dot_menu/dot_menu_edit.test.jsx
@@ -14,6 +14,7 @@ describe('components/dot_menu/DotMenuEdit', () => {
         post: {id: 'post_id_1'},
         type: 'Post',
         commentsCount: 1,
+        isRHS: false,
         actions: {setEditingPost: jest.fn()},
     };
 
@@ -26,7 +27,7 @@ describe('components/dot_menu/DotMenuEdit', () => {
 
         wrapper.find('button').first().simulate('click');
         expect(baseProps.actions.setEditingPost).toHaveBeenCalledTimes(1);
-        expect(baseProps.actions.setEditingPost).toHaveBeenCalledWith('post_id_1', 1, 'post_textbox', 'Post');
+        expect(baseProps.actions.setEditingPost).toHaveBeenCalledWith('post_id_1', 1, 'post_textbox', 'Post', false);
 
         expect(wrapper.find('#center2').exists()).toBe(false);
         wrapper.setProps({idCount: 2});
@@ -43,7 +44,7 @@ describe('components/dot_menu/DotMenuEdit', () => {
 
         wrapper.find('button').first().simulate('click');
         expect(baseProps.actions.setEditingPost).toHaveBeenCalledTimes(1);
-        expect(baseProps.actions.setEditingPost).toHaveBeenCalledWith('post_id_1', 1, 'reply_textbox', 'Comment');
+        expect(baseProps.actions.setEditingPost).toHaveBeenCalledWith('post_id_1', 1, 'reply_textbox', 'Comment', false);
 
         expect(wrapper.find('#rhs3').exists()).toBe(false);
         wrapper.setProps({idCount: 3});

--- a/tests/redux/actions/posts.test.js
+++ b/tests/redux/actions/posts.test.js
@@ -23,6 +23,7 @@ describe('Actions.Posts', () => {
                 refocusId: 'test',
                 show: true,
                 title: 'title',
+                isRHS: false,
             }
         );
 
@@ -36,6 +37,7 @@ describe('Actions.Posts', () => {
                 refocusId: 'test2',
                 show: true,
                 title: 'title2',
+                isRHS: false,
             }
         );
     });


### PR DESCRIPTION
#### Summary
Fixes [#8429](https://github.com/mattermost/mattermost-server/issues/8429)

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/MM-9771)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
