### PR TITLE
Init translation for redux lib

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -13,6 +13,7 @@ import {setUrl} from 'mattermost-redux/actions/general';
 import {setSystemEmojis} from 'mattermost-redux/actions/emojis';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {Client4} from 'mattermost-redux/client';
+import {setLocalizeFunction} from 'mattermost-redux/utils/i18n_utils.js';
 
 import * as UserAgent from 'utils/user_agent.jsx';
 import {EmojiIndicesByAlias} from 'utils/emoji.jsx';
@@ -26,6 +27,7 @@ import {loadMeAndConfig} from 'actions/user_actions.jsx';
 import {loadRecentlyUsedCustomEmojis} from 'actions/emoji_actions.jsx';
 import * as I18n from 'i18n/i18n.jsx';
 import {initializePlugins} from 'plugins';
+import {localizeMessage} from 'utils/utils.jsx';
 import Constants, {StoragePrefixes} from 'utils/constants.jsx';
 import {HFTRoute, LoggedInHFTRoute} from 'components/header_footer_template_route';
 import NeedsTeam from 'components/needs_team';
@@ -172,6 +174,7 @@ export default class Root extends React.Component {
         const afterIntl = () => {
             initializePlugins();
             I18n.doAddLocaleData();
+            setLocalizeFunction(localizeMessage);
 
             // Setup localization listener
             LocalizationStore.addChangeListener(this.localizationChanged);


### PR DESCRIPTION
  #### Summary
Use init function in redux to store a reference for translation

#### Ticket Link
[MM-10331](https://mattermost.atlassian.net/browse/MM-10331)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has redux changes (https://github.com/mattermost/mattermost-redux/pull/475)
- [x] Has UI changes
