### PR TITLE
replace a well-intentioned &nbsp; with a ' ' instead

### DIFF
--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -285,18 +285,13 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
 
         let body;
         if (data.description || imageUrl) {
-            let separator;
-            if (data.description && imageUrl) {
-                separator = ' &nbsp';
-            }
-
             body = (
                 <React.Fragment>
                     <div className={'attachment__body attachment__body--opengraph'}>
                         <div>
                             <div>
                                 {this.truncateText(data.description)}
-                                {separator}
+                                {' '}
                                 {this.imageToggleAnchorTag(imageUrl)}
                             </div>
                             {this.imageTag(imageUrl, true)}


### PR DESCRIPTION
#### Summary
The code looks to ensure there is a space between the end of the opengraph text and the expand/contract icon. However, after some refactorings, the &nbsp; in question ended up inside a string, and only conditionally displayed. Simplify all of this with just the necessary {' '} that accomplishes the desired purpose in React.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11009

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed