### PR TITLE
MM-10981: Fix redirect to last channel http://<host>/ load

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -7,7 +7,6 @@ import {
     getChannel,
     createDirectChannel,
     getChannelByNameAndTeamName,
-    getChannelAndMyMember,
     getChannelStats,
     getMyChannelMember,
     joinChannel,
@@ -515,18 +514,11 @@ export async function redirectUserToDefaultTeam() {
 
     const team = teams[teamId];
     if (team) {
-        const channelId = BrowserStore.getGlobalItem(teamId);
-        const channel = ChannelStore.getChannelById(channelId);
-        let channelName = Constants.DEFAULT_CHANNEL;
+        let channelName = BrowserStore.getGlobalItem(Constants.PREV_CHANNEL_KEY + teamId, Constants.DEFAULT_CHANNEL);
+        const channel = ChannelStore.getChannelNamesMap()[channelName];
         if (channel && channel.team_id === team.id) {
             dispatch(selectChannel(channel.id));
             channelName = channel.name;
-        } else if (channelId) {
-            const {data} = await getChannelAndMyMember(channelId)(dispatch, getState);
-            if (data) {
-                dispatch(selectChannel(channelId));
-                channelName = data.channel.name;
-            }
         } else {
             const {data} = await dispatch(getChannelByNameAndTeamName(team.name, channelName));
             if (data) {


### PR DESCRIPTION
#### Summary
Fix the redirect to the last opened channel when you go to http://<host>/.

To easy the understanding of the fix, this was broken in the PR #875 fixing
other redirection to last opened channel. The PR changes how is stored the last
opened channel and I'm only propagating the change to the
redirectUserToDefaultTeam function.

#### Ticket Link
[MM-10981](https://mattermost.atlassian.net/browse/MM-10981)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed