### PR TITLE
MM-6988 Added Elasticsearch-based search result highlighting

### DIFF
--- a/components/search_results/index.jsx
+++ b/components/search_results/index.jsx
@@ -3,7 +3,7 @@
 
 import {connect} from 'react-redux';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getSearchResults} from 'mattermost-redux/selectors/entities/posts';
+import {getSearchMatches, getSearchResults} from 'mattermost-redux/selectors/entities/posts';
 import * as PreferenceSelectors from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
@@ -68,6 +68,7 @@ function makeMapStateToProps() {
 
         return {
             results: posts,
+            matches: getSearchMatches(state),
             channels,
             searchTerms: getSearchResultsTerms(state),
             isFlaggedByPostId,

--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -42,6 +42,7 @@ export function renderThumbVertical(props) {
 export default class SearchResults extends React.PureComponent {
     static propTypes = {
         results: PropTypes.array,
+        matches: PropTypes.object,
         channels: PropTypes.object,
         searchTerms: PropTypes.string,
         isFlaggedByPostId: PropTypes.object,
@@ -55,6 +56,10 @@ export default class SearchResults extends React.PureComponent {
         channelDisplayName: PropTypes.string.isRequired,
         dataRetentionEnableMessageDeletion: PropTypes.bool.isRequired,
         dataRetentionMessageRetentionDays: PropTypes.string,
+    };
+
+    static defaultProps = {
+        matches: {},
     };
 
     constructor(props) {
@@ -327,7 +332,7 @@ export default class SearchResults extends React.PureComponent {
                 sortedResults = results;
             }
 
-            ctls = sortedResults.map(function searchResults(post, idx, arr) {
+            ctls = sortedResults.map((post, idx, arr) => {
                 let profile;
                 if (UserStore.getCurrentId() === post.user_id) {
                     profile = UserStore.getCurrentUser();
@@ -353,6 +358,7 @@ export default class SearchResults extends React.PureComponent {
                         channel={this.props.channels.get(post.channel_id)}
                         compactDisplay={this.props.compactDisplay}
                         post={post}
+                        matches={this.props.matches[post.id]}
                         lastPostCount={(reverseCount >= 0 && reverseCount < Constants.TEST_ID_COUNT) ? reverseCount : -1}
                         user={profile}
                         term={searchTerms}

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -32,6 +32,11 @@ export default class SearchResultsItem extends React.PureComponent {
         post: PropTypes.object,
 
         /**
+        * An array of strings in this post that were matched by the search
+        */
+        matches: PropTypes.array,
+
+        /**
         *  count used for passing down to PostFlagIcon, DotMenu and CommentIcon
         */
         lastPostCount: PropTypes.number,
@@ -284,6 +289,7 @@ export default class SearchResultsItem extends React.PureComponent {
                         post={post}
                         options={{
                             searchTerm: this.props.term,
+                            searchMatches: this.props.matches,
                             mentionHighlight: this.props.isMentionSearch,
                         }}
                     />

--- a/package-lock.json
+++ b/package-lock.json
@@ -10869,8 +10869,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
-      "from": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
+      "version": "github:mattermost/mattermost-redux#6aee7c45bcde7d2079ee5b24f70e7e8d071ae0a6",
+      "from": "github:mattermost/mattermost-redux#6aee7c45bcde7d2079ee5b24f70e7e8d071ae0a6",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "localforage": "1.7.1",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#85edf0d1cae3b786d9be1946f19a23603af18417",
+    "mattermost-redux": "github:mattermost/mattermost-redux#6aee7c45bcde7d2079ee5b24f70e7e8d071ae0a6",
     "moment-timezone": "0.5.17",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/tests/components/__snapshots__/search_results_item.test.jsx.snap
+++ b/tests/components/__snapshots__/search_results_item.test.jsx.snap
@@ -177,6 +177,7 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
                 options={
                   Object {
                     "mentionHighlight": false,
+                    "searchMatches": undefined,
                     "searchTerm": "test",
                   }
                 }
@@ -367,6 +368,7 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
                 options={
                   Object {
                     "mentionHighlight": false,
+                    "searchMatches": undefined,
                     "searchTerm": "test",
                   }
                 }

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -20,6 +20,8 @@ const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-
 // @mentions and ~channels to links by taking a user's message and returning a string of formatted html. Also takes
 // a number of options as part of the second parameter:
 // - searchTerm - If specified, this word is highlighted in the resulting html. Defaults to nothing.
+// - searchMatches - If specified, an array of words that will be highlighted. Defaults to nothing. If both
+//     this and searchTerm are specified, this takes precedence.
 // - mentionHighlight - Specifies whether or not to highlight mentions of the current user. Defaults to true.
 // - mentionKeys - A list of mention keys for the current user to highlight.
 // - singleline - Specifies whether or not to remove newlines. Defaults to false.
@@ -29,7 +31,7 @@ const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-
 //     links that can be handled by a special click handler.
 // - atMentions - Whether or not to render at mentions into spans with a data-mention attribute. Defaults to false.
 // - channelNamesMap - An object mapping channel display names to channels. If provided, ~channel mentions will be replaced with
-//      links to the relevant channel.
+//     links to the relevant channel.
 // - team - The current team.
 // - proxyImages - If specified, images are proxied. Defaults to false.
 // - autolinkedUrlSchemes - An array of url schemes that will be allowed for autolinking. Defaults to autolinking with any url scheme.
@@ -41,7 +43,12 @@ export function formatText(text, inputOptions) {
     let output = text;
 
     const options = Object.assign({}, inputOptions);
-    options.searchPatterns = parseSearchTerms(options.searchTerm).map(convertSearchTermToRegex);
+
+    if (options.searchMatches) {
+        options.searchPatterns = options.searchMatches.map(convertSearchTermToRegex);
+    } else {
+        options.searchPatterns = parseSearchTerms(options.searchTerm).map(convertSearchTermToRegex);
+    }
 
     if (!('markdown' in options) || options.markdown) {
         // the markdown renderer will call doFormatText as necessary


### PR DESCRIPTION
Since Elasticsearch gives us more detailed matches, we can use those to highlight the matched words without trying to guess for things like wildcard searches

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-6988

#### Checklist
- Added or updated unit tests (required for all new features)
- Has server changes (https://github.com/mattermost/mattermost-server/pull/8861)
- Has redux changes (https://github.com/mattermost/mattermost-redux/pull/541)
- Has UI changes
