### PR TITLE
MM-9846 Not try to reply when the root message is deleted

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -41,6 +41,11 @@ export default class CreateComment extends React.PureComponent {
         rootId: PropTypes.string.isRequired,
 
         /**
+         * True if the root message was deleted
+         */
+        rootDeleted: PropTypes.bool.isRequired,
+
+        /**
          * The current history message selected
          */
         messageInHistory: PropTypes.string,
@@ -278,6 +283,11 @@ export default class CreateComment extends React.PureComponent {
             setTimeout(() => {
                 this.setState({errorClass: null});
             }, Constants.ANIMATION_TIMEOUT);
+            return;
+        }
+
+        if (this.props.rootDeleted) {
+            this.showPostDeletedModal();
             return;
         }
 

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -6,6 +6,7 @@ import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Scrollbars from 'react-custom-scrollbars';
+import {Posts} from 'mattermost-redux/constants';
 
 import PreferenceStore from 'stores/preference_store.jsx';
 import UserStore from 'stores/user_store.jsx';
@@ -390,6 +391,7 @@ export default class RhsThread extends React.Component {
                     <CreateComment
                         channelId={selected.channel_id}
                         rootId={selected.id}
+                        rootDeleted={selected.state === Posts.POST_DELETED}
                         latestPostId={postsLength > 0 ? postsArray[postsLength - 1].id : selected.id}
                         getSidebarBody={this.getSidebarBody}
                     />


### PR DESCRIPTION
#### Summary
When you try to reply to a deleted message, we were sending the reply to the
server, and getting an error to show a modal about it. Now, because we know
that the message is already deleted, we show the modal directly without sending
anything to the server.

This behavior have the edge case where you send the reply before the app know
that the message was deleted in the server. In that case the behavior is the
same as before, wait until the server error and show the modal. That cases are
unusual, and we haven't another good solution for this.

#### Ticket Link
[MM-9846](https://mattermost.atlassian.net/browse/MM-9846)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed