### PR TITLE
Fixing the header of the team statistics in the admin console

### DIFF
--- a/components/analytics/team_analytics/team_analytics.jsx
+++ b/components/analytics/team_analytics/team_analytics.jsx
@@ -238,7 +238,7 @@ export default class TeamAnalytics extends React.Component {
             <div className='wrapper--fixed team_statistics'>
                 <div className='admin-console-header team-statistics__header-row'>
                     <div className='team-statistics__header'>
-                        <h3>
+                        <h3 className='admin-console-header'>
                             <FormattedMessage
                                 id='analytics.team.title'
                                 defaultMessage='Team Statistics for {team}'


### PR DESCRIPTION
#### Summary
Fixing the header of the team statistics in the admin console

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed