### PR TITLE
[MM-10024] Fix optional parameter of haveIChannelPermission to correctly evaluate whether a user can manage members

### DIFF
--- a/utils/channel_utils.jsx
+++ b/utils/channel_utils.jsx
@@ -57,8 +57,8 @@ export function canManageMembers(channel) {
         return haveIChannelPermission(
             store.getState(),
             {
-                channelId: channel.id,
-                teamId: channel.team_id,
+                channel: channel.id,
+                team: channel.team_id,
                 permission: Permissions.MANAGE_PRIVATE_CHANNEL_MEMBERS,
             }
         );
@@ -68,8 +68,8 @@ export function canManageMembers(channel) {
         return haveIChannelPermission(
             store.getState(),
             {
-                channelId: channel.id,
-                teamId: channel.team_id,
+                channel: channel.id,
+                team: channel.team_id,
                 permission: Permissions.MANAGE_PUBLIC_CHANNEL_MEMBERS,
             }
         );


### PR DESCRIPTION
#### Summary
Fix optional parameter of haveIChannelPermission to correctly evaluate whether a user can manage members
- this fixes the issue of non-admin user (but with appropriate permission to manage channel members) not seeing a link to add user/s after at-mention to the channel.

#### Ticket Link
Jira ticket: [MM-10024](https://mattermost.atlassian.net/browse/MM-10024)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
