### PR TITLE
Migrate delete_post_modal.jsx to be pure and use Redux

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -188,16 +188,6 @@ export function toggleShortcutsModal() {
     });
 }
 
-export function showDeletePostModal(post, commentCount = 0, isRHS) {
-    AppDispatcher.handleViewAction({
-        type: ActionTypes.TOGGLE_DELETE_POST_MODAL,
-        value: true,
-        isRHS,
-        post,
-        commentCount,
-    });
-}
-
 export function showChannelHeaderUpdateModal(channel) {
     AppDispatcher.handleViewAction({
         type: ActionTypes.TOGGLE_CHANNEL_HEADER_UPDATE_MODAL,

--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -8,7 +8,6 @@ import * as PostActions from 'mattermost-redux/actions/posts';
 import * as Selectors from 'mattermost-redux/selectors/entities/posts';
 import {comparePosts} from 'mattermost-redux/utils/post_utils';
 
-import {browserHistory} from 'utils/browser_history';
 import {sendDesktopNotification} from 'actions/notification_actions.jsx';
 import {loadNewDMIfNeeded, loadNewGMIfNeeded} from 'actions/user_actions.jsx';
 import * as RhsActions from 'actions/views/rhs';
@@ -16,8 +15,7 @@ import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 import PostStore from 'stores/post_store.jsx';
 import store from 'stores/redux_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
-import {getSelectedPostId, getRhsState} from 'selectors/rhs';
+import {getRhsState} from 'selectors/rhs';
 import {ActionTypes, Constants, RHSStates} from 'utils/constants.jsx';
 import {EMOJI_PATTERN} from 'utils/emoticons.jsx';
 import * as UserAgent from 'utils/user_agent';

--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -202,46 +202,6 @@ export function emitEmojiPosted(emoji) {
     });
 }
 
-export async function deletePost(channelId, post, success) {
-    const {currentUserId} = getState().entities.users;
-
-    let hardDelete = false;
-    if (post.user_id === currentUserId) {
-        hardDelete = true;
-    }
-
-    await PostActions.deletePost(post, hardDelete)(dispatch, getState);
-
-    if (post.id === getSelectedPostId(getState())) {
-        dispatch({
-            type: ActionTypes.SELECT_POST,
-            postId: '',
-            channelId: '',
-        });
-    }
-
-    dispatch({
-        type: PostTypes.REMOVE_POST,
-        data: post,
-    });
-
-    // Needed for search store
-    AppDispatcher.handleViewAction({
-        type: Constants.ActionTypes.REMOVE_POST,
-        post,
-    });
-
-    const {focusedPostId} = getState().views.channel;
-    const channel = getState().entities.channels.channels[post.channel_id];
-    if (post.id === focusedPostId && channel) {
-        browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + channel.name);
-    }
-
-    if (success) {
-        success();
-    }
-}
-
 const POST_INCREASE_AMOUNT = Constants.POST_CHUNK_SIZE / 2;
 
 // Returns true if there are more posts to load

--- a/components/channel_layout/channel_controller.jsx
+++ b/components/channel_layout/channel_controller.jsx
@@ -7,7 +7,6 @@ import {Route} from 'react-router-dom';
 
 import Pluggable from 'plugins/pluggable';
 import AnnouncementBar from 'components/announcement_bar';
-import DeletePostModal from 'components/delete_post_modal';
 import EditPostModal from 'components/edit_post_modal';
 import GetPostLinkModal from 'components/get_post_link_modal';
 import GetTeamInviteLinkModal from 'components/get_team_invite_link_modal';
@@ -64,7 +63,6 @@ export default class ChannelController extends React.Component {
                     <ImportThemeModal/>
                     <TeamSettingsModal/>
                     <EditPostModal/>
-                    <DeletePostModal/>
                     <RemovedFromChannelModal/>
                     <ResetStatusModal/>
                     <LeavePrivateChannelModal/>

--- a/components/channel_layout/channel_controller.jsx
+++ b/components/channel_layout/channel_controller.jsx
@@ -7,7 +7,7 @@ import {Route} from 'react-router-dom';
 
 import Pluggable from 'plugins/pluggable';
 import AnnouncementBar from 'components/announcement_bar';
-import DeletePostModal from 'components/delete_post_modal.jsx';
+import DeletePostModal from 'components/delete_post_modal';
 import EditPostModal from 'components/edit_post_modal';
 import GetPostLinkModal from 'components/get_post_link_modal';
 import GetTeamInviteLinkModal from 'components/get_team_invite_link_modal';

--- a/components/delete_post_modal/delete_post_modal.jsx
+++ b/components/delete_post_modal/delete_post_modal.jsx
@@ -11,14 +11,7 @@ import * as UserAgent from 'utils/user_agent.jsx';
 export default class DeletePostModal extends React.PureComponent {
     static propTypes = {
 
-        /**
-         * post data
-         */
         post: PropTypes.object.isRequired,
-
-        /**
-         * post comment count
-         */
         commentCount: PropTypes.number.isRequired,
 
         /**
@@ -34,9 +27,8 @@ export default class DeletePostModal extends React.PureComponent {
         actions: PropTypes.shape({
 
             /**
-            * Function called for deleting post,
+            * Function called for deleting post
             */
-
             deletePost: PropTypes.func.isRequired,
         }),
     }
@@ -72,10 +64,6 @@ export default class DeletePostModal extends React.PureComponent {
     }
 
     render() {
-        if (!this.props.post) {
-            return null;
-        }
-
         var commentWarning = '';
         if (this.props.commentCount > 0) {
             commentWarning = (

--- a/components/delete_post_modal/delete_post_modal.jsx
+++ b/components/delete_post_modal/delete_post_modal.jsx
@@ -6,11 +6,15 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
+import {browserHistory} from 'utils/browser_history';
 import * as UserAgent from 'utils/user_agent.jsx';
 
 export default class DeletePostModal extends React.PureComponent {
     static propTypes = {
 
+        channelName: PropTypes.string,
+        focusedPostId: PropTypes.string,
+        currentTeamDetails: PropTypes.object,
         post: PropTypes.object.isRequired,
         commentCount: PropTypes.number.isRequired,
 
@@ -42,9 +46,24 @@ export default class DeletePostModal extends React.PureComponent {
         };
     }
 
-    handleDelete() {
-        this.props.actions.deletePost(this.props.post);
-        this.onHide();
+    handleDelete = async () => {
+        const {
+            actions,
+            channelName,
+            focusedPostId,
+            post,
+            currentTeamDetails,
+        } = this.props;
+
+        const {data} = await actions.deletePost(post);
+
+        if (post.id === focusedPostId && channelName) {
+            browserHistory.push('/' + currentTeamDetails.name + '/channels/' + channelName);
+        }
+
+        if (data) {
+            this.onHide();
+        }
     }
 
     onHide() {

--- a/components/delete_post_modal/delete_post_modal.jsx
+++ b/components/delete_post_modal/delete_post_modal.jsx
@@ -14,7 +14,7 @@ export default class DeletePostModal extends React.PureComponent {
 
         channelName: PropTypes.string,
         focusedPostId: PropTypes.string,
-        currentTeamDetails: PropTypes.object,
+        teamName: PropTypes.string,
         post: PropTypes.object.isRequired,
         commentCount: PropTypes.number.isRequired,
 
@@ -52,13 +52,13 @@ export default class DeletePostModal extends React.PureComponent {
             channelName,
             focusedPostId,
             post,
-            currentTeamDetails,
+            teamName,
         } = this.props;
 
         const {data} = await actions.deletePost(post);
 
         if (post.id === focusedPostId && channelName) {
-            browserHistory.push('/' + currentTeamDetails.name + '/channels/' + channelName);
+            browserHistory.push('/' + teamName + '/channels/' + channelName);
         }
 
         if (data) {

--- a/components/delete_post_modal/delete_post_modal.jsx
+++ b/components/delete_post_modal/delete_post_modal.jsx
@@ -1,106 +1,95 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
-import {deletePost} from 'actions/post_actions.jsx';
-import ModalStore from 'stores/modal_store.jsx';
-import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 
-var ActionTypes = Constants.ActionTypes;
+export default class DeletePostModal extends React.PureComponent {
+    static propTypes = {
 
-export default class DeletePostModal extends React.Component {
+        /**
+         * post data
+         */
+        post: PropTypes.object.isRequired,
+
+        /**
+         * post comment count
+         */
+        commentCount: PropTypes.number.isRequired,
+
+        /**
+         * Does the post come from RHS mode
+         */
+        isRHS: PropTypes.bool.isRequired,
+
+        /**
+        * Function called when modal is dismissed
+        */
+        onHide: PropTypes.func.isRequired,
+
+        actions: PropTypes.shape({
+
+            /**
+            * Function called for deleting post,
+            */
+
+            deletePost: PropTypes.func.isRequired,
+        }),
+    }
+
     constructor(props) {
         super(props);
-
+        this.handleDelete = this.handleDelete.bind(this);
+        this.onHide = this.onHide.bind(this);
         this.state = {
-            show: false,
-            post: null,
-            commentCount: 0,
-            error: '',
+            show: true,
         };
     }
 
-    componentDidMount() {
-        ModalStore.addModalListener(ActionTypes.TOGGLE_DELETE_POST_MODAL, this.handleToggle);
+    handleDelete() {
+        this.props.actions.deletePost(this.props.post);
+        this.onHide();
     }
 
-    componentWillUnmount() {
-        ModalStore.removeModalListener(ActionTypes.TOGGLE_DELETE_POST_MODAL, this.handleToggle);
-    }
-
-    componentDidUpdate(prevProps, prevState) {
-        if (this.state.show && !prevState.show) {
-            setTimeout(() => {
-                if (this.deletePostBtn) {
-                    this.deletePostBtn.focus();
-                }
-            }, 200);
-        }
-    }
-
-    handleDelete = () => {
-        deletePost(
-            this.state.post.channel_id,
-            this.state.post,
-            () => {
-                this.handleHide();
-            },
-            (err) => {
-                this.setState({error: err.message});
-            }
-        );
-    }
-
-    handleToggle = (value, args) => {
-        this.setState({
-            show: value,
-            post: args.post,
-            isRHS: args.isRHS,
-            commentCount: args.commentCount,
-            error: '',
-        });
-    }
-
-    handleHide = () => {
+    onHide() {
         this.setState({show: false});
 
         if (!UserAgent.isMobile()) {
-            if (this.state.isRHS) {
-                document.getElementById('reply_textbox').focus();
+            var element;
+            if (this.props.isRHS) {
+                element = document.getElementById('reply_textbox');
             } else {
-                document.getElementById('post_textbox').focus();
+                element = document.getElementById('post_textbox');
+            }
+            if (element) {
+                element.focus();
             }
         }
     }
 
     render() {
-        if (!this.state.post) {
+        if (!this.props.post) {
             return null;
         }
 
-        var error = null;
-        if (this.state.error) {
-            error = <div className='form-group has-error'><label className='control-label'>{this.state.error}</label></div>;
-        }
-
         var commentWarning = '';
-        if (this.state.commentCount > 0) {
+        if (this.props.commentCount > 0) {
             commentWarning = (
                 <FormattedMessage
                     id='delete_post.warning'
                     defaultMessage='This post has {count, number} {count, plural, one {comment} other {comments}} on it.'
                     values={{
-                        count: this.state.commentCount,
+                        count: this.props.commentCount,
                     }}
                 />
             );
         }
 
-        const postTerm = this.state.post.root_id ? (
+        const postTerm = this.props.post.root_id ? (
             <FormattedMessage
                 id='delete_post.comment'
                 defaultMessage='Comment'
@@ -115,7 +104,8 @@ export default class DeletePostModal extends React.Component {
         return (
             <Modal
                 show={this.state.show}
-                onHide={this.handleHide}
+                onHide={this.onHide}
+                onExited={this.props.onHide}
                 enforceFocus={false}
             >
                 <Modal.Header closeButton={true}>
@@ -140,7 +130,6 @@ export default class DeletePostModal extends React.Component {
                     <br/>
                     <br/>
                     {commentWarning}
-                    {error}
                 </Modal.Body>
                 <Modal.Footer>
                     <button

--- a/components/delete_post_modal/index.js
+++ b/components/delete_post_modal/index.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+import {deletePost} from 'mattermost-redux/actions/posts';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import DeletePostModal from './delete_post_modal.jsx';
+
+function mapStateToProps(state, ownProps) {
+    return {
+        ...ownProps,
+        currentTeamDetails: getCurrentTeam(state),
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            deletePost,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DeletePostModal);

--- a/components/delete_post_modal/index.js
+++ b/components/delete_post_modal/index.js
@@ -21,7 +21,7 @@ function mapStateToProps(state, ownProps) {
     return {
         channelName,
         focusedPostId,
-        currentTeamDetails: getCurrentTeam(state),
+        teamName: getCurrentTeam(state).name,
     };
 }
 

--- a/components/delete_post_modal/index.js
+++ b/components/delete_post_modal/index.js
@@ -4,16 +4,8 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {deletePost} from 'mattermost-redux/actions/posts';
-import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import DeletePostModal from './delete_post_modal.jsx';
-
-function mapStateToProps(state, ownProps) {
-    return {
-        ...ownProps,
-        currentTeamDetails: getCurrentTeam(state),
-    };
-}
 
 function mapDispatchToProps(dispatch) {
     return {
@@ -23,4 +15,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DeletePostModal);
+export default connect(null, mapDispatchToProps)(DeletePostModal);

--- a/components/delete_post_modal/index.js
+++ b/components/delete_post_modal/index.js
@@ -4,8 +4,26 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {deletePost} from 'mattermost-redux/actions/posts';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import DeletePostModal from './delete_post_modal.jsx';
+
+function mapStateToProps(state, ownProps) {
+    const channel = getChannel(state, ownProps.post.channel_id);
+    let channelName = '';
+    if (channel) {
+        channelName = channel.name;
+    }
+
+    const {focusedPostId} = state.views.channel;
+
+    return {
+        channelName,
+        focusedPostId,
+        currentTeamDetails: getCurrentTeam(state),
+    };
+}
 
 function mapDispatchToProps(dispatch) {
     return {
@@ -15,4 +33,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(null, mapDispatchToProps)(DeletePostModal);
+export default connect(mapStateToProps, mapDispatchToProps)(DeletePostModal);

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -27,30 +27,35 @@ export default class DotMenu extends Component {
 
         actions: PropTypes.shape({
 
-            /*
+            /**
              * Function flag the post
              */
             flagPost: PropTypes.func.isRequired,
 
-            /*
+            /**
              * Function to unflag the post
              */
             unflagPost: PropTypes.func.isRequired,
 
-            /*
-             * Function to set the edting post
+            /**
+             * Function to set the editing post
              */
             setEditingPost: PropTypes.func.isRequired,
 
-            /*
+            /**
              * Function to pin the post
              */
             pinPost: PropTypes.func.isRequired,
 
-            /*
+            /**
              * Function to unpin the post
              */
             unpinPost: PropTypes.func.isRequired,
+
+            /**
+             * Function to open a modal
+             */
+            openModal: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -185,6 +190,9 @@ export default class DotMenu extends Component {
                     idCount={this.props.idCount}
                     post={this.props.post}
                     commentCount={type === 'Post' ? this.props.commentCount : 0}
+                    actions={{
+                        openModal: this.props.actions.openModal,
+                    }}
                 />
             );
         }

--- a/components/dot_menu/dot_menu_item.jsx
+++ b/components/dot_menu/dot_menu_item.jsx
@@ -29,7 +29,7 @@ export default function DotMenuItem(props) {
     function handleDeletePost(e) {
         e.preventDefault();
 
-        const modalData = {
+        const deletePostModalData = {
             ModalId: ModalIdentifiers.DELETE_POST,
             dialogType: DeletePostModal,
             dialogProps: {
@@ -39,7 +39,7 @@ export default function DotMenuItem(props) {
             },
         };
 
-        props.actions.openModal(modalData);
+        props.actions.openModal(deletePostModalData);
     }
 
     const attrib = {};

--- a/components/dot_menu/dot_menu_item.jsx
+++ b/components/dot_menu/dot_menu_item.jsx
@@ -5,8 +5,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import {showDeletePostModal, showGetPostLinkModal} from 'actions/global_actions.jsx';
-import Constants from 'utils/constants.jsx';
+import {showGetPostLinkModal} from 'actions/global_actions.jsx';
+import DeletePostModal from 'components/delete_post_modal';
+import {Constants, ModalIdentifiers} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 export default function DotMenuItem(props) {
@@ -27,7 +28,18 @@ export default function DotMenuItem(props) {
 
     function handleDeletePost(e) {
         e.preventDefault();
-        showDeletePostModal(props.post, props.commentCount, props.isRHS);
+
+        const modalData = {
+            ModalId: ModalIdentifiers.DELETE_POST,
+            dialogType: DeletePostModal,
+            dialogProps: {
+                post: props.post,
+                commentCount: props.commentCount,
+                isRHS: props.isRHS,
+            },
+        };
+
+        props.actions.openModal(modalData);
     }
 
     const attrib = {};
@@ -101,15 +113,20 @@ DotMenuItem.propTypes = {
 
     actions: PropTypes.shape({
 
-        /*
+        /**
          * Function to pin the post
          */
         pinPost: PropTypes.func,
 
-        /*
+        /**
          * Function to unpin the post
          */
         unpinPost: PropTypes.func,
+
+        /**
+         * Function to open a modal
+         */
+        openModal: PropTypes.func,
     }),
 };
 

--- a/components/dot_menu/index.js
+++ b/components/dot_menu/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {flagPost, unflagPost} from 'mattermost-redux/actions/posts';
 
+import {openModal} from 'actions/views/modals';
 import {pinPost, unpinPost, setEditingPost} from 'actions/post_actions.jsx';
 
 import DotMenu from './dot_menu.jsx';
@@ -21,6 +22,7 @@ function mapDispatchToProps(dispatch) {
             setEditingPost,
             pinPost,
             unpinPost,
+            openModal
         }, dispatch),
     };
 }

--- a/components/dot_menu/index.js
+++ b/components/dot_menu/index.js
@@ -22,7 +22,7 @@ function mapDispatchToProps(dispatch) {
             setEditingPost,
             pinPost,
             unpinPost,
-            openModal
+            openModal,
         }, dispatch),
     };
 }

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -166,7 +166,7 @@ export default class EditPostModal extends React.PureComponent {
         if (updatedPost.message.trim().length === 0 && !hasAttachment) {
             this.handleHide(false);
 
-            const modalData = {
+            const deletePostModalData = {
                 ModalId: ModalIdentifiers.DELETE_POST,
                 dialogType: DeletePostModal,
                 dialogProps: {
@@ -176,7 +176,7 @@ export default class EditPostModal extends React.PureComponent {
                 },
             };
 
-            this.props.actions.openModal(modalData);
+            this.props.actions.openModal(deletePostModalData);
             return;
         }
 

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -9,9 +9,10 @@ import * as Selectors from 'mattermost-redux/selectors/entities/posts';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import store from 'stores/redux_store.jsx';
-import Constants from 'utils/constants.jsx';
+import {Constants, ModalIdentifiers} from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
+import DeletePostModal from 'components/delete_post_modal';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
 import EmojiIcon from 'components/svg/emoji_icon';
 import Textbox from 'components/textbox.jsx';
@@ -165,7 +166,18 @@ export default class EditPostModal extends React.PureComponent {
         const hasAttachment = editingPost.post.file_ids && editingPost.post.file_ids.length > 0;
         if (updatedPost.message.trim().length === 0 && !hasAttachment) {
             this.handleHide(false);
-            GlobalActions.showDeletePostModal(Selectors.getPost(getState(), editingPost.postId), editingPost.commentsCount, editingPost.isRHS);
+            
+            const modalData = {
+                ModalId: ModalIdentifiers.DELETE_POST,
+                dialogType: DeletePostModal,
+                dialogProps: {
+                    post: Selectors.getPost(getState(), editingPost.postId), 
+                    commentCount: editingPost.commentsCount,
+                    isRHS: editingPost.isRHS
+                }
+            };
+
+            this.props.actions.openModal(modalData);
             return;
         }
 

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -7,7 +7,6 @@ import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import * as Selectors from 'mattermost-redux/selectors/entities/posts';
 
-import * as GlobalActions from 'actions/global_actions.jsx';
 import store from 'stores/redux_store.jsx';
 import {Constants, ModalIdentifiers} from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
@@ -166,15 +165,15 @@ export default class EditPostModal extends React.PureComponent {
         const hasAttachment = editingPost.post.file_ids && editingPost.post.file_ids.length > 0;
         if (updatedPost.message.trim().length === 0 && !hasAttachment) {
             this.handleHide(false);
-            
+
             const modalData = {
                 ModalId: ModalIdentifiers.DELETE_POST,
                 dialogType: DeletePostModal,
                 dialogProps: {
-                    post: Selectors.getPost(getState(), editingPost.postId), 
+                    post: Selectors.getPost(getState(), editingPost.postId),
                     commentCount: editingPost.commentsCount,
-                    isRHS: editingPost.isRHS
-                }
+                    isRHS: editingPost.isRHS,
+                },
             };
 
             this.props.actions.openModal(modalData);

--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -8,6 +8,7 @@ import {Preferences} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 
+import {openModal} from 'actions/views/modals';
 import {hideEditPostModal} from 'actions/post_actions';
 import {editPost} from 'actions/views/edit_post_modal';
 import {getEditingPost} from 'selectors/posts';
@@ -28,6 +29,7 @@ function mapDispatchToProps(dispatch) {
             addMessageIntoHistory,
             editPost,
             hideEditPostModal,
+            openModal,
         }, dispatch),
     };
 }

--- a/tests/components/__snapshots__/delete_post_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/delete_post_modal.test.jsx.snap
@@ -210,5 +210,3 @@ exports[`components/delete_post_modal should match snapshot for delete_post_moda
   </ModalFooter>
 </Modal>
 `;
-
-exports[`components/delete_post_modal should match snapshot for delete_post_modal with no post 1`] = `""`;

--- a/tests/components/__snapshots__/delete_post_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/delete_post_modal.test.jsx.snap
@@ -1,0 +1,214 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/delete_post_modal should match snapshot for delete_post_modal with 0 comments 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={false}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onExited={[Function]}
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Confirm {term} Delete"
+        id="delete_post.confirm"
+        values={
+          Object {
+            "term": <FormattedMessage
+              defaultMessage="Post"
+              id="delete_post.post"
+              values={Object {}}
+            />,
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <FormattedMessage
+      defaultMessage="Are you sure you want to delete this {term}?"
+      id="delete_post.question"
+      values={
+        Object {
+          "term": <FormattedMessage
+            defaultMessage="Post"
+            id="delete_post.post"
+            values={Object {}}
+          />,
+        }
+      }
+    />
+    <br />
+    <br />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-default"
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="delete_post.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      autoFocus={true}
+      className="btn btn-danger"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Delete"
+        id="delete_post.del"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`components/delete_post_modal should match snapshot for delete_post_modal with 1 comment 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={false}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onExited={[Function]}
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Confirm {term} Delete"
+        id="delete_post.confirm"
+        values={
+          Object {
+            "term": <FormattedMessage
+              defaultMessage="Post"
+              id="delete_post.post"
+              values={Object {}}
+            />,
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <FormattedMessage
+      defaultMessage="Are you sure you want to delete this {term}?"
+      id="delete_post.question"
+      values={
+        Object {
+          "term": <FormattedMessage
+            defaultMessage="Post"
+            id="delete_post.post"
+            values={Object {}}
+          />,
+        }
+      }
+    />
+    <br />
+    <br />
+    <FormattedMessage
+      defaultMessage="This post has {count, number} {count, plural, one {comment} other {comments}} on it."
+      id="delete_post.warning"
+      values={
+        Object {
+          "count": 1,
+        }
+      }
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-default"
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="delete_post.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      autoFocus={true}
+      className="btn btn-danger"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Delete"
+        id="delete_post.del"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`components/delete_post_modal should match snapshot for delete_post_modal with no post 1`] = `""`;

--- a/tests/components/delete_post_modal.test.jsx
+++ b/tests/components/delete_post_modal.test.jsx
@@ -55,9 +55,10 @@ describe('components/delete_post_modal', () => {
         expect(wrapper.state('show')).toEqual(false);
     });
 
-    test('should have called actions.deletePost when handleDelete is called', () => {
+    test('should have called actions.deletePost when handleDelete is called', async () => {
         browserHistory.push = jest.fn();
         const actions = {deletePost: jest.fn()};
+        actions.deletePost.mockReturnValueOnce({data: true});
         const props = {...baseProps, actions};
         const wrapper = shallow(
             <DeletePostModal {...props}/>
@@ -66,7 +67,7 @@ describe('components/delete_post_modal', () => {
         wrapper.setState({show: true});
         wrapper.instance().handleDelete();
 
-        expect(actions.deletePost).toHaveBeenCalledTimes(1);
+        await expect(actions.deletePost).toHaveBeenCalledTimes(1);
         expect(actions.deletePost).toHaveBeenCalledWith(props.post);
         expect(wrapper.state('show')).toEqual(false);
     });

--- a/tests/components/delete_post_modal.test.jsx
+++ b/tests/components/delete_post_modal.test.jsx
@@ -53,7 +53,6 @@ describe('components/delete_post_modal', () => {
         wrapper.instance().onHide();
         expect(wrapper.state('show')).toEqual(false);
     });
-    
 
     test('should have called actions.deletePost when handleDelete is called', async () => {
         browserHistory.push = jest.fn();

--- a/tests/components/delete_post_modal.test.jsx
+++ b/tests/components/delete_post_modal.test.jsx
@@ -1,0 +1,91 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import {Modal} from 'react-bootstrap';
+
+import {browserHistory} from 'utils/browser_history';
+
+import DeletePostModal from 'components/delete_post_modal/delete_post_modal.jsx';
+
+describe('components/delete_post_modal', () => {
+    function emptyFunction() {} //eslint-disable-line no-empty-function
+
+    const post = {
+        id: '123',
+        message: 'test',
+        channel_id: '5',
+    };
+
+    const nonPostProps = {
+        commentCount: 0,
+        isRHS: false,
+        actions: {
+            deletePost: emptyFunction,
+        },
+        onHide: emptyFunction,
+    };
+
+    const baseProps = {...nonPostProps, post};
+
+    test('should match snapshot for delete_post_modal with 0 comments', () => {
+        const wrapper = shallow(
+            <DeletePostModal {...baseProps}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot for delete_post_modal with 1 comment', () => {
+        const commentCount = 1;
+        const props = {...baseProps, commentCount};
+        const wrapper = shallow(
+            <DeletePostModal {...props}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot for delete_post_modal with no post', () => {
+        const wrapper = shallow(
+            <DeletePostModal {...nonPostProps}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match state when onHide is called', () => {
+        const wrapper = shallow(
+            <DeletePostModal {...baseProps}/>
+        );
+
+        wrapper.setState({show: true});
+        wrapper.instance().onHide();
+        expect(wrapper.state('show')).toEqual(false);
+    });
+
+    test('should have called actions.deletePost when handleDelete is called', () => {
+        browserHistory.push = jest.fn();
+        const actions = {deletePost: jest.fn()};
+        const props = {...baseProps, actions};
+        const wrapper = shallow(
+            <DeletePostModal {...props}/>
+        );
+
+        wrapper.setState({show: true});
+        wrapper.instance().handleDelete();
+
+        expect(actions.deletePost).toHaveBeenCalledTimes(1);
+        expect(actions.deletePost).toHaveBeenCalledWith(props.post);
+        expect(wrapper.state('show')).toEqual(false);
+    });
+
+    test('should have called props.onHide when Modal.onExited is called', () => {
+        const onHide = jest.fn();
+        const props = {...baseProps, onHide};
+        const wrapper = shallow(
+            <DeletePostModal {...props}/>
+        );
+
+        wrapper.find(Modal).props().onExited();
+        expect(onHide).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/components/delete_post_modal.test.jsx
+++ b/tests/components/delete_post_modal.test.jsx
@@ -18,7 +18,8 @@ describe('components/delete_post_modal', () => {
         channel_id: '5',
     };
 
-    const nonPostProps = {
+    const baseProps = {
+        post,
         commentCount: 0,
         isRHS: false,
         actions: {
@@ -26,8 +27,6 @@ describe('components/delete_post_modal', () => {
         },
         onHide: emptyFunction,
     };
-
-    const baseProps = {...nonPostProps, post};
 
     test('should match snapshot for delete_post_modal with 0 comments', () => {
         const wrapper = shallow(
@@ -54,6 +53,7 @@ describe('components/delete_post_modal', () => {
         wrapper.instance().onHide();
         expect(wrapper.state('show')).toEqual(false);
     });
+    
 
     test('should have called actions.deletePost when handleDelete is called', async () => {
         browserHistory.push = jest.fn();
@@ -70,6 +70,20 @@ describe('components/delete_post_modal', () => {
         await expect(actions.deletePost).toHaveBeenCalledTimes(1);
         expect(actions.deletePost).toHaveBeenCalledWith(props.post);
         expect(wrapper.state('show')).toEqual(false);
+    });
+
+    test('should call browserHistory.push on handleDelete with post.id === focusedPostId && channelName', async () => {
+        browserHistory.push = jest.fn();
+        const actions = {deletePost: jest.fn()};
+        actions.deletePost.mockReturnValueOnce({data: true});
+        const props = {...baseProps, actions, focusedPostId: '123', channelName: 'channel_name', teamName: 'team_name'};
+        const wrapper = shallow(
+            <DeletePostModal {...props}/>
+        );
+
+        await wrapper.instance().handleDelete();
+        expect(browserHistory.push).toHaveBeenCalledTimes(1);
+        expect(browserHistory.push).toHaveBeenCalledWith('/team_name/channels/channel_name');
     });
 
     test('should have called props.onHide when Modal.onExited is called', () => {

--- a/tests/components/delete_post_modal.test.jsx
+++ b/tests/components/delete_post_modal.test.jsx
@@ -45,13 +45,6 @@ describe('components/delete_post_modal', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should match snapshot for delete_post_modal with no post', () => {
-        const wrapper = shallow(
-            <DeletePostModal {...nonPostProps}/>
-        );
-        expect(wrapper).toMatchSnapshot();
-    });
-
     test('should match state when onHide is called', () => {
         const wrapper = shallow(
             <DeletePostModal {...baseProps}/>

--- a/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
@@ -53,6 +53,11 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
           }
         />
         <DotMenuItem
+          actions={
+            Object {
+              "openModal": [MockFunction],
+            }
+          }
           commentCount={0}
           idCount={-1}
           idPrefix="centerDotMenuDelete"

--- a/tests/components/dot_menu/dot_menu.test.jsx
+++ b/tests/components/dot_menu/dot_menu.test.jsx
@@ -38,6 +38,7 @@ describe('components/dot_menu/DotMenu', () => {
             setEditingPost: jest.fn(),
             pinPost: jest.fn(),
             unpinPost: jest.fn(),
+            openModal: jest.fn(),
         },
     };
 

--- a/tests/components/dot_menu/dot_menu_item.test.jsx
+++ b/tests/components/dot_menu/dot_menu_item.test.jsx
@@ -4,12 +4,11 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import {showDeletePostModal, showGetPostLinkModal} from 'actions/global_actions.jsx';
+import {showGetPostLinkModal} from 'actions/global_actions.jsx';
 import DotMenuItem from 'components/dot_menu/dot_menu_item.jsx';
 
 jest.mock('actions/global_actions.jsx', () => {
     return {
-        showDeletePostModal: jest.fn(),
         showGetPostLinkModal: jest.fn(),
     };
 });
@@ -20,6 +19,11 @@ describe('components/dot_menu/DotMenuItem', () => {
             idPrefix: 'idPrefixDotMenuReply',
             idCount: -1,
             handleOnClick: jest.fn(),
+            actions: {
+                pinPost: jest.fn(),
+                unpinPost: jest.fn(),
+                openModal: jest.fn(),
+            },
         };
 
         const wrapper = shallow(
@@ -41,6 +45,11 @@ describe('components/dot_menu/DotMenuItem', () => {
             idPrefix: 'idPrefixDotMenuPermalink',
             idCount: -1,
             post: {id: 'post_id_1'},
+            actions: {
+                pinPost: jest.fn(),
+                unpinPost: jest.fn(),
+                openModal: jest.fn(),
+            },
         };
 
         const wrapper = shallow(
@@ -65,6 +74,7 @@ describe('components/dot_menu/DotMenuItem', () => {
             actions: {
                 pinPost: jest.fn(),
                 unpinPost: jest.fn(),
+                openModal: jest.fn(),
             },
         };
 
@@ -92,6 +102,7 @@ describe('components/dot_menu/DotMenuItem', () => {
             actions: {
                 pinPost: jest.fn(),
                 unpinPost: jest.fn(),
+                openModal: jest.fn(),
             },
         };
 
@@ -113,6 +124,11 @@ describe('components/dot_menu/DotMenuItem', () => {
             idCount: -1,
             post: {id: 'post_id_1'},
             commentCount: 0,
+            actions: {
+                pinPost: jest.fn(),
+                unpinPost: jest.fn(),
+                openModal: jest.fn(),
+            },
         };
 
         const wrapper = shallow(
@@ -122,7 +138,7 @@ describe('components/dot_menu/DotMenuItem', () => {
         expect(wrapper).toMatchSnapshot();
 
         wrapper.find('button').first().simulate('click', {preventDefault: jest.fn()});
-        expect(showDeletePostModal).toHaveBeenCalledTimes(1);
+        expect(props.actions.openModal).toHaveBeenCalledTimes(1);
 
         expect(wrapper.find('#idPrefixDotMenuDelete5').exists()).toBe(false);
         wrapper.setProps({idCount: 5});

--- a/tests/components/edit_post_modal.test.jsx
+++ b/tests/components/edit_post_modal.test.jsx
@@ -9,7 +9,6 @@ import EditPostModal from 'components/edit_post_modal/edit_post_modal.jsx';
 jest.useFakeTimers();
 
 jest.mock('actions/global_actions.jsx', () => ({
-    showDeletePostModal: jest.fn(),
     emitClearSuggestions: jest.fn(),
 }));
 
@@ -39,6 +38,7 @@ function createEditPost({ctrlSend, config, license, editingPost, actions} = {}) 
         editPost: jest.fn(),
         addMessageIntoHistory: jest.fn(),
         hideEditPostModal: jest.fn(),
+        openModal: jest.fn(),
     };
     return (
         <EditPostModal
@@ -67,11 +67,12 @@ describe('components/EditPostModal', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('should not call GlobalActions.showDeletePostModal on empty edited message but with attachment', () => {
+    it('should not call openModal on empty edited message but with attachment', () => {
         const actions = {
             editPost: jest.fn(),
             addMessageIntoHistory: jest.fn(),
             hideEditPostModal: jest.fn(),
+            openModal: jest.fn(),
         };
         const editingPost = {
             postId: '123',
@@ -92,7 +93,7 @@ describe('components/EditPostModal', () => {
         wrapper.setState({editText: ''});
         instance.handleEdit();
 
-        expect(GlobalActions.showDeletePostModal).not.toHaveBeenCalled();
+        expect(actions.openModal).not.toHaveBeenCalled();
         expect(actions.addMessageIntoHistory).toBeCalled();
         expect(actions.editPost).toBeCalled();
     });
@@ -102,6 +103,7 @@ describe('components/EditPostModal', () => {
             editPost: jest.fn(),
             addMessageIntoHistory: jest.fn(),
             hideEditPostModal: jest.fn(),
+            openModal: jest.fn(),
         };
         const wrapper = shallow(createEditPost({actions}));
 
@@ -216,6 +218,7 @@ describe('components/EditPostModal', () => {
             editPost: jest.fn(),
             addMessageIntoHistory: jest.fn(),
             hideEditPostModal: jest.fn(),
+            openModal: jest.fn(),
         };
         const wrapper = shallow(createEditPost({actions}));
         const instance = wrapper.instance();
@@ -234,6 +237,7 @@ describe('components/EditPostModal', () => {
             editPost: jest.fn(),
             addMessageIntoHistory: jest.fn(),
             hideEditPostModal: jest.fn(),
+            openModal: jest.fn(),
         };
         var wrapper = shallow(createEditPost({actions}));
         var instance = wrapper.instance();
@@ -244,7 +248,7 @@ describe('components/EditPostModal', () => {
         instance.handleEdit();
 
         expect(actions.hideEditPostModal).toBeCalled();
-        expect(GlobalActions.showDeletePostModal).toHaveBeenCalled();
+        expect(actions.openModal).toHaveBeenCalled();
         expect(actions.addMessageIntoHistory).not.toBeCalled();
         expect(actions.editPost).not.toBeCalled();
 
@@ -259,7 +263,7 @@ describe('components/EditPostModal', () => {
         await instance.handleEdit();
 
         expect(actions.hideEditPostModal).toBeCalled();
-        expect(GlobalActions.showDeletePostModal).toHaveBeenCalled();
+        expect(actions.openModal).toHaveBeenCalled();
         expect(actions.addMessageIntoHistory).not.toBeCalled();
         expect(actions.editPost).not.toBeCalled();
     });
@@ -271,6 +275,7 @@ describe('components/EditPostModal', () => {
             }),
             addMessageIntoHistory: jest.fn(),
             hideEditPostModal: jest.fn(),
+            openModal: jest.fn(),
         };
         global.scrollTo = jest.fn();
         const wrapper = shallow(createEditPost({actions}));
@@ -297,6 +302,7 @@ describe('components/EditPostModal', () => {
             editPost: jest.fn((data) => data),
             addMessageIntoHistory: jest.fn(),
             hideEditPostModal: jest.fn(),
+            openModal: jest.fn(),
         };
         const wrapper = shallow(createEditPost({actions}));
         const instance = wrapper.instance();
@@ -313,6 +319,7 @@ describe('components/EditPostModal', () => {
             editPost: jest.fn((data) => data),
             addMessageIntoHistory: jest.fn(),
             hideEditPostModal: jest.fn(),
+            openModal: jest.fn(),
         };
         const wrapper = shallow(createEditPost({actions}));
         const instance = wrapper.instance();

--- a/tests/components/edit_post_modal.test.jsx
+++ b/tests/components/edit_post_modal.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
-import * as GlobalActions from 'actions/global_actions.jsx';
 import Constants from 'utils/constants';
 import EditPostModal from 'components/edit_post_modal/edit_post_modal.jsx';
 

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -269,6 +269,7 @@ export const ModalIdentifiers = {
     CHANNEL_INVITE: 'channel_invite',
     CREATE_DM_CHANNEL: 'create_dm_channel',
     EDIT_CHANNEL_HEADER: 'edit_channel_header',
+    DELETE_POST: 'delete_post'
 };
 
 export const UserStatuses = {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -269,7 +269,7 @@ export const ModalIdentifiers = {
     CHANNEL_INVITE: 'channel_invite',
     CREATE_DM_CHANNEL: 'create_dm_channel',
     EDIT_CHANNEL_HEADER: 'edit_channel_header',
-    DELETE_POST: 'delete_post'
+    DELETE_POST: 'delete_post',
 };
 
 export const UserStatuses = {


### PR DESCRIPTION
#### Summary
Migrate delete_post_modal.jsx to be pure and use Redux.
Updated unit tests for editing post and menu item.
Also added new unit tests for delete_post_modal

#### Ticket Link
mattermost/mattermost-server#7660

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
 - [x] Ran make check-style to check for style errors (required for all pull requests)
 - [x] Ran make test to ensure unit and component tests passed
 - [x] Added or updated unit tests
