### PR TITLE
MM-10096: Fix permissions checking in mobile view menu

### DIFF
--- a/components/sidebar_right_menu/index.js
+++ b/components/sidebar_right_menu/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getInt} from 'mattermost-redux/selectors/entities/preferences';
 
 import {showMentions, showFlaggedPosts, closeRightHandSide, openMenu as openRhsMenu, closeMenu as closeRhsMenu} from 'actions/views/rhs';
@@ -33,6 +34,7 @@ function mapStateToProps(state) {
     const siteName = config.SiteName;
 
     return {
+        teamId: getCurrentTeamId(state),
         isOpen: getIsRhsMenuOpen(state),
         isMentionSearch: rhsState === RHSStates.MENTION,
         showTutorialTip: enableTutorial && isMobile() && tutorialStep === TutorialSteps.MENU_POPOVER,


### PR DESCRIPTION
#### Summary
The permissions checking on team menu wasn't working because we haven't the
teamId defined.

#### Ticket Link
[MM-10096](https://mattermost.atlassian.net/browse/MM-10096)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed