### PR TITLE
MM-9816 Fix PDF previews on Firefox

### DIFF
--- a/components/pdf_preview.jsx
+++ b/components/pdf_preview.jsx
@@ -11,7 +11,6 @@ import loadingGif from 'images/load.gif';
 import FileInfoPreview from './file_info_preview.jsx';
 
 const MAX_PDF_PAGES = 5;
-PDFJS.disableWorker = true;
 
 export default class PDFPreview extends React.PureComponent {
     static propTypes = {

--- a/root.jsx
+++ b/root.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import {Router, Route} from 'react-router-dom';
+import PDFJS from 'pdfjs-dist';
 
 // Import our styles
 import 'bootstrap-colorpicker/dist/css/bootstrap-colorpicker.css';
@@ -17,6 +18,8 @@ import store from 'stores/redux_store.jsx';
 import loadRoot from 'bundle-loader?lazy!components/root.jsx';
 
 const Root = makeAsyncComponent(loadRoot);
+
+PDFJS.disableWorker = true;
 
 // This is for anything that needs to be done for ALL react components.
 // This runs before we start to render anything.


### PR DESCRIPTION
#### Summary
I don't know the exact reason this works, but my guess is that it needs to run on start and the PDFPreview component was being lazy loaded in by react router so that code wouldn't run until someone opened a PDF.

This is also how it was being done before the react router upgrade.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9816