### PR TITLE
use getFileDownloadUrl when attempting to trigger downloads

### DIFF
--- a/components/file_attachment/filename_overlay.jsx
+++ b/components/file_attachment/filename_overlay.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
-import {getFileUrl} from 'mattermost-redux/utils/file_utils';
+import {getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
 
 import AttachmentIcon from 'components/svg/attachment_icon';
 import {trimFilename} from 'utils/file_utils';
@@ -56,7 +56,6 @@ export default class FilenameOverlay extends React.PureComponent {
 
         const fileName = fileInfo.name;
         const trimmedFilename = trimFilename(fileName);
-        const fileUrl = getFileUrl(fileInfo.id);
 
         let filenameOverlay;
         if (compactDisplay) {
@@ -81,7 +80,7 @@ export default class FilenameOverlay extends React.PureComponent {
         } else if (canDownload) {
             filenameOverlay = (
                 <a
-                    href={fileUrl}
+                    href={getFileDownloadUrl(fileInfo.id)}
                     download={fileName}
                     className={iconClass || 'post-image__name'}
                     target='_blank'

--- a/components/view_image/image_preview.jsx
+++ b/components/view_image/image_preview.jsx
@@ -3,11 +3,11 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {getFilePreviewUrl, getFileUrl} from 'mattermost-redux/utils/file_utils';
+import {getFilePreviewUrl, getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
 
 export default function ImagePreview({fileInfo, canDownloadFiles}) {
     const {has_preview_image: hasPreviewImage, id, link} = fileInfo;
-    const fileUrl = link || getFileUrl(id);
+    const fileUrl = link || getFileDownloadUrl(id);
     const previewUrl = hasPreviewImage ? getFilePreviewUrl(id) : fileUrl;
 
     if (!canDownloadFiles) {

--- a/tests/components/__snapshots__/image_preview.test.jsx.snap
+++ b/tests/components/__snapshots__/image_preview.test.jsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports['components/view_image/ImagePreview should match snapshot, with preview 1'] = `
+exports[`components/view_image/ImagePreview should match snapshot, with preview 1`] = `
 <a
   download={true}
-  href="/api/v4/files/file_id_1"
+  href="/api/v4/files/file_id_1?download=1"
   rel="noopener noreferrer"
   target="_blank"
 >
@@ -13,27 +13,27 @@ exports['components/view_image/ImagePreview should match snapshot, with preview 
 </a>
 `;
 
-exports['components/view_image/ImagePreview should match snapshot, with preview, cannot download 1'] = `
+exports[`components/view_image/ImagePreview should match snapshot, with preview, cannot download 1`] = `
 <img
   src="/api/v4/files/file_id_1/preview"
 />
 `;
 
-exports['components/view_image/ImagePreview should match snapshot, without preview 1'] = `
+exports[`components/view_image/ImagePreview should match snapshot, without preview 1`] = `
 <a
   download={true}
-  href="/api/v4/files/file_id"
+  href="/api/v4/files/file_id?download=1"
   rel="noopener noreferrer"
   target="_blank"
 >
   <img
-    src="/api/v4/files/file_id"
+    src="/api/v4/files/file_id?download=1"
   />
 </a>
 `;
 
-exports['components/view_image/ImagePreview should match snapshot, without preview, cannot download 1'] = `
+exports[`components/view_image/ImagePreview should match snapshot, without preview, cannot download 1`] = `
 <img
-  src="/api/v4/files/file_id"
+  src="/api/v4/files/file_id?download=1"
 />
 `;

--- a/tests/components/file_attachment/__snapshots__/filename_overlay.test.jsx.snap
+++ b/tests/components/file_attachment/__snapshots__/filename_overlay.test.jsx.snap
@@ -47,7 +47,7 @@ exports[`components/file_attachment/FilenameOverlay should match snapshot, stand
 <a
   className="post-image__name"
   download="test_filename"
-  href="/api/v4/files/thumbnail_id"
+  href="/api/v4/files/thumbnail_id?download=1"
   rel="noopener noreferrer"
   target="_blank"
 >
@@ -80,7 +80,7 @@ exports[`components/file_attachment/FilenameOverlay should match snapshot, with 
 <a
   className="post-image__name"
   download="test_filename"
-  href="/api/v4/files/thumbnail_id"
+  href="/api/v4/files/thumbnail_id?download=1"
   rel="noopener noreferrer"
   target="_blank"
 >

--- a/yarn.lock
+++ b/yarn.lock
@@ -5592,7 +5592,7 @@ math-expression-evaluator@^1.2.14:
 
 mattermost-redux@mattermost/mattermost-redux:
   version "1.2.0"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/d78f4b92d590e9c4f8542c0c397f8adfe2cf47e7"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/91cd41ec58433034390d8dc16d3ef4b6eae6ce17"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"


### PR DESCRIPTION
#### Summary
Restore the ability to trigger actual file downloads for images and videos hosted by the Mattermost server. Remote assets will likely still load in a tab.

~Pending merge of the linked mattermost-redux changes, after which I'll update yarn.lock accordingly.~

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9941

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has redux changes: https://github.com/mattermost/mattermost-redux/pull/450