### PR TITLE
MM-10602 Removed extra space from OpenGraph preview for links without a description

### DIFF
--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -156,7 +156,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
         img.src = src;
     }
 
-    imageToggleAnchoreTag(imageUrl) {
+    imageToggleAnchorTag(imageUrl) {
         if (imageUrl && this.state.hasLargeImage) {
             return (
                 <a
@@ -282,6 +282,29 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
             this.loadImage(imageUrl);
         }
 
+        let body;
+        if (data.description || imageUrl) {
+            let separator;
+            if (data.description && imageUrl) {
+                separator = ' &nbsp';
+            }
+
+            body = (
+                <div>
+                    <div className={'attachment__body attachment__body--opengraph'}>
+                        <div>
+                            <div>
+                                {this.truncateText(data.description)}
+                                {separator}
+                                {this.imageToggleAnchorTag(imageUrl)}
+                            </div>
+                            {this.imageTag(imageUrl, true)}
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+
         return (
             <div
                 className='attachment attachment--opengraph'
@@ -309,19 +332,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
                                     {this.truncateText(data.title || data.url || this.props.link)}
                                 </a>
                             </h1>
-                            <div >
-                                <div
-                                    className={'attachment__body attachment__body--opengraph'}
-                                >
-                                    <div>
-                                        <div>
-                                            {this.truncateText(data.description)} &nbsp;
-                                            {this.imageToggleAnchoreTag(imageUrl)}
-                                        </div>
-                                        {this.imageTag(imageUrl, true)}
-                                    </div>
-                                </div>
-                            </div>
+                            {body}
                         </div>
                         {this.imageTag(imageUrl, false)}
                     </div>


### PR DESCRIPTION
An empty div was being rendered in that case which would take up an extra line below the title.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10602