### PR TITLE
MM-10397: Reducing persist debounce

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -148,7 +148,7 @@ export default function configureStore(initialState) {
                 log: false,
             },
             blacklist: ['errors', 'offline', 'requests', 'entities', 'views', 'plugins'],
-            debounce: 500,
+            debounce: 30,
             transforms: [
                 setTransformer,
             ],


### PR DESCRIPTION
#### Summary
The problem is related to how redux-persist "debounce" writes. It iterate over
pending writes and then wait the "debounce" time. Normally redux-persist only
read or write the entire state in one single action. We have a modification to
write the different keys in different localForage keys, to reduce the inter-tab
synchronization conflicts. So, the debounce was delaying the whole "save to
localforage" process to 500ms per item stored. Sometimes with multiple tabs
opened or in reload, this delay implies that the data isn't saved to localForage.

It can still happen, but now is more difficult.

#### Ticket Link
[MM-10397](https://mattermost.atlassian.net/browse/MM-10397)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed