### PR TITLE
user.settings.custom_theme.mentionBg typo

### DIFF
--- a/components/user_settings/display/custom_theme_chooser.jsx
+++ b/components/user_settings/display/custom_theme_chooser.jsx
@@ -61,7 +61,7 @@ const messages = defineMessages({
         defaultMessage: 'Do Not Disturb Indicator',
     },
     mentionBg: {
-        id: 'user.settings.custom_theme.mentionBj',
+        id: 'user.settings.custom_theme.mentionBg',
         defaultMessage: 'Mention Jewel BG',
     },
     mentionColor: {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3151,7 +3151,7 @@
   "user.settings.custom_theme.dndIndicator": "Do Not Disturb Indicator",
   "user.settings.custom_theme.linkButtonTitle": "Link and Button Styles",
   "user.settings.custom_theme.linkColor": "Link Color",
-  "user.settings.custom_theme.mentionBj": "Mention Jewel BG",
+  "user.settings.custom_theme.mentionBg": "Mention Jewel BG",
   "user.settings.custom_theme.mentionColor": "Mention Jewel Text",
   "user.settings.custom_theme.mentionHighlightBg": "Mention Highlight BG",
   "user.settings.custom_theme.mentionHighlightLink": "Mention Highlight Link",


### PR DESCRIPTION
#### Summary
There is a typo in the localization files for user.settings.custom_theme.mentionBg

See:
https://github.com/mattermost/mattermost-mobile/pull/1770

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
