### PR TITLE
add different colors to different threads

### DIFF
--- a/components/post_view/post_body/post_body.jsx
+++ b/components/post_view/post_body/post_body.jsx
@@ -278,10 +278,17 @@ export default class PostBody extends React.PureComponent {
             ephemeralPostClass = 'post--ephemeral';
         }
 
+        let threadStyle;
+        if (post && post.root_id && post.root_id.length > 0) {
+
+            // id format is something like 8g48askid3bmuc1ucswgm1g5ir -> take last character, 12 is length of style classes
+            threadStyle = "post-threadstyle-"+post.root_id.substring(1).charCodeAt(0)%12;
+        }
+
         return (
             <div>
                 {comment}
-                <div className={`post__body ${mentionHighlightClass} ${ephemeralPostClass}`}>
+                <div className={`post__body ${mentionHighlightClass} ${ephemeralPostClass} ${threadStyle}`}>
                     {messageWithAdditionalContent}
                     {fileAttachmentHolder}
                     <ReactionListContainer

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -399,6 +399,54 @@
     padding: 15px;
 }
 
+.post-threadstyle-0 {
+    border-left: 4px solid #9741f4 !important;
+}
+
+.post-threadstyle-1 {
+    border-left: 4px solid #55c1ff !important;
+}
+
+.post-threadstyle-2 {
+    border-left: 4px solid #00a651 !important;
+}
+
+.post-threadstyle-3 {
+    border-left: 4px solid #ff6e84 !important;
+}
+
+.post-threadstyle-4 {
+    border-left: 4px solid #038bdd !important;
+}
+
+.post-threadstyle-5 {
+    border-left: 4px solid #433a85 !important;
+}
+
+.post-threadstyle-6 {
+    border-left: 4px solid #d02d6b !important;
+}
+
+.post-threadstyle-7 {
+    border-left: 4px solid #ffce1c !important;
+}
+
+.post-threadstyle-8 {
+    border-left: 4px solid #17cea6 !important;
+}
+
+.post-threadstyle-9 {
+    border-left: 4px solid #ffa651 !important;
+}
+
+.post-threadstyle-10 {
+    border-left: 4px solid #036e84 !important;
+}
+
+.post-threadstyle-11 {
+    border-left: 4px solid #c6e44a !important;
+}
+
 .post-create__container {
     @include flex(0 0 auto);
     width: 100%;


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
This PR makes different thread colors to different threads. However, as you might see from the pull request - it is still possible that two different threads have same colors. I tried to think how this could be solved, but there is not easy way. I was also thinking to convert whole post_id to hexadecimal html color, but that is not easy solution either, it can generate colors which are not visible for most of the users (like white).

#### Ticket Link
I could not find jira ticket for this

https://forum.mattermost.org/t/adding-colors-to-help-follow-threaded-messages/1874/2
https://mattermost.uservoice.com/forums/306457-general/suggestions/15440058-use-a-different-color-thread-bar-for-different-thr

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
