### PR TITLE
Add shadow on link preview image

### DIFF
--- a/sass/components/_videos.scss
+++ b/sass/components/_videos.scss
@@ -87,6 +87,10 @@
         max-width: 450px;
         position: relative;
 
+        &:hover {
+            @include box-shadow(0 2px 5px 0 rgba($black, 0.1), 0 2px 10px 0 rgba($black, 0.1));
+        }
+        
         &.placeholder {
             height: 500px;
         }

--- a/sass/components/_videos.scss
+++ b/sass/components/_videos.scss
@@ -80,6 +80,7 @@
     }
 
     .img-div {
+        @include single-transition(all, .1s, linear);
         -moz-force-broken-image-icon: 1;
         border-radius: 5px;
         margin-bottom: 8px;
@@ -90,7 +91,7 @@
         &:hover {
             @include box-shadow(0 2px 5px 0 rgba($black, 0.1), 0 2px 10px 0 rgba($black, 0.1));
         }
-        
+
         &.placeholder {
             height: 500px;
         }


### PR DESCRIPTION
#### Summary
Shadow appears on image that are linked when the mouse hovers over the image. 

#### Ticket Link
MM-10104

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes

#### Screenshot
Left: when mouse is not hovering over image that is uploaded using link
Right: when mouse is hovering over image that is uploaded using link
<img width="1680" alt="screenshot 2018-04-05 22 26 47" src="https://user-images.githubusercontent.com/15200562/38403402-83c6bfda-3920-11e8-83ed-4874da44f5af.png">

Left: when mouse is not hovering over image that is uploaded using paperclip icon in message box
Right: when mouse is hovering over image that is uploaded using paperclip icon in message box
<img width="1680" alt="screenshot 2018-04-05 22 46 51" src="https://user-images.githubusercontent.com/15200562/38403835-60b66cea-3923-11e8-9792-e47d1f4e97be.png">

