### PR TITLE
MM-9858: Declares character encoding in HTML.

### DIFF
--- a/root.html
+++ b/root.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8">
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' cdn.segment.com/analytics.js/ 'unsafe-eval'">
 
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>


### PR DESCRIPTION
#### Summary
Set character encoding in HTML.

Until I get the test back from the original reporter I won't know if this fix closes MM-9858 but it should go in nevertheless.

#### Ticket Link
[MM-9858](https://mattermost.atlassian.net/browse/MM-9858)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed