### PR TITLE
[MM-9280] Link preview is removed for all users if the user that posted the link removes it

### DIFF
--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -248,8 +248,8 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
         });
     }
 
-    isRemovePreview(post, currentUser) {
-        if (post && post.props && currentUser.id === post.user_id) {
+    isRemovePreview(post) {
+        if (post && post.props) {
             return post.props[PostTypes.REMOVE_LINK_PREVIEW] && post.props[PostTypes.REMOVE_LINK_PREVIEW] === 'true';
         }
 


### PR DESCRIPTION
…k removes it.

#### Summary
Link preview that is shared will be collapsed if the original user that posted the link removes the preview. 

#### Ticket Link
If I remove a link preview that I shared, it should also be removed for other users
https://mattermost.atlassian.net/browse/MM-9280

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)

