### PR TITLE
MM-9827 Remove getState usage in SwitchChannelSuggestion

### DIFF
--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -2,6 +2,8 @@
 // See License.txt for license information.
 
 import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
 import {Client4} from 'mattermost-redux/client';
 import {Preferences} from 'mattermost-redux/constants';
 import {
@@ -30,11 +32,18 @@ import Suggestion from './suggestion.jsx';
 const getState = store.getState;
 
 class SwitchChannelSuggestion extends Suggestion {
+    static get propTypes() {
+        return {
+            ...super.propTypes,
+            channelMember: PropTypes.object,
+        };
+    }
+
     render() {
         const {item, isSelection} = this.props;
         const channel = item.channel;
 
-        const member = getMyChannelMemberships(getState())[item.id];
+        const member = this.props.channelMember;
         let badge = null;
         if (member) {
             if (member.notify_props && member.mention_count > 0) {
@@ -83,6 +92,15 @@ class SwitchChannelSuggestion extends Suggestion {
         );
     }
 }
+
+function mapStateToPropsForSwitchChannelSuggestion(state, ownProps) {
+    const channelId = ownProps.item && ownProps.item.channel ? ownProps.item.channel.id : '';
+    return {
+        channelMember: getMyChannelMemberships(state)[channelId],
+    };
+}
+
+const ConnectedSwitchChannelSuggestion = connect(mapStateToPropsForSwitchChannelSuggestion)(SwitchChannelSuggestion);
 
 let prefix = '';
 
@@ -335,7 +353,7 @@ export default class SwitchChannelProvider extends Provider {
                 matchedPretext: channelPrefix,
                 terms: channelNames,
                 items: channels,
-                component: SwitchChannelSuggestion,
+                component: ConnectedSwitchChannelSuggestion,
             });
         }, 0);
     }
@@ -358,7 +376,6 @@ export default class SwitchChannelProvider extends Provider {
                 );
             }
             wrappedChannel.type = Constants.MENTION_UNREAD_CHANNELS;
-            wrappedChannel.id = channel.id;
             channels.push(wrappedChannel);
         }
 
@@ -371,7 +388,7 @@ export default class SwitchChannelProvider extends Provider {
                 matchedPretext: '',
                 terms: channelNames,
                 items: channels,
-                component: SwitchChannelSuggestion,
+                component: ConnectedSwitchChannelSuggestion,
             });
         }, 0);
     }


### PR DESCRIPTION
#### Summary
The other usages of getState() in the suggestion components aren't really a problem since they are triggered by events and the suggestions are ephemeral. In reality, this one wasn't a big deal either but since it was easy to fix I did so anyway.

@jasonblais I think I also fixed a bug with this. Previously if you opened the channel switcher it would show the mention badge for channels with mentions but as soon as you started typing the mention badge would disappear (even if you could still see that channel in the list). I assumed this was a bug and fixed it so that the badge would remain. Let me know if this wasn't a bug and I can revert that change

![screen shot 2018-04-13 at 12 12 43](https://user-images.githubusercontent.com/2672098/38746791-91cbd358-3f16-11e8-826d-c915567ce062.png)

![screen shot 2018-04-13 at 12 12 50](https://user-images.githubusercontent.com/2672098/38746768-81fc2bf8-3f16-11e8-9ff1-c01489b6b4af.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9827

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed