### PR TITLE
MM-10706 Made sure to update post height when image loads

### DIFF
--- a/components/markdown_image.jsx
+++ b/components/markdown_image.jsx
@@ -56,8 +56,25 @@ export default class MarkdownImage extends React.PureComponent {
         if (this.heightTimeout !== 0) {
             clearTimeout(this.heightTimeout);
             this.heightTimeout = 0;
+
+            return true;
         }
+
+        return false;
     }
+
+    handleLoad = () => {
+        const wasWaiting = this.stopWaitingForHeight();
+
+        // The image loaded before we caught its layout event, so we still need to notify that its height changed
+        if (wasWaiting && this.props.onHeightReceived) {
+            this.props.onHeightReceived(this.refs.image.height);
+        }
+    };
+
+    handleError = () => {
+        this.stopWaitingForHeight();
+    };
 
     render() {
         const props = {...this.props};
@@ -67,8 +84,8 @@ export default class MarkdownImage extends React.PureComponent {
             <img
                 ref='image'
                 {...props}
-                onLoad={this.stopWaitingForHeight}
-                onError={this.stopWaitingForHeight}
+                onLoad={this.handleLoad}
+                onError={this.handleError}
             />
         );
     }


### PR DESCRIPTION
The previous version of this code only updated post height (which determined whether or not the post is shown as collapsed) after 100ms, so it would be theoretically possible that the post loaded before that happened, causing the timeout to be cancelled and that code to not be called. This should fix that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10706