### PR TITLE
MM-10915 Plus sign missing to add more reactions in GM and DM channels

### DIFF
--- a/components/permissions_gates/channel_permission_gate/index.js
+++ b/components/permissions_gates/channel_permission_gate/index.js
@@ -8,7 +8,7 @@ import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles'
 import ChannelPermissionGate from './channel_permission_gate.jsx';
 
 function mapStateToProps(state, ownProps) {
-    if ((!ownProps.teamId && ownProps.teamId !== '') || !ownProps.channelId) {
+    if (!ownProps.channelId || ownProps.teamId === null || typeof ownProps.teamId === 'undefined') {
         return {hasPermission: false};
     }
 

--- a/components/permissions_gates/channel_permission_gate/index.js
+++ b/components/permissions_gates/channel_permission_gate/index.js
@@ -8,7 +8,7 @@ import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles'
 import ChannelPermissionGate from './channel_permission_gate.jsx';
 
 function mapStateToProps(state, ownProps) {
-    if (!ownProps.teamId || !ownProps.channelId) {
+    if ((!ownProps.teamId && ownProps.teamId !== '') || !ownProps.channelId) {
         return {hasPermission: false};
     }
 

--- a/tests/components/__snapshots__/permissions_gates.test.jsx.snap
+++ b/tests/components/__snapshots__/permissions_gates.test.jsx.snap
@@ -38,6 +38,44 @@ exports[`components/permissions_gates ChannelPermissionGate should match snapsho
 </Provider>
 `;
 
+exports[`components/permissions_gates ChannelPermissionGate should match snapshot when user does not have permissions in DM and GM 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(ChannelPermissionGate)
+    channelId="channel_id"
+    permissions={
+      Array [
+        "invalid_permission",
+      ]
+    }
+    teamId=""
+  >
+    <ChannelPermissionGate
+      channelId="channel_id"
+      dispatch={[Function]}
+      hasPermission={false}
+      invert={false}
+      permissions={
+        Array [
+          "invalid_permission",
+        ]
+      }
+      teamId=""
+    />
+  </Connect(ChannelPermissionGate)>
+</Provider>
+`;
+
 exports[`components/permissions_gates ChannelPermissionGate should match snapshot when user have at least on of the permissions 1`] = `
 <Provider
   store={
@@ -236,6 +274,48 @@ exports[`components/permissions_gates ChannelPermissionGate should match snapsho
         ]
       }
       teamId="team_id"
+    >
+      <p>
+        Valid permission (shown)
+      </p>
+    </ChannelPermissionGate>
+  </Connect(ChannelPermissionGate)>
+</Provider>
+`;
+
+exports[`components/permissions_gates ChannelPermissionGate should match snapshot when user have permissions in DM and GM 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(ChannelPermissionGate)
+    channelId="channel_id"
+    permissions={
+      Array [
+        "test_channel_permission",
+      ]
+    }
+    teamId=""
+  >
+    <ChannelPermissionGate
+      channelId="channel_id"
+      dispatch={[Function]}
+      hasPermission={true}
+      invert={false}
+      permissions={
+        Array [
+          "test_channel_permission",
+        ]
+      }
+      teamId=""
     >
       <p>
         Valid permission (shown)

--- a/tests/components/permissions_gates.test.jsx
+++ b/tests/components/permissions_gates.test.jsx
@@ -333,5 +333,37 @@ describe('components/permissions_gates', () => {
 
             expect(wrapper).toMatchSnapshot();
         });
+
+        test('should match snapshot when user have permissions in DM and GM', () => {
+            const wrapper = mount(
+                <Provider store={store}>
+                    <ChannelPermissionGate
+                        channelId={'channel_id'}
+                        teamId={''}
+                        permissions={['test_channel_permission']}
+                    >
+                        <p>{'Valid permission (shown)'}</p>
+                    </ChannelPermissionGate>
+                </Provider>
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('should match snapshot when user does not have permissions in DM and GM', () => {
+            const wrapper = mount(
+                <Provider store={store}>
+                    <ChannelPermissionGate
+                        channelId={'channel_id'}
+                        teamId={''}
+                        permissions={['invalid_permission']}
+                    >
+                        <p>{'Invalid permission (not shown)'}</p>
+                    </ChannelPermissionGate>
+                </Provider>
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
     });
 });


### PR DESCRIPTION
#### Summary
Check if teamId is empty string before returning permissions as false it is the case for DM and GM

#### Ticket Link
[MM-10915](https://mattermost.atlassian.net/browse/MM-10915)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
