### PR TITLE
Clean up getPasswordConfig by removing unused parameter

### DIFF
--- a/components/admin_console/reset_password_modal/index.js
+++ b/components/admin_console/reset_password_modal/index.js
@@ -2,18 +2,17 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {getPasswordConfig} from 'utils/utils.jsx';
 
 import ResetPasswordModal from './reset_password_modal.jsx';
 
 function mapStateToProps(state) {
-    const license = getLicense(state);
     const config = getConfig(state);
 
     return {
-        passwordConfig: getPasswordConfig(license, config),
+        passwordConfig: getPasswordConfig(config),
     };
 }
 

--- a/components/claim/index.js
+++ b/components/claim/index.js
@@ -2,14 +2,13 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {getPasswordConfig} from 'utils/utils.jsx';
 
 import ClaimController from './claim_controller.jsx';
 
 function mapStateToProps(state) {
-    const license = getLicense(state);
     const config = getConfig(state);
     const siteName = config.SiteName;
     const ldapLoginFieldName = config.LdapLoginFieldName;
@@ -17,7 +16,7 @@ function mapStateToProps(state) {
     return {
         siteName,
         ldapLoginFieldName,
-        passwordConfig: getPasswordConfig(license, config),
+        passwordConfig: getPasswordConfig(config),
     };
 }
 

--- a/components/signup/signup_email/index.js
+++ b/components/signup/signup_email/index.js
@@ -30,7 +30,7 @@ function mapStateToProps(state) {
         customBrand,
         enableCustomBrand,
         customDescriptionText,
-        passwordConfig: getPasswordConfig(license, config),
+        passwordConfig: getPasswordConfig(config),
     };
 }
 

--- a/components/user_settings/security/index.js
+++ b/components/user_settings/security/index.js
@@ -46,7 +46,7 @@ function mapStateToProps(state, ownProps) {
         enableSaml,
         enableSignUpWithOffice365,
         experimentalEnableAuthenticationTransfer,
-        passwordConfig: getPasswordConfig(license, config),
+        passwordConfig: getPasswordConfig(config),
     };
 }
 

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1431,7 +1431,7 @@ export function canCreateCustomEmoji(user) {
     return true;
 }
 
-export function getPasswordConfig(license, config) {
+export function getPasswordConfig(config) {
     return {
         minimumLength: parseInt(config.PasswordMinimumLength, 10),
         requireLowercase: config.PasswordRequireLowercase === 'true',


### PR DESCRIPTION
#### Summary
Clean up getPasswordConfig by removing unused `license` parameter.  I missed that when I did this PR - https://github.com/mattermost/mattermost-webapp/pull/1242

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
