### PR TITLE
MM-10811 - Fixing overflow on long posts

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -784,10 +784,6 @@
             }
         }
 
-        .post-message {
-            overflow: initial;
-        }
-
         .post-message--collapsed + .post-image__columns {
             &:before {
                 content: '';
@@ -1155,7 +1151,6 @@
     }
 
     .post__content {
-        @include clearfix;
         display: table;
         margin: 0 auto;
         padding: 0 5px;

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1813,7 +1813,6 @@
 
 .post-message {
     position: relative;
-    overflow-y: hidden;
 }
 
 .post-collapse {

--- a/sass/responsive/_tablet.scss
+++ b/sass/responsive/_tablet.scss
@@ -188,6 +188,15 @@
     .post {
         &.post--compact {
 
+            &.post--root {
+                .post-message {
+                    &.post-message--overflow {
+                        @include clearfix;
+                        margin-top: 22px;
+                    }
+                }
+            }
+
             .channel__wrap & {
                 .post__time {
                     font-size: .85em;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -632,7 +632,7 @@ export function applyTheme(theme) {
         changeCss('@media(max-width: 640px){.app__body .post .dropdown .dropdown-menu button', 'background:' + theme.centerChannelBg);
         changeCss('@media(min-width: 768px){.app__body .post:hover .post__header .col__reply, .app__body .post.post--hovered .post__header .col__reply', 'background:' + theme.centerChannelBg);
         changeCss('@media(max-width: 320px){.tutorial-steps__container', 'background:' + theme.centerChannelBg);
-        changeCss('.app__body .post.post--compact .post__body .post-reaction-list, .app__body .bg--white, .app__body .system-notice, .app__body .channel-header__info .channel-header__description:before, .app__body .app__content, .app__body .markdown__table, .app__body .markdown__table tbody tr, .app__body .suggestion-list__content, .app__body .modal .modal-content, .app__body .modal .modal-footer, .app__body .post.post--compact .post-image__column, .app__body .suggestion-list__divider > span, .app__body .status-wrapper .status, .app__body .alert.alert-transparent, .app__body .post-image__column', 'background:' + theme.centerChannelBg);
+        changeCss('.app__body .bg--white, .app__body .system-notice, .app__body .channel-header__info .channel-header__description:before, .app__body .app__content, .app__body .markdown__table, .app__body .markdown__table tbody tr, .app__body .suggestion-list__content, .app__body .modal .modal-content, .app__body .modal .modal-footer, .app__body .post.post--compact .post-image__column, .app__body .suggestion-list__divider > span, .app__body .status-wrapper .status, .app__body .alert.alert-transparent, .app__body .post-image__column', 'background:' + theme.centerChannelBg);
         changeCss('#post-list .post-list-holder-by-time, .app__body .post .dropdown-menu a', 'background:' + theme.centerChannelBg);
         changeCss('#post-create, .app__body .emoji-picker__preview', 'background:' + theme.centerChannelBg);
         changeCss('.app__body .date-separator .separator__text, .app__body .new-separator .separator__text', 'background:' + theme.centerChannelBg);
@@ -650,7 +650,7 @@ export function applyTheme(theme) {
         changeCss('.app__body .shortcut-key, .app__body .post-list__new-messages-below', 'color:' + theme.centerChannelBg);
         changeCss('.app__body .emoji-picker, .app__body .emoji-picker__search', 'background:' + theme.centerChannelBg);
         changeCss('.app__body .nav-tabs, .app__body .nav-tabs > li.active > a', 'background:' + theme.centerChannelBg);
-        changeCss('.app__body .post .post-image__columns, .app__body .post .file-view--single', `background:${theme.centerChannelBg}`);
+        changeCss('.app__body .post .file-view--single', `background:${theme.centerChannelBg}`);
 
         changeCss(
             '.app__body .post-list__table .post:not(.current--user) .post-collapse__gradient, ' +


### PR DESCRIPTION
#### Summary
MM-10811 - Fixing overflow on long posts

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10832

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)

@hmhealey I previously had an overflow hidden on `.post__content`, and thought that would fix the issue with the long post stuff. However, that does not work, since it then does not allow the post control dropdown to overflow.

I have been trying to figure out a bunch of hacky ways to fix it, but couldn't come up with any. Overflows won't work as the post control dropdown is inside the header, and overflowing anything above the header would also cut the dropdown.

So the most viable fix in my opinion was to have the name appear on the top for long posts on compact view. Seeing as we are this close to release, we don't have much time to refractor the code in a way to make this work as expected.

![download](https://user-images.githubusercontent.com/11034289/41122618-8cb1f7f6-6ab5-11e8-8c51-17f44ac54f8e.png)

CC: @esethna.
