### PR TITLE
[MM-9844] Make site description (config.CustomDescriptionText) not dependent from config.EnableCustomBrand

### DIFF
--- a/components/admin_console/custom_brand_settings.jsx
+++ b/components/admin_console/custom_brand_settings.jsx
@@ -14,18 +14,14 @@ import SettingsGroup from './settings_group.jsx';
 import TextSetting from './text_setting.jsx';
 
 export default class CustomBrandSettings extends AdminSettings {
-    constructor(props) {
-        super(props);
-
-        this.getConfigFromState = this.getConfigFromState.bind(this);
-
-        this.renderSettings = this.renderSettings.bind(this);
-    }
-
     getConfigFromState(config) {
         config.TeamSettings.SiteName = this.state.siteName;
+
+        if (this.props.license.IsLicensed === 'true') {
+            config.TeamSettings.CustomDescriptionText = this.state.customDescriptionText;
+        }
+
         if (this.props.license.IsLicensed === 'true' && this.props.license.CustomBrand === 'true') {
-            config.TeamSettings.customDescriptionText = this.state.customDescriptionText;
             config.TeamSettings.EnableCustomBrand = this.state.enableCustomBrand;
             config.TeamSettings.CustomBrandText = this.state.customBrandText;
         }

--- a/components/common/site_name_and_description.jsx
+++ b/components/common/site_name_and_description.jsx
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+export default class SiteNameAndDescription extends React.PureComponent {
+    static propTypes = {
+
+        /**
+         * Custom description of the site
+         */
+        customDescriptionText: PropTypes.string,
+
+        /**
+         * Set to true if instance is licensed; false as default
+         */
+        isLicensed: PropTypes.bool,
+
+        /**
+         * Site name; "Mattermost" as default
+         */
+        siteName: PropTypes.string,
+    };
+
+    static defaultProps = {
+        isLicensed: false,
+        siteName: 'Mattermost',
+    };
+
+    render() {
+        const {
+            customDescriptionText,
+            isLicensed,
+            siteName,
+        } = this.props;
+        let description = null;
+        if (isLicensed && customDescriptionText) {
+            description = customDescriptionText;
+        } else {
+            description = (
+                <FormattedMessage
+                    id='web.root.signup_info'
+                    defaultMessage='All team communication in one place, searchable and accessible anywhere'
+                />
+            );
+        }
+
+        return (
+            <React.Fragment>
+                <h1>{siteName}</h1>
+                <h4 className='color--light'>
+                    {description}
+                </h4>
+            </React.Fragment>
+        );
+    }
+}

--- a/components/common/site_name_and_description.jsx
+++ b/components/common/site_name_and_description.jsx
@@ -7,20 +7,8 @@ import {FormattedMessage} from 'react-intl';
 
 export default class SiteNameAndDescription extends React.PureComponent {
     static propTypes = {
-
-        /**
-         * Custom description of the site
-         */
         customDescriptionText: PropTypes.string,
-
-        /**
-         * Set to true if instance is licensed; false as default
-         */
         isLicensed: PropTypes.bool,
-
-        /**
-         * Site name; "Mattermost" as default
-         */
         siteName: PropTypes.string,
     };
 

--- a/components/create_team/create_team.jsx
+++ b/components/create_team/create_team.jsx
@@ -8,7 +8,7 @@ import {Route, Switch, Redirect} from 'react-router-dom';
 import AnnouncementBar from 'components/announcement_bar';
 import BackButton from 'components/common/back_button.jsx';
 import DisplayName from 'components/create_team/components/display_name';
-import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
+import SiteNameAndDescription from 'components/common/site_name_and_description';
 import TeamUrl from 'components/create_team/components/team_url';
 
 export default class CreateTeam extends React.PureComponent {

--- a/components/create_team/create_team.jsx
+++ b/components/create_team/create_team.jsx
@@ -3,14 +3,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
 import {Route, Switch, Redirect} from 'react-router-dom';
 
 import AnnouncementBar from 'components/announcement_bar';
 import BackButton from 'components/common/back_button.jsx';
-
-import TeamUrl from 'components/create_team/components/team_url';
 import DisplayName from 'components/create_team/components/display_name';
+import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
+import TeamUrl from 'components/create_team/components/team_url';
 
 export default class CreateTeam extends React.PureComponent {
     static propTypes = {
@@ -29,16 +28,6 @@ export default class CreateTeam extends React.PureComponent {
          * Boolean value that determines whether server has a valid Enterprise license
          */
         isLicensed: PropTypes.bool.isRequired,
-
-        /*
-         * Boolean value that determines whether license supports custom branding
-         */
-        customBrand: PropTypes.bool.isRequired,
-
-        /*
-         * Boolean value that determines whether the custom brand feature has been enabled
-         */
-        enableCustomBrand: PropTypes.bool.isRequired,
 
         /*
          * String containing the custom branding's text
@@ -66,25 +55,20 @@ export default class CreateTeam extends React.PureComponent {
     }
 
     render() {
-        let description = null;
-        if (this.props.isLicensed && this.props.customBrand && this.props.enableCustomBrand) {
-            description = this.props.customDescriptionText;
-        } else {
-            description = (
-                <FormattedMessage
-                    id='web.root.signup_info'
-                    defaultMessage='All team communication in one place, searchable and accessible anywhere'
-                />
-            );
-        }
+        const {
+            currentChannel,
+            currentTeam,
+            customDescriptionText,
+            isLicensed,
+            match,
+            siteName,
+        } = this.props;
 
         let url = '/select_team';
-        const team = this.props.currentTeam;
-        const channel = this.props.currentChannel;
-        if (team) {
-            url = `/${team.name}`;
-            if (channel) {
-                url += `/channels/${channel.name}`;
+        if (currentTeam) {
+            url = `/${currentTeam.name}`;
+            if (currentChannel) {
+                url += `/channels/${currentChannel.name}`;
             }
         }
 
@@ -94,10 +78,11 @@ export default class CreateTeam extends React.PureComponent {
                 <BackButton url={url}/>
                 <div className='col-sm-12'>
                     <div className='signup-team__container'>
-                        <h1>{this.props.siteName}</h1>
-                        <h4 className='color--light'>
-                            {description}
-                        </h4>
+                        <SiteNameAndDescription
+                            customDescriptionText={customDescriptionText}
+                            isLicensed={isLicensed}
+                            siteName={siteName}
+                        />
                         <div className='signup__content'>
                             <Switch>
                                 <Route
@@ -120,7 +105,7 @@ export default class CreateTeam extends React.PureComponent {
                                         />
                                 )}
                                 />
-                                <Redirect to={`${this.props.match.url}/display_name`}/>
+                                <Redirect to={`${match.url}/display_name`}/>
                             </Switch>
                         </div>
                     </div>

--- a/components/create_team/index.js
+++ b/components/create_team/index.js
@@ -16,8 +16,6 @@ function mapStateToProps(state) {
     const currentTeam = getCurrentTeam(state);
 
     const isLicensed = license.IsLicensed === 'true';
-    const customBrand = license.CustomBrand === 'true';
-    const enableCustomBrand = config.EnableCustomBrand === 'true';
     const customDescriptionText = config.CustomDescriptionText;
     const siteName = config.SiteName;
 
@@ -25,8 +23,6 @@ function mapStateToProps(state) {
         currentChannel,
         currentTeam,
         isLicensed,
-        customBrand,
-        enableCustomBrand,
         customDescriptionText,
         siteName,
     };

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -5,25 +5,29 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
+
 import {Client4} from 'mattermost-redux/client';
 
-import {browserHistory} from 'utils/browser_history';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {addUserToTeamFromInvite} from 'actions/team_actions.jsx';
 import {checkMfa, webLogin} from 'actions/user_actions.jsx';
 import BrowserStore from 'stores/browser_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
+
+import {browserHistory} from 'utils/browser_history';
 import Constants from 'utils/constants.jsx';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {messageHtmlToComponent} from 'utils/post_utils.jsx';
+
 import logoImage from 'images/logo.png';
+
+import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
 import AnnouncementBar from 'components/announcement_bar';
 import FormError from 'components/form_error.jsx';
 
 import LoginMfa from '../login_mfa.jsx';
-
 export default class LoginController extends React.Component {
     static get propTypes() {
         return {
@@ -624,6 +628,12 @@ export default class LoginController extends React.Component {
     }
 
     render() {
+        const {
+            customDescriptionText,
+            isLicensed,
+            siteName,
+        } = this.props;
+
         let content;
         let customContent;
         let customClass;
@@ -643,18 +653,6 @@ export default class LoginController extends React.Component {
             }
         }
 
-        let description = null;
-        if (this.props.isLicensed && this.props.customBrand && this.props.enableCustomBrand) {
-            description = this.props.customDescriptionText;
-        } else {
-            description = (
-                <FormattedMessage
-                    id='web.root.signup_info'
-                    defaultMessage='All team communication in one place, searchable and accessible anywhere'
-                />
-            );
-        }
-
         return (
             <div>
                 <AnnouncementBar/>
@@ -668,10 +666,11 @@ export default class LoginController extends React.Component {
                             src={logoImage}
                         />
                         <div className='signup__content'>
-                            <h1>{this.props.siteName}</h1>
-                            <h4 className='color--light'>
-                                {description}
-                            </h4>
+                            <SiteNameAndDescription
+                                customDescriptionText={customDescriptionText}
+                                isLicensed={isLicensed}
+                                siteName={siteName}
+                            />
                             {content}
                         </div>
                     </div>

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -23,7 +23,7 @@ import {messageHtmlToComponent} from 'utils/post_utils.jsx';
 
 import logoImage from 'images/logo.png';
 
-import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
+import SiteNameAndDescription from 'components/common/site_name_and_description';
 import AnnouncementBar from 'components/announcement_bar';
 import FormError from 'components/form_error.jsx';
 

--- a/components/select_team/index.js
+++ b/components/select_team/index.js
@@ -15,8 +15,6 @@ function mapStateToProps(state) {
 
     return {
         isLicensed: license.IsLicensed === 'true',
-        customBrand: license.CustomBrand === 'true',
-        enableCustomBrand: config.EnableCustomBrand === 'true',
         customDescriptionText: config.CustomDescriptionText,
         enableTeamCreation: config.EnableTeamCreation === 'true',
         siteName: config.SiteName,

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -12,18 +12,19 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
+
 import logoImage from 'images/logo.png';
+
 import AnnouncementBar from 'components/announcement_bar';
 import BackButton from 'components/common/back_button.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
+import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
 
 import SelectTeamItem from './components/select_team_item.jsx';
 
 export default class SelectTeam extends React.Component {
     static propTypes = {
         isLicensed: PropTypes.bool.isRequired,
-        customBrand: PropTypes.bool.isRequired,
-        enableCustomBrand: PropTypes.bool.isRequired,
         customDescriptionText: PropTypes.string,
         enableTeamCreation: PropTypes.bool.isRequired,
         siteName: PropTypes.string,
@@ -97,6 +98,13 @@ export default class SelectTeam extends React.Component {
     }
 
     render() {
+        const {
+            customDescriptionText,
+            enableTeamCreation,
+            isLicensed,
+            siteName,
+        } = this.props;
+
         const isSystemAdmin = Utils.isSystemAdmin(UserStore.getCurrentUser().roles);
 
         let openContent;
@@ -136,7 +144,7 @@ export default class SelectTeam extends React.Component {
                 }
             }
 
-            if (openTeamContents.length === 0 && (this.props.enableTeamCreation || isSystemAdmin)) {
+            if (openTeamContents.length === 0 && (enableTeamCreation || isSystemAdmin)) {
                 openTeamContents = (
                     <div className='signup-team-dir-err'>
                         <div>
@@ -180,7 +188,7 @@ export default class SelectTeam extends React.Component {
         }
 
         let teamHelp = null;
-        if (isSystemAdmin && !this.props.enableTeamCreation) {
+        if (isSystemAdmin && !enableTeamCreation) {
             teamHelp = (
                 <FormattedMessage
                     id='login.createTeamAdminOnly'
@@ -190,7 +198,7 @@ export default class SelectTeam extends React.Component {
         }
 
         let teamSignUp;
-        if (isSystemAdmin || this.props.enableTeamCreation) {
+        if (isSystemAdmin || enableTeamCreation) {
             teamSignUp = (
                 <div className='margin--extra'>
                     <Link
@@ -226,18 +234,6 @@ export default class SelectTeam extends React.Component {
             );
         }
 
-        let description = null;
-        if (this.props.isLicensed && this.props.customBrand && this.props.enableCustomBrand) {
-            description = this.props.customDescriptionText;
-        } else {
-            description = (
-                <FormattedMessage
-                    id='web.root.signup_info'
-                    defaultMessage='All team communication in one place, searchable and accessible anywhere'
-                />
-            );
-        }
-
         let headerButton;
         if (this.state.error) {
             headerButton = <BackButton onClick={this.clearError}/>;
@@ -266,10 +262,11 @@ export default class SelectTeam extends React.Component {
                             className='signup-team-logo'
                             src={logoImage}
                         />
-                        <h1>{this.props.siteName}</h1>
-                        <h4 className='color--light'>
-                            {description}
-                        </h4>
+                        <SiteNameAndDescription
+                            customDescriptionText={customDescriptionText}
+                            isLicensed={isLicensed}
+                            siteName={siteName}
+                        />
                         {openContent}
                         {teamSignUp}
                         {adminConsoleLink}

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -18,7 +18,7 @@ import logoImage from 'images/logo.png';
 import AnnouncementBar from 'components/announcement_bar';
 import BackButton from 'components/common/back_button.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
-import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
+import SiteNameAndDescription from 'components/common/site_name_and_description';
 
 import SelectTeamItem from './components/select_team_item.jsx';
 

--- a/components/signup/signup_email/signup_email.jsx
+++ b/components/signup/signup_email/signup_email.jsx
@@ -20,7 +20,7 @@ import logoImage from 'images/logo.png';
 
 import BackButton from 'components/common/back_button.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
-import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
+import SiteNameAndDescription from 'components/common/site_name_and_description';
 
 export default class SignupEmail extends React.Component {
     static get propTypes() {

--- a/components/signup/signup_email/signup_email.jsx
+++ b/components/signup/signup_email/signup_email.jsx
@@ -6,17 +6,21 @@ import React from 'react';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
-import {browserHistory} from 'utils/browser_history';
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {getInviteInfo} from 'actions/team_actions.jsx';
 import {createUserWithInvite, loadMe, loginById} from 'actions/user_actions.jsx';
 import BrowserStore from 'stores/browser_store.jsx';
+
+import {browserHistory} from 'utils/browser_history';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
+
 import logoImage from 'images/logo.png';
+
 import BackButton from 'components/common/back_button.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
+import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
 
 export default class SignupEmail extends React.Component {
     static get propTypes() {
@@ -420,6 +424,16 @@ export default class SignupEmail extends React.Component {
     }
 
     render() {
+        const {
+            customDescriptionText,
+            enableSignUpWithEmail,
+            isLicensed,
+            location,
+            privacyPolicyLink,
+            siteName,
+            termsOfServiceLink,
+        } = this.props;
+
         let serverError = null;
         if (this.state.serverError) {
             serverError = (
@@ -434,7 +448,7 @@ export default class SignupEmail extends React.Component {
         }
 
         let emailSignup;
-        if (this.props.enableSignUpWithEmail) {
+        if (enableSignUpWithEmail) {
             emailSignup = this.renderEmailSignup();
         } else {
             return null;
@@ -448,9 +462,9 @@ export default class SignupEmail extends React.Component {
                         id='create_team.agreement'
                         defaultMessage="By proceeding to create your account and use {siteName}, you agree to our <a href='{TermsOfServiceLink}'>Terms of Service</a> and <a href='{PrivacyPolicyLink}'>Privacy Policy</a>. If you do not agree, you cannot use {siteName}."
                         values={{
-                            siteName: this.props.siteName,
-                            TermsOfServiceLink: this.props.termsOfServiceLink,
-                            PrivacyPolicyLink: this.props.privacyPolicyLink,
+                            siteName,
+                            TermsOfServiceLink: termsOfServiceLink,
+                            PrivacyPolicyLink: privacyPolicyLink,
                         }}
                     />
                 </p>
@@ -459,18 +473,6 @@ export default class SignupEmail extends React.Component {
 
         if (this.state.noOpenServerError) {
             emailSignup = null;
-        }
-
-        let description = null;
-        if (this.props.isLicensed && this.props.customBrand && this.props.enableCustomBrand) {
-            description = this.props.customDescriptionText;
-        } else {
-            description = (
-                <FormattedMessage
-                    id='web.root.signup_info'
-                    defaultMessage='All team communication in one place, searchable and accessible anywhere'
-                />
-            );
         }
 
         return (
@@ -482,10 +484,11 @@ export default class SignupEmail extends React.Component {
                             className='signup-team-logo'
                             src={logoImage}
                         />
-                        <h1>{this.props.siteName}</h1>
-                        <h4 className='color--light'>
-                            {description}
-                        </h4>
+                        <SiteNameAndDescription
+                            customDescriptionText={customDescriptionText}
+                            isLicensed={isLicensed}
+                            siteName={siteName}
+                        />
                         <h4 className='color--light'>
                             <FormattedMessage
                                 id='signup_user_completed.lets'
@@ -499,7 +502,7 @@ export default class SignupEmail extends React.Component {
                             />
                             {' '}
                             <Link
-                                to={'/login' + this.props.location.search}
+                                to={'/login' + location.search}
                             >
                                 <FormattedMessage
                                     id='signup_user_completed.signIn'

--- a/components/signup/signup_ldap/index.js
+++ b/components/signup/signup_ldap/index.js
@@ -17,8 +17,6 @@ function mapStateToProps(state) {
     const siteName = config.SiteName;
     const termsOfServiceLink = config.TermsOfServiceLink;
     const privacyPolicyLink = config.PrivacyPolicyLink;
-    const customBrand = license.CustomBrand === 'true';
-    const enableCustomBrand = config.EnableCustomBrand === 'true';
     const customDescriptionText = config.CustomDescriptionText;
 
     return {
@@ -29,8 +27,6 @@ function mapStateToProps(state) {
         siteName,
         termsOfServiceLink,
         privacyPolicyLink,
-        customBrand,
-        enableCustomBrand,
         customDescriptionText,
     };
 }

--- a/components/signup/signup_ldap/signup_ldap.jsx
+++ b/components/signup/signup_ldap/signup_ldap.jsx
@@ -6,15 +6,19 @@ import React from 'react';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
-import {browserHistory} from 'utils/browser_history';
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {addUserToTeamFromInvite} from 'actions/team_actions.jsx';
 import {loadMe, webLoginByLdap} from 'actions/user_actions.jsx';
+
 import * as Utils from 'utils/utils.jsx';
+import {browserHistory} from 'utils/browser_history';
+
 import logoImage from 'images/logo.png';
+
 import BackButton from 'components/common/back_button.jsx';
 import FormError from 'components/form_error.jsx';
+import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
 
 export default class SignupLdap extends React.Component {
     static get propTypes() {
@@ -27,8 +31,6 @@ export default class SignupLdap extends React.Component {
             siteName: PropTypes.string,
             termsOfServiceLink: PropTypes.string,
             privacyPolicyLink: PropTypes.string,
-            customBrand: PropTypes.bool.isRequired,
-            enableCustomBrand: PropTypes.bool.isRequired,
             customDescriptionText: PropTypes.string.isRequired,
         };
     }
@@ -121,6 +123,12 @@ export default class SignupLdap extends React.Component {
     }
 
     render() {
+        const {
+            customDescriptionText,
+            isLicensed,
+            siteName,
+        } = this.props;
+
         let ldapIdPlaceholder;
         if (this.props.ldapLoginFieldName) {
             ldapIdPlaceholder = this.props.ldapLoginFieldName;
@@ -212,18 +220,6 @@ export default class SignupLdap extends React.Component {
             );
         }
 
-        let description = null;
-        if (this.props.isLicensed && this.props.customBrand && this.props.enableCustomBrand) {
-            description = this.props.customDescriptionText;
-        } else {
-            description = (
-                <FormattedMessage
-                    id='web.root.signup_info'
-                    defaultMessage='All team communication in one place, searchable and accessible anywhere'
-                />
-            );
-        }
-
         return (
             <div>
                 <BackButton/>
@@ -233,10 +229,11 @@ export default class SignupLdap extends React.Component {
                             className='signup-team-logo'
                             src={logoImage}
                         />
-                        <h1>{this.props.siteName}</h1>
-                        <h4 className='color--light'>
-                            {description}
-                        </h4>
+                        <SiteNameAndDescription
+                            customDescriptionText={customDescriptionText}
+                            isLicensed={isLicensed}
+                            siteName={siteName}
+                        />
                         <h4 className='color--light'>
                             <FormattedMessage
                                 id='signup_user_completed.lets'

--- a/components/signup/signup_ldap/signup_ldap.jsx
+++ b/components/signup/signup_ldap/signup_ldap.jsx
@@ -18,7 +18,7 @@ import logoImage from 'images/logo.png';
 
 import BackButton from 'components/common/back_button.jsx';
 import FormError from 'components/form_error.jsx';
-import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
+import SiteNameAndDescription from 'components/common/site_name_and_description';
 
 export default class SignupLdap extends React.Component {
     static get propTypes() {

--- a/tests/components/common/__snapshots__/site_name_and_description.test.jsx.snap
+++ b/tests/components/common/__snapshots__/site_name_and_description.test.jsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`/components/common/SiteNameAndDescription should match snapshot, default 1`] = `
+<React.Fragment>
+  <h1>
+    Mattermost
+  </h1>
+  <h4
+    className="color--light"
+  >
+    <FormattedMessage
+      defaultMessage="All team communication in one place, searchable and accessible anywhere"
+      id="web.root.signup_info"
+      values={Object {}}
+    />
+  </h4>
+</React.Fragment>
+`;
+
+exports[`/components/common/SiteNameAndDescription should match snapshot, with custom site name and description 1`] = `
+<React.Fragment>
+  <h1>
+    other_site
+  </h1>
+  <h4
+    className="color--light"
+  >
+    <FormattedMessage
+      defaultMessage="All team communication in one place, searchable and accessible anywhere"
+      id="web.root.signup_info"
+      values={Object {}}
+    />
+  </h4>
+</React.Fragment>
+`;
+
+exports[`/components/common/SiteNameAndDescription should match snapshot, with custom site name and description 2`] = `
+<React.Fragment>
+  <h1>
+    other_site
+  </h1>
+  <h4
+    className="color--light"
+  >
+    custom_description_text
+  </h4>
+</React.Fragment>
+`;

--- a/tests/components/common/site_name_and_description.test.jsx
+++ b/tests/components/common/site_name_and_description.test.jsx
@@ -1,0 +1,37 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import {FormattedMessage} from 'react-intl';
+
+import SiteNameAndDescription from 'components/common/site_name_and_description.jsx';
+
+describe('/components/common/SiteNameAndDescription', () => {
+    const baseProps = {
+        customDescriptionText: '',
+        isLicensed: false,
+        siteName: 'Mattermost',
+    };
+
+    test('should match snapshot, default', () => {
+        const wrapper = shallow(<SiteNameAndDescription {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('h1').text()).toEqual(baseProps.siteName);
+        expect(wrapper.find(FormattedMessage).exists()).toBe(true);
+    });
+
+    test('should match snapshot, with custom site name and description', () => {
+        const props = {...baseProps, customDescriptionText: 'custom_description_text', siteName: 'other_site'};
+        const wrapper = shallow(<SiteNameAndDescription {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('h1').text()).toEqual(props.siteName);
+        expect(wrapper.find('h4').text()).not.toEqual(props.customDescriptionText);
+
+        wrapper.setProps({isLicensed: true});
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('h1').text()).toEqual(props.siteName);
+        expect(wrapper.find('h4').text()).toEqual(props.customDescriptionText);
+    });
+});

--- a/tests/components/create_team/__snapshots__/create_team.test.jsx.snap
+++ b/tests/components/create_team/__snapshots__/create_team.test.jsx.snap
@@ -12,14 +12,11 @@ exports[`/components/create_team should match snapshot 1`] = `
     <div
       className="signup-team__container"
     >
-      <h1>
-        Mattermost
-      </h1>
-      <h4
-        className="color--light"
-      >
-        Welcome to our custom branded site!
-      </h4>
+      <SiteNameAndDescription
+        customDescriptionText="Welcome to our custom branded site!"
+        isLicensed={true}
+        siteName="Mattermost"
+      />
       <div
         className="signup__content"
       >

--- a/tests/components/create_team/create_team.test.jsx
+++ b/tests/components/create_team/create_team.test.jsx
@@ -34,14 +34,6 @@ describe('/components/create_team', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should display custom branded description', () => {
-        const wrapper = shallowWithIntl(<CreateTeam {...defaultProps}/>);
-
-        const customText = wrapper.find('h4').text();
-
-        expect(customText).toBe(defaultProps.customDescriptionText);
-    });
-
     test('should run props.history.push with new state', () => {
         const wrapper = shallowWithIntl(<CreateTeam {...defaultProps}/>);
 


### PR DESCRIPTION
#### Summary
Make site description (config.CustomDescriptionText) not dependent from config.EnableCustomBrand
- add separate component as `SiteNameAndDescription`
- use that component to all that require it

#### Ticket Link
Jira ticket: [MM-9844](https://mattermost.atlassian.net/browse/MM-9844)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
