### PR TITLE
MM-9784 Filter out current user when adding member to GM

### DIFF
--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -90,6 +90,11 @@ export default class MoreDirectChannels extends React.Component {
         if (props.currentChannelMembers) {
             for (let i = 0; i < props.currentChannelMembers.length; i++) {
                 const user = Object.assign({}, props.currentChannelMembers[i]);
+
+                if (user.id === props.currentUserId) {
+                    continue;
+                }
+
                 user.value = user.id;
                 user.label = '@' + user.username;
                 values.push(user);


### PR DESCRIPTION
#### Summary
Filter out current user when adding a member to GMs to prevent the -1 count and to be consistent with the regular GM channel modal where you can't add yourself to the list.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9784