### PR TITLE
MM-10599: Accept multiple youtube start time formats.

### DIFF
--- a/components/youtube_video/youtube_video.jsx
+++ b/components/youtube_video/youtube_video.jsx
@@ -69,16 +69,16 @@ export default class YoutubeVideo extends React.PureComponent {
     }
 
     handleYoutubeTime(link) {
-        const timeRegex = /[\\?&]t=([0-9]+h)?([0-9]+m)?([0-9]+s?)/;
+        const timeRegex = /[\\?&](t|start|time_continue)=([0-9]+h)?([0-9]+m)?([0-9]+s?)/;
 
         const time = link.match(timeRegex);
         if (!time || !time[0]) {
             return '';
         }
 
-        const hours = time[1] ? time[1].match(/([0-9]+)h/) : null;
-        const minutes = time[2] ? time[2].match(/([0-9]+)m/) : null;
-        const seconds = time[3] ? time[3].match(/([0-9]+)s?/) : null;
+        const hours = time[2] ? time[2].match(/([0-9]+)h/) : null;
+        const minutes = time[3] ? time[3].match(/([0-9]+)m/) : null;
+        const seconds = time[4] ? time[4].match(/([0-9]+)s?/) : null;
 
         let ticks = 0;
 

--- a/tests/components/youtube_video/youtube_video.test.jsx
+++ b/tests/components/youtube_video/youtube_video.test.jsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import YoutubeVideo from 'components/youtube_video/youtube_video.jsx';
+
+describe('components/YoutubeVideo', () => {
+    function shallowYoutubeVideo() {
+        const allProps = {
+            channelId: 'channelid',
+            currentChannelId: 'currentchannelid',
+            link: 'https://www.youtube.com/watch?v=xqCoNej8Zxo',
+            show: true,
+            googleDeveloperKey: 'googledevkey',
+            onLinkLoaded: jest.fn(),
+        };
+
+        return shallow(<YoutubeVideo {...allProps}/>);
+    }
+
+    test('should correctly parse youtube start time formats', () => {
+        const wrapper = shallowYoutubeVideo();
+        for (const youtube of [
+            {
+                link: 'https://www.youtube.com/watch?time_continue=490&v=xqCoNej8Zxo',
+                time: '&start=490',
+            },
+            {
+                link: 'https://www.youtube.com/watch?start=490&v=xqCoNej8Zxo',
+                time: '&start=490',
+            },
+            {
+                link: 'https://www.youtube.com/watch?t=490&v=xqCoNej8Zxo',
+                time: '&start=490',
+            },
+        ]) {
+            expect(wrapper.instance().handleYoutubeTime(youtube.link)).toEqual(youtube.time);
+        }
+    });
+});


### PR DESCRIPTION
#### Summary
Update youtube link parsing regex to accept 3 known formats of "start time" in youtube links.

The following should all work correctly now:
* https://www.youtube.com/watch?time_continue=490&v=xqCoNej8Zxo
* https://www.youtube.com/watch?start=490&v=xqCoNej8Zxo
* https://www.youtube.com/watch?t=490&v=xqCoNej8Zxo

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-10599

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed