### PR TITLE
MM-9766 Export text formatting as 'post-utils' for use in plugins

### DIFF
--- a/plugins/index.js
+++ b/plugins/index.js
@@ -8,6 +8,8 @@ import {Client4} from 'mattermost-redux/client';
 import store from 'stores/redux_store.jsx';
 import {ActionTypes} from 'utils/constants.jsx';
 import {getSiteURL} from 'utils/url.jsx';
+import {formatText} from 'utils/text_formatting.jsx';
+import {messageHtmlToComponent} from 'utils/post_utils.jsx';
 
 window.plugins = {};
 
@@ -17,6 +19,7 @@ window['react-dom'] = require('react-dom');
 window.redux = require('redux');
 window['react-redux'] = require('react-redux');
 window['react-bootstrap'] = require('react-bootstrap');
+window['post-utils'] = {formatText, messageHtmlToComponent};
 
 export function registerComponents(id, components = {}, postTypes = {}) {
     const wrappedComponents = {};


### PR DESCRIPTION
#### Summary
I'm selectively exporting these two functions as they'll allow plugins to format text, emojis, markdown, etc. just like we do in the web app.

To use these in a plugin:

```javascript
const React = window.react;
const PostUtils = window['post-utils']; // import the post utilities
import PropTypes from 'prop-types';
import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';

export default class PostTypeFormatted extends React.PureComponent {

    // ...

    render() {
        const style = getStyle(this.props.theme);
        const post = this.props.post;

        const formattedText = PostUtils.formatText(post.message); // format the text

        return (
            <div
                style={{...style.container}}
            >
                {'Formatted text: '}
                {PostUtils.messageHtmlToComponent(formattedText)} // convert the html to components
            </div>
        );
    }
}
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9766
