### PR TITLE
[MM-10406] Ignore extra whitespace in commands that use mentions

### DIFF
--- a/actions/channel_actions.jsx
+++ b/actions/channel_actions.jsx
@@ -58,7 +58,7 @@ export function executeCommand(message, args, success, error) {
         cmdLength = msg.length;
     }
     const cmd = msg.substring(0, cmdLength).toLowerCase();
-    msg = cmd + msg.substring(cmdLength, msg.length);
+    msg = cmd + ' ' + msg.substring(cmdLength, msg.length).trim();
 
     switch (cmd) {
     case '/search':


### PR DESCRIPTION
#### Summary
Before, commands that used mentions, such as `/invite @user`, would not work if there was extra whitespace (more than just one space) between `/invite` and `@user`. This PR changes it such that a typed command like this would still work: `/invite    @user`.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/8720
https://mattermost.atlassian.net/browse/MM-10406

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed