### PR TITLE
Clarify logic in EmojiListItem when user isn't loaded

### DIFF
--- a/components/emoji/emoji_list_item/index.js
+++ b/components/emoji/emoji_list_item/index.js
@@ -15,12 +15,12 @@ import EmojiListItem from './emoji_list_item.jsx';
 
 function mapStateToProps(state, ownProps) {
     const emoji = state.entities.emojis.customEmoji[ownProps.emojiId];
-    const creator = getUser(state, emoji.creator_id) || {};
+    const creator = getUser(state, emoji.creator_id);
 
     return {
         emoji,
         creatorDisplayName: getDisplayNameByUser(creator),
-        creatorUsername: creator.username,
+        creatorUsername: creator ? creator.username : '',
         currentUserId: getCurrentUserId(state),
         currentTeam: getCurrentTeam(state),
     };


### PR DESCRIPTION
This doesn't change any functionality, but there was previously a bug where passing an empty user object to `getDisplayNameByUser` caused a null pointer exception (as reported [here](https://github.com/mattermost/mattermost-server/issues/8844)), so I wanted to clarify what's happening here in case since that function has always handled the case of an `undefined` user.