### PR TITLE
Remove unused props in the account settings

### DIFF
--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -574,9 +574,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
 }
 
 AdvancedSettingsDisplay.propTypes = {
-    user: PropTypes.object,
     updateSection: PropTypes.func,
-    updateTab: PropTypes.func,
     activeSection: PropTypes.string,
     prevActiveSection: PropTypes.string,
     closeModal: PropTypes.func.isRequired,

--- a/components/user_settings/notifications/user_settings_notifications.jsx
+++ b/components/user_settings/notifications/user_settings_notifications.jsx
@@ -904,10 +904,8 @@ export default class NotificationsTab extends React.Component {
 NotificationsTab.propTypes = {
     user: PropTypes.object,
     updateSection: PropTypes.func,
-    updateTab: PropTypes.func,
     activeSection: PropTypes.string,
     prevActiveSection: PropTypes.string,
-    activeTab: PropTypes.string,
     closeModal: PropTypes.func.isRequired,
     collapseModal: PropTypes.func.isRequired,
     sendEmailNotifications: PropTypes.bool,

--- a/components/user_settings/security/user_settings_security.jsx
+++ b/components/user_settings/security/user_settings_security.jsx
@@ -31,10 +31,8 @@ export default class SecurityTab extends React.Component {
         user: PropTypes.object,
         activeSection: PropTypes.string,
         updateSection: PropTypes.func,
-        updateTab: PropTypes.func,
         closeModal: PropTypes.func.isRequired,
         collapseModal: PropTypes.func.isRequired,
-        setEnforceFocus: PropTypes.func.isRequired,
         setRequireConfirm: PropTypes.func.isRequired,
 
         /*

--- a/components/user_settings/sidebar/user_settings_sidebar.jsx
+++ b/components/user_settings/sidebar/user_settings_sidebar.jsx
@@ -45,7 +45,6 @@ export default class UserSettingsSidebar extends React.Component {
          */
         showUnreadOption: PropTypes.bool.isRequired,
         updateSection: PropTypes.func,
-        updateTab: PropTypes.func,
         activeSection: PropTypes.string,
         closeModal: PropTypes.func.isRequired,
         collapseModal: PropTypes.func.isRequired,

--- a/components/user_settings/user_settings.jsx
+++ b/components/user_settings/user_settings.jsx
@@ -59,10 +59,8 @@ export default class UserSettings extends React.Component {
                         activeSection={this.props.activeSection}
                         prevActiveSection={this.props.prevActiveSection}
                         updateSection={this.props.updateSection}
-                        updateTab={this.props.updateTab}
                         closeModal={this.props.closeModal}
                         collapseModal={this.props.collapseModal}
-                        setEnforceFocus={this.props.setEnforceFocus}
                         setRequireConfirm={this.props.setRequireConfirm}
                     />
                 </div>
@@ -75,7 +73,6 @@ export default class UserSettings extends React.Component {
                         activeSection={this.props.activeSection}
                         prevActiveSection={this.props.prevActiveSection}
                         updateSection={this.props.updateSection}
-                        updateTab={this.props.updateTab}
                         closeModal={this.props.closeModal}
                         collapseModal={this.props.collapseModal}
                     />
@@ -89,7 +86,6 @@ export default class UserSettings extends React.Component {
                         activeSection={this.props.activeSection}
                         prevActiveSection={this.props.prevActiveSection}
                         updateSection={this.props.updateSection}
-                        updateTab={this.props.updateTab}
                         closeModal={this.props.closeModal}
                         collapseModal={this.props.collapseModal}
                         setEnforceFocus={this.props.setEnforceFocus}
@@ -104,7 +100,6 @@ export default class UserSettings extends React.Component {
                         activeSection={this.props.activeSection}
                         prevActiveSection={this.props.prevActiveSection}
                         updateSection={this.props.updateSection}
-                        updateTab={this.props.updateTab}
                         closeModal={this.props.closeModal}
                         collapseModal={this.props.collapseModal}
                     />
@@ -114,11 +109,9 @@ export default class UserSettings extends React.Component {
             return (
                 <div>
                     <AdvancedTab
-                        user={this.state.user}
                         activeSection={this.props.activeSection}
                         prevActiveSection={this.props.prevActiveSection}
                         updateSection={this.props.updateSection}
-                        updateTab={this.props.updateTab}
                         closeModal={this.props.closeModal}
                         collapseModal={this.props.collapseModal}
                     />


### PR DESCRIPTION
#### Summary
While working on [MM-9984](https://mattermost.atlassian.net/browse/MM-9984) - https://github.com/mattermost/mattermost-webapp/pull/1111, I've found unused props in the Account Settings and thought to clean it up here separately.

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
