### PR TITLE
Cleanup jquery from post_attachment.jsx 

### DIFF
--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -36,7 +36,7 @@ export default class PostAttachment extends React.PureComponent {
 
         this.state = {
             collapsed: true,
-        }
+        };
     }
 
     toggleCollapseState(e) {
@@ -276,15 +276,19 @@ export default class PostAttachment extends React.PureComponent {
         if (data.text) {
             const shouldCollapse = this.shouldCollapse();
             const collapsed = shouldCollapse && this.state.collapsed;
-            const textHTML = collapsed ? this.getCollapsedTextHTML() : TextFormatting.formatText(this.props.attachment.text || '');    
+            const textHTML = collapsed ? this.getCollapsedTextHTML() : TextFormatting.formatText(this.props.attachment.text || '');
             const collapseMessage = collapsed ? localizeMessage('post_attachment.more', 'Show more...') : localizeMessage('post_attachment.collapse', 'Show less...');
 
             text = (
                 <div className='attachment__text'>
                     {messageHtmlToComponent(textHTML, false)}
-                    {shouldCollapse && 
+                    {shouldCollapse &&
                         <div>
-                            <a class="attachment-link-more" href="#" onClick={this.toggleCollapseState}>
+                            <a 
+                                className="attachment-link-more" 
+                                href="#" 
+                                onClick={this.toggleCollapseState}
+                            >
                                 {collapseMessage}
                             </a>
                         </div>

--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -30,7 +30,6 @@ export default class PostAttachment extends React.PureComponent {
         this.handleActionButtonClick = this.handleActionButtonClick.bind(this);
         this.getActionView = this.getActionView.bind(this);
         this.getFieldsTable = this.getFieldsTable.bind(this);
-        this.getInitState = this.getInitState.bind(this);
         this.shouldCollapse = this.shouldCollapse.bind(this);
         this.toggleCollapseState = this.toggleCollapseState.bind(this);
 

--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -284,8 +284,8 @@ export default class PostAttachment extends React.PureComponent {
                     {shouldCollapse &&
                         <div>
                             <a 
-                                className="attachment-link-more" 
-                                href="#" 
+                                className="attachment-link-more"
+                                href="#"
                                 onClick={this.toggleCollapseState}
                             >
                                 {collapseMessage}

--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -27,18 +27,12 @@ export default class PostAttachment extends React.PureComponent {
     constructor(props) {
         super(props);
 
-        this.handleActionButtonClick = this.handleActionButtonClick.bind(this);
-        this.getActionView = this.getActionView.bind(this);
-        this.getFieldsTable = this.getFieldsTable.bind(this);
-        this.shouldCollapse = this.shouldCollapse.bind(this);
-        this.toggleCollapseState = this.toggleCollapseState.bind(this);
-
         this.state = {
             collapsed: true,
         };
     }
 
-    toggleCollapseState(e) {
+    toggleCollapseState = (e) => {
         e.preventDefault();
         this.setState((prevState) => {
             return {
@@ -98,7 +92,7 @@ export default class PostAttachment extends React.PureComponent {
         );
     }
 
-    handleActionButtonClick(e) {
+    handleActionButtonClick = (e) => {
         e.preventDefault();
         const actionId = e.currentTarget.getAttribute('data-action-id');
         PostActions.doPostAction(this.props.postId, actionId);

--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -36,14 +35,6 @@ export default class PostAttachment extends React.PureComponent {
         this.toggleCollapseState = this.toggleCollapseState.bind(this);
     }
 
-    componentDidMount() {
-        $(this.refs.attachment).on('click', '.attachment-link-more', this.toggleCollapseState);
-    }
-
-    componentWillUnmount() {
-        $(this.refs.attachment).off('click', '.attachment-link-more', this.toggleCollapseState);
-    }
-
     componentWillMount() {
         this.setState(this.getInitState());
     }
@@ -51,7 +42,7 @@ export default class PostAttachment extends React.PureComponent {
     getInitState() {
         const shouldCollapse = this.shouldCollapse();
         const text = TextFormatting.formatText(this.props.attachment.text || '');
-        const uncollapsedTextHTML = text + (shouldCollapse ? `<div><a class="attachment-link-more" href="#">${localizeMessage('post_attachment.collapse', 'Show less...')}</a></div>` : '');
+        const uncollapsedTextHTML = text;
         const collapsedTextHTML = shouldCollapse ? this.getCollapsedTextHTML() : text;
 
         return {
@@ -87,7 +78,7 @@ export default class PostAttachment extends React.PureComponent {
             text = text.substr(0, 300);
         }
 
-        return TextFormatting.formatText(text) + `<div><a class="attachment-link-more" href="#">${localizeMessage('post_attachment.more', 'Show more...')}</a></div>`;
+        return TextFormatting.formatText(text);
     }
 
     getActionView() {
@@ -297,9 +288,13 @@ export default class PostAttachment extends React.PureComponent {
 
         let text;
         if (data.text) {
+            const collapseMessage = this.state.collapsed ? localizeMessage('post_attachment.more', 'Show more...') : localizeMessage('post_attachment.collapse', 'Show less...');
             text = (
                 <div className='attachment__text'>
                     {messageHtmlToComponent(this.state.textHTML, false)}
+                    <a class="attachment-link-more" href="#" onClick={this.toggleCollapseState}>
+                        {collapseMessage}
+                    </a>
                 </div>
             );
         }

--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -283,9 +283,11 @@ export default class PostAttachment extends React.PureComponent {
                 <div className='attachment__text'>
                     {messageHtmlToComponent(textHTML, false)}
                     {shouldCollapse && 
-                        <a class="attachment-link-more" href="#" onClick={this.toggleCollapseState}>
-                            {collapseMessage}
-                        </a>
+                        <div>
+                            <a class="attachment-link-more" href="#" onClick={this.toggleCollapseState}>
+                                {collapseMessage}
+                            </a>
+                        </div>
                     }
                 </div>
             );

--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -283,9 +283,9 @@ export default class PostAttachment extends React.PureComponent {
                     {messageHtmlToComponent(textHTML, false)}
                     {shouldCollapse &&
                         <div>
-                            <a 
-                                className="attachment-link-more"
-                                href="#"
+                            <a
+                                className='attachment-link-more'
+                                href='#'
                                 onClick={this.toggleCollapseState}
                             >
                                 {collapseMessage}


### PR DESCRIPTION
#### Summary
Cleaned up post_attachment.jsx from jquery; especially considering that these jquery selectors were very heavy on performance...
While I am on it, I took the chance to further purify the component as a cleanup.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
