### PR TITLE
MM-10873 Preserve newlines in mobile view channel headers

### DIFF
--- a/components/navbar/navbar_info_button.jsx
+++ b/components/navbar/navbar_info_button.jsx
@@ -9,7 +9,7 @@ import {FormattedMessage} from 'react-intl';
 import Markdown from 'components/markdown';
 import InfoIcon from 'components/svg/info_icon';
 
-const headerMarkdownOptions = {singleline: true, mentionHighlight: false};
+const headerMarkdownOptions = {mentionHighlight: false};
 
 export default class NavbarInfoButton extends React.PureComponent {
     static propTypes = {
@@ -80,6 +80,7 @@ export default class NavbarInfoButton extends React.PureComponent {
             <Popover
                 bsStyle='info'
                 placement='bottom'
+                className='navbar__popover'
                 id='header-popover'
             >
                 {popoverContent}

--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -352,7 +352,8 @@
     }
 }
 
-.channel-header__popover {
+.channel-header__popover,
+.navbar__popover {
     p {
         white-space: pre-wrap;
     }

--- a/tests/components/navbar/__snapshots__/navbar_info_button.test.jsx.snap
+++ b/tests/components/navbar/__snapshots__/navbar_info_button.test.jsx.snap
@@ -42,6 +42,7 @@ exports[`components/navbar/NavbarInfoButton should match snapshot, with channel 
       <Popover
         bsClass="popover"
         bsStyle="info"
+        className="navbar__popover"
         id="header-popover"
         placement="bottom"
       >
@@ -50,7 +51,6 @@ exports[`components/navbar/NavbarInfoButton should match snapshot, with channel 
           options={
             Object {
               "mentionHighlight": false,
-              "singleline": true,
             }
           }
         />
@@ -159,6 +159,7 @@ exports[`components/navbar/NavbarInfoButton should match snapshot, without chann
       <Popover
         bsClass="popover"
         bsStyle="info"
+        className="navbar__popover"
         id="header-popover"
         placement="bottom"
       >


### PR DESCRIPTION
The previous PR for this only changed this in desktop view, so this adds it for mobile view.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10873