### PR TITLE
MM-10806: Fix for no search highlighting.

### DIFF
--- a/components/markdown/markdown.jsx
+++ b/components/markdown/markdown.jsx
@@ -70,6 +70,8 @@ export default class Markdown extends React.PureComponent {
          * Any extra props that should be passed into the MarkdownImage component
          */
         imageProps: PropTypes.object,
+
+        searchTerm: PropTypes.string,
     };
 
     static defaultProps = {
@@ -91,6 +93,7 @@ export default class Markdown extends React.PureComponent {
             channelNamesMap: this.props.channelNamesMap,
             proxyImages: this.props.hasImageProxy && this.props.proxyImages,
             team: this.props.team,
+            searchTerm: this.props.searchTerm,
         }, this.props.options);
 
         const htmlFormattedText = TextFormatting.formatText(this.props.message, options);

--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -30,6 +30,8 @@ export default class PostMarkdown extends React.PureComponent {
          * The optional post for which this message is being rendered
          */
         post: PropTypes.object,
+
+        options: PropTypes.object,
     };
 
     static defaultProps = {
@@ -53,6 +55,7 @@ export default class PostMarkdown extends React.PureComponent {
                 isRHS={this.props.isRHS}
                 message={this.props.message}
                 proxyImages={proxyImages}
+                searchTerm={this.props.options.searchTerm}
             />
         );
     }


### PR DESCRIPTION
#### Summary
Adds forgotten `searchTerm` parameter required to highlight search results.

#### Ticket Link
[MM-10806](https://mattermost.atlassian.net/browse/MM-10806)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed