### PR TITLE
Fix description opacity in permissions tree headers

### DIFF
--- a/sass/components/_permissions.scss
+++ b/sass/components/_permissions.scss
@@ -131,6 +131,7 @@
             color: $black;
             display: block;
             width: 100%;
+            opacity: 1;
         }
     }
 


### PR DESCRIPTION
#### Summary
Fix description opacity in permissions tree headers

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed