### PR TITLE
MM-10036 Properly handle case-insensitive at mentions

### DIFF
--- a/tests/utils/formatting_at_mentions.test.jsx
+++ b/tests/utils/formatting_at_mentions.test.jsx
@@ -55,4 +55,32 @@ describe('TextFormatting.AtMentions', function() {
             'user@email.com'
         );
     });
+
+    it('Highlighted at mentions', function() {
+        assert.equal(
+            TextFormatting.formatText('@user', {atMentions: true, mentionKeys: [{key: '@user'}]}).trim(),
+            '<p><span class=\'mention--highlight\'><span data-mention="user">@user</span></span></p>',
+        );
+        assert.equal(
+            TextFormatting.formatText('@channel', {atMentions: true, mentionKeys: [{key: '@channel'}]}).trim(),
+            '<p><span class=\'mention--highlight\'><span data-mention="channel">@channel</span></span></p>',
+        );
+        assert.equal(
+            TextFormatting.formatText('@all', {atMentions: true, mentionKeys: [{key: '@all'}]}).trim(),
+            '<p><span class=\'mention--highlight\'><span data-mention="all">@all</span></span></p>',
+        );
+
+        assert.equal(
+            TextFormatting.formatText('@USER', {atMentions: true, mentionKeys: [{key: '@user'}]}).trim(),
+            '<p><span class=\'mention--highlight\'><span data-mention="user">@USER</span></span></p>',
+        );
+        assert.equal(
+            TextFormatting.formatText('@CHanNEL', {atMentions: true, mentionKeys: [{key: '@channel'}]}).trim(),
+            '<p><span class=\'mention--highlight\'><span data-mention="channel">@CHanNEL</span></span></p>',
+        );
+        assert.equal(
+            TextFormatting.formatText('@ALL', {atMentions: true, mentionKeys: [{key: '@all'}]}).trim(),
+            '<p><span class=\'mention--highlight\'><span data-mention="all">@ALL</span></span></p>',
+        );
+    });
 });

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -253,7 +253,9 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
     // look for any existing tokens which are self mentions and should be highlighted
     var newTokens = new Map();
     for (const [alias, token] of tokens) {
-        if (mentionKeys.findIndex((key) => key.key === token.originalText) !== -1) {
+        const tokenTextLower = token.originalText.toLowerCase();
+
+        if (mentionKeys.findIndex((key) => key.key.toLowerCase() === tokenTextLower) !== -1) {
             const index = tokens.size + newTokens.size;
             const newAlias = `$MM_SELFMENTION${index}`;
 
@@ -293,7 +295,9 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
             flags += 'i';
         }
 
-        output = output.replace(new RegExp(`(^|\\W)(${escapeRegex(mention.key)})\\b`, flags), replaceCurrentMentionWithToken);
+        const pattern = new RegExp(`(^|\\W)(${escapeRegex(mention.key)})\\b`, flags);
+
+        output = output.replace(pattern, replaceCurrentMentionWithToken);
     }
 
     return output;

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -162,7 +162,7 @@ export function autolinkAtMentions(text, tokens) {
         const alias = `$MM_ATMENTION${index}`;
 
         tokens.set(alias, {
-            value: `<span data-mention="${username}">@${username}</span>`,
+            value: `<span data-mention="${username.toLowerCase()}">@${username}</span>`,
             originalText: fullMatch,
         });
 


### PR DESCRIPTION
This fixes:
1. Highlighting of uppercase at mentions (eg `@CHANNEL`, `@aLL`)
2. Linking of uppercase at mentions (eg clicking `@USER` now properly opens the profile popover for that user)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10036

#### Checklist
- Ran `make test` to ensure unit and component tests passed