### PR TITLE
MM-11109 Properly highlight mentions followed by an underscore

### DIFF
--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -275,7 +275,7 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
     }
 
     // look for self mentions in the text
-    function replaceCurrentMentionWithToken(fullMatch, prefix, mention) {
+    function replaceCurrentMentionWithToken(fullMatch, prefix, mention, suffix = '') {
         const index = tokens.size;
         const alias = `$MM_SELFMENTION${index}`;
 
@@ -284,7 +284,7 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
             originalText: mention,
         });
 
-        return prefix + alias;
+        return prefix + alias + suffix;
     }
 
     for (const mention of mentionKeys) {
@@ -297,7 +297,7 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
             flags += 'i';
         }
 
-        const pattern = new RegExp(`(^|\\W)(${escapeRegex(mention.key)})\\b`, flags);
+        const pattern = new RegExp(`(^|\\W)(${escapeRegex(mention.key)})(\\b|_+\\b)`, flags);
 
         output = output.replace(pattern, replaceCurrentMentionWithToken);
     }


### PR DESCRIPTION
The `\b` at the end of the regex pattern matches a boundary between a word and non-word character. An underscore is considered a word character, so the pattern wouldn't match a word followed by an underscore.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11109