### PR TITLE
MM-9829 Remove store.getState() usages from user list modals

### DIFF
--- a/actions/search.js
+++ b/actions/search.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {SearchTypes} from 'utils/constants';
+
+export function setAddUsersToTeamSearchTerm(term) {
+    return async (dispatch) => {
+        dispatch({
+            type: SearchTypes.SET_ADD_USERS_TO_TEAM_SEARCH,
+            data: term,
+        });
+        return {data: true};
+    };
+}

--- a/actions/team_actions.jsx
+++ b/actions/team_actions.jsx
@@ -91,14 +91,18 @@ export function addUserToTeamFromInvite(data, hash, inviteId, success, error) {
     );
 }
 
-export async function addUsersToTeam(teamId, userIds, success, error) {
-    const {data: teamMembers, error: err} = await TeamActions.addUsersToTeam(teamId, userIds)(dispatch, getState);
-    getChannelStats(ChannelStore.getCurrentId())(dispatch, getState);
-    if (teamMembers && success) {
-        success(teamMembers);
-    } else if (err && error) {
-        error({id: err.server_error_id, ...err});
-    }
+export function addUsersToTeam(teamId, userIds) {
+    return async (doDispatch, doGetState) => {
+        const {data, error} = await doDispatch(TeamActions.addUsersToTeam(teamId, userIds));
+
+        if (error) {
+            return {error};
+        }
+
+        doDispatch(getChannelStats(doGetState().entities.channels.currentChannelId));
+
+        return {data};
+    };
 }
 
 export function getInviteInfo(inviteId, success, error) {

--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -400,15 +400,6 @@ export async function searchUsers(term, teamId = TeamStore.getCurrentId(), optio
     }
 }
 
-export async function searchUsersNotInTeam(term, teamId = TeamStore.getCurrentId(), options = {}, success) {
-    const {data} = await UserActions.searchProfiles(term, {not_in_team_id: teamId, ...options})(dispatch, getState);
-    loadStatusesForProfilesList(data);
-
-    if (success) {
-        success(data);
-    }
-}
-
 export async function autocompleteUsersInChannel(username, channelId, success) {
     const channel = ChannelStore.get(channelId);
     const teamId = channel ? channel.team_id : TeamStore.getCurrentId();

--- a/actions/views/search.js
+++ b/actions/views/search.js
@@ -3,20 +3,10 @@
 
 import {SearchTypes} from 'utils/constants';
 
-export function setAddUsersToTeamSearchTerm(term) {
+export function setModalSearchTerm(term) {
     return async (dispatch) => {
         dispatch({
-            type: SearchTypes.SET_ADD_USERS_TO_TEAM_SEARCH,
-            data: term,
-        });
-        return {data: true};
-    };
-}
-
-export function setMoreDirectChannelsSearchTerm(term) {
-    return async (dispatch) => {
-        dispatch({
-            type: SearchTypes.SET_MORE_DIRECT_CHANNELS_SEARCH,
+            type: SearchTypes.SET_MODAL_SEARCH,
             data: term,
         });
         return {data: true};

--- a/actions/views/search.js
+++ b/actions/views/search.js
@@ -12,3 +12,13 @@ export function setAddUsersToTeamSearchTerm(term) {
         return {data: true};
     };
 }
+
+export function setMoreDirectChannelsSearchTerm(term) {
+    return async (dispatch) => {
+        dispatch({
+            type: SearchTypes.SET_MORE_DIRECT_CHANNELS_SEARCH,
+            data: term,
+        });
+        return {data: true};
+    };
+}

--- a/components/add_users_to_team/add_users_to_team.jsx
+++ b/components/add_users_to_team/add_users_to_team.jsx
@@ -6,15 +6,11 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import {Client4} from 'mattermost-redux/client';
-import {searchProfilesNotInCurrentTeam} from 'mattermost-redux/selectors/entities/users';
 
-import {addUsersToTeam} from 'actions/team_actions.jsx';
-import {searchUsersNotInTeam} from 'actions/user_actions.jsx';
-import store from 'stores/redux_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
-import UserStore from 'stores/user_store.jsx';
+import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import {displayEntireNameForUser, localizeMessage} from 'utils/utils.jsx';
+
 import MultiSelect from 'components/multiselect/multiselect.jsx';
 import ProfilePicture from 'components/profile_picture.jsx';
 
@@ -23,28 +19,25 @@ const MAX_SELECTABLE_VALUES = 20;
 
 export default class AddUsersToTeam extends React.Component {
     static propTypes = {
+        currentTeamName: PropTypes.string.isRequired,
+        currentTeamId: PropTypes.string.isRequired,
+        searchTerm: PropTypes.string.isRequired,
+        users: PropTypes.array.isRequired,
         onModalDismissed: PropTypes.func,
         actions: PropTypes.shape({
             getProfilesNotInTeam: PropTypes.func.isRequired,
+            setAddUsersToTeamSearchTerm: PropTypes.func.isRequired,
+            searchProfiles: PropTypes.func.isRequired,
+            addUsersToTeam: PropTypes.func.isRequired,
         }).isRequired,
     }
 
     constructor(props) {
         super(props);
 
-        this.handleHide = this.handleHide.bind(this);
-        this.handleExit = this.handleExit.bind(this);
-        this.handleSubmit = this.handleSubmit.bind(this);
-        this.handleDelete = this.handleDelete.bind(this);
-        this.onChange = this.onChange.bind(this);
-        this.search = this.search.bind(this);
-        this.addValue = this.addValue.bind(this);
-        this.handlePageChange = this.handlePageChange.bind(this);
-
         this.searchTimeoutId = 0;
 
         this.state = {
-            users: Object.assign([], UserStore.getProfileListNotInTeam(TeamStore.getCurrentId(), true)),
             values: [],
             show: true,
             search: false,
@@ -55,32 +48,46 @@ export default class AddUsersToTeam extends React.Component {
     }
 
     componentDidMount() {
-        UserStore.addChangeListener(this.onChange);
-        UserStore.addNotInTeamChangeListener(this.onChange);
-        UserStore.addStatusesChangeListener(this.onChange);
-
-        this.props.actions.getProfilesNotInTeam(TeamStore.getCurrentId(), 0, USERS_PER_PAGE * 2).then(() => {
+        this.props.actions.getProfilesNotInTeam(this.props.currentTeamId, 0, USERS_PER_PAGE * 2).then(() => {
             this.setUsersLoadingState(false);
         });
     }
 
-    componentWillUnmount() {
-        UserStore.removeChangeListener(this.onChange);
-        UserStore.removeNotInTeamChangeListener(this.onChange);
-        UserStore.removeStatusesChangeListener(this.onChange);
+    componentWillReceiveProps(nextProps) {
+        if (this.props.searchTerm !== nextProps.searchTerm) {
+            clearTimeout(this.searchTimeoutId);
+
+            const searchTerm = nextProps.searchTerm;
+            if (searchTerm === '') {
+                return;
+            }
+
+            this.searchTimeoutId = setTimeout(
+                async () => {
+                    this.setUsersLoadingState(true);
+                    const {data} = await this.props.actions.searchProfiles(searchTerm, {not_in_team_id: this.props.currentTeamId});
+                    if (data) {
+                        loadStatusesForProfilesList(data);
+                    }
+                    this.setUsersLoadingState(false);
+                },
+                Constants.SEARCH_TIMEOUT_MILLISECONDS
+            );
+        }
     }
 
-    handleHide() {
+    handleHide = () => {
+        this.props.actions.setAddUsersToTeamSearchTerm('');
         this.setState({show: false});
     }
 
-    handleExit() {
+    handleExit = () => {
         if (this.props.onModalDismissed) {
             this.props.onModalDismissed();
         }
     }
 
-    handleResponse(err) {
+    handleResponse = (err) => {
         let addError = null;
         if (err && err.message) {
             addError = err.message;
@@ -92,7 +99,7 @@ export default class AddUsersToTeam extends React.Component {
         });
     }
 
-    handleSubmit(e) {
+    handleSubmit = async (e) => {
         if (e) {
             e.preventDefault();
         }
@@ -104,20 +111,14 @@ export default class AddUsersToTeam extends React.Component {
 
         this.setState({saving: true});
 
-        addUsersToTeam(
-            TeamStore.getCurrentId(),
-            userIds,
-            () => {
-                this.handleResponse();
-                this.handleHide();
-            },
-            (err) => {
-                this.handleResponse(err);
-            }
-        );
+        const {error} = await this.props.actions.addUsersToTeam(this.props.currentTeamId, userIds);
+        this.handleResponse(error);
+        if (!error) {
+            this.handleHide();
+        }
     }
 
-    addValue(value) {
+    addValue = (value) => {
         const values = Object.assign([], this.state.values);
         const userIds = values.map((v) => v.id);
         if (value && value.id && userIds.indexOf(value.id) === -1) {
@@ -133,55 +134,21 @@ export default class AddUsersToTeam extends React.Component {
         });
     }
 
-    onChange() {
-        let users;
-        if (this.term) {
-            users = Object.assign([], searchProfilesNotInCurrentTeam(store.getState(), this.term, true));
-        } else {
-            users = Object.assign([], UserStore.getProfileListNotInTeam(TeamStore.getCurrentId(), true));
-        }
-
-        for (let i = 0; i < users.length; i++) {
-            const user = Object.assign({}, users[i]);
-            users[i] = user;
-        }
-
-        this.setState({
-            users,
-        });
-    }
-
-    handlePageChange(page, prevPage) {
+    handlePageChange = (page, prevPage) => {
         if (page > prevPage) {
             this.setUsersLoadingState(true);
-            this.props.actions.getProfilesNotInTeam(TeamStore.getCurrentId(), page + 1, USERS_PER_PAGE).then(() => {
+            this.props.actions.getProfilesNotInTeam(this.props.currentTeamId, page + 1, USERS_PER_PAGE).then(() => {
                 this.setUsersLoadingState(false);
             });
         }
     }
 
-    search(term) {
-        clearTimeout(this.searchTimeoutId);
-        this.term = term;
-
-        if (term === '') {
-            this.onChange();
-            return;
-        }
-
-        this.searchTimeoutId = setTimeout(
-            () => {
-                this.setUsersLoadingState(true);
-                searchUsersNotInTeam(term, TeamStore.getCurrentId(), {}).then(() => {
-                    this.setUsersLoadingState(false);
-                });
-            },
-            Constants.SEARCH_TIMEOUT_MILLISECONDS
-        );
+    handleDelete = (values) => {
+        this.setState({values});
     }
 
-    handleDelete(values) {
-        this.setState({values});
+    search = (term) => {
+        this.props.actions.setAddUsersToTeamSearchTerm(term);
     }
 
     renderOption(option, isSelected, onAdd) {
@@ -239,8 +206,8 @@ export default class AddUsersToTeam extends React.Component {
         const buttonSubmitText = localizeMessage('multiselect.add', 'Add');
 
         let users = [];
-        if (this.state.users) {
-            users = this.state.users.filter((user) => user.delete_at === 0);
+        if (this.props.users) {
+            users = this.props.users.filter((user) => user.delete_at === 0);
         }
 
         let addError = null;
@@ -262,7 +229,7 @@ export default class AddUsersToTeam extends React.Component {
                             defaultMessage='Add New Members To {teamName} Team'
                             values={{
                                 teamName: (
-                                    <strong>{TeamStore.getCurrent().display_name}</strong>
+                                    <strong>{this.props.currentTeamName}</strong>
                                 ),
                             }}
                         />

--- a/components/add_users_to_team/add_users_to_team.jsx
+++ b/components/add_users_to_team/add_users_to_team.jsx
@@ -26,7 +26,7 @@ export default class AddUsersToTeam extends React.Component {
         onModalDismissed: PropTypes.func,
         actions: PropTypes.shape({
             getProfilesNotInTeam: PropTypes.func.isRequired,
-            setAddUsersToTeamSearchTerm: PropTypes.func.isRequired,
+            setModalSearchTerm: PropTypes.func.isRequired,
             searchProfiles: PropTypes.func.isRequired,
             addUsersToTeam: PropTypes.func.isRequired,
         }).isRequired,
@@ -77,7 +77,7 @@ export default class AddUsersToTeam extends React.Component {
     }
 
     handleHide = () => {
-        this.props.actions.setAddUsersToTeamSearchTerm('');
+        this.props.actions.setModalSearchTerm('');
         this.setState({show: false});
     }
 
@@ -148,7 +148,7 @@ export default class AddUsersToTeam extends React.Component {
     }
 
     search = (term) => {
-        this.props.actions.setAddUsersToTeamSearchTerm(term);
+        this.props.actions.setModalSearchTerm(term);
     }
 
     renderOption(option, isSelected, onAdd) {

--- a/components/add_users_to_team/index.js
+++ b/components/add_users_to_team/index.js
@@ -3,13 +3,32 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {getProfilesNotInTeam} from 'mattermost-redux/actions/users';
+import {getProfilesNotInTeam, searchProfiles} from 'mattermost-redux/actions/users';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {searchProfilesNotInCurrentTeam, getProfilesNotInCurrentTeam} from 'mattermost-redux/selectors/entities/users';
+
+import {addUsersToTeam} from 'actions/team_actions.jsx';
+import {setAddUsersToTeamSearchTerm} from 'actions/search.js';
 
 import AddUsersToTeam from './add_users_to_team.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
+    const searchTerm = state.views.search.addUsersToTeam;
+
+    let users;
+    if (searchTerm) {
+        users = searchProfilesNotInCurrentTeam(state, searchTerm, true);
+    } else {
+        users = getProfilesNotInCurrentTeam(state);
+    }
+
+    const team = getCurrentTeam(state) || {};
+
     return {
-        ...ownProps,
+        currentTeamName: team.display_name,
+        currentTeamId: team.id,
+        searchTerm,
+        users,
     };
 }
 
@@ -17,6 +36,9 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             getProfilesNotInTeam,
+            setAddUsersToTeamSearchTerm,
+            searchProfiles,
+            addUsersToTeam,
         }, dispatch),
     };
 }

--- a/components/add_users_to_team/index.js
+++ b/components/add_users_to_team/index.js
@@ -8,12 +8,12 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {searchProfilesNotInCurrentTeam, getProfilesNotInCurrentTeam} from 'mattermost-redux/selectors/entities/users';
 
 import {addUsersToTeam} from 'actions/team_actions.jsx';
-import {setAddUsersToTeamSearchTerm} from 'actions/views/search';
+import {setModalSearchTerm} from 'actions/views/search';
 
 import AddUsersToTeam from './add_users_to_team.jsx';
 
 function mapStateToProps(state) {
-    const searchTerm = state.views.search.addUsersToTeam;
+    const searchTerm = state.views.search.modalSearch;
 
     let users;
     if (searchTerm) {
@@ -36,7 +36,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             getProfilesNotInTeam,
-            setAddUsersToTeamSearchTerm,
+            setModalSearchTerm,
             searchProfiles,
             addUsersToTeam,
         }, dispatch),

--- a/components/add_users_to_team/index.js
+++ b/components/add_users_to_team/index.js
@@ -8,7 +8,7 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {searchProfilesNotInCurrentTeam, getProfilesNotInCurrentTeam} from 'mattermost-redux/selectors/entities/users';
 
 import {addUsersToTeam} from 'actions/team_actions.jsx';
-import {setAddUsersToTeamSearchTerm} from 'actions/search.js';
+import {setAddUsersToTeamSearchTerm} from 'actions/views/search';
 
 import AddUsersToTeam from './add_users_to_team.jsx';
 

--- a/components/member_list_channel/index.js
+++ b/components/member_list_channel/index.js
@@ -3,16 +3,77 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {createSelector} from 'reselect';
+import {searchProfilesInCurrentChannel, getProfilesInCurrentChannel} from 'mattermost-redux/selectors/entities/users';
+import {getMembersInCurrentChannel, getCurrentChannelStats, getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getMembersInCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getChannelStats} from 'mattermost-redux/actions/channels';
+import {searchProfiles} from 'mattermost-redux/actions/users';
+import {sortByUsername} from 'mattermost-redux/utils/user_utils';
+
+import {setModalSearchTerm} from 'actions/views/search';
 
 import MemberListChannel from './member_list_channel.jsx';
+
+const getUsersAndActionsToDisplay = createSelector(
+    (state, users) => users,
+    getMembersInCurrentTeam,
+    getMembersInCurrentChannel,
+    getCurrentChannel,
+    (users = [], teamMembers = {}, channelMembers = {}, channel = {}) => {
+        const actionUserProps = {};
+        const usersToDisplay = [];
+
+        for (let i = 0; i < users.length; i++) {
+            const user = users[i];
+
+            if (teamMembers[user.id] && channelMembers[user.id] && user.delete_at === 0) {
+                usersToDisplay.push(user);
+
+                actionUserProps[user.id] = {
+                    channel,
+                    teamMember: teamMembers[user.id],
+                    channelMember: channelMembers[user.id],
+                };
+            }
+        }
+
+        return {
+            usersToDisplay: usersToDisplay.sort(sortByUsername),
+            actionUserProps,
+        };
+    }
+);
+
+function mapStateToProps(state) {
+    const searchTerm = state.views.search.modalSearch;
+
+    let users;
+    if (searchTerm) {
+        users = searchProfilesInCurrentChannel(state, searchTerm);
+    } else {
+        users = getProfilesInCurrentChannel(state);
+    }
+
+    const stats = getCurrentChannelStats(state) || {member_count: 0};
+
+    return {
+        ...getUsersAndActionsToDisplay(state, users),
+        currentTeamId: state.entities.teams.currentTeamId,
+        currentChannelId: state.entities.channels.currentChannelId,
+        searchTerm,
+        totalChannelMembers: stats.member_count,
+    };
+}
 
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            searchProfiles,
             getChannelStats,
+            setModalSearchTerm,
         }, dispatch),
     };
 }
 
-export default connect(null, mapDispatchToProps)(MemberListChannel);
+export default connect(mapStateToProps, mapDispatchToProps)(MemberListChannel);

--- a/components/member_list_channel/member_list_channel.jsx
+++ b/components/member_list_channel/member_list_channel.jsx
@@ -4,203 +4,105 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {searchProfilesInCurrentChannel} from 'mattermost-redux/selectors/entities/users';
-import {sortByUsername} from 'mattermost-redux/utils/user_utils';
-
-import {loadProfilesAndTeamMembersAndChannelMembers, loadTeamMembersAndChannelMembersForProfilesList, searchUsers} from 'actions/user_actions.jsx';
-import ChannelStore from 'stores/channel_store.jsx';
-import store from 'stores/redux_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
-import UserStore from 'stores/user_store.jsx';
+import {loadProfilesAndTeamMembersAndChannelMembers, loadTeamMembersAndChannelMembersForProfilesList} from 'actions/user_actions.jsx';
+import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
-import * as Utils from 'utils/utils.jsx';
 
 import ChannelMembersDropdown from 'components/channel_members_dropdown';
 import SearchableUserList from 'components/searchable_user_list/searchable_user_list_container.jsx';
 
 const USERS_PER_PAGE = 50;
 
-export default class MemberListChannel extends React.Component {
+export default class MemberListChannel extends React.PureComponent {
     static propTypes = {
+        currentTeamId: PropTypes.string.isRequired,
+        currentChannelId: PropTypes.string.isRequired,
+        searchTerm: PropTypes.string.isRequired,
+        usersToDisplay: PropTypes.arrayOf(PropTypes.object).isRequired,
+        actionUserProps: PropTypes.object.isRequired,
+        totalChannelMembers: PropTypes.number.isRequired,
         channel: PropTypes.object.isRequired,
         actions: PropTypes.shape({
+            searchProfiles: PropTypes.func.isRequired,
             getChannelStats: PropTypes.func.isRequired,
+            setModalSearchTerm: PropTypes.func.isRequired,
         }).isRequired,
     }
 
     constructor(props) {
         super(props);
 
-        this.onChange = this.onChange.bind(this);
-        this.onStatsChange = this.onStatsChange.bind(this);
-        this.handleSearch = this.handleSearch.bind(this);
-        this.loadComplete = this.loadComplete.bind(this);
-
         this.searchTimeoutId = 0;
-        this.term = '';
-
-        const stats = ChannelStore.getCurrentStats();
 
         this.state = {
-            users: UserStore.getProfileListInChannel(ChannelStore.getCurrentId(), false, true),
-            teamMembers: Object.assign({}, TeamStore.getMembersInTeam()),
-            channelMembers: Object.assign({}, ChannelStore.getMembersInChannel()),
-            total: stats.member_count,
             loading: true,
-            actionUserProps: {},
-            usersToDisplay: [],
         };
     }
 
     componentDidMount() {
-        UserStore.addInChannelChangeListener(this.onChange);
-        TeamStore.addChangeListener(this.onChange);
-        ChannelStore.addChangeListener(this.onChange);
-        ChannelStore.addStatsChangeListener(this.onStatsChange);
-
-        loadProfilesAndTeamMembersAndChannelMembers(0, Constants.PROFILE_CHUNK_SIZE, TeamStore.getCurrentId(), ChannelStore.getCurrentId(), this.loadComplete);
-        this.props.actions.getChannelStats(ChannelStore.getCurrentId());
+        loadProfilesAndTeamMembersAndChannelMembers(0, Constants.PROFILE_CHUNK_SIZE, this.props.currentTeamId, this.props.currentChannelId, this.loadComplete);
+        this.props.actions.getChannelStats(this.props.currentChannelId);
     }
 
     componentWillUnmount() {
-        UserStore.removeInTeamChangeListener(this.onChange);
-        TeamStore.removeChangeListener(this.onChange);
-        ChannelStore.removeChangeListener(this.onChange);
-        ChannelStore.removeStatsChangeListener(this.onStatsChange);
+        this.props.actions.setModalSearchTerm('');
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
-        if (nextState.loading !== this.state.loading) {
-            return true;
-        }
+    componentWillReceiveProps(nextProps) {
+        if (this.props.searchTerm !== nextProps.searchTerm) {
+            clearTimeout(this.searchTimeoutId);
+            const searchTerm = nextProps.searchTerm;
 
-        if (nextState.total !== this.state.total) {
-            return true;
-        }
-
-        if (!Utils.areObjectsEqual(nextState.usersToDisplay, this.state.usersToDisplay)) {
-            return true;
-        }
-
-        if (!Utils.areObjectsEqual(nextState.actionUserProps, this.state.actionUserProps)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    componentWillUpdate(_, nextState) {
-        if (!nextState.loading) {
-            const {
-                users,
-                teamMembers,
-                channelMembers,
-            } = nextState;
-
-            this.setUsersDisplayAndActionProps(users, teamMembers, channelMembers);
-        }
-    }
-
-    setUsersDisplayAndActionProps(users, teamMembers, channelMembers) {
-        const actionUserProps = {};
-        const usersToDisplay = [];
-
-        for (let i = 0; i < users.length; i++) {
-            const user = users[i];
-
-            if (teamMembers[user.id] && channelMembers[user.id] && user.delete_at === 0) {
-                usersToDisplay.push(user);
-
-                actionUserProps[user.id] = {
-                    channel: this.props.channel,
-                    teamMember: teamMembers[user.id],
-                    channelMember: channelMembers[user.id],
-                };
+            if (searchTerm === '') {
+                this.loadComplete();
+                this.searchTimeoutId = '';
+                return;
             }
-        }
 
-        this.setState({
-            usersToDisplay: usersToDisplay.sort(sortByUsername),
-            actionUserProps,
-        });
+            const searchTimeoutId = setTimeout(
+                async () => {
+                    const {data} = await this.props.actions.searchProfiles(searchTerm, {team_id: nextProps.currentTeamId, in_channel_id: nextProps.currentChannelId});
+
+                    if (searchTimeoutId !== this.searchTimeoutId) {
+                        return;
+                    }
+
+                    this.setState({loading: true});
+
+                    loadStatusesForProfilesList(data);
+                    loadTeamMembersAndChannelMembersForProfilesList(data, nextProps.currentTeamId, nextProps.currentChannelId, this.loadComplete);
+                },
+                Constants.SEARCH_TIMEOUT_MILLISECONDS
+            );
+
+            this.searchTimeoutId = searchTimeoutId;
+        }
     }
 
-    loadComplete() {
+    loadComplete = () => {
         this.setState({loading: false});
-    }
-
-    onChange() {
-        let users;
-        if (this.term) {
-            users = searchProfilesInCurrentChannel(store.getState(), this.term);
-        } else {
-            users = UserStore.getProfileListInChannel(ChannelStore.getCurrentId(), false, true);
-        }
-
-        const teamMembers = Object.assign({}, TeamStore.getMembersInTeam());
-        const channelMembers = Object.assign({}, ChannelStore.getMembersInChannel());
-
-        this.setState({
-            users,
-            teamMembers,
-            channelMembers,
-        });
-
-        this.setUsersDisplayAndActionProps(users, teamMembers, channelMembers);
-    }
-
-    onStatsChange() {
-        const stats = ChannelStore.getCurrentStats();
-        this.setState({total: stats.member_count});
     }
 
     nextPage(page) {
         loadProfilesAndTeamMembersAndChannelMembers(page + 1, USERS_PER_PAGE);
     }
 
-    handleSearch(term) {
-        clearTimeout(this.searchTimeoutId);
-        this.term = term;
-
-        if (term === '') {
-            this.setState({loading: false});
-            this.searchTimeoutId = '';
-            this.onChange();
-            return;
-        }
-
-        const searchTimeoutId = setTimeout(
-            () => {
-                searchUsers(term, '', {in_channel_id: ChannelStore.getCurrentId()},
-                    (users) => {
-                        if (searchTimeoutId !== this.searchTimeoutId) {
-                            return;
-                        }
-
-                        this.setState({loading: true});
-
-                        loadTeamMembersAndChannelMembersForProfilesList(users, TeamStore.getCurrentId(), ChannelStore.getCurrentId(), this.loadComplete);
-                    }
-                );
-            },
-            Constants.SEARCH_TIMEOUT_MILLISECONDS
-        );
-
-        this.searchTimeoutId = searchTimeoutId;
+    handleSearch = (term) => {
+        this.props.actions.setModalSearchTerm(term);
     }
 
     render() {
         return (
             <SearchableUserList
-                users={this.state.usersToDisplay}
+                users={this.props.usersToDisplay}
                 usersPerPage={USERS_PER_PAGE}
-                total={this.state.total}
+                total={this.props.totalChannelMembers}
                 nextPage={this.nextPage}
                 search={this.handleSearch}
                 actions={[ChannelMembersDropdown]}
-                actionUserProps={this.state.actionUserProps}
+                actionUserProps={this.props.actionUserProps}
                 focusOnMount={!UserAgent.isMobile()}
             />
         );

--- a/components/member_list_team/index.js
+++ b/components/member_list_team/index.js
@@ -5,22 +5,45 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getTeamStats} from 'mattermost-redux/actions/teams';
 import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
+import {getMembersInCurrentTeam, getCurrentTeamStats} from 'mattermost-redux/selectors/entities/teams';
+import {getProfilesInCurrentTeam, searchProfilesInCurrentTeam} from 'mattermost-redux/selectors/entities/users';
 import {Permissions} from 'mattermost-redux/constants';
+import {searchProfiles} from 'mattermost-redux/actions/users';
+
+import {setModalSearchTerm} from 'actions/views/search';
 
 import MemberListTeam from './member_list_team.jsx';
 
 function mapStateToProps(state, ownProps) {
     const canManageTeamMembers = haveITeamPermission(state, {team: ownProps.teamId, permission: Permissions.MANAGE_TEAM_ROLES});
+
+    const searchTerm = state.views.search.modalSearch;
+
+    let users;
+    if (searchTerm) {
+        users = searchProfilesInCurrentTeam(state, searchTerm);
+    } else {
+        users = getProfilesInCurrentTeam(state);
+    }
+
+    const stats = getCurrentTeamStats(state) || {active_member_count: 0};
+
     return {
+        searchTerm,
+        users,
+        teamMembers: getMembersInCurrentTeam(state) || {},
+        currentTeamId: state.entities.teams.currentTeamId,
+        totalTeamMembers: stats.active_member_count,
         canManageTeamMembers,
-        ...ownProps,
     };
 }
 
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            searchProfiles,
             getTeamStats,
+            setModalSearchTerm,
         }, dispatch),
     };
 }

--- a/components/member_list_team/member_list_team.jsx
+++ b/components/member_list_team/member_list_team.jsx
@@ -3,14 +3,12 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {searchProfilesInCurrentTeam} from 'mattermost-redux/selectors/entities/users';
 
-import {loadProfilesAndTeamMembers, loadTeamMembersForProfilesList, searchUsers} from 'actions/user_actions.jsx';
-import store from 'stores/redux_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
-import UserStore from 'stores/user_store.jsx';
+import {loadProfilesAndTeamMembers, loadTeamMembersForProfilesList} from 'actions/user_actions.jsx';
+import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
+
 import SearchableUserList from 'components/searchable_user_list/searchable_user_list_container.jsx';
 import TeamMembersDropdown from 'components/team_members_dropdown';
 
@@ -18,105 +16,79 @@ const USERS_PER_PAGE = 50;
 
 export default class MemberListTeam extends React.Component {
     static propTypes = {
-        teamId: PropTypes.string.isRequired,
+        searchTerm: PropTypes.string.isRequired,
+        users: PropTypes.arrayOf(PropTypes.object).isRequired,
+        teamMembers: PropTypes.object.isRequired,
+        currentTeamId: PropTypes.string.isRequired,
+        totalTeamMembers: PropTypes.number.isRequired,
         canManageTeamMembers: PropTypes.bool,
         actions: PropTypes.shape({
+            searchProfiles: PropTypes.func.isRequired,
             getTeamStats: PropTypes.func.isRequired,
+            setModalSearchTerm: PropTypes.func.isRequired,
         }).isRequired,
     }
 
     constructor(props) {
         super(props);
 
-        this.onChange = this.onChange.bind(this);
-        this.onStatsChange = this.onStatsChange.bind(this);
-        this.search = this.search.bind(this);
-        this.loadComplete = this.loadComplete.bind(this);
-
         this.searchTimeoutId = 0;
-        this.term = '';
-
-        const stats = TeamStore.getCurrentStats();
 
         this.state = {
-            users: UserStore.getProfileListInTeam(),
-            teamMembers: Object.assign([], TeamStore.getMembersInTeam()),
-            total: stats.active_member_count,
             loading: true,
         };
     }
 
     componentDidMount() {
-        UserStore.addInTeamChangeListener(this.onChange);
-        UserStore.addStatusesChangeListener(this.onChange);
-        TeamStore.addChangeListener(this.onChange);
-        TeamStore.addStatsChangeListener(this.onStatsChange);
-
-        loadProfilesAndTeamMembers(0, Constants.PROFILE_CHUNK_SIZE, TeamStore.getCurrentId(), this.loadComplete);
-        this.props.actions.getTeamStats(TeamStore.getCurrentId());
+        loadProfilesAndTeamMembers(0, Constants.PROFILE_CHUNK_SIZE, this.props.currentTeamId, this.loadComplete);
+        this.props.actions.getTeamStats(this.props.currentTeamId);
     }
 
     componentWillUnmount() {
-        UserStore.removeInTeamChangeListener(this.onChange);
-        UserStore.removeStatusesChangeListener(this.onChange);
-        TeamStore.removeChangeListener(this.onChange);
-        TeamStore.removeStatsChangeListener(this.onStatsChange);
+        this.props.actions.setModalSearchTerm('');
     }
 
-    loadComplete() {
-        this.setState({loading: false});
-    }
+    componentWillReceiveProps(nextProps) {
+        if (this.props.searchTerm !== nextProps.searchTerm) {
+            clearTimeout(this.searchTimeoutId);
 
-    onChange() {
-        let users;
-        if (this.term) {
-            users = searchProfilesInCurrentTeam(store.getState(), this.term);
-        } else {
-            users = UserStore.getProfileListInTeam();
+            const searchTerm = nextProps.searchTerm;
+            if (searchTerm === '') {
+                this.loadComplete();
+                this.searchTimeoutId = '';
+                return;
+            }
+
+            const searchTimeoutId = setTimeout(
+                async () => {
+                    const {data} = await this.props.actions.searchProfiles(searchTerm, {team_id: nextProps.currentTeamId});
+
+                    if (searchTimeoutId !== this.searchTimeoutId) {
+                        return;
+                    }
+
+                    this.setState({loading: true});
+
+                    loadStatusesForProfilesList(data);
+                    loadTeamMembersForProfilesList(data, nextProps.currentTeamId, this.loadComplete);
+                },
+                Constants.SEARCH_TIMEOUT_MILLISECONDS
+            );
+
+            this.searchTimeoutId = searchTimeoutId;
         }
-
-        this.setState({users, teamMembers: Object.assign([], TeamStore.getMembersInTeam())});
     }
 
-    onStatsChange() {
-        const stats = TeamStore.getCurrentStats();
-        this.setState({total: stats.active_member_count});
+    loadComplete = () => {
+        this.setState({loading: false});
     }
 
     nextPage(page) {
         loadProfilesAndTeamMembers(page + 1, USERS_PER_PAGE);
     }
 
-    search(term) {
-        clearTimeout(this.searchTimeoutId);
-        this.term = term;
-
-        if (term === '') {
-            this.setState({loading: false});
-            this.searchTimeoutId = '';
-            this.onChange();
-            return;
-        }
-
-        const searchTimeoutId = setTimeout(
-            () => {
-                searchUsers(
-                    term,
-                    TeamStore.getCurrentId(),
-                    {},
-                    (users) => {
-                        if (searchTimeoutId !== this.searchTimeoutId) {
-                            return;
-                        }
-                        this.setState({loading: true});
-                        loadTeamMembersForProfilesList(users, TeamStore.getCurrentId(), this.loadComplete);
-                    }
-                );
-            },
-            Constants.SEARCH_TIMEOUT_MILLISECONDS
-        );
-
-        this.searchTimeoutId = searchTimeoutId;
+    search = (term) => {
+        this.props.actions.setModalSearchTerm(term);
     }
 
     render() {
@@ -125,8 +97,8 @@ export default class MemberListTeam extends React.Component {
             teamMembersDropdown = [TeamMembersDropdown];
         }
 
-        const teamMembers = this.state.teamMembers;
-        const users = this.state.users;
+        const teamMembers = this.props.teamMembers;
+        const users = this.props.users;
         const actionUserProps = {};
 
         let usersToDisplay;
@@ -151,7 +123,7 @@ export default class MemberListTeam extends React.Component {
             <SearchableUserList
                 users={usersToDisplay}
                 usersPerPage={USERS_PER_PAGE}
-                total={this.state.total}
+                total={this.props.totalTeamMembers}
                 nextPage={this.nextPage}
                 search={this.search}
                 actions={teamMembersDropdown}

--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -15,7 +15,7 @@ import {
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
-import {setMoreDirectChannelsSearchTerm} from 'actions/views/search';
+import {setModalSearchTerm} from 'actions/views/search';
 
 import MoreDirectChannels from './more_direct_channels.jsx';
 
@@ -28,7 +28,7 @@ function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
     const restrictDirectMessage = config.RestrictDirectMessage;
 
-    const searchTerm = state.views.search.moreDirectChannels;
+    const searchTerm = state.views.search.modalSearch;
 
     let users;
     if (searchTerm) {
@@ -63,7 +63,7 @@ function mapDispatchToProps(dispatch) {
             getProfiles,
             getProfilesInTeam,
             searchProfiles,
-            setMoreDirectChannelsSearchTerm,
+            setModalSearchTerm,
         }, dispatch),
     };
 }

--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -3,12 +3,19 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {getProfiles, getProfilesInTeam} from 'mattermost-redux/actions/users';
+import {getProfiles, getProfilesInTeam, searchProfiles} from 'mattermost-redux/actions/users';
 import {
     getCurrentUserId,
+    getProfiles as selectProfiles,
     getProfilesInCurrentChannel,
+    getProfilesInCurrentTeam,
+    searchProfiles as searchProfilesSelector,
+    searchProfilesInCurrentTeam,
 } from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import {setMoreDirectChannelsSearchTerm} from 'actions/views/search';
 
 import MoreDirectChannels from './more_direct_channels.jsx';
 
@@ -21,7 +28,29 @@ function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
     const restrictDirectMessage = config.RestrictDirectMessage;
 
+    const searchTerm = state.views.search.moreDirectChannels;
+
+    let users;
+    if (searchTerm) {
+        if (restrictDirectMessage === 'any') {
+            users = searchProfilesSelector(state, searchTerm, false);
+        } else {
+            users = searchProfilesInCurrentTeam(state, searchTerm, false);
+        }
+    } else if (restrictDirectMessage === 'any') {
+        users = selectProfiles(state);
+    } else {
+        users = getProfilesInCurrentTeam(state);
+    }
+
+    const team = getCurrentTeam(state);
+
     return {
+        currentTeamId: team.id,
+        currentTeamName: team.name,
+        searchTerm,
+        users,
+        statuses: state.entities.users.statuses,
         currentChannelMembers,
         currentUserId: getCurrentUserId(state),
         restrictDirectMessage,
@@ -33,6 +62,8 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             getProfiles,
             getProfilesInTeam,
+            searchProfiles,
+            setMoreDirectChannelsSearchTerm,
         }, dispatch),
     };
 }

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -49,7 +49,7 @@ export default class MoreDirectChannels extends React.Component {
             getProfiles: PropTypes.func.isRequired,
             getProfilesInTeam: PropTypes.func.isRequired,
             searchProfiles: PropTypes.func.isRequired,
-            setMoreDirectChannelsSearchTerm: PropTypes.func.isRequired,
+            setModalSearchTerm: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -112,6 +112,7 @@ export default class MoreDirectChannels extends React.Component {
     }
 
     handleHide = () => {
+        this.props.actions.setModalSearchTerm('');
         this.setState({show: false});
     }
 
@@ -204,7 +205,7 @@ export default class MoreDirectChannels extends React.Component {
     }
 
     search = (term) => {
-        this.props.actions.setMoreDirectChannelsSearchTerm(term);
+        this.props.actions.setModalSearchTerm(term);
     }
 
     handleDelete = (values) => {

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -6,14 +6,10 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import {Client4} from 'mattermost-redux/client';
-import {searchProfiles, searchProfilesInCurrentTeam} from 'mattermost-redux/selectors/entities/users';
 
 import {browserHistory} from 'utils/browser_history';
 import {openDirectChannelToUser, openGroupChannelToUsers} from 'actions/channel_actions.jsx';
-import {searchUsers} from 'actions/user_actions.jsx';
-import store from 'stores/redux_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
-import UserStore from 'stores/user_store.jsx';
+import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import {displayEntireNameForUser, localizeMessage} from 'utils/utils.jsx';
 import MultiSelect from 'components/multiselect/multiselect.jsx';
@@ -25,10 +21,12 @@ const MAX_SELECTABLE_VALUES = Constants.MAX_USERS_IN_GM - 1;
 export default class MoreDirectChannels extends React.Component {
     static propTypes = {
 
-        /*
-         * Current user's ID
-         */
         currentUserId: PropTypes.string.isRequired,
+        currentTeamId: PropTypes.string.isRequired,
+        currentTeamName: PropTypes.string.isRequired,
+        searchTerm: PropTypes.string.isRequired,
+        users: PropTypes.arrayOf(PropTypes.object).isRequired,
+        statuses: PropTypes.object.isRequired,
 
         /*
          * List of current channel members of existing channel
@@ -44,46 +42,21 @@ export default class MoreDirectChannels extends React.Component {
          * The mode by which direct messages are restricted, if at all.
          */
         restrictDirectMessage: PropTypes.string,
-
-        /*
-         * Function to call on modal dismissed
-         */
         onModalDismissed: PropTypes.func,
-
-        /**
-         * Function to call on modal hide
-         */
         onHide: PropTypes.func,
 
         actions: PropTypes.shape({
-
-            /**
-             * Function to get profiles
-             */
             getProfiles: PropTypes.func.isRequired,
-
-            /**
-             * Function to get profiles in team
-             */
             getProfilesInTeam: PropTypes.func.isRequired,
+            searchProfiles: PropTypes.func.isRequired,
+            setMoreDirectChannelsSearchTerm: PropTypes.func.isRequired,
         }).isRequired,
     }
 
     constructor(props) {
         super(props);
 
-        this.handleHide = this.handleHide.bind(this);
-        this.handleExit = this.handleExit.bind(this);
-        this.handleSubmit = this.handleSubmit.bind(this);
-        this.handleDelete = this.handleDelete.bind(this);
-        this.handlePageChange = this.handlePageChange.bind(this);
-        this.onChange = this.onChange.bind(this);
-        this.search = this.search.bind(this);
-        this.addValue = this.addValue.bind(this);
-
         this.searchTimeoutId = 0;
-        this.term = '';
-        this.listType = this.props.restrictDirectMessage;
 
         const values = [];
 
@@ -100,7 +73,6 @@ export default class MoreDirectChannels extends React.Component {
         }
 
         this.state = {
-            users: null,
             values,
             show: true,
             search: false,
@@ -110,19 +82,36 @@ export default class MoreDirectChannels extends React.Component {
     }
 
     componentDidMount() {
-        UserStore.addChangeListener(this.onChange);
-        UserStore.addInTeamChangeListener(this.onChange);
-        UserStore.addStatusesChangeListener(this.onChange);
         this.getUserProfiles();
     }
 
-    componentWillUnmount() {
-        UserStore.removeChangeListener(this.onChange);
-        UserStore.removeInTeamChangeListener(this.onChange);
-        UserStore.removeStatusesChangeListener(this.onChange);
+    componentWillReceiveProps(nextProps) {
+        if (this.props.searchTerm !== nextProps.searchTerm) {
+            clearTimeout(this.searchTimeoutId);
+
+            const searchTerm = nextProps.searchTerm;
+            if (searchTerm === '') {
+                this.resetPaging();
+            } else {
+                const teamId = nextProps.restrictDirectMessage === 'any' ? '' : nextProps.currentTeamId;
+
+                this.searchTimeoutId = setTimeout(
+                    async () => {
+                        this.setUsersLoadingState(true);
+                        const {data} = await this.props.actions.searchProfiles(searchTerm, {team_id: teamId});
+                        if (data) {
+                            loadStatusesForProfilesList(data);
+                            this.resetPaging();
+                        }
+                        this.setUsersLoadingState(false);
+                    },
+                    Constants.SEARCH_TIMEOUT_MILLISECONDS
+                );
+            }
+        }
     }
 
-    handleHide() {
+    handleHide = () => {
         this.setState({show: false});
     }
 
@@ -132,7 +121,7 @@ export default class MoreDirectChannels extends React.Component {
         });
     }
 
-    handleExit() {
+    handleExit = () => {
         if (this.exitToChannel) {
             browserHistory.push(this.exitToChannel);
         }
@@ -146,7 +135,7 @@ export default class MoreDirectChannels extends React.Component {
         }
     }
 
-    handleSubmit(values = this.state.values) {
+    handleSubmit = (values = this.state.values) => {
         if (this.state.saving) {
             return;
         }
@@ -162,7 +151,7 @@ export default class MoreDirectChannels extends React.Component {
             // Due to how react-overlays Modal handles focus, we delay pushing
             // the new channel information until the modal is fully exited.
             // The channel information will be pushed in `handleExit`
-            this.exitToChannel = TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + channel.name;
+            this.exitToChannel = '/' + this.props.currentTeamName + '/channels/' + channel.name;
             this.setState({saving: false});
             this.handleHide();
         };
@@ -178,7 +167,7 @@ export default class MoreDirectChannels extends React.Component {
         }
     }
 
-    addValue(value) {
+    addValue = (value) => {
         const values = Object.assign([], this.state.values);
 
         if (values.indexOf(value) === -1) {
@@ -188,45 +177,20 @@ export default class MoreDirectChannels extends React.Component {
         this.setState({values});
     }
 
-    onChange() {
-        let users;
-
-        if (this.term) {
-            if (this.listType === 'any') {
-                users = Object.assign([], searchProfiles(store.getState(), this.term, false));
-            } else {
-                users = Object.assign([], searchProfilesInCurrentTeam(store.getState(), this.term, false));
-            }
-        } else if (this.listType === 'any') {
-            users = Object.assign([], UserStore.getProfileList(false, true));
-        } else {
-            users = Object.assign([], UserStore.getProfileListInTeam(TeamStore.getCurrentId(), false, false));
-        }
-
-        for (let i = 0; i < users.length; i++) {
-            const user = Object.assign({}, users[i]);
-            users[i] = user;
-        }
-
-        this.setState({
-            users,
-        });
-    }
-
-    getUserProfiles(page) {
+    getUserProfiles = (page) => {
         const pageNum = page ? page + 1 : 0;
-        if (this.listType === 'any') {
+        if (this.props.restrictDirectMessage === 'any') {
             this.props.actions.getProfiles(pageNum, USERS_PER_PAGE * 2).then(() => {
                 this.setUsersLoadingState(false);
             });
         } else {
-            this.props.actions.getProfilesInTeam(TeamStore.getCurrentId(), pageNum, USERS_PER_PAGE * 2).then(() => {
+            this.props.actions.getProfilesInTeam(this.props.currentTeamId, pageNum, USERS_PER_PAGE * 2).then(() => {
                 this.setUsersLoadingState(false);
             });
         }
     }
 
-    handlePageChange(page, prevPage) {
+    handlePageChange = (page, prevPage) => {
         if (page > prevPage) {
             this.setUsersLoadingState(true);
             this.getUserProfiles(page);
@@ -239,44 +203,19 @@ export default class MoreDirectChannels extends React.Component {
         }
     }
 
-    search(term) {
-        clearTimeout(this.searchTimeoutId);
-        this.term = term;
-
-        if (term === '') {
-            this.resetPaging();
-            this.onChange();
-            return;
-        }
-
-        let teamId;
-        if (this.listType === 'any') {
-            teamId = '';
-        } else {
-            teamId = TeamStore.getCurrentId();
-        }
-
-        this.searchTimeoutId = setTimeout(
-            () => {
-                this.setUsersLoadingState(true);
-                searchUsers(term, teamId, {}, this.resetPaging).then(() => {
-                    this.setUsersLoadingState(false);
-                });
-            },
-            Constants.SEARCH_TIMEOUT_MILLISECONDS
-        );
+    search = (term) => {
+        this.props.actions.setMoreDirectChannelsSearchTerm(term);
     }
 
-    handleDelete(values) {
+    handleDelete = (values) => {
         this.setState({values});
     }
 
-    renderOption(option, isSelected, onAdd) {
-        const currentUser = UserStore.getCurrentUser();
+    renderOption = (option, isSelected, onAdd) => {
         const displayName = displayEntireNameForUser(option);
 
         let modalName = displayName;
-        if (option.id === currentUser.id) {
+        if (option.id === this.props.currentUserId) {
             modalName = (
                 <FormattedMessage
                     id='more_direct_channels.directchannel.you'
@@ -303,7 +242,7 @@ export default class MoreDirectChannels extends React.Component {
             rowSelected = 'more-modal__row--selected';
         }
 
-        const status = option.delete_at ? null : UserStore.getStatus(option.id);
+        const status = option.delete_at ? null : this.props.statuses[option.id];
 
         return (
             <div
@@ -377,7 +316,7 @@ export default class MoreDirectChannels extends React.Component {
             />
         );
 
-        let users = this.state.users || [];
+        let users = this.props.users || [];
 
         if (this.state.values.length) {
             users = users.filter((user) => user.delete_at === 0 && user.id !== this.props.currentUserId);

--- a/components/post_view/post_add_channel_member/index.js
+++ b/components/post_view/post_add_channel_member/index.js
@@ -22,7 +22,6 @@ function mapStateToProps(state, ownProps) {
     }
 
     return {
-        ...ownProps,
         channelType,
         currentUser: getCurrentUser(state),
         post,

--- a/reducers/views/index.js
+++ b/reducers/views/index.js
@@ -11,6 +11,7 @@ import modals from './modals';
 import emoji from './emoji';
 import lhs from './lhs';
 import webrtc from './webrtc';
+import search from './search';
 
 export default combineReducers({
     admin,
@@ -21,4 +22,5 @@ export default combineReducers({
     emoji,
     lhs,
     webrtc,
+    search,
 });

--- a/reducers/views/search.js
+++ b/reducers/views/search.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {combineReducers} from 'redux';
+
+import {SearchTypes} from 'utils/constants';
+
+function addUsersToTeam(state = '', action) {
+    switch (action.type) {
+    case SearchTypes.SET_ADD_USERS_TO_TEAM_SEARCH: {
+        return action.data;
+    }
+    default:
+        return state;
+    }
+}
+
+export default combineReducers({
+    addUsersToTeam,
+});

--- a/reducers/views/search.js
+++ b/reducers/views/search.js
@@ -5,19 +5,9 @@ import {combineReducers} from 'redux';
 
 import {SearchTypes} from 'utils/constants';
 
-function addUsersToTeam(state = '', action) {
+function modalSearch(state = '', action) {
     switch (action.type) {
-    case SearchTypes.SET_ADD_USERS_TO_TEAM_SEARCH: {
-        return action.data;
-    }
-    default:
-        return state;
-    }
-}
-
-function moreDirectChannels(state = '', action) {
-    switch (action.type) {
-    case SearchTypes.SET_MORE_DIRECT_CHANNELS_SEARCH: {
+    case SearchTypes.SET_MODAL_SEARCH: {
         return action.data;
     }
     default:
@@ -26,6 +16,5 @@ function moreDirectChannels(state = '', action) {
 }
 
 export default combineReducers({
-    addUsersToTeam,
-    moreDirectChannels,
+    modalSearch,
 });

--- a/reducers/views/search.js
+++ b/reducers/views/search.js
@@ -15,6 +15,17 @@ function addUsersToTeam(state = '', action) {
     }
 }
 
+function moreDirectChannels(state = '', action) {
+    switch (action.type) {
+    case SearchTypes.SET_MORE_DIRECT_CHANNELS_SEARCH: {
+        return action.data;
+    }
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
     addUsersToTeam,
+    moreDirectChannels,
 });

--- a/tests/components/add_users_to_team.test.jsx
+++ b/tests/components/add_users_to_team.test.jsx
@@ -6,35 +6,37 @@ import {Modal} from 'react-bootstrap';
 import {shallow} from 'enzyme';
 
 import AddUsersToTeam from 'components/add_users_to_team/add_users_to_team.jsx';
-import {searchUsersNotInTeam} from 'actions/user_actions.jsx';
 
 jest.useFakeTimers();
 
-jest.mock('stores/team_store.jsx', () => {
-    const original = require.requireActual('stores/team_store.jsx');
-    return {
-        ...original,
-        getCurrentId: jest.fn(() => 'current_team_id'),
-        getCurrent: jest.fn(() => {
-            return {display_name: 'display_name'};
-        }),
-    };
-});
-
-jest.mock('actions/team_actions.jsx');
-jest.mock('actions/user_actions.jsx', () => ({
-    searchUsersNotInTeam: jest.fn(() => {
-        return new Promise((resolve) => {
-            process.nextTick(() => resolve());
-        });
-    }),
+jest.mock('actions/status_actions.jsx', () => ({
+    loadStatusesForProfilesList: jest.fn(),
 }));
 
 describe('components/AddUsersToTeam', () => {
     const baseProps = {
+        currentTeamId: 'current_team_id',
+        currentTeamName: 'display_name',
+        searchTerm: '',
+        users: [{id: 'someid', username: 'somename', email: 'someemail'}],
         onModalDismissed: jest.fn(),
         actions: {
             getProfilesNotInTeam: jest.fn(() => {
+                return new Promise((resolve) => {
+                    process.nextTick(() => resolve());
+                });
+            }),
+            setAddUsersToTeamSearchTerm: jest.fn(() => {
+                return new Promise((resolve) => {
+                    process.nextTick(() => resolve());
+                });
+            }),
+            searchProfiles: jest.fn(() => {
+                return new Promise((resolve) => {
+                    process.nextTick(() => resolve());
+                });
+            }),
+            addUsersToTeam: jest.fn(() => {
                 return new Promise((resolve) => {
                     process.nextTick(() => resolve());
                 });
@@ -44,6 +46,7 @@ describe('components/AddUsersToTeam', () => {
 
     test('should match snapshot', () => {
         const actions = {
+            ...baseProps.actions,
             getProfilesNotInTeam: jest.fn(() => {
                 return new Promise((resolve) => {
                     process.nextTick(() => resolve());
@@ -99,20 +102,28 @@ describe('components/AddUsersToTeam', () => {
     });
 
     test('should match state when handleSubmit is called', () => {
-        const {addUsersToTeam} = require.requireMock('actions/team_actions.jsx');
+        const actions = {
+            ...baseProps.actions,
+            addUsersToTeam: jest.fn(() => {
+                return new Promise((resolve) => {
+                    process.nextTick(() => resolve());
+                });
+            }),
+        };
+        const props = {...baseProps, actions};
         const wrapper = shallow(
-            <AddUsersToTeam {...baseProps}/>
+            <AddUsersToTeam {...props}/>
         );
 
         wrapper.setState({values: []});
         wrapper.instance().handleSubmit({preventDefault: jest.fn()});
-        expect(addUsersToTeam).not.toBeCalled();
+        expect(actions.addUsersToTeam).not.toBeCalled();
 
         wrapper.setState({saving: false, values: [{id: 'id_1'}, {id: 'id_2'}]});
         wrapper.instance().handleSubmit({preventDefault: jest.fn()});
 
-        expect(addUsersToTeam).toBeCalled();
-        expect(addUsersToTeam).toHaveBeenCalledTimes(1);
+        expect(actions.addUsersToTeam).toBeCalled();
+        expect(actions.addUsersToTeam).toHaveBeenCalledTimes(1);
         expect(wrapper.state('saving')).toEqual(true);
     });
 
@@ -132,6 +143,7 @@ describe('components/AddUsersToTeam', () => {
 
     test('should match state when handlePageChange is called', () => {
         const actions = {
+            ...baseProps.actions,
             getProfilesNotInTeam: jest.fn(() => {
                 return new Promise((resolve) => {
                     process.nextTick(() => resolve());
@@ -155,21 +167,28 @@ describe('components/AddUsersToTeam', () => {
     });
 
     test('should match state when search is called', () => {
+        const actions = {
+            ...baseProps.actions,
+            setAddUsersToTeamSearchTerm: jest.fn(() => {
+                return new Promise((resolve) => {
+                    process.nextTick(() => resolve());
+                });
+            }),
+        };
+        const props = {...baseProps, actions};
         const wrapper = shallow(
-            <AddUsersToTeam {...baseProps}/>
+            <AddUsersToTeam {...props}/>
         );
 
         wrapper.instance().search('');
         jest.runAllTimers();
-        expect(searchUsersNotInTeam).not.toBeCalled();
+        expect(actions.setAddUsersToTeamSearchTerm).toBeCalled();
 
         const searchTerm = 'term';
         wrapper.instance().search(searchTerm);
         expect(wrapper.state('loadingUsers')).toEqual(true);
         jest.runAllTimers();
-        expect(wrapper.instance().term).toEqual(searchTerm);
-        expect(searchUsersNotInTeam).toBeCalled();
-        expect(searchUsersNotInTeam).toHaveBeenCalledTimes(1);
+        expect(actions.setAddUsersToTeamSearchTerm).toHaveBeenCalledTimes(2);
     });
 
     test('should match state when handleDelete is called', () => {

--- a/tests/components/add_users_to_team.test.jsx
+++ b/tests/components/add_users_to_team.test.jsx
@@ -26,7 +26,7 @@ describe('components/AddUsersToTeam', () => {
                     process.nextTick(() => resolve());
                 });
             }),
-            setAddUsersToTeamSearchTerm: jest.fn(() => {
+            setModalSearchTerm: jest.fn(() => {
                 return new Promise((resolve) => {
                     process.nextTick(() => resolve());
                 });
@@ -169,7 +169,7 @@ describe('components/AddUsersToTeam', () => {
     test('should match state when search is called', () => {
         const actions = {
             ...baseProps.actions,
-            setAddUsersToTeamSearchTerm: jest.fn(() => {
+            setModalSearchTerm: jest.fn(() => {
                 return new Promise((resolve) => {
                     process.nextTick(() => resolve());
                 });
@@ -182,13 +182,13 @@ describe('components/AddUsersToTeam', () => {
 
         wrapper.instance().search('');
         jest.runAllTimers();
-        expect(actions.setAddUsersToTeamSearchTerm).toBeCalled();
+        expect(actions.setModalSearchTerm).toBeCalled();
 
         const searchTerm = 'term';
         wrapper.instance().search(searchTerm);
         expect(wrapper.state('loadingUsers')).toEqual(true);
         jest.runAllTimers();
-        expect(actions.setAddUsersToTeamSearchTerm).toHaveBeenCalledTimes(2);
+        expect(actions.setModalSearchTerm).toHaveBeenCalledTimes(2);
     });
 
     test('should match state when handleDelete is called', () => {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -394,6 +394,7 @@ export const StatTypes = keyMirror({
 
 export const SearchTypes = keyMirror({
     SET_ADD_USERS_TO_TEAM_SEARCH: null,
+    SET_MORE_DIRECT_CHANNELS_SEARCH: null,
 });
 
 export const StorageTypes = keyMirror({

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -392,6 +392,10 @@ export const StatTypes = keyMirror({
     MONTHLY_ACTIVE_USERS: null,
 });
 
+export const SearchTypes = keyMirror({
+    SET_ADD_USERS_TO_TEAM_SEARCH: null,
+});
+
 export const StorageTypes = keyMirror({
     SET_ITEM: null,
     REMOVE_ITEM: null,

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -393,8 +393,7 @@ export const StatTypes = keyMirror({
 });
 
 export const SearchTypes = keyMirror({
-    SET_ADD_USERS_TO_TEAM_SEARCH: null,
-    SET_MORE_DIRECT_CHANNELS_SEARCH: null,
+    SET_MODAL_SEARCH: null,
 });
 
 export const StorageTypes = keyMirror({


### PR DESCRIPTION
#### Summary
Added a new view reducer for tracking modal search terms, removed flux store and `store.getState()` usages and performed some other minor refactoring.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9829

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)