### PR TITLE
MM-9803: Fixes cursor placement in team and user settings.

### DIFF
--- a/components/team_general_tab/team_general_tab.jsx
+++ b/components/team_general_tab/team_general_tab.jsx
@@ -414,6 +414,7 @@ export default class GeneralTab extends React.Component {
                                 onChange={this.updateInviteId}
                                 value={this.state.invite_id}
                                 maxLength='32'
+                                onFocus={Utils.moveCursorToEnd}
                             />
                             <div className='padding-top x2'>
                                 <button
@@ -499,6 +500,7 @@ export default class GeneralTab extends React.Component {
                             maxLength={Constants.MAX_TEAMNAME_LENGTH.toString()}
                             onChange={this.updateName}
                             value={this.state.name}
+                            onFocus={Utils.moveCursorToEnd}
                         />
                     </div>
                 </div>
@@ -560,6 +562,7 @@ export default class GeneralTab extends React.Component {
                             maxLength={Constants.MAX_TEAMDESCRIPTION_LENGTH.toString()}
                             onChange={this.updateDescription}
                             value={this.state.description}
+                            onFocus={Utils.moveCursorToEnd}
                         />
                     </div>
                 </div>

--- a/components/user_settings/general/user_settings_general.jsx
+++ b/components/user_settings/general/user_settings_general.jsx
@@ -726,6 +726,7 @@ class UserSettingsGeneralTab extends React.Component {
                                 type='text'
                                 onChange={this.updateFirstName}
                                 value={this.state.firstName}
+                                onFocus={Utils.moveCursorToEnd}
                             />
                         </div>
                     </div>
@@ -968,6 +969,7 @@ class UserSettingsGeneralTab extends React.Component {
                                 onChange={this.updateUsername}
                                 value={this.state.username}
                                 autoCapitalize='off'
+                                onFocus={Utils.moveCursorToEnd}
                             />
                         </div>
                     </div>
@@ -1058,6 +1060,7 @@ class UserSettingsGeneralTab extends React.Component {
                                 value={this.state.position}
                                 maxLength={Constants.MAX_POSITION_LENGTH}
                                 autoCapitalize='off'
+                                onFocus={Utils.moveCursorToEnd}
                             />
                         </div>
                     </div>

--- a/components/user_settings/notifications/user_settings_notifications.jsx
+++ b/components/user_settings/notifications/user_settings_notifications.jsx
@@ -621,6 +621,7 @@ export default class NotificationsTab extends React.Component {
                         type='text'
                         defaultValue={this.state.customKeys}
                         onChange={this.onCustomChange}
+                        onFocus={Utils.moveCursorToEnd}
                     />
                 </div>
             );

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -304,10 +304,10 @@ export function areObjectsEqual(x, y) {
     // Comparing dates is a common scenario. Another built-ins?
     // We can even handle functions passed across iframes
     if ((typeof x === 'function' && typeof y === 'function') ||
-       (x instanceof Date && y instanceof Date) ||
-       (x instanceof RegExp && y instanceof RegExp) ||
-       (x instanceof String && y instanceof String) ||
-       (x instanceof Number && y instanceof Number)) {
+        (x instanceof Date && y instanceof Date) ||
+        (x instanceof RegExp && y instanceof RegExp) ||
+        (x instanceof String && y instanceof String) ||
+        (x instanceof Number && y instanceof Number)) {
         return x.toString() === y.toString();
     }
 
@@ -1603,4 +1603,12 @@ export function copyToClipboard(e, data) {
     textArea.select();
     document.execCommand('copy');
     document.body.removeChild(textArea);
+}
+
+export function moveCursorToEnd(e) {
+    const val = e.target.value;
+    if (val.length) {
+        e.target.value = '';
+        e.target.value = val;
+    }
 }


### PR DESCRIPTION
#### Summary
Chrome sets the cursor at the beginning of text inputs with a value by default ([example fiddle](https://jsfiddle.net/geo5guky/)).

#### Ticket Link
[MM-9803](https://mattermost.atlassian.net/browse/MM-9803)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed