### PR TITLE
Adds FormattedMarkdownMessage component.

### DIFF
--- a/components/formatted_markdown_message.jsx
+++ b/components/formatted_markdown_message.jsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {FormattedHTMLMessage, injectIntl, intlShape} from 'react-intl';
+import PropTypes from 'prop-types';
+import marked from 'marked';
+
+const UNESCAPED_TAGS = ['BR'];
+const TARGET_BLANK_URL_PREFIX = '!';
+
+class FormattedMarkdownMessage extends React.PureComponent {
+    constructor(props) {
+        super(props);
+        this.renderer = new marked.Renderer();
+        this.renderer.link = FormattedMarkdownMessage.linkF;
+    }
+
+    static linkF(href, title, text) {
+        if (href[0] === TARGET_BLANK_URL_PREFIX) {
+            return `<a href="${href.substring(1, href.length)}" target="_blank">${text}</a>`;
+        }
+        return `<a href="${href}">${text}</a>`;
+    }
+
+    static get propTypes() {
+        return {
+            intl: intlShape.isRequired,
+            id: PropTypes.string.isRequired,
+            defaultMessage: PropTypes.string.isRequired,
+            values: PropTypes.object,
+        };
+    }
+
+    static escapeHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    }
+
+    static sanitizer(p1) {
+        const parser = new DOMParser();
+        const htmlDoc = parser.parseFromString(p1, 'text/html');
+        const childNodes = htmlDoc.getElementsByTagName('body')[0].childNodes;
+        if (childNodes.length > 0) {
+            const {tagName} = childNodes[0];
+            if (UNESCAPED_TAGS.includes(tagName)) {
+                return p1;
+            }
+        }
+        return FormattedMarkdownMessage.escapeHtml(p1);
+    }
+
+    render() {
+        const origMsg = this.props.intl.formatMessage({
+            id: this.props.id,
+            defaultMessage: this.props.defaultMessage,
+        }, this.props.values);
+        return (
+            <FormattedHTMLMessage
+                id='00000000-0000-0000-0000-000000000000' // Some id that will never match.
+                defaultMessage={marked(origMsg, {
+                    sanitize: true,
+                    sanitizer: FormattedMarkdownMessage.sanitizer,
+                    renderer: this.renderer,
+                })}
+                values={this.props.values}
+            />
+        );
+    }
+}
+
+export default injectIntl(FormattedMarkdownMessage);

--- a/components/formatted_markdown_message.jsx
+++ b/components/formatted_markdown_message.jsx
@@ -6,10 +6,9 @@ import {injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 import marked from 'marked';
 
-const UNESCAPED_TAGS = ['BR'];
 const TARGET_BLANK_URL_PREFIX = '!';
 
-class MarkdownRenderer extends marked.Renderer {
+class CustomRenderer extends marked.Renderer {
     link(href, title, text) {
         if (href[0] === TARGET_BLANK_URL_PREFIX) {
             return `<a href="${href.substring(1, href.length)}" target="_blank">${text}</a>`;
@@ -28,25 +27,6 @@ class FormattedMarkdownMessage extends React.PureComponent {
         };
     }
 
-    static escapeHtml(str) {
-        var div = document.createElement('div');
-        div.appendChild(document.createTextNode(str));
-        return div.innerHTML;
-    }
-
-    static sanitizer(p1) {
-        const parser = new DOMParser();
-        const htmlDoc = parser.parseFromString(p1, 'text/html');
-        const childNodes = htmlDoc.getElementsByTagName('body')[0].childNodes;
-        if (childNodes.length > 0) {
-            const {tagName} = childNodes[0];
-            if (UNESCAPED_TAGS.includes(tagName)) {
-                return p1;
-            }
-        }
-        return FormattedMarkdownMessage.escapeHtml(p1);
-    }
-
     render() {
         const origMsg = this.props.intl.formatMessage({
             id: this.props.id,
@@ -54,9 +34,9 @@ class FormattedMarkdownMessage extends React.PureComponent {
         }, this.props.values);
 
         const markedUpMessage = marked(origMsg, {
+            breaks: true,
             sanitize: true,
-            sanitizer: FormattedMarkdownMessage.sanitizer,
-            renderer: new MarkdownRenderer(),
+            renderer: new CustomRenderer(),
         });
 
         return (<span dangerouslySetInnerHTML={{__html: markedUpMessage}}/>);

--- a/tests/components/__snapshots__/formatted_markdown_message.test.jsx.snap
+++ b/tests/components/__snapshots__/formatted_markdown_message.test.jsx.snap
@@ -1,0 +1,287 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/FormattedMarkdownMessage should backup to default 1`] = `
+<IntlProvider
+  locale="en"
+  messages={
+    Object {
+      "test.bar": "<b>hello</b> <script>var malicious = true;</script> world!",
+      "test.foo": "**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)",
+      "test.vals": "*Hi* {petName}!",
+    }
+  }
+>
+  <InjectIntl(FormattedMarkdownMessage)
+    defaultMessage="testing default message"
+    id="xxx"
+  >
+    <FormattedMarkdownMessage
+      defaultMessage="testing default message"
+      id="xxx"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {},
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {
+            "test.bar": "<b>hello</b> <script>var malicious = true;</script> world!",
+            "test.foo": "**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)",
+            "test.vals": "*Hi* {petName}!",
+          },
+          "now": [Function],
+          "textComponent": "span",
+        }
+      }
+    >
+      <FormattedHTMLMessage
+        defaultMessage="<p>testing default message</p>
+"
+        id="00000000-0000-0000-0000-000000000000"
+        values={Object {}}
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>testing default message</p>
+",
+            }
+          }
+        />
+      </FormattedHTMLMessage>
+    </FormattedMarkdownMessage>
+  </InjectIntl(FormattedMarkdownMessage)>
+</IntlProvider>
+`;
+
+exports[`components/FormattedMarkdownMessage should escape non-BR 1`] = `
+<IntlProvider
+  locale="en"
+  messages={
+    Object {
+      "test.bar": "<b>hello</b> <script>var malicious = true;</script> world!",
+      "test.foo": "**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)",
+      "test.vals": "*Hi* {petName}!",
+    }
+  }
+>
+  <InjectIntl(FormattedMarkdownMessage)
+    defaultMessage=""
+    id="test.bar"
+  >
+    <FormattedMarkdownMessage
+      defaultMessage=""
+      id="test.bar"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {},
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {
+            "test.bar": "<b>hello</b> <script>var malicious = true;</script> world!",
+            "test.foo": "**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)",
+            "test.vals": "*Hi* {petName}!",
+          },
+          "now": [Function],
+          "textComponent": "span",
+        }
+      }
+    >
+      <FormattedHTMLMessage
+        defaultMessage="<p>&lt;b&gt;hello&lt;/b&gt; &lt;script&gt;var malicious = true;&lt;/script&gt; world!</p>
+"
+        id="00000000-0000-0000-0000-000000000000"
+        values={Object {}}
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p>&lt;b&gt;hello&lt;/b&gt; &lt;script&gt;var malicious = true;&lt;/script&gt; world!</p>
+",
+            }
+          }
+        />
+      </FormattedHTMLMessage>
+    </FormattedMarkdownMessage>
+  </InjectIntl(FormattedMarkdownMessage)>
+</IntlProvider>
+`;
+
+exports[`components/FormattedMarkdownMessage should render message 1`] = `
+<IntlProvider
+  locale="en"
+  messages={
+    Object {
+      "test.bar": "<b>hello</b> <script>var malicious = true;</script> world!",
+      "test.foo": "**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)",
+      "test.vals": "*Hi* {petName}!",
+    }
+  }
+>
+  <InjectIntl(FormattedMarkdownMessage)
+    defaultMessage="**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)"
+    id="test.foo"
+  >
+    <FormattedMarkdownMessage
+      defaultMessage="**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)"
+      id="test.foo"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {},
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {
+            "test.bar": "<b>hello</b> <script>var malicious = true;</script> world!",
+            "test.foo": "**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)",
+            "test.vals": "*Hi* {petName}!",
+          },
+          "now": [Function],
+          "textComponent": "span",
+        }
+      }
+    >
+      <FormattedHTMLMessage
+        defaultMessage="<p><strong>bold</strong> <em>italic</em> <a href=\\"https://mattermost.com/\\">link</a> <br/> <a href=\\"https://mattermost.com/\\" target=\\"_blank\\">link target blank</a></p>
+"
+        id="00000000-0000-0000-0000-000000000000"
+        values={Object {}}
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p><strong>bold</strong> <em>italic</em> <a href=\\"https://mattermost.com/\\">link</a> <br/> <a href=\\"https://mattermost.com/\\" target=\\"_blank\\">link target blank</a></p>
+",
+            }
+          }
+        />
+      </FormattedHTMLMessage>
+    </FormattedMarkdownMessage>
+  </InjectIntl(FormattedMarkdownMessage)>
+</IntlProvider>
+`;
+
+exports[`components/FormattedMarkdownMessage values should work 1`] = `
+<IntlProvider
+  locale="en"
+  messages={
+    Object {
+      "test.bar": "<b>hello</b> <script>var malicious = true;</script> world!",
+      "test.foo": "**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)",
+      "test.vals": "*Hi* {petName}!",
+    }
+  }
+>
+  <InjectIntl(FormattedMarkdownMessage)
+    defaultMessage="*Hi* {petName}!"
+    id="test.vals"
+    values={
+      Object {
+        "petName": "sweetie",
+      }
+    }
+  >
+    <FormattedMarkdownMessage
+      defaultMessage="*Hi* {petName}!"
+      id="test.vals"
+      intl={
+        Object {
+          "defaultFormats": Object {},
+          "defaultLocale": "en",
+          "formatDate": [Function],
+          "formatHTMLMessage": [Function],
+          "formatMessage": [Function],
+          "formatNumber": [Function],
+          "formatPlural": [Function],
+          "formatRelative": [Function],
+          "formatTime": [Function],
+          "formats": Object {},
+          "formatters": Object {
+            "getDateTimeFormat": [Function],
+            "getMessageFormat": [Function],
+            "getNumberFormat": [Function],
+            "getPluralFormat": [Function],
+            "getRelativeFormat": [Function],
+          },
+          "locale": "en",
+          "messages": Object {
+            "test.bar": "<b>hello</b> <script>var malicious = true;</script> world!",
+            "test.foo": "**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)",
+            "test.vals": "*Hi* {petName}!",
+          },
+          "now": [Function],
+          "textComponent": "span",
+        }
+      }
+      values={
+        Object {
+          "petName": "sweetie",
+        }
+      }
+    >
+      <FormattedHTMLMessage
+        defaultMessage="<p><em>Hi</em> sweetie!</p>
+"
+        id="00000000-0000-0000-0000-000000000000"
+        values={
+          Object {
+            "petName": "sweetie",
+          }
+        }
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<p><em>Hi</em> sweetie!</p>
+",
+            }
+          }
+        />
+      </FormattedHTMLMessage>
+    </FormattedMarkdownMessage>
+  </InjectIntl(FormattedMarkdownMessage)>
+</IntlProvider>
+`;

--- a/tests/components/__snapshots__/formatted_markdown_message.test.jsx.snap
+++ b/tests/components/__snapshots__/formatted_markdown_message.test.jsx.snap
@@ -173,7 +173,7 @@ exports[`components/FormattedMarkdownMessage should render message 1`] = `
       <span
         dangerouslySetInnerHTML={
           Object {
-            "__html": "<p><strong>bold</strong> <em>italic</em> <a href=\\"https://mattermost.com/\\">link</a> <br/> <a href=\\"https://mattermost.com/\\" target=\\"_blank\\">link target blank</a></p>
+            "__html": "<p><strong>bold</strong> <em>italic</em> <a href=\\"https://mattermost.com/\\">link</a> &lt;br/&gt; <a href=\\"https://mattermost.com/\\" target=\\"_blank\\">link target blank</a></p>
 ",
           }
         }

--- a/tests/components/__snapshots__/formatted_markdown_message.test.jsx.snap
+++ b/tests/components/__snapshots__/formatted_markdown_message.test.jsx.snap
@@ -48,21 +48,14 @@ exports[`components/FormattedMarkdownMessage should backup to default 1`] = `
         }
       }
     >
-      <FormattedHTMLMessage
-        defaultMessage="<p>testing default message</p>
-"
-        id="00000000-0000-0000-0000-000000000000"
-        values={Object {}}
-      >
-        <span
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>testing default message</p>
+      <span
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p>testing default message</p>
 ",
-            }
           }
-        />
-      </FormattedHTMLMessage>
+        }
+      />
     </FormattedMarkdownMessage>
   </InjectIntl(FormattedMarkdownMessage)>
 </IntlProvider>
@@ -116,21 +109,14 @@ exports[`components/FormattedMarkdownMessage should escape non-BR 1`] = `
         }
       }
     >
-      <FormattedHTMLMessage
-        defaultMessage="<p>&lt;b&gt;hello&lt;/b&gt; &lt;script&gt;var malicious = true;&lt;/script&gt; world!</p>
-"
-        id="00000000-0000-0000-0000-000000000000"
-        values={Object {}}
-      >
-        <span
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>&lt;b&gt;hello&lt;/b&gt; &lt;script&gt;var malicious = true;&lt;/script&gt; world!</p>
+      <span
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p>&lt;b&gt;hello&lt;/b&gt; &lt;script&gt;var malicious = true;&lt;/script&gt; world!</p>
 ",
-            }
           }
-        />
-      </FormattedHTMLMessage>
+        }
+      />
     </FormattedMarkdownMessage>
   </InjectIntl(FormattedMarkdownMessage)>
 </IntlProvider>
@@ -184,21 +170,14 @@ exports[`components/FormattedMarkdownMessage should render message 1`] = `
         }
       }
     >
-      <FormattedHTMLMessage
-        defaultMessage="<p><strong>bold</strong> <em>italic</em> <a href=\\"https://mattermost.com/\\">link</a> <br/> <a href=\\"https://mattermost.com/\\" target=\\"_blank\\">link target blank</a></p>
-"
-        id="00000000-0000-0000-0000-000000000000"
-        values={Object {}}
-      >
-        <span
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p><strong>bold</strong> <em>italic</em> <a href=\\"https://mattermost.com/\\">link</a> <br/> <a href=\\"https://mattermost.com/\\" target=\\"_blank\\">link target blank</a></p>
+      <span
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p><strong>bold</strong> <em>italic</em> <a href=\\"https://mattermost.com/\\">link</a> <br/> <a href=\\"https://mattermost.com/\\" target=\\"_blank\\">link target blank</a></p>
 ",
-            }
           }
-        />
-      </FormattedHTMLMessage>
+        }
+      />
     </FormattedMarkdownMessage>
   </InjectIntl(FormattedMarkdownMessage)>
 </IntlProvider>
@@ -262,25 +241,14 @@ exports[`components/FormattedMarkdownMessage values should work 1`] = `
         }
       }
     >
-      <FormattedHTMLMessage
-        defaultMessage="<p><em>Hi</em> sweetie!</p>
-"
-        id="00000000-0000-0000-0000-000000000000"
-        values={
+      <span
+        dangerouslySetInnerHTML={
           Object {
-            "petName": "sweetie",
+            "__html": "<p><em>Hi</em> sweetie!</p>
+",
           }
         }
-      >
-        <span
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p><em>Hi</em> sweetie!</p>
-",
-            }
-          }
-        />
-      </FormattedHTMLMessage>
+      />
     </FormattedMarkdownMessage>
   </InjectIntl(FormattedMarkdownMessage)>
 </IntlProvider>

--- a/tests/components/formatted_markdown_message.test.jsx
+++ b/tests/components/formatted_markdown_message.test.jsx
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {mount} from 'enzyme';
+import {IntlProvider} from 'react-intl';
+
+import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
+
+describe('components/FormattedMarkdownMessage', () => {
+    test('should render message', () => {
+        const descriptor = {
+            id: 'test.foo',
+            defaultMessage: '**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)',
+        };
+        const wrapper = mount(wrapProvider(<FormattedMarkdownMessage {...descriptor}/>));
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should backup to default', () => {
+        const descriptor = {
+            id: 'xxx',
+            defaultMessage: 'testing default message',
+        };
+        const wrapper = mount(wrapProvider(<FormattedMarkdownMessage {...descriptor}/>));
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should escape non-BR', () => {
+        const descriptor = {
+            id: 'test.bar',
+            defaultMessage: '',
+        };
+        const wrapper = mount(wrapProvider(<FormattedMarkdownMessage {...descriptor}/>));
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('values should work', () => {
+        const descriptor = {
+            id: 'test.vals',
+            defaultMessage: '*Hi* {petName}!',
+            values: {
+                petName: 'sweetie',
+            },
+        };
+        const wrapper = mount(wrapProvider(<FormattedMarkdownMessage {...descriptor}/>));
+        expect(wrapper).toMatchSnapshot();
+    });
+});
+
+export function wrapProvider(el) {
+    const enTranslationData = {
+        'test.foo': '**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)',
+        'test.bar': '<b>hello</b> <script>var malicious = true;</script> world!',
+        'test.vals': '*Hi* {petName}!',
+    };
+    return (
+        <IntlProvider
+            locale={'en'}
+            messages={enTranslationData}
+        >
+            {el}
+        </IntlProvider>)
+    ;
+}


### PR DESCRIPTION
#### Summary
Adds new component `<FormattedMarkdownMessage>` that can replace all (I think) instances of `<FormattedHTMLMessage>` in Mattermost. 

Example usage:

```jsx
<FormattedMarkdownMessage
    id='admin.cluster.foo'
    defaultMessage='Cluster {clusterId} is **awesome**! *Please* see <br> the [documentation](http://docs.mattermost.com/deployment/cluster.html).'
    values={{
        clusterId: '123',
    }}
/>
```

... would output:

Cluster 123 is **awesome**! *Please* see 
the [documentation](http://docs.mattermost.com/deployment/cluster.html).

Rules:
* Accepts most markdown, but we'll probably just use the basics (bold, italics, etc)
* To make a normal anchor tag use `[text](url)`
* To make an anchar tag with `target="_blank"` use `[text](!url)` (note the exclamation mark prefix).

#### Ticket Link
n/a

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)