### PR TITLE
MM-10666: fix RECEIVED_PROFILE_IN_CHANNEL

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -464,8 +464,10 @@ function handleUserAddedEvent(msg) {
         getChannelStats(ChannelStore.getCurrentId())(dispatch, getState);
         dispatch({
             type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL,
-            data: {user_id: msg.data.user_id},
-            id: msg.broadcast.channel_id,
+            data: {
+                id: msg.broadcast.channel_id,
+                user_id: msg.data.user_id,
+            },
         });
     }
 
@@ -503,8 +505,10 @@ function handleUserRemovedEvent(msg) {
         getChannelStats(ChannelStore.getCurrentId())(dispatch, getState);
         dispatch({
             type: UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL,
-            data: {user_id: msg.data.user_id},
-            id: msg.broadcast.channel_id,
+            data: {
+                id: msg.broadcast.channel_id,
+                user_id: msg.data.user_id,
+            },
         });
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9508,7 +9508,7 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#b1bb31daf58d5ec88f4f14627d6fe655d1570c03",
+      "version": "github:mattermost/mattermost-redux#d40b0960fdb810d3ff3d3726c69cae6ea2992292",
       "requires": {
         "deep-equal": "1.0.1",
         "form-data": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "localforage": "1.5.6",
     "localforage-observable": "1.4.0",
     "marked": "mattermost/marked#4bc7e5f00c324d2eadec6b932224871497af6f7c",
-    "mattermost-redux": "github:mattermost/mattermost-redux#b1bb31daf58d5ec88f4f14627d6fe655d1570c03",
+    "mattermost-redux": "github:mattermost/mattermost-redux#d40b0960fdb810d3ff3d3726c69cae6ea2992292",
     "moment-timezone": "0.5.14",
     "pdfjs-dist": "2.0.290",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
Include the channel `id` a property of `data`, not the action itself. Note that the `UserStore` is also doing this incorrectly, but the methods appear to be unused.

This also update mattermost-redux to pull in https://github.com/mattermost/mattermost-redux/pull/505.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10666

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [x] Has redux changes: https://github.com/mattermost/mattermost-redux/pull/505