### PR TITLE
Missing short_name properties in web app manifest

### DIFF
--- a/config/manifest.json
+++ b/config/manifest.json
@@ -1,5 +1,6 @@
 {
     "name": "Mattermost",
+    "short_name": "Mattermost",
     "description": "Mattermost is an open source, self-hosted Slack-alternative",
     "icons": [{
         "src": "/static/images/favicon/android-chrome-192x192.png",


### PR DESCRIPTION
#### Summary
Google [recommends](https://developers.google.com/web/tools/lighthouse/audits/install-prompt) having a valid `short_name` property in the manifest.

(We are missing other recommended properties but this is a first step.)

#### Ticket Link
Sorry for not opening a ticket first but this is a really small change.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
