### PR TITLE
If experimental auth change setting isn't set, default to on

### DIFF
--- a/components/user_settings/security/index.js
+++ b/components/user_settings/security/index.js
@@ -28,7 +28,7 @@ function mapStateToProps(state, ownProps) {
     const enableLdap = config.EnableLdap === 'true';
     const enableSaml = config.EnableSaml === 'true';
     const enableSignUpWithOffice365 = config.EnableSignUpWithOffice365 === 'true';
-    const experimentalEnableAuthenticationTransfer = config.ExperimentalEnableAuthenticationTransfer === 'true';
+    const experimentalEnableAuthenticationTransfer = config.ExperimentalEnableAuthenticationTransfer !== 'false';
 
     return {
         userAccessTokens: state.entities.users.myUserAccessTokens,


### PR DESCRIPTION
#### Summary
Proposing for 4.8

This would prevent a user from changing sign-in method if this setting wasn't set (when there is no license for example).

~~A casualty of the config changes and not having defaults set for some settings in non-licensed servers.~~