### PR TITLE
Collapse uploaded image

### DIFF
--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -83,7 +83,7 @@ export default class FileAttachmentList extends React.Component {
                         />
                     );
                 }
-            } else if (fileCount === 1) {
+            } else if (fileCount === 1 && this.props.isEmbedVisible) {
                 return (
                     <div style={style.minHeightPlaceholder}/>
                 );

--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -34,6 +34,8 @@ export default class FileAttachmentList extends React.Component {
          */
         compactDisplay: PropTypes.bool,
 
+        isEmbedVisible: PropTypes.bool,
+
         actions: PropTypes.shape({
 
             /*
@@ -76,6 +78,8 @@ export default class FileAttachmentList extends React.Component {
                     return (
                         <SingleImageView
                             fileInfo={fileInfos[0]}
+                            isEmbedVisible={this.props.isEmbedVisible}
+                            post={this.props.post}
                         />
                     );
                 }

--- a/components/file_attachment_list/index.js
+++ b/components/file_attachment_list/index.js
@@ -6,11 +6,21 @@ import {bindActionCreators} from 'redux';
 import {getMissingFilesForPost} from 'mattermost-redux/actions/files';
 import {makeGetFilesForPost} from 'mattermost-redux/selectors/entities/files';
 
+import {get} from 'mattermost-redux/selectors/entities/preferences';
+
+import {makeGetGlobalItem} from 'selectors/storage';
+
+import {Preferences, StoragePrefixes} from 'utils/constants.jsx';
+
 import FileAttachmentList from './file_attachment_list.jsx';
 
 function makeMapStateToProps() {
     const selectFilesForPost = makeGetFilesForPost();
+
     return function mapStateToProps(state, ownProps) {
+        const previewCollapsed = get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.COLLAPSE_DISPLAY, Preferences.COLLAPSE_DISPLAY_DEFAULT);
+        const isEmbedVisible = makeGetGlobalItem(StoragePrefixes.EMBED_VISIBLE + ownProps.post.id, previewCollapsed.startsWith('false'))(state);
+
         const postId = ownProps.post ? ownProps.post.id : '';
         const fileInfos = selectFilesForPost(state, postId);
 
@@ -25,6 +35,7 @@ function makeMapStateToProps() {
             ...ownProps,
             fileInfos,
             fileCount,
+            isEmbedVisible,
         };
     };
 }

--- a/components/single_image_view/single_image_view.jsx
+++ b/components/single_image_view/single_image_view.jsx
@@ -36,6 +36,7 @@ export default class SingleImageView extends React.PureComponent {
 
     static defaultProps = {
         fileInfo: {},
+        previewEnabled: false,
     };
 
     constructor(props) {
@@ -173,12 +174,12 @@ export default class SingleImageView extends React.PureComponent {
         );
 
         const fileHeader = (
-            <span
+            <div
                 className='image-name'
                 onClick={this.handleImageClick}
             >
                 {fileInfo.name}
-            </span>
+            </div>
         );
 
         const fileType = getFileType(fileInfo.extension);
@@ -222,7 +223,7 @@ export default class SingleImageView extends React.PureComponent {
             fadeInClass = 'image-fade-in';
             imageStyle = {cursor: 'pointer'};
             imageLoadedStyle = {};
-        } else {
+        } else if (this.props.isEmbedVisible) {
             loadingImagePreview = (
                 <LoadingImagePreview
                     loading={loading}
@@ -253,6 +254,7 @@ export default class SingleImageView extends React.PureComponent {
                     className='file__image'
                 >
                     {toggle} {fileHeader}
+                    {this.props.isEmbedVisible &&
                     <div
                         className='image-container'
                         style={imageContainerStyle}
@@ -267,6 +269,7 @@ export default class SingleImageView extends React.PureComponent {
                             {loadingImagePreview}
                         </div>
                     </div>
+                    }
                     {viewImageModal}
                 </div>
             </div>

--- a/components/single_image_view/single_image_view.jsx
+++ b/components/single_image_view/single_image_view.jsx
@@ -36,7 +36,6 @@ export default class SingleImageView extends React.PureComponent {
 
     static defaultProps = {
         fileInfo: {},
-        previewEnabled: false,
     };
 
     constructor(props) {
@@ -167,7 +166,6 @@ export default class SingleImageView extends React.PureComponent {
             <a
                 key='toggle'
                 className='post__embed-visibility'
-                data-expanded={this.props.isEmbedVisible}
                 aria-label='Toggle Embed Visibility'
                 onClick={this.toggleEmbedVisibility}
             />

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -147,6 +147,12 @@
     .file__image {
         @include legacy-pie-clearfix;
 
+        .image-name {
+            display: inline-block;
+            font-size: 14px;
+            font-weight: bold; 
+        }
+
         .image-container {
             position: relative;
             width: 100%;


### PR DESCRIPTION
#### Summary
Added a feature to allow the image uploaded to be collapsed using an icon and using /collapse command

#### Ticket Link
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes

#### Screenshots
Left: Image is collapsed 
<img width="1680" alt="screenshot 2018-04-05 23 34 42" src="https://user-images.githubusercontent.com/15200562/38404834-fab8d3e0-3929-11e8-96c2-8676a3ff8e5f.png">

