### PR TITLE
Fix login screen flash on entering base URL

### DIFF
--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -47,7 +47,7 @@ export default class NeedsTeam extends React.Component {
          */
         match: PropTypes.shape({
             params: PropTypes.shape({
-                team: PropTypes.string.isRequired,
+                team: PropTypes.string,
             }).isRequired,
         }).isRequired,
     };

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -319,6 +319,10 @@ export default class Root extends React.Component {
                         path={'/:team'}
                         component={NeedsTeam}
                     />
+                    <LoggedInRoute
+                        path={'/'}
+                        component={NeedsTeam}
+                    />
                     <Redirect to={'/login'}/>
                 </Switch>
             </IntlProvider>


### PR DESCRIPTION
#### Summary
Fixes redirect to login page flash as router path does not match base URL.

To replicate this one has to be on slow network or throttle network to fast3g
![jun-14-2018 13-13-13](https://user-images.githubusercontent.com/4973621/41398468-10e06a98-6fd5-11e8-9c2b-b3ce1d900368.gif)


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
