### PR TITLE
Fix resize listener to remove on unmount

### DIFF
--- a/components/single_image_view/single_image_view.jsx
+++ b/components/single_image_view/single_image_view.jsx
@@ -57,12 +57,15 @@ export default class SingleImageView extends React.PureComponent {
     }
 
     componentWillReceiveProps(nextProps) {
-        window.removeEventListener('resize', this.handleResize);
         this.loadImage(nextProps.fileInfo);
 
         if (nextProps.isRhsOpen !== this.props.isRhsOpen) {
             this.handleResize();
         }
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.handleResize);
     }
 
     handleResize = () => {


### PR DESCRIPTION
#### Summary
Fix resize listener to be removed on unmount.
Fixes a memory leak for image components
Before:
![screen shot 2018-04-24 at 10 06 47 pm](https://user-images.githubusercontent.com/4973621/39202640-1d4b5d2a-4810-11e8-85dc-268c12b612b6.png)
After:
![screen shot 2018-04-24 at 10 08 03 pm](https://user-images.githubusercontent.com/4973621/39202664-2df4c29c-4810-11e8-9e0d-cdbb338f6f0a.png)
 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed