### PR TITLE
[MM-9783] Fix file upload removal by setting intl as context types instead of props to easily access component via ref

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -431,8 +431,8 @@ export default class CreateComment extends React.PureComponent {
             if (index !== -1) {
                 uploadsInProgress.splice(index, 1);
 
-                if (this.refs.fileUpload && this.refs.fileUpload.getWrappedInstance().refs.FileUpload) {
-                    this.refs.fileUpload.getWrappedInstance().refs.FileUpload.getWrappedInstance().cancelUpload(id);
+                if (this.refs.fileUpload && this.refs.fileUpload.getWrappedInstance()) {
+                    this.refs.fileUpload.getWrappedInstance().cancelUpload(id);
                 }
             }
         } else {

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -536,8 +536,8 @@ export default class CreatePost extends React.Component {
                     uploadsInProgress,
                 };
 
-                if (this.refs.fileUpload && this.refs.fileUpload.getWrappedInstance().refs.FileUpload) {
-                    this.refs.fileUpload.getWrappedInstance().refs.FileUpload.getWrappedInstance().cancelUpload(id);
+                if (this.refs.fileUpload && this.refs.fileUpload.getWrappedInstance()) {
+                    this.refs.fileUpload.getWrappedInstance().cancelUpload(id);
                 }
             }
         } else {

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -5,7 +5,7 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
 import ReactDOM from 'react-dom';
-import {defineMessages, injectIntl, intlShape} from 'react-intl';
+import {defineMessages, intlShape} from 'react-intl';
 import 'jquery-dragster/jquery.dragster.js';
 
 import Constants from 'utils/constants.jsx';
@@ -47,18 +47,13 @@ const holders = defineMessages({
 
 const OVERLAY_TIMEOUT = 500;
 
-class FileUpload extends PureComponent {
+export default class FileUpload extends PureComponent {
     static propTypes = {
 
         /**
          * Current channel's ID
          */
         currentChannelId: PropTypes.string.isRequired,
-
-        /**
-         * react-intl helper object
-         */
-        intl: intlShape.isRequired,
 
         /**
          * Number of files to attach
@@ -114,6 +109,10 @@ class FileUpload extends PureComponent {
          * Whether or not file upload is allowed.
          */
         canUploadFiles: PropTypes.bool.isRequired,
+    };
+
+    static contextTypes = {
+        intl: intlShape,
     };
 
     constructor(props) {
@@ -208,7 +207,7 @@ class FileUpload extends PureComponent {
 
         this.props.onUploadStart(clientIds, currentChannelId);
 
-        const {formatMessage} = this.props.intl;
+        const {formatMessage} = this.context.intl;
         if (sortedFiles.length > uploadsRemaining) {
             this.props.onUploadError(formatMessage(holders.limited, {count: Constants.MAX_UPLOAD_FILES}));
         } else if (tooLargeFiles.length > 1) {
@@ -302,7 +301,7 @@ class FileUpload extends PureComponent {
     }
 
     pasteUpload = (e) => {
-        const {formatMessage} = this.props.intl;
+        const {formatMessage} = this.context.intl;
 
         if (!e.clipboardData || !e.clipboardData.items) {
             return;
@@ -422,7 +421,8 @@ class FileUpload extends PureComponent {
     handleMaxUploadReached = (e) => {
         e.preventDefault();
 
-        const {onUploadError, intl: {formatMessage}} = this.props;
+        const {onUploadError} = this.props;
+        const {formatMessage} = this.context.intl;
 
         onUploadError(formatMessage(holders.limited, {count: Constants.MAX_UPLOAD_FILES}));
     }
@@ -468,5 +468,3 @@ class FileUpload extends PureComponent {
         );
     }
 }
-
-export default injectIntl(FileUpload, {withRef: true});

--- a/tests/components/create_comment/__snapshots__/create_comment.test.jsx.snap
+++ b/tests/components/create_comment/__snapshots__/create_comment.test.jsx.snap
@@ -126,7 +126,7 @@ exports[`components/CreateComment should match snapshot, comment with message 1`
         <span
           className="post-body__actions"
         >
-          <Connect(InjectIntl(FileUpload))
+          <Connect(FileUpload)
             fileCount={0}
             getTarget={[Function]}
             onFileUpload={[Function]}
@@ -246,7 +246,7 @@ exports[`components/CreateComment should match snapshot, emoji picker disabled 1
         <span
           className="post-body__actions"
         >
-          <Connect(InjectIntl(FileUpload))
+          <Connect(FileUpload)
             fileCount={3}
             getTarget={[Function]}
             onFileUpload={[Function]}
@@ -358,7 +358,7 @@ exports[`components/CreateComment should match snapshot, empty comment 1`] = `
         <span
           className="post-body__actions"
         >
-          <Connect(InjectIntl(FileUpload))
+          <Connect(FileUpload)
             fileCount={0}
             getTarget={[Function]}
             onFileUpload={[Function]}
@@ -478,7 +478,7 @@ exports[`components/CreateComment should match snapshot, non-empty message and u
         <span
           className="post-body__actions"
         >
-          <Connect(InjectIntl(FileUpload))
+          <Connect(FileUpload)
             fileCount={4}
             getTarget={[Function]}
             onFileUpload={[Function]}

--- a/tests/components/create_post/__snapshots__/create_post.test.jsx.snap
+++ b/tests/components/create_post/__snapshots__/create_post.test.jsx.snap
@@ -36,7 +36,7 @@ exports[`components/create_post should match snapshot for center textbox 1`] = `
         <span
           className="post-body__actions"
         >
-          <Connect(InjectIntl(FileUpload))
+          <Connect(FileUpload)
             fileCount={0}
             getTarget={[Function]}
             onFileUpload={[Function]}
@@ -256,7 +256,7 @@ exports[`components/create_post should match snapshot when file upload disabled 
         <span
           className="post-body__actions"
         >
-          <Connect(InjectIntl(FileUpload))
+          <Connect(FileUpload)
             fileCount={0}
             getTarget={[Function]}
             onFileUpload={[Function]}
@@ -380,7 +380,7 @@ exports[`components/create_post should match snapshot, init 1`] = `
         <span
           className="post-body__actions"
         >
-          <Connect(InjectIntl(FileUpload))
+          <Connect(FileUpload)
             fileCount={0}
             getTarget={[Function]}
             onFileUpload={[Function]}

--- a/tests/components/file_upload/__snapshots__/file_upload.test.jsx.snap
+++ b/tests/components/file_upload/__snapshots__/file_upload.test.jsx.snap
@@ -1,43 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/FileUpload should match snapshot 1`] = `
-<FileUpload
-  canUploadFiles={true}
-  currentChannelId="channel_id"
-  fileCount={1}
-  getTarget={[Function]}
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "textComponent": "span",
-    }
-  }
-  maxFileSize={10}
-  onClick={[Function]}
-  onFileUpload={[Function]}
-  onFileUploadChange={[Function]}
-  onUploadError={[Function]}
-  onUploadStart={[Function]}
-  postType="post"
-  uploadFile={[Function]}
-/>
+<span
+  className=""
+>
+  <div
+    className="icon icon--attachment"
+    id="fileUploadButton"
+  >
+    <AttachmentIcon />
+    <input
+      accept=""
+      multiple={true}
+      onChange={[Function]}
+      onClick={[Function]}
+      type="file"
+    />
+  </div>
+</span>
 `;

--- a/tests/components/file_upload/file_upload.test.jsx
+++ b/tests/components/file_upload/file_upload.test.jsx
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import React from 'react';
+import {shallow} from 'enzyme';
 
 import {clearFileInput} from 'utils/utils';
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
@@ -49,7 +50,7 @@ describe('components/FileUpload', () => {
     };
 
     test('should match snapshot', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <FileUpload {...baseProps}/>
         );
 
@@ -60,11 +61,11 @@ describe('components/FileUpload', () => {
         const onClick = jest.fn();
         const props = {...baseProps, onClick};
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <FileUpload {...props}/>
         );
 
-        wrapper.props().onClick();
+        wrapper.find('input').simulate('click');
         expect(onClick).toHaveBeenCalledTimes(1);
     });
 
@@ -76,12 +77,11 @@ describe('components/FileUpload', () => {
             client_ids: {id1: 'id1'},
         };
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <FileUpload {...props}/>
         );
 
-        const instance = wrapper.dive().instance();
-        instance.fileUploadSuccess(data);
+        wrapper.instance().fileUploadSuccess(data);
 
         expect(onFileUpload).toHaveBeenCalledTimes(1);
         expect(onFileUpload).toHaveBeenCalledWith(data.file_infos, data.client_ids, props.currentChannelId);
@@ -95,12 +95,11 @@ describe('components/FileUpload', () => {
             clientId: 'client_id',
         };
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <FileUpload {...props}/>
         );
 
-        const instance = wrapper.dive().instance();
-        instance.fileUploadFail(params.err, params.clientId);
+        wrapper.instance().fileUploadFail(params.err, params.clientId);
 
         expect(onUploadError).toHaveBeenCalledTimes(1);
         expect(onUploadError).toHaveBeenCalledWith(params.err, params.clientId, props.currentChannelId);
@@ -117,8 +116,7 @@ describe('components/FileUpload', () => {
             <FileUpload {...props}/>
         );
 
-        const instance = wrapper.dive().instance();
-        instance.uploadFiles(files);
+        wrapper.instance().uploadFiles(files);
 
         expect(uploadFile).toHaveBeenCalledTimes(2);
 
@@ -141,8 +139,7 @@ describe('components/FileUpload', () => {
             <FileUpload {...props}/>
         );
 
-        const instance = wrapper.dive().instance();
-        instance.uploadFiles(files);
+        wrapper.instance().uploadFiles(files);
 
         expect(uploadFile).not.toBeCalled();
 
@@ -164,8 +161,7 @@ describe('components/FileUpload', () => {
             <FileUpload {...props}/>
         );
 
-        const instance = wrapper.dive().instance();
-        instance.uploadFiles(files);
+        wrapper.instance().uploadFiles(files);
 
         expect(uploadFile).not.toBeCalled();
 
@@ -186,8 +182,7 @@ describe('components/FileUpload', () => {
             <FileUpload {...props}/>
         );
 
-        const instance = wrapper.dive().instance();
-        instance.uploadFiles(files);
+        wrapper.instance().uploadFiles(files);
 
         expect(uploadFile).not.toBeCalled();
 
@@ -201,12 +196,12 @@ describe('components/FileUpload', () => {
         const onFileUploadChange = jest.fn();
         const props = {...baseProps, onFileUploadChange};
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <FileUpload {...props}/>
         );
 
         const e = {target: {files: [{name: 'file1.pdf'}]}};
-        const instance = wrapper.dive().instance();
+        const instance = wrapper.instance();
         instance.uploadFiles = jest.fn();
         instance.handleChange(e);
 
@@ -225,12 +220,12 @@ describe('components/FileUpload', () => {
         const onFileUploadChange = jest.fn();
         const props = {...baseProps, onUploadError, onFileUploadChange};
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <FileUpload {...props}/>
         );
 
         const e = {originalEvent: {dataTransfer: {files: [{name: 'file1.pdf'}]}}};
-        const instance = wrapper.dive().instance();
+        const instance = wrapper.instance();
         instance.uploadFiles = jest.fn();
         instance.handleDrop(e);
 


### PR DESCRIPTION
#### Summary
Fix file upload removal by setting `intl` as context types instead of props to easily access component via ref

#### Ticket Link
Jira ticket: [MM-9783](https://mattermost.atlassian.net/browse/MM-9783)

Looks like my initial attempt to solve the issue only fixed the JS error but not actually able to cancel on going file upload. It turned out that to access the `cancelUpload` function, I need to do it like so:
```
this.refs.fileUpload.wrappedInstance.refs.FileUpload.wrappedInstance.cancelUpload(id)
```

However, it's already too deep to access and will require validation to every object's member. To solve it, I set `intl` as context type instead of wrapping the component with `injectIntl` which eventually receive `intl` via props.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
