### PR TITLE
Shift+up switch keyboard focus to RHS if it's already open to the current thread

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -30,6 +30,8 @@ const KeyCodes = Constants.KeyCodes;
 export default class CreatePost extends React.Component {
     static propTypes = {
 
+        isRhsOpen: PropTypes.bool.isRequired,
+
         /**
         *  ref passed from channelView for EmojiPickerOverlay
         */
@@ -422,10 +424,6 @@ export default class CreatePost extends React.Component {
         }
     }
 
-    rhsFocus = (keepFocus = false) => {
-            this.refs.textbox.focus();
-    }
-
     postMsgKeyPress = (e) => {
         const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
         if (!UserAgent.isMobile() && ((this.props.ctrlSend && ctrlOrMetaKeyPressed) || !this.props.ctrlSend)) {
@@ -604,7 +602,6 @@ export default class CreatePost extends React.Component {
         const upKeyOnly = !ctrlOrMetaKeyPressed && !e.altKey && !e.shiftKey && Utils.isKeyPressed(e, KeyCodes.UP);
         const shiftUpKeyCombo = !ctrlOrMetaKeyPressed && !e.altKey && e.shiftKey && Utils.isKeyPressed(e, KeyCodes.UP);
         const ctrlKeyCombo = ctrlOrMetaKeyPressed && !e.altKey && !e.shiftKey;
-        const test = false;
 
         if (ctrlEnterKeyCombo) {
             this.postMsgKeyPress(e);
@@ -642,8 +639,12 @@ export default class CreatePost extends React.Component {
     replyToLastPost = (e) => {
         e.preventDefault();
         const latestReplyablePostId = this.props.latestReplyablePostId;
+        const isRhsOpen = this.props.isRhsOpen;
+        if (isRhsOpen) {
+            document.getElementById('reply_textbox').focus();
+        }
         if (latestReplyablePostId) {
-             this.props.actions.selectPostFromRightHandSideSearchByPostId(latestReplyablePostId);
+            this.props.actions.selectPostFromRightHandSideSearchByPostId(latestReplyablePostId);
         }
     }
 

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -422,6 +422,10 @@ export default class CreatePost extends React.Component {
         }
     }
 
+    rhsFocus = (keepFocus = false) => {
+            this.refs.textbox.focus();
+    }
+
     postMsgKeyPress = (e) => {
         const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
         if (!UserAgent.isMobile() && ((this.props.ctrlSend && ctrlOrMetaKeyPressed) || !this.props.ctrlSend)) {
@@ -600,6 +604,7 @@ export default class CreatePost extends React.Component {
         const upKeyOnly = !ctrlOrMetaKeyPressed && !e.altKey && !e.shiftKey && Utils.isKeyPressed(e, KeyCodes.UP);
         const shiftUpKeyCombo = !ctrlOrMetaKeyPressed && !e.altKey && e.shiftKey && Utils.isKeyPressed(e, KeyCodes.UP);
         const ctrlKeyCombo = ctrlOrMetaKeyPressed && !e.altKey && !e.shiftKey;
+        const test = false;
 
         if (ctrlEnterKeyCombo) {
             this.postMsgKeyPress(e);
@@ -638,7 +643,7 @@ export default class CreatePost extends React.Component {
         e.preventDefault();
         const latestReplyablePostId = this.props.latestReplyablePostId;
         if (latestReplyablePostId) {
-            this.props.actions.selectPostFromRightHandSideSearchByPostId(latestReplyablePostId);
+             this.props.actions.selectPostFromRightHandSideSearchByPostId(latestReplyablePostId);
         }
     }
 

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -28,7 +28,7 @@ import {Posts} from 'mattermost-redux/constants';
 import {emitUserPostedEvent, postListScrollChangeToBottom} from 'actions/global_actions.jsx';
 import {createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
-import {getPostDraft} from 'selectors/rhs';
+import {getPostDraft, getIsRhsOpen} from 'selectors/rhs';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import {Constants, Preferences, StoragePrefixes, TutorialSteps} from 'utils/constants.jsx';
 import {canUploadFiles} from 'utils/file_utils';
@@ -49,6 +49,7 @@ function mapStateToProps() {
         const tutorialStep = getInt(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), TutorialSteps.FINISHED);
         const enableEmojiPicker = config.EnableEmojiPicker === 'true';
         const enableConfirmNotificationsToChannel = config.EnableConfirmNotificationsToChannel === 'true';
+        const isRhsOpen = getIsRhsOpen(state);
 
         return {
             currentTeamId: getCurrentTeamId(state),
@@ -69,6 +70,7 @@ function mapStateToProps() {
             enableEmojiPicker,
             enableConfirmNotificationsToChannel,
             maxPostSize: parseInt(config.MaxPostSize, 10) || Constants.DEFAULT_CHARACTER_LIMIT,
+            isRhsOpen,
         };
     };
 }

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -75,6 +75,7 @@ const actionsProp = {
 };
 
 function createPost({
+    isRhsOpen = false,
     currentChannel = currentChannelProp,
     currentTeamId = currentTeamIdProp,
     currentUserId = currentUserIdProp,
@@ -93,6 +94,7 @@ function createPost({
 } = {}) {
     return (
         <CreatePost
+            isRhsOpen={isRhsOpen}
             currentChannel={currentChannel}
             currentTeamId={currentTeamId}
             currentUserId={currentUserId}


### PR DESCRIPTION
#### Summary
The focus will go back to the RHS text box using SHIFT+UP combo when the RHS is already open. 

#### Ticket Link
[PLT-7803] https://github.com/mattermost/mattermost-server/issues/7580

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Added or updated unit tests (required for all new features)
