### PR TITLE
Fix UI string ID in system_notice.jsx

### DIFF
--- a/components/system_notice/system_notice.jsx
+++ b/components/system_notice/system_notice.jsx
@@ -129,7 +129,7 @@ export default class SystemNotice extends React.PureComponent {
                         onClick={this.hideAndRemind}
                     >
                         <FormattedMessage
-                            id='system_notice_remind_me'
+                            id='system_notice.remind_me'
                             defaultMessage='Remind me later'
                         />
                     </button>
@@ -139,7 +139,7 @@ export default class SystemNotice extends React.PureComponent {
                         onClick={this.hideAndForget}
                     >
                         <FormattedMessage
-                            id='system_notice_dont_show'
+                            id='system_notice.dont_show'
                             defaultMessage="Don't show again"
                         />
                     </button>

--- a/tests/components/__snapshots__/system_notice.test.jsx.snap
+++ b/tests/components/__snapshots__/system_notice.test.jsx.snap
@@ -45,7 +45,7 @@ exports[`components/SystemNotice should match snapshot for admin, admin notice 1
     >
       <FormattedMessage
         defaultMessage="Remind me later"
-        id="system_notice_remind_me"
+        id="system_notice.remind_me"
         values={Object {}}
       />
     </button>
@@ -56,7 +56,7 @@ exports[`components/SystemNotice should match snapshot for admin, admin notice 1
     >
       <FormattedMessage
         defaultMessage="Don't show again"
-        id="system_notice_dont_show"
+        id="system_notice.dont_show"
         values={Object {}}
       />
     </button>
@@ -97,7 +97,7 @@ exports[`components/SystemNotice should match snapshot for admin, regular notice
     >
       <FormattedMessage
         defaultMessage="Remind me later"
-        id="system_notice_remind_me"
+        id="system_notice.remind_me"
         values={Object {}}
       />
     </button>
@@ -108,7 +108,7 @@ exports[`components/SystemNotice should match snapshot for admin, regular notice
     >
       <FormattedMessage
         defaultMessage="Don't show again"
-        id="system_notice_dont_show"
+        id="system_notice.dont_show"
         values={Object {}}
       />
     </button>
@@ -149,7 +149,7 @@ exports[`components/SystemNotice should match snapshot for regular user, admin a
     >
       <FormattedMessage
         defaultMessage="Remind me later"
-        id="system_notice_remind_me"
+        id="system_notice.remind_me"
         values={Object {}}
       />
     </button>
@@ -160,7 +160,7 @@ exports[`components/SystemNotice should match snapshot for regular user, admin a
     >
       <FormattedMessage
         defaultMessage="Don't show again"
-        id="system_notice_dont_show"
+        id="system_notice.dont_show"
         values={Object {}}
       />
     </button>
@@ -209,7 +209,7 @@ exports[`components/SystemNotice should match snapshot for regular user, regular
     >
       <FormattedMessage
         defaultMessage="Remind me later"
-        id="system_notice_remind_me"
+        id="system_notice.remind_me"
         values={Object {}}
       />
     </button>
@@ -220,7 +220,7 @@ exports[`components/SystemNotice should match snapshot for regular user, regular
     >
       <FormattedMessage
         defaultMessage="Don't show again"
-        id="system_notice_dont_show"
+        id="system_notice.dont_show"
         values={Object {}}
       />
     </button>


### PR DESCRIPTION
#### Summary
Fix UI string ID in system_notice.jsx

I had the option of just fixing the string in en.json, but this would have been inconsistent with other strings. Hence fixed it in system_notice.jsx and updated the relevant test snapshots.

Wondering if there's anything we can do in future to capture errors affecting localization via unit tests?

#### Ticket Link
Reported by French community: https://pre-release.mattermost.com/core/pl/wmjsjq4dqffpbbq6ecisnbxpxa

#### Checklist
- [X] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
