### PR TITLE
MM-8528: prevent duplicate posts on retries

### DIFF
--- a/components/post_view/failed_post_options/failed_post_options.jsx
+++ b/components/post_view/failed_post_options/failed_post_options.jsx
@@ -20,30 +20,41 @@ export default class FailedPostOptions extends React.PureComponent {
         this.retryPost = this.retryPost.bind(this);
         this.cancelPost = this.cancelPost.bind(this);
 
-        this.submitting = false;
+        this.state = {
+            submitting: false,
+            submitted: false,
+        };
     }
 
     retryPost(e) {
         e.preventDefault();
 
-        if (this.submitting) {
+        // Don't retry if already retrying or previously retried and succeeded (and waiting for
+        // re-render).
+        if (this.state.submitting || this.state.submitted) {
             return;
         }
 
-        this.submitting = true;
+        this.setState({
+            submitting: true,
+        });
 
         const post = {...this.props.post};
         Reflect.deleteProperty(post, 'id');
         this.props.actions.createPost(post,
             () => {
-                this.submitting = false;
+                this.setState({
+                    submitted: true,
+                });
             },
             (err) => {
                 if (err && err.id && err.id === 'api.post.create_post.root_id.app_error') {
                     this.showPostDeletedModal();
                 }
 
-                this.submitting = false;
+                this.setState({
+                    submitting: false,
+                });
             }
         );
     }

--- a/components/post_view/failed_post_options/failed_post_options.jsx
+++ b/components/post_view/failed_post_options/failed_post_options.jsx
@@ -5,20 +5,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import {createPost} from 'actions/post_actions.jsx';
-
 export default class FailedPostOptions extends React.PureComponent {
     static propTypes = {
-
-        /*
-         * The failed post
-         */
         post: PropTypes.object.isRequired,
         actions: PropTypes.shape({
-
-            /**
-             * The function to delete the post
-             */
+            createPost: PropTypes.func.isRequired,
             removePost: PropTypes.func.isRequired,
         }).isRequired,
     }
@@ -43,7 +34,7 @@ export default class FailedPostOptions extends React.PureComponent {
 
         const post = {...this.props.post};
         Reflect.deleteProperty(post, 'id');
-        createPost(post,
+        this.props.actions.createPost(post,
             () => {
                 this.submitting = false;
             },

--- a/components/post_view/failed_post_options/failed_post_options.jsx
+++ b/components/post_view/failed_post_options/failed_post_options.jsx
@@ -20,10 +20,16 @@ export default class FailedPostOptions extends React.PureComponent {
         this.retryPost = this.retryPost.bind(this);
         this.cancelPost = this.cancelPost.bind(this);
 
-        this.state = {
-            submitting: false,
-            submitted: false,
-        };
+        this.submitting = false;
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.post.id !== this.props.post.id) {
+            this.setState({
+                submitting: false,
+                submitted: false,
+            });
+        }
     }
 
     retryPost(e) {

--- a/components/post_view/failed_post_options/index.js
+++ b/components/post_view/failed_post_options/index.js
@@ -5,6 +5,8 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {removePost} from 'mattermost-redux/actions/posts';
 
+import {createPost} from 'actions/post_actions.jsx';
+
 import FailedPostOptions from './failed_post_options.jsx';
 
 function mapStateToProps(state, ownProps) {
@@ -15,9 +17,12 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        actions: bindActionCreators({
-            removePost,
-        }, dispatch),
+        actions: {
+            ...bindActionCreators({
+                removePost,
+            }, dispatch),
+            createPost,
+        },
     };
 }
 

--- a/tests/components/post_view/__snapshots__/failed_post_options.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/failed_post_options.test.jsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/post_view/FailedPostOptions should match snapshot 1`] = `
+<span
+  className="pending-post-actions"
+>
+  <a
+    className="post-retry"
+    href="#"
+    onClick={[Function]}
+  >
+    <FormattedMessage
+      defaultMessage="Retry"
+      id="pending_post_actions.retry"
+      values={Object {}}
+    />
+  </a>
+   - 
+  <a
+    className="post-cancel"
+    href="#"
+    onClick={[Function]}
+  >
+    <FormattedMessage
+      defaultMessage="Cancel"
+      id="pending_post_actions.cancel"
+      values={Object {}}
+    />
+  </a>
+</span>
+`;

--- a/tests/components/post_view/failed_post_options.test.jsx
+++ b/tests/components/post_view/failed_post_options.test.jsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import FailedPostOptions from 'components/post_view/failed_post_options/failed_post_options.jsx';
+
+describe('components/post_view/FailedPostOptions', () => {
+    const baseProps = {
+        post: {
+            id: 'post_id',
+        },
+        actions: {
+            createPost: jest.fn(),
+            removePost: jest.fn(),
+        },
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(<FailedPostOptions {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should create post at most once', () => {
+        const props = {
+            ...baseProps,
+            actions: {
+                ...baseProps.actions,
+                createPost: jest.fn().
+                    mockImplementationOnce((post, success, failure) => failure()).
+                    mockImplementation((post, success) => success()),
+            },
+        };
+
+        const wrapper = shallow(<FailedPostOptions {...props}/>);
+        const e = {preventDefault: jest.fn()};
+
+        // First attempt should fail, allowing retry
+        wrapper.find('.post-retry').simulate('click', e);
+        expect(props.actions.createPost.mock.calls.length).toBe(1);
+
+        // Second attempt should succeed
+        wrapper.find('.post-retry').simulate('click', e);
+        expect(props.actions.createPost.mock.calls.length).toBe(2);
+
+        // Third attempt should be ignored, since already succeeded.
+        wrapper.find('.post-retry').simulate('click', e);
+        expect(props.actions.createPost.mock.calls.length).toBe(2);
+    });
+});

--- a/tests/components/post_view/failed_post_options.test.jsx
+++ b/tests/components/post_view/failed_post_options.test.jsx
@@ -47,5 +47,16 @@ describe('components/post_view/FailedPostOptions', () => {
         // Third attempt should be ignored, since already succeeded.
         wrapper.find('.post-retry').simulate('click', e);
         expect(props.actions.createPost.mock.calls.length).toBe(2);
+
+        // Next attempt should succeed when post id changes.
+        wrapper.setProps({
+            ...props,
+            post: {
+                ...props.post,
+                id: 'post_id_new',
+            },
+        });
+        wrapper.find('.post-retry').simulate('click', e);
+        expect(props.actions.createPost.mock.calls.length).toBe(3);
     });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -21,14 +21,37 @@ Object.defineProperty(document, 'execCommand', {
     value: (cmd) => supportedCommands.includes(cmd),
 });
 
+let logs;
+let warns;
+let errors;
+beforeAll(() => {
+    console.originalLog = console.log;
+    console.log = jest.fn((...params) => {
+        console.originalLog(...params);
+        logs.push(params);
+    });
+
+    console.originalWarn = console.warn;
+    console.warn = jest.fn((...params) => {
+        console.originalWarn.call(...params);
+        warns.push(params);
+    });
+
+    console.originalError = console.error;
+    console.error = jest.fn((...params) => {
+        console.originalError.call(...params);
+        errors.push(params);
+    });
+});
+
 beforeEach(() => {
-    console.log = jest.fn((error) => {
-        throw new Error('Unexpected console log: ' + error);
-    });
-    console.warn = jest.fn((error) => {
-        throw new Error('Unexpected console warning: ' + error);
-    });
-    console.error = jest.fn((error) => {
-        throw new Error('Unexpected console error: ' + error);
-    });
+    logs = [];
+    warns = [];
+    errors = [];
+});
+
+afterEach(() => {
+    if (logs.length > 0 || warns.length > 0 || errors.length > 0) {
+        throw new Error('Unexpected console logs');
+    }
 });


### PR DESCRIPTION
#### Summary
The race was such that the component would transition out of the `submitted` state before the Redux store would reflect the non-failed status of the post and in turn remove the component. This was most easily reproduced by posting when offline, switching to slow 3G, and then mashing the retry button.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8528

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)