### PR TITLE
MM-10360 Render OpenGraph previews for pages with an empty description

### DIFF
--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -54,7 +54,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
             height: 80,
             width: 80,
         };
-        this.textMaxLenght = 300;
+        this.textMaxLength = 300;
         this.textEllipsis = '...';
         this.largeImageMinRatio = 16 / 9;
         this.smallImageContainerLeftPadding = 15;
@@ -227,8 +227,8 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
         return element;
     }
 
-    truncateText(text, maxLength = this.textMaxLenght, ellipsis = this.textEllipsis) {
-        if (text.length > maxLength) {
+    truncateText(text, maxLength = this.textMaxLength, ellipsis = this.textEllipsis) {
+        if (text && text.length > maxLength) {
             return text.substring(0, maxLength - ellipsis.length) + ellipsis;
         }
         return text;
@@ -258,7 +258,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
 
     render() {
         const data = this.props.openGraphData;
-        if (!data || Utils.isEmptyObject(data.description) || this.state.removePreview) {
+        if (!data || data.description == null || this.state.removePreview) {
             return null;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9508,7 +9508,7 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#912553f719bce2a5c60d3ad528fd301f716441ce",
+      "version": "github:mattermost/mattermost-redux#6e347814cfefdd8ef3292fef2576ff8a0f082b58",
       "requires": {
         "deep-equal": "1.0.1",
         "form-data": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "localforage": "1.5.6",
     "localforage-observable": "1.4.0",
     "marked": "mattermost/marked#4bc7e5f00c324d2eadec6b932224871497af6f7c",
-    "mattermost-redux": "mattermost/mattermost-redux#912553f719bce2a5c60d3ad528fd301f716441ce",
+    "mattermost-redux": "github:mattermost/mattermost-redux#6e347814cfefdd8ef3292fef2576ff8a0f082b58",
     "moment-timezone": "0.5.14",
     "pdfjs-dist": "2.0.290",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
Some pages (like a GitHub PR with no description set) include an empty OpenGraph description, so this null check prevented the OpenGraph data for those pages from being saved into the store and eventually shown in a preview

Redux PR: https://github.com/mattermost/mattermost-redux/pull/478

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10360