### PR TITLE
[MM-10033] Make the pinned and member buttons clickable after blur of search box

### DIFF
--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -84,7 +84,11 @@ export default class SearchBar extends React.Component {
     }
 
     handleUserBlur = () => {
-        this.setState({focused: false});
+        // add time out so that the pinned and member buttons are clickable
+        // when focus is released from the search box.
+        setTimeout(() => {
+            this.setState({focused: false});
+        }, 100);
     }
 
     handleClear = () => {


### PR DESCRIPTION
#### Summary
Make the pinned and member buttons clickable after blur of search box

#### Ticket Link
Jira ticket: [MM-10033](https://mattermost.atlassian.net/browse/MM-10033)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
