### PR TITLE
MM-10767: Fix the ordering for chrome

### DIFF
--- a/components/team_selector_modal/team_selector_modal.jsx
+++ b/components/team_selector_modal/team_selector_modal.jsx
@@ -210,7 +210,17 @@ export default class TeamSelectorModal extends React.Component {
             teams = this.props.teams.filter((team) => team.delete_at === 0);
             teams = teams.filter((team) => team.scheme_id !== this.currentSchemeId);
             teams = teams.filter((team) => this.props.alreadySelected.indexOf(team.id) === -1);
-            teams.sort((a, b) => a.display_name.toUpperCase() > b.display_name.toUpperCase());
+            teams.sort((a, b) => {
+                const aName = a.display_name.toUpperCase();
+                const bName = b.display_name.toUpperCase();
+                if (aName === bName) {
+                    return 0;
+                }
+                if (aName > bName) {
+                    return 1;
+                }
+                return -1;
+            });
         }
 
         return (


### PR DESCRIPTION
#### Summary
In chrome the sort function receive a function that must return a `-1`, `0` or
`1`. If you return a boolean it works fine for any other browser, but in chrome
give you a random order.

Here you can see an explanation of this: https://bugs.chromium.org/p/v8/issues/detail?id=103

#### Ticket Link
[MM-10767](https://mattermost.atlassian.net/browse/MM-10767)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed