### PR TITLE
[MM-10771] Add E2E for account settings display

### DIFF
--- a/nightwatch.json
+++ b/nightwatch.json
@@ -33,7 +33,7 @@
                 "path": "./tests/reports/screenshots"
             },
             "desiredCapabilities": {
-                "browserName": "firefox",
+                "browserName": "chrome",
                 "unexpectedAlertBehaviour": "dismiss",
                 "javascriptEnabled": true,
                 "acceptSslCerts": true,
@@ -41,6 +41,7 @@
             }
         },
         "chrome": {
+            "resolution": "1920x1080",
             "desiredCapabilities": {
                 "browserName": "chrome",
                 "javascriptEnabled": true,
@@ -51,6 +52,7 @@
             }
         },
         "firefox": {
+            "resolution": "1920x1080",
             "desiredCapabilities": {
                 "browserName": "firefox",
                 "unexpectedAlertBehaviour": "dismiss",

--- a/tests/e2e/globals.js
+++ b/tests/e2e/globals.js
@@ -39,7 +39,7 @@ module.exports = {
     },
 
     beforeEach(browser, cb) {
-        cb();
+        browser.resizeWindow(1920, 1080, cb);
     },
 
     after(cb) {

--- a/tests/e2e/test.sh
+++ b/tests/e2e/test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+PLATFORM_FILES="./cmd/mattermost/main.go"
+
 function message {
     echo ""
     printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
@@ -41,14 +43,21 @@ function local_setup {
     trap local_cleanup EXIT
     selenium_start
     sleep 5
+}
 
-    add_test_users
+function reset_db {
+    cd ../mattermost-server
+
+    echo "reset the database"
+    go run $PLATFORM_FILES reset --confirm true
+
+    cd ../mattermost-webapp
+    sleep 5
 }
 
 function add_test_users {
     message "Adding test users..."
     cd ../mattermost-server
-    PLATFORM_FILES="./cmd/mattermost/main.go"
 
     echo "reset the database"
     go run $PLATFORM_FILES reset --confirm true
@@ -85,6 +94,8 @@ function local_tests {
         skip_tutorial
         nightwatch -e chrome --suiteRetries 1 --tag $1
     else
+        reset_db
+        add_test_users
         message "E2E full local chrome starts..."
         nightwatch -e chrome --suiteRetries 1
 

--- a/tests/e2e/tests/3_sidebarLeft/accountSettingsDisplay.action.js
+++ b/tests/e2e/tests/3_sidebarLeft/accountSettingsDisplay.action.js
@@ -67,6 +67,62 @@ module.exports = {
             click('#saveSetting').
             assert.containsText('@clockDesc', '12-hour clock (example: 4:00 PM)');
     },
+    'Test account settings display - Teammate Name Display': (client) => {
+        const accountSettingsModalPage = client.page.accountSettingsModalPage();
+        accountSettingsModalPage.expect.section('@accountSettingsModal').to.be.visible;
+
+        const accountSettingsModalSection = accountSettingsModalPage.section.accountSettingsModal;
+
+        accountSettingsModalSection.click('@displayButton');
+        accountSettingsModalSection.expect.section('@displaySettings').to.be.visible;
+
+        const displaySettingsSection = accountSettingsModalSection.section.displaySettings;
+
+        // contents and cancel check
+        displaySettingsSection.
+            waitForElementVisible('@teammateNameDisplayEdit', Constants.DEFAULT_WAIT).
+            click('@teammateNameDisplayEdit').
+            assert.containsText('.setting-list-item', 'Show username').
+            assert.containsText('.setting-list-item', 'Show nickname if one exists, otherwise show first and last name').
+            assert.containsText('.setting-list-item', 'Show first and last name').
+            assert.containsText('.setting-list-item', 'Show username').
+            waitForElementVisible('#name_formatFormatA', Constants.DEFAULT_WAIT).
+            waitForElementVisible('#name_formatFormatB', Constants.DEFAULT_WAIT).
+            waitForElementVisible('#name_formatFormatC', Constants.DEFAULT_WAIT).
+            waitForElementVisible('#saveSetting', Constants.DEFAULT_WAIT).
+            assert.containsText('#saveSetting', 'Save').
+            waitForElementVisible('#cancelSetting', Constants.DEFAULT_WAIT).
+            assert.containsText('#cancelSetting', 'Cancel').
+            click('#cancelSetting').
+            assert.containsText('@teammateNameDisplayDesc', 'Show username');
+
+        // save/change setting to "Show nickname if one exists, otherwise show first and last name"
+        displaySettingsSection.
+            waitForElementVisible('@teammateNameDisplayEdit', Constants.DEFAULT_WAIT).
+            click('@teammateNameDisplayEdit').
+            waitForElementVisible('#name_formatFormatB', Constants.DEFAULT_WAIT).
+            click('#name_formatFormatB').
+            click('#saveSetting').
+            assert.containsText('@teammateNameDisplayDesc', 'Show nickname if one exists, otherwise show first and last name');
+
+        // save/change setting to "Show first and last name"
+        displaySettingsSection.
+            waitForElementVisible('@teammateNameDisplayEdit', Constants.DEFAULT_WAIT).
+            click('@teammateNameDisplayEdit').
+            waitForElementVisible('#name_formatFormatC', Constants.DEFAULT_WAIT).
+            click('#name_formatFormatC').
+            click('#saveSetting').
+            assert.containsText('@teammateNameDisplayDesc', 'Show first and last name');
+
+        // save/change setting to "Show username"
+        displaySettingsSection.
+            waitForElementVisible('@teammateNameDisplayEdit', Constants.DEFAULT_WAIT).
+            click('@teammateNameDisplayEdit').
+            waitForElementVisible('#name_formatFormatA', Constants.DEFAULT_WAIT).
+            click('#name_formatFormatA').
+            click('#saveSetting').
+            assert.containsText('@teammateNameDisplayDesc', 'Show username');
+    },
     'Test account settings display - Website Link Previews': (client) => {
         const accountSettingsModalPage = client.page.accountSettingsModalPage();
         accountSettingsModalPage.expect.section('@accountSettingsModal').to.be.visible;
@@ -112,7 +168,7 @@ module.exports = {
             click('#saveSetting').
             assert.containsText('@linkPreviewDesc', 'On');
     },
-    'Test account settings display - Default appearance of image link previews': (client) => {
+    'Test account settings display - Default appearance of image previews': (client) => {
         const accountSettingsModalPage = client.page.accountSettingsModalPage();
         accountSettingsModalPage.expect.section('@accountSettingsModal').to.be.visible;
 
@@ -129,7 +185,7 @@ module.exports = {
             click('@collapseEdit').
             assert.containsText('.setting-list-item', 'Expanded').
             assert.containsText('.setting-list-item', 'Collapsed').
-            assert.containsText('.setting-list-item', 'Set whether previews of image links show as expanded or collapsed by default. This setting can also be controlled using the slash commands /expand and /collapse.').
+            assert.containsText('.setting-list-item', 'Set whether previews of image links and image attachment thumbnails show as expanded or collapsed by default. This setting can also be controlled using the slash commands /expand and /collapse.').
             waitForElementVisible('#collapseFormatA', Constants.DEFAULT_WAIT).
             waitForElementVisible('#collapseFormatB', Constants.DEFAULT_WAIT).
             waitForElementVisible('#saveSetting', Constants.DEFAULT_WAIT).
@@ -156,5 +212,95 @@ module.exports = {
             click('#collapseFormatA').
             click('#saveSetting').
             assert.containsText('@collapseDesc', 'Expanded');
+    },
+    'Test account settings display - Message Display': (client) => {
+        const accountSettingsModalPage = client.page.accountSettingsModalPage();
+        accountSettingsModalPage.expect.section('@accountSettingsModal').to.be.visible;
+
+        const accountSettingsModalSection = accountSettingsModalPage.section.accountSettingsModal;
+
+        accountSettingsModalSection.click('@displayButton');
+        accountSettingsModalSection.expect.section('@displaySettings').to.be.visible;
+
+        const displaySettingsSection = accountSettingsModalSection.section.displaySettings;
+
+        // contents and cancel check
+        displaySettingsSection.
+            waitForElementVisible('@messageDisplayEdit', Constants.DEFAULT_WAIT).
+            click('@messageDisplayEdit').
+            assert.containsText('.setting-list-item', 'Standard: Easy to scan and read.').
+            assert.containsText('.setting-list-item', 'Compact: Fit as many messages on the screen as we can.').
+            assert.containsText('.setting-list-item', 'Select how messages in a channel should be displayed.').
+            waitForElementVisible('#message_displayFormatA', Constants.DEFAULT_WAIT).
+            waitForElementVisible('#message_displayFormatB', Constants.DEFAULT_WAIT).
+            waitForElementVisible('#saveSetting', Constants.DEFAULT_WAIT).
+            assert.containsText('#saveSetting', 'Save').
+            waitForElementVisible('#cancelSetting', Constants.DEFAULT_WAIT).
+            assert.containsText('#cancelSetting', 'Cancel').
+            click('#cancelSetting').
+            assert.containsText('@messageDisplayDesc', 'Standard');
+
+        // save/change setting to "Compact: Fit as many messages on the screen as we can."
+        displaySettingsSection.
+            waitForElementVisible('@messageDisplayEdit', Constants.DEFAULT_WAIT).
+            click('@messageDisplayEdit').
+            waitForElementVisible('#message_displayFormatB', Constants.DEFAULT_WAIT).
+            click('#message_displayFormatB').
+            click('#saveSetting').
+            assert.containsText('@messageDisplayDesc', 'Compact');
+
+        // save/change setting to "Standard: Easy to scan and read."
+        displaySettingsSection.
+            waitForElementVisible('@messageDisplayEdit', Constants.DEFAULT_WAIT).
+            click('@messageDisplayEdit').
+            waitForElementVisible('#message_displayFormatA', Constants.DEFAULT_WAIT).
+            click('#message_displayFormatA').
+            click('#saveSetting').
+            assert.containsText('@messageDisplayDesc', 'Standard');
+    },
+    'Test account settings display - Channel Display Mode': (client) => {
+        const accountSettingsModalPage = client.page.accountSettingsModalPage();
+        accountSettingsModalPage.expect.section('@accountSettingsModal').to.be.visible;
+
+        const accountSettingsModalSection = accountSettingsModalPage.section.accountSettingsModal;
+
+        accountSettingsModalSection.click('@displayButton');
+        accountSettingsModalSection.expect.section('@displaySettings').to.be.visible;
+
+        const displaySettingsSection = accountSettingsModalSection.section.displaySettings;
+
+        // contents and cancel check
+        displaySettingsSection.
+            waitForElementVisible('@channelDisplayModeEdit', Constants.DEFAULT_WAIT).
+            click('@channelDisplayModeEdit').
+            assert.containsText('.setting-list-item', 'Full width').
+            assert.containsText('.setting-list-item', 'Fixed width, centered').
+            assert.containsText('.setting-list-item', 'Select the width of the center channel.').
+            waitForElementVisible('#channel_display_modeFormatA', Constants.DEFAULT_WAIT).
+            waitForElementVisible('#channel_display_modeFormatB', Constants.DEFAULT_WAIT).
+            waitForElementVisible('#saveSetting', Constants.DEFAULT_WAIT).
+            assert.containsText('#saveSetting', 'Save').
+            waitForElementVisible('#cancelSetting', Constants.DEFAULT_WAIT).
+            assert.containsText('#cancelSetting', 'Cancel').
+            click('#cancelSetting').
+            assert.containsText('@channelDisplayModeDesc', 'Full width');
+
+        // save/change setting to "Fixed width, centered"
+        displaySettingsSection.
+            waitForElementVisible('@channelDisplayModeEdit', Constants.DEFAULT_WAIT).
+            click('@channelDisplayModeEdit').
+            waitForElementVisible('#channel_display_modeFormatB', Constants.DEFAULT_WAIT).
+            click('#channel_display_modeFormatB').
+            click('#saveSetting').
+            assert.containsText('@channelDisplayModeDesc', 'Fixed width, centered');
+
+        // save/change setting to "Full width"
+        displaySettingsSection.
+            waitForElementVisible('@channelDisplayModeEdit', Constants.DEFAULT_WAIT).
+            click('@channelDisplayModeEdit').
+            waitForElementVisible('#channel_display_modeFormatA', Constants.DEFAULT_WAIT).
+            click('#channel_display_modeFormatA').
+            click('#saveSetting').
+            assert.containsText('@channelDisplayModeDesc', 'Full width');
     },
 };

--- a/tests/e2e/tests/3_sidebarLeft/accountSettingsModalPage.element.js
+++ b/tests/e2e/tests/3_sidebarLeft/accountSettingsModalPage.element.js
@@ -99,7 +99,7 @@ module.exports = {
             assert.visible('@linkPreviewDesc').
             assert.containsText('@linkPreviewDesc', 'On').
             assert.visible('@collapseTitle').
-            assert.containsText('@collapseTitle', 'Default appearance of image link previews').
+            assert.containsText('@collapseTitle', 'Default appearance of image previews').
             assert.visible('@collapseEdit').
             assert.visible('@collapseDesc').
             assert.containsText('@collapseDesc', 'Expanded').


### PR DESCRIPTION
#### Summary
Convert HTML test case into NIghtwatchJS
- https://github.com/mattermost/mattermost-selenium/blob/master/src/test/html/AccountSettingsDisplay.html

Plus,
- add test to Teammate Name Display
- fix other test on recent text/label change
- fix other test setup 

#### Ticket Link
Jira ticket: [MM-10771](https://mattermost.atlassian.net/browse/MM-10771)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
