### PR TITLE
Removing pure components from gates

### DIFF
--- a/components/permissions_gates/channel_permission_gate/channel_permission_gate.jsx
+++ b/components/permissions_gates/channel_permission_gate/channel_permission_gate.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class ChannelPermissionGate extends React.PureComponent {
+export default class ChannelPermissionGate extends React.Component {
     static defaultProps = {
         invert: false,
     }

--- a/components/permissions_gates/system_permission_gate/system_permission_gate.jsx
+++ b/components/permissions_gates/system_permission_gate/system_permission_gate.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class SystemPermissionGate extends React.PureComponent {
+export default class SystemPermissionGate extends React.Component {
     static defaultProps = {
         invert: false,
     }

--- a/components/permissions_gates/team_permission_gate/team_permission_gate.jsx
+++ b/components/permissions_gates/team_permission_gate/team_permission_gate.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class TeamPermissionGate extends React.PureComponent {
+export default class TeamPermissionGate extends React.Component {
     static defaultProps = {
         invert: false,
     }


### PR DESCRIPTION
Basically PureComponent is not really needed, because the children prop will be
almost alwais a new object, so will rerender almost every single time, so we
can skip the props comparison.