### PR TITLE
MM-10506: Hide the invite-code config from Team Settings when no invite permissions.

### DIFF
--- a/components/team_general_tab/index.js
+++ b/components/team_general_tab/index.js
@@ -6,6 +6,8 @@ import {connect} from 'react-redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {updateTeam, removeTeamIcon, setTeamIcon} from 'mattermost-redux/actions/teams';
+import {Permissions} from 'mattermost-redux/constants';
+import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 
 import TeamGeneralTab from './team_general_tab.jsx';
 
@@ -13,9 +15,12 @@ function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
     const maxFileSize = parseInt(config.MaxFileSize, 10);
 
+    const canInviteTeamMembers = haveITeamPermission(state, {team: ownProps.team.id, permission: Permissions.INVITE_USER});
+
     return {
         ...ownProps,
         maxFileSize,
+        canInviteTeamMembers,
     };
 }
 

--- a/components/team_general_tab/team_general_tab.jsx
+++ b/components/team_general_tab/team_general_tab.jsx
@@ -27,6 +27,7 @@ export default class GeneralTab extends React.Component {
             removeTeamIcon: PropTypes.func.isRequired,
             setTeamIcon: PropTypes.func.isRequired,
         }).isRequired,
+        canInviteTeamMembers: PropTypes.bool.isRequired,
     }
 
     constructor(props) {
@@ -418,7 +419,7 @@ export default class GeneralTab extends React.Component {
 
         let inviteSection;
 
-        if (this.props.activeSection === 'invite_id') {
+        if (this.props.activeSection === 'invite_id' && this.props.canInviteTeamMembers) {
             const inputs = [];
 
             inputs.push(
@@ -479,7 +480,7 @@ export default class GeneralTab extends React.Component {
                     updateSection={this.handleUpdateSection}
                 />
             );
-        } else {
+        } else if (this.props.canInviteTeamMembers) {
             inviteSection = (
                 <SettingItemMin
                     title={Utils.localizeMessage('general_tab.codeTitle', 'Invite Code')}

--- a/tests/components/__snapshots__/team_general_tab.test.jsx.snap
+++ b/tests/components/__snapshots__/team_general_tab.test.jsx.snap
@@ -1,0 +1,230 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/TeamSettings hide invite code if no permissions for team inviting 1`] = `
+<div>
+  <div
+    className="modal-header"
+  >
+    <button
+      aria-label="Close"
+      className="close"
+      data-dismiss="modal"
+      id="closeButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+      >
+        ×
+      </span>
+    </button>
+    <h4
+      className="modal-title"
+    >
+      <div
+        className="modal-back"
+      >
+        <i
+          className="fa fa-angle-left"
+          onClick={[Function]}
+        />
+      </div>
+      <FormattedMessage
+        defaultMessage="General Settings"
+        id="general_tab.title"
+        values={Object {}}
+      />
+    </h4>
+  </div>
+  <div
+    className="user-settings"
+  >
+    <h3
+      className="tab-header"
+    >
+      <FormattedMessage
+        defaultMessage="General Settings"
+        id="general_tab.title"
+        values={Object {}}
+      />
+    </h3>
+    <div
+      className="divider-dark first"
+    />
+    <SettingItemMin
+      focused={false}
+      section="name"
+      title="Team Name"
+      updateSection={[Function]}
+    />
+    <div
+      className="divider-light"
+    />
+    <SettingItemMin
+      describe={
+        <FormattedMessage
+          defaultMessage="Click 'Edit' to add a team description."
+          id="general_tab.emptyDescription"
+          values={Object {}}
+        />
+      }
+      focused={false}
+      section="description"
+      title="Team Description"
+      updateSection={[Function]}
+    />
+    <div
+      className="divider-light"
+    />
+    <SettingPicture
+      clientError=""
+      file={null}
+      imageContext="team"
+      loadingPicture={false}
+      onFileChange={[Function]}
+      onRemove={[Function]}
+      onSubmit={[Function]}
+      serverError=""
+      src={null}
+      submitActive={false}
+      title="Team Icon"
+      updateSection={[Function]}
+    />
+    <div
+      className="divider-light"
+    />
+    <SettingItemMin
+      describe="No"
+      focused={false}
+      section="open_invite"
+      title="Allow any user with an account on this server to join this team"
+      updateSection={[Function]}
+    />
+    <div
+      className="divider-light"
+    />
+    <SettingItemMin
+      describe="Click 'Edit' to regenerate Invite Code."
+      focused={false}
+      section="invite_id"
+      title="Invite Code"
+      updateSection={[Function]}
+    />
+    <div
+      className="divider-dark"
+    />
+  </div>
+</div>
+`;
+
+exports[`components/TeamSettings hide invite code if no permissions for team inviting 2`] = `
+<div>
+  <div
+    className="modal-header"
+  >
+    <button
+      aria-label="Close"
+      className="close"
+      data-dismiss="modal"
+      id="closeButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+      >
+        ×
+      </span>
+    </button>
+    <h4
+      className="modal-title"
+    >
+      <div
+        className="modal-back"
+      >
+        <i
+          className="fa fa-angle-left"
+          onClick={[Function]}
+        />
+      </div>
+      <FormattedMessage
+        defaultMessage="General Settings"
+        id="general_tab.title"
+        values={Object {}}
+      />
+    </h4>
+  </div>
+  <div
+    className="user-settings"
+  >
+    <h3
+      className="tab-header"
+    >
+      <FormattedMessage
+        defaultMessage="General Settings"
+        id="general_tab.title"
+        values={Object {}}
+      />
+    </h3>
+    <div
+      className="divider-dark first"
+    />
+    <SettingItemMin
+      focused={false}
+      section="name"
+      title="Team Name"
+      updateSection={[Function]}
+    />
+    <div
+      className="divider-light"
+    />
+    <SettingItemMin
+      describe={
+        <FormattedMessage
+          defaultMessage="Click 'Edit' to add a team description."
+          id="general_tab.emptyDescription"
+          values={Object {}}
+        />
+      }
+      focused={false}
+      section="description"
+      title="Team Description"
+      updateSection={[Function]}
+    />
+    <div
+      className="divider-light"
+    />
+    <SettingPicture
+      clientError=""
+      file={null}
+      imageContext="team"
+      loadingPicture={false}
+      onFileChange={[Function]}
+      onRemove={[Function]}
+      onSubmit={[Function]}
+      serverError=""
+      src={null}
+      submitActive={false}
+      title="Team Icon"
+      updateSection={[Function]}
+    />
+    <div
+      className="divider-light"
+    />
+    <SettingItemMin
+      describe="No"
+      focused={false}
+      section="open_invite"
+      title="Allow any user with an account on this server to join this team"
+      updateSection={[Function]}
+    />
+    <div
+      className="divider-light"
+    />
+    <div
+      className="divider-dark"
+    />
+  </div>
+</div>
+`;

--- a/tests/components/team_general_tab.test.jsx
+++ b/tests/components/team_general_tab.test.jsx
@@ -20,6 +20,7 @@ describe('components/TeamSettings', () => {
             removeTeamIcon: () => {}, //eslint-disable-line no-empty-function
             setTeamIcon: () => {}, //eslint-disable-line no-empty-function
         },
+        canInviteTeamMembers: true,
     };
 
     test('should handle bad updateTeamIcon function call', () => {
@@ -102,5 +103,15 @@ describe('components/TeamSettings', () => {
 
         expect(actions.removeTeamIcon).toHaveBeenCalledTimes(1);
         expect(actions.removeTeamIcon).toHaveBeenCalledWith(props.team.id);
+    });
+
+    test('hide invite code if no permissions for team inviting', () => {
+        const props = {...defaultProps, canInviteTeamMembers: false};
+
+        const wrapper1 = shallow(<GeneralTab {...defaultProps}/>);
+        const wrapper2 = shallow(<GeneralTab {...props}/>);
+
+        expect(wrapper1).toMatchSnapshot();
+        expect(wrapper2).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Summary
Hides the "invite code" section from team settings if you don't have permission to invite users to the team.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10506

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes