### PR TITLE
Update mattermost-redux to deduplicate retrying posts.

### DIFF
--- a/components/post_view/failed_post_options/failed_post_options.jsx
+++ b/components/post_view/failed_post_options/failed_post_options.jsx
@@ -5,60 +5,26 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import {createPost} from 'actions/post_actions.jsx';
-
 export default class FailedPostOptions extends React.PureComponent {
     static propTypes = {
-
-        /*
-         * The failed post
-         */
         post: PropTypes.object.isRequired,
         actions: PropTypes.shape({
-
-            /**
-             * The function to delete the post
-             */
+            createPost: PropTypes.func.isRequired,
             removePost: PropTypes.func.isRequired,
         }).isRequired,
     }
 
-    constructor(props) {
-        super(props);
-
-        this.retryPost = this.retryPost.bind(this);
-        this.cancelPost = this.cancelPost.bind(this);
-
-        this.submitting = false;
-    }
-
-    retryPost(e) {
+    retryPost = (e) => {
         e.preventDefault();
-
-        if (this.submitting) {
-            return;
-        }
-
-        this.submitting = true;
 
         const post = {...this.props.post};
         Reflect.deleteProperty(post, 'id');
-        createPost(post,
-            () => {
-                this.submitting = false;
-            },
-            (err) => {
-                if (err && err.id && err.id === 'api.post.create_post.root_id.app_error') {
-                    this.showPostDeletedModal();
-                }
-
-                this.submitting = false;
-            }
-        );
+        this.props.actions.createPost(post);
     }
 
-    cancelPost(e) {
+    cancelPost = (e) => {
         e.preventDefault();
+
         this.props.actions.removePost(this.props.post);
     }
 

--- a/components/post_view/failed_post_options/index.js
+++ b/components/post_view/failed_post_options/index.js
@@ -5,6 +5,8 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {removePost} from 'mattermost-redux/actions/posts';
 
+import {createPost} from 'actions/post_actions.jsx';
+
 import FailedPostOptions from './failed_post_options.jsx';
 
 function mapStateToProps(state, ownProps) {
@@ -15,9 +17,12 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        actions: bindActionCreators({
-            removePost,
-        }, dispatch),
+        actions: {
+            ...bindActionCreators({
+                removePost,
+            }, dispatch),
+            createPost,
+        },
     };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9502,7 +9502,7 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#5ac9b9f15170656c4150c1af57dc9927bb074d3c",
+      "version": "github:mattermost/mattermost-redux#5335eeb4b27f9fa48980453f3ed26248091a3755",
       "requires": {
         "deep-equal": "1.0.1",
         "form-data": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "localforage": "1.5.6",
     "localforage-observable": "1.4.0",
     "marked": "mattermost/marked#802e981ade71149a497cbe79d12b8a3f82f7657e",
-    "mattermost-redux": "mattermost/mattermost-redux#5ac9b9f15170656c4150c1af57dc9927bb074d3c",
+    "mattermost-redux": "mattermost/mattermost-redux#5335eeb4b27f9fa48980453f3ed26248091a3755",
     "moment-timezone": "0.5.14",
     "pdfjs-dist": "2.0.290",
     "perfect-scrollbar": "0.8.1",

--- a/tests/components/post_view/__snapshots__/failed_post_options.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/failed_post_options.test.jsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/post_view/FailedPostOptions should match snapshot 1`] = `
+<span
+  className="pending-post-actions"
+>
+  <a
+    className="post-retry"
+    href="#"
+    onClick={[Function]}
+  >
+    <FormattedMessage
+      defaultMessage="Retry"
+      id="pending_post_actions.retry"
+      values={Object {}}
+    />
+  </a>
+   - 
+  <a
+    className="post-cancel"
+    href="#"
+    onClick={[Function]}
+  >
+    <FormattedMessage
+      defaultMessage="Cancel"
+      id="pending_post_actions.cancel"
+      values={Object {}}
+    />
+  </a>
+</span>
+`;

--- a/tests/components/post_view/failed_post_options.test.jsx
+++ b/tests/components/post_view/failed_post_options.test.jsx
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import FailedPostOptions from 'components/post_view/failed_post_options/failed_post_options.jsx';
+
+describe('components/post_view/FailedPostOptions', () => {
+    const baseProps = {
+        post: {
+            id: 'post_id',
+        },
+        actions: {
+            createPost: jest.fn(),
+            removePost: jest.fn(),
+        },
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(<FailedPostOptions {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should create post on retry', () => {
+        const props = {
+            ...baseProps,
+            actions: {
+                ...baseProps.actions,
+                createPost: jest.fn(),
+            },
+        };
+
+        const wrapper = shallow(<FailedPostOptions {...props}/>);
+        const e = {preventDefault: jest.fn()};
+
+        wrapper.find('.post-retry').simulate('click', e);
+        expect(props.actions.createPost.mock.calls.length).toBe(1);
+
+        wrapper.find('.post-retry').simulate('click', e);
+        expect(props.actions.createPost.mock.calls.length).toBe(2);
+    });
+
+    test('should remove post on cancel', () => {
+        const props = {
+            ...baseProps,
+            actions: {
+                ...baseProps.actions,
+                removePost: jest.fn(),
+            },
+        };
+
+        const wrapper = shallow(<FailedPostOptions {...props}/>);
+        const e = {preventDefault: jest.fn()};
+
+        wrapper.find('.post-cancel').simulate('click', e);
+        expect(props.actions.removePost.mock.calls.length).toBe(1);
+    });
+});


### PR DESCRIPTION
#### Summary
This is the PR that complements https://github.com/mattermost/mattermost-redux/pull/466.

This restores some of 8e1241ab7000d64134fa55afd2cc85e43518c035 with changes to reflect the relocated logic into mattermost-redux.

Note that the retry component never actually supported handling the `api.post.craete_post.root_id.app_error` error: `showPostDeletedModal` was never implemented. Hence the simple removal of this code for now: a separate JIRA issue will be filed to track the root post deletion case.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8528

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)