### PR TITLE
Update wording on DM restriction config setting

### DIFF
--- a/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
+++ b/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
@@ -264,7 +264,7 @@ export default class UsersAndTeamsSettings extends AdminSettings {
                     helpText={
                         <FormattedHTMLMessage
                             id='admin.team.restrictDirectMessageDesc'
-                            defaultMessage='"Any user on the Mattermost server" enables users to open a Direct Message channel with any user on the server, even if they are not on any teams together. "Any member of the team" limits the ability to open Direct Message channels to only users who are in the same team.'
+                            defaultMessage='"Any user on the Mattermost server" enables users to open a Direct Message channel with any user on the server, even if they are not on any teams together. "Any member of the team" limits the ability in the Direct Messages "More" menu to only open Direct Message channels with users who are in the same team.<br /><br />Note: This setting only affects the UI, not permissions on the server.'
                         />
                     }
                     value={this.state.restrictDirectMessage}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1125,7 +1125,7 @@
   "admin.team.openServerTitle": "Enable Open Server: ",
   "admin.team.restrictDescription": "Teams and user accounts can only be created from a specific domain (e.g. \"mattermost.org\") or list of comma-separated domains (e.g. \"corp.mattermost.com, mattermost.org\").",
   "admin.team.restrictDirectMessage": "Enable users to open Direct Message channels with:",
-  "admin.team.restrictDirectMessageDesc": "'Any user on the Mattermost server' enables users to open a Direct Message channel with any user on the server, even if they are not on any teams together. 'Any member of the team' limits the ability to open Direct Message channels to only users who are in the same team.",
+  "admin.team.restrictDirectMessageDesc": "'Any user on the Mattermost server' enables users to open a Direct Message channel with any user on the server, even if they are not on any teams together. 'Any member of the team' limits the ability in the Direct Messages 'More' menu to only open Direct Message channels with users who are in the same team.<br /><br />Note: This setting only affects the UI, not permissions on the server.",
   "admin.team.restrictExample": "E.g.: \"corp.mattermost.com, mattermost.org\"",
   "admin.team.restrictNameDesc": "When true, You cannot create a team name with reserved words like www, admin, support, test, channel, etc",
   "admin.team.restrictNameTitle": "Restrict Team Names: ",


### PR DESCRIPTION
Doc PR: mattermost/docs#1890

Resubmitting https://github.com/mattermost/mattermost-webapp/pull/1007, which had issues with spinmints.

UI text now loos like:
![image](https://user-images.githubusercontent.com/13119842/38196886-5eaeaad4-3653-11e8-97e0-5398b27250ea.png)
