### PR TITLE
Throttling the postListScrollChange action

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import debounce from 'lodash/debounce';
+
 import {
     getChannel,
     createDirectChannel,
@@ -537,10 +539,17 @@ export async function redirectUserToDefaultTeam() {
     }
 }
 
-export function postListScrollChange(forceScrollToBottom = false) {
+export const postListScrollChange = debounce(() => {
     AppDispatcher.handleViewAction({
         type: EventTypes.POST_LIST_SCROLL_CHANGE,
-        value: forceScrollToBottom,
+        value: false,
+    });
+});
+
+export function postListScrollChangeToBottom() {
+    AppDispatcher.handleViewAction({
+        type: EventTypes.POST_LIST_SCROLL_CHANGE,
+        value: true,
     });
 }
 

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -25,7 +25,7 @@ import {
 } from 'mattermost-redux/actions/posts';
 import {Posts} from 'mattermost-redux/constants';
 
-import {emitUserPostedEvent, postListScrollChange} from 'actions/global_actions.jsx';
+import {emitUserPostedEvent, postListScrollChangeToBottom} from 'actions/global_actions.jsx';
 import {createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
 import {getPostDraft} from 'selectors/rhs';
@@ -76,7 +76,7 @@ function onSubmitPost(post, fileInfos) {
     return () => {
         emitUserPostedEvent(post);
         createPost(post, fileInfos);
-        postListScrollChange(true);
+        postListScrollChangeToBottom();
     };
 }
 


### PR DESCRIPTION
#### Summary
A lot of elements (markdown elements, emojis, images...) emits
postListScrollChange events, so each event is handled, basically if almost 0
effect except for the last one, or the "forcedToBottom" one. So I splitted the
actions in 2, one for forcedToBottom, without debounce, and the action without
forceToBottom, which is debounced. It reduce the number of calls to
handleScroll in the post_list component from 60 to 1 or something like that
(depends on the posts of the channel).

#### Ticket
[MM-10043](https://mattermost.atlassian.net/browse/MM-10043)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [X] Ran `make test` to ensure unit and component tests passed