### PR TITLE
MM-10789: propagate post channel_mentions to Markdown

### DIFF
--- a/components/markdown/index.js
+++ b/components/markdown/index.js
@@ -18,7 +18,7 @@ import Markdown from './markdown';
 function makeGetChannelNamesMap() {
     return createSelector(
         getChannelsNameMapInCurrentTeam,
-        (state, props) => props && props.channel_mentions,
+        (state, props) => props && props.channelNamesMap,
         (channelNamesMap, channelMentions) => {
             if (channelMentions) {
                 return Object.assign({}, channelMentions, channelNamesMap);

--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -46,6 +46,7 @@ export default class PostMarkdown extends React.PureComponent {
 
         // Proxy images if we have an image proxy and the server hasn't already rewritten the post's image URLs.
         const proxyImages = !this.props.post || !this.props.post.message_source || this.props.post.message === this.props.post.message_source;
+        const channelNamesMap = this.props.post && this.props.post.props && this.props.post.props.channel_mentions;
 
         return (
             <Markdown
@@ -53,6 +54,7 @@ export default class PostMarkdown extends React.PureComponent {
                 isRHS={this.props.isRHS}
                 message={this.props.message}
                 proxyImages={proxyImages}
+                channelNamesMap={channelNamesMap}
             />
         );
     }

--- a/tests/components/__snapshots__/post_markdown.test.jsx.snap
+++ b/tests/components/__snapshots__/post_markdown.test.jsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/PostMarkdown should render properly with a post 1`] = `
+<Connect(Markdown)
+  channelNamesMap={
+    Object {
+      "test": Object {
+        "display_name": "Test",
+      },
+    }
+  }
+  imageProps={Object {}}
+  isRHS={false}
+  message="message"
+  proxyImages={true}
+/>
+`;
+
+exports[`components/PostMarkdown should render properly with an empty post 1`] = `
+<Connect(Markdown)
+  imageProps={Object {}}
+  isRHS={false}
+  message="message"
+  proxyImages={true}
+/>
+`;

--- a/tests/components/post_markdown.test.jsx
+++ b/tests/components/post_markdown.test.jsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import PostMarkdown from 'components/post_markdown/post_markdown';
+
+describe('components/PostMarkdown', () => {
+    const baseProps = {
+        imageProps: {},
+        isRHS: false,
+        message: 'message',
+        post: {},
+    };
+
+    test('should render properly with an empty post', () => {
+        const wrapper = shallow(
+            <PostMarkdown {...baseProps}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render properly with a post', () => {
+        const props = {
+            ...baseProps,
+            post: {
+                props: {
+                    channel_mentions: {
+                        test: {
+                            display_name: 'Test',
+                        },
+                    },
+                },
+            },
+        };
+        const wrapper = shallow(
+            <PostMarkdown {...props}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
The `post.props.channel_mentions` structure sent by the server needed to be passed to the Markdown component to allow merging with the already known channels for linking.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10789

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)