### PR TITLE
MM-10324: Don't hide dot menu on center pane messages.

### DIFF
--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -117,7 +117,7 @@ export default class DotMenu extends Component {
         const isSystemMessage = PostUtils.isSystemMessage(this.props.post);
         const isMobile = Utils.isMobile();
 
-        if (this.props.idPrefix === Constants.CENTER && ((!isMobile || isSystemMessage) && !this.state.canDelete && !this.state.canEdit)) {
+        if (this.props.idPrefix === Constants.CENTER && isSystemMessage && !this.state.canDelete && !this.state.canEdit) {
             return null;
         }
 

--- a/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
@@ -75,7 +75,63 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
 </div>
 `;
 
-exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `""`;
+exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
+<div
+  className="dropdown"
+  id={null}
+>
+  <div
+    id="center_dropdownpost_id_1"
+  >
+    <button
+      aria-expanded="false"
+      className="dropdown-toggle post__dropdown color--link style--none"
+      data-toggle="dropdown"
+      type="button"
+    />
+    <div
+      className="dropdown-menu__content"
+    >
+      <ul
+        className="dropdown-menu"
+        role="menu"
+      >
+        <DotMenuItem
+          handleOnClick={[MockFunction]}
+          idCount={-1}
+          idPrefix="centerDotMenuReply"
+        />
+        <DotMenuItem
+          idCount={-1}
+          idPrefix="centerDotMenuPermalink"
+          post={
+            Object {
+              "id": "post_id_1",
+              "is_pinned": false,
+            }
+          }
+        />
+        <DotMenuItem
+          actions={
+            Object {
+              "pinPost": [MockFunction],
+              "unpinPost": [MockFunction],
+            }
+          }
+          idCount={-1}
+          idPrefix="centerDotMenuPin"
+          post={
+            Object {
+              "id": "post_id_1",
+              "is_pinned": false,
+            }
+          }
+        />
+      </ul>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`components/dot_menu/DotMenu should match snapshot, on Center 2`] = `
 <div

--- a/tests/components/dot_menu/dot_menu.test.jsx
+++ b/tests/components/dot_menu/dot_menu.test.jsx
@@ -55,7 +55,7 @@ describe('components/dot_menu/DotMenu', () => {
 
         expect(wrapper.find('#centerDotMenu2').exists()).toBe(false);
         wrapper.setProps({idCount: 2});
-        expect(wrapper.find('#centerDotMenu2').exists()).toBe(false);
+        expect(wrapper.find('#centerDotMenu2').exists()).toBe(true);
 
         expect(wrapper.find('#rhsrootDotMenu').exists()).toBe(false);
         wrapper.setProps({idPrefix: Constants.RHS_ROOT});


### PR DESCRIPTION
#### Summary
Dot menu should be shown in center pane on messages.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10324

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
