### PR TITLE
MM-10041: Fixed reactions permissions on RHS posts

### DIFF
--- a/components/rhs_comment/index.js
+++ b/components/rhs_comment/index.js
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 import {isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import RhsComment from './rhs_comment.jsx';
@@ -11,11 +12,13 @@ function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
     const enableEmojiPicker = config.EnableEmojiPicker === 'true';
     const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
+    const teamId = ownProps.teamId || getCurrentTeamId(state);
 
     return {
         enableEmojiPicker,
         enablePostUsernameOverride,
         isReadOnly: isChannelReadOnlyById(state, ownProps.post.channel_id),
+        teamId,
     };
 }
 

--- a/components/rhs_root_post/index.js
+++ b/components/rhs_root_post/index.js
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 import {isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import RhsRootPost from './rhs_root_post.jsx';
@@ -11,11 +12,13 @@ function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
     const enableEmojiPicker = config.EnableEmojiPicker === 'true';
     const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
+    const teamId = ownProps.teamId || getCurrentTeamId(state);
 
     return {
         enableEmojiPicker,
         enablePostUsernameOverride,
         isReadOnly: isChannelReadOnlyById(state, ownProps.post.channel_id),
+        teamId,
     };
 }
 

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Posts} from 'mattermost-redux/constants';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
+import Permissions from 'mattermost-redux/constants/permissions';
 
 import {addReaction, emitEmojiPosted} from 'actions/post_actions.jsx';
 import UserStore from 'stores/user_store.jsx';
@@ -25,6 +26,7 @@ import PostTime from 'components/post_view/post_time.jsx';
 import ProfilePicture from 'components/profile_picture.jsx';
 import EmojiIcon from 'components/svg/emoji_icon';
 import MattermostLogo from 'components/svg/mattermost_logo';
+import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 
 import UserProfile from 'components/user_profile.jsx';
 
@@ -32,6 +34,7 @@ export default class RhsRootPost extends React.Component {
     static propTypes = {
         post: PropTypes.object.isRequired,
         user: PropTypes.object.isRequired,
+        teamId: PropTypes.string.isRequired,
         currentUser: PropTypes.object.isRequired,
         compactDisplay: PropTypes.bool,
         commentCount: PropTypes.number.isRequired,
@@ -190,7 +193,7 @@ export default class RhsRootPost extends React.Component {
     };
 
     render() {
-        const {post, user, isReadOnly} = this.props;
+        const {post, user, isReadOnly, teamId} = this.props;
         var channel = ChannelStore.get(post.channel_id);
 
         const isEphemeral = Utils.isPostEphemeral(post);
@@ -224,13 +227,19 @@ export default class RhsRootPost extends React.Component {
                         spaceRequiredAbove={342}
                         spaceRequiredBelow={342}
                     />
-                    <button
-                        className='reacticon__container reaction color--link style--none'
-                        onClick={this.toggleEmojiPicker}
-                        ref='rhs_root_reacticon'
+                    <ChannelPermissionGate
+                        channelId={post.channel_id}
+                        teamId={teamId}
+                        permissions={[Permissions.ADD_REACTION]}
                     >
-                        <EmojiIcon className='icon icon--emoji'/>
-                    </button>
+                        <button
+                            className='reacticon__container reaction color--link style--none'
+                            onClick={this.toggleEmojiPicker}
+                            ref='rhs_root_reacticon'
+                        >
+                            <EmojiIcon className='icon icon--emoji'/>
+                        </button>
+                    </ChannelPermissionGate>
                 </span>
 
             );

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -443,6 +443,7 @@ export default class RhsThread extends React.Component {
                             post={selected}
                             commentCount={postsLength}
                             user={profile}
+                            teamId={this.props.channel.team_id}
                             currentUser={this.props.currentUser}
                             compactDisplay={this.state.compactDisplay}
                             isFlagged={isRootFlagged}


### PR DESCRIPTION
#### Summary
ADD_REACTIONS permissions wasn't checked for the rhs_root_post and wasn't
correctly checked for replys on direct/group chat messages.

#### Ticket Link
[MM-10041](https://mattermost.atlassian.net/browse/MM-10041)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed