### PR TITLE
MM-10352: Enable locking incoming webhooks to a single channel.

### DIFF
--- a/components/integrations/abstract_incoming_webhook.jsx
+++ b/components/integrations/abstract_incoming_webhook.jsx
@@ -273,7 +273,7 @@ export default class AbstractIncomingWebhook extends React.Component {
                                 <div className='form__help'>
                                     <FormattedMessage
                                         id='add_incoming_webhook.channelLocked.help'
-                                        defaultMessage='If selected, the incoming web hook can only post to the selected channel above.'
+                                        defaultMessage='If set, the incoming webhook can only post to the channel selected above.'
                                     />
                                 </div>
                             </div>

--- a/components/integrations/abstract_incoming_webhook.jsx
+++ b/components/integrations/abstract_incoming_webhook.jsx
@@ -66,6 +66,7 @@ export default class AbstractIncomingWebhook extends React.Component {
             displayName: hook.display_name || '',
             description: hook.description || '',
             channelId: hook.channel_id || '',
+            channelLocked: hook.channel_locked || false,
             username: hook.username || '',
             iconURL: hook.icon_url || '',
             saving: false,
@@ -103,6 +104,7 @@ export default class AbstractIncomingWebhook extends React.Component {
 
         const hook = {
             channel_id: this.state.channelId,
+            channel_locked: this.state.channelLocked,
             display_name: this.state.displayName,
             description: this.state.description,
             username: this.state.username,
@@ -127,6 +129,12 @@ export default class AbstractIncomingWebhook extends React.Component {
     updateChannelId = (e) => {
         this.setState({
             channelId: e.target.value,
+        });
+    }
+
+    updateChannelLocked = (e) => {
+        this.setState({
+            channelLocked: e.target.checked,
         });
     }
 
@@ -241,6 +249,31 @@ export default class AbstractIncomingWebhook extends React.Component {
                                     <FormattedMessage
                                         id='add_incoming_webhook.channel.help'
                                         defaultMessage='The default public or private channel that receives the webhook payloads. You must belong to the private channel when setting up the webhook.'
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                        <div className='form-group'>
+                            <label
+                                className='control-label col-sm-4'
+                                htmlFor='channelLocked'
+                            >
+                                <FormattedMessage
+                                    id='add_incoming_webhook.channelLocked'
+                                    defaultMessage='Lock to this channel'
+                                />
+                            </label>
+                            <div className='col-md-5 col-sm-8 checkbox'>
+                                <input
+                                    id='channelLocked'
+                                    type='checkbox'
+                                    checked={this.state.channelLocked}
+                                    onChange={this.updateChannelLocked}
+                                />
+                                <div className='form__help'>
+                                    <FormattedMessage
+                                        id='add_incoming_webhook.channelLocked.help'
+                                        defaultMessage='If selected, the incoming web hook can only post to the selected channel above.'
                                     />
                                 </div>
                             </div>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -107,7 +107,7 @@
   "add_incoming_webhook.username": "Username",
   "add_incoming_webhook.username.help": "Choose the username this integration will post as. Usernames can be up to 22 characters, and may contain lowercase letters, numbers and the symbols \"-\", \"_\", and \".\" .",
   "add_incoming_webhook.channelLocked": "Lock to this channel",
-  "add_incoming_webhook.channelLocked.help": "If selected, the incoming web hook can only post to the selected channel above.",
+  "add_incoming_webhook.channelLocked.help": "If set, the incoming webhook can only post to the channel selected above.",
   "add_oauth_app.callbackUrls.help": "The redirect URIs to which the service will redirect users after accepting or denying authorization of your application, and which will handle authorization codes or access tokens. Must be a valid URL and start with http:// or https://.",
   "add_oauth_app.callbackUrlsRequired": "One or more callback URLs are required",
   "add_oauth_app.clientId": "<b>Client ID</b>: {id}",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -106,6 +106,8 @@
   "add_incoming_webhook.url": "<b>URL</b>: {url}",
   "add_incoming_webhook.username": "Username",
   "add_incoming_webhook.username.help": "Choose the username this integration will post as. Usernames can be up to 22 characters, and may contain lowercase letters, numbers and the symbols \"-\", \"_\", and \".\" .",
+  "add_incoming_webhook.channelLocked": "Lock to this channel",
+  "add_incoming_webhook.channelLocked.help": "If selected, the incoming web hook can only post to the selected channel above.",
   "add_oauth_app.callbackUrls.help": "The redirect URIs to which the service will redirect users after accepting or denying authorization of your application, and which will handle authorization codes or access tokens. Must be a valid URL and start with http:// or https://.",
   "add_oauth_app.callbackUrlsRequired": "One or more callback URLs are required",
   "add_oauth_app.clientId": "<b>Client ID</b>: {id}",

--- a/tests/components/integrations/__snapshots__/abstract_incoming_hook.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/abstract_incoming_hook.test.jsx.snap
@@ -159,7 +159,7 @@ exports[`components/integrations/AbstractIncomingWebhook should call action func
             className="form__help"
           >
             <FormattedMessage
-              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              defaultMessage="If set, the incoming webhook can only post to the channel selected above."
               id="add_incoming_webhook.channelLocked.help"
               values={Object {}}
             />
@@ -437,7 +437,7 @@ exports[`components/integrations/AbstractIncomingWebhook should match snapshot 1
             className="form__help"
           >
             <FormattedMessage
-              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              defaultMessage="If set, the incoming webhook can only post to the channel selected above."
               id="add_incoming_webhook.channelLocked.help"
               values={Object {}}
             />
@@ -715,7 +715,7 @@ exports[`components/integrations/AbstractIncomingWebhook should match snapshot, 
             className="form__help"
           >
             <FormattedMessage
-              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              defaultMessage="If set, the incoming webhook can only post to the channel selected above."
               id="add_incoming_webhook.channelLocked.help"
               values={Object {}}
             />
@@ -997,7 +997,7 @@ exports[`components/integrations/AbstractIncomingWebhook should match snapshot, 
             className="form__help"
           >
             <FormattedMessage
-              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              defaultMessage="If set, the incoming webhook can only post to the channel selected above."
               id="add_incoming_webhook.channelLocked.help"
               values={Object {}}
             />
@@ -1240,7 +1240,7 @@ exports[`components/integrations/AbstractIncomingWebhook should match snapshot, 
             className="form__help"
           >
             <FormattedMessage
-              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              defaultMessage="If set, the incoming webhook can only post to the channel selected above."
               id="add_incoming_webhook.channelLocked.help"
               values={Object {}}
             />
@@ -1483,7 +1483,7 @@ exports[`components/integrations/AbstractIncomingWebhook should match snapshot, 
             className="form__help"
           >
             <FormattedMessage
-              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              defaultMessage="If set, the incoming webhook can only post to the channel selected above."
               id="add_incoming_webhook.channelLocked.help"
               values={Object {}}
             />

--- a/tests/components/integrations/__snapshots__/abstract_incoming_hook.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/abstract_incoming_hook.test.jsx.snap
@@ -138,6 +138,39 @@ exports[`components/integrations/AbstractIncomingWebhook should call action func
       >
         <label
           className="control-label col-sm-4"
+          htmlFor="channelLocked"
+        >
+          <FormattedMessage
+            defaultMessage="Lock to this channel"
+            id="add_incoming_webhook.channelLocked"
+            values={Object {}}
+          />
+        </label>
+        <div
+          className="col-md-5 col-sm-8 checkbox"
+        >
+          <input
+            checked={false}
+            id="channelLocked"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="form__help"
+          >
+            <FormattedMessage
+              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              id="add_incoming_webhook.channelLocked.help"
+              values={Object {}}
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label col-sm-4"
           htmlFor="username"
         >
           <FormattedMessage
@@ -383,6 +416,39 @@ exports[`components/integrations/AbstractIncomingWebhook should match snapshot 1
       >
         <label
           className="control-label col-sm-4"
+          htmlFor="channelLocked"
+        >
+          <FormattedMessage
+            defaultMessage="Lock to this channel"
+            id="add_incoming_webhook.channelLocked"
+            values={Object {}}
+          />
+        </label>
+        <div
+          className="col-md-5 col-sm-8 checkbox"
+        >
+          <input
+            checked={false}
+            id="channelLocked"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="form__help"
+          >
+            <FormattedMessage
+              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              id="add_incoming_webhook.channelLocked.help"
+              values={Object {}}
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label col-sm-4"
           htmlFor="username"
         >
           <FormattedMessage
@@ -618,6 +684,39 @@ exports[`components/integrations/AbstractIncomingWebhook should match snapshot, 
             <FormattedMessage
               defaultMessage="The default public or private channel that receives the webhook payloads. You must belong to the private channel when setting up the webhook."
               id="add_incoming_webhook.channel.help"
+              values={Object {}}
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label col-sm-4"
+          htmlFor="channelLocked"
+        >
+          <FormattedMessage
+            defaultMessage="Lock to this channel"
+            id="add_incoming_webhook.channelLocked"
+            values={Object {}}
+          />
+        </label>
+        <div
+          className="col-md-5 col-sm-8 checkbox"
+        >
+          <input
+            checked={false}
+            id="channelLocked"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="form__help"
+          >
+            <FormattedMessage
+              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              id="add_incoming_webhook.channelLocked.help"
               values={Object {}}
             />
           </div>
@@ -877,6 +976,39 @@ exports[`components/integrations/AbstractIncomingWebhook should match snapshot, 
       >
         <label
           className="control-label col-sm-4"
+          htmlFor="channelLocked"
+        >
+          <FormattedMessage
+            defaultMessage="Lock to this channel"
+            id="add_incoming_webhook.channelLocked"
+            values={Object {}}
+          />
+        </label>
+        <div
+          className="col-md-5 col-sm-8 checkbox"
+        >
+          <input
+            checked={false}
+            id="channelLocked"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="form__help"
+          >
+            <FormattedMessage
+              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              id="add_incoming_webhook.channelLocked.help"
+              values={Object {}}
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label col-sm-4"
           htmlFor="username"
         >
           <FormattedMessage
@@ -1087,6 +1219,39 @@ exports[`components/integrations/AbstractIncomingWebhook should match snapshot, 
       >
         <label
           className="control-label col-sm-4"
+          htmlFor="channelLocked"
+        >
+          <FormattedMessage
+            defaultMessage="Lock to this channel"
+            id="add_incoming_webhook.channelLocked"
+            values={Object {}}
+          />
+        </label>
+        <div
+          className="col-md-5 col-sm-8 checkbox"
+        >
+          <input
+            checked={false}
+            id="channelLocked"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="form__help"
+          >
+            <FormattedMessage
+              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              id="add_incoming_webhook.channelLocked.help"
+              values={Object {}}
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label col-sm-4"
           htmlFor="iconURL"
         >
           <FormattedMessage
@@ -1287,6 +1452,39 @@ exports[`components/integrations/AbstractIncomingWebhook should match snapshot, 
             <FormattedMessage
               defaultMessage="The default public or private channel that receives the webhook payloads. You must belong to the private channel when setting up the webhook."
               id="add_incoming_webhook.channel.help"
+              values={Object {}}
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label col-sm-4"
+          htmlFor="channelLocked"
+        >
+          <FormattedMessage
+            defaultMessage="Lock to this channel"
+            id="add_incoming_webhook.channelLocked"
+            values={Object {}}
+          />
+        </label>
+        <div
+          className="col-md-5 col-sm-8 checkbox"
+        >
+          <input
+            checked={false}
+            id="channelLocked"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="form__help"
+          >
+            <FormattedMessage
+              defaultMessage="If selected, the incoming web hook can only post to the selected channel above."
+              id="add_incoming_webhook.channelLocked.help"
               values={Object {}}
             />
           </div>


### PR DESCRIPTION
#### Summary
Add the ability to lock an incoming webhook to a single channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10352

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has server changes https://github.com/mattermost/mattermost-server/pull/8835
- [x] Has UI changes
- [x] Includes text changes and localization file updates
