### PR TITLE
MM-9988: rename to "Open" external images

### DIFF
--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -245,7 +245,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
                 onModalDismissed={() => this.setState({showPreviewModal: false})}
                 startIndex={0}
                 fileInfos={[{
-                    hasPreviewImage: false,
+                    has_preview_image: false,
                     link,
                     extension: ext,
                 }]}

--- a/components/view_image/popover_bar/index.js
+++ b/components/view_image/popover_bar/index.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {isDesktopApp} from 'utils/user_agent.jsx';
+
+import PopoverBar from './popover_bar.jsx';
+
+function mapStateToProps() {
+    return {
+        isDesktopApp: isDesktopApp(),
+    };
+}
+
+export default connect(mapStateToProps)(PopoverBar);

--- a/components/view_image/popover_bar/popover_bar.jsx
+++ b/components/view_image/popover_bar/popover_bar.jsx
@@ -7,48 +7,17 @@ import {FormattedMessage} from 'react-intl';
 
 export default class PopoverBar extends React.PureComponent {
     static propTypes = {
-
-        /**
-         * Set whether to show this component or not
-         */
         show: PropTypes.bool.isRequired,
-
-        /**
-         * The index number of the current file.
-         */
         fileIndex: PropTypes.number.isRequired,
-
-        /**
-         * The count of total files.
-         */
         totalFiles: PropTypes.number.isRequired,
-
-        /**
-         * The name of current file.
-         */
         filename: PropTypes.string.isRequired,
-
-        /**
-         * The API route to get current file.
-         */
         fileURL: PropTypes.string.isRequired,
-
-        /**
-         * Set whether to show "Get Public Link"
-         */
         showPublicLink: PropTypes.bool,
-
-        /**
-         * Set whether public links are enabled.
-         */
         enablePublicLink: PropTypes.bool.isRequired,
-
         canDownloadFiles: PropTypes.bool.isRequired,
-
-        /**
-         * Function to call when click on "Get Public Link"
-         */
+        isExternalFile: PropTypes.bool.isRequired,
         onGetPublicLink: PropTypes.func,
+        isDesktopApp: PropTypes.bool.isRequired,
     };
 
     static defaultProps = {
@@ -88,6 +57,23 @@ export default class PopoverBar extends React.PureComponent {
 
         let downloadLinks = null;
         if (this.props.canDownloadFiles) {
+            let downloadLinkText;
+            if (this.props.isExternalFile && !this.props.isDesktopApp) {
+                downloadLinkText = (
+                    <FormattedMessage
+                        id='view_image_popover.open'
+                        defaultMessage='Open'
+                    />
+                );
+            } else {
+                downloadLinkText = (
+                    <FormattedMessage
+                        id='view_image_popover.download'
+                        defaultMessage='Download'
+                    />
+                );
+            }
+
             downloadLinks = (
                 <div className='image-links'>
                     {publicLink}
@@ -98,10 +84,7 @@ export default class PopoverBar extends React.PureComponent {
                         target='_blank'
                         rel='noopener noreferrer'
                     >
-                        <FormattedMessage
-                            id='view_image_popover.download'
-                            defaultMessage='Download'
-                        />
+                        {downloadLinkText}
                     </a>
                 </div>
             );

--- a/components/view_image/view_image.jsx
+++ b/components/view_image/view_image.jsx
@@ -206,6 +206,7 @@ export default class ViewImageModal extends React.PureComponent {
         const fileName = fileInfo.link || fileInfo.name;
         const fileUrl = fileInfo.link || getFileUrl(fileInfo.id);
         const fileDownloadUrl = fileInfo.link || getFileDownloadUrl(fileInfo.id);
+        const isExternalFile = !fileInfo.id;
 
         let content;
         if (this.state.loaded[this.state.imageIndex]) {
@@ -330,6 +331,7 @@ export default class ViewImageModal extends React.PureComponent {
                                 fileURL={fileDownloadUrl}
                                 enablePublicLink={this.props.enablePublicLink}
                                 canDownloadFiles={this.props.canDownloadFiles}
+                                isExternalFile={isExternalFile}
                                 onGetPublicLink={this.handleGetPublicLink}
                             />
                         </div>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3080,6 +3080,7 @@
   "user_profile.webrtc.unavailable": "New call unavailable until your existing call ends",
   "view_image.loading": "Loading ",
   "view_image_popover.download": "Download",
+  "view_image_popover.open": "Open",
   "view_image_popover.file": "File {count, number} of {total, number}",
   "view_image_popover.publicLink": "Get Public Link",
   "web.footer.about": "About",

--- a/tests/components/__snapshots__/view_image.test.jsx.snap
+++ b/tests/components/__snapshots__/view_image.test.jsx.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/ViewImageModal should match snapshot for external file 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  className="modal-image"
+  dialogClassName="modal-image"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[MockFunction]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+    modalClassName="modal-image__body"
+    onClick={[MockFunction]}
+  >
+    <div
+      className="modal-image__wrapper"
+      onClick={[MockFunction]}
+    >
+      <div
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <div
+          className="modal-close"
+          onClick={[MockFunction]}
+        />
+        <div
+          className="modal-image__content"
+        >
+          <LoadingImagePreview
+            containerClass="view-image__loading"
+            loading="Loading"
+            progress={0}
+          />
+        </div>
+        <PopoverBar
+          canDownloadFiles={true}
+          enablePublicLink={true}
+          fileIndex={0}
+          fileURL="/api/v4/files/undefined?download=1"
+          filename=""
+          isExternalFile={true}
+          onGetPublicLink={[Function]}
+          show={false}
+          showPublicLink={true}
+          totalFiles={1}
+        />
+      </div>
+    </div>
+  </ModalBody>
+</Modal>
+`;
+
 exports[`components/ViewImageModal should match snapshot on onModalShown and onModalHidden 1`] = `
 <Modal
   animation={true}
@@ -66,6 +140,7 @@ exports[`components/ViewImageModal should match snapshot on onModalShown and onM
           fileIndex={0}
           fileURL="/api/v4/files/file_id_1?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -163,6 +238,7 @@ exports[`components/ViewImageModal should match snapshot on onModalShown and onM
           fileIndex={0}
           fileURL="/api/v4/files/file_id_1?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -260,6 +336,7 @@ exports[`components/ViewImageModal should match snapshot, loaded 1`] = `
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -337,6 +414,7 @@ exports[`components/ViewImageModal should match snapshot, loaded and showing foo
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={true}
           showPublicLink={true}
@@ -414,6 +492,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with .js file 1
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -491,6 +570,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with .m4a file 
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -568,6 +648,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with .mov file 
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -645,6 +726,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with footer 1`]
           fileIndex={0}
           fileURL="/api/v4/files/file_id_1?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={true}
           showPublicLink={true}
@@ -742,6 +824,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with image 1`] 
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -819,6 +902,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
           fileIndex={0}
           fileURL="/api/v4/files/file_id_1?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -916,6 +1000,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
           fileIndex={1}
           fileURL="/api/v4/files/file_id_2?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -1013,6 +1098,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
           fileIndex={1}
           fileURL="/api/v4/files/file_id_2?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -1110,6 +1196,7 @@ exports[`components/ViewImageModal should match snapshot, loaded with other file
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -1183,6 +1270,7 @@ exports[`components/ViewImageModal should match snapshot, loading 1`] = `
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}
@@ -1256,6 +1344,7 @@ exports[`components/ViewImageModal should match snapshot, modal not shown 1`] = 
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
           filename=""
+          isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
           showPublicLink={true}

--- a/tests/components/__snapshots__/view_image.test.jsx.snap
+++ b/tests/components/__snapshots__/view_image.test.jsx.snap
@@ -56,12 +56,11 @@ exports[`components/ViewImageModal should match snapshot for external file 1`] =
             progress={0}
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/undefined?download=1"
-          filename=""
           isExternalFile={true}
           onGetPublicLink={[Function]}
           show={false}
@@ -134,12 +133,11 @@ exports[`components/ViewImageModal should match snapshot on onModalShown and onM
             }
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id_1?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -232,12 +230,11 @@ exports[`components/ViewImageModal should match snapshot on onModalShown and onM
             }
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id_1?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -330,12 +327,11 @@ exports[`components/ViewImageModal should match snapshot, loaded 1`] = `
             }
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -408,12 +404,11 @@ exports[`components/ViewImageModal should match snapshot, loaded and showing foo
             }
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={true}
@@ -486,12 +481,11 @@ exports[`components/ViewImageModal should match snapshot, loaded with .js file 1
             fileUrl="/api/v4/files/file_id"
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -564,12 +558,11 @@ exports[`components/ViewImageModal should match snapshot, loaded with .m4a file 
             fileUrl="/api/v4/files/file_id"
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -642,12 +635,11 @@ exports[`components/ViewImageModal should match snapshot, loaded with .mov file 
             fileUrl="/api/v4/files/file_id"
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -720,12 +712,11 @@ exports[`components/ViewImageModal should match snapshot, loaded with footer 1`]
             }
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id_1?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={true}
@@ -818,12 +809,11 @@ exports[`components/ViewImageModal should match snapshot, loaded with image 1`] 
             }
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -896,12 +886,11 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
             }
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id_1?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -994,12 +983,11 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
             fileUrl="/api/v4/files/file_id_2"
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={1}
           fileURL="/api/v4/files/file_id_2?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -1092,12 +1080,11 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
             fileUrl="/api/v4/files/file_id_2"
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={1}
           fileURL="/api/v4/files/file_id_2?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -1190,12 +1177,11 @@ exports[`components/ViewImageModal should match snapshot, loaded with other file
             fileUrl="/api/v4/files/file_id"
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -1264,12 +1250,11 @@ exports[`components/ViewImageModal should match snapshot, loading 1`] = `
             progress={0}
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}
@@ -1338,12 +1323,11 @@ exports[`components/ViewImageModal should match snapshot, modal not shown 1`] = 
             progress={0}
           />
         </div>
-        <PopoverBar
+        <Connect(PopoverBar)
           canDownloadFiles={true}
           enablePublicLink={true}
           fileIndex={0}
           fileURL="/api/v4/files/file_id?download=1"
-          filename=""
           isExternalFile={false}
           onGetPublicLink={[Function]}
           show={false}

--- a/tests/components/__snapshots__/view_image_popover_bar.test.jsx.snap
+++ b/tests/components/__snapshots__/view_image_popover_bar.test.jsx.snap
@@ -1,6 +1,158 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports['components/view_image/PopoverBar should match snapshot with public links disabled 1'] = `
+exports[`components/view_image/popover_bar/PopoverBar should match snapshot for downloadable file when externally hosted 1`] = `
+<div
+  className="modal-button-bar footer--show"
+>
+  <span
+    className="pull-left text"
+  >
+    <FormattedMessage
+      defaultMessage="File {count, number} of {total, number}"
+      id="view_image_popover.file"
+      values={
+        Object {
+          "count": 1,
+          "total": 0,
+        }
+      }
+    />
+  </span>
+  <div
+    className="image-links"
+  >
+    <a
+      className="text"
+      download="img.png"
+      href=""
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <FormattedMessage
+        defaultMessage="Open"
+        id="view_image_popover.open"
+        values={Object {}}
+      />
+    </a>
+  </div>
+</div>
+`;
+
+exports[`components/view_image/popover_bar/PopoverBar should match snapshot for downloadable file when externally hosted and on the desktop app 1`] = `
+<div
+  className="modal-button-bar footer--show"
+>
+  <span
+    className="pull-left text"
+  >
+    <FormattedMessage
+      defaultMessage="File {count, number} of {total, number}"
+      id="view_image_popover.file"
+      values={
+        Object {
+          "count": 1,
+          "total": 0,
+        }
+      }
+    />
+  </span>
+  <div
+    className="image-links"
+  >
+    <a
+      className="text"
+      download="img.png"
+      href=""
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <FormattedMessage
+        defaultMessage="Download"
+        id="view_image_popover.download"
+        values={Object {}}
+      />
+    </a>
+  </div>
+</div>
+`;
+
+exports[`components/view_image/popover_bar/PopoverBar should match snapshot for downloadable file when internally hosted 1`] = `
+<div
+  className="modal-button-bar footer--show"
+>
+  <span
+    className="pull-left text"
+  >
+    <FormattedMessage
+      defaultMessage="File {count, number} of {total, number}"
+      id="view_image_popover.file"
+      values={
+        Object {
+          "count": 1,
+          "total": 0,
+        }
+      }
+    />
+  </span>
+  <div
+    className="image-links"
+  >
+    <a
+      className="text"
+      download="img.png"
+      href=""
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <FormattedMessage
+        defaultMessage="Download"
+        id="view_image_popover.download"
+        values={Object {}}
+      />
+    </a>
+  </div>
+</div>
+`;
+
+exports[`components/view_image/popover_bar/PopoverBar should match snapshot for downloadable file when internally hosted and on the desktop app 1`] = `
+<div
+  className="modal-button-bar footer--show"
+>
+  <span
+    className="pull-left text"
+  >
+    <FormattedMessage
+      defaultMessage="File {count, number} of {total, number}"
+      id="view_image_popover.file"
+      values={
+        Object {
+          "count": 1,
+          "total": 0,
+        }
+      }
+    />
+  </span>
+  <div
+    className="image-links"
+  >
+    <a
+      className="text"
+      download="img.png"
+      href=""
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <FormattedMessage
+        defaultMessage="Download"
+        id="view_image_popover.download"
+        values={Object {}}
+      />
+    </a>
+  </div>
+</div>
+`;
+
+exports[`components/view_image/popover_bar/PopoverBar should match snapshot with public links disabled 1`] = `
 <div
   className="modal-button-bar footer--show"
 >
@@ -38,7 +190,7 @@ exports['components/view_image/PopoverBar should match snapshot with public link
 </div>
 `;
 
-exports['components/view_image/PopoverBar should match snapshot with public links enabled 1'] = `
+exports[`components/view_image/popover_bar/PopoverBar should match snapshot with public links enabled 1`] = `
 <div
   className="modal-button-bar footer--show"
 >

--- a/tests/components/view_image.test.jsx
+++ b/tests/components/view_image.test.jsx
@@ -200,6 +200,15 @@ describe('components/ViewImageModal', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should match snapshot for external file', () => {
+        const fileInfos = [
+            {extension: 'png'},
+        ];
+        const props = {...requiredProps, fileInfos};
+        const wrapper = shallow(<ViewImageModal {...props}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should have called loadImage', () => {
         const fileInfos = [
             {id: 'file_id_1', extension: 'gif'},

--- a/tests/components/view_image_popover_bar.test.jsx
+++ b/tests/components/view_image_popover_bar.test.jsx
@@ -1,46 +1,106 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import PopoverBar from 'components/view_image/popover_bar.jsx';
+import PopoverBar from 'components/view_image/popover_bar/popover_bar.jsx';
 
-describe('components/view_image/PopoverBar', () => {
+describe('components/view_image/popover_bar/PopoverBar', () => {
+    const defaultProps = {
+        show: true,
+        isDesktopApp: true,
+        enablePublicLink: false,
+        canDownloadFiles: true,
+        isExternalFile: false,
+    };
+
     test('should match snapshot with public links disabled', () => {
-        const wrapper = shallow(
-            <PopoverBar
-                show={true}
-                enablePublicLink={false}
-                canDownloadFiles={true}
-            />
-        );
+        const props = {
+            ...defaultProps,
+            enablePublicLink: false,
+        };
 
+        const wrapper = shallow(<PopoverBar {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot with public links enabled', () => {
-        const wrapper = shallow(
-            <PopoverBar
-                show={true}
-                enablePublicLink={true}
-                canDownloadFiles={true}
-            />
-        );
+        const props = {
+            ...defaultProps,
+            enablePublicLink: true,
+        };
 
+        const wrapper = shallow(<PopoverBar {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should call publick link callback', () => {
+    test('should call public link callback', () => {
         const mockOnClick = jest.fn();
+        const props = {
+            ...defaultProps,
+            enablePublicLink: true,
+            onGetPublicLink: mockOnClick,
+        };
 
-        const wrapper = shallow(
-            <PopoverBar
-                show={true}
-                enablePublicLink={true}
-                canDownloadFiles={true}
-                onGetPublicLink={mockOnClick}
-            />
-        );
-
+        const wrapper = shallow(<PopoverBar {...props}/>);
         wrapper.find('a.public-link').first().simulate('click');
         expect(mockOnClick).toHaveBeenCalled();
+    });
+
+    describe('should match snapshot for downloadable file', () => {
+        const props = {
+            ...defaultProps,
+            canDownloadFiles: true,
+            isExternalFile: false,
+            fileUrl: 'http://example.com/img.png',
+            filename: 'img.png',
+            isDesktopApp: true,
+        };
+
+        test('when externally hosted', () => {
+            const wrapper = shallow(
+                <PopoverBar
+                    {...props}
+                    isExternalFile={true}
+                    isDesktopApp={false}
+                />
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('when externally hosted and on the desktop app', () => {
+            const wrapper = shallow(
+                <PopoverBar
+                    {...props}
+                    isExternalFile={true}
+                    isDesktopApp={true}
+                />
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('when internally hosted', () => {
+            const wrapper = shallow(
+                <PopoverBar
+                    {...props}
+                    isExternalFile={false}
+                    isDesktopApp={false}
+                />
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('when internally hosted and on the desktop app', () => {
+            const wrapper = shallow(
+                <PopoverBar
+                    {...props}
+                    isExternalFile={false}
+                    isDesktopApp={true}
+                />
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
     });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -33,13 +33,13 @@ beforeAll(() => {
 
     console.originalWarn = console.warn;
     console.warn = jest.fn((...params) => {
-        console.originalWarn.call(...params);
+        console.originalWarn(...params);
         warns.push(params);
     });
 
     console.originalError = console.error;
     console.error = jest.fn((...params) => {
-        console.originalError.call(...params);
+        console.originalError(...params);
         errors.push(params);
     });
 });


### PR DESCRIPTION
#### Summary
This PR distinguishes between internally hosted images and externally hosted images to show a "Download" or "Open" option on the image popover bar respectively.

A recent change had been made to ensure "Download" actually triggered a `Content-Disposition: attachment` for files hosted by Mattermost, but no such guarantee could be made for external files despite showing the same user interface element. Hence this PR.

I've also included a single commit to address a logging issue re: props handling.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9988

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)