### PR TITLE
[MM-10062] Revert help note when team creation is set to system admin only

### DIFF
--- a/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
+++ b/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
@@ -90,7 +90,6 @@ export default class UsersAndTeamsSettings extends AdminSettings {
 
     getConfigFromState = (config) => {
         config.TeamSettings.EnableUserCreation = this.state.enableUserCreation;
-        config.TeamSettings.EnableTeamCreation = this.state.enableTeamCreation;
         config.TeamSettings.MaxUsersPerTeam = this.parseIntNonZero(this.state.maxUsersPerTeam, Constants.DEFAULT_MAX_USERS_PER_TEAM);
         config.TeamSettings.RestrictCreationToDomains = this.state.restrictCreationToDomains;
         config.TeamSettings.RestrictDirectMessage = this.state.restrictDirectMessage;

--- a/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
+++ b/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
@@ -90,6 +90,7 @@ export default class UsersAndTeamsSettings extends AdminSettings {
 
     getConfigFromState = (config) => {
         config.TeamSettings.EnableUserCreation = this.state.enableUserCreation;
+        config.TeamSettings.EnableTeamCreation = this.state.enableTeamCreation;
         config.TeamSettings.MaxUsersPerTeam = this.parseIntNonZero(this.state.maxUsersPerTeam, Constants.DEFAULT_MAX_USERS_PER_TEAM);
         config.TeamSettings.RestrictCreationToDomains = this.state.restrictCreationToDomains;
         config.TeamSettings.RestrictDirectMessage = this.state.restrictDirectMessage;

--- a/components/select_team/index.js
+++ b/components/select_team/index.js
@@ -20,7 +20,6 @@ function mapStateToProps(state) {
         isLicensed: license.IsLicensed === 'true',
         customDescriptionText: config.CustomDescriptionText,
         roles: getRoles(state),
-        rolesRequest: state.requests.roles.getRolesByNames,
         siteName: config.SiteName,
     };
 }

--- a/components/select_team/index.js
+++ b/components/select_team/index.js
@@ -28,7 +28,6 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            loadRolesIfNeeded,
             getTeams,
             loadRolesIfNeeded,
         }, dispatch),

--- a/components/select_team/index.js
+++ b/components/select_team/index.js
@@ -3,10 +3,12 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {withRouter} from 'react-router-dom';
+
 import {getTeams} from 'mattermost-redux/actions/teams';
 import {loadRolesIfNeeded} from 'mattermost-redux/actions/roles';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
-import {withRouter} from 'react-router-dom';
+import {getRoles} from 'mattermost-redux/selectors/entities/roles';
 
 import SelectTeam from './select_team.jsx';
 
@@ -17,7 +19,8 @@ function mapStateToProps(state) {
     return {
         isLicensed: license.IsLicensed === 'true',
         customDescriptionText: config.CustomDescriptionText,
-        enableTeamCreation: config.EnableTeamCreation === 'true',
+        roles: getRoles(state),
+        rolesRequest: state.requests.roles.getRolesByNames,
         siteName: config.SiteName,
     };
 }
@@ -27,6 +30,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             loadRolesIfNeeded,
             getTeams,
+            loadRolesIfNeeded,
         }, dispatch),
     };
 }

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -219,6 +219,12 @@ export default class SelectTeam extends React.Component {
                         />
                     </Link>
                 </div>
+                {!enableTeamCreation &&
+                    <FormattedMessage
+                        id='login.createTeamAdminOnly'
+                        defaultMessage='This option is only available for System Administrators, and does not show up for other users.'
+                    />
+                }
             </SystemPermissionGate>
         );
 

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -35,7 +35,6 @@ export default class SelectTeam extends React.Component {
         rolesRequest: PropTypes.object.isRequired,
         siteName: PropTypes.string,
         actions: PropTypes.shape({
-            loadRolesIfNeeded: PropTypes.func.isRequired,
             getTeams: PropTypes.func.isRequired,
             loadRolesIfNeeded: PropTypes.func.isRequired,
         }).isRequired,
@@ -50,17 +49,13 @@ export default class SelectTeam extends React.Component {
         this.state = state;
     }
 
-    componentWillMount() {
-        this.props.actions.loadRolesIfNeeded(['system_user', 'system_admin']);
-    }
-
     componentDidMount() {
         TeamStore.addChangeListener(this.onTeamChange);
         this.props.actions.getTeams(0, 200);
     }
 
     componentWillMount() {
-        this.props.actions.loadRolesIfNeeded([General.SYSTEM_USER_ROLE]).then(() => {
+        this.props.actions.loadRolesIfNeeded([General.SYSTEM_ADMIN_ROLE, General.SYSTEM_USER_ROLE]).then(() => {
             this.loadPoliciesIntoState(this.props.rolesRequest, this.props.roles);
         });
     }


### PR DESCRIPTION
#### Summary
Revert help note when team creation is set to system admin only

#### Ticket Link
Jira ticket: [MM-10062]

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
