### PR TITLE
MM-10845 Allowed system console error message to wrap to 2 lines

### DIFF
--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -437,11 +437,10 @@
         }
         .error-message {
             overflow: hidden;
+
             .control-label {
                 padding: 0;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
+                @include text-clamp(2, 20);
             }
         }
         .reset-defaults-btn {

--- a/sass/utils/_mixins.scss
+++ b/sass/utils/_mixins.scss
@@ -36,3 +36,17 @@
         }
     }
 }
+
+// From https://gist.github.com/kaelig/7528069
+@mixin text-clamp($lines: 2, $line-height: false) {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: $lines;
+
+    // Fallback for non-Webkit browsers
+    // (won't show `…` at the end of the block)
+    @if $line-height {
+        max-height: $line-height * $lines * 1px;
+    }
+}


### PR DESCRIPTION
The error message currently gets truncated at one line, so this allows it to expand nicely to 2 lines. The text is cut off with ellipses on Webkit browsers (ie Chrome, Safari), but it gets cut off a bit more abruptly on other browsers.

Chrome Screenshots:
![image](https://user-images.githubusercontent.com/3277310/41233017-1a08c074-6d56-11e8-9926-e0537d435d07.png)
![image](https://user-images.githubusercontent.com/3277310/41233021-1bd44554-6d56-11e8-9658-b9eb4b1d2851.png)

IE11 Screenshot:
![image](https://user-images.githubusercontent.com/3277310/41233073-4602d66a-6d56-11e8-956b-bbc8ff33acda.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10845

#### Checklist
- Has UI changes
