### PR TITLE
MM-10844: maximum file size is a TYPE_NUMBER

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -1388,7 +1388,7 @@ export default {
                             isHidden: needsUtils.not(needsUtils.hasLicense),
                         },
                         {
-                            type: Constants.SettingsTypes.TYPE_TEXT,
+                            type: Constants.SettingsTypes.TYPE_NUMBER,
                             key: 'FileSettings.MaxFileSize',
                             label: 'admin.image.maxFileSizeTitle',
                             label_default: 'Maximum File Size:',


### PR DESCRIPTION
#### Summary
Maximum file size is a `TYPE_NUMBER`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10844

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)