### PR TITLE
MM-9806 Remove unneeded URL replacement

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -179,14 +179,6 @@ export default class Sidebar extends React.PureComponent {
         }
 
         this.updateTitle();
-
-        if (this.props.currentChannel.type === Constants.DM_CHANNEL &&
-            this.props.currentTeammate && prevProps.currentTeammate &&
-            this.props.currentTeammate.display_name !== prevProps.currentTeammate.display_name
-        ) {
-            window.history.replaceState(null, null, `/${this.props.currentTeam.name}/messages/@${this.props.currentTeammate.display_name}`);
-        }
-
         this.setBadgesActiveAndFavicon();
         this.setFirstAndLastUnreadChannels();
     }


### PR DESCRIPTION
#### Summary
We didn't need this code, changing the URL in the address bar is handled by react-router. It was also changing the URL to the unsupported `/messages/(at){full_name}` when it should be `/messages/(at){username}`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9806