### PR TITLE
Fix CMD/CTRL+K switch to DM channels

### DIFF
--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -147,7 +147,7 @@ export default class QuickSwitchModal extends React.PureComponent {
             const selectedChannel = selected.channel;
             if (selectedChannel.type === Constants.DM_CHANNEL) {
                 this.props.actions.openDirectChannelToUser(
-                    selectedChannel.id,
+                    selectedChannel.userId,
                     (ch) => {
                         channel = ch;
                         this.switchToChannel(channel);

--- a/tests/components/quick_switch_modal.test.jsx
+++ b/tests/components/quick_switch_modal.test.jsx
@@ -58,11 +58,11 @@ describe('components/QuickSwitchModal', () => {
                 <QuickSwitchModal {...props}/>
             );
 
-            wrapper.instance().handleSubmit({channel: {id: 'channel_id', type: Constants.DM_CHANNEL}});
+            wrapper.instance().handleSubmit({channel: {id: 'channel_id', userId: 'user_id', type: Constants.DM_CHANNEL}});
             expect(baseProps.onHide).not.toBeCalled();
             expect(props.actions.goToChannel).not.toBeCalled();
             expect(props.actions.goToChannelById).not.toBeCalled();
-            expect(props.actions.openDirectChannelToUser).toBeCalledWith('channel_id', expect.anything(), expect.anything());
+            expect(props.actions.openDirectChannelToUser).toBeCalledWith('user_id', expect.anything(), expect.anything());
         });
 
         it('should switch to group channel when selecting a group channel', () => {


### PR DESCRIPTION
#### Summary
Fixes the quick channel switcher modal to actually switch to a DM channel without throwing errors, we were using the channel.id instead of the user.id I forgot about that in my last PR

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10429

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
