### PR TITLE
[MM-10337] Remove users from Add Members selection whenever it's added by other user

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -462,6 +462,11 @@ function handleDirectAddedEvent(msg) {
 function handleUserAddedEvent(msg) {
     if (ChannelStore.getCurrentId() === msg.broadcast.channel_id) {
         getChannelStats(ChannelStore.getCurrentId())(dispatch, getState);
+        dispatch({
+            type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL,
+            data: {user_id: msg.data.user_id},
+            id: msg.broadcast.channel_id,
+        });
     }
 
     if (TeamStore.getCurrentId() === msg.data.team_id && UserStore.getCurrentId() === msg.data.user_id) {


### PR DESCRIPTION
…

#### Summary
Remove users from Add Members selection whenever it's added by other user
- dispatch `UserTypes.RECEIVED_PROFILE_IN_CHANNEL` whenever `SocketEvents.USER_ADDED` is received.

Note: I tried to add test but I am not sure how to achieve it since `handleUserAddedEvent` is not exported.  `WebSocketActions` in general I think is hard to test currently.

#### Ticket Link
Jira ticket: [MM-10337](https://mattermost.atlassian.net/browse/MM-10337)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
