### PR TITLE
Fix incorrect post date when data retention has deleted root.

### DIFF
--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -319,7 +319,7 @@ export default class RhsThread extends React.Component {
 
         let createAt = selected.create_at;
         if (!createAt) {
-            createAt = this.props.posts[0].create_at;
+            createAt = this.props.posts[this.props.posts.length - 1].create_at;
         }
         const rootPostDay = Utils.getDateForUnixTicks(createAt);
         let previousPostDay = rootPostDay;


### PR DESCRIPTION
#### Summary
Wrong substitute value was being used for `rootPostDay` when data retention deleted the root post.

#### Ticket Link
Release 4.10 bug.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes