### PR TITLE
WIP: Infinite Scroll

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
+import {debounce} from 'underscore';
 
 import Constants, {PostTypes} from 'utils/constants.jsx';
 import DelayedAction from 'utils/delayed_action.jsx';
@@ -117,6 +118,7 @@ export default class PostList extends React.PureComponent {
             isDoingInitialLoad: true,
             isScrolling: false,
             lastViewed: props.lastViewedAt,
+            loadedMorePosts: true,
         };
     }
 
@@ -246,6 +248,7 @@ export default class PostList extends React.PureComponent {
             // New posts added at the top, maintain scroll position
             if (this.previousScrollHeight !== postList.scrollHeight && posts[0].id === prevPosts[0].id) {
                 postList.scrollTop = this.previousScrollTop + (postList.scrollHeight - this.previousScrollHeight);
+                this.setLoadedMorePosts();
             }
         }
     }
@@ -310,6 +313,10 @@ export default class PostList extends React.PureComponent {
         }
 
         return this.refs.postlist.clientHeight + this.refs.postlist.scrollTop >= this.refs.postlist.scrollHeight - CLOSE_TO_BOTTOM_SCROLL_MARGIN;
+    }
+
+    setLoadedMorePosts = () => {
+        this.setState({loadedMorePosts: true});
     }
 
     handleWindowResize = () => {
@@ -380,6 +387,17 @@ export default class PostList extends React.PureComponent {
         });
     }
 
+    shouldInfiniteScroll = () => {
+        return this.state.loadedMorePosts === true && this.refs.postlist.scrollTop <= 500;
+    }
+
+    infiniteScroll = debounce(() => {
+        if (this.shouldInfiniteScroll()) {
+            this.loadMorePosts();
+            this.setState({loadedMorePosts: false});
+        }
+    }, 250);
+
     handleScroll = () => {
         // Only count as user scroll if we've already performed our first load scroll
         this.hasScrolled = this.hasScrolledToNewMessageSeparator || this.hasScrolledToFocusedPost;
@@ -407,6 +425,10 @@ export default class PostList extends React.PureComponent {
                 unViewedCount: 0,
                 isScrolling: false,
             });
+        }
+
+        if (this.shouldInfiniteScroll()) {
+            this.infiniteScroll();
         }
 
         this.scrollStopAction.fireAfter(Constants.SCROLL_DELAY);
@@ -570,16 +592,15 @@ export default class PostList extends React.PureComponent {
             topRow = <LoadingScreen style={{height: '0px'}}/>;
         } else {
             topRow = (
-                <button
+                <div
                     ref='loadmoretop'
-                    className='more-messages-text theme style--none color--link'
-                    onClick={this.loadMorePosts}
+                    className='more-messages-text theme style--none'
                 >
                     <FormattedMessage
-                        id='posts_view.loadMore'
-                        defaultMessage='Load more messages'
+                        id='posts_view.loadingMore'
+                        defaultMessage='Loading more messages...'
                     />
-                </button>
+                </div>
             );
         }
 

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -393,8 +393,8 @@ export default class PostList extends React.PureComponent {
 
     infiniteScroll = debounce(() => {
         if (this.shouldInfiniteScroll()) {
-            this.loadMorePosts();
             this.setState({loadedMorePosts: false});
+            this.loadMorePosts();
         }
     }, 250);
 


### PR DESCRIPTION
#### Summary
- When at top (<= 500 scroll), load more posts
- Debounce loading more posts, so it isn't triggered multiple times on scroll
- Use a state to mark when more posts are loaded, so it can be triggered again.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-1629
- Older, outdated PR for reference: https://github.com/mattermost/mattermost-server/pull/5886

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, posting, etc.)
