### PR TITLE
MM-10338 Disabled time zones on IE11

### DIFF
--- a/components/local_date_time/index.js
+++ b/components/local_date_time/index.js
@@ -3,18 +3,18 @@
 
 import {connect} from 'react-redux';
 
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
 import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+
+import {areTimezonesEnabledAndSupported} from 'selectors/general';
 
 import {Preferences} from 'utils/constants.jsx';
 
 import LocalDateTime from './local_date_time';
 
 function mapStateToProps(state, props) {
-    const config = getConfig(state);
     const currentUserId = getCurrentUserId(state);
 
     let userTimezone;
@@ -25,7 +25,7 @@ function mapStateToProps(state, props) {
     }
 
     return {
-        enableTimezone: config.ExperimentalTimezone === 'true',
+        enableTimezone: areTimezonesEnabledAndSupported(state),
         useMilitaryTime: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false),
         timeZone: getUserCurrentTimezone(userTimezone),
     };

--- a/components/profile_popover/index.js
+++ b/components/profile_popover/index.js
@@ -3,18 +3,19 @@
 
 import {connect} from 'react-redux';
 
+import {areTimezonesEnabledAndSupported} from 'selectors/general';
+
 import ProfilePopover from './profile_popover.jsx';
 
 function mapStateToProps(state, ownProps) {
     const config = state.entities.general.config;
 
     const enableWebrtc = config.EnableWebrtc === 'true';
-    const enableTimezone = config.ExperimentalTimezone === 'true';
 
     return {
         ...ownProps,
         enableWebrtc,
-        enableTimezone,
+        enableTimezone: areTimezonesEnabledAndSupported(state),
     };
 }
 

--- a/selectors/general.js
+++ b/selectors/general.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import * as UserAgent from 'utils/user_agent';
+
+export function areTimezonesEnabledAndSupported(state) {
+    if (UserAgent.isInternetExplorer()) {
+        return false;
+    }
+
+    const config = getConfig(state);
+    return config.ExperimentalTimezone === 'true';
+}


### PR DESCRIPTION
IE11 only supports the default UTC time zone, so trying to give it any other time zone causes it to error out and display the date incorrectly. I've created a followup ticket to decide on how to move forward with this, but in the mean time, I've disabled it since it's an experimental feature anyway.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10338

#### Checklist
- Has UI changes