### PR TITLE
JS error quick fix on teamId props of RhsComment

### DIFF
--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -32,7 +32,7 @@ import UserProfile from 'components/user_profile.jsx';
 export default class RhsComment extends React.Component {
     static propTypes = {
         post: PropTypes.object,
-        teamId: PropTypes.object.isRequired,
+        teamId: PropTypes.string.isRequired,
         lastPostCount: PropTypes.number,
         user: PropTypes.object,
         currentUser: PropTypes.object.isRequired,

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -18,7 +18,7 @@ import * as UserAgent from 'utils/user_agent.jsx';
 import CreateComment from 'components/create_comment';
 import DateSeparator from 'components/post_view/date_separator.jsx';
 import FloatingTimestamp from 'components/post_view/floating_timestamp.jsx';
-import Comment from 'components/rhs_comment';
+import RhsComment from 'components/rhs_comment';
 import RhsHeaderPost from 'components/rhs_header_post';
 import RootPost from 'components/rhs_root_post';
 
@@ -359,7 +359,7 @@ export default class RhsThread extends React.Component {
             const reverseCount = postsLength - i - 1;
             commentsLists.push(
                 <div key={keyPrefix + 'commentKey'}>
-                    <Comment
+                    <RhsComment
                         ref={comPost.id}
                         post={comPost}
                         teamId={this.props.channel.team_id}


### PR DESCRIPTION
#### Summary
- JS error quick fix on teamId props of RhsComment
- also renamed Comment to RhsComment when using that component so it's easier to locate

<img width="693" alt="screen shot 2018-04-03 at 6 41 14 pm" src="https://user-images.githubusercontent.com/5334504/38246157-6ac06242-3773-11e8-9b97-15e62d66c0a8.png">

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
