### PR TITLE
MM-9923: Avoid to show a gray screen on jump

### DIFF
--- a/components/permalink_view/permalink_view.jsx
+++ b/components/permalink_view/permalink_view.jsx
@@ -67,7 +67,12 @@ export default class PermalinkView extends React.PureComponent {
         } = this.props;
 
         if (!this.isStateValid()) {
-            return null;
+            return (
+                <div
+                    id='app-content'
+                    className='app__content'
+                />
+            );
         }
 
         return (


### PR DESCRIPTION
#### Summary
On Jump link clicked, the permalink preview was returning a `null` which
provokes a gray screen in this case. This with dark themes generate a very ugly
visual effect. Now use the default color for the content.

#### Ticket Link
[MM-9923](https://mattermost.atlassian.net/browse/MM-9923)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed