### PR TITLE
Update mattermost-redux to point to last master commit (fix MM-10464 bug)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9508,7 +9508,7 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#6e347814cfefdd8ef3292fef2576ff8a0f082b58",
+      "version": "github:mattermost/mattermost-redux#fab078f80ce57d9e827d09cc936383e794b7ab71",
       "requires": {
         "deep-equal": "1.0.1",
         "form-data": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "localforage": "1.5.6",
     "localforage-observable": "1.4.0",
     "marked": "mattermost/marked#4bc7e5f00c324d2eadec6b932224871497af6f7c",
-    "mattermost-redux": "github:mattermost/mattermost-redux#6e347814cfefdd8ef3292fef2576ff8a0f082b58",
+    "mattermost-redux": "github:mattermost/mattermost-redux#fab078f80ce57d9e827d09cc936383e794b7ab71",
     "moment-timezone": "0.5.14",
     "pdfjs-dist": "2.0.290",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
Update mattermost-redux to point to last master commit (fix MM-10464 bug)

#### Ticket Link
[MM-10464](https://mattermost.atlassian.net/browse/MM-10464)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed