### PR TITLE
MM-9831: expunge get state in admin console

### DIFF
--- a/components/admin_console/system_users/index.js
+++ b/components/admin_console/system_users/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 import {connect} from 'react-redux';

--- a/components/admin_console/system_users/list/index.js
+++ b/components/admin_console/system_users/list/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 import {connect} from 'react-redux';

--- a/components/admin_console/system_users/list/index.js
+++ b/components/admin_console/system_users/list/index.js
@@ -17,7 +17,8 @@ function mapStateToProps(state, ownProps) {
 
     let users = [];
     if (ownProps.loading) {
-        // Clear the users while loading.
+        // Show no users while loading.
+        users = [];
     } else if (term) {
         if (teamId) {
             users = searchProfilesInTeam(state, teamId, term);

--- a/components/admin_console/system_users/list/index.js
+++ b/components/admin_console/system_users/list/index.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import {getUser, getProfiles, getProfilesInTeam, getProfilesWithoutTeam, searchProfiles, searchProfilesInTeam} from 'mattermost-redux/selectors/entities/users';
+
+import SystemUsersList from './system_users_list.jsx';
+
+const ALL_USERS = '';
+const NO_TEAM = 'no_team';
+const USER_ID_LENGTH = 26;
+
+function mapStateToProps(state, ownProps) {
+    const teamId = ownProps.teamId;
+    const term = ownProps.term;
+
+    let users = [];
+    if (ownProps.loading) {
+        // Clear the users while loading.
+    } else if (term) {
+        if (teamId) {
+            users = searchProfilesInTeam(state, teamId, term);
+        } else {
+            users = searchProfiles(state, term);
+        }
+
+        if (users.length === 0 && term.length === USER_ID_LENGTH) {
+            const user = getUser(state, term);
+            if (user) {
+                users = [user];
+            }
+        }
+    } else if (teamId === ALL_USERS) {
+        users = getProfiles(state);
+    } else if (teamId === NO_TEAM) {
+        users = getProfilesWithoutTeam(state);
+    } else {
+        users = getProfilesInTeam(state, teamId);
+    }
+
+    return {
+        users,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getUser,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SystemUsersList);

--- a/components/admin_console/system_users/list/index.js
+++ b/components/admin_console/system_users/list/index.js
@@ -3,45 +3,15 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {getUser, getProfiles, getProfilesInTeam, getProfilesWithoutTeam, searchProfiles, searchProfilesInTeam} from 'mattermost-redux/selectors/entities/users';
+
+import {getUser} from 'mattermost-redux/selectors/entities/users';
 
 import SystemUsersList from './system_users_list.jsx';
-
-const ALL_USERS = '';
-const NO_TEAM = 'no_team';
-const USER_ID_LENGTH = 26;
+import {getUsers} from './selectors.jsx';
 
 function mapStateToProps(state, ownProps) {
-    const teamId = ownProps.teamId;
-    const term = ownProps.term;
-
-    let users = [];
-    if (ownProps.loading) {
-        // Show no users while loading.
-        users = [];
-    } else if (term) {
-        if (teamId) {
-            users = searchProfilesInTeam(state, teamId, term);
-        } else {
-            users = searchProfiles(state, term);
-        }
-
-        if (users.length === 0 && term.length === USER_ID_LENGTH) {
-            const user = getUser(state, term);
-            if (user) {
-                users = [user];
-            }
-        }
-    } else if (teamId === ALL_USERS) {
-        users = getProfiles(state);
-    } else if (teamId === NO_TEAM) {
-        users = getProfilesWithoutTeam(state);
-    } else {
-        users = getProfilesInTeam(state, teamId);
-    }
-
     return {
-        users,
+        users: getUsers(state, ownProps.loading, ownProps.teamId, ownProps.term),
     };
 }
 

--- a/components/admin_console/system_users/list/selectors.jsx
+++ b/components/admin_console/system_users/list/selectors.jsx
@@ -1,0 +1,38 @@
+import {getUser, getProfiles, getProfilesInTeam, getProfilesWithoutTeam, searchProfiles, searchProfilesInTeam} from 'mattermost-redux/selectors/entities/users';
+
+const ALL_USERS = '';
+const NO_TEAM = 'no_team';
+const USER_ID_LENGTH = 26;
+
+export function getUsers(state, loading, teamId, term) {
+    if (loading) {
+        // Show no users while loading.
+        return [];
+    }
+
+    if (term) {
+        let users = [];
+        if (teamId) {
+            users = searchProfilesInTeam(state, teamId, term);
+        } else {
+            users = searchProfiles(state, term);
+        }
+
+        if (users.length === 0 && term.length === USER_ID_LENGTH) {
+            const user = getUser(state, term);
+            if (user) {
+                users = [user];
+            }
+        }
+
+        return users;
+    }
+
+    if (teamId === ALL_USERS) {
+        return getProfiles(state);
+    } else if (teamId === NO_TEAM) {
+        return getProfilesWithoutTeam(state);
+    }
+
+    return getProfilesInTeam(state, teamId);
+}

--- a/components/admin_console/system_users/list/selectors.jsx
+++ b/components/admin_console/system_users/list/selectors.jsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 import {getUser, getProfiles, getProfilesInTeam, getProfilesWithoutTeam, searchProfiles, searchProfilesInTeam} from 'mattermost-redux/selectors/entities/users';
 
 const ALL_USERS = '';

--- a/components/admin_console/system_users/list/system_users_list.jsx
+++ b/components/admin_console/system_users/list/system_users_list.jsx
@@ -4,9 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
-import {getUser} from 'mattermost-redux/actions/users';
 
-import store from 'stores/redux_store.jsx';
 import {Constants} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import ManageRolesModal from 'components/admin_console/manage_roles_modal';
@@ -16,10 +14,7 @@ import ResetPasswordModal from 'components/admin_console/reset_password_modal';
 import SearchableUserList from 'components/searchable_user_list/searchable_user_list.jsx';
 import UserListRowWithError from 'components/user_list_row_with_error.jsx';
 
-import SystemUsersDropdown from './system_users_dropdown.jsx';
-
-const dispatch = store.dispatch;
-const getState = store.getState;
+import SystemUsersDropdown from '../system_users_dropdown.jsx';
 
 export default class SystemUsersList extends React.Component {
     static propTypes = {
@@ -49,6 +44,10 @@ export default class SystemUsersList extends React.Component {
          * Whether or not the experimental authentication transfer is enabled.
          */
         experimentalEnableAuthenticationTransfer: PropTypes.bool.isRequired,
+
+        actions: PropTypes.shape({
+            getUser: PropTypes.func.isRequired,
+        }).isRequired,
     };
 
     constructor(props) {
@@ -146,7 +145,7 @@ export default class SystemUsersList extends React.Component {
     }
 
     doPasswordResetSubmit = (user) => {
-        getUser(user.id)(dispatch, getState);
+        this.props.actions.getUser(user.id);
 
         this.setState({
             showPasswordModal: false,

--- a/components/admin_console/system_users/system_users.jsx
+++ b/components/admin_console/system_users/system_users.jsx
@@ -4,19 +4,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {searchProfiles, searchProfilesInTeam} from 'mattermost-redux/selectors/entities/users';
 
 import {getStandardAnalytics} from 'actions/admin_actions.jsx';
 import {reloadIfServerVersionChanged} from 'actions/global_actions.jsx';
 import {loadProfiles, loadProfilesAndTeamMembers, loadProfilesWithoutTeam, searchUsers} from 'actions/user_actions.jsx';
 import AnalyticsStore from 'stores/analytics_store.jsx';
-import store from 'stores/redux_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import {Constants, StatTypes, UserSearchOptions} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-import SystemUsersList from './system_users_list.jsx';
+import SystemUsersList from './list';
 
 const ALL_USERS = '';
 const NO_TEAM = 'no_team';
@@ -80,7 +78,6 @@ export default class SystemUsers extends React.Component {
         super(props);
 
         this.updateTotalUsersFromStore = this.updateTotalUsersFromStore.bind(this);
-        this.updateUsersFromStore = this.updateUsersFromStore.bind(this);
 
         this.loadDataForTeam = this.loadDataForTeam.bind(this);
         this.loadComplete = this.loadComplete.bind(this);
@@ -97,7 +94,6 @@ export default class SystemUsers extends React.Component {
 
         this.state = {
             totalUsers: AnalyticsStore.getAllSystem()[StatTypes.TOTAL_USERS],
-            users: UserStore.getProfileList(),
 
             teamId: ALL_USERS,
             term: '',
@@ -110,10 +106,6 @@ export default class SystemUsers extends React.Component {
         AnalyticsStore.addChangeListener(this.updateTotalUsersFromStore);
         TeamStore.addStatsChangeListener(this.updateTotalUsersFromStore);
 
-        UserStore.addChangeListener(this.updateUsersFromStore);
-        UserStore.addInTeamChangeListener(this.updateUsersFromStore);
-        UserStore.addWithoutTeamChangeListener(this.updateUsersFromStore);
-
         this.loadDataForTeam(this.state.teamId);
         this.props.actions.getTeams(0, 1000).then(reloadIfServerVersionChanged);
     }
@@ -123,7 +115,6 @@ export default class SystemUsers extends React.Component {
 
         if (this.state.teamId !== nextTeamId) {
             this.updateTotalUsersFromStore(nextTeamId);
-            this.updateUsersFromStore(nextTeamId, nextState.term);
 
             this.loadDataForTeam(nextTeamId);
         }
@@ -132,10 +123,6 @@ export default class SystemUsers extends React.Component {
     componentWillUnmount() {
         AnalyticsStore.removeChangeListener(this.updateTotalUsersFromStore);
         TeamStore.removeStatsChangeListener(this.updateTotalUsersFromStore);
-
-        UserStore.removeChangeListener(this.updateUsersFromStore);
-        UserStore.removeInTeamChangeListener(this.updateUsersFromStore);
-        UserStore.removeWithoutTeamChangeListener(this.updateUsersFromStore);
     }
 
     updateTotalUsersFromStore(teamId = this.state.teamId) {
@@ -151,32 +138,6 @@ export default class SystemUsers extends React.Component {
             this.setState({
                 totalUsers: TeamStore.getStats(teamId).total_member_count,
             });
-        }
-    }
-
-    updateUsersFromStore(teamId = this.state.teamId, term = this.state.term) {
-        if (term) {
-            let users;
-            if (teamId) {
-                users = searchProfilesInTeam(store.getState(), teamId, term);
-            } else {
-                users = searchProfiles(store.getState(), term);
-            }
-
-            if (users.length === 0 && UserStore.hasProfile(term)) {
-                users = [UserStore.getProfile(term)];
-            }
-
-            this.setState({users});
-            return;
-        }
-
-        if (teamId === ALL_USERS) {
-            this.setState({users: UserStore.getProfileList(false, true)});
-        } else if (teamId === NO_TEAM) {
-            this.setState({users: UserStore.getProfileListWithoutTeam()});
-        } else {
-            this.setState({users: UserStore.getProfileListInTeam(this.state.teamId)});
         }
     }
 
@@ -223,8 +184,6 @@ export default class SystemUsers extends React.Component {
 
     search(term, teamId = this.state.teamId) {
         if (term === '') {
-            this.updateUsersFromStore(teamId, term);
-
             this.setState({
                 loading: false,
             });
@@ -294,7 +253,6 @@ export default class SystemUsers extends React.Component {
             if (data) {
                 this.term = data.user_id;
                 this.setState({term: data.user_id});
-                this.updateUsersFromStore(this.state.teamId, data.user_id);
                 this.getUserById(data.user_id);
                 return;
             }
@@ -348,11 +306,6 @@ export default class SystemUsers extends React.Component {
     }
 
     render() {
-        let users = null;
-        if (!this.state.loading) {
-            users = this.state.users;
-        }
-
         return (
             <div className='wrapper--fixed'>
                 <h3 className='admin-console-header'>
@@ -366,10 +319,10 @@ export default class SystemUsers extends React.Component {
                 </h3>
                 <div className='more-modal__list member-list-holder'>
                     <SystemUsersList
+                        loading={this.state.loading}
                         renderFilterRow={this.renderFilterRow}
                         search={this.search}
                         nextPage={this.nextPage}
-                        users={users}
                         usersPerPage={USERS_PER_PAGE}
                         total={this.state.totalUsers}
                         teams={this.props.teams}

--- a/package.json
+++ b/package.json
@@ -143,7 +143,9 @@
     "transformIgnorePatterns": [
       "node_modules/(?!react-native|react-router)"
     ],
-    "setupFiles": ["jest-canvas-mock"],
+    "setupFiles": [
+      "jest-canvas-mock"
+    ],
     "setupTestFrameworkScriptFile": "<rootDir>/tests/setup.js",
     "testURL": "http://localhost:8065"
   },

--- a/tests/components/admin_console/system_users/__snapshots__/system_users.test.jsx.snap
+++ b/tests/components/admin_console/system_users/__snapshots__/system_users.test.jsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/admin_console/system_users should match default snapshot 1`] = `
+<div
+  className="wrapper--fixed"
+>
+  <h3
+    className="admin-console-header"
+  >
+    <FormattedMessage
+      defaultMessage="{siteName} Users"
+      id="admin.system_users.title"
+      values={
+        Object {
+          "siteName": "Site name",
+        }
+      }
+    />
+  </h3>
+  <div
+    className="more-modal__list member-list-holder"
+  >
+    <Connect(SystemUsersList)
+      enableUserAccessTokens={false}
+      experimentalEnableAuthenticationTransfer={false}
+      loading={true}
+      mfaEnabled={false}
+      nextPage={[Function]}
+      onTermChange={[Function]}
+      renderFilterRow={[Function]}
+      search={[Function]}
+      teamId=""
+      teams={Array []}
+      term=""
+      usersPerPage={50}
+    />
+  </div>
+</div>
+`;

--- a/tests/components/admin_console/system_users/__snapshots__/system_users_list.test.jsx.snap
+++ b/tests/components/admin_console/system_users/__snapshots__/system_users_list.test.jsx.snap
@@ -1,0 +1,365 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/admin_console/system_users/list should match default snapshot 1`] = `
+<div>
+  <SearchableUserList
+    actionProps={
+      Object {
+        "doManageRoles": [Function],
+        "doManageTeams": [Function],
+        "doManageTokens": [Function],
+        "doPasswordReset": [Function],
+        "enableUserAccessTokens": false,
+        "experimentalEnableAuthenticationTransfer": false,
+        "mfaEnabled": false,
+      }
+    }
+    actionUserProps={Object {}}
+    actions={
+      Array [
+        [Function],
+      ]
+    }
+    enableUserAccessTokens={false}
+    experimentalEnableAuthenticationTransfer={false}
+    extraInfo={Object {}}
+    focusOnMount={false}
+    mfaEnabled={false}
+    nextPage={[Function]}
+    onTermChange={[MockFunction]}
+    page={0}
+    previousPage={[Function]}
+    renderCount={[Function]}
+    renderFilterRow={[MockFunction]}
+    rowComponentType={[Function]}
+    search={[Function]}
+    showTeamToggle={false}
+    teamId=""
+    term=""
+    total={0}
+    users={Array []}
+    usersPerPage={0}
+  />
+  <ManageTeamsModal
+    onModalDismissed={[Function]}
+    show={false}
+    user={null}
+  />
+  <Connect(ManageRolesModal)
+    onModalDismissed={[Function]}
+    show={false}
+    user={null}
+  />
+  <Connect(ManageTokensModal)
+    onModalDismissed={[Function]}
+    show={false}
+    user={null}
+  />
+  <Connect(ResetPasswordModal)
+    onModalDismissed={[Function]}
+    onModalSubmit={[Function]}
+    show={false}
+    user={null}
+  />
+</div>
+`;
+
+exports[`components/admin_console/system_users/list should match default snapshot, with users and mfa disabled 1`] = `
+<div>
+  <SearchableUserList
+    actionProps={
+      Object {
+        "doManageRoles": [Function],
+        "doManageTeams": [Function],
+        "doManageTokens": [Function],
+        "doPasswordReset": [Function],
+        "enableUserAccessTokens": false,
+        "experimentalEnableAuthenticationTransfer": false,
+        "mfaEnabled": false,
+      }
+    }
+    actionUserProps={Object {}}
+    actions={
+      Array [
+        [Function],
+      ]
+    }
+    enableUserAccessTokens={false}
+    experimentalEnableAuthenticationTransfer={false}
+    extraInfo={
+      Object {
+        "id1": Array [
+          <FormattedHTMLMessage
+            defaultMessage="<strong>Sign-in Method:</strong> Email"
+            id="admin.user_item.authServiceEmail"
+            values={Object {}}
+          />,
+        ],
+        "id2": Array [
+          <FormattedHTMLMessage
+            defaultMessage="<strong>Sign-in Method:</strong> Email"
+            id="admin.user_item.authServiceEmail"
+            values={Object {}}
+          />,
+        ],
+        "id3": Array [
+          <FormattedHTMLMessage
+            defaultMessage="<strong>Sign-in Method:</strong> {service}"
+            id="admin.user_item.authServiceNotEmail"
+            values={
+              Object {
+                "service": "LDAP",
+              }
+            }
+          />,
+        ],
+        "id4": Array [
+          <FormattedHTMLMessage
+            defaultMessage="<strong>Sign-in Method:</strong> {service}"
+            id="admin.user_item.authServiceNotEmail"
+            values={
+              Object {
+                "service": "SAML",
+              }
+            }
+          />,
+        ],
+        "id5": Array [
+          <FormattedHTMLMessage
+            defaultMessage="<strong>Sign-in Method:</strong> {service}"
+            id="admin.user_item.authServiceNotEmail"
+            values={
+              Object {
+                "service": "Other Service",
+              }
+            }
+          />,
+        ],
+      }
+    }
+    focusOnMount={false}
+    mfaEnabled={false}
+    nextPage={[Function]}
+    onTermChange={[MockFunction]}
+    page={0}
+    previousPage={[Function]}
+    renderCount={[Function]}
+    renderFilterRow={[MockFunction]}
+    rowComponentType={[Function]}
+    search={[Function]}
+    showTeamToggle={false}
+    teamId=""
+    term=""
+    total={0}
+    users={
+      Array [
+        Object {
+          "id": "id1",
+        },
+        Object {
+          "id": "id2",
+        },
+        Object {
+          "auth_service": "ldap",
+          "id": "id3",
+        },
+        Object {
+          "auth_service": "saml",
+          "id": "id4",
+        },
+        Object {
+          "auth_service": "other service",
+          "id": "id5",
+        },
+      ]
+    }
+    usersPerPage={0}
+  />
+  <ManageTeamsModal
+    onModalDismissed={[Function]}
+    show={false}
+    user={null}
+  />
+  <Connect(ManageRolesModal)
+    onModalDismissed={[Function]}
+    show={false}
+    user={null}
+  />
+  <Connect(ManageTokensModal)
+    onModalDismissed={[Function]}
+    show={false}
+    user={null}
+  />
+  <Connect(ResetPasswordModal)
+    onModalDismissed={[Function]}
+    onModalSubmit={[Function]}
+    show={false}
+    user={null}
+  />
+</div>
+`;
+
+exports[`components/admin_console/system_users/list should match default snapshot, with users and mfa enabled 1`] = `
+<div>
+  <SearchableUserList
+    actionProps={
+      Object {
+        "doManageRoles": [Function],
+        "doManageTeams": [Function],
+        "doManageTokens": [Function],
+        "doPasswordReset": [Function],
+        "enableUserAccessTokens": false,
+        "experimentalEnableAuthenticationTransfer": false,
+        "mfaEnabled": true,
+      }
+    }
+    actionUserProps={Object {}}
+    actions={
+      Array [
+        [Function],
+      ]
+    }
+    enableUserAccessTokens={false}
+    experimentalEnableAuthenticationTransfer={false}
+    extraInfo={
+      Object {
+        "id1": Array [
+          <FormattedHTMLMessage
+            defaultMessage="<strong>Sign-in Method:</strong> Email"
+            id="admin.user_item.authServiceEmail"
+            values={Object {}}
+          />,
+          ", ",
+          <FormattedHTMLMessage
+            defaultMessage="<strong>MFA</strong>: No"
+            id="admin.user_item.mfaNo"
+            values={Object {}}
+          />,
+        ],
+        "id2": Array [
+          <FormattedHTMLMessage
+            defaultMessage="<strong>Sign-in Method:</strong> Email"
+            id="admin.user_item.authServiceEmail"
+            values={Object {}}
+          />,
+          ", ",
+          <FormattedHTMLMessage
+            defaultMessage="<strong>MFA</strong>: No"
+            id="admin.user_item.mfaNo"
+            values={Object {}}
+          />,
+        ],
+        "id3": Array [
+          <FormattedHTMLMessage
+            defaultMessage="<strong>Sign-in Method:</strong> {service}"
+            id="admin.user_item.authServiceNotEmail"
+            values={
+              Object {
+                "service": "LDAP",
+              }
+            }
+          />,
+          ", ",
+          <FormattedHTMLMessage
+            defaultMessage="<strong>MFA</strong>: No"
+            id="admin.user_item.mfaNo"
+            values={Object {}}
+          />,
+        ],
+        "id4": Array [
+          <FormattedHTMLMessage
+            defaultMessage="<strong>Sign-in Method:</strong> {service}"
+            id="admin.user_item.authServiceNotEmail"
+            values={
+              Object {
+                "service": "SAML",
+              }
+            }
+          />,
+          ", ",
+          <FormattedHTMLMessage
+            defaultMessage="<strong>MFA</strong>: No"
+            id="admin.user_item.mfaNo"
+            values={Object {}}
+          />,
+        ],
+        "id5": Array [
+          <FormattedHTMLMessage
+            defaultMessage="<strong>Sign-in Method:</strong> {service}"
+            id="admin.user_item.authServiceNotEmail"
+            values={
+              Object {
+                "service": "Other Service",
+              }
+            }
+          />,
+          ", ",
+          <FormattedHTMLMessage
+            defaultMessage="<strong>MFA</strong>: No"
+            id="admin.user_item.mfaNo"
+            values={Object {}}
+          />,
+        ],
+      }
+    }
+    focusOnMount={false}
+    mfaEnabled={true}
+    nextPage={[Function]}
+    onTermChange={[MockFunction]}
+    page={0}
+    previousPage={[Function]}
+    renderCount={[Function]}
+    renderFilterRow={[MockFunction]}
+    rowComponentType={[Function]}
+    search={[Function]}
+    showTeamToggle={false}
+    teamId=""
+    term=""
+    total={0}
+    users={
+      Array [
+        Object {
+          "id": "id1",
+        },
+        Object {
+          "id": "id2",
+        },
+        Object {
+          "auth_service": "ldap",
+          "id": "id3",
+        },
+        Object {
+          "auth_service": "saml",
+          "id": "id4",
+        },
+        Object {
+          "auth_service": "other service",
+          "id": "id5",
+        },
+      ]
+    }
+    usersPerPage={0}
+  />
+  <ManageTeamsModal
+    onModalDismissed={[Function]}
+    show={false}
+    user={null}
+  />
+  <Connect(ManageRolesModal)
+    onModalDismissed={[Function]}
+    show={false}
+    user={null}
+  />
+  <Connect(ManageTokensModal)
+    onModalDismissed={[Function]}
+    show={false}
+    user={null}
+  />
+  <Connect(ResetPasswordModal)
+    onModalDismissed={[Function]}
+    onModalSubmit={[Function]}
+    show={false}
+    user={null}
+  />
+</div>
+`;

--- a/tests/components/admin_console/system_users/selectors.test.jsx
+++ b/tests/components/admin_console/system_users/selectors.test.jsx
@@ -1,0 +1,135 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import * as users from 'mattermost-redux/selectors/entities/users';
+
+import {getUsers} from 'components/admin_console/system_users/list/selectors.jsx';
+
+jest.mock('mattermost-redux/selectors/entities/users');
+
+describe('components/admin_console/system_users/list/selectors', () => {
+    const state = {};
+
+    test('should return no users when loading', () => {
+        const loading = true;
+        const teamId = 'teamId';
+        const term = 'term';
+
+        expect(getUsers(state, loading, teamId, term)).toEqual([]);
+    });
+
+    describe('should search by term', () => {
+        const loading = false;
+
+        describe('over all profiles', () => {
+            const teamId = '';
+
+            it('returning users users', () => {
+                const term = 'term';
+
+                const expectedUsers = [{id: 'id1'}, {id: 'id2'}];
+                users.searchProfiles.mockReturnValue(expectedUsers);
+
+                expect(getUsers(state, loading, teamId, term)).toEqual(expectedUsers);
+                expect(users.searchProfiles).toBeCalledWith(state, term);
+            });
+
+            describe('falling back to fetching user by id', () => {
+                const term = 'x'.repeat(26);
+
+                it('and the user is found', () => {
+                    const expectedUsers = [{id: 'id1'}];
+                    users.searchProfiles.mockReturnValue([]);
+                    users.getUser.mockReturnValue(expectedUsers[0]);
+
+                    expect(getUsers(state, loading, teamId, term)).toEqual(expectedUsers);
+                    expect(users.searchProfiles).toBeCalledWith(state, term);
+                    expect(users.getUser).toBeCalledWith(state, term);
+                });
+
+                it('and the user is not found', () => {
+                    const expectedUsers = [];
+                    users.searchProfiles.mockReturnValue([]);
+                    users.getUser.mockReturnValue(null);
+
+                    expect(getUsers(state, loading, teamId, term)).toEqual(expectedUsers);
+                    expect(users.searchProfiles).toBeCalledWith(state, term);
+                    expect(users.getUser).toBeCalledWith(state, term);
+                });
+            });
+        });
+
+        describe('and team id', () => {
+            const teamId = 'teamId';
+
+            it('returning users users found in team', () => {
+                const term = 'term';
+
+                const expectedUsers = [{id: 'id1'}, {id: 'id2'}];
+                users.searchProfilesInTeam.mockReturnValue(expectedUsers);
+
+                expect(getUsers(state, loading, teamId, term)).toEqual(expectedUsers);
+                expect(users.searchProfilesInTeam).toBeCalledWith(state, teamId, term);
+            });
+
+            describe('falling back to fetching user by id', () => {
+                const term = 'x'.repeat(26);
+
+                it('and the user is found', () => {
+                    const expectedUsers = [{id: 'id1'}];
+                    users.searchProfilesInTeam.mockReturnValue([]);
+                    users.getUser.mockReturnValue(expectedUsers[0]);
+
+                    expect(getUsers(state, loading, teamId, term)).toEqual(expectedUsers);
+                    expect(users.searchProfilesInTeam).toBeCalledWith(state, teamId, term);
+                    expect(users.getUser).toBeCalledWith(state, term);
+                });
+
+                it('and the user is not found', () => {
+                    const expectedUsers = [];
+                    users.searchProfilesInTeam.mockReturnValue([]);
+                    users.getUser.mockReturnValue(null);
+
+                    expect(getUsers(state, loading, teamId, term)).toEqual(expectedUsers);
+                    expect(users.searchProfilesInTeam).toBeCalledWith(state, teamId, term);
+                    expect(users.getUser).toBeCalledWith(state, term);
+                });
+            });
+        });
+    });
+
+    describe('should return', () => {
+        const loading = false;
+        const term = '';
+
+        it('all profiles', () => {
+            const teamId = '';
+
+            const expectedUsers = [{id: 'id1'}, {id: 'id2'}];
+            users.getProfiles.mockReturnValue(expectedUsers);
+
+            expect(getUsers(state, loading, teamId, term)).toEqual(expectedUsers);
+            expect(users.getProfiles).toBeCalledWith(state);
+        });
+
+        it('profiles without a team', () => {
+            const teamId = 'no_team';
+
+            const expectedUsers = [{id: 'id1'}, {id: 'id2'}];
+            users.getProfilesWithoutTeam.mockReturnValue(expectedUsers);
+
+            expect(getUsers(state, loading, teamId, term)).toEqual(expectedUsers);
+            expect(users.getProfilesWithoutTeam).toBeCalledWith(state);
+        });
+
+        it('profiles for the given team', () => {
+            const teamId = 'team_id1';
+
+            const expectedUsers = [{id: 'id1'}, {id: 'id2'}];
+            users.getProfilesInTeam.mockReturnValue(expectedUsers);
+
+            expect(getUsers(state, loading, teamId, term)).toEqual(expectedUsers);
+            expect(users.getProfilesInTeam).toBeCalledWith(state, teamId);
+        });
+    });
+});

--- a/tests/components/admin_console/system_users/system_users.test.jsx
+++ b/tests/components/admin_console/system_users/system_users.test.jsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import SystemUsers from 'components/admin_console/system_users/system_users.jsx';
+
+describe('components/admin_console/system_users', () => {
+    const defaultProps = {
+        teams: [],
+        siteName: 'Site name',
+        mfaEnabled: false,
+        enableUserAccessTokens: false,
+        experimentalEnableAuthenticationTransfer: false,
+        actions: {
+            getTeams: jest.fn().mockImplementation(() => Promise.resolve()),
+            getTeamStats: jest.fn().mockImplementation(() => Promise.resolve()),
+            getUser: jest.fn().mockImplementation(() => Promise.resolve()),
+            getUserAccessToken: jest.fn().mockImplementation(() => Promise.resolve()),
+        },
+    };
+
+    test('should match default snapshot', () => {
+        const props = defaultProps;
+        const wrapper = shallow(<SystemUsers {...props}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/tests/components/admin_console/system_users/system_users_list.test.jsx
+++ b/tests/components/admin_console/system_users/system_users_list.test.jsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {Constants} from 'utils/constants.jsx';
+
+import SystemUsersList from 'components/admin_console/system_users/list/system_users_list.jsx';
+
+describe('components/admin_console/system_users/list', () => {
+    const defaultProps = {
+        users: [],
+        usersPerPage: 0,
+        total: 0,
+        nextPage: jest.fn(),
+        search: jest.fn(),
+        focusOnMount: false,
+        renderFilterRow: jest.fn(),
+        teamId: '',
+        term: '',
+        onTermChange: jest.fn(),
+        mfaEnabled: false,
+        enableUserAccessTokens: false,
+        experimentalEnableAuthenticationTransfer: false,
+        actions: {
+            getUser: jest.fn(),
+        },
+    };
+
+    test('should match default snapshot', () => {
+        const props = defaultProps;
+        const wrapper = shallow(<SystemUsersList {...props}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    describe('should match default snapshot, with users', () => {
+        const props = {
+            ...defaultProps,
+            users: [
+                {id: 'id1'},
+                {id: 'id2'},
+                {id: 'id3', auth_service: Constants.LDAP_SERVICE},
+                {id: 'id4', auth_service: Constants.SAML_SERVICE},
+                {id: 'id5', auth_service: 'other service'},
+            ],
+        };
+
+        it('and mfa enabled', () => {
+            const wrapper = shallow(
+                <SystemUsersList
+                    {...props}
+                    mfaEnabled={true}
+                />
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        it('and mfa disabled', () => {
+            const wrapper = shallow(
+                <SystemUsersList
+                    {...props}
+                    mfaEnabled={false}
+                />
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4028,9 +4028,15 @@ iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
-iconv-lite@0.4.19, iconv-lite@~0.4.13:
+iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+iconv-lite@~0.4.13:
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
+  dependencies:
+    safer-buffer "^2.1.0"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
@@ -5596,7 +5602,7 @@ math-expression-evaluator@^1.2.14:
 
 mattermost-redux@mattermost/mattermost-redux:
   version "1.2.0"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/6725f81174fe4c8514f5217a3f05b6b0368f2642"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/562e1287d8f4ee309ad6150a27ab2848b87bd43f"
   dependencies:
     deep-equal "1.0.1"
     form-data "2.3.1"
@@ -7799,6 +7805,10 @@ rx-lite@^3.1.2:
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safer-buffer@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sane@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
#### Summary
This is one of a series of JIRAs to resolve the use of `getState` in components outside of the Redux connector flow. The problem with using `getState` like this is that changes to the store do not automatically reflect into the component unless something else changes to trigger re-render. While the config is no longer accessed via `window.mm_config`, this usage is effectively just as "global", and is hampering our attempts to eliminate the refresh on a config change.

The crux of this particular change is to move the computation of the users to be shown in the system console users page out of the component and into the connector. This is done by passing down the parameters (e.g. selected team, search term) into the system users list, whose connector intercepts and selects the requisite subset of data to pass into the list component.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9831

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed