### PR TITLE
[MM-10519] Fix permission error on channel_converted event

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -6,7 +6,6 @@ import {batchActions} from 'redux-batched-actions';
 import {ChannelTypes, EmojiTypes, PostTypes, TeamTypes, UserTypes, RoleTypes, GeneralTypes, AdminTypes} from 'mattermost-redux/action_types';
 import {WebsocketEvents, General} from 'mattermost-redux/constants';
 import {
-    getChannel,
     getChannelAndMyMember,
     getChannelStats,
     viewChannel,
@@ -19,6 +18,7 @@ import {Client4} from 'mattermost-redux/client';
 import {getCurrentUser, getCurrentUserId, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
 import {getMyTeams} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import {browserHistory} from 'utils/browser_history';
 import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
@@ -305,9 +305,18 @@ function handleEvent(msg) {
     }
 }
 
+// handleChannelConvertedEvent handles updating of channel which is converted from public to private
 function handleChannelConvertedEvent(msg) {
     const channelId = msg.data.channel_id;
-    dispatch(getChannel(channelId));
+    if (channelId) {
+        const channel = getChannel(getState(), channelId);
+        if (channel) {
+            dispatch({
+                type: ChannelTypes.RECEIVED_CHANNEL,
+                data: {...channel, type: General.PRIVATE_CHANNEL},
+            });
+        }
+    }
 }
 
 function handleChannelUpdatedEvent(msg) {


### PR DESCRIPTION
#### Summary
(This is a follow up PR for MM-10519 which encounter permission error when the observing user is a regular user.)

Fix permission error on channel_converted event by not getting the channel via redux action which performs API calls.  
This change optimistically update the channel into private whenever the user has the said channel in store.

Note: I'll update `mattermost-redux` for mobile RN's similar implementation.  However, that change is not necessary for the webapp.

#### Ticket Link
Jira ticket: [MM-10519](https://mattermost.atlassian.net/browse/MM-10519)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
