### PR TITLE
MM-9804: simplify ExperimentalEnableAuthenticationTransfer comparisons

### DIFF
--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -65,7 +65,7 @@ function mapStateToProps() {
             latestReplyablePostId,
             currentUsersLatestPost: getCurrentUsersLatestPost(state),
             readOnlyChannel: !isCurrentUserSystemAdmin(state) && config.ExperimentalTownSquareIsReadOnly === 'true' && currentChannel.name === Constants.DEFAULT_CHANNEL,
-            canUploadFiles: canUploadFiles(state),
+            canUploadFiles: canUploadFiles(config),
             enableEmojiPicker,
             enableConfirmNotificationsToChannel,
         };

--- a/components/file_attachment/index.js
+++ b/components/file_attachment/index.js
@@ -2,18 +2,17 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
-import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {canDownloadFiles} from 'utils/file_utils.jsx';
 
 import FileAttachment from './file_attachment.jsx';
 
 function mapStateToProps(state) {
-    const license = getLicense(state);
     const config = getConfig(state);
 
     return {
-        canDownloadFiles: canDownloadFiles(license, config),
+        canDownloadFiles: canDownloadFiles(config),
     };
 }
 

--- a/components/file_info_preview/index.js
+++ b/components/file_info_preview/index.js
@@ -2,18 +2,17 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
-import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {canDownloadFiles} from 'utils/file_utils.jsx';
 
 import FileInfoPreview from './file_info_preview.jsx';
 
 function mapStateToProps(state) {
-    const license = getLicense(state);
     const config = getConfig(state);
 
     return {
-        canDownloadFiles: canDownloadFiles(license, config),
+        canDownloadFiles: canDownloadFiles(config),
     };
 }
 

--- a/components/file_upload/index.js
+++ b/components/file_upload/index.js
@@ -19,7 +19,7 @@ function mapStateToProps(state) {
         currentChannelId: getCurrentChannelId(state),
         uploadFile,
         maxFileSize,
-        canUploadFiles: canUploadFiles(state),
+        canUploadFiles: canUploadFiles(config),
     };
 }
 

--- a/components/user_settings/security/index.js
+++ b/components/user_settings/security/index.js
@@ -30,7 +30,7 @@ function mapStateToProps(state, ownProps) {
     const enableLdap = config.EnableLdap === 'true';
     const enableSaml = config.EnableSaml === 'true';
     const enableSignUpWithOffice365 = config.EnableSignUpWithOffice365 === 'true';
-    const experimentalEnableAuthenticationTransfer = config.ExperimentalEnableAuthenticationTransfer !== 'false';
+    const experimentalEnableAuthenticationTransfer = config.ExperimentalEnableAuthenticationTransfer === 'true';
 
     return {
         userAccessTokens: state.entities.users.myUserAccessTokens,

--- a/components/view_image/index.js
+++ b/components/view_image/index.js
@@ -2,18 +2,17 @@
 // See License.txt for license information.
 
 import {connect} from 'react-redux';
-import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {canDownloadFiles} from 'utils/file_utils.jsx';
 
 import ViewImage from './view_image.jsx';
 
 function mapStateToProps(state) {
-    const license = getLicense(state);
     const config = getConfig(state);
 
     return {
-        canDownloadFiles: canDownloadFiles(license, config),
+        canDownloadFiles: canDownloadFiles(config),
         enablePublicLink: config.EnablePublicLink === 'true',
     };
 }

--- a/tests/utils/file_utils.test.jsx
+++ b/tests/utils/file_utils.test.jsx
@@ -26,21 +26,11 @@ describe('FileUtils.canUploadFiles', function() {
     UserAgent.isMobileApp = jest.fn().mockImplementation(() => false);
 
     it('is false when file attachments are disabled', function() {
-        const state = {
-            entities: {
-                general: {
-                    license: {
-                        IsLicensed: 'true',
-                        Compliance: 'true',
-                    },
-                    config: {
-                        EnableFileAttachments: 'false',
-                        EnableMobileFileUpload: 'true',
-                    },
-                },
-            },
+        const config = {
+            EnableFileAttachments: 'false',
+            EnableMobileFileUpload: 'true',
         };
-        assert.equal(canUploadFiles(state), false);
+        assert.equal(canUploadFiles(config), false);
     });
 
     describe('is true when file attachments are enabled', () => {
@@ -49,81 +39,31 @@ describe('FileUtils.canUploadFiles', function() {
         it('and not on mobile', () => {
             UserAgent.isMobileApp.mockImplementation(() => false);
 
-            const state = {
-                entities: {
-                    general: {
-                        license: {
-                            IsLicensed: 'true',
-                            Compliance: 'true',
-                        },
-                        config: {
-                            EnableFileAttachments: 'true',
-                            EnableMobileFileUpload: 'false',
-                        },
-                    },
-                },
+            const config = {
+                EnableFileAttachments: 'true',
+                EnableMobileFileUpload: 'false',
             };
-            assert.equal(canUploadFiles(state), true);
+            assert.equal(canUploadFiles(config), true);
         });
 
-        it('and on mobile but no compliance license enabled', function() {
+        it('and on mobile with mobile file upload enabled', () => {
             UserAgent.isMobileApp.mockImplementation(() => true);
 
-            const state = {
-                entities: {
-                    general: {
-                        license: {
-                            IsLicensed: 'false',
-                            Compliance: 'false',
-                        },
-                        config: {
-                            EnableFileAttachments: 'true',
-                            EnableMobileFileUpload: 'false',
-                        },
-                    },
-                },
+            const config = {
+                EnableFileAttachments: 'true',
+                EnableMobileFileUpload: 'true',
             };
-            assert.equal(canUploadFiles(state), true);
+            assert.equal(canUploadFiles(config), true);
         });
 
-        it('and on mobile with compliance license enabled but mobile file upload enabled', () => {
+        it('unless on mobile with mobile file upload disabled', () => {
             UserAgent.isMobileApp.mockImplementation(() => true);
 
-            const state = {
-                entities: {
-                    general: {
-                        license: {
-                            IsLicensed: 'true',
-                            Compliance: 'true',
-                        },
-                        config: {
-                            EnableFileAttachments: 'true',
-                            EnableMobileFileUpload: 'true',
-                        },
-                    },
-                },
+            const config = {
+                EnableFileAttachments: 'true',
+                EnableMobileFileUpload: 'false',
             };
-            assert.equal(canUploadFiles(state), true);
-        });
-
-        it('unless on mobile with compliance license enabled and mobile file upload disabled', () => {
-            UserAgent.isMobileApp.mockImplementation(() => true);
-
-            const state = {
-                entities: {
-                    general: {
-                        license: {
-                            IsLicensed: 'true',
-                            Compliance: 'true',
-                        },
-                        config: {
-                            EnableFileAttachments: 'true',
-                            EnableMobileFileUpload: 'false',
-                        },
-                    },
-                },
-            };
-            assert.equal(canUploadFiles(state), false);
+            assert.equal(canUploadFiles(config), false);
         });
     });
 });

--- a/utils/file_utils.jsx
+++ b/utils/file_utils.jsx
@@ -4,12 +4,7 @@
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent';
 
-export function canUploadFiles(state) {
-    const license = state.entities.general.license;
-    const config = state.entities.general.config;
-
-    const isLicensed = license && license.IsLicensed === 'true';
-    const compliance = license && license.Compliance === 'true';
+export function canUploadFiles(config) {
     const enableFileAttachments = config.EnableFileAttachments === 'true';
     const enableMobileFileUpload = config.EnableMobileFileUpload === 'true';
 
@@ -17,16 +12,16 @@ export function canUploadFiles(state) {
         return false;
     }
 
-    if (UserAgent.isMobileApp() && isLicensed && compliance) {
+    if (UserAgent.isMobileApp()) {
         return enableMobileFileUpload;
     }
 
     return true;
 }
 
-export function canDownloadFiles(license, config) {
-    if (UserAgent.isMobileApp() && license.IsLicensed === 'true' && license.Compliance === 'true') {
-        return config.EnableMobileFileDownload !== 'false';
+export function canDownloadFiles(config) {
+    if (UserAgent.isMobileApp()) {
+        return config.EnableMobileFileDownload === 'true';
     }
 
     return true;


### PR DESCRIPTION
#### Summary
With the server now sending down all configurations by default, and this
defaulting to `true`, we can adopt the more conventional `=== 'true'`
check than the previous `!== 'false'`, subtly hiding the business logic
of defaults in the check itself.

See https://github.com/mattermost/mattermost-server/pull/8490 for the corresponding server changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9804

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed