### PR TITLE
MM-9997 Track search box input seaprate from results highlighting

### DIFF
--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import {batchActions} from 'redux-batched-actions';
+
 import {SearchTypes} from 'mattermost-redux/action_types';
 import {searchPosts} from 'mattermost-redux/actions/search';
 import * as PostActions from 'mattermost-redux/actions/posts';
@@ -71,6 +72,10 @@ export function showSearchResults() {
         const searchTerms = getSearchTerms(getState());
 
         dispatch(updateRhsState(RHSStates.SEARCH));
+        dispatch({
+            type: ActionTypes.UPDATE_RHS_SEARCH_RESULTS_TERMS,
+            terms: searchTerms,
+        });
 
         return dispatch(performSearch(searchTerms));
     };

--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -35,13 +35,12 @@ export default class SearchBar extends React.Component {
         }),
     };
 
-    constructor(props) {
-        super(props);
+    constructor() {
+        super();
 
         this.state = {
             focused: false,
             isPristine: true,
-            searchTerms: this.props.searchTerms,
         };
 
         this.suggestionProviders = [new SearchChannelProvider(), new SearchUserProvider()];
@@ -58,12 +57,6 @@ export default class SearchBar extends React.Component {
         }
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.setState({
-            searchTerms: nextProps.searchTerms,
-        });
-    }
-
     handleClose = () => {
         this.props.actions.closeWebrtc();
         this.props.actions.closeRightHandSide();
@@ -78,9 +71,7 @@ export default class SearchBar extends React.Component {
 
     handleChange = (e) => {
         var term = e.target.value;
-        this.setState({
-            searchTerms: term,
-        });
+        this.props.actions.updateSearchTerms(term);
     }
 
     handleUserBlur = () => {
@@ -92,9 +83,7 @@ export default class SearchBar extends React.Component {
     }
 
     handleClear = () => {
-        this.setState({
-            searchTerms: '',
-        });
+        this.props.actions.updateSearchTerms('');
     }
 
     handleUserFocus = () => {
@@ -106,8 +95,6 @@ export default class SearchBar extends React.Component {
             this.setState({
                 isPristine: false,
             });
-
-            this.props.actions.updateSearchTerms(terms);
 
             const {error} = await this.props.actions.showSearchResults();
 
@@ -125,7 +112,7 @@ export default class SearchBar extends React.Component {
 
     handleSubmit = (e) => {
         e.preventDefault();
-        const terms = this.state.searchTerms.trim();
+        const terms = this.props.searchTerms.trim();
 
         if (terms.length === 0) {
             return;
@@ -185,7 +172,7 @@ export default class SearchBar extends React.Component {
         }
 
         let helpClass = 'search-help-popover';
-        if (!this.state.searchTerms && this.state.focused) {
+        if (!this.props.searchTerms && this.state.focused) {
             helpClass += ' visible';
         }
 
@@ -225,7 +212,7 @@ export default class SearchBar extends React.Component {
         }
 
         let clearClass = 'sidebar__search-clear';
-        if (!this.props.isSearchingTerm && this.state.searchTerms && this.state.searchTerms.trim() !== '') {
+        if (!this.props.isSearchingTerm && this.props.searchTerms && this.props.searchTerms.trim() !== '') {
             clearClass += ' visible';
         }
 
@@ -265,7 +252,7 @@ export default class SearchBar extends React.Component {
                             ref={this.getSearch}
                             className='search-bar'
                             placeholder={Utils.localizeMessage('search_bar.search', 'Search')}
-                            value={this.state.searchTerms}
+                            value={this.props.searchTerms}
                             onFocus={this.handleUserFocus}
                             onBlur={this.handleUserBlur}
                             onChange={this.handleChange}
@@ -273,7 +260,7 @@ export default class SearchBar extends React.Component {
                             listComponent={SearchSuggestionList}
                             providers={this.suggestionProviders}
                             type='search'
-                            autoFocus={this.props.isFocus && this.state.searchTerms === ''}
+                            autoFocus={this.props.isFocus && this.props.searchTerms === ''}
                             delayInputUpdate={true}
                         />
                         <div

--- a/components/search_results/index.jsx
+++ b/components/search_results/index.jsx
@@ -9,7 +9,7 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {selectPostFromRightHandSideSearch} from 'actions/views/rhs';
 import {
-    getSearchTerms,
+    getSearchResultsTerms,
     getIsSearchingTerm,
     getIsSearchingFlaggedPost,
     getIsSearchingPinnedPost,
@@ -70,7 +70,7 @@ function makeMapStateToProps() {
         return {
             results: posts,
             channels,
-            searchTerms: getSearchTerms(state),
+            searchTerms: getSearchResultsTerms(state),
             isFlaggedByPostId,
             isSearchingTerm: getIsSearchingTerm(state),
             isSearchingFlaggedPost: getIsSearchingFlaggedPost(state),

--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -77,7 +77,7 @@ export default class SearchResults extends React.PureComponent {
         UserStore.addStatusesChangeListener(this.onStatusChange);
         WebrtcStore.addBusyListener(this.onBusy);
 
-        this.resize();
+        this.scrollToTop();
         window.addEventListener('resize', this.handleResize);
     }
 
@@ -91,7 +91,7 @@ export default class SearchResults extends React.PureComponent {
 
     componentDidUpdate(prevProps) {
         if (this.props.searchTerms !== prevProps.searchTerms) {
-            this.resize();
+            this.scrollToTop();
         }
     }
 
@@ -114,7 +114,7 @@ export default class SearchResults extends React.PureComponent {
         this.setState({statuses: Object.assign({}, UserStore.getStatuses())});
     }
 
-    resize = () => {
+    scrollToTop = () => {
         $('#search-items-container').scrollTop(0);
     }
 

--- a/reducers/views/rhs.js
+++ b/reducers/views/rhs.js
@@ -68,6 +68,15 @@ function searchTerms(state = '', action) {
     }
 }
 
+function searchResultsTerms(state = '', action) {
+    switch (action.type) {
+    case ActionTypes.UPDATE_RHS_SEARCH_RESULTS_TERMS:
+        return action.terms;
+    default:
+        return state;
+    }
+}
+
 function isSearchingTerm(state = false, action) {
     switch (action.type) {
     case SearchTypes.SEARCH_POSTS_REQUEST:
@@ -150,6 +159,7 @@ export default combineReducers({
     previousRhsState,
     rhsState,
     searchTerms,
+    searchResultsTerms,
     isSearchingTerm,
     isSearchingFlaggedPost,
     isSearchingPinnedPost,

--- a/selectors/rhs.jsx
+++ b/selectors/rhs.jsx
@@ -55,6 +55,10 @@ export function getSearchTerms(state) {
     return state.views.rhs.searchTerms;
 }
 
+export function getSearchResultsTerms(state) {
+    return state.views.rhs.searchResultsTerms;
+}
+
 export function getIsSearchingTerm(state) {
     return state.views.rhs.isSearchingTerm;
 }

--- a/tests/redux/actions/views/rhs.test.js
+++ b/tests/redux/actions/views/rhs.test.js
@@ -200,6 +200,10 @@ describe('rhs view actions', () => {
 
             const compareStore = mockStore(testInitialState);
             compareStore.dispatch(updateRhsState(RHSStates.SEARCH));
+            compareStore.dispatch({
+                type: ActionTypes.UPDATE_RHS_SEARCH_RESULTS_TERMS,
+                terms,
+            });
             compareStore.dispatch(performSearch(terms));
 
             expect(store.getActions()).toEqual(compareStore.getActions());

--- a/tests/redux/reducers/views/rhs.test.js
+++ b/tests/redux/reducers/views/rhs.test.js
@@ -13,6 +13,7 @@ describe('Reducers.RHS', () => {
         previousRhsState: null,
         rhsState: null,
         searchTerms: '',
+        searchResultsTerms: '',
         isSearchingTerm: false,
         isSearchingFlaggedPost: false,
         isSearchingPinnedPost: false,

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -119,6 +119,7 @@ export const ActionTypes = keyMirror({
 
     UPDATE_RHS_STATE: null,
     UPDATE_RHS_SEARCH_TERMS: null,
+    UPDATE_RHS_SEARCH_RESULTS_TERMS: null,
 
     UPDATE_MOBILE_VIEW: null,
 


### PR DESCRIPTION
This PR reverts an earlier one that moved the search box state out of redux and into the component state because that PR assumed that there was only one search box component. We actually use two search boxes that are visible at different times but should always have the same value, so that state needs to be in redux.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9997
