### PR TITLE
MM-10339 Always use short months in Korean

### DIFF
--- a/components/activity_log_modal/activity_log_modal.jsx
+++ b/components/activity_log_modal/activity_log_modal.jsx
@@ -9,11 +9,13 @@ import {FormattedDate, FormattedMessage, FormattedTime} from 'react-intl';
 import {General} from 'mattermost-redux/constants';
 
 import UserStore from 'stores/user_store.jsx';
+import {getMonthLong} from 'utils/i18n';
 import * as Utils from 'utils/utils.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
 export default class ActivityLogModal extends React.Component {
     static propTypes = {
+        locale: PropTypes.string.isRequired,
         onHide: PropTypes.func.isRequired,
         actions: PropTypes.shape({
             getSessions: PropTypes.func.isRequired,
@@ -191,7 +193,7 @@ export default class ActivityLogModal extends React.Component {
                                         <FormattedDate
                                             value={firstAccessTime}
                                             day='2-digit'
-                                            month='long'
+                                            month={getMonthLong(this.props.locale)}
                                             year='numeric'
                                         />
                                     ),
@@ -266,7 +268,7 @@ export default class ActivityLogModal extends React.Component {
                                             <FormattedDate
                                                 value={lastAccessTime}
                                                 day='2-digit'
-                                                month='long'
+                                                month={getMonthLong(this.props.locale)}
                                                 year='numeric'
                                             />
                                         ),

--- a/components/activity_log_modal/index.js
+++ b/components/activity_log_modal/index.js
@@ -5,11 +5,13 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getSessions, revokeSession} from 'mattermost-redux/actions/users';
 
+import {getCurrentLocale} from 'selectors/i18n';
+
 import ActivityLogModal from './activity_log_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     return {
-        ...ownProps,
+        locale: getCurrentLocale(state),
     };
 }
 

--- a/components/analytics/team_analytics/index.js
+++ b/components/analytics/team_analytics/index.js
@@ -8,19 +8,20 @@ import {getProfilesInTeam} from 'mattermost-redux/actions/users';
 import {getTeamsList} from 'mattermost-redux/selectors/entities/teams';
 
 import BrowserStore from 'stores/browser_store.jsx';
+import {getCurrentLocale} from 'selectors/i18n';
 
 import TeamAnalytics from './team_analytics.jsx';
 
 const LAST_ANALYTICS_TEAM = 'last_analytics_team';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     const teams = getTeamsList(state);
     const teamId = BrowserStore.getGlobalItem(LAST_ANALYTICS_TEAM, teams.length > 0 ? teams[0].id : '');
 
     return {
         initialTeam: state.entities.teams.teams[teamId],
+        locale: getCurrentLocale(state),
         teams,
-        ...ownProps,
     };
 }
 

--- a/components/analytics/team_analytics/team_analytics.jsx
+++ b/components/analytics/team_analytics/team_analytics.jsx
@@ -16,6 +16,8 @@ import StatisticCount from 'components/analytics/statistic_count.jsx';
 import TableChart from 'components/analytics/table_chart.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
+import {getMonthLong} from 'utils/i18n';
+
 import {formatPostsPerDayData, formatUsersWithPostsPerDayData} from '../format.jsx';
 
 const LAST_ANALYTICS_TEAM = 'last_analytics_team';
@@ -32,6 +34,11 @@ export default class TeamAnalytics extends React.Component {
          * Initial team to load analytics for
          */
         initialTeam: PropTypes.object,
+
+        /**
+         * The locale of the current user
+          */
+        locale: PropTypes.string.isRequired,
 
         actions: PropTypes.shape({
 
@@ -213,8 +220,8 @@ export default class TeamAnalytics extends React.Component {
             );
         }
 
-        const recentActiveUsers = formatRecentUsersData(this.state.recentlyActiveUsers);
-        const newlyCreatedUsers = formatNewUsersData(this.state.newUsers);
+        const recentActiveUsers = formatRecentUsersData(this.state.recentlyActiveUsers, this.props.locale);
+        const newlyCreatedUsers = formatNewUsersData(this.state.newUsers, this.props.locale);
 
         const teams = this.props.teams.map((team) => {
             return (
@@ -312,7 +319,7 @@ export default class TeamAnalytics extends React.Component {
     }
 }
 
-export function formatRecentUsersData(data) {
+export function formatRecentUsersData(data, locale) {
     if (data == null) {
         return [];
     }
@@ -324,7 +331,7 @@ export function formatRecentUsersData(data) {
             <FormattedDate
                 value={user.last_activity_at}
                 day='numeric'
-                month='long'
+                month={getMonthLong(locale)}
                 year='numeric'
                 hour12={true}
                 hour='2-digit'
@@ -339,7 +346,7 @@ export function formatRecentUsersData(data) {
     return formattedData;
 }
 
-export function formatNewUsersData(data) {
+export function formatNewUsersData(data, locale) {
     if (data == null) {
         return [];
     }
@@ -351,7 +358,7 @@ export function formatNewUsersData(data) {
             <FormattedDate
                 value={user.create_at}
                 day='numeric'
-                month='long'
+                month={getMonthLong(locale)}
                 year='numeric'
                 hour12={true}
                 hour='2-digit'

--- a/components/post_view/channel_intro_message/channel_intro_message.jsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.jsx
@@ -21,37 +21,43 @@ import UserProfile from 'components/user_profile.jsx';
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
 
+import {getMonthLong} from 'utils/i18n.jsx';
 import * as Utils from 'utils/utils.jsx';
 import store from 'stores/redux_store.jsx';
 
-const CreateChannelIntroMessage = ({
-    channel,
-    fullWidth,
-}) => {
-    let centeredIntro = '';
-    if (!fullWidth) {
-        centeredIntro = 'channel-intro--centered';
+export default class ChannelIntroMessage extends React.PureComponent {
+    static propTypes = {
+        channel: PropTypes.object.isRequired,
+        fullWidth: PropTypes.bool.isRequired,
+        locale: PropTypes.string.isRequired,
+    };
+
+    render() {
+        const {
+            channel,
+            fullWidth,
+            locale,
+        } = this.props;
+
+        let centeredIntro = '';
+        if (!fullWidth) {
+            centeredIntro = 'channel-intro--centered';
+        }
+
+        if (channel.type === Constants.DM_CHANNEL) {
+            return createDMIntroMessage(channel, centeredIntro);
+        } else if (channel.type === Constants.GM_CHANNEL) {
+            return createGMIntroMessage(channel, centeredIntro);
+        } else if (ChannelStore.isDefault(channel)) {
+            return createDefaultIntroMessage(channel, centeredIntro);
+        } else if (channel.name === Constants.OFFTOPIC_CHANNEL) {
+            return createOffTopicIntroMessage(channel, centeredIntro);
+        } else if (channel.type === Constants.OPEN_CHANNEL || channel.type === Constants.PRIVATE_CHANNEL) {
+            return createStandardIntroMessage(channel, centeredIntro, locale);
+        }
+        return null;
     }
-
-    if (channel.type === Constants.DM_CHANNEL) {
-        return createDMIntroMessage(channel, centeredIntro);
-    } else if (channel.type === Constants.GM_CHANNEL) {
-        return createGMIntroMessage(channel, centeredIntro);
-    } else if (ChannelStore.isDefault(channel)) {
-        return createDefaultIntroMessage(channel, centeredIntro);
-    } else if (channel.name === Constants.OFFTOPIC_CHANNEL) {
-        return createOffTopicIntroMessage(channel, centeredIntro);
-    } else if (channel.type === Constants.OPEN_CHANNEL || channel.type === Constants.PRIVATE_CHANNEL) {
-        return createStandardIntroMessage(channel, centeredIntro);
-    }
-    return null;
-};
-
-CreateChannelIntroMessage.propTypes = {
-    isLicensed: PropTypes.bool.isRequired,
-};
-
-export default CreateChannelIntroMessage;
+}
 
 function createGMIntroMessage(channel, centeredIntro) {
     const profiles = UserStore.getProfileListInChannel(channel.id, true);
@@ -284,7 +290,7 @@ export function createDefaultIntroMessage(channel, centeredIntro) {
     );
 }
 
-function createStandardIntroMessage(channel, centeredIntro) {
+function createStandardIntroMessage(channel, centeredIntro, locale) {
     var uiName = channel.display_name;
     var creatorName = Utils.getDisplayNameByUserId(channel.creator_id);
     var uiType;
@@ -321,7 +327,7 @@ function createStandardIntroMessage(channel, centeredIntro) {
     const date = (
         <FormattedDate
             value={channel.create_at}
-            month='long'
+            month={getMonthLong(locale)}
             day='2-digit'
             year='numeric'
         />

--- a/components/post_view/channel_intro_message/index.js
+++ b/components/post_view/channel_intro_message/index.js
@@ -2,15 +2,14 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {getLicense} from 'mattermost-redux/selectors/entities/general';
+
+import {getCurrentLocale} from 'selectors/i18n';
 
 import ChannelIntroMessage from './channel_intro_message.jsx';
 
 function mapStateToProps(state) {
-    const license = getLicense(state);
-
     return {
-        isLicensed: license.IsLicensed === 'true',
+        locale: getCurrentLocale(state),
     };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9508,7 +9508,7 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#6e347814cfefdd8ef3292fef2576ff8a0f082b58",
+      "version": "github:mattermost/mattermost-redux#e20f8881e6d1a8eaff76bb5ac98a2f3d884804d1",
       "requires": {
         "deep-equal": "1.0.1",
         "form-data": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "localforage": "1.5.6",
     "localforage-observable": "1.4.0",
     "marked": "mattermost/marked#4bc7e5f00c324d2eadec6b932224871497af6f7c",
-    "mattermost-redux": "github:mattermost/mattermost-redux#6e347814cfefdd8ef3292fef2576ff8a0f082b58",
+    "mattermost-redux": "github:mattermost/mattermost-redux#e20f8881e6d1a8eaff76bb5ac98a2f3d884804d1",
     "moment-timezone": "0.5.14",
     "pdfjs-dist": "2.0.290",
     "perfect-scrollbar": "0.8.1",

--- a/selectors/i18n.js
+++ b/selectors/i18n.js
@@ -1,0 +1,9 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getCurrentUserLocale} from 'mattermost-redux/selectors/entities/i18n';
+
+// This is a placeholder for if we ever implement browser-locale detection
+export function getCurrentLocale(state) {
+    return getCurrentUserLocale(state);
+}

--- a/tests/components/activity_log_modal.test.jsx
+++ b/tests/components/activity_log_modal.test.jsx
@@ -7,6 +7,8 @@ import {FormattedMessage} from 'react-intl';
 import $ from 'jquery';
 require('perfect-scrollbar/jquery')($);
 
+import {General} from 'mattermost-redux/constants';
+
 import ActivityLogModal from 'components/activity_log_modal/activity_log_modal.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
@@ -17,6 +19,7 @@ describe('components/ActivityLogModal', () => {
             getSessions: jest.fn(),
             revokeSession: jest.fn(),
         },
+        locale: General.DEFAULT_LOCALE,
     };
 
     test('should match snapshot', () => {

--- a/utils/i18n.jsx
+++ b/utils/i18n.jsx
@@ -1,0 +1,11 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export function getMonthLong(locale) {
+    if (locale === 'ko') {
+        // Long and short are equivalent in Korean except long has a bug on IE11/Windows 7
+        return 'short';
+    }
+
+    return 'long';
+}

--- a/utils/license_utils.jsx
+++ b/utils/license_utils.jsx
@@ -6,6 +6,8 @@ import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import LocalizationStore from 'stores/localization_store.jsx';
 import store from 'stores/redux_store.jsx';
 
+import {getMonthLong} from 'utils/i18n';
+
 const LICENSE_EXPIRY_NOTIFICATION = 1000 * 60 * 60 * 24 * 60; // 60 days
 const LICENSE_GRACE_PERIOD = 1000 * 60 * 60 * 24 * 15; // 15 days
 
@@ -42,5 +44,13 @@ export function isLicensePastGracePeriod() {
 export function displayExpiryDate() {
     const license = getLicense(store.getState());
     const date = new Date(parseInt(license.ExpiresAt, 10));
-    return date.toLocaleString(LocalizationStore.getLocale(), {year: 'numeric', month: 'long', day: 'numeric'});
+
+    const locale = LocalizationStore.getLocale();
+    const format = {
+        year: 'numeric',
+        month: getMonthLong(locale),
+        day: 'numeric',
+    };
+
+    return date.toLocaleString(locale, format);
 }


### PR DESCRIPTION
There's a bug on IE11/Windows 7 where formatting a month as "long" prints a second 월 character in the month like "5월월" instead of "5월", so we need to make the month "short" to work around that bug.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10339

#### Checklist
- Added or updated unit tests (required for all new features)
- Has redux changes (https://github.com/mattermost/mattermost-redux/pull/481)
