### PR TITLE
MM-10403 Fixed rendering of text following a latex block

### DIFF
--- a/tests/utils/__snapshots__/post_utils.test.jsx.snap
+++ b/tests/utils/__snapshots__/post_utils.test.jsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PostUtils.containsAtChannel messageHtmlToComponent latex 1`] = `
+Array [
+  <p>
+    This is some latex!
+  </p>,
+  "
+",
+  <LatexBlock
+    content="x^2 + y^2 = z^2
+"
+  />,
+  <LatexBlock
+    content="F_m - 2 = F_0 F_1 \\\\dots F_{m-1}
+"
+  />,
+  <p>
+    That was some latex!
+  </p>,
+  "
+",
+]
+`;
+
+exports[`PostUtils.containsAtChannel messageHtmlToComponent plain text 1`] = `
+Array [
+  <p>
+    Hello, world!
+  </p>,
+  "
+",
+]
+`;

--- a/tests/utils/post_utils.test.jsx
+++ b/tests/utils/post_utils.test.jsx
@@ -4,6 +4,7 @@
 import assert from 'assert';
 
 import * as PostUtils from 'utils/post_utils.jsx';
+import * as TextFormatting from 'utils/text_formatting.jsx';
 
 describe('PostUtils.containsAtChannel', function() {
     test('should return correct @all (same for @channel)', function() {
@@ -169,5 +170,30 @@ describe('PostUtils.containsAtChannel', function() {
 
             assert.equal(containsAtChannel, data.result, data.text);
         }
+    });
+
+    describe('messageHtmlToComponent', () => {
+        test('plain text', () => {
+            const input = 'Hello, world!';
+            const html = TextFormatting.formatText(input);
+
+            expect(PostUtils.messageHtmlToComponent(html)).toMatchSnapshot();
+        });
+
+        test('latex', () => {
+            const input = `This is some latex!
+\`\`\`latex
+x^2 + y^2 = z^2
+\`\`\`
+
+\`\`\`latex
+F_m - 2 = F_0 F_1 \\dots F_{m-1}
+\`\`\`
+
+That was some latex!`;
+            const html = TextFormatting.formatText(input);
+
+            expect(PostUtils.messageHtmlToComponent(html)).toMatchSnapshot();
+        });
     });
 });

--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -24,7 +24,7 @@ export default class Renderer extends marked.Renderer {
         usedLanguage = usedLanguage.toLowerCase();
 
         if (usedLanguage === 'tex' || usedLanguage === 'latex') {
-            return `<div data-latex="${TextFormatting.escapeHtml(code)}" />`;
+            return `<div data-latex="${TextFormatting.escapeHtml(code)}"></div>`;
         }
 
         // treat html as xml to prevent injection attacks


### PR DESCRIPTION
Empty divs aren't valid in plain HTML, so html-to-react tries by default to "fix" the html which causes problems.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10403
https://github.com/mattermost/mattermost-server/issues/8660
https://github.com/mattermost/mattermost-server/issues/8683