### PR TITLE
MM-10197 Stopped setting QuickInput value when already set

### DIFF
--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -4,9 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import * as UserAgent from 'utils/user_agent';
-import * as Utils from 'utils/utils';
-
 // A component that can be used to make controlled inputs that function properly in certain
 // environments (ie. IE11) where typing quickly would sometimes miss inputs
 export default class QuickInput extends React.PureComponent {
@@ -44,20 +41,7 @@ export default class QuickInput extends React.PureComponent {
     }
 
     updateInputFromProps = () => {
-        if (!this.input) {
-            return;
-        }
-
-        if ((UserAgent.isWindows7() && UserAgent.isInternetExplorer()) || UserAgent.isDesktopApp()) {
-            // The textbox already knows where it's cursor is supposed to be because we've already
-            // typed in it, but it needs to be reminded of that
-            const caret = Utils.getCaretPosition(this.input);
-
-            this.input.value = this.props.value;
-
-            this.input.selectionStart = caret;
-            this.input.selectionEnd = this.input.selectionStart;
-
+        if (!this.input || this.input.value === this.props.value) {
             return;
         }
 


### PR DESCRIPTION
After various attempts to fix this issue in a way that doesn't cause IE11 and the desktop app to break constantly, I realized that it was more simple to fix the QuickInput by just being more careful about when we call `this.textbox.value = this.props.value`. If we only call it when it's needed, we won't need to deal with issues caused by setting it.

This replaces https://github.com/mattermost/mattermost-webapp/pull/945 and https://github.com/mattermost/mattermost-webapp/pull/1027 which fixed their bugs but introduced the one that this ticket was filed for

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10197

#### Checklist
- Touches critical sections of the codebase (auth, posting, etc.)
