### PR TITLE
MM-10180 Better handle characters after periods in URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9483,7 +9483,7 @@
       }
     },
     "marked": {
-      "version": "github:mattermost/marked#802e981ade71149a497cbe79d12b8a3f82f7657e"
+      "version": "github:mattermost/marked#4bc7e5f00c324d2eadec6b932224871497af6f7c"
     },
     "match-at": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "key-mirror": "1.0.1",
     "localforage": "1.5.6",
     "localforage-observable": "1.4.0",
-    "marked": "mattermost/marked#802e981ade71149a497cbe79d12b8a3f82f7657e",
+    "marked": "github:mattermost/marked#4bc7e5f00c324d2eadec6b932224871497af6f7c",
     "mattermost-redux": "mattermost/mattermost-redux#5335eeb4b27f9fa48980453f3ed26248091a3755",
     "moment-timezone": "0.5.14",
     "pdfjs-dist": "2.0.290",


### PR DESCRIPTION
This is to make our link parsing slightly more forgiving and GitHub-like since we don't currently allow links containing periods followed by punctuation like https://example.com/?text=Test+phrase.+Please+ignore

Based off of https://github.com/mattermost/mattermost-webapp/pull/1126

Marked changes here: https://github.com/mattermost/marked/commit/4bc7e5f00c324d2eadec6b932224871497af6f7c

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10180

#### Checklist
- Added or updated unit tests (required for all new features)