### PR TITLE
MM-10647: Fix for Korean character double post on ctrl+enter.

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -644,7 +644,10 @@ export default class CreatePost extends React.Component {
         const ctrlKeyCombo = ctrlOrMetaKeyPressed && !e.altKey && !e.shiftKey;
 
         if (ctrlEnterKeyCombo) {
-            this.postMsgKeyPress(e);
+            e.persist();
+            setTimeout(() => {
+                this.postMsgKeyPress(e);
+            }, 0);
         } else if (upKeyOnly && messageIsEmpty) {
             this.editLastPost(e);
         } else if (shiftUpKeyCombo && messageIsEmpty) {

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -529,8 +529,10 @@ describe('components/create_post', () => {
             ctrlSend: true,
         }));
         const instance = wrapper.instance();
-        instance.handleKeyDown({ctrlKey: true, key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], preventDefault: jest.fn});
-        expect(GlobalActions.emitLocalUserTypingEvent).toHaveBeenCalledWith(currentChannelProp.id, '');
+        instance.handleKeyDown({ctrlKey: true, key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], preventDefault: jest.fn, persist: jest.fn});
+        setTimeout(() => {
+            expect(GlobalActions.emitLocalUserTypingEvent).toHaveBeenCalledWith(currentChannelProp.id, '');
+        }, 0);
     });
 
     it('Should call edit action as comment for arrow up', () => {


### PR DESCRIPTION
#### Summary
Waiting until the stack is clear before continuing with the execution.

#### Ticket Link
[MM-10647](https://mattermost.atlassian.net/browse/MM-10647)

#### Checklist
- [x] Ran `make check-style` to check for style errors
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests