### PR TITLE
JS error quick fix on onHide function of MoreDirectChannels

### DIFF
--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -53,7 +53,7 @@ export default class MoreDirectChannels extends React.Component {
         /**
          * Function to call on modal hide
          */
-        onHide: PropTypes.func.isRequired,
+        onHide: PropTypes.func,
 
         actions: PropTypes.shape({
 


### PR DESCRIPTION
#### Summary
JS error quick fix on onHide function of MoreDirectChannels

![screen shot 2018-04-12 at 11 56 13 pm](https://user-images.githubusercontent.com/5334504/38689805-19d0ad18-3eaf-11e8-94d3-a3d1a0fffbda.png)

Said props is not really required as we are doing this inside the component itself:
```
        if (this.props.onHide) {
            this.props.onHide();
        }
```

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
