### PR TITLE
White labeling the file sharing functionality in Android

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2353,7 +2353,7 @@
   "mobile.extension.max_file_size": "File attachments shared in Mattermost must be less than {size}.",
   "mobile.extension.permission": "Mattermost needs access to the device storage to share files.",
   "mobile.extension.posting": "Posting...",
-  "mobile.extension.title": "Share in Mattermost",
+  "mobile.extension.title": "Share in {siteName}",
   "mobile.failed_network_action.description": "There seems to be a problem with your internet connection. Make sure you have an active connection and try again.",
   "mobile.failed_network_action.retry": "Try Again",
   "mobile.failed_network_action.title": "No internet connection",


### PR DESCRIPTION
#### Summary
When you share a file from your Android device then click "Mattermost" as the target.  A screen pops up that shows "Share in Mattermost". I have white labelled this functionality to use the SiteName config value.

The only change that needs made in this repo is the localization file.

See:
https://github.com/mattermost/mattermost-mobile/pull/1793

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
