### PR TITLE
Fixing SHIFT+UP shortcuts when reply while Search is open

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -31,8 +31,6 @@ const KeyCodes = Constants.KeyCodes;
 export default class CreatePost extends React.Component {
     static propTypes = {
 
-        isRhsOpen: PropTypes.bool.isRequired,
-
         /**
         *  ref passed from channelView for EmojiPickerOverlay
         */
@@ -681,9 +679,9 @@ export default class CreatePost extends React.Component {
     replyToLastPost = (e) => {
         e.preventDefault();
         const latestReplyablePostId = this.props.latestReplyablePostId;
-        const isRhsOpen = this.props.isRhsOpen;
-        if (isRhsOpen) {
-            document.getElementById('reply_textbox').focus();
+        const replyBox = document.getElementById('reply_textbox');
+        if (replyBox) {
+            replyBox.focus();
         }
         if (latestReplyablePostId) {
             this.props.actions.selectPostFromRightHandSideSearchByPostId(latestReplyablePostId);

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -28,7 +28,7 @@ import {Posts} from 'mattermost-redux/constants';
 import {emitUserPostedEvent, postListScrollChangeToBottom} from 'actions/global_actions.jsx';
 import {createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
-import {getPostDraft, getIsRhsOpen} from 'selectors/rhs';
+import {getPostDraft} from 'selectors/rhs';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import {openModal} from 'actions/views/modals';
 import {Constants, Preferences, StoragePrefixes, TutorialSteps, UserStatuses} from 'utils/constants.jsx';
@@ -50,7 +50,6 @@ function mapStateToProps() {
         const tutorialStep = getInt(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), TutorialSteps.FINISHED);
         const enableEmojiPicker = config.EnableEmojiPicker === 'true';
         const enableConfirmNotificationsToChannel = config.EnableConfirmNotificationsToChannel === 'true';
-        const isRhsOpen = getIsRhsOpen(state);
         const currentUserId = getCurrentUserId(state);
         const userIsOutOfOffice = getStatusForUserId(state, currentUserId) === UserStatuses.OUT_OF_OFFICE;
 
@@ -73,7 +72,6 @@ function mapStateToProps() {
             enableEmojiPicker,
             enableConfirmNotificationsToChannel,
             maxPostSize: parseInt(config.MaxPostSize, 10) || Constants.DEFAULT_CHARACTER_LIMIT,
-            isRhsOpen,
             userIsOutOfOffice,
         };
     };

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -78,7 +78,6 @@ const actionsProp = {
 };
 
 function createPost({
-    isRhsOpen = false,
     currentChannel = currentChannelProp,
     currentTeamId = currentTeamIdProp,
     currentUserId = currentUserIdProp,
@@ -97,7 +96,6 @@ function createPost({
 } = {}) {
     return (
         <CreatePost
-            isRhsOpen={isRhsOpen}
             currentChannel={currentChannel}
             currentTeamId={currentTeamId}
             currentUserId={currentUserId}


### PR DESCRIPTION
#### Summary
Fix the problem introduced by the PR #1129. Basically, you can have the RHS open but not in the reply panel.

#### Ticket Link
[MM-10522](https://mattermost.atlassian.net/browse/MM-10522)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed