### PR TITLE
Track the nickname when needed, not the username

### DIFF
--- a/components/user_settings/general/user_settings_general.jsx
+++ b/components/user_settings/general/user_settings_general.jsx
@@ -158,7 +158,7 @@ class UserSettingsGeneralTab extends React.Component {
 
         user.nickname = nickname;
 
-        trackEvent('settings', 'user_settings_update', {field: 'username'});
+        trackEvent('settings', 'user_settings_update', {field: 'nickname'});
 
         this.submitUser(user, false);
     }


### PR DESCRIPTION
#### Summary
The wrong event is tracked during submitNickname. A trivial username -> nickname typo

#### Ticket Link
N/A

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
