### PR TITLE
MM-9814 Fix/change element IDs of SettingItemMin and SettingItemMax for end-to-end testing

### DIFF
--- a/components/channel_notifications_modal/components/collapse_view.jsx
+++ b/components/channel_notifications_modal/components/collapse_view.jsx
@@ -21,6 +21,7 @@ export default function CollapseView({onExpandSection, globalNotifyLevel, member
                 />
             }
             updateSection={onExpandSection}
+            section={section}
         />
     );
 }

--- a/components/setting_item_max.jsx
+++ b/components/setting_item_max.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import SaveButton from 'components/save_button.jsx';
 import Constants from 'utils/constants.jsx';
-import * as Utils from 'utils/utils.jsx';
+import {isKeyPressed} from 'utils/utils.jsx';
 
 export default class SettingItemMax extends React.PureComponent {
     static defaultProps = {
@@ -98,7 +98,7 @@ export default class SettingItemMax extends React.PureComponent {
     }
 
     onKeyDown = (e) => {
-        if (Utils.isKeyPressed(e, Constants.KeyCodes.ENTER) && this.props.submit) {
+        if (isKeyPressed(e, Constants.KeyCodes.ENTER) && this.props.submit) {
             this.handleSubmit(e);
         }
     }
@@ -179,10 +179,8 @@ export default class SettingItemMax extends React.PureComponent {
         }
 
         let title;
-        let titleProp = 'unknownTitle';
         if (this.props.title) {
             title = <li className='col-sm-12 section-title'>{this.props.title}</li>;
-            titleProp = this.props.title;
         }
 
         let listContent = (
@@ -226,7 +224,7 @@ export default class SettingItemMax extends React.PureComponent {
                             {clientError}
                             {submit}
                             <button
-                                id={Utils.createSafeId(titleProp) + 'Cancel'}
+                                id={'cancelSetting'}
                                 className='btn btn-sm cursor--pointer style--none'
                                 onClick={this.handleUpdateSection}
                             >

--- a/components/setting_item_min.jsx
+++ b/components/setting_item_min.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import * as Utils from 'utils/utils.jsx';
+import {isMobile} from 'utils/utils.jsx';
 
 export default class SettingItemMin extends React.PureComponent {
     static defaultProps = {
@@ -71,11 +71,11 @@ export default class SettingItemMin extends React.PureComponent {
         let editButton = null;
         let describeSection = null;
 
-        if (!this.props.disableOpen && Utils.isMobile()) {
+        if (!this.props.disableOpen && isMobile()) {
             editButton = (
                 <li className='col-xs-12 col-sm-3 section-edit'>
                     <button
-                        id={Utils.createSafeId(this.props.title) + 'Edit'}
+                        id={this.props.section + 'Edit'}
                         className='color--link cursor--pointer style--none'
                         onClick={this.handleUpdateSection}
                         ref={this.getEdit}
@@ -89,7 +89,7 @@ export default class SettingItemMin extends React.PureComponent {
             editButton = (
                 <li className='col-xs-12 col-sm-3 section-edit'>
                     <button
-                        id={Utils.createSafeId(this.props.title) + 'Edit'}
+                        id={this.props.section + 'Edit'}
                         className='color--link cursor--pointer style--none text-left'
                         onClick={this.handleUpdateSection}
                         ref={this.getEdit}
@@ -105,7 +105,7 @@ export default class SettingItemMin extends React.PureComponent {
 
             describeSection = (
                 <li
-                    id={Utils.createSafeId(this.props.title) + 'Desc'}
+                    id={this.props.section + 'Desc'}
                     className='col-xs-12 section-describe'
                 >
                     {this.props.describe}
@@ -119,7 +119,7 @@ export default class SettingItemMin extends React.PureComponent {
                 onClick={this.handleUpdateSection}
             >
                 <li
-                    id={Utils.createSafeId(this.props.title) + 'Title'}
+                    id={this.props.section + 'Title'}
                     className='col-xs-12 col-sm-9 section-title'
                 >
                     {this.props.title}

--- a/tests/components/__snapshots__/setting_item_max.test.jsx.snap
+++ b/tests/components/__snapshots__/setting_item_max.test.jsx.snap
@@ -35,7 +35,7 @@ exports[`components/SettingItemMin should match snapshot 1`] = `
         />
         <button
           className="btn btn-sm cursor--pointer style--none"
-          id="titleCancel"
+          id="cancelSetting"
           onClick={[Function]}
         >
           <FormattedMessage
@@ -95,7 +95,7 @@ exports[`components/SettingItemMin should match snapshot, on clientError 1`] = `
         />
         <button
           className="btn btn-sm cursor--pointer style--none"
-          id="titleCancel"
+          id="cancelSetting"
           onClick={[Function]}
         >
           <FormattedMessage
@@ -155,7 +155,7 @@ exports[`components/SettingItemMin should match snapshot, on serverError 1`] = `
         />
         <button
           className="btn btn-sm cursor--pointer style--none"
-          id="titleCancel"
+          id="cancelSetting"
           onClick={[Function]}
         >
           <FormattedMessage
@@ -196,7 +196,7 @@ exports[`components/SettingItemMin should match snapshot, without submit 1`] = `
         <hr />
         <button
           className="btn btn-sm cursor--pointer style--none"
-          id="titleCancel"
+          id="cancelSetting"
           onClick={[Function]}
         >
           <FormattedMessage

--- a/tests/components/__snapshots__/setting_item_min.test.jsx.snap
+++ b/tests/components/__snapshots__/setting_item_min.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`components/SettingItemMin should match snapshot 1`] = `
 >
   <li
     className="col-xs-12 col-sm-9 section-title"
-    id="titleTitle"
+    id="sectionTitle"
   >
     title
   </li>
@@ -16,7 +16,7 @@ exports[`components/SettingItemMin should match snapshot 1`] = `
   >
     <button
       className="color--link cursor--pointer style--none text-left"
-      id="titleEdit"
+      id="sectionEdit"
       onClick={[Function]}
     >
       <i
@@ -31,7 +31,7 @@ exports[`components/SettingItemMin should match snapshot 1`] = `
   </li>
   <li
     className="col-xs-12 section-describe"
-    id="titleDesc"
+    id="sectionDesc"
   >
     describe
   </li>
@@ -45,7 +45,7 @@ exports[`components/SettingItemMin should match snapshot, on disableOpen to true
 >
   <li
     className="col-xs-12 col-sm-9 section-title"
-    id="titleTitle"
+    id="sectionTitle"
   >
     title
   </li>

--- a/tests/components/channel_notifications_modal/__snapshots__/collapse_view.test.jsx.snap
+++ b/tests/components/channel_notifications_modal/__snapshots__/collapse_view.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`components/channel_notifications_modal/CollapseView should match snapsh
     />
   }
   focused={false}
-  section=""
+  section="desktop"
   title={
     <SectionTitle
       section="desktop"
@@ -30,7 +30,7 @@ exports[`components/channel_notifications_modal/CollapseView should match snapsh
     />
   }
   focused={false}
-  section=""
+  section="markUnread"
   title={
     <SectionTitle
       section="markUnread"
@@ -50,7 +50,7 @@ exports[`components/channel_notifications_modal/CollapseView should match snapsh
     />
   }
   focused={false}
-  section=""
+  section="push"
   title={
     <SectionTitle
       section="push"

--- a/tests/components/channel_notifications_modal/__snapshots__/expand_view.test.jsx.snap
+++ b/tests/components/channel_notifications_modal/__snapshots__/expand_view.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`components/channel_notifications_modal/ExpandView should match snapshot
     />
   }
   focused={false}
-  section=""
+  section="desktop"
   title={
     <SectionTitle
       section="desktop"
@@ -29,7 +29,7 @@ exports[`components/channel_notifications_modal/ExpandView should match snapshot
     />
   }
   focused={false}
-  section=""
+  section="markUnread"
   title={
     <SectionTitle
       section="markUnread"
@@ -48,7 +48,7 @@ exports[`components/channel_notifications_modal/ExpandView should match snapshot
     />
   }
   focused={false}
-  section=""
+  section="push"
   title={
     <SectionTitle
       section="push"

--- a/tests/components/user_settings/__snapshots__/email_notification_setting.test.jsx.snap
+++ b/tests/components/user_settings/__snapshots__/email_notification_setting.test.jsx.snap
@@ -237,7 +237,7 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
             </SaveButton>
             <button
               className="btn btn-sm cursor--pointer style--none"
-              id="Email_notificationsCancel"
+              id="cancelSetting"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -661,7 +661,7 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
             </SaveButton>
             <button
               className="btn btn-sm cursor--pointer style--none"
-              id="Email_notificationsCancel"
+              id="cancelSetting"
               onClick={[Function]}
             >
               <FormattedMessage


### PR DESCRIPTION
#### Summary
Fix/change element IDs of SettingItemMin and SettingItemMax for end-to-end testing

@lindalumitchell This will definitely break current selenium tests due to changes on IDs but I think we'll have this permanently moving forward. 

Please note of the changes on IDs:
1. (SettingItemMax) Expanded settings’ view, selector IDs are:
- `saveSetting` button 
- `cancelSetting` button

2. (SettingItemMin) Collapsed settings’ view, selector IDs are:
- {section name} + `Edit` 
- {section name} + `Title` 
- {section name} + `Desc` 

(Note: I'll send separate PR to fix test on yarn test:e2e)

#### Ticket Link
Jira ticket: [MM-9814](https://mattermost.atlassian.net/browse/MM-9814)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
