### PR TITLE
MM-10664: Fix the Centre Channel scroll when using Grammarly in chrome.

### DIFF
--- a/components/logged_in/logged_in.jsx
+++ b/components/logged_in/logged_in.jsx
@@ -34,7 +34,6 @@ export default class LoggedIn extends React.Component {
             user: UserStore.getCurrentUser(),
         };
 
-        document.getElementsByTagName('body')[0].className += ' channel-view';
         document.getElementById('root').className += ' channel-view';
     }
 

--- a/components/logged_in/logged_in.jsx
+++ b/components/logged_in/logged_in.jsx
@@ -33,6 +33,8 @@ export default class LoggedIn extends React.Component {
         this.state = {
             user: UserStore.getCurrentUser(),
         };
+
+        document.getElementsByTagName('body')[0].className += ' channel-view';
         document.getElementById('root').className += ' channel-view';
     }
 

--- a/sass/base/_structure.scss
+++ b/sass/base/_structure.scss
@@ -10,6 +10,7 @@ body {
 }
 
 body {
+    @include clearfix;
     background: $bg--gray;
     position: relative;
     width: 100%;


### PR DESCRIPTION
#### Summary
Fix the Centre Channel scroll when using Grammarly in chrome.

Added `channel-view`(has `overflow: hidden;`) class into not only root div but also body, when entering to channel view.

#### Ticket Link
- https://github.com/mattermost/mattermost-server/issues/8839
- [Jira Ticket](https://mattermost.atlassian.net/browse/MM-10664)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed

