### PR TITLE
MM-10001 Channel mute hide desktop and push settings

### DIFF
--- a/components/channel_notifications_modal/channel_notifications_modal.jsx
+++ b/components/channel_notifications_modal/channel_notifications_modal.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
+import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
+
 import {NotificationLevels, NotificationSections} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -24,6 +26,7 @@ export default class ChannelNotificationsModal extends React.Component {
             updateChannelNotifyProps: PropTypes.func.isRequired,
         }),
     };
+
     constructor(props) {
         super(props);
 
@@ -157,6 +160,7 @@ export default class ChannelNotificationsModal extends React.Component {
 
         const {
             channel,
+            channelMember,
             currentUser,
             sendPushNotifications,
             show,
@@ -201,29 +205,33 @@ export default class ChannelNotificationsModal extends React.Component {
                                     onUpdateSection={this.handleUpdateMarkUnreadSection}
                                     serverError={serverError}
                                 />
-                                <div className='divider-light'/>
-                                <NotificationSection
-                                    section={NotificationSections.DESKTOP}
-                                    expand={activeSection === NotificationSections.DESKTOP}
-                                    memberNotificationLevel={desktopNotifyLevel}
-                                    globalNotificationLevel={currentUser.notify_props ? currentUser.notify_props.desktop : NotificationLevels.ALL}
-                                    onChange={this.handleUpdateDesktopNotifyLevel}
-                                    onSubmit={this.handleSubmitDesktopNotifyLevel}
-                                    onUpdateSection={this.handleUpdateDesktopSection}
-                                    serverError={serverError}
-                                />
-                                <div className='divider-light'/>
-                                {sendPushNotifications &&
-                                <NotificationSection
-                                    section={NotificationSections.PUSH}
-                                    expand={activeSection === NotificationSections.PUSH}
-                                    memberNotificationLevel={pushNotifyLevel}
-                                    globalNotificationLevel={currentUser.notify_props ? currentUser.notify_props.push : NotificationLevels.ALL}
-                                    onChange={this.handleUpdatePushNotificationLevel}
-                                    onSubmit={this.handleSubmitPushNotificationLevel}
-                                    onUpdateSection={this.handleUpdatePushSection}
-                                    serverError={serverError}
-                                />
+                                {!isChannelMuted(channelMember) &&
+                                <div>
+                                    <div className='divider-light'/>
+                                    <NotificationSection
+                                        section={NotificationSections.DESKTOP}
+                                        expand={activeSection === NotificationSections.DESKTOP}
+                                        memberNotificationLevel={desktopNotifyLevel}
+                                        globalNotificationLevel={currentUser.notify_props ? currentUser.notify_props.desktop : NotificationLevels.ALL}
+                                        onChange={this.handleUpdateDesktopNotifyLevel}
+                                        onSubmit={this.handleSubmitDesktopNotifyLevel}
+                                        onUpdateSection={this.handleUpdateDesktopSection}
+                                        serverError={serverError}
+                                    />
+                                    <div className='divider-light'/>
+                                    {sendPushNotifications &&
+                                    <NotificationSection
+                                        section={NotificationSections.PUSH}
+                                        expand={activeSection === NotificationSections.PUSH}
+                                        memberNotificationLevel={pushNotifyLevel}
+                                        globalNotificationLevel={currentUser.notify_props ? currentUser.notify_props.push : NotificationLevels.ALL}
+                                        onChange={this.handleUpdatePushNotificationLevel}
+                                        onSubmit={this.handleSubmitPushNotificationLevel}
+                                        onUpdateSection={this.handleUpdatePushSection}
+                                        serverError={serverError}
+                                    />
+                                    }
+                                </div>
                                 }
                                 <div className='divider-dark'/>
                             </div>

--- a/tests/components/__snapshots__/channel_notifications_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/channel_notifications_modal.test.jsx.snap
@@ -73,29 +73,31 @@ exports[`components/channel_notifications_modal/ChannelNotificationsModal should
             onUpdateSection={[Function]}
             section="markUnread"
           />
-          <div
-            className="divider-light"
-          />
-          <NotificationSection
-            expand={false}
-            globalNotificationLevel="all"
-            memberNotificationLevel="all"
-            onChange={[Function]}
-            onSubmit={[Function]}
-            onUpdateSection={[Function]}
-            section="desktop"
-          />
-          <div
-            className="divider-light"
-          />
-          <NotificationSection
-            expand={false}
-            memberNotificationLevel="default"
-            onChange={[Function]}
-            onSubmit={[Function]}
-            onUpdateSection={[Function]}
-            section="push"
-          />
+          <div>
+            <div
+              className="divider-light"
+            />
+            <NotificationSection
+              expand={false}
+              globalNotificationLevel="all"
+              memberNotificationLevel="all"
+              onChange={[Function]}
+              onSubmit={[Function]}
+              onUpdateSection={[Function]}
+              section="desktop"
+            />
+            <div
+              className="divider-light"
+            />
+            <NotificationSection
+              expand={false}
+              memberNotificationLevel="default"
+              onChange={[Function]}
+              onSubmit={[Function]}
+              onUpdateSection={[Function]}
+              section="push"
+            />
+          </div>
           <div
             className="divider-dark"
           />


### PR DESCRIPTION
#### Summary
Hides the option settings for desktop and push notifications in the channel preferences when the channel is muted.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10001

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
