### PR TITLE
Fix allways typo in the edit post modal tests

### DIFF
--- a/tests/components/edit_post_modal.test.jsx
+++ b/tests/components/edit_post_modal.test.jsx
@@ -18,7 +18,7 @@ jest.mock('actions/global_actions.jsx', () => ({
 function createEditPost({ctrlSend, config, license, editingPost, actions} = {}) {
     const ctrlSendProp = ctrlSend || false;
     const configProp = config || {
-        AllowEditPost: 'allways',
+        AllowEditPost: 'always',
         PostEditTimeLimit: 300,
         EnableEmojiPicker: 'true',
     };
@@ -63,7 +63,7 @@ describe('components/EditPostModal', () => {
 
     it('should match without emoji picker', () => {
         const config = {
-            AllowEditPost: 'allways',
+            AllowEditPost: 'always',
             PostEditTimeLimit: 300,
             EnableEmojiPicker: 'false',
         };


### PR DESCRIPTION
#### Summary
The string "allways" is unknown identifier, while "always" is valid one.

#### Ticket Link
N/A

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
