### PR TITLE
Adding a default username for typing

### DIFF
--- a/components/msg_typing/msg_typing.jsx
+++ b/components/msg_typing/msg_typing.jsx
@@ -5,24 +5,31 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
+import {localizeMessage} from 'utils/utils.jsx';
+
 export default class MsgTyping extends React.Component {
     static propTypes = {
         typingUsers: PropTypes.array.isRequired,
-        channelId: PropTypes.string.isRequired,
-        postId: PropTypes.string,
     }
 
     getTypingText = () => {
         let users = [];
         let numUsers = 0;
+        const defaultUsername = localizeMessage('msg_typing.someone', 'Someone');
         if (this.props.typingUsers) {
-            users = [...this.props.typingUsers];
+            users = this.props.typingUsers.map((userName) => {
+                if (userName !== '') {
+                    return userName;
+                }
+                return defaultUsername;
+            });
             numUsers = users.length;
         }
 
         if (numUsers === 0) {
             return '';
         }
+
         if (numUsers === 1) {
             return (
                 <FormattedMessage


### PR DESCRIPTION
#### Summary
If a user is missing from store then use a default string for populating typing information

#### Ticket Link
[MM-10331](https://mattermost.atlassian.net/browse/MM-10331)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
