### PR TITLE
[MM-9785] Fix timestamp, ability to flag and not respecting teammate name display setting of add to channel ephemeral post on RHS

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -345,8 +345,7 @@ export function sendEphemeralPost(message, channelId, parentId) {
     handleNewPost(post);
 }
 
-export function sendAddToChannelEphemeralPost(user, addedUsername, channelId, postRootId = '') {
-    const timestamp = Utils.getTimestamp();
+export function sendAddToChannelEphemeralPost(user, addedUsername, addedUserId, channelId, postRootId = '', timestamp) {
     const post = {
         id: Utils.generateId(),
         user_id: user.id,
@@ -360,6 +359,7 @@ export function sendAddToChannelEphemeralPost(user, addedUsername, channelId, po
         props: {
             username: user.username,
             addedUsername,
+            addedUserId,
         },
     };
 

--- a/components/post_view/post_add_channel_member/post_add_channel_member.jsx
+++ b/components/post_view/post_add_channel_member/post_add_channel_member.jsx
@@ -60,9 +60,11 @@ export default class PostAddChannelMember extends React.PureComponent {
         const {currentUser, post, userIds, usernames} = this.props;
 
         if (post && post.channel_id) {
+            let createAt = parseInt(post.create_at, 10);
             userIds.forEach((userId, index) => {
+                createAt++;
                 this.props.actions.addChannelMember(post.channel_id, userId);
-                sendAddToChannelEphemeralPost(currentUser, usernames[index], post.channel_id, post.root_id);
+                sendAddToChannelEphemeralPost(currentUser, usernames[index], userId, post.channel_id, post.root_id, createAt);
             });
 
             this.props.actions.removePost(post);

--- a/components/post_view/post_add_channel_member/post_add_channel_member.jsx
+++ b/components/post_view/post_add_channel_member/post_add_channel_member.jsx
@@ -60,7 +60,7 @@ export default class PostAddChannelMember extends React.PureComponent {
         const {currentUser, post, userIds, usernames} = this.props;
 
         if (post && post.channel_id) {
-            let createAt = parseInt(post.create_at, 10);
+            let createAt = post.create_at;
             userIds.forEach((userId, index) => {
                 createAt++;
                 this.props.actions.addChannelMember(post.channel_id, userId);

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -5,7 +5,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Posts} from 'mattermost-redux/constants/index';
-import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
+import {
+    isPostEphemeral,
+    isPostPendingOrFailed,
+} from 'mattermost-redux/utils/post_utils';
 import Permissions from 'mattermost-redux/constants/permissions';
 
 import {addReaction, emitEmojiPosted} from 'actions/post_actions.jsx';
@@ -136,7 +139,7 @@ export default class RhsComment extends React.Component {
 
         const isPermalink = !(isEphemeral ||
             Posts.POST_DELETED === post.state ||
-            ReduxPostUtils.isPostPendingOrFailed(post));
+            isPostPendingOrFailed(post));
 
         return (
             <PostTime
@@ -208,7 +211,7 @@ export default class RhsComment extends React.Component {
             idCount = this.props.lastPostCount;
         }
 
-        const isEphemeral = Utils.isPostEphemeral(post);
+        const isEphemeral = isPostEphemeral(post);
         const isSystemMessage = PostUtils.isSystemMessage(post);
 
         let status = this.props.status;

--- a/tests/components/post_view/post_add_channel_member/post_add_channel_member.test.jsx
+++ b/tests/components/post_view/post_add_channel_member/post_add_channel_member.test.jsx
@@ -18,6 +18,7 @@ describe('components/post_view/PostAddChannelMember', () => {
         id: 'post_id_1',
         root_id: 'root_id',
         channel_id: 'channel_id',
+        create_at: 1,
     };
     const requiredProps = {
         currentUser: {id: 'current_user_id', username: 'current_username'},
@@ -81,7 +82,7 @@ describe('components/post_view/PostAddChannelMember', () => {
         expect(actions.addChannelMember).toHaveBeenCalledTimes(1);
         expect(actions.addChannelMember).toHaveBeenCalledWith(post.channel_id, requiredProps.userIds[0]);
         expect(sendAddToChannelEphemeralPost).toHaveBeenCalledTimes(1);
-        expect(sendAddToChannelEphemeralPost).toHaveBeenCalledWith(props.currentUser, props.usernames[0], post.channel_id, post.root_id);
+        expect(sendAddToChannelEphemeralPost).toHaveBeenCalledWith(props.currentUser, props.usernames[0], props.userIds[0], post.channel_id, post.root_id, 2);
         expect(actions.removePost).toHaveBeenCalledTimes(1);
         expect(actions.removePost).toHaveBeenCalledWith(post);
     });


### PR DESCRIPTION
#### Summary
Fix the remaining issues of MM-9785
1. Timestamp of ephemeral post is earlier than message where the user posted at-mention
- not sure why `Utils.getTimestamp()` is not working as I would expect it to be, so I just increment `create_at` so it will always be next to where the user posted at-mention
2. Can flag ephemeral post
- used the `isEphemeralPost` function from the mattermost-redux since it's considering the new ephemeral post type of `POST_TYPES.EPHEMERAL_ADD_TO_CHANNEL`. On master, for I'm planning to update all `Utils.isEphemeralPost` to use the said utility function from mattermost-redux as well.
3. Update ephemeral post of add to channel so that it respects the teammate name display setting.

#### Ticket Link
Jira ticket: [MM-9785](https://mattermost.atlassian.net/browse/MM-9785)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
