### PR TITLE
Fix bot indicator style for mobile

### DIFF
--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -263,7 +263,6 @@
         &:not(.post--compact) {
             .bot-indicator {
                 left: 6px;
-                position: absolute;
                 top: 31px;
             }
         }


### PR DESCRIPTION
#### Summary
Fix for bot indicator style overlapping on mobile.

#### Before
<img width="600" alt="screen shot 2018-06-07 at 3 34 01 pm" src="https://user-images.githubusercontent.com/6182543/41122307-1aa0c440-6a69-11e8-8034-036a44502018.png">

#### After
<img width="606" alt="screen shot 2018-06-07 at 3 32 44 pm" src="https://user-images.githubusercontent.com/6182543/41122308-1ab5cc3c-6a69-11e8-974a-2f430cab6197.png">