### PR TITLE
Fix error in LDAP sync help text

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -558,7 +558,7 @@ export default {
                             label: 'admin.ldap.enableSyncTitle',
                             label_default: 'Enable Synchronization with AD/LDAP:',
                             help_text: 'admin.ldap.enableSyncDesc',
-                            help_text_default: 'When true, Mattermost periodically synchronizes users from AD/LDAP. When false, user attributes are updated in Mattermost during user login.',
+                            help_text_default: 'When true, Mattermost periodically synchronizes users from AD/LDAP. When false, user attributes are updated from AD/LDAP during user login only.',
                         },
                         {
                             type: Constants.SettingsTypes.TYPE_TEXT,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -600,7 +600,7 @@
   "admin.ldap.emailAttrEx": "E.g.: \"mail\" or \"userPrincipalName\"",
   "admin.ldap.emailAttrTitle": "Email Attribute:",
   "admin.ldap.enableDesc": "When true, Mattermost allows login using AD/LDAP",
-  "admin.ldap.enableSyncDesc": "When true, Mattermost periodically synchronizes users from AD/LDAP. When false, user attributes are updated from SAML during user login.",
+  "admin.ldap.enableSyncDesc": "When true, Mattermost periodically synchronizes users from AD/LDAP. When false, user attributes are updated in Mattermost during user login.",
   "admin.ldap.enableSyncTitle": "Enable Synchronization with AD/LDAP:",
   "admin.ldap.enableTitle": "Enable sign-in with AD/LDAP:",
   "admin.ldap.firstnameAttrDesc": "(Optional) The attribute in the AD/LDAP server that will be used to populate the first name of users in Mattermost. When set, users will not be able to edit their first name, since it is synchronized with the LDAP server. When left blank, users can set their own first name in Account Settings.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -600,7 +600,7 @@
   "admin.ldap.emailAttrEx": "E.g.: \"mail\" or \"userPrincipalName\"",
   "admin.ldap.emailAttrTitle": "Email Attribute:",
   "admin.ldap.enableDesc": "When true, Mattermost allows login using AD/LDAP",
-  "admin.ldap.enableSyncDesc": "When true, Mattermost periodically synchronizes users from AD/LDAP. When false, user attributes are updated in Mattermost during user login.",
+  "admin.ldap.enableSyncDesc": "When true, Mattermost periodically synchronizes users from AD/LDAP. When false, user attributes are updated from AD/LDAP during user login only.",
   "admin.ldap.enableSyncTitle": "Enable Synchronization with AD/LDAP:",
   "admin.ldap.enableTitle": "Enable sign-in with AD/LDAP:",
   "admin.ldap.firstnameAttrDesc": "(Optional) The attribute in the AD/LDAP server that will be used to populate the first name of users in Mattermost. When set, users will not be able to edit their first name, since it is synchronized with the LDAP server. When left blank, users can set their own first name in Account Settings.",


### PR DESCRIPTION
#### Summary
The string is correct in the [webapp component](https://github.com/mattermost/mattermost-webapp/blob/master/components/admin_console/admin_definition.jsx#L561) but not in en.json.

#### Ticket Link
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
