### PR TITLE
[MM-11222] Fix overflow issue on help pages

### DIFF
--- a/sass/base/_structure.scss
+++ b/sass/base/_structure.scss
@@ -11,7 +11,6 @@ body {
 }
 
 body {
-    @include clearfix;
     background: $bg--gray;
     position: relative;
     width: 100%;


### PR DESCRIPTION
#### Summary
Fix overflow issue with help pages.

The code i removed was introduced [here](https://mattermost.atlassian.net/browse/MM-11222) to fix Grammarly scroll issue. But I cannot replicate this anymore so, there is a good chance Grammarly might have fixed it on their end

#### Ticket Link
[MM-11222](https://mattermost.atlassian.net/browse/MM-11222)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
