### PR TITLE
MM-10032: Fix permission used to show IsTrusted field in Oauth 2 integrations form

### DIFF
--- a/components/integrations/abstract_oauth_app.jsx
+++ b/components/integrations/abstract_oauth_app.jsx
@@ -222,7 +222,7 @@ export default class AbstractOAuthApp extends React.PureComponent {
         }
 
         const trusted = (
-            <SystemPermissionGate permissions={[Permissions.MANAGE_OAUTH]}>
+            <SystemPermissionGate permissions={[Permissions.MANAGE_SYSTEM]}>
                 <div className='form-group'>
                     <label
                         className='control-label col-sm-4'

--- a/tests/components/integrations/__snapshots__/abstract_oauth_app.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/abstract_oauth_app.test.jsx.snap
@@ -37,7 +37,7 @@ exports[`components/integrations/AbstractOAuthApp should match snapshot 1`] = `
       <Connect(SystemPermissionGate)
         permissions={
           Array [
-            "manage_oauth",
+            "manage_system",
           ]
         }
       >
@@ -357,7 +357,7 @@ exports[`components/integrations/AbstractOAuthApp should match snapshot, display
       <Connect(SystemPermissionGate)
         permissions={
           Array [
-            "manage_oauth",
+            "manage_system",
           ]
         }
       >


### PR DESCRIPTION
#### Summary
IsTrusted field is only showed if you have permissions to manage the entire system.

#### Ticket Link
[MM-10032](https://mattermost.atlassian.net/browse/MM-10032)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed