### PR TITLE
MM-10700 - Updating modal preview css

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -325,8 +325,8 @@
             }
 
             .modal-image__content {
-                max-height: 85vh;
-                max-width: 90vw;
+                max-height: 95vh;
+                max-width: 95vw;
                 overflow-x: hidden;
                 overflow-y: visible;
             }
@@ -406,7 +406,7 @@
                 }
 
                 img {
-                    max-height: calc(100vh - 200px);
+                    max-height: calc(100vh - 150px);
                     max-width: 100%;
                 }
 
@@ -484,7 +484,7 @@
                 bottom: -40px;
                 left: 0;
                 line-height: 40px;
-                max-width: 90vw;
+                max-width: 100%;
                 padding: 0 10px;
                 position: absolute;
                 right: 0;

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -406,7 +406,7 @@
                 }
 
                 img {
-                    max-height: calc(100vh - 150px);
+                    max-height: 100vh;
                     max-width: 100%;
                 }
 
@@ -478,10 +478,9 @@
 
             .modal-button-bar {
                 @include single-transition(opacity, .6s);
-                @include border-radius(0 0 3px 3px);
                 @include opacity(0);
                 background-color: $black;
-                bottom: -40px;
+                bottom: 0;
                 left: 0;
                 line-height: 40px;
                 max-width: 100%;


### PR DESCRIPTION
#### Summary
MM-10700 - Updating modal preview css

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10700

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)

 Hey @esethna, I have made the css change to enlarge the preview window however we are ourselves generating the preview image and it is limited to 1024px. So any image above that gets generated to 1024px for display inside the preview window on the server if I'm correct.
In order for us to expand the size based on the screen size, we would have to modify that limitation and most probably move it to a higher resolution, so somewhere around 2600px, so that it can cater to higher resolution screen sizes. Though that would have performance concerns when opening the previewer.

So let me know if we need to make this change. if we do, we would have to update that on the server as well, but that will not update the already generated images. Correct me if I'm wrong @hmhealey.