### PR TITLE
MM-9973: ignore dispatched events against unregistered suggestion boxes

### DIFF
--- a/stores/suggestion_store.jsx
+++ b/stores/suggestion_store.jsx
@@ -117,6 +117,10 @@ class SuggestionStore extends EventEmitter {
         suggestion.selection = '';
     }
 
+    suggestionBoxExists(id) {
+        return this.suggestions.has(id);
+    }
+
     hasSuggestions(id) {
         return this.getSuggestions(id).terms.length > 0;
     }
@@ -249,6 +253,10 @@ class SuggestionStore extends EventEmitter {
 
     handleEventPayload(payload) {
         const {type, id, ...other} = payload.action;
+
+        if (id && !this.suggestionBoxExists(id)) {
+            return;
+        }
 
         switch (type) {
         case ActionTypes.SUGGESTION_PRETEXT_CHANGED:

--- a/tests/stores/suggestion_store.test.jsx
+++ b/tests/stores/suggestion_store.test.jsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import {ActionTypes} from 'utils/constants.jsx';
+import SuggestionStore from 'stores/suggestion_store.jsx';
+
+describe('stores/SuggestionStore', () => {
+    test('should ignore events from unknown suggestion boxes', () => {
+        const id = 'unknown';
+        const pretext = 'pretext';
+        SuggestionStore.handleEventPayload({
+            action: {
+                id,
+                type: ActionTypes.SUGGESTION_PRETEXT_CHANGED,
+                pretext,
+            },
+        });
+        assert.equal(SuggestionStore.suggestions.has(id), false);
+    });
+
+    test('should process events from registered suggestion boxes', () => {
+        const id = 'id1';
+        const pretext = 'pretext';
+        SuggestionStore.registerSuggestionBox(id);
+        SuggestionStore.handleEventPayload({
+            action: {
+                id,
+                type: ActionTypes.SUGGESTION_PRETEXT_CHANGED,
+                pretext,
+            },
+        });
+        assert.equal(SuggestionStore.suggestions.get(id).pretext, pretext);
+    });
+
+    test('should ignore events from unregistered suggestion boxes', () => {
+        const id = 'id1';
+        const pretext = 'pretext';
+        SuggestionStore.registerSuggestionBox(id);
+        SuggestionStore.unregisterSuggestionBox(id);
+
+        SuggestionStore.handleEventPayload({
+            action: {
+                id,
+                type: ActionTypes.SUGGESTION_PRETEXT_CHANGED,
+                pretext,
+            },
+        });
+        assert.equal(SuggestionStore.suggestions.has(id), false);
+    });
+});


### PR DESCRIPTION
#### Summary
In a slow network environment, typing a channel name, then erasing it,
then quickly typing again and hitting enter to unmount the suggestion
box could result in a previous network call eventually dispatching an
event for the now unregistered suggestion box. If the dispatched event
was for an empty string, it would incorrectly try to handle that,
ultimately attempting to dereference `undefined.push`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9973

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)