### PR TITLE
MM-9860: mark atBottom only after finish initial positioning

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -202,6 +202,7 @@ export default class PostList extends React.PureComponent {
                 const rect = element.getBoundingClientRect();
                 const listHeight = postList.clientHeight / 2;
                 postList.scrollTop += rect.top - listHeight;
+                this.atBottom = this.checkBottom();
             } else if (this.previousScrollHeight !== postList.scrollHeight && posts[0].id === prevPosts[0].id) {
                 postList.scrollTop = this.previousScrollTop + (postList.scrollHeight - this.previousScrollHeight);
             }


### PR DESCRIPTION
#### Summary
The post_list handle scroll changes, and mark "atBottom" in the component if
you are at the bottom, to be sure the next scroll change move you to there.

Because a race condition, sometimes is marked atBottom before the focused post
is positioned, so nexts scroll updates, move you to the bottom.

I have forced to recalculate the "atBottom" property after positioning the post.

#### Ticket Link
[MM-9860](https://mattermost.atlassian.net/browse/MM-9860)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed