### PR TITLE
Shrink RHS when clicking on the backdrop

### DIFF
--- a/components/sidebar_right/index.js
+++ b/components/sidebar_right/index.js
@@ -8,7 +8,7 @@ import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
 import PostStore from 'stores/post_store';
-import {getPinnedPosts, getFlaggedPosts} from 'actions/views/rhs';
+import {getPinnedPosts, getFlaggedPosts, setRhsExpanded} from 'actions/views/rhs';
 import {
     getIsRhsExpanded,
     getIsRhsOpen,
@@ -60,6 +60,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             getPinnedPosts,
             getFlaggedPosts,
+            setRhsExpanded,
         }, dispatch),
     };
 }

--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -29,8 +29,9 @@ export default class SidebarRight extends React.Component {
         isPinnedPosts: PropTypes.bool,
         previousRhsState: PropTypes.string,
         actions: PropTypes.shape({
-            getPinnedPosts: PropTypes.func,
-            getFlaggedPosts: PropTypes.func,
+            getPinnedPosts: PropTypes.func.isRequired,
+            getFlaggedPosts: PropTypes.func.isRequired,
+            setRhsExpanded: PropTypes.func.isRequired,
         }),
     }
 
@@ -72,6 +73,10 @@ export default class SidebarRight extends React.Component {
             this.props.actions.getPinnedPosts(this.props.channel.id);
         }
     }
+
+    onShrink = () => {
+        this.props.actions.setRhsExpanded(false);
+    };
 
     render() {
         const {


### PR DESCRIPTION
#### Summary
the function `onShrink` was not even present, this PR fixes the behavior of clicking on the backdrop for the RHS when expanded.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11076
