### PR TITLE
MM-10888 Hide parts of combined system messages that don't affect the current user

### DIFF
--- a/components/post_view/combined_system_message/combined_system_message.jsx
+++ b/components/post_view/combined_system_message/combined_system_message.jsx
@@ -153,6 +153,7 @@ export default class CombinedSystemMessage extends React.PureComponent {
         currentUserId: PropTypes.string.isRequired,
         currentUsername: PropTypes.string.isRequired,
         messageData: PropTypes.array.isRequired,
+        showJoinLeave: PropTypes.bool.isRequired,
         teammateNameDisplay: PropTypes.string.isRequired,
         actions: PropTypes.shape({
             getProfilesByIds: PropTypes.func.isRequired,
@@ -323,18 +324,39 @@ export default class CombinedSystemMessage extends React.PureComponent {
     render() {
         const {messageData} = this.props;
 
+        const content = [];
+        for (const message of messageData) {
+            const {
+                postType,
+                actorId,
+            } = message;
+            let userIds = message.userIds;
+
+            if (!this.props.showJoinLeave && actorId !== this.props.currentUserId) {
+                const affectsCurrentUser = userIds.indexOf(this.props.currentUserId) !== -1;
+
+                if (affectsCurrentUser) {
+                    // Only show the message that the current user was added, etc
+                    userIds = [this.props.currentUserId];
+                } else {
+                    // Not something the current user did or was affected by
+                    continue;
+                }
+            }
+
+            content.push(
+                <React.Fragment key={postType + actorId}>
+                    <span>
+                        {this.renderFormattedMessage(postType, userIds, actorId)}
+                    </span>
+                    <br/>
+                </React.Fragment>
+            );
+        }
+
         return (
             <React.Fragment>
-                {messageData.map(({postType, userIds, actorId}) => {
-                    return (
-                        <React.Fragment key={postType + actorId}>
-                            <span>
-                                {this.renderFormattedMessage(postType, userIds, actorId)}
-                            </span>
-                            <br/>
-                        </React.Fragment>
-                    );
-                })}
+                {content}
             </React.Fragment>
         );
     }

--- a/components/post_view/combined_system_message/index.js
+++ b/components/post_view/combined_system_message/index.js
@@ -5,17 +5,19 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getProfilesByIds, getProfilesByUsernames} from 'mattermost-redux/actions/users';
-
-import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
+import {Preferences} from 'mattermost-redux/constants';
+import {getBool, getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import CombinedSystemMessage from './combined_system_message.jsx';
 
 function mapStateToProps(state) {
     const currentUser = getCurrentUser(state);
+
     return {
         currentUserId: currentUser.id,
         currentUsername: currentUser.username,
+        showJoinLeave: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE, true),
         teammateNameDisplay: getTeammateNameDisplaySetting(state),
     };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10869,8 +10869,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
-      "from": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
+      "version": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
+      "from": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10869,8 +10869,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#bdbe02322265ba8a8e6391b0db869993b501b36a",
-      "from": "github:mattermost/mattermost-redux#bdbe02322265ba8a8e6391b0db869993b501b36a",
+      "version": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
+      "from": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "localforage": "1.7.1",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
+    "mattermost-redux": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
     "moment-timezone": "0.5.17",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "localforage": "1.7.1",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#bdbe02322265ba8a8e6391b0db869993b501b36a",
+    "mattermost-redux": "github:mattermost/mattermost-redux#0d727a50cf32c3f1e591906b16ccd6922f720134",
     "moment-timezone": "0.5.17",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/tests/components/combined_system_message/__snapshots__/combined_system_message.test.jsx.snap
+++ b/tests/components/combined_system_message/__snapshots__/combined_system_message.test.jsx.snap
@@ -5,7 +5,89 @@ exports[`components/post_view/CombinedSystemMessage should match snapshot 1`] = 
   <React.Fragment
     key="system_add_to_channeluser_id_1"
   >
-    <span />
+    <span>
+      <FormattedHTMLMessage
+        defaultMessage="{firstUser} <b>added to the channel</b> by {actor}."
+        id="combined_system_message.added_to_channel.one"
+        values={
+          Object {
+            "actor": "@User1",
+            "firstUser": "@AddedUser1",
+          }
+        }
+      />
+    </span>
+    <br />
+  </React.Fragment>
+  <React.Fragment
+    key="system_add_to_channeluser_id_1"
+  >
+    <span>
+      <FormattedHTMLMessage
+        defaultMessage="You were <b>added to the channel</b> by {actor}."
+        id="combined_system_message.added_to_channel.one_you"
+        values={
+          Object {
+            "actor": "@User1",
+          }
+        }
+      />
+    </span>
+    <br />
+  </React.Fragment>
+  <React.Fragment
+    key="system_add_to_channelcurrent_user_id"
+  >
+    <span>
+      <FormattedHTMLMessage
+        defaultMessage="{firstUser} <b>added to the channel</b> by {actor}."
+        id="combined_system_message.added_to_channel.one"
+        values={
+          Object {
+            "actor": "you",
+            "firstUser": "@AddedUser2",
+          }
+        }
+      />
+    </span>
+    <br />
+  </React.Fragment>
+</React.Fragment>
+`;
+
+exports[`components/post_view/CombinedSystemMessage should match snapshot when join leave messages are turned off 1`] = `
+<React.Fragment>
+  <React.Fragment
+    key="system_add_to_channeluser_id_1"
+  >
+    <span>
+      <FormattedHTMLMessage
+        defaultMessage="You were <b>added to the channel</b> by {actor}."
+        id="combined_system_message.added_to_channel.one_you"
+        values={
+          Object {
+            "actor": "@User1",
+          }
+        }
+      />
+    </span>
+    <br />
+  </React.Fragment>
+  <React.Fragment
+    key="system_add_to_channelcurrent_user_id"
+  >
+    <span>
+      <FormattedHTMLMessage
+        defaultMessage="{firstUser} <b>added to the channel</b> by {actor}."
+        id="combined_system_message.added_to_channel.one"
+        values={
+          Object {
+            "actor": "you",
+            "firstUser": "@AddedUser2",
+          }
+        }
+      />
+    </span>
     <br />
   </React.Fragment>
 </React.Fragment>

--- a/tests/components/combined_system_message/combined_system_message.test.jsx
+++ b/tests/components/combined_system_message/combined_system_message.test.jsx
@@ -58,6 +58,8 @@ describe('components/post_view/CombinedSystemMessage', () => {
         const wrapper = shallowWithIntl(
             <CombinedSystemMessage {...baseProps}/>
         );
+
+        // Fake this state change since getProfilesByIds is called asynchronously
         wrapper.setState({userProfiles});
 
         expect(wrapper).toMatchSnapshot();
@@ -70,6 +72,8 @@ describe('components/post_view/CombinedSystemMessage', () => {
                 showJoinLeave={false}
             />
         );
+
+        // Fake this state change since getProfilesByIds is called asynchronously
         wrapper.setState({userProfiles});
 
         expect(wrapper).toMatchSnapshot();

--- a/tests/components/combined_system_message/combined_system_message.test.jsx
+++ b/tests/components/combined_system_message/combined_system_message.test.jsx
@@ -12,22 +12,65 @@ import CombinedSystemMessage from 'components/post_view/combined_system_message/
 describe('components/post_view/CombinedSystemMessage', () => {
     function emptyFunc() {} // eslint-disable-line no-empty-function
     const baseProps = {
-        teammateNameDisplay: General.TEAMMATE_NAME_DISPLAY.SHOW_USERNAME,
         currentUserId: 'current_user_id',
         currentUsername: 'current_username',
-        allUserIds: ['added_user_id_1', 'user_id_1'],
+        allUserIds: ['added_user_id_1', 'added_user_id_2', 'current_user_id', 'user_id_1'],
         allUsernames: [],
-        messageData: [{actorId: 'user_id_1', postType: Posts.POST_TYPES.ADD_TO_CHANNEL, userIds: ['added_user_id_1']}],
+        messageData: [{
+            actorId: 'user_id_1',
+            postType: Posts.POST_TYPES.ADD_TO_CHANNEL,
+            userIds: ['added_user_id_1'],
+        }, {
+            actorId: 'user_id_1',
+            postType: Posts.POST_TYPES.ADD_TO_CHANNEL,
+            userIds: ['current_user_id'],
+        }, {
+            actorId: 'current_user_id',
+            postType: Posts.POST_TYPES.ADD_TO_CHANNEL,
+            userIds: ['added_user_id_2'],
+        }],
+        showJoinLeave: true,
+        teammateNameDisplay: General.TEAMMATE_NAME_DISPLAY.SHOW_USERNAME,
         actions: {
             getProfilesByIds: emptyFunc,
             getProfilesByUsernames: emptyFunc,
         },
     };
 
+    const userProfiles = [{
+        id: 'added_user_id_1',
+        username: 'AddedUser1',
+    },
+    {
+        id: 'added_user_id_2',
+        username: 'AddedUser2',
+    },
+    {
+        id: 'current_user',
+        username: 'CurrentUser',
+    },
+    {
+        id: 'user_id_1',
+        username: 'User1',
+    }];
+
     test('should match snapshot', () => {
         const wrapper = shallowWithIntl(
             <CombinedSystemMessage {...baseProps}/>
         );
+        wrapper.setState({userProfiles});
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot when join leave messages are turned off', () => {
+        const wrapper = shallowWithIntl(
+            <CombinedSystemMessage
+                {...baseProps}
+                showJoinLeave={false}
+            />
+        );
+        wrapper.setState({userProfiles});
 
         expect(wrapper).toMatchSnapshot();
     });


### PR DESCRIPTION
The redux changes filter out combined system messages that don't relate to the current user while this makes combined system messages for the current user only show the parts that affect the current user. This only affects users that have join/leave messages turned off in Account Settings.

User adding and removing people:
![image](https://user-images.githubusercontent.com/3277310/41378551-5fae79ce-6f2d-11e8-9001-bc0ee55fa9b4.png)

User being added and removed:
![image](https://user-images.githubusercontent.com/3277310/41378571-70eb37e0-6f2d-11e8-9e2e-4a60d07f0afd.png)

Redux PR: https://github.com/mattermost/mattermost-redux/pull/532

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10888

#### Checklist
- Added or updated unit tests (required for all new features)