### PR TITLE
MM-10113: Get the access tokens list from the correct places

### DIFF
--- a/components/admin_console/manage_tokens_modal/index.js
+++ b/components/admin_console/manage_tokens_modal/index.js
@@ -11,8 +11,7 @@ function mapStateToProps(state, ownProps) {
     const userId = ownProps.user ? ownProps.user.id : '';
 
     return {
-        ...ownProps,
-        userAccessTokens: state.entities.admin.userAccessTokens[userId],
+        userAccessTokens: state.entities.admin.userAccessTokensByUser[userId],
     };
 }
 


### PR DESCRIPTION
#### Summary
The access tokens list for the user was been get from the wrong place. Probably
in another PR we should move the (state.entities.admin...) access to a selector
in mattermost-redux.

#### Ticket Link
[MM-10113](https://mattermost.atlassian.net/browse/MM-10113)

#### Checklist
- [X] Ran `make check-style` to check for style errors (required for all pull requests)
- [X] Ran `make test` to ensure unit and component tests passed