### PR TITLE
Add missing getState on forceLogoutIfNecessary

### DIFF
--- a/actions/file_actions.jsx
+++ b/actions/file_actions.jsx
@@ -25,7 +25,7 @@ export function uploadFile(file, name, channelId, clientId, successCallback, err
                 e = {message: Utils.localizeMessage('channel_loader.unknown_error', 'We received an unexpected status code from the server.') + ' (' + err.status + ')'};
             }
 
-            forceLogoutIfNecessary(err, dispatch);
+            forceLogoutIfNecessary(err, dispatch, getState);
 
             const failure = {
                 type: FileTypes.UPLOAD_FILES_FAILURE,


### PR DESCRIPTION
#### Summary
Add missing getState on forceLogoutIfNecessary call on upload fail.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed