### PR TITLE
MM-10260: only scroll to new message separator if it doesn't fit in the current screen

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -267,16 +267,15 @@ export default class PostList extends React.PureComponent {
         }
 
         const messageSeparator = this.refs.newMessageSeparator;
-        if (messageSeparator) {
-            // Scroll to new message indicator since we have unread posts
+
+        // Scroll to new message indicator since we have unread posts and we can't show every new post in the screen
+        if (messageSeparator && (postList.scrollHeight - messageSeparator.offsetTop) > postList.clientHeight) {
             messageSeparator.scrollIntoView();
-            if (!this.checkBottom()) {
-                this.setUnreadsBelow(posts, this.props.currentUserId);
-            }
+            this.setUnreadsBelow(posts, this.props.currentUserId);
             return true;
         }
 
-        // Scroll to bottom since we don't have unread posts
+        // Scroll to bottom since we don't have unread posts or we can show every new post in the screen
         postList.scrollTop = postList.scrollHeight;
         this.atBottom = true;
         return true;


### PR DESCRIPTION
#### Summary
We was scrolling to new posts separator every time, and this makes sense only when the separator is out of the screen.

I'm not sure about the need of `setUnreadsBelow` call, but the current behavior if you reach the bottom and go up again in a channel with a lot of unreads, is to not show the "new messages" badge. So I think we are good not calling `setUnreadsBelow`.

#### Ticket Link
[MM-10260](https://mattermost.atlassian.net/browse/MM-10260)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed