### PR TITLE
Update mattermost-redux to latest webapp-4.8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5582,7 +5582,7 @@ math-expression-evaluator@^1.2.14:
 
 mattermost-redux@mattermost/mattermost-redux#webapp-4.8:
   version "1.2.0"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/3cbf86c6be6bb91cb893fdeabaa0bc5977d4fc71"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/12705c723514251bea165f79a87e7dd30f98df4b"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"


### PR DESCRIPTION
#### Summary

Simply update the last version of mattermost-redux to use in the webapp (fixes a problem with IOS classic app).