### PR TITLE
MM-10293: More robust initial load on admin_console pages for loadRolesIfNeeded

### DIFF
--- a/components/admin_console/custom_integrations_settings/custom_integrations_settings.jsx
+++ b/components/admin_console/custom_integrations_settings/custom_integrations_settings.jsx
@@ -5,8 +5,6 @@ import React from 'react';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 
-import {RequestStatus} from 'mattermost-redux/constants';
-
 import {rolesFromMapping, mappingValueFromRoles} from 'utils/policy_roles_adapter';
 
 import AdminSettings from '.././admin_settings.jsx';
@@ -18,7 +16,6 @@ import LoadingScreen from 'components/loading_screen.jsx';
 export default class WebhookSettings extends AdminSettings {
     static propTypes = {
         roles: PropTypes.object.isRequired,
-        rolesRequest: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             loadRolesIfNeeded: PropTypes.func.isRequired,
             editRole: PropTypes.func.isRequired,
@@ -35,9 +32,19 @@ export default class WebhookSettings extends AdminSettings {
     }
 
     componentWillMount() {
-        this.props.actions.loadRolesIfNeeded(['team_user', 'system_user']).then(() => {
+        this.props.actions.loadRolesIfNeeded(['team_user', 'system_user']);
+        if (this.props.roles.system_user &&
+            this.props.roles.team_user) {
             this.loadPoliciesIntoState(this.props);
-        });
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (!this.state.loaded &&
+            nextProps.roles.system_user &&
+            nextProps.roles.team_user) {
+            this.loadPoliciesIntoState(nextProps);
+        }
     }
 
     handleSubmit = async (e) => {
@@ -67,15 +74,13 @@ export default class WebhookSettings extends AdminSettings {
     };
 
     loadPoliciesIntoState(props) {
-        if (props.rolesRequest.status === RequestStatus.SUCCESS) {
-            const {roles} = props;
+        const {roles} = props;
 
-            // Purposely parsing boolean from string 'true' or 'false'
-            // because the string comes from the policy roles adapter mapping.
-            const enableOnlyAdminIntegrations = (mappingValueFromRoles('enableOnlyAdminIntegrations', roles) === 'true');
+        // Purposely parsing boolean from string 'true' or 'false'
+        // because the string comes from the policy roles adapter mapping.
+        const enableOnlyAdminIntegrations = (mappingValueFromRoles('enableOnlyAdminIntegrations', roles) === 'true');
 
-            this.setState({enableOnlyAdminIntegrations, loaded: true});
-        }
+        this.setState({enableOnlyAdminIntegrations, loaded: true});
     }
 
     getConfigFromState = (config) => {

--- a/components/admin_console/custom_integrations_settings/index.jsx
+++ b/components/admin_console/custom_integrations_settings/index.jsx
@@ -13,7 +13,6 @@ import WebhookSettings from './custom_integrations_settings.jsx';
 function mapStateToProps(state) {
     return {
         roles: getRoles(state),
-        rolesRequest: state.requests.roles.getRolesByNames,
     };
 }
 

--- a/components/admin_console/policy_settings/index.jsx
+++ b/components/admin_console/policy_settings/index.jsx
@@ -13,7 +13,6 @@ import PolicySettings from './policy_settings.jsx';
 function mapStateToProps(state) {
     return {
         roles: getRoles(state),
-        rolesRequest: state.requests.roles.getRolesByNames,
     };
 }
 

--- a/components/admin_console/users_and_teams_settings/index.jsx
+++ b/components/admin_console/users_and_teams_settings/index.jsx
@@ -13,7 +13,6 @@ import UsersAndTeamsSettings from './users_and_teams_settings.jsx';
 function mapStateToProps(state) {
     return {
         roles: getRoles(state),
-        rolesRequest: state.requests.roles.getRolesByNames,
     };
 }
 

--- a/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
+++ b/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
@@ -5,8 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
 
-import {RequestStatus} from 'mattermost-redux/constants';
-
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {rolesFromMapping, mappingValueFromRoles} from 'utils/policy_roles_adapter';
@@ -25,7 +23,6 @@ const RESTRICT_DIRECT_MESSAGE_TEAM = 'team';
 export default class UsersAndTeamsSettings extends AdminSettings {
     static propTypes = {
         roles: PropTypes.object.isRequired,
-        rolesRequest: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             loadRolesIfNeeded: PropTypes.func.isRequired,
             editRole: PropTypes.func.isRequired,
@@ -43,9 +40,16 @@ export default class UsersAndTeamsSettings extends AdminSettings {
     }
 
     componentWillMount() {
-        this.props.actions.loadRolesIfNeeded(['system_user']).then(() => {
+        this.props.actions.loadRolesIfNeeded(['system_user']);
+        if (this.props.roles.system_user) {
             this.loadPoliciesIntoState(this.props);
-        });
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (!this.state.loaded && nextProps.roles.system_user) {
+            this.loadPoliciesIntoState(nextProps);
+        }
     }
 
     handleSubmit = async (e) => {
@@ -75,15 +79,13 @@ export default class UsersAndTeamsSettings extends AdminSettings {
     };
 
     loadPoliciesIntoState(props) {
-        if (props.rolesRequest.status === RequestStatus.SUCCESS) {
-            const {roles} = props;
+        const {roles} = props;
 
-            // Purposely parsing boolean from string 'true' or 'false'
-            // because the string comes from the policy roles adapter mapping.
-            const enableTeamCreation = (mappingValueFromRoles('enableTeamCreation', roles) === 'true');
+        // Purposely parsing boolean from string 'true' or 'false'
+        // because the string comes from the policy roles adapter mapping.
+        const enableTeamCreation = (mappingValueFromRoles('enableTeamCreation', roles) === 'true');
 
-            this.setState({enableTeamCreation, loaded: true});
-        }
+        this.setState({enableTeamCreation, loaded: true});
     }
 
     getConfigFromState = (config) => {


### PR DESCRIPTION
#### Summary
The problem was that the roles loading can have different states.

  - If the version is not loaded yet, it store the roles to load in a list and returns directly. (this was the problematic case).
  - If the version is already there, it get the list of pending roles, add the new requested roles, and make the request to load them. (this was working fine)

My change simply load into the state when the component realize that everything is ready.

#### Ticket Link
[MM-10293](https://mattermost.atlassian.net/browse/MM-10293)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed