### PR TITLE
Added explicit versions to all packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9502,7 +9502,7 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#3d058a0d98095885e4712ad6c0aadf7e3913ad1c",
+      "version": "github:mattermost/mattermost-redux#5ac9b9f15170656c4150c1af57dc9927bb074d3c",
       "requires": {
         "deep-equal": "1.0.1",
         "form-data": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "localforage": "1.5.6",
     "localforage-observable": "1.4.0",
     "marked": "mattermost/marked#802e981ade71149a497cbe79d12b8a3f82f7657e",
-    "mattermost-redux": "mattermost/mattermost-redux",
+    "mattermost-redux": "mattermost/mattermost-redux#5ac9b9f15170656c4150c1af57dc9927bb074d3c",
     "moment-timezone": "0.5.14",
     "pdfjs-dist": "2.0.290",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
The version of all packages in package.json has to be locked or else `npm install` will grab the latest ones