### PR TITLE
MM-10793: Handle the show/hide custom emojis in menu using permissions

### DIFF
--- a/components/backstage/backstage_controller.jsx
+++ b/components/backstage/backstage_controller.jsx
@@ -64,6 +64,7 @@ export default class BackstageController extends React.Component {
         enableOutgoingWebhooks: PropTypes.bool.isRequired,
         enableCommands: PropTypes.bool.isRequired,
         enableOAuthServiceProvider: PropTypes.bool.isRequired,
+        canCreateCustomEmoji: PropTypes.bool.isRequired,
     }
 
     scrollToTop = () => {
@@ -106,6 +107,7 @@ export default class BackstageController extends React.Component {
                         enableOutgoingWebhooks={this.props.enableOutgoingWebhooks}
                         enableCommands={this.props.enableCommands}
                         enableOAuthServiceProvider={this.props.enableOAuthServiceProvider}
+                        canCreateCustomEmoji={this.props.canCreateCustomEmoji}
                     />
                     <Switch>
                         <BackstageRoute

--- a/components/backstage/components/backstage_sidebar.jsx
+++ b/components/backstage/components/backstage_sidebar.jsx
@@ -7,8 +7,6 @@ import {FormattedMessage} from 'react-intl';
 
 import {Permissions} from 'mattermost-redux/constants';
 
-import * as Utils from 'utils/utils.jsx';
-
 import SystemPermissionGate from 'components/permissions_gates/system_permission_gate';
 import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
 
@@ -25,11 +23,12 @@ export default class BackstageSidebar extends React.Component {
             enableOutgoingWebhooks: PropTypes.bool.isRequired,
             enableCommands: PropTypes.bool.isRequired,
             enableOAuthServiceProvider: PropTypes.bool.isRequired,
+            canCreateCustomEmoji: PropTypes.bool.isRequired,
         };
     }
 
     renderCustomEmoji() {
-        if (!this.props.enableCustomEmoji || !Utils.canCreateCustomEmoji(this.props.user)) {
+        if (!this.props.enableCustomEmoji || !this.props.canCreateCustomEmoji) {
             return null;
         }
 

--- a/components/backstage/index.js
+++ b/components/backstage/index.js
@@ -5,8 +5,10 @@ import {connect} from 'react-redux';
 import {withRouter} from 'react-router-dom';
 
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
-import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {getMyTeams, getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {haveITeamPermission, haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
+import {Permissions} from 'mattermost-redux/constants';
 
 import BackstageController from './backstage_controller.jsx';
 
@@ -23,6 +25,16 @@ function mapStateToProps(state) {
     const enableCommands = config.EnableCommands === 'true';
     const enableOAuthServiceProvider = config.EnableOAuthServiceProvider === 'true';
 
+    let canCreateCustomEmoji = haveISystemPermission(state, {permission: Permissions.MANAGE_EMOJIS});
+    if (!canCreateCustomEmoji) {
+        for (const t of getMyTeams(state)) {
+            if (haveITeamPermission(state, {team: t.id, permission: Permissions.MANAGE_EMOJIS})) {
+                canCreateCustomEmoji = true;
+                break;
+            }
+        }
+    }
+
     return {
         user,
         team,
@@ -32,6 +44,7 @@ function mapStateToProps(state) {
         enableOutgoingWebhooks,
         enableCommands,
         enableOAuthServiceProvider,
+        canCreateCustomEmoji,
     };
 }
 

--- a/components/sidebar/header/dropdown/index.js
+++ b/components/sidebar/header/dropdown/index.js
@@ -3,6 +3,9 @@
 
 import {connect} from 'react-redux';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getMyTeams} from 'mattermost-redux/selectors/entities/teams';
+import {haveITeamPermission, haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
+import {Permissions} from 'mattermost-redux/constants';
 
 import SidebarHeaderDropdown from './sidebar_header_dropdown.jsx';
 
@@ -26,6 +29,16 @@ function mapStateToProps(state) {
     const reportAProblemLink = config.ReportAProblemLink;
     const restrictTeamInvite = config.RestrictTeamInvite;
 
+    let canCreateCustomEmoji = haveISystemPermission(state, {permission: Permissions.MANAGE_EMOJIS});
+    if (!canCreateCustomEmoji) {
+        for (const team of getMyTeams(state)) {
+            if (haveITeamPermission(state, {team: team.id, permission: Permissions.MANAGE_EMOJIS})) {
+                canCreateCustomEmoji = true;
+                break;
+            }
+        }
+    }
+
     return {
         isLicensed,
         appDownloadLink,
@@ -42,6 +55,7 @@ function mapStateToProps(state) {
         reportAProblemLink,
         restrictTeamInvite,
         pluginMenuItems: state.plugins.mainMenuActions,
+        canCreateCustomEmoji,
     };
 }
 

--- a/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
+++ b/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
@@ -16,7 +16,6 @@ import WebrtcStore from 'stores/webrtc_store.jsx';
 import {Constants, WebrtcActionTypes} from 'utils/constants.jsx';
 import {useSafeUrl} from 'utils/url';
 import * as UserAgent from 'utils/user_agent.jsx';
-import * as Utils from 'utils/utils.jsx';
 import AboutBuildModal from 'components/about_build_modal';
 import AddUsersToTeam from 'components/add_users_to_team';
 import TeamMembersModal from 'components/team_members_modal';
@@ -37,6 +36,7 @@ export default class SidebarHeaderDropdown extends React.Component {
         appDownloadLink: PropTypes.string,
         enableCommands: PropTypes.bool.isRequired,
         enableCustomEmoji: PropTypes.bool.isRequired,
+        canCreateCustomEmoji: PropTypes.bool.isRequired,
         enableIncomingWebhooks: PropTypes.bool.isRequired,
         enableOAuthServiceProvider: PropTypes.bool.isRequired,
         enableOnlyAdminIntegrations: PropTypes.bool.isRequired,
@@ -213,7 +213,7 @@ export default class SidebarHeaderDropdown extends React.Component {
     }
 
     renderCustomEmojiLink() {
-        if (!this.props.enableCustomEmoji || !Utils.canCreateCustomEmoji(this.props.currentUser)) {
+        if (!this.props.enableCustomEmoji || !this.props.canCreateCustomEmoji) {
             return null;
         }
 

--- a/tests/plugins/main_menu_action.test.jsx
+++ b/tests/plugins/main_menu_action.test.jsx
@@ -28,6 +28,7 @@ describe('plugins/MainMenuActions', () => {
             showDropdown: true,
             onToggleDropdown: () => {}, //eslint-disable-line no-empty-function
             pluginMenuItems: [{id: 'someplugin', text: 'some plugin text', action: pluginAction}],
+            canCreateCustomEmoji: true,
         };
 
         const wrapper = shallow(

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -7,7 +7,6 @@ import {FormattedMessage} from 'react-intl';
 
 import {Client4} from 'mattermost-redux/client';
 import {Posts} from 'mattermost-redux/constants';
-import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
 import {
     blendColors,
@@ -1402,34 +1401,6 @@ export function mod(a, b) {
 }
 
 export const REACTION_PATTERN = /^(\+|-):([^:\s]+):\s*$/;
-
-export function canCreateCustomEmoji(user) {
-    const state = store.getState();
-    const license = getLicense(state);
-    const config = getConfig(state);
-
-    if (license.IsLicensed !== 'true') {
-        return true;
-    }
-
-    if (isSystemAdmin(user.roles)) {
-        return true;
-    }
-
-    // already checked for system admin for both these cases
-    if (config.RestrictCustomEmojiCreation === 'system_admin') {
-        return false;
-    } else if (config.RestrictCustomEmojiCreation === 'admin') {
-        // check whether the user is an admin on any of their teams
-        if (TeamStore.isTeamAdminForAnyTeam()) {
-            return true;
-        }
-
-        return false;
-    }
-
-    return true;
-}
 
 export function getPasswordConfig(config) {
     return {


### PR DESCRIPTION
#### Summary
The emojis option in the menus wasn't based in permissions. This commit fix that problem.

#### Ticket Link
[MM-10793](https://mattermost.atlassian.net/browse/MM-10793)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed