### PR TITLE
MM-10432: Adds next Redux commit for dot release.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9508,7 +9508,7 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#b1bb31daf58d5ec88f4f14627d6fe655d1570c03",
+      "version": "github:mattermost/mattermost-redux#5408311258ba18fccf886759ef878c458471417c",
       "requires": {
         "deep-equal": "1.0.1",
         "form-data": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "localforage": "1.5.6",
     "localforage-observable": "1.4.0",
     "marked": "mattermost/marked#4bc7e5f00c324d2eadec6b932224871497af6f7c",
-    "mattermost-redux": "github:mattermost/mattermost-redux#b1bb31daf58d5ec88f4f14627d6fe655d1570c03",
+    "mattermost-redux": "github:mattermost/mattermost-redux#5408311258ba18fccf886759ef878c458471417c",
     "moment-timezone": "0.5.14",
     "pdfjs-dist": "2.0.290",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
Adds the next commit from Redux:

https://github.com/mattermost/mattermost-redux/compare/d40b0960fdb810d3ff3d3726c69cae6ea2992292...5408311258ba18fccf886759ef878c458471417c

#### Ticket Link
Request: https://pre-release.mattermost.com/core/pl/ffbsecko97ygbmjo8i9ez1kb1o

#### Checklist
n/a