### PR TITLE
MM-10876 Removed horizontal scrollbar on some posts in IE11

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1817,7 +1817,7 @@
 
 .post-message {
     position: relative;
-    overflow-y: hidden;
+    overflow: hidden;
 }
 
 .post-collapse {


### PR DESCRIPTION
It seems like the issue here is that setting `overflow-y` was allowing the post text to sometimes overflow the `post-message` div into the parent div because the parent had `padding` set. IE11 is weird.

In this screenshot, the hovered post caused the scroll bar because of something to do with the line ending in "id." This is how it looks after the change on IE11.
![image](https://user-images.githubusercontent.com/3277310/41254128-82d63ef8-6d90-11e8-9183-dd02eea9dca7.png)

And here's that same post in Chrome to show that this didn't break the [...] menu hover effect
![image](https://user-images.githubusercontent.com/3277310/41254164-b2f3015c-6d90-11e8-999b-f170f6208dcd.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10876
