### PR TITLE
Allowing empty submission of MFA for hardened mode.

### DIFF
--- a/components/login/login_mfa.jsx
+++ b/components/login/login_mfa.jsx
@@ -52,12 +52,6 @@ export default class LoginMfa extends React.PureComponent {
         e.preventDefault();
         const state = {};
 
-        if (!this.state.token) {
-            state.serverError = localizeMessage('login_mfa.tokenReq', 'Please enter an MFA token');
-            this.setState(state);
-            return;
-        }
-
         state.serverError = '';
         state.saving = true;
         this.setState(state);

--- a/tests/components/login/login_mfa.test.jsx
+++ b/tests/components/login/login_mfa.test.jsx
@@ -41,9 +41,10 @@ describe('components/login/LoginMfa', () => {
 
         wrapper.setState({token: '', serverError: '', saving: false});
         wrapper.instance().handleSubmit({preventDefault: jest.fn()});
-        expect(wrapper.state('serverError')).toEqual('Please enter an MFA token');
-        expect(wrapper.state('saving')).toEqual(false);
-        expect(submit).not.toBeCalled();
+        expect(wrapper.state('serverError')).toEqual('');
+        expect(wrapper.state('saving')).toEqual(true);
+        expect(submit).toBeCalled(); // This is not a bug. See https://github.com/mattermost/mattermost-server/pull/8881
+        expect(submit).toBeCalledWith(props.loginId, props.password, '');
 
         wrapper.setState({token: '123456', serverError: ''});
         wrapper.instance().handleSubmit({preventDefault: jest.fn()});


### PR DESCRIPTION
For: https://github.com/mattermost/mattermost-server/pull/8881

In hardened mode we don't want to disclose if a user has MFA enabled or not, so we need to show this screen every time when MFA and hardened mode is enabled. A user needs to be able to bypass it. Submitting a blank is a convenient way to do that. This allows blank submissions. (will still error properly when hardened mode is disabled.)