### PR TITLE
pass the download link to the PopoverBar to "Download"

### DIFF
--- a/components/view_image/view_image.jsx
+++ b/components/view_image/view_image.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
-import {getFilePreviewUrl, getFileUrl} from 'mattermost-redux/utils/file_utils';
+import {getFilePreviewUrl, getFileUrl, getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
 
 import * as GlobalActions from 'actions/global_actions';
 import Constants, {FileTypes} from 'utils/constants';
@@ -205,6 +205,7 @@ export default class ViewImageModal extends React.PureComponent {
         const showPublicLink = !fileInfo.link;
         const fileName = fileInfo.link || fileInfo.name;
         const fileUrl = fileInfo.link || getFileUrl(fileInfo.id);
+        const fileDownloadUrl = fileInfo.link || getFileDownloadUrl(fileInfo.id);
 
         let content;
         if (this.state.loaded[this.state.imageIndex]) {
@@ -326,7 +327,7 @@ export default class ViewImageModal extends React.PureComponent {
                                 fileIndex={this.state.imageIndex}
                                 totalFiles={this.props.fileInfos.length}
                                 filename={fileName}
-                                fileURL={fileUrl}
+                                fileURL={fileDownloadUrl}
                                 enablePublicLink={this.props.enablePublicLink}
                                 canDownloadFiles={this.props.canDownloadFiles}
                                 onGetPublicLink={this.handleGetPublicLink}

--- a/tests/components/__snapshots__/view_image.test.jsx.snap
+++ b/tests/components/__snapshots__/view_image.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports['components/ViewImageModal should match snapshot on onModalShown and onModalHidden 1'] = `
+exports[`components/ViewImageModal should match snapshot on onModalShown and onModalHidden 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -64,7 +64,7 @@ exports['components/ViewImageModal should match snapshot on onModalShown and onM
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id_1"
+          fileURL="/api/v4/files/file_id_1?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -97,7 +97,7 @@ exports['components/ViewImageModal should match snapshot on onModalShown and onM
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot on onModalShown and onModalHidden 2'] = `
+exports[`components/ViewImageModal should match snapshot on onModalShown and onModalHidden 2`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -161,7 +161,7 @@ exports['components/ViewImageModal should match snapshot on onModalShown and onM
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id_1"
+          fileURL="/api/v4/files/file_id_1?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -194,7 +194,7 @@ exports['components/ViewImageModal should match snapshot on onModalShown and onM
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded 1'] = `
+exports[`components/ViewImageModal should match snapshot, loaded 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -258,7 +258,7 @@ exports['components/ViewImageModal should match snapshot, loaded 1'] = `
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id"
+          fileURL="/api/v4/files/file_id?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -271,7 +271,7 @@ exports['components/ViewImageModal should match snapshot, loaded 1'] = `
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded and showing footer 1'] = `
+exports[`components/ViewImageModal should match snapshot, loaded and showing footer 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -335,7 +335,7 @@ exports['components/ViewImageModal should match snapshot, loaded and showing foo
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id"
+          fileURL="/api/v4/files/file_id?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={true}
@@ -348,7 +348,7 @@ exports['components/ViewImageModal should match snapshot, loaded and showing foo
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded with .js file 1'] = `
+exports[`components/ViewImageModal should match snapshot, loaded with .js file 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -412,7 +412,7 @@ exports['components/ViewImageModal should match snapshot, loaded with .js file 1
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id"
+          fileURL="/api/v4/files/file_id?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -425,7 +425,7 @@ exports['components/ViewImageModal should match snapshot, loaded with .js file 1
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded with .m4a file 1'] = `
+exports[`components/ViewImageModal should match snapshot, loaded with .m4a file 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -489,7 +489,7 @@ exports['components/ViewImageModal should match snapshot, loaded with .m4a file 
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id"
+          fileURL="/api/v4/files/file_id?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -502,7 +502,7 @@ exports['components/ViewImageModal should match snapshot, loaded with .m4a file 
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded with .mov file 1'] = `
+exports[`components/ViewImageModal should match snapshot, loaded with .mov file 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -566,7 +566,7 @@ exports['components/ViewImageModal should match snapshot, loaded with .mov file 
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id"
+          fileURL="/api/v4/files/file_id?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -579,7 +579,7 @@ exports['components/ViewImageModal should match snapshot, loaded with .mov file 
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded with footer 1'] = `
+exports[`components/ViewImageModal should match snapshot, loaded with footer 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -643,7 +643,7 @@ exports['components/ViewImageModal should match snapshot, loaded with footer 1']
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id_1"
+          fileURL="/api/v4/files/file_id_1?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={true}
@@ -676,7 +676,7 @@ exports['components/ViewImageModal should match snapshot, loaded with footer 1']
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded with image 1'] = `
+exports[`components/ViewImageModal should match snapshot, loaded with image 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -740,7 +740,7 @@ exports['components/ViewImageModal should match snapshot, loaded with image 1'] 
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id"
+          fileURL="/api/v4/files/file_id?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -753,7 +753,7 @@ exports['components/ViewImageModal should match snapshot, loaded with image 1'] 
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded with left and right arrows 1'] = `
+exports[`components/ViewImageModal should match snapshot, loaded with left and right arrows 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -817,7 +817,7 @@ exports['components/ViewImageModal should match snapshot, loaded with left and r
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id_1"
+          fileURL="/api/v4/files/file_id_1?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -850,7 +850,7 @@ exports['components/ViewImageModal should match snapshot, loaded with left and r
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded with left and right arrows 2'] = `
+exports[`components/ViewImageModal should match snapshot, loaded with left and right arrows 2`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -914,7 +914,7 @@ exports['components/ViewImageModal should match snapshot, loaded with left and r
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={1}
-          fileURL="/api/v4/files/file_id_2"
+          fileURL="/api/v4/files/file_id_2?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -947,7 +947,7 @@ exports['components/ViewImageModal should match snapshot, loaded with left and r
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded with left and right arrows 3'] = `
+exports[`components/ViewImageModal should match snapshot, loaded with left and right arrows 3`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -1011,7 +1011,7 @@ exports['components/ViewImageModal should match snapshot, loaded with left and r
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={1}
-          fileURL="/api/v4/files/file_id_2"
+          fileURL="/api/v4/files/file_id_2?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -1044,7 +1044,7 @@ exports['components/ViewImageModal should match snapshot, loaded with left and r
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loaded with other file 1'] = `
+exports[`components/ViewImageModal should match snapshot, loaded with other file 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -1108,7 +1108,7 @@ exports['components/ViewImageModal should match snapshot, loaded with other file
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id"
+          fileURL="/api/v4/files/file_id?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -1121,7 +1121,7 @@ exports['components/ViewImageModal should match snapshot, loaded with other file
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, loading 1'] = `
+exports[`components/ViewImageModal should match snapshot, loading 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -1181,7 +1181,7 @@ exports['components/ViewImageModal should match snapshot, loading 1'] = `
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id"
+          fileURL="/api/v4/files/file_id?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}
@@ -1194,7 +1194,7 @@ exports['components/ViewImageModal should match snapshot, loading 1'] = `
 </Modal>
 `;
 
-exports['components/ViewImageModal should match snapshot, modal not shown 1'] = `
+exports[`components/ViewImageModal should match snapshot, modal not shown 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -1254,7 +1254,7 @@ exports['components/ViewImageModal should match snapshot, modal not shown 1'] = 
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
-          fileURL="/api/v4/files/file_id"
+          fileURL="/api/v4/files/file_id?download=1"
           filename=""
           onGetPublicLink={[Function]}
           show={false}


### PR DESCRIPTION
#### Summary
Ironically, my earlier attempt to fix this somehow avoided fixing the
very report of the issue, instead only fixing clicking on the image to
download.

I've since mapped out all the various preview components and believe this correctly covers things.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9941

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)