### PR TITLE
Update help text for Google API Key

### DIFF
--- a/components/admin_console/external_service_settings.jsx
+++ b/components/admin_console/external_service_settings.jsx
@@ -54,7 +54,7 @@ export default class ExternalServiceSettings extends AdminSettings {
                     helpText={
                         <FormattedHTMLMessage
                             id='admin.service.googleDescription'
-                            defaultMessage='Set this key to enable the display of titles for embedded YouTube video previews. Without the key, YouTube previews will still be created based on hyperlinks appearing in messages or comments but they will not show the video title. View a <a href="https://www.youtube.com/watch?v=Im69kzhpR3I" target="_blank">Google Developers Tutorial</a> for instructions on how to obtain a key.'
+                            defaultMessage='Set this key to enable the display of titles for embedded YouTube video previews. Without the key, YouTube previews will still be created based on hyperlinks appearing in messages or comments but they will not show the video title. View a <a href="https://www.youtube.com/watch?v=Im69kzhpR3I" target="_blank">Google Developers Tutorial</a> for instructions on how to obtain a key and add YouTube Data API v3 as a service to your key.'
                         />
                     }
                     value={this.state.googleDeveloperKey}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -902,7 +902,7 @@
   "admin.service.enforceMfaTitle": "Enforce Multi-factor Authentication:",
   "admin.service.forward80To443": "Forward port 80 to 443:",
   "admin.service.forward80To443Description": "Forwards all insecure traffic from port 80 to secure port 443",
-  "admin.service.googleDescription": "Set this key to enable the display of titles for embedded YouTube video previews. Without the key, YouTube previews will still be created based on hyperlinks appearing in messages or comments but they will not show the video title. View a <a href=\"https://www.youtube.com/watch?v=Im69kzhpR3I\" target='_blank'>Google Developers Tutorial</a> for instructions on how to obtain a key.",
+  "admin.service.googleDescription": "Set this key to enable the display of titles for embedded YouTube video previews. Without the key, YouTube previews will still be created based on hyperlinks appearing in messages or comments but they will not show the video title. View a <a href=\"https://www.youtube.com/watch?v=Im69kzhpR3I\" target='_blank'>Google Developers Tutorial</a> for instructions on how to obtain a key and add YouTube Data API v3 as a service to your key.",
   "admin.service.googleExample": "E.g.: \"7rAh6iwQCkV4cA1Gsg3fgGOXJAQ43QV\"",
   "admin.service.googleTitle": "Google API Key:",
   "admin.service.iconDescription": "When true, webhooks, slash commands and other integrations, such as <a href=\"https://docs.mattermost.com/integrations/zapier.html\" target='_blank'>Zapier</a>, will be allowed to change the profile picture they post with. Note: Combined with allowing integrations to override usernames, users may be able to perform phishing attacks by attempting to impersonate other users.",


### PR DESCRIPTION
#### Summary
A Mattermost server had broken YouTube videos for months because it wasn't clear YouTube Data API v3 needs to be added as a service to the Google API Key

Doc update: https://github.com/mattermost/docs/commit/c72755cb60ff67740c1a49c5d0b6df216ebeb03f

#### Checklist
- [X] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
