### PR TITLE
[MM-10519] Remove channel from MoreChannels whenever a channel is converted form public to private

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -6,6 +6,7 @@ import {batchActions} from 'redux-batched-actions';
 import {ChannelTypes, EmojiTypes, PostTypes, TeamTypes, UserTypes, RoleTypes, GeneralTypes, AdminTypes} from 'mattermost-redux/action_types';
 import {WebsocketEvents, General} from 'mattermost-redux/constants';
 import {
+    getChannel,
     getChannelAndMyMember,
     getChannelStats,
     viewChannel,
@@ -217,6 +218,9 @@ function handleEvent(msg) {
         break;
 
     case SocketEvents.CHANNEL_CONVERTED:
+        handleChannelConvertedEvent(msg);
+        break;
+
     case SocketEvents.CHANNEL_UPDATED:
         handleChannelUpdatedEvent(msg);
         break;
@@ -299,6 +303,11 @@ function handleEvent(msg) {
 
     default:
     }
+}
+
+function handleChannelConvertedEvent(msg) {
+    const channelId = msg.data.channel_id;
+    dispatch(getChannel(channelId));
 }
 
 function handleChannelUpdatedEvent(msg) {

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -5,7 +5,12 @@ import $ from 'jquery';
 import {batchActions} from 'redux-batched-actions';
 import {ChannelTypes, EmojiTypes, PostTypes, TeamTypes, UserTypes, RoleTypes, GeneralTypes, AdminTypes} from 'mattermost-redux/action_types';
 import {WebsocketEvents, General} from 'mattermost-redux/constants';
-import {getChannelAndMyMember, getChannelStats, viewChannel} from 'mattermost-redux/actions/channels';
+import {
+    getChannel,
+    getChannelAndMyMember,
+    getChannelStats,
+    viewChannel,
+} from 'mattermost-redux/actions/channels';
 import {setServerVersion} from 'mattermost-redux/actions/general';
 import {getPosts, getProfilesAndStatusesForPosts, getCustomEmojiForReaction} from 'mattermost-redux/actions/posts';
 import * as TeamActions from 'mattermost-redux/actions/teams';
@@ -296,9 +301,9 @@ function handleEvent(msg) {
     }
 }
 
-function handleChannelUpdatedEvent(msg) {
-    const channel = JSON.parse(msg.data.channel);
-    dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
+async function handleChannelUpdatedEvent(msg) {
+    const channelId = msg.data.channel_id;
+    await dispatch(getChannel(channelId));
 }
 
 function handleChannelMemberUpdatedEvent(msg) {

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -6,7 +6,6 @@ import {batchActions} from 'redux-batched-actions';
 import {ChannelTypes, EmojiTypes, PostTypes, TeamTypes, UserTypes, RoleTypes, GeneralTypes, AdminTypes} from 'mattermost-redux/action_types';
 import {WebsocketEvents, General} from 'mattermost-redux/constants';
 import {
-    getChannel,
     getChannelAndMyMember,
     getChannelStats,
     viewChannel,
@@ -217,6 +216,7 @@ function handleEvent(msg) {
         handleChannelDeletedEvent(msg);
         break;
 
+    case SocketEvents.CHANNEL_CONVERTED:
     case SocketEvents.CHANNEL_UPDATED:
         handleChannelUpdatedEvent(msg);
         break;
@@ -301,9 +301,9 @@ function handleEvent(msg) {
     }
 }
 
-async function handleChannelUpdatedEvent(msg) {
-    const channelId = msg.data.channel_id;
-    await dispatch(getChannel(channelId));
+function handleChannelUpdatedEvent(msg) {
+    const channel = JSON.parse(msg.data.channel);
+    dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
 }
 
 function handleChannelMemberUpdatedEvent(msg) {

--- a/components/more_channels/index.js
+++ b/components/more_channels/index.js
@@ -11,14 +11,6 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import MoreChannels from './more_channels.jsx';
 
-function mapDispatchToProps(dispatch) {
-    return {
-        actions: bindActionCreators({
-            getChannels,
-        }, dispatch),
-    };
-}
-
 function mapStateToProps(state) {
     const team = getCurrentTeam(state) || {};
 
@@ -26,6 +18,14 @@ function mapStateToProps(state) {
         channels: getOtherChannels(state) || [],
         teamId: team.id,
         teamName: team.name,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getChannels,
+        }, dispatch),
     };
 }
 

--- a/components/more_channels/index.js
+++ b/components/more_channels/index.js
@@ -3,7 +3,11 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+
 import {getChannels} from 'mattermost-redux/actions/channels';
+
+import {getOtherChannels} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import MoreChannels from './more_channels.jsx';
 
@@ -15,4 +19,14 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(null, mapDispatchToProps)(MoreChannels);
+function mapStateToProps(state) {
+    const team = getCurrentTeam(state) || {};
+
+    return {
+        channels: getOtherChannels(state) || [],
+        teamId: team.id,
+        teamName: team.name,
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(MoreChannels);

--- a/components/more_channels/more_channels.jsx
+++ b/components/more_channels/more_channels.jsx
@@ -19,7 +19,7 @@ const CHANNELS_CHUNK_SIZE = 50;
 const CHANNELS_PER_PAGE = 50;
 const SEARCH_TIMEOUT_MILLISECONDS = 100;
 
-export default class MoreChannels extends React.PureComponent {
+export default class MoreChannels extends React.Component {
     static propTypes = {
         channels: PropTypes.array.isRequired,
         teamId: PropTypes.string.isRequired,

--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -28,6 +28,7 @@ export default class QuickInput extends React.PureComponent {
 
     static defaultProps = {
         delayInputUpdate: false,
+        value: '',
     };
 
     componentDidUpdate(prevProps) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10869,8 +10869,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#74440af4513c2a77c3a17ecede72cb5c9cd59774",
-      "from": "github:mattermost/mattermost-redux#74440af4513c2a77c3a17ecede72cb5c9cd59774",
+      "version": "github:mattermost/mattermost-redux#4e32d267a0a9ae72b04e55d3ce5f2bec7a1878d9",
+      "from": "github:mattermost/mattermost-redux#4e32d267a0a9ae72b04e55d3ce5f2bec7a1878d9",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "localforage": "1.7.1",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#74440af4513c2a77c3a17ecede72cb5c9cd59774",
+    "mattermost-redux": "github:mattermost/mattermost-redux#4e32d267a0a9ae72b04e55d3ce5f2bec7a1878d9",
     "moment-timezone": "0.5.17",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/tests/components/__snapshots__/more_channels.test.jsx.snap
+++ b/tests/components/__snapshots__/more_channels.test.jsx.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/MoreChannels should match snapshot and state 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="more-modal more-modal--action"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onExited={[Function]}
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="More Channels"
+        id="more_channels.title"
+        values={Object {}}
+      />
+    </ModalTitle>
+    <Connect(TeamPermissionGate)
+      permissions={
+        Array [
+          "create_public_channel",
+        ]
+      }
+      teamId="team_id"
+    >
+      <button
+        className="btn btn-primary channel-create-btn"
+        id="createNewChannel"
+        onClick={[Function]}
+        type="button"
+      >
+        <FormattedMessage
+          defaultMessage="Create New Channel"
+          id="more_channels.create"
+          values={Object {}}
+        />
+      </button>
+    </Connect(TeamPermissionGate)>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <SearchableChannelList
+      channels={
+        Array [
+          Object {
+            "id": "channel_id_1",
+          },
+        ]
+      }
+      channelsPerPage={50}
+      handleJoin={[Function]}
+      isSearch={false}
+      nextPage={[Function]}
+      noResultsText={
+        <Connect(TeamPermissionGate)
+          permissions={
+            Array [
+              "create_public_channel",
+            ]
+          }
+          teamId="team_id"
+        >
+          <p
+            className="secondary-message"
+          >
+            <FormattedMessage
+              defaultMessage="Click 'Create New Channel' to make a new one"
+              id="more_channels.createClick"
+              values={Object {}}
+            />
+          </p>
+        </Connect(TeamPermissionGate)>
+      }
+      search={[Function]}
+    />
+  </ModalBody>
+</Modal>
+`;

--- a/tests/components/more_channels.test.jsx
+++ b/tests/components/more_channels.test.jsx
@@ -1,0 +1,88 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import MoreChannels from 'components/more_channels/more_channels.jsx';
+
+describe('components/MoreChannels', () => {
+    const baseProps = {
+        channels: [{id: 'channel_id_1'}],
+        teamId: 'team_id',
+        teamName: 'team_name',
+        onModalDismissed: () => {},  // eslint-disable-line no-empty-function
+        handleNewChannel: () => {},  // eslint-disable-line no-empty-function
+        actions: {
+            getChannels: () => {},  // eslint-disable-line no-empty-function
+        },
+    };
+
+    test('should match snapshot and state', () => {
+        const actions = {getChannels: jest.fn()};
+        const props = {...baseProps, actions};
+        const wrapper = shallow(
+            <MoreChannels {...props}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.state('channels')).toEqual(props.channels);
+        expect(wrapper.state('show')).toEqual(true);
+        expect(wrapper.state('search')).toEqual(false);
+        expect(wrapper.state('serverError')).toBeNull();
+
+        // on componentDidMount
+        expect(actions.getChannels).toHaveBeenCalledTimes(1);
+        expect(actions.getChannels).toHaveBeenCalledWith(props.teamId, 0, 100);
+
+        // on componentWillReceiveProps
+        const newChannels = [{id: 'channel_id_1'}, {id: 'channel_id_2'}];
+        wrapper.setProps({channels: newChannels});
+        expect(wrapper.state('channels')).toEqual(newChannels);
+    });
+
+    test('should match state on handleHide', () => {
+        const wrapper = shallow(
+            <MoreChannels {...baseProps}/>
+        );
+        wrapper.setState({show: true});
+        wrapper.instance().handleHide();
+        expect(wrapper.state('show')).toEqual(false);
+    });
+
+    test('should call props.onModalDismissed on handleExit', () => {
+        const props = {...baseProps, onModalDismissed: jest.fn()};
+        const wrapper = shallow(
+            <MoreChannels {...props}/>
+        );
+
+        wrapper.instance().handleExit();
+        expect(props.onModalDismissed).toHaveBeenCalledTimes(1);
+        expect(props.onModalDismissed).toHaveBeenCalledWith();
+    });
+
+    test('should match state on onChange', () => {
+        const wrapper = shallow(
+            <MoreChannels {...baseProps}/>
+        );
+        wrapper.setState({channels: [{id: 'other_channel_id'}]});
+        wrapper.instance().onChange();
+        expect(wrapper.state('channels')).toEqual(baseProps.channels);
+
+        // on search
+        wrapper.setState({search: true});
+        expect(wrapper.instance().onChange(false)).toEqual();
+    });
+
+    test('should call props.getChannels on nextPage', () => {
+        const actions = {getChannels: jest.fn()};
+        const props = {...baseProps, actions};
+        const wrapper = shallow(
+            <MoreChannels {...props}/>
+        );
+
+        wrapper.instance().nextPage(1);
+
+        expect(actions.getChannels).toHaveBeenCalledTimes(2);
+        expect(actions.getChannels).toHaveBeenCalledWith(props.teamId, 2, 50);
+    });
+});

--- a/tests/components/more_channels.test.jsx
+++ b/tests/components/more_channels.test.jsx
@@ -25,7 +25,7 @@ describe('components/MoreChannels', () => {
             <MoreChannels {...props}/>
         );
         expect(wrapper).toMatchSnapshot();
-        expect(wrapper.state('channels')).toEqual(props.channels);
+        expect(wrapper.state('searchedChannels')).toEqual([]);
         expect(wrapper.state('show')).toEqual(true);
         expect(wrapper.state('search')).toEqual(false);
         expect(wrapper.state('serverError')).toBeNull();
@@ -33,11 +33,6 @@ describe('components/MoreChannels', () => {
         // on componentDidMount
         expect(actions.getChannels).toHaveBeenCalledTimes(1);
         expect(actions.getChannels).toHaveBeenCalledWith(props.teamId, 0, 100);
-
-        // on componentWillReceiveProps
-        const newChannels = [{id: 'channel_id_1'}, {id: 'channel_id_2'}];
-        wrapper.setProps({channels: newChannels});
-        expect(wrapper.state('channels')).toEqual(newChannels);
     });
 
     test('should match state on handleHide', () => {
@@ -64,9 +59,9 @@ describe('components/MoreChannels', () => {
         const wrapper = shallow(
             <MoreChannels {...baseProps}/>
         );
-        wrapper.setState({channels: [{id: 'other_channel_id'}]});
+        wrapper.setState({searchedChannels: [{id: 'other_channel_id'}]});
         wrapper.instance().onChange();
-        expect(wrapper.state('channels')).toEqual(baseProps.channels);
+        expect(wrapper.state('searchedChannels')).toEqual([]);
 
         // on search
         wrapper.setState({search: true});

--- a/tests/components/more_channels.test.jsx
+++ b/tests/components/more_channels.test.jsx
@@ -11,10 +11,10 @@ describe('components/MoreChannels', () => {
         channels: [{id: 'channel_id_1'}],
         teamId: 'team_id',
         teamName: 'team_name',
-        onModalDismissed: () => {},  // eslint-disable-line no-empty-function
-        handleNewChannel: () => {},  // eslint-disable-line no-empty-function
+        onModalDismissed: () => {}, // eslint-disable-line no-empty-function
+        handleNewChannel: () => {}, // eslint-disable-line no-empty-function
         actions: {
-            getChannels: () => {},  // eslint-disable-line no-empty-function
+            getChannels: () => {}, // eslint-disable-line no-empty-function
         },
     };
 

--- a/tests/utils/url.test.jsx
+++ b/tests/utils/url.test.jsx
@@ -1,0 +1,10 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getRelativeChannelURL} from 'utils/url.jsx';
+
+describe('Utils.URL', function() {
+    test('getRelativeChannelURL', function() {
+        expect(getRelativeChannelURL('teamName', 'channelName')).toEqual('/teamName/channels/channelName');
+    });
+});

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -316,6 +316,7 @@ export const SocketEvents = {
     POST_EDITED: 'post_edited',
     POST_DELETED: 'post_deleted',
     POST_UPDATED: 'post_updated',
+    CHANNEL_CONVERTED: 'channel_converted',
     CHANNEL_CREATED: 'channel_created',
     CHANNEL_DELETED: 'channel_deleted',
     CHANNEL_UPDATED: 'channel_updated',

--- a/utils/url.jsx
+++ b/utils/url.jsx
@@ -28,6 +28,10 @@ export function getSiteURL() {
     return window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
 }
 
+export function getRelativeChannelURL(teamName, channelName) {
+    return `/${teamName}/channels/${channelName}`;
+}
+
 export function isUrlSafe(url) {
     let unescaped;
 


### PR DESCRIPTION
#### Summary
Remove channel from MoreChannels whenever a channel is converted form public to private.

Also migrate `MoreChannels` to PureComponent using redux store. 

#### Ticket Link
Jira ticket: [MM-10519](https://mattermost.atlassian.net/browse/MM-10519)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has server changes (https://github.com/mattermost/mattermost-server/pull/8798)
