### PR TITLE
MM-10095: Fix for invalid wildcard suffix pattern.

### DIFF
--- a/tests/utils/formatting_wildcards.text.jsx
+++ b/tests/utils/formatting_wildcards.text.jsx
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import * as TextFormatting from 'utils/text_formatting.jsx';
+
+describe('TextFormatting Wildcard Prefixes', () => {
+    it('finds words with various last characters', () => {
+        assertTextMatch('foobar', 'foo*', 'foo', 'bar');
+        assertTextMatch('foo1bar', 'foo1*', 'foo1', 'bar');
+        assertTextMatch('foo_bar', 'foo_*', 'foo_', 'bar');
+        assertTextMatch('foo.bar', 'foo.*', 'foo.', 'bar');
+        assertTextMatch('foo?bar', 'foo?*', 'foo?', 'bar');
+        assertTextMatch('foo bar', 'foo*', 'foo', ' bar');
+        assertTextMatch('foo bar', 'foo *', 'foo', ' bar');
+        assertTextMatch('foo⺑bar', 'foo⺑*', 'foo⺑', ' bar');
+    });
+});
+
+function assertTextMatch(input, search, expectedMatch, afterMatch) {
+    assert.equal(
+        TextFormatting.formatText(input, {searchTerm: search}).trim(),
+        `<p><span class='search-highlight'>${expectedMatch}</span>${afterMatch}</p>`,
+    );
+}

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -416,7 +416,7 @@ function convertSearchTermToRegex(term) {
     if (cjkPattern.test(term)) {
         // term contains Chinese, Japanese, or Korean characters so don't mark word boundaries
         pattern = '()(' + escapeRegex(term.replace(/\*/g, '')) + ')';
-    } else if (term.endsWith('*')) {
+    } else if (/[^\s][*]$/.test(term)) {
         pattern = '\\b()(' + escapeRegex(term.substring(0, term.length - 1)) + ')';
     } else if (term.startsWith('@') || term.startsWith('#')) {
         // needs special handling of the first boundary because a word boundary doesn't work before a symbol


### PR DESCRIPTION
#### Summary
Should only match `*` character when it's preceded by a word character.

#### Ticket Link
[MM-10095](https://mattermost.atlassian.net/browse/MM-10095)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

<img width="1680" alt="screen shot 2018-04-20 at 9 35 01 am" src="https://user-images.githubusercontent.com/1149597/39053915-4113825e-447e-11e8-8493-9b7d5e3de9c0.png">
<img width="1680" alt="screen shot 2018-04-20 at 9 35 12 am" src="https://user-images.githubusercontent.com/1149597/39053916-4127b33c-447e-11e8-9158-be792017ec7e.png">