### PR TITLE
MM-10812 Attempt to load posts to fill screen

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -27,7 +27,7 @@ import CreateChannelIntroMessage from './channel_intro_message';
 
 const CLOSE_TO_BOTTOM_SCROLL_MARGIN = 10;
 const POSTS_PER_PAGE = Constants.POST_CHUNK_SIZE / 2;
-const MAX_EXTRA_PAGES_INITIALLY_LOADED = 10;
+const MAX_EXTRA_PAGES_LOADED = 10;
 
 export default class PostList extends React.PureComponent {
     static propTypes = {
@@ -116,7 +116,7 @@ export default class PostList extends React.PureComponent {
         this.previousClientHeight = 0;
         this.atBottom = false;
 
-        this.extraPagesInitiallyLoaded = 0;
+        this.extraPagesLoaded = 0;
 
         this.state = {
             atEnd: false,
@@ -163,7 +163,7 @@ export default class PostList extends React.PureComponent {
                 this.hasScrolledToNewMessageSeparator = false;
                 this.atBottom = false;
 
-                this.extraPagesInitiallyLoaded = 0;
+                this.extraPagesLoaded = 0;
 
                 this.setState({atEnd: false, lastViewed: nextProps.lastViewedAt, isDoingInitialLoad: !nextProps.posts, unViewedCount: 0});
 
@@ -283,7 +283,7 @@ export default class PostList extends React.PureComponent {
             return;
         }
 
-        if (this.extraPagesInitiallyLoaded > MAX_EXTRA_PAGES_INITIALLY_LOADED) {
+        if (this.extraPagesLoaded > MAX_EXTRA_PAGES_LOADED) {
             // Prevent this from loading a lot of pages in a channel with only hidden messages
             return;
         }
@@ -292,7 +292,7 @@ export default class PostList extends React.PureComponent {
     };
 
     doLoadPostsToFillScreen = debounce(() => {
-        this.extraPagesInitiallyLoaded += 1;
+        this.extraPagesLoaded += 1;
 
         this.loadMorePosts();
     }, 100);


### PR DESCRIPTION
When you have posts that aren't shown because they're combined or hidden, you can end up in a scenario where the channel looks mostly empty as in the case described in this ticket. To mitigate that, we now load up to 5 extra pages of posts (technically 10 half pages since we only show half a page each time you load more) to attempt to fill the screen when switching to a channel.

When we add in infinite scrolling, we'll be able to remove the cap since that's just how infinite scrolling works. This isn't a great solution since you can get into some bad scenarios where it just loads dozens of pages of hidden posts, but it's the best I can think of without the server understanding what posts are visible and what are either combined or hidden completely.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10812

#### Checklist
- Has UI changes
