### PR TITLE
Fix Opening the channel switch modal triggers a JS error when user is undefined

### DIFF
--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -416,8 +416,14 @@ export default class SwitchChannelProvider extends Provider {
             if (channel.type === Constants.GM_CHANNEL) {
                 wrappedChannel.name = getChannelDisplayName(channel);
             } else if (channel.type === Constants.DM_CHANNEL) {
+                const user = getUser(getState(), Utils.getUserIdFromChannelId(channel.name));
+
+                if (!user) {
+                    continue;
+                }
+
                 wrappedChannel = this.userWrappedChannel(
-                    getUser(getState(), Utils.getUserIdFromChannelId(channel.name)),
+                    user,
                     channel
                 );
             }


### PR DESCRIPTION
#### Summary
Sometimes when using CMD/CTRL+K the users to build the unread dm's haven't yet loaded making the user object undefined, if that is the case the PR just skips it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10878

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
