### PR TITLE
Clear redux cache before yarn install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ test: .yarninstall ## Runs tests
 
 .yarninstall: package.json
 	@echo Getting dependencies using yarn
-
+	
+	yarn cache clean --pattern "mattermost-redux"
 	yarn install --pure-lockfile
 	cd node_modules/mattermost-redux; npm run build
 


### PR DESCRIPTION
@jwilander can you have a look at this change? this clears the cache for the redux package before the yarn install command.
