### PR TITLE
MM-10767: Sort the teams in the teams selector modal

### DIFF
--- a/components/team_selector_modal/team_selector_modal.jsx
+++ b/components/team_selector_modal/team_selector_modal.jsx
@@ -210,6 +210,7 @@ export default class TeamSelectorModal extends React.Component {
             teams = this.props.teams.filter((team) => team.delete_at === 0);
             teams = teams.filter((team) => team.scheme_id !== this.currentSchemeId);
             teams = teams.filter((team) => this.props.alreadySelected.indexOf(team.id) === -1);
+            teams.sort((a, b) => a.display_name.toUpperCase() > b.display_name.toUpperCase());
         }
 
         return (


### PR DESCRIPTION
#### Summary
Sort the teams in the teams selector modal (for cases where the instance have
more than 50 teams, is posible that we need to set the order in the backend
too)

#### Ticket Link
[MM-10767](https://mattermost.atlassian.net/browse/MM-10767)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed