### PR TITLE
Clean up combined_system_message component

### DIFF
--- a/components/post_view/combined_system_message/combined_system_message.jsx
+++ b/components/post_view/combined_system_message/combined_system_message.jsx
@@ -155,9 +155,10 @@ export default class CombinedSystemMessage extends React.PureComponent {
         messageData: PropTypes.array.isRequired,
         showJoinLeave: PropTypes.bool.isRequired,
         teammateNameDisplay: PropTypes.string.isRequired,
+        userProfiles: PropTypes.array.isRequired,
         actions: PropTypes.shape({
-            getProfilesByIds: PropTypes.func.isRequired,
-            getProfilesByUsernames: PropTypes.func.isRequired,
+            getMissingProfilesByIds: PropTypes.func.isRequired,
+            getMissingProfilesByUsernames: PropTypes.func.isRequired,
         }).isRequired,
     };
 
@@ -170,14 +171,6 @@ export default class CombinedSystemMessage extends React.PureComponent {
         intl: intlShape,
     };
 
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            userProfiles: [],
-        };
-    }
-
     componentDidMount() {
         this.loadUserProfiles(this.props.allUserIds, this.props.allUsernames);
     }
@@ -188,34 +181,24 @@ export default class CombinedSystemMessage extends React.PureComponent {
         }
     }
 
-    loadUserProfiles = async (allUserIds, allUsernames) => {
-        const {actions} = this.props;
-        const userProfiles = [];
+    loadUserProfiles = (allUserIds, allUsernames) => {
         if (allUserIds.length > 0) {
-            const {data} = await actions.getProfilesByIds(allUserIds);
-            if (data.length > 0) {
-                userProfiles.push(...data);
-            }
+            this.props.actions.getMissingProfilesByIds(allUserIds);
         }
 
         if (allUsernames.length > 0) {
-            const {data} = await actions.getProfilesByUsernames(allUsernames);
-            if (data.length > 0) {
-                userProfiles.push(...data);
-            }
+            this.props.actions.getMissingProfilesByUsernames(allUsernames);
         }
-
-        this.setState({userProfiles});
     }
 
     getAllUsersDisplayName = () => {
-        const {userProfiles} = this.state;
         const {
             allUserIds,
             allUsernames,
             currentUserId,
             currentUsername,
             teammateNameDisplay,
+            userProfiles,
         } = this.props;
         const {formatMessage} = this.context.intl;
         const usersDisplayName = userProfiles.reduce((acc, user) => {

--- a/components/post_view/combined_system_message/index.js
+++ b/components/post_view/combined_system_message/index.js
@@ -4,31 +4,37 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {getProfilesByIds, getProfilesByUsernames} from 'mattermost-redux/actions/users';
+import {getMissingProfilesByIds, getMissingProfilesByUsernames} from 'mattermost-redux/actions/users';
 import {Preferences} from 'mattermost-redux/constants';
 import {getBool, getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUser, makeGetProfilesByIdsAndUsernames} from 'mattermost-redux/selectors/entities/users';
 
 import CombinedSystemMessage from './combined_system_message.jsx';
 
-function mapStateToProps(state) {
-    const currentUser = getCurrentUser(state);
+function makeMapStateToProps() {
+    const getProfilesByIdsAndUsernames = makeGetProfilesByIdsAndUsernames();
 
-    return {
-        currentUserId: currentUser.id,
-        currentUsername: currentUser.username,
-        showJoinLeave: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE, true),
-        teammateNameDisplay: getTeammateNameDisplaySetting(state),
+    return (state, ownProps) => {
+        const currentUser = getCurrentUser(state);
+        const {allUserIds, allUsernames} = ownProps;
+
+        return {
+            currentUserId: currentUser.id,
+            currentUsername: currentUser.username,
+            showJoinLeave: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE, true),
+            teammateNameDisplay: getTeammateNameDisplaySetting(state),
+            userProfiles: getProfilesByIdsAndUsernames(state, {allUserIds, allUsernames}),
+        };
     };
 }
 
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            getProfilesByIds,
-            getProfilesByUsernames,
+            getMissingProfilesByIds,
+            getMissingProfilesByUsernames,
         }, dispatch),
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CombinedSystemMessage);
+export default connect(makeMapStateToProps, mapDispatchToProps)(CombinedSystemMessage);


### PR DESCRIPTION
#### Summary
Clean up combined_system_message component
- eliminate async calls that sometimes resolve when the component is unmounted
- get only missing profiles
- let the mattermost-redux handles the profiles (success, failure, store)

~~Note:  This is submitted to master since memory leak encountered on Android RN app is not happening on webapp.  I'll update this once the redux PR (submitted to release-5.0) is merged to master.~~ done update

#### Ticket Link
None but was reported on pre-release:
- https://pre-release.mattermost.com/core/pl/ofbk3xz7jp8u38ckm78usbe5ih
- https://pre-release.mattermost.com/core/pl/ck75xrjispd8mdn4h9edzw1y8c

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has redux changes (https://github.com/mattermost/mattermost-redux/pull/538)
