### PR TITLE
MM-9773 Fixed permalinks on IE11

### DIFF
--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -177,7 +177,7 @@ export default class Renderer extends marked.Renderer {
         }
 
         if (internalLink) {
-            output += ' data-link="' + outHref.substring(this.formattingOptions.siteURL) + '"';
+            output += ' data-link="' + outHref.substring(this.formattingOptions.siteURL.length) + '"';
         } else {
             output += ' target="_blank"';
         }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1469,10 +1469,7 @@ export function handleFormattedTextClick(e) {
         if (!(e.button === MIDDLE_MOUSE_BUTTON || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) {
             e.preventDefault();
 
-            const urlparse = document.createElement('a');
-            urlparse.href = linkAttribute.value;
-
-            browserHistory.push(urlparse.pathname);
+            browserHistory.push(linkAttribute.value);
         }
     } else if (channelMentionAttribute) {
         e.preventDefault();


### PR DESCRIPTION
It turns out that calling substring and passing a string as the argument does nothing so we were passing the whole link URL through to the click handler where we would remove the domain name. Unfortunately, the way that we were doing that works slightly differently on IE11 because it removes the preceding slash from the URL path (eg IE11 would produce `<team_name>/pl/<post_id>` instead of `/<team_name/pl/<post_id>` like other browsers)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9773
