### PR TITLE
Fix loading state of invite channel modal

### DIFF
--- a/components/channel_invite_modal/channel_invite_modal.jsx
+++ b/components/channel_invite_modal/channel_invite_modal.jsx
@@ -16,7 +16,6 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import Constants from 'utils/constants.jsx';
 import {displayEntireNameForUser, localizeMessage} from 'utils/utils.jsx';
-import LoadingScreen from 'components/loading_screen.jsx';
 import ProfilePicture from 'components/profile_picture.jsx';
 import MultiSelect from 'components/multiselect/multiselect.jsx';
 
@@ -249,31 +248,26 @@ export default class ChannelInviteModal extends React.Component {
             users = this.state.users.filter((user) => user.delete_at === 0);
         }
 
-        let content;
-        if (this.state.loading) {
-            content = (<LoadingScreen/>);
-        } else {
-            content = (
-                <MultiSelect
-                    key='addUsersToChannelKey'
-                    options={users}
-                    optionRenderer={this.renderOption}
-                    values={this.state.values}
-                    valueKey='id'
-                    valueRenderer={this.renderValue}
-                    perPage={USERS_PER_PAGE}
-                    handlePageChange={this.handlePageChange}
-                    handleInput={this.search}
-                    handleDelete={this.handleDelete}
-                    handleAdd={this.addValue}
-                    handleSubmit={this.handleSubmit}
-                    maxValues={MAX_SELECTABLE_VALUES}
-                    numRemainingText={numRemainingText}
-                    buttonSubmitText={buttonSubmitText}
-                    saving={this.state.saving}
-                />
-            );
-        }
+        const content = (
+            <MultiSelect
+                key='addUsersToChannelKey'
+                options={users}
+                optionRenderer={this.renderOption}
+                values={this.state.values}
+                valueRenderer={this.renderValue}
+                perPage={USERS_PER_PAGE}
+                handlePageChange={this.handlePageChange}
+                handleInput={this.search}
+                handleDelete={this.handleDelete}
+                handleAdd={this.addValue}
+                handleSubmit={this.handleSubmit}
+                maxValues={MAX_SELECTABLE_VALUES}
+                numRemainingText={numRemainingText}
+                buttonSubmitText={buttonSubmitText}
+                saving={this.state.saving}
+                loading={this.state.loadingUsers}
+            />
+        );
 
         return (
             <Modal


### PR DESCRIPTION
#### Summary
Adds a loader for channel invite modal

instead of empty state on load, it shows a loader.
![apr-05-2018 18-14-35](https://user-images.githubusercontent.com/4973621/38367175-99c87c36-38ff-11e8-9318-a54909dfd932.gif)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
