### PR TITLE
Updating mattermost-redux in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5590,7 +5590,7 @@ math-expression-evaluator@^1.2.14:
 
 mattermost-redux@mattermost/mattermost-redux:
   version "1.2.0"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/c18630944852b7cf85a483ba5aace7d93ddc785e"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/654708cc1bd2962758e197479a62200ea4d41852"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"


### PR DESCRIPTION
Using the last commit of mattermost-redux as commit to get mattermost-redux in yarn.lock