### PR TITLE
MM-10890: Restore the previous behavior avoiding system admins removing itself from team admin

### DIFF
--- a/components/team_members_dropdown/team_members_dropdown.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.jsx
@@ -189,7 +189,7 @@ export default class TeamMembersDropdown extends React.Component {
         }
 
         const me = UserStore.getCurrentUser();
-        let showMakeMember = (Utils.isAdmin(teamMember.roles) && !Utils.isSystemAdmin(user.roles)) || teamMember.scheme_admin;
+        let showMakeMember = (Utils.isAdmin(teamMember.roles) || teamMember.scheme_admin) && !Utils.isSystemAdmin(user.roles);
         let showMakeAdmin = !Utils.isAdmin(teamMember.roles) && !Utils.isSystemAdmin(user.roles) && !teamMember.scheme_admin;
         let showMakeActive = false;
         let showMakeNotActive = Utils.isSystemAdmin(user.roles);


### PR DESCRIPTION
#### Summary
Restore the previous behavior avoiding system admins removing itself from team admin. There was a small boolean logic error.

#### Ticket Link
[MM-10890](https://mattermost.atlassian.net/browse/MM-10890)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed