### PR TITLE
Fixing missing channel unread and mentions when activating window

### DIFF
--- a/components/needs_team/index.js
+++ b/components/needs_team/index.js
@@ -3,7 +3,7 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {fetchMyChannelsAndMembers, getMyChannelMembers, markChannelAsRead, viewChannel} from 'mattermost-redux/actions/channels';
+import {fetchMyChannelsAndMembers, markChannelAsRead, viewChannel} from 'mattermost-redux/actions/channels';
 import {getMyTeamUnreads} from 'mattermost-redux/actions/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {withRouter} from 'react-router-dom';
@@ -30,7 +30,6 @@ function mapDispatchToProps(dispatch) {
             getMyTeamUnreads,
             viewChannel,
             markChannelAsRead,
-            getMyChannelMembers,
         }, dispatch),
     };
 }

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -38,7 +38,6 @@ export default class NeedsTeam extends React.Component {
             getMyTeamUnreads: PropTypes.func.isRequired,
             viewChannel: PropTypes.func.isRequired,
             markChannelAsRead: PropTypes.func.isRequired,
-            getMyChannelMembers: PropTypes.func.isRequired,
         }).isRequired,
         theme: PropTypes.object.isRequired,
         mfaRequired: PropTypes.bool.isRequired,
@@ -149,7 +148,7 @@ export default class NeedsTeam extends React.Component {
             window.isActive = true;
 
             if (new Date().getTime() - this.blurTime > UNREAD_CHECK_TIME_MILLISECONDS) {
-                this.props.actions.getMyChannelMembers(TeamStore.getCurrentId()).then(loadProfilesForSidebar);
+                this.props.actions.fetchMyChannelsAndMembers(TeamStore.getCurrentId()).then(loadProfilesForSidebar);
             }
         });
 


### PR DESCRIPTION
#### Summary
When returning to Mattermost after having the window inactive we are fetching the channels and members instead of just the members to have the unread count in sync.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10172

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
