### PR TITLE
MM-9692: Add note to use Slack Importer CLI for larger ones.

### DIFF
--- a/components/team_import_tab.jsx
+++ b/components/team_import_tab.jsx
@@ -45,7 +45,7 @@ class TeamImportTab extends React.Component {
 
     render() {
         const {formatMessage} = this.props.intl;
-        var uploadDocsLink = (
+        const uploadDocsLink = (
             <a
                 href='https://docs.mattermost.com/administration/migrating.html#migrating-from-slack'
                 target='_blank'
@@ -58,7 +58,7 @@ class TeamImportTab extends React.Component {
             </a>
         );
 
-        var uploadExportInstructions = (
+        const uploadExportInstructions = (
             <strong>
                 <FormattedMessage
                     id='team_import_tab.importHelpExportInstructions'
@@ -67,7 +67,7 @@ class TeamImportTab extends React.Component {
             </strong>
         );
 
-        var uploadExporterLink = (
+        const uploadExporterLink = (
             <a
                 href='https://github.com/grundleborg/slack-advanced-exporter'
                 target='_blank'
@@ -80,7 +80,20 @@ class TeamImportTab extends React.Component {
             </a>
         );
 
-        var uploadHelpText = (
+        const importCliLink = (
+            <a
+                href='https://docs.mattermost.com/administration/migrating.html#migrating-from-slack-using-the-mattermost-cli'
+                target='_blank'
+                rel='noopener noreferrer'
+            >
+                <FormattedMessage
+                    id='team_import_tab.importHelpCliDocsLink'
+                    defaultMessage='CLI tool for Slack import'
+                />
+            </a>
+        );
+
+        const uploadHelpText = (
             <div>
                 <p>
                     <FormattedMessage
@@ -107,10 +120,19 @@ class TeamImportTab extends React.Component {
                         }}
                     />
                 </p>
+                <p>
+                    <FormattedMessage
+                        id='team_import_tab.importHelpLine4'
+                        defaultMessage='For Slack teams with over 10,000 messages, we recommend using the {cliLink}.'
+                        values={{
+                            cliLink: importCliLink,
+                        }}
+                    />
+                </p>
             </div>
         );
 
-        var uploadSection = (
+        const uploadSection = (
             <SettingUpload
                 title={formatMessage(holders.importSlack)}
                 submit={this.doImportSlack}
@@ -119,7 +141,7 @@ class TeamImportTab extends React.Component {
             />
         );
 
-        var messageSection;
+        let messageSection;
         switch (this.state.status) {
         case 'ready':
             messageSection = '';

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2736,6 +2736,8 @@
   "team_import_tab.importHelpLine1": "Slack import to Mattermost supports importing of messages in your Slack team's public channels.",
   "team_import_tab.importHelpLine2": "To import a team from Slack, go to {exportInstructions}. See {uploadDocsLink} to learn more.",
   "team_import_tab.importHelpLine3": "To import posts with attached files, see {slackAdvancedExporterLink} for details.",
+  "team_import_tab.importHelpLine4": "For Slack teams with over 10,000 messages, we recommend using the {cliLink}.",
+  "team_import_tab.importHelpCliDocsLink": "CLI tool for Slack import",
   "team_import_tab.importSlack": "Import from Slack (Beta)",
   "team_import_tab.importing": " Importing...",
   "team_import_tab.successful": " Import successful: ",


### PR DESCRIPTION
#### Summary
The actual fix for this issue is very involved, and doesn't make sense to do given we are trying to move towards an out-of-band Slack-to-Bulk-Import converter.

Instead, add a note in the web UI recommending using the CLI for larger Slack team imports.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9692

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
