### PR TITLE
MM-11158: fix subpath logout

### DIFF
--- a/selectors/general.js
+++ b/selectors/general.js
@@ -17,5 +17,9 @@ export function areTimezonesEnabledAndSupported(state) {
 export function getBasePath(state) {
     const config = getConfig(state) || {};
 
-    return new URL(config.SiteURL || window.location.origin).pathname;
+    if (config.SiteURL) {
+        return new URL(config.SiteURL).pathname;
+    }
+
+    return window.basename || window.location.origin;
 }


### PR DESCRIPTION
#### Summary
Fall back to `window.basename` instead of `window.location.origin`, to ensure the subpath is reflected on logout. This ended up being a last minute regression in the PR phase :/

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11158

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
