### PR TITLE
MM-10174: reflect that log settings require a restart

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -411,6 +411,13 @@ export default {
                     name_default: 'Logging',
                     settings: [
                         {
+                            type: Constants.SettingsTypes.TYPE_BANNER,
+                            label: 'admin.log.noteDescription',
+                            label_default: 'Changing properties other than <a href="#EnableWebhookDebugging">Enable Webhook Debugging</a> and <a href="#EnableDiagnostics">Enable Diagnostics and Error Reporting</a> in this section will require a server restart before taking effect.',
+                            label_html: true,
+                            banner_type: 'info',
+                        },
+                        {
                             type: Constants.SettingsTypes.TYPE_BOOL,
                             key: 'EnableConsole',
                             label: 'admin.log.consoleTitle',

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -665,6 +665,7 @@
   "admin.license.upload": "Upload",
   "admin.license.uploadDesc": "Upload a license key for Mattermost Enterprise Edition to upgrade this server. <a href=\"http://mattermost.com\" target='_blank'>Visit us online</a> to learn more about the benefits of Enterprise Edition or to purchase a key.",
   "admin.license.uploading": "Uploading License...",
+  "admin.log.noteDescription": "Changing properties other than <a href=\"#EnableWebhookDebugging\">Enable Webhook Debugging</a> and <a href=\"#EnableDiagnostics\">Enable Diagnostics and Error Reporting</a> in this section will require a server restart before taking effect.",
   "admin.log.consoleDescription": "Typically set to false in production. Developers may set this field to true to output log messages to console based on the console level option.  If true, server writes messages to the standard output stream (stdout).",
   "admin.log.consoleLogLevel": "Console Log Level",
   "admin.log.consoleTitle": "Output logs to console: ",


### PR DESCRIPTION
#### Summary
This is the corresponding change to https://github.com/mattermost/mattermost-server/pull/8628, reflecting that changing log settings require a restart.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10174

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed