### PR TITLE
Fix incorrect translation id

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -1072,7 +1072,7 @@ export default {
                         {
                             type: Constants.SettingsTypes.TYPE_TEXT,
                             key: 'ServiceSettings.AllowCorsFrom',
-                            label: 'min.service.corsTitle',
+                            label: 'admin.service.corsTitle',
                             label_default: 'Enable cross-origin requests from:',
                             placeholder: 'admin.service.corsEx',
                             placeholder_default: 'http://example.com',


### PR DESCRIPTION
#### Summary
Fix incorrect translation id (produced by [this commit](https://github.com/mattermost/mattermost-webapp/commit/2b85ae63e9c644c10f6eedbd153f2b252251a64d))

#### Ticket Link
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
