### PR TITLE
MM-11163: Handle mobile view switch_team case

### DIFF
--- a/components/get_android_app/get_android_app.jsx
+++ b/components/get_android_app/get_android_app.jsx
@@ -59,7 +59,7 @@ export default function GetAndroidApp({androidAppDownloadLink}) {
                     defaultMessage='Or {link}'
                     values={{
                         link: (
-                            <Link to='/switch_team'>
+                            <Link to='/'>
                                 <FormattedMessage
                                     id='get_app.continueWithBrowserLink'
                                     defaultMessage='continue with browser'

--- a/components/get_ios_app/get_ios_app.jsx
+++ b/components/get_ios_app/get_ios_app.jsx
@@ -52,7 +52,7 @@ export default function GetIosApp({iosAppDownloadLink}) {
                     defaultMessage='Or {link}'
                     values={{
                         link: (
-                            <Link to='/switch_team'>
+                            <Link to='/'>
                                 <FormattedMessage
                                     id='get_app.continueWithBrowserLink'
                                     defaultMessage='continue with browser'


### PR DESCRIPTION
#### Summary
After the inclusion of "try to auto join by url to a channel if it is
open" the trick done from mobile view to go to the default team (use the
/switch_team url) wasn't working anymore. This fix that problem.

#### Ticket Link
[MM-11163](https://mattermost.atlassian.net/browse/MM-11163)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed