### PR TITLE
Fix CTLR+SHIFT+L shortcut when the textbox is not visible

### DIFF
--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -128,10 +128,19 @@ export default class NeedsTeam extends React.Component {
 
     onShortcutKeyDown(e) {
         if (e.shiftKey && Utils.cmdOrCtrlPressed(e) && Utils.isKeyPressed(e, Constants.KeyCodes.L)) {
-            if (document.getElementById('sidebar-right').className.match('sidebar--right sidebar--right--expanded')) {
-                document.getElementById('reply_textbox').focus();
-            } else {
-                document.getElementById('post_textbox').focus();
+            const sidebar = document.getElementById('sidebar-right');
+            if (sidebar) {
+                if (sidebar.className.match('sidebar--right move--left')) {
+                    const replyTextbox = document.getElementById('reply_textbox');
+                    if (replyTextbox) {
+                        replyTextbox.focus();
+                    }
+                } else {
+                    const postTextbox = document.getElementById('post_textbox');
+                    if (postTextbox) {
+                        postTextbox.focus();
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
#### Summary
Fix CTLR+SHIFT+L shortcut when the textbox is not visible (for example, integrations section).

#### Ticket Link
[MM-10080](https://mattermost.atlassian.net/browse/MM-10080)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed