### PR TITLE
MM-9712: ignore typing after ref unassigned

### DIFF
--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -47,37 +47,37 @@ export default class QuickInput extends React.PureComponent {
         if (UserAgent.isWindows7() && UserAgent.isInternetExplorer()) {
             // The textbox already knows where it's cursor is supposed to be because we've already
             // typed in it, but it needs to be reminded of that
-            const caret = Utils.getCaretPosition(this.refs.input);
+            const caret = Utils.getCaretPosition(this.input);
 
-            this.refs.input.value = this.props.value;
+            this.input.value = this.props.value;
 
-            this.refs.input.selectionStart = caret;
-            this.refs.input.selectionEnd = this.refs.input.selectionStart;
+            this.input.selectionStart = caret;
+            this.input.selectionEnd = this.input.selectionStart;
 
             return;
         }
 
-        this.refs.input.value = this.props.value;
+        this.input.value = this.props.value;
     }
 
     get value() {
-        return this.refs.input.value;
+        return this.input.value;
     }
 
     set value(value) {
-        this.refs.input.value = value;
+        this.input.value = value;
     }
 
     focus() {
-        this.refs.input.focus();
+        this.input.focus();
     }
 
     blur() {
-        this.refs.input.blur();
+        this.input.blur();
     }
 
     getInput = () => {
-        return this.refs.input;
+        return this.input;
     };
 
     render() {
@@ -89,7 +89,9 @@ export default class QuickInput extends React.PureComponent {
             inputComponent || 'input',
             {
                 ...props,
-                ref: 'input',
+                ref: (input) => {
+                    this.input = input;
+                },
                 defaultValue: value, // Only set the defaultValue since the real one will be updated using componentDidUpdate
             }
         );

--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -84,6 +84,10 @@ export default class QuickInput extends React.PureComponent {
         return this.input;
     };
 
+    setInput = (input) => {
+        this.input = input;
+    }
+
     render() {
         const {value, inputComponent, ...props} = this.props;
 
@@ -93,9 +97,7 @@ export default class QuickInput extends React.PureComponent {
             inputComponent || 'input',
             {
                 ...props,
-                ref: (input) => {
-                    this.input = input;
-                },
+                ref: this.setInput,
                 defaultValue: value, // Only set the defaultValue since the real one will be updated using componentDidUpdate
             }
         );

--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -44,6 +44,10 @@ export default class QuickInput extends React.PureComponent {
     }
 
     updateInputFromProps = () => {
+        if (!this.input) {
+            return;
+        }
+
         if (UserAgent.isWindows7() && UserAgent.isInternetExplorer()) {
             // The textbox already knows where it's cursor is supposed to be because we've already
             // typed in it, but it needs to be reminded of that


### PR DESCRIPTION
#### Summary
The quick input `componentDidUpdate` uses `requestAnimationFrame` when `this.props.delayInputUpdate`, but this opens up the possibility that the component has unmounted by the time we `updateInputFromProps`. Check for same.

This PR also switches to the callback form to assign the ref.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9712

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed