### PR TITLE
[MM-10974] Remove Character Limit in Reset Email Modal

### DIFF
--- a/components/admin_console/reset_email_modal/reset_email_modal.jsx
+++ b/components/admin_console/reset_email_modal/reset_email_modal.jsx
@@ -121,7 +121,6 @@ export default class ResetEmailModal extends React.Component {
                                         type='email'
                                         ref='email'
                                         className='form-control'
-                                        maxLength='22'
                                         autoFocus={true}
                                         tabIndex='1'
                                     />

--- a/components/admin_console/reset_email_modal/reset_email_modal.jsx
+++ b/components/admin_console/reset_email_modal/reset_email_modal.jsx
@@ -121,6 +121,7 @@ export default class ResetEmailModal extends React.Component {
                                         type='email'
                                         ref='email'
                                         className='form-control'
+                                        maxLength='128'
                                         autoFocus={true}
                                         tabIndex='1'
                                     />


### PR DESCRIPTION
#### Summary
Remove the character limit that currently exists in the reset email modal under system console.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10974

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed