### PR TITLE
MM-9974: expose and use react-select's valueKey prop

### DIFF
--- a/components/add_users_to_team/add_users_to_team.jsx
+++ b/components/add_users_to_team/add_users_to_team.jsx
@@ -143,8 +143,6 @@ export default class AddUsersToTeam extends React.Component {
 
         for (let i = 0; i < users.length; i++) {
             const user = Object.assign({}, users[i]);
-            user.value = user.id;
-            user.label = '@' + user.username;
             users[i] = user;
         }
 
@@ -277,6 +275,7 @@ export default class AddUsersToTeam extends React.Component {
                         options={users}
                         optionRenderer={this.renderOption}
                         values={this.state.values}
+                        valueKey='id'
                         valueRenderer={this.renderValue}
                         perPage={USERS_PER_PAGE}
                         handlePageChange={this.handlePageChange}

--- a/components/channel_invite_modal/channel_invite_modal.jsx
+++ b/components/channel_invite_modal/channel_invite_modal.jsx
@@ -259,6 +259,7 @@ export default class ChannelInviteModal extends React.Component {
                     options={users}
                     optionRenderer={this.renderOption}
                     values={this.state.values}
+                    valueKey='id'
                     valueRenderer={this.renderValue}
                     perPage={USERS_PER_PAGE}
                     handlePageChange={this.handlePageChange}

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -95,8 +95,6 @@ export default class MoreDirectChannels extends React.Component {
                     continue;
                 }
 
-                user.value = user.id;
-                user.label = '@' + user.username;
                 values.push(user);
             }
         }
@@ -207,8 +205,6 @@ export default class MoreDirectChannels extends React.Component {
 
         for (let i = 0; i < users.length; i++) {
             const user = Object.assign({}, users[i]);
-            user.value = user.id;
-            user.label = '@' + user.username;
             users[i] = user;
         }
 
@@ -416,6 +412,7 @@ export default class MoreDirectChannels extends React.Component {
                         options={users}
                         optionRenderer={this.renderOption}
                         values={this.state.values}
+                        valueKey='id'
                         valueRenderer={this.renderValue}
                         perPage={USERS_PER_PAGE}
                         handlePageChange={this.handlePageChange}

--- a/components/multiselect/multiselect.jsx
+++ b/components/multiselect/multiselect.jsx
@@ -241,6 +241,7 @@ export default class MultiSelect extends React.Component {
                             onCloseResetsInput={false}
                             onChange={this.onChange}
                             value={this.props.values}
+                            valueKey={this.props.valueKey}
                             valueRenderer={this.props.valueRenderer}
                             menuRenderer={this.handleRender}
                             arrowRenderer={this.handleRender}
@@ -283,6 +284,7 @@ MultiSelect.propTypes = {
     options: PropTypes.arrayOf(PropTypes.object),
     optionRenderer: PropTypes.func,
     values: PropTypes.arrayOf(PropTypes.object),
+    valueKey: PropTypes.string,
     valueRenderer: PropTypes.func,
     handleInput: PropTypes.func,
     handleDelete: PropTypes.func,

--- a/tests/components/__snapshots__/add_users_to_team.test.jsx.snap
+++ b/tests/components/__snapshots__/add_users_to_team.test.jsx.snap
@@ -79,6 +79,7 @@ exports[`components/AddUsersToTeam should match snapshot 1`] = `
       options={Array []}
       perPage={50}
       saving={false}
+      valueKey="id"
       valueRenderer={[Function]}
       values={Array []}
     />


### PR DESCRIPTION
#### Summary
Two of the three components using MultiSelect modified their dataset to
assign a `value` key to the selectable values, triggering react-select's
default `valueKey` prop of `value` to handle item removal.

The component for adding users to a channel did not, resulting in the
removal of any one user in the list removing all of them. Exposing
`valueKey` and passing that as `id` in all three cases instead resolves
the issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9974

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)