### PR TITLE
MM-10372 Fixed linking between teams from channels with the same name

### DIFF
--- a/components/channel_layout/channel_identifier_router.jsx
+++ b/components/channel_layout/channel_identifier_router.jsx
@@ -215,6 +215,7 @@ export default class ChannelIdentifierRouter extends React.PureComponent {
         match: PropTypes.shape({
             params: PropTypes.shape({
                 identifier: PropTypes.string.isRequired,
+                team: PropTypes.string.isRequired,
             }).isRequired,
         }).isRequired,
     }
@@ -226,7 +227,8 @@ export default class ChannelIdentifierRouter extends React.PureComponent {
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        if (this.props.match.params.identifier !== nextProps.match.params.identifier) {
+        if (this.props.match.params.team !== nextProps.match.params.team ||
+            this.props.match.params.identifier !== nextProps.match.params.identifier) {
             onChannelByIdentifierEnter(nextProps);
         }
     }


### PR DESCRIPTION
The problem is that the ChannelIdentifierRouter code just uses the current team ID, and it didn't recalculate the current channel ID before unless the URL changed after the team name. It still accesses the Flux stores, but I don't think I have time to change that for 5.0

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10372

#### Checklist
- Touches critical sections of the codebase (auth, posting, etc.)
