### PR TITLE
MM-10086: fix cancel delete post modal

### DIFF
--- a/components/delete_post_modal/delete_post_modal.jsx
+++ b/components/delete_post_modal/delete_post_modal.jsx
@@ -142,7 +142,7 @@ export default class DeletePostModal extends React.PureComponent {
                     <button
                         type='button'
                         className='btn btn-default'
-                        onClick={this.handleHide}
+                        onClick={this.onHide}
                     >
                         <FormattedMessage
                             id='delete_post.cancel'

--- a/tests/components/__snapshots__/delete_post_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/delete_post_modal.test.jsx.snap
@@ -77,6 +77,7 @@ exports[`components/delete_post_modal should match snapshot for delete_post_moda
   >
     <button
       className="btn btn-default"
+      onClick={[Function]}
       type="button"
     >
       <FormattedMessage
@@ -187,6 +188,7 @@ exports[`components/delete_post_modal should match snapshot for delete_post_moda
   >
     <button
       className="btn btn-default"
+      onClick={[Function]}
       type="button"
     >
       <FormattedMessage

--- a/tests/components/delete_post_modal.test.jsx
+++ b/tests/components/delete_post_modal.test.jsx
@@ -53,6 +53,16 @@ describe('components/delete_post_modal', () => {
         expect(wrapper.state('show')).toEqual(false);
     });
 
+    test('should match state when the cancel button is clicked', () => {
+        const wrapper = shallow(
+            <DeletePostModal {...baseProps}/>
+        );
+
+        wrapper.setState({show: true});
+        wrapper.find('button').at(0).simulate('click');
+        expect(wrapper.state('show')).toEqual(false);
+    });
+
     test('should have called actions.deleteAndRemovePost when handleDelete is called', async () => {
         browserHistory.push = jest.fn();
         const deleteAndRemovePost = jest.fn().mockReturnValueOnce({data: true});


### PR DESCRIPTION
#### Summary
Fix a regression around cancelling the delete post modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10086

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)