### PR TITLE
MM-9845: Moves event handlers back to img tag.

### DIFF
--- a/components/emoji_picker/components/emoji_picker_item.jsx
+++ b/components/emoji_picker/components/emoji_picker_item.jsx
@@ -70,31 +70,30 @@ export default class EmojiPickerItem extends React.Component {
         spriteClassName += ' emoji-' + emoji.filename;
 
         let image;
-        let handleMouseOver;
         if (emoji.category && emoji.batch) {
             image = (
                 <img
+                    onMouseOver={this.handleMouseOverThrottle}
                     src='/static/images/img_trans.gif'
                     className={spriteClassName}
+                    onClick={this.handleClick}
                 />
             );
-            handleMouseOver = this.handleMouseOverThrottle;
         } else {
             image = (
                 <img
+                    onMouseOver={this.handleMouseOver}
                     src={EmojiStore.getEmojiImageUrl(emoji)}
                     className={'emoji-category--custom'}
+                    onClick={this.handleClick}
                 />
             );
-            handleMouseOver = this.handleMouseOver;
         }
 
         return (
             <div
                 className={itemClassName}
                 ref={this.emojiItemRef}
-                onMouseOver={handleMouseOver}
-                onClick={this.handleClick}
             >
                 <div>
                     {image}


### PR DESCRIPTION
#### Summary
Some event handlers in https://github.com/mattermost/mattermost-webapp/commit/e3ecc5625753653b7696165d58bea7b50938c705 were moved form the `img` to the `div` tag and that caused the scroll to trigger on hover when the image wasn't in view, and also cause a JS error on click.

#### Ticket Link
[MM-9845](https://mattermost.atlassian.net/browse/MM-9845)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed