### PR TITLE
Various plugin updates and fixes

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -145,12 +145,24 @@ export function stopPeriodicSync() {
     clearInterval(intervalId);
 }
 
-export function registerPluginWebSocketEvent(event, action) {
-    pluginEventHandlers[event] = action;
+export function registerPluginWebSocketEvent(pluginId, event, action) {
+    if (!pluginEventHandlers[pluginId]) {
+        pluginEventHandlers[pluginId] = {};
+    }
+    pluginEventHandlers[pluginId][event] = action;
 }
 
-export function unregisterPluginWebSocketEvent(event) {
-    Reflect.deleteProperty(pluginEventHandlers, event);
+export function unregisterPluginWebSocketEvent(pluginId, event) {
+    const events = pluginEventHandlers[pluginId];
+    if (!events) {
+        return;
+    }
+
+    Reflect.deleteProperty(events, event);
+}
+
+export function unregisterAllPluginWebSocketEvents(pluginId) {
+    Reflect.deleteProperty(pluginEventHandlers, pluginId);
 }
 
 function handleFirstConnect() {
@@ -321,9 +333,15 @@ function handleEvent(msg) {
     default:
     }
 
-    if (pluginEventHandlers.hasOwnProperty(msg.event) && typeof pluginEventHandlers[msg.event] === 'function') {
-        pluginEventHandlers[msg.event](msg);
-    }
+    Object.values(pluginEventHandlers).forEach((pluginEvents) => {
+        if (!pluginEvents) {
+            return;
+        }
+
+        if (pluginEvents.hasOwnProperty(msg.event) && typeof pluginEvents[msg.event] === 'function') {
+            pluginEvents[msg.event](msg);
+        }
+    });
 }
 
 // handleChannelConvertedEvent handles updating of channel which is converted from public to private

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -105,12 +105,28 @@ function reconnectWebSocket() {
     initialize();
 }
 
+const pluginReconnectHandlers = {};
+
+export function registerPluginReconnectHandler(pluginId, handler) {
+    pluginReconnectHandlers[pluginId] = handler;
+}
+
+export function unregisterPluginReconnectHandler(pluginId) {
+    Reflect.deleteProperty(pluginReconnectHandlers, pluginId);
+}
+
 export function reconnect(includeWebSocket = true) {
     if (includeWebSocket) {
         reconnectWebSocket();
     }
 
     loadPluginsIfNecessary();
+
+    Object.values(pluginReconnectHandlers).forEach((handler) => {
+        if (handler && typeof handler === 'function') {
+            handler();
+        }
+    });
 
     const currentTeamId = getState().entities.teams.currentTeamId;
     if (currentTeamId) {

--- a/components/post_profile_picture/post_profile_picture.jsx
+++ b/components/post_profile_picture/post_profile_picture.jsx
@@ -4,6 +4,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {PostTypes} from 'mattermost-redux/constants/posts';
+
 import ProfilePicture from 'components/profile_picture';
 import MattermostLogo from 'components/svg/mattermost_logo';
 
@@ -58,12 +60,13 @@ export default class PostProfilePicture extends React.PureComponent {
 
     render() {
         const isSystemMessage = PostUtils.isSystemMessage(this.props.post);
-        if (isSystemMessage && !this.props.compactDisplay) {
+        const isEphemeral = PostUtils.isEphemeral(this.props.post);
+        const fromWebhook = PostUtils.isFromWebhook(this.props.post);
+        if (isSystemMessage && !this.props.compactDisplay && isEphemeral && !fromWebhook) {
             return <MattermostLogo className='icon'/>;
         }
 
         const fromAutoResponder = PostUtils.fromAutoResponder(this.props.post);
-        const fromWebhook = PostUtils.isFromWebhook(this.props.post);
 
         const hasMention = !fromAutoResponder && !fromWebhook;
         const src = this.getProfilePicSrcForPost(fromAutoResponder, fromWebhook);

--- a/components/post_profile_picture/post_profile_picture.jsx
+++ b/components/post_profile_picture/post_profile_picture.jsx
@@ -60,9 +60,8 @@ export default class PostProfilePicture extends React.PureComponent {
 
     render() {
         const isSystemMessage = PostUtils.isSystemMessage(this.props.post);
-        const isEphemeral = PostUtils.isEphemeral(this.props.post);
         const fromWebhook = PostUtils.isFromWebhook(this.props.post);
-        if (isSystemMessage && !this.props.compactDisplay && isEphemeral && !fromWebhook) {
+        if (isSystemMessage && !this.props.compactDisplay && !fromWebhook) {
             return <MattermostLogo className='icon'/>;
         }
 

--- a/components/post_profile_picture/post_profile_picture.jsx
+++ b/components/post_profile_picture/post_profile_picture.jsx
@@ -4,8 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {PostTypes} from 'mattermost-redux/constants/posts';
-
 import ProfilePicture from 'components/profile_picture';
 import MattermostLogo from 'components/svg/mattermost_logo';
 

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -15,6 +15,7 @@ import EventTypes from 'utils/event_types.jsx';
 import GlobalEventEmitter from 'utils/global_event_emitter.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
+import {isFromWebhook} from 'utils/post_utils.jsx';
 
 import LoadingScreen from 'components/loading_screen.jsx';
 import DateSeparator from 'components/post_view/date_separator.jsx';
@@ -538,7 +539,8 @@ export default class PostList extends React.PureComponent {
                 );
             }
 
-            if (post.user_id !== currentUserId &&
+            const isNotCurrentUser = post.user_id !== currentUserId || isFromWebhook(post);
+            if (isNotCurrentUser &&
                     lastViewed !== 0 &&
                     post.create_at > lastViewed &&
                     !Utils.isPostEphemeral(post) &&

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -22,6 +22,7 @@ import redFavicon from 'images/favicon/redfavicon-16x16.png';
 import MoreChannels from 'components/more_channels';
 import MoreDirectChannels from 'components/more_direct_channels';
 import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
+import Pluggable from 'plugins/pluggable';
 
 import NewChannelFlow from '../new_channel_flow.jsx';
 import UnreadChannelIndicator from '../unread_channel_indicator.jsx';
@@ -664,109 +665,115 @@ export default class Sidebar extends React.PureComponent {
                     currentUser={this.props.currentUser}
                 />
 
-                <UnreadChannelIndicator
-                    name='Top'
-                    show={this.state.showTopUnread}
-                    onClick={this.scrollToFirstUnreadChannel}
-                    extraClass='nav-pills__unread-indicator-top'
-                    content={above}
-                />
-                <UnreadChannelIndicator
-                    name='Bottom'
-                    show={this.state.showBottomUnread}
-                    onClick={this.scrollToLastUnreadChannel}
-                    extraClass='nav-pills__unread-indicator-bottom'
-                    content={below}
-                />
+                <div className='sidebar--left__icons'>
+                    <Pluggable pluggableName='LeftSidebarHeader'/>
+                </div>
 
-                <div
-                    id='sidebarChannelContainer'
-                    ref='container'
-                    className='nav-pills__container'
-                    onScroll={this.onScroll}
-                >
-                    {unreadChannelItems.length !== 0 && <ul className='nav nav-pills nav-stacked'>
-                        <li>
-                            <h4 id='favoriteChannel'>
-                                <FormattedMessage
-                                    id='sidebar.unreadSection'
-                                    defaultMessage='UNREADS'
-                                />
-                            </h4>
-                        </li>
-                        {unreadChannelItems}
-                    </ul>}
-                    {favoriteItems.length !== 0 && <ul className='nav nav-pills nav-stacked'>
-                        <li>
-                            <h4 id='favoriteChannel'>
-                                <FormattedMessage
-                                    id='sidebar.favorite'
-                                    defaultMessage='FAVORITE CHANNELS'
-                                />
-                            </h4>
-                        </li>
-                        {favoriteItems}
-                    </ul>}
-                    <ul className='nav nav-pills nav-stacked'>
-                        <li>
-                            <h4 id='publicChannel'>
-                                <FormattedMessage
-                                    id='sidebar.channels'
-                                    defaultMessage='PUBLIC CHANNELS'
-                                />
-                                <TeamPermissionGate
-                                    teamId={this.props.currentTeam.id}
-                                    permissions={[Permissions.CREATE_PUBLIC_CHANNEL]}
-                                >
-                                    {createPublicChannelIcon}
-                                </TeamPermissionGate>
-                            </h4>
-                        </li>
-                        {publicChannelItems}
-                        <li>
-                            <button
-                                id='sidebarChannelsMore'
-                                className='nav-more cursor--pointer style--none btn--block'
-                                onClick={this.showMoreChannelsModal}
-                            >
-                                <FormattedMessage
-                                    id='sidebar.moreElips'
-                                    defaultMessage='More...'
-                                />
-                            </button>
-                        </li>
-                    </ul>
+                <div className='sidebar--left__list'>
+                    <UnreadChannelIndicator
+                        name='Top'
+                        show={this.state.showTopUnread}
+                        onClick={this.scrollToFirstUnreadChannel}
+                        extraClass='nav-pills__unread-indicator-top'
+                        content={above}
+                    />
+                    <UnreadChannelIndicator
+                        name='Bottom'
+                        show={this.state.showBottomUnread}
+                        onClick={this.scrollToLastUnreadChannel}
+                        extraClass='nav-pills__unread-indicator-bottom'
+                        content={below}
+                    />
 
-                    <ul className='nav nav-pills nav-stacked'>
-                        <li>
-                            <h4 id='privateChannel'>
-                                <FormattedMessage
-                                    id='sidebar.pg'
-                                    defaultMessage='PRIVATE CHANNELS'
-                                />
-                                <TeamPermissionGate
-                                    teamId={this.props.currentTeam.id}
-                                    permissions={[Permissions.CREATE_PRIVATE_CHANNEL]}
+                    <div
+                        id='sidebarChannelContainer'
+                        ref='container'
+                        className='nav-pills__container'
+                        onScroll={this.onScroll}
+                    >
+                        {unreadChannelItems.length !== 0 && <ul className='nav nav-pills nav-stacked'>
+                            <li>
+                                <h4 id='favoriteChannel'>
+                                    <FormattedMessage
+                                        id='sidebar.unreadSection'
+                                        defaultMessage='UNREADS'
+                                    />
+                                </h4>
+                            </li>
+                            {unreadChannelItems}
+                        </ul>}
+                        {favoriteItems.length !== 0 && <ul className='nav nav-pills nav-stacked'>
+                            <li>
+                                <h4 id='favoriteChannel'>
+                                    <FormattedMessage
+                                        id='sidebar.favorite'
+                                        defaultMessage='FAVORITE CHANNELS'
+                                    />
+                                </h4>
+                            </li>
+                            {favoriteItems}
+                        </ul>}
+                        <ul className='nav nav-pills nav-stacked'>
+                            <li>
+                                <h4 id='publicChannel'>
+                                    <FormattedMessage
+                                        id='sidebar.channels'
+                                        defaultMessage='PUBLIC CHANNELS'
+                                    />
+                                    <TeamPermissionGate
+                                        teamId={this.props.currentTeam.id}
+                                        permissions={[Permissions.CREATE_PUBLIC_CHANNEL]}
+                                    >
+                                        {createPublicChannelIcon}
+                                    </TeamPermissionGate>
+                                </h4>
+                            </li>
+                            {publicChannelItems}
+                            <li>
+                                <button
+                                    id='sidebarChannelsMore'
+                                    className='nav-more cursor--pointer style--none btn--block'
+                                    onClick={this.showMoreChannelsModal}
                                 >
-                                    {createPrivateChannelIcon}
-                                </TeamPermissionGate>
-                            </h4>
-                        </li>
-                        {privateChannelItems}
-                    </ul>
-                    <ul className='nav nav-pills nav-stacked'>
-                        <li>
-                            <h4 id='directChannel'>
-                                <FormattedMessage
-                                    id='sidebar.direct'
-                                    defaultMessage='DIRECT MESSAGES'
-                                />
-                                {createDirectMessageIcon}
-                            </h4>
-                        </li>
-                        {directMessageItems}
-                        {directMessageMore}
-                    </ul>
+                                    <FormattedMessage
+                                        id='sidebar.moreElips'
+                                        defaultMessage='More...'
+                                    />
+                                </button>
+                            </li>
+                        </ul>
+
+                        <ul className='nav nav-pills nav-stacked'>
+                            <li>
+                                <h4 id='privateChannel'>
+                                    <FormattedMessage
+                                        id='sidebar.pg'
+                                        defaultMessage='PRIVATE CHANNELS'
+                                    />
+                                    <TeamPermissionGate
+                                        teamId={this.props.currentTeam.id}
+                                        permissions={[Permissions.CREATE_PRIVATE_CHANNEL]}
+                                    >
+                                        {createPrivateChannelIcon}
+                                    </TeamPermissionGate>
+                                </h4>
+                            </li>
+                            {privateChannelItems}
+                        </ul>
+                        <ul className='nav nav-pills nav-stacked'>
+                            <li>
+                                <h4 id='directChannel'>
+                                    <FormattedMessage
+                                        id='sidebar.direct'
+                                        defaultMessage='DIRECT MESSAGES'
+                                    />
+                                    {createDirectMessageIcon}
+                                </h4>
+                            </li>
+                            {directMessageItems}
+                            {directMessageMore}
+                        </ul>
+                    </div>
                 </div>
                 <div className='sidebar__switcher'>
                     <button

--- a/components/team_sidebar/team_sidebar_controller.jsx
+++ b/components/team_sidebar/team_sidebar_controller.jsx
@@ -15,6 +15,7 @@ import {filterAndSortTeamsByDisplayName} from 'utils/team_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import SystemPermissionGate from 'components/permissions_gates/system_permission_gate';
+import Pluggable from 'plugins/pluggable';
 
 import TeamButton from './components/team_button.jsx';
 
@@ -182,6 +183,12 @@ export default class TeamSidebar extends React.Component {
                 </SystemPermissionGate>
             );
         }
+
+        teams.push(
+            <div className='team-sidebar-bottom-plugin'>
+                <Pluggable pluggableName='BottomTeamSidebar'/>
+            </div>
+        );
 
         return (
             <div className={classNames('team-sidebar', {'move--right': this.props.isOpen})}>

--- a/components/user_profile.jsx
+++ b/components/user_profile.jsx
@@ -16,6 +16,7 @@ export default class UserProfile extends React.Component {
 
         this.hideProfilePopover = this.hideProfilePopover.bind(this);
     }
+
     shouldComponentUpdate(nextProps) {
         if (!Utils.areObjectsEqual(nextProps.user, this.props.user)) {
             return true;

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -9,7 +9,7 @@ import messageHtmlToComponent from 'utils/message_html_to_component';
 import {getSiteURL} from 'utils/url.jsx';
 import {formatText} from 'utils/text_formatting.jsx';
 import PluginRegistry from 'plugins/registry';
-import {unregisterAllPluginWebSocketEvents} from 'actions/websocket_actions.jsx';
+import {unregisterAllPluginWebSocketEvents, unregisterPluginReconnectHandler} from 'actions/websocket_actions.jsx';
 
 window.plugins = {};
 
@@ -86,6 +86,7 @@ export function removePlugin(manifest) {
         plugin.deinitialize();
     }
     unregisterAllPluginWebSocketEvents(manifest.id);
+    unregisterPluginReconnectHandler(manifest.id);
     const script = document.getElementById('plugin_' + manifest.id);
     if (!script) {
         return;

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -80,6 +80,10 @@ export function loadPlugin(manifest) {
 }
 
 export function removePlugin(manifest) {
+    const plugin = window.plugins[manifest.id];
+    if (plugin && plugin.deinitialize) {
+        plugin.deinitialize();
+    }
     const script = document.getElementById('plugin_' + manifest.id);
     if (!script) {
         return;

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -9,6 +9,7 @@ import messageHtmlToComponent from 'utils/message_html_to_component';
 import {getSiteURL} from 'utils/url.jsx';
 import {formatText} from 'utils/text_formatting.jsx';
 import PluginRegistry from 'plugins/registry';
+import {unregisterAllPluginWebSocketEvents} from 'actions/websocket_actions.jsx';
 
 window.plugins = {};
 
@@ -84,6 +85,7 @@ export function removePlugin(manifest) {
     if (plugin && plugin.deinitialize) {
         plugin.deinitialize();
     }
+    unregisterAllPluginWebSocketEvents(manifest.id);
     const script = document.getElementById('plugin_' + manifest.id);
     if (!script) {
         return;

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -122,6 +122,10 @@ export default class PluginRegistry {
         return id;
     }
 
+    registerBottomTeamSidebarComponent = (component) => {
+        return dispatchPluginComponentAction('BottomTeamSidebar', this.id, component);
+    }
+
     // Unregister a component using the unique identifier returned after registration.
     // Accepts a string id.
     // Returns undefined in all cases.

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -122,6 +122,10 @@ export default class PluginRegistry {
         return id;
     }
 
+    registerLeftSidebarHeaderComponent = (component) => {
+        return dispatchPluginComponentAction('LeftSidebarHeader', this.id, component);
+    }
+
     registerBottomTeamSidebarComponent = (component) => {
         return dispatchPluginComponentAction('BottomTeamSidebar', this.id, component);
     }

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -46,6 +46,19 @@ export default class PluginRegistry {
         return dispatchPluginComponentAction('PopoverUserActions', this.id, component);
     }
 
+    // Register a component fixed to the top of the left-hand channel sidebar.
+    // Accepts a React component. Returns a unique identifier.
+    registerLeftSidebarHeaderComponent = (component) => {
+        return dispatchPluginComponentAction('LeftSidebarHeader', this.id, component);
+    }
+
+    // Register a component fixed to the bottom of the team sidebar. Does not render if
+    // user is only on one team and the team sidebar is not shown.
+    // Accepts a React component. Returns a unique identifier.
+    registerBottomTeamSidebarComponent = (component) => {
+        return dispatchPluginComponentAction('BottomTeamSidebar', this.id, component);
+    }
+
     // Add a button to the channel header. If there are more than one buttons registered by any
     // plugin, a dropdown menu is created to contain all the plugin buttons.
     // Accepts the following:
@@ -122,14 +135,6 @@ export default class PluginRegistry {
         return id;
     }
 
-    registerLeftSidebarHeaderComponent = (component) => {
-        return dispatchPluginComponentAction('LeftSidebarHeader', this.id, component);
-    }
-
-    registerBottomTeamSidebarComponent = (component) => {
-        return dispatchPluginComponentAction('BottomTeamSidebar', this.id, component);
-    }
-
     // Unregister a component using the unique identifier returned after registration.
     // Accepts a string id.
     // Returns undefined in all cases.
@@ -154,13 +159,13 @@ export default class PluginRegistry {
     // - handler - a function to handle the event, receives the event message as an argument
     // Returns undefined.
     registerWebSocketEventHandler = (event, handler) => {
-        registerPluginWebSocketEvent(event, handler);
+        registerPluginWebSocketEvent(this.id, event, handler);
     }
 
     // Unregister a handler for a custom WebSocket event.
     // Accepts a string event type.
     // Returns undefined.
     unregisterWebSocketEventHandler = (event) => {
-        unregisterPluginWebSocketEvent(event);
+        unregisterPluginWebSocketEvent(this.id, event);
     }
 }

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -181,7 +181,7 @@ export default class PluginRegistry {
         registerPluginReconnectHandler(this.id, handler);
     }
 
-    // Unregister the a previously registered reconnect handler.
+    // Unregister a previously registered reconnect handler.
     // Returns undefined.
     unregisterReconnectHandler = () => {
         unregisterPluginReconnectHandler(this.id);

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -3,7 +3,12 @@
 
 import reducerRegistry from 'mattermost-redux/store/reducer_registry';
 
-import {registerPluginWebSocketEvent, unregisterPluginWebSocketEvent} from 'actions/websocket_actions.jsx';
+import {
+    registerPluginWebSocketEvent,
+    unregisterPluginWebSocketEvent,
+    registerPluginReconnectHandler,
+    unregisterPluginReconnectHandler,
+} from 'actions/websocket_actions.jsx';
 
 import store from 'stores/redux_store.jsx';
 import {ActionTypes} from 'utils/constants.jsx';
@@ -167,5 +172,18 @@ export default class PluginRegistry {
     // Returns undefined.
     unregisterWebSocketEventHandler = (event) => {
         unregisterPluginWebSocketEvent(this.id, event);
+    }
+
+    // Register a handler that will be called when the app reconnects to the
+    // internet after previously disconnecting.
+    // Accepts a function to handle the event. Returns undefined.
+    registerReconnectHandler = (handler) => {
+        registerPluginReconnectHandler(this.id, handler);
+    }
+
+    // Unregister the a previously registered reconnect handler.
+    // Returns undefined.
+    unregisterReconnectHandler = () => {
+        unregisterPluginReconnectHandler(this.id);
     }
 }

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -17,22 +17,7 @@
     }
 
     .sidebar--left__icons {
-        display: flex;
-        height: 35px;
-        align-items: center;
         border-bottom: 1px solid transparent;
-
-        > div {
-            @include single-transition(all, .15s, ease);
-            @include opacity(.6);
-            flex: 1;
-            text-align: center;
-            cursor: pointer;
-
-            &:hover {
-                @include opacity(1);
-            }
-        }
     }
 
     .sidebar-item {

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -16,6 +16,25 @@
         padding-top: 44px;
     }
 
+    .sidebar--left__icons {
+        display: flex;
+        height: 35px;
+        align-items: center;
+        border-bottom: 1px solid transparent;
+
+        > div {
+            @include single-transition(all, .15s, ease);
+            @include opacity(.6);
+            flex: 1;
+            text-align: center;
+            cursor: pointer;
+
+            &:hover {
+                @include opacity(1);
+            }
+        }
+    }
+
     .sidebar-item {
         .icon {
             display: inline-block;
@@ -166,6 +185,16 @@
             svg {
                 @include transform(rotate(180deg));
             }
+        }
+    }
+
+    .sidebar--left__list {
+        .nav-pills__unread-indicator-top {
+            top: 120px;
+        }
+
+        .nav-pills__container {
+            height: calc(100vh - 145px);
         }
     }
 

--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -7,6 +7,14 @@
         width: 65px;
         z-index: 12;
 
+        .team-sidebar-bottom-plugin {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            margin-bottom: 15px;
+        }
+
         .team-wrapper {
             -webkit-overflow-scrolling: touch;
             background-color: alpha-color($black, .2);

--- a/tests/components/sidebar/__snapshots__/sidebar.test.jsx.snap
+++ b/tests/components/sidebar/__snapshots__/sidebar.test.jsx.snap
@@ -23,152 +23,226 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     teamName="test-team"
     teamType="team-type"
   />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-top"
-    name="Top"
-    onClick={[Function]}
-    show={false}
-  />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-bottom"
-    name="Bottom"
-    onClick={[Function]}
-    show={false}
-  />
   <div
-    className="nav-pills__container"
-    id="sidebarChannelContainer"
-    onScroll={[Function]}
+    className="sidebar--left__icons"
   >
-    <ul
-      className="nav nav-pills nav-stacked"
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <div
+      className="nav-pills__container"
+      id="sidebarChannelContainer"
+      onScroll={[Function]}
     >
-      <li>
-        <h4
-          id="publicChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PUBLIC CHANNELS"
-            id="sidebar.channels"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_public_channel",
-              ]
-            }
-            teamId="team_id"
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="publicChannel"
           >
-            <OverlayTrigger
-              defaultOverlayShown={false}
-              delayShow={500}
-              overlay={
-                <Tooltip
-                  bsClass="tooltip"
-                  id="new-channel-tooltip"
-                  placement="right"
-                >
-                  <FormattedMessage
-                    defaultMessage="Create new public channel"
-                    id="sidebar.createChannel"
-                    values={Object {}}
-                  />
-                </Tooltip>
-              }
-              placement="top"
-              trigger={
+            <FormattedMessage
+              defaultMessage="PUBLIC CHANNELS"
+              id="sidebar.channels"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
                 Array [
-                  "hover",
-                  "focus",
+                  "create_public_channel",
                 ]
               }
+              teamId="team_id"
             >
-              <button
-                className="add-channel-btn cursor--pointer style--none"
-                id="createPublicChannel"
-                onClick={[Function]}
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-channel-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new public channel"
+                      id="sidebar.createChannel"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
               >
-                +
-              </button>
-            </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={true}
-        channelId="c1"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c1"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c2"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c2"
-      />
-      <li>
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="sidebarChannelsMore"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="privateChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PRIVATE CHANNELS"
-            id="sidebar.pg"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_private_channel",
-              ]
-            }
-            teamId="team_id"
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPublicChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={true}
+          channelId="c1"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c1"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c2"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c2"
+        />
+        <li>
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="sidebarChannelsMore"
+            onClick={[Function]}
           >
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="privateChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PRIVATE CHANNELS"
+              id="sidebar.pg"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
+                Array [
+                  "create_private_channel",
+                ]
+              }
+              teamId="team_id"
+            >
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new private channel"
+                      id="sidebar.createGroup"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPrivateChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c4"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c4"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="directChannel"
+          >
+            <FormattedMessage
+              defaultMessage="DIRECT MESSAGES"
+              id="sidebar.direct"
+              values={Object {}}
+            />
             <OverlayTrigger
+              className="hidden-xs"
               defaultOverlayShown={false}
               delayShow={500}
               overlay={
                 <Tooltip
                   bsClass="tooltip"
+                  className="hidden-xs"
                   id="new-group-tooltip"
                   placement="right"
                 >
                   <FormattedMessage
-                    defaultMessage="Create new private channel"
-                    id="sidebar.createGroup"
+                    defaultMessage="Create new direct message"
+                    id="sidebar.createDirectMessage"
                     values={Object {}}
                   />
                 </Tooltip>
@@ -183,107 +257,44 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
             >
               <button
                 className="add-channel-btn cursor--pointer style--none"
-                id="createPrivateChannel"
                 onClick={[Function]}
               >
                 +
               </button>
             </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c4"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c4"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="directChannel"
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c6"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c6"
+        />
+        <li
+          key="more"
         >
-          <FormattedMessage
-            defaultMessage="DIRECT MESSAGES"
-            id="sidebar.direct"
-            values={Object {}}
-          />
-          <OverlayTrigger
-            className="hidden-xs"
-            defaultOverlayShown={false}
-            delayShow={500}
-            overlay={
-              <Tooltip
-                bsClass="tooltip"
-                className="hidden-xs"
-                id="new-group-tooltip"
-                placement="right"
-              >
-                <FormattedMessage
-                  defaultMessage="Create new direct message"
-                  id="sidebar.createDirectMessage"
-                  values={Object {}}
-                />
-              </Tooltip>
-            }
-            placement="top"
-            trigger={
-              Array [
-                "hover",
-                "focus",
-              ]
-            }
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="moreDirectMessage"
+            onClick={[Function]}
           >
-            <button
-              className="add-channel-btn cursor--pointer style--none"
-              onClick={[Function]}
-            >
-              +
-            </button>
-          </OverlayTrigger>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c6"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c6"
-      />
-      <li
-        key="more"
-      >
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="moreDirectMessage"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
   <div
     className="sidebar__switcher"
@@ -335,188 +346,262 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     teamName="test-team"
     teamType="team-type"
   />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-top"
-    name="Top"
-    onClick={[Function]}
-    show={false}
-  />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-bottom"
-    name="Bottom"
-    onClick={[Function]}
-    show={false}
-  />
   <div
-    className="nav-pills__container"
-    id="sidebarChannelContainer"
-    onScroll={[Function]}
+    className="sidebar--left__icons"
   >
-    <ul
-      className="nav nav-pills nav-stacked"
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <div
+      className="nav-pills__container"
+      id="sidebarChannelContainer"
+      onScroll={[Function]}
     >
-      <li>
-        <h4
-          id="favoriteChannel"
-        >
-          <FormattedMessage
-            defaultMessage="FAVORITE CHANNELS"
-            id="sidebar.favorite"
-            values={Object {}}
-          />
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={true}
-        channelId="c1"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c1"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="publicChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PUBLIC CHANNELS"
-            id="sidebar.channels"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_public_channel",
-              ]
-            }
-            teamId="team_id"
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="favoriteChannel"
           >
-            <OverlayTrigger
-              defaultOverlayShown={false}
-              delayShow={500}
-              overlay={
-                <Tooltip
-                  bsClass="tooltip"
-                  id="new-channel-tooltip"
-                  placement="right"
-                >
-                  <FormattedMessage
-                    defaultMessage="Create new public channel"
-                    id="sidebar.createChannel"
-                    values={Object {}}
-                  />
-                </Tooltip>
-              }
-              placement="top"
-              trigger={
+            <FormattedMessage
+              defaultMessage="FAVORITE CHANNELS"
+              id="sidebar.favorite"
+              values={Object {}}
+            />
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={true}
+          channelId="c1"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c1"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="publicChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PUBLIC CHANNELS"
+              id="sidebar.channels"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
                 Array [
-                  "hover",
-                  "focus",
+                  "create_public_channel",
                 ]
               }
+              teamId="team_id"
             >
-              <button
-                className="add-channel-btn cursor--pointer style--none"
-                id="createPublicChannel"
-                onClick={[Function]}
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-channel-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new public channel"
+                      id="sidebar.createChannel"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
               >
-                +
-              </button>
-            </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={true}
-        channelId="c1"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c1"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c2"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c2"
-      />
-      <li>
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="sidebarChannelsMore"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="privateChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PRIVATE CHANNELS"
-            id="sidebar.pg"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_private_channel",
-              ]
-            }
-            teamId="team_id"
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPublicChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={true}
+          channelId="c1"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c1"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c2"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c2"
+        />
+        <li>
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="sidebarChannelsMore"
+            onClick={[Function]}
           >
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="privateChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PRIVATE CHANNELS"
+              id="sidebar.pg"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
+                Array [
+                  "create_private_channel",
+                ]
+              }
+              teamId="team_id"
+            >
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new private channel"
+                      id="sidebar.createGroup"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPrivateChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c4"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c4"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="directChannel"
+          >
+            <FormattedMessage
+              defaultMessage="DIRECT MESSAGES"
+              id="sidebar.direct"
+              values={Object {}}
+            />
             <OverlayTrigger
+              className="hidden-xs"
               defaultOverlayShown={false}
               delayShow={500}
               overlay={
                 <Tooltip
                   bsClass="tooltip"
+                  className="hidden-xs"
                   id="new-group-tooltip"
                   placement="right"
                 >
                   <FormattedMessage
-                    defaultMessage="Create new private channel"
-                    id="sidebar.createGroup"
+                    defaultMessage="Create new direct message"
+                    id="sidebar.createDirectMessage"
                     values={Object {}}
                   />
                 </Tooltip>
@@ -531,107 +616,44 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
             >
               <button
                 className="add-channel-btn cursor--pointer style--none"
-                id="createPrivateChannel"
                 onClick={[Function]}
               >
                 +
               </button>
             </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c4"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c4"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="directChannel"
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c6"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c6"
+        />
+        <li
+          key="more"
         >
-          <FormattedMessage
-            defaultMessage="DIRECT MESSAGES"
-            id="sidebar.direct"
-            values={Object {}}
-          />
-          <OverlayTrigger
-            className="hidden-xs"
-            defaultOverlayShown={false}
-            delayShow={500}
-            overlay={
-              <Tooltip
-                bsClass="tooltip"
-                className="hidden-xs"
-                id="new-group-tooltip"
-                placement="right"
-              >
-                <FormattedMessage
-                  defaultMessage="Create new direct message"
-                  id="sidebar.createDirectMessage"
-                  values={Object {}}
-                />
-              </Tooltip>
-            }
-            placement="top"
-            trigger={
-              Array [
-                "hover",
-                "focus",
-              ]
-            }
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="moreDirectMessage"
+            onClick={[Function]}
           >
-            <button
-              className="add-channel-btn cursor--pointer style--none"
-              onClick={[Function]}
-            >
-              +
-            </button>
-          </OverlayTrigger>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c6"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c6"
-      />
-      <li
-        key="more"
-      >
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="moreDirectMessage"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
   <div
     className="sidebar__switcher"
@@ -683,181 +705,255 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     teamName="test-team"
     teamType="team-type"
   />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-top"
-    name="Top"
-    onClick={[Function]}
-    show={false}
-  />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-bottom"
-    name="Bottom"
-    onClick={[Function]}
-    show={false}
-  />
   <div
-    className="nav-pills__container"
-    id="sidebarChannelContainer"
-    onScroll={[Function]}
+    className="sidebar--left__icons"
   >
-    <ul
-      className="nav nav-pills nav-stacked"
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <div
+      className="nav-pills__container"
+      id="sidebarChannelContainer"
+      onScroll={[Function]}
     >
-      <li>
-        <h4
-          id="favoriteChannel"
-        >
-          <FormattedMessage
-            defaultMessage="UNREADS"
-            id="sidebar.unreadSection"
-            values={Object {}}
-          />
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="publicChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PUBLIC CHANNELS"
-            id="sidebar.channels"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_public_channel",
-              ]
-            }
-            teamId="team_id"
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="favoriteChannel"
           >
-            <OverlayTrigger
-              defaultOverlayShown={false}
-              delayShow={500}
-              overlay={
-                <Tooltip
-                  bsClass="tooltip"
-                  id="new-channel-tooltip"
-                  placement="right"
-                >
-                  <FormattedMessage
-                    defaultMessage="Create new public channel"
-                    id="sidebar.createChannel"
-                    values={Object {}}
-                  />
-                </Tooltip>
-              }
-              placement="top"
-              trigger={
+            <FormattedMessage
+              defaultMessage="UNREADS"
+              id="sidebar.unreadSection"
+              values={Object {}}
+            />
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="publicChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PUBLIC CHANNELS"
+              id="sidebar.channels"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
                 Array [
-                  "hover",
-                  "focus",
+                  "create_public_channel",
                 ]
               }
+              teamId="team_id"
             >
-              <button
-                className="add-channel-btn cursor--pointer style--none"
-                id="createPublicChannel"
-                onClick={[Function]}
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-channel-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new public channel"
+                      id="sidebar.createChannel"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
               >
-                +
-              </button>
-            </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={true}
-        channelId="c1"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c1"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c2"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c2"
-      />
-      <li>
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="sidebarChannelsMore"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="privateChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PRIVATE CHANNELS"
-            id="sidebar.pg"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_private_channel",
-              ]
-            }
-            teamId="team_id"
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPublicChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={true}
+          channelId="c1"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c1"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c2"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c2"
+        />
+        <li>
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="sidebarChannelsMore"
+            onClick={[Function]}
           >
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="privateChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PRIVATE CHANNELS"
+              id="sidebar.pg"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
+                Array [
+                  "create_private_channel",
+                ]
+              }
+              teamId="team_id"
+            >
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new private channel"
+                      id="sidebar.createGroup"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPrivateChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c4"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c4"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="directChannel"
+          >
+            <FormattedMessage
+              defaultMessage="DIRECT MESSAGES"
+              id="sidebar.direct"
+              values={Object {}}
+            />
             <OverlayTrigger
+              className="hidden-xs"
               defaultOverlayShown={false}
               delayShow={500}
               overlay={
                 <Tooltip
                   bsClass="tooltip"
+                  className="hidden-xs"
                   id="new-group-tooltip"
                   placement="right"
                 >
                   <FormattedMessage
-                    defaultMessage="Create new private channel"
-                    id="sidebar.createGroup"
+                    defaultMessage="Create new direct message"
+                    id="sidebar.createDirectMessage"
                     values={Object {}}
                   />
                 </Tooltip>
@@ -872,107 +968,44 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
             >
               <button
                 className="add-channel-btn cursor--pointer style--none"
-                id="createPrivateChannel"
                 onClick={[Function]}
               >
                 +
               </button>
             </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c4"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c4"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="directChannel"
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c6"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c6"
+        />
+        <li
+          key="more"
         >
-          <FormattedMessage
-            defaultMessage="DIRECT MESSAGES"
-            id="sidebar.direct"
-            values={Object {}}
-          />
-          <OverlayTrigger
-            className="hidden-xs"
-            defaultOverlayShown={false}
-            delayShow={500}
-            overlay={
-              <Tooltip
-                bsClass="tooltip"
-                className="hidden-xs"
-                id="new-group-tooltip"
-                placement="right"
-              >
-                <FormattedMessage
-                  defaultMessage="Create new direct message"
-                  id="sidebar.createDirectMessage"
-                  values={Object {}}
-                />
-              </Tooltip>
-            }
-            placement="top"
-            trigger={
-              Array [
-                "hover",
-                "focus",
-              ]
-            }
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="moreDirectMessage"
+            onClick={[Function]}
           >
-            <button
-              className="add-channel-btn cursor--pointer style--none"
-              onClick={[Function]}
-            >
-              +
-            </button>
-          </OverlayTrigger>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c6"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c6"
-      />
-      <li
-        key="more"
-      >
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="moreDirectMessage"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
   <div
     className="sidebar__switcher"
@@ -1032,152 +1065,226 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     teamName="test-team"
     teamType="team-type"
   />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-top"
-    name="Top"
-    onClick={[Function]}
-    show={false}
-  />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-bottom"
-    name="Bottom"
-    onClick={[Function]}
-    show={false}
-  />
   <div
-    className="nav-pills__container"
-    id="sidebarChannelContainer"
-    onScroll={[Function]}
+    className="sidebar--left__icons"
   >
-    <ul
-      className="nav nav-pills nav-stacked"
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <div
+      className="nav-pills__container"
+      id="sidebarChannelContainer"
+      onScroll={[Function]}
     >
-      <li>
-        <h4
-          id="publicChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PUBLIC CHANNELS"
-            id="sidebar.channels"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_public_channel",
-              ]
-            }
-            teamId="team_id"
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="publicChannel"
           >
-            <OverlayTrigger
-              defaultOverlayShown={false}
-              delayShow={500}
-              overlay={
-                <Tooltip
-                  bsClass="tooltip"
-                  id="new-channel-tooltip"
-                  placement="right"
-                >
-                  <FormattedMessage
-                    defaultMessage="Create new public channel"
-                    id="sidebar.createChannel"
-                    values={Object {}}
-                  />
-                </Tooltip>
-              }
-              placement="top"
-              trigger={
+            <FormattedMessage
+              defaultMessage="PUBLIC CHANNELS"
+              id="sidebar.channels"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
                 Array [
-                  "hover",
-                  "focus",
+                  "create_public_channel",
                 ]
               }
+              teamId="team_id"
             >
-              <button
-                className="add-channel-btn cursor--pointer style--none"
-                id="createPublicChannel"
-                onClick={[Function]}
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-channel-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new public channel"
+                      id="sidebar.createChannel"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
               >
-                +
-              </button>
-            </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={true}
-        channelId="c1"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c1"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c2"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c2"
-      />
-      <li>
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="sidebarChannelsMore"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="privateChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PRIVATE CHANNELS"
-            id="sidebar.pg"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_private_channel",
-              ]
-            }
-            teamId="team_id"
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPublicChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={true}
+          channelId="c1"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c1"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c2"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c2"
+        />
+        <li>
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="sidebarChannelsMore"
+            onClick={[Function]}
           >
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="privateChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PRIVATE CHANNELS"
+              id="sidebar.pg"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
+                Array [
+                  "create_private_channel",
+                ]
+              }
+              teamId="team_id"
+            >
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new private channel"
+                      id="sidebar.createGroup"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPrivateChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c4"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c4"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="directChannel"
+          >
+            <FormattedMessage
+              defaultMessage="DIRECT MESSAGES"
+              id="sidebar.direct"
+              values={Object {}}
+            />
             <OverlayTrigger
+              className="hidden-xs"
               defaultOverlayShown={false}
               delayShow={500}
               overlay={
                 <Tooltip
                   bsClass="tooltip"
+                  className="hidden-xs"
                   id="new-group-tooltip"
                   placement="right"
                 >
                   <FormattedMessage
-                    defaultMessage="Create new private channel"
-                    id="sidebar.createGroup"
+                    defaultMessage="Create new direct message"
+                    id="sidebar.createDirectMessage"
                     values={Object {}}
                   />
                 </Tooltip>
@@ -1192,107 +1299,44 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
             >
               <button
                 className="add-channel-btn cursor--pointer style--none"
-                id="createPrivateChannel"
                 onClick={[Function]}
               >
                 +
               </button>
             </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c4"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c4"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="directChannel"
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c6"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c6"
+        />
+        <li
+          key="more"
         >
-          <FormattedMessage
-            defaultMessage="DIRECT MESSAGES"
-            id="sidebar.direct"
-            values={Object {}}
-          />
-          <OverlayTrigger
-            className="hidden-xs"
-            defaultOverlayShown={false}
-            delayShow={500}
-            overlay={
-              <Tooltip
-                bsClass="tooltip"
-                className="hidden-xs"
-                id="new-group-tooltip"
-                placement="right"
-              >
-                <FormattedMessage
-                  defaultMessage="Create new direct message"
-                  id="sidebar.createDirectMessage"
-                  values={Object {}}
-                />
-              </Tooltip>
-            }
-            placement="top"
-            trigger={
-              Array [
-                "hover",
-                "focus",
-              ]
-            }
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="moreDirectMessage"
+            onClick={[Function]}
           >
-            <button
-              className="add-channel-btn cursor--pointer style--none"
-              onClick={[Function]}
-            >
-              +
-            </button>
-          </OverlayTrigger>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c6"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c6"
-      />
-      <li
-        key="more"
-      >
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="moreDirectMessage"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
   <div
     className="sidebar__switcher"
@@ -1344,152 +1388,226 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     teamName="test-team"
     teamType="team-type"
   />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-top"
-    name="Top"
-    onClick={[Function]}
-    show={false}
-  />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-bottom"
-    name="Bottom"
-    onClick={[Function]}
-    show={false}
-  />
   <div
-    className="nav-pills__container"
-    id="sidebarChannelContainer"
-    onScroll={[Function]}
+    className="sidebar--left__icons"
   >
-    <ul
-      className="nav nav-pills nav-stacked"
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <div
+      className="nav-pills__container"
+      id="sidebarChannelContainer"
+      onScroll={[Function]}
     >
-      <li>
-        <h4
-          id="publicChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PUBLIC CHANNELS"
-            id="sidebar.channels"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_public_channel",
-              ]
-            }
-            teamId="team_id"
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="publicChannel"
           >
-            <OverlayTrigger
-              defaultOverlayShown={false}
-              delayShow={500}
-              overlay={
-                <Tooltip
-                  bsClass="tooltip"
-                  id="new-channel-tooltip"
-                  placement="right"
-                >
-                  <FormattedMessage
-                    defaultMessage="Create new public channel"
-                    id="sidebar.createChannel"
-                    values={Object {}}
-                  />
-                </Tooltip>
-              }
-              placement="top"
-              trigger={
+            <FormattedMessage
+              defaultMessage="PUBLIC CHANNELS"
+              id="sidebar.channels"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
                 Array [
-                  "hover",
-                  "focus",
+                  "create_public_channel",
                 ]
               }
+              teamId="team_id"
             >
-              <button
-                className="add-channel-btn cursor--pointer style--none"
-                id="createPublicChannel"
-                onClick={[Function]}
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-channel-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new public channel"
+                      id="sidebar.createChannel"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
               >
-                +
-              </button>
-            </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={true}
-        channelId="c1"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c1"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c2"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c2"
-      />
-      <li>
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="sidebarChannelsMore"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="privateChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PRIVATE CHANNELS"
-            id="sidebar.pg"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_private_channel",
-              ]
-            }
-            teamId="team_id"
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPublicChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={true}
+          channelId="c1"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c1"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c2"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c2"
+        />
+        <li>
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="sidebarChannelsMore"
+            onClick={[Function]}
           >
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="privateChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PRIVATE CHANNELS"
+              id="sidebar.pg"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
+                Array [
+                  "create_private_channel",
+                ]
+              }
+              teamId="team_id"
+            >
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new private channel"
+                      id="sidebar.createGroup"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPrivateChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c4"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c4"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="directChannel"
+          >
+            <FormattedMessage
+              defaultMessage="DIRECT MESSAGES"
+              id="sidebar.direct"
+              values={Object {}}
+            />
             <OverlayTrigger
+              className="hidden-xs"
               defaultOverlayShown={false}
               delayShow={500}
               overlay={
                 <Tooltip
                   bsClass="tooltip"
+                  className="hidden-xs"
                   id="new-group-tooltip"
                   placement="right"
                 >
                   <FormattedMessage
-                    defaultMessage="Create new private channel"
-                    id="sidebar.createGroup"
+                    defaultMessage="Create new direct message"
+                    id="sidebar.createDirectMessage"
                     values={Object {}}
                   />
                 </Tooltip>
@@ -1504,107 +1622,44 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
             >
               <button
                 className="add-channel-btn cursor--pointer style--none"
-                id="createPrivateChannel"
                 onClick={[Function]}
               >
                 +
               </button>
             </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c4"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c4"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="directChannel"
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c6"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c6"
+        />
+        <li
+          key="more"
         >
-          <FormattedMessage
-            defaultMessage="DIRECT MESSAGES"
-            id="sidebar.direct"
-            values={Object {}}
-          />
-          <OverlayTrigger
-            className="hidden-xs"
-            defaultOverlayShown={false}
-            delayShow={500}
-            overlay={
-              <Tooltip
-                bsClass="tooltip"
-                className="hidden-xs"
-                id="new-group-tooltip"
-                placement="right"
-              >
-                <FormattedMessage
-                  defaultMessage="Create new direct message"
-                  id="sidebar.createDirectMessage"
-                  values={Object {}}
-                />
-              </Tooltip>
-            }
-            placement="top"
-            trigger={
-              Array [
-                "hover",
-                "focus",
-              ]
-            }
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="moreDirectMessage"
+            onClick={[Function]}
           >
-            <button
-              className="add-channel-btn cursor--pointer style--none"
-              onClick={[Function]}
-            >
-              +
-            </button>
-          </OverlayTrigger>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c6"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c6"
-      />
-      <li
-        key="more"
-      >
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="moreDirectMessage"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
   <div
     className="sidebar__switcher"
@@ -1660,152 +1715,226 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     teamName="test-team"
     teamType="team-type"
   />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-top"
-    name="Top"
-    onClick={[Function]}
-    show={false}
-  />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-bottom"
-    name="Bottom"
-    onClick={[Function]}
-    show={false}
-  />
   <div
-    className="nav-pills__container"
-    id="sidebarChannelContainer"
-    onScroll={[Function]}
+    className="sidebar--left__icons"
   >
-    <ul
-      className="nav nav-pills nav-stacked"
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <div
+      className="nav-pills__container"
+      id="sidebarChannelContainer"
+      onScroll={[Function]}
     >
-      <li>
-        <h4
-          id="publicChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PUBLIC CHANNELS"
-            id="sidebar.channels"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_public_channel",
-              ]
-            }
-            teamId="team_id"
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="publicChannel"
           >
-            <OverlayTrigger
-              defaultOverlayShown={false}
-              delayShow={500}
-              overlay={
-                <Tooltip
-                  bsClass="tooltip"
-                  id="new-channel-tooltip"
-                  placement="right"
-                >
-                  <FormattedMessage
-                    defaultMessage="Create new public channel"
-                    id="sidebar.createChannel"
-                    values={Object {}}
-                  />
-                </Tooltip>
-              }
-              placement="top"
-              trigger={
+            <FormattedMessage
+              defaultMessage="PUBLIC CHANNELS"
+              id="sidebar.channels"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
                 Array [
-                  "hover",
-                  "focus",
+                  "create_public_channel",
                 ]
               }
+              teamId="team_id"
             >
-              <button
-                className="add-channel-btn cursor--pointer style--none"
-                id="createPublicChannel"
-                onClick={[Function]}
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-channel-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new public channel"
+                      id="sidebar.createChannel"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
               >
-                +
-              </button>
-            </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={true}
-        channelId="c1"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c1"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c2"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c2"
-      />
-      <li>
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="sidebarChannelsMore"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="privateChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PRIVATE CHANNELS"
-            id="sidebar.pg"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_private_channel",
-              ]
-            }
-            teamId="team_id"
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPublicChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={true}
+          channelId="c1"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c1"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c2"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c2"
+        />
+        <li>
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="sidebarChannelsMore"
+            onClick={[Function]}
           >
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="privateChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PRIVATE CHANNELS"
+              id="sidebar.pg"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
+                Array [
+                  "create_private_channel",
+                ]
+              }
+              teamId="team_id"
+            >
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new private channel"
+                      id="sidebar.createGroup"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPrivateChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c4"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c4"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="directChannel"
+          >
+            <FormattedMessage
+              defaultMessage="DIRECT MESSAGES"
+              id="sidebar.direct"
+              values={Object {}}
+            />
             <OverlayTrigger
+              className="hidden-xs"
               defaultOverlayShown={false}
               delayShow={500}
               overlay={
                 <Tooltip
                   bsClass="tooltip"
+                  className="hidden-xs"
                   id="new-group-tooltip"
                   placement="right"
                 >
                   <FormattedMessage
-                    defaultMessage="Create new private channel"
-                    id="sidebar.createGroup"
+                    defaultMessage="Create new direct message"
+                    id="sidebar.createDirectMessage"
                     values={Object {}}
                   />
                 </Tooltip>
@@ -1820,107 +1949,44 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
             >
               <button
                 className="add-channel-btn cursor--pointer style--none"
-                id="createPrivateChannel"
                 onClick={[Function]}
               >
                 +
               </button>
             </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c4"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c4"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="directChannel"
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c6"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c6"
+        />
+        <li
+          key="more"
         >
-          <FormattedMessage
-            defaultMessage="DIRECT MESSAGES"
-            id="sidebar.direct"
-            values={Object {}}
-          />
-          <OverlayTrigger
-            className="hidden-xs"
-            defaultOverlayShown={false}
-            delayShow={500}
-            overlay={
-              <Tooltip
-                bsClass="tooltip"
-                className="hidden-xs"
-                id="new-group-tooltip"
-                placement="right"
-              >
-                <FormattedMessage
-                  defaultMessage="Create new direct message"
-                  id="sidebar.createDirectMessage"
-                  values={Object {}}
-                />
-              </Tooltip>
-            }
-            placement="top"
-            trigger={
-              Array [
-                "hover",
-                "focus",
-              ]
-            }
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="moreDirectMessage"
+            onClick={[Function]}
           >
-            <button
-              className="add-channel-btn cursor--pointer style--none"
-              onClick={[Function]}
-            >
-              +
-            </button>
-          </OverlayTrigger>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c6"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c6"
-      />
-      <li
-        key="more"
-      >
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="moreDirectMessage"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
   <div
     className="sidebar__switcher"
@@ -1972,152 +2038,226 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     teamName="test-team"
     teamType="team-type"
   />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-top"
-    name="Top"
-    onClick={[Function]}
-    show={false}
-  />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-bottom"
-    name="Bottom"
-    onClick={[Function]}
-    show={false}
-  />
   <div
-    className="nav-pills__container"
-    id="sidebarChannelContainer"
-    onScroll={[Function]}
+    className="sidebar--left__icons"
   >
-    <ul
-      className="nav nav-pills nav-stacked"
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <div
+      className="nav-pills__container"
+      id="sidebarChannelContainer"
+      onScroll={[Function]}
     >
-      <li>
-        <h4
-          id="publicChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PUBLIC CHANNELS"
-            id="sidebar.channels"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_public_channel",
-              ]
-            }
-            teamId="team_id"
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="publicChannel"
           >
-            <OverlayTrigger
-              defaultOverlayShown={false}
-              delayShow={500}
-              overlay={
-                <Tooltip
-                  bsClass="tooltip"
-                  id="new-channel-tooltip"
-                  placement="right"
-                >
-                  <FormattedMessage
-                    defaultMessage="Create new public channel"
-                    id="sidebar.createChannel"
-                    values={Object {}}
-                  />
-                </Tooltip>
-              }
-              placement="top"
-              trigger={
+            <FormattedMessage
+              defaultMessage="PUBLIC CHANNELS"
+              id="sidebar.channels"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
                 Array [
-                  "hover",
-                  "focus",
+                  "create_public_channel",
                 ]
               }
+              teamId="team_id"
             >
-              <button
-                className="add-channel-btn cursor--pointer style--none"
-                id="createPublicChannel"
-                onClick={[Function]}
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-channel-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new public channel"
+                      id="sidebar.createChannel"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
               >
-                +
-              </button>
-            </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={true}
-        channelId="c1"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c1"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c2"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c2"
-      />
-      <li>
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="sidebarChannelsMore"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="privateChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PRIVATE CHANNELS"
-            id="sidebar.pg"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_private_channel",
-              ]
-            }
-            teamId="team_id"
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPublicChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={true}
+          channelId="c1"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c1"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c2"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c2"
+        />
+        <li>
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="sidebarChannelsMore"
+            onClick={[Function]}
           >
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="privateChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PRIVATE CHANNELS"
+              id="sidebar.pg"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
+                Array [
+                  "create_private_channel",
+                ]
+              }
+              teamId="team_id"
+            >
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new private channel"
+                      id="sidebar.createGroup"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPrivateChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c4"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c4"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="directChannel"
+          >
+            <FormattedMessage
+              defaultMessage="DIRECT MESSAGES"
+              id="sidebar.direct"
+              values={Object {}}
+            />
             <OverlayTrigger
+              className="hidden-xs"
               defaultOverlayShown={false}
               delayShow={500}
               overlay={
                 <Tooltip
                   bsClass="tooltip"
+                  className="hidden-xs"
                   id="new-group-tooltip"
                   placement="right"
                 >
                   <FormattedMessage
-                    defaultMessage="Create new private channel"
-                    id="sidebar.createGroup"
+                    defaultMessage="Create new direct message"
+                    id="sidebar.createDirectMessage"
                     values={Object {}}
                   />
                 </Tooltip>
@@ -2132,107 +2272,44 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
             >
               <button
                 className="add-channel-btn cursor--pointer style--none"
-                id="createPrivateChannel"
                 onClick={[Function]}
               >
                 +
               </button>
             </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c4"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c4"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="directChannel"
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c6"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c6"
+        />
+        <li
+          key="more"
         >
-          <FormattedMessage
-            defaultMessage="DIRECT MESSAGES"
-            id="sidebar.direct"
-            values={Object {}}
-          />
-          <OverlayTrigger
-            className="hidden-xs"
-            defaultOverlayShown={false}
-            delayShow={500}
-            overlay={
-              <Tooltip
-                bsClass="tooltip"
-                className="hidden-xs"
-                id="new-group-tooltip"
-                placement="right"
-              >
-                <FormattedMessage
-                  defaultMessage="Create new direct message"
-                  id="sidebar.createDirectMessage"
-                  values={Object {}}
-                />
-              </Tooltip>
-            }
-            placement="top"
-            trigger={
-              Array [
-                "hover",
-                "focus",
-              ]
-            }
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="moreDirectMessage"
+            onClick={[Function]}
           >
-            <button
-              className="add-channel-btn cursor--pointer style--none"
-              onClick={[Function]}
-            >
-              +
-            </button>
-          </OverlayTrigger>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c6"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c6"
-      />
-      <li
-        key="more"
-      >
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="moreDirectMessage"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
   <div
     className="sidebar__switcher"
@@ -2284,152 +2361,226 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     teamName="test-team"
     teamType="team-type"
   />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-top"
-    name="Top"
-    onClick={[Function]}
-    show={false}
-  />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-bottom"
-    name="Bottom"
-    onClick={[Function]}
-    show={false}
-  />
   <div
-    className="nav-pills__container"
-    id="sidebarChannelContainer"
-    onScroll={[Function]}
+    className="sidebar--left__icons"
   >
-    <ul
-      className="nav nav-pills nav-stacked"
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <div
+      className="nav-pills__container"
+      id="sidebarChannelContainer"
+      onScroll={[Function]}
     >
-      <li>
-        <h4
-          id="publicChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PUBLIC CHANNELS"
-            id="sidebar.channels"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_public_channel",
-              ]
-            }
-            teamId="team_id"
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="publicChannel"
           >
-            <OverlayTrigger
-              defaultOverlayShown={false}
-              delayShow={500}
-              overlay={
-                <Tooltip
-                  bsClass="tooltip"
-                  id="new-channel-tooltip"
-                  placement="right"
-                >
-                  <FormattedMessage
-                    defaultMessage="Create new public channel"
-                    id="sidebar.createChannel"
-                    values={Object {}}
-                  />
-                </Tooltip>
-              }
-              placement="top"
-              trigger={
+            <FormattedMessage
+              defaultMessage="PUBLIC CHANNELS"
+              id="sidebar.channels"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
                 Array [
-                  "hover",
-                  "focus",
+                  "create_public_channel",
                 ]
               }
+              teamId="team_id"
             >
-              <button
-                className="add-channel-btn cursor--pointer style--none"
-                id="createPublicChannel"
-                onClick={[Function]}
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-channel-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new public channel"
+                      id="sidebar.createChannel"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
               >
-                +
-              </button>
-            </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={true}
-        channelId="c1"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c1"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c2"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c2"
-      />
-      <li>
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="sidebarChannelsMore"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="privateChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PRIVATE CHANNELS"
-            id="sidebar.pg"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_private_channel",
-              ]
-            }
-            teamId="team_id"
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPublicChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={true}
+          channelId="c1"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c1"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c2"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c2"
+        />
+        <li>
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="sidebarChannelsMore"
+            onClick={[Function]}
           >
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="privateChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PRIVATE CHANNELS"
+              id="sidebar.pg"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
+                Array [
+                  "create_private_channel",
+                ]
+              }
+              teamId="team_id"
+            >
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new private channel"
+                      id="sidebar.createGroup"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPrivateChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c4"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c4"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="directChannel"
+          >
+            <FormattedMessage
+              defaultMessage="DIRECT MESSAGES"
+              id="sidebar.direct"
+              values={Object {}}
+            />
             <OverlayTrigger
+              className="hidden-xs"
               defaultOverlayShown={false}
               delayShow={500}
               overlay={
                 <Tooltip
                   bsClass="tooltip"
+                  className="hidden-xs"
                   id="new-group-tooltip"
                   placement="right"
                 >
                   <FormattedMessage
-                    defaultMessage="Create new private channel"
-                    id="sidebar.createGroup"
+                    defaultMessage="Create new direct message"
+                    id="sidebar.createDirectMessage"
                     values={Object {}}
                   />
                 </Tooltip>
@@ -2444,107 +2595,44 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
             >
               <button
                 className="add-channel-btn cursor--pointer style--none"
-                id="createPrivateChannel"
                 onClick={[Function]}
               >
                 +
               </button>
             </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c4"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c4"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="directChannel"
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c6"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c6"
+        />
+        <li
+          key="more"
         >
-          <FormattedMessage
-            defaultMessage="DIRECT MESSAGES"
-            id="sidebar.direct"
-            values={Object {}}
-          />
-          <OverlayTrigger
-            className="hidden-xs"
-            defaultOverlayShown={false}
-            delayShow={500}
-            overlay={
-              <Tooltip
-                bsClass="tooltip"
-                className="hidden-xs"
-                id="new-group-tooltip"
-                placement="right"
-              >
-                <FormattedMessage
-                  defaultMessage="Create new direct message"
-                  id="sidebar.createDirectMessage"
-                  values={Object {}}
-                />
-              </Tooltip>
-            }
-            placement="top"
-            trigger={
-              Array [
-                "hover",
-                "focus",
-              ]
-            }
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="moreDirectMessage"
+            onClick={[Function]}
           >
-            <button
-              className="add-channel-btn cursor--pointer style--none"
-              onClick={[Function]}
-            >
-              +
-            </button>
-          </OverlayTrigger>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c6"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c6"
-      />
-      <li
-        key="more"
-      >
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="moreDirectMessage"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
   <div
     className="sidebar__switcher"
@@ -2596,152 +2684,226 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     teamName="test-team"
     teamType="team-type"
   />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-top"
-    name="Top"
-    onClick={[Function]}
-    show={false}
-  />
-  <UnreadChannelIndicator
-    content={
-      <FormattedMessage
-        defaultMessage="More unreads"
-        id="sidebar.unreads"
-        values={Object {}}
-      />
-    }
-    extraClass="nav-pills__unread-indicator-bottom"
-    name="Bottom"
-    onClick={[Function]}
-    show={false}
-  />
   <div
-    className="nav-pills__container"
-    id="sidebarChannelContainer"
-    onScroll={[Function]}
+    className="sidebar--left__icons"
   >
-    <ul
-      className="nav nav-pills nav-stacked"
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <div
+      className="nav-pills__container"
+      id="sidebarChannelContainer"
+      onScroll={[Function]}
     >
-      <li>
-        <h4
-          id="publicChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PUBLIC CHANNELS"
-            id="sidebar.channels"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_public_channel",
-              ]
-            }
-            teamId="team_id"
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="publicChannel"
           >
-            <OverlayTrigger
-              defaultOverlayShown={false}
-              delayShow={500}
-              overlay={
-                <Tooltip
-                  bsClass="tooltip"
-                  id="new-channel-tooltip"
-                  placement="right"
-                >
-                  <FormattedMessage
-                    defaultMessage="Create new public channel"
-                    id="sidebar.createChannel"
-                    values={Object {}}
-                  />
-                </Tooltip>
-              }
-              placement="top"
-              trigger={
+            <FormattedMessage
+              defaultMessage="PUBLIC CHANNELS"
+              id="sidebar.channels"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
                 Array [
-                  "hover",
-                  "focus",
+                  "create_public_channel",
                 ]
               }
+              teamId="team_id"
             >
-              <button
-                className="add-channel-btn cursor--pointer style--none"
-                id="createPublicChannel"
-                onClick={[Function]}
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-channel-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new public channel"
+                      id="sidebar.createChannel"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
               >
-                +
-              </button>
-            </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={true}
-        channelId="c1"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c1"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c2"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c2"
-      />
-      <li>
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="sidebarChannelsMore"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="privateChannel"
-        >
-          <FormattedMessage
-            defaultMessage="PRIVATE CHANNELS"
-            id="sidebar.pg"
-            values={Object {}}
-          />
-          <Connect(TeamPermissionGate)
-            permissions={
-              Array [
-                "create_private_channel",
-              ]
-            }
-            teamId="team_id"
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPublicChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={true}
+          channelId="c1"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c1"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c2"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c2"
+        />
+        <li>
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="sidebarChannelsMore"
+            onClick={[Function]}
           >
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="privateChannel"
+          >
+            <FormattedMessage
+              defaultMessage="PRIVATE CHANNELS"
+              id="sidebar.pg"
+              values={Object {}}
+            />
+            <Connect(TeamPermissionGate)
+              permissions={
+                Array [
+                  "create_private_channel",
+                ]
+              }
+              teamId="team_id"
+            >
+              <OverlayTrigger
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new private channel"
+                      id="sidebar.createGroup"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  id="createPrivateChannel"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </Connect(TeamPermissionGate)>
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c3"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c3"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c4"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c4"
+        />
+      </ul>
+      <ul
+        className="nav nav-pills nav-stacked"
+      >
+        <li>
+          <h4
+            id="directChannel"
+          >
+            <FormattedMessage
+              defaultMessage="DIRECT MESSAGES"
+              id="sidebar.direct"
+              values={Object {}}
+            />
             <OverlayTrigger
+              className="hidden-xs"
               defaultOverlayShown={false}
               delayShow={500}
               overlay={
                 <Tooltip
                   bsClass="tooltip"
+                  className="hidden-xs"
                   id="new-group-tooltip"
                   placement="right"
                 >
                   <FormattedMessage
-                    defaultMessage="Create new private channel"
-                    id="sidebar.createGroup"
+                    defaultMessage="Create new direct message"
+                    id="sidebar.createDirectMessage"
                     values={Object {}}
                   />
                 </Tooltip>
@@ -2756,107 +2918,44 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
             >
               <button
                 className="add-channel-btn cursor--pointer style--none"
-                id="createPrivateChannel"
                 onClick={[Function]}
               >
                 +
               </button>
             </OverlayTrigger>
-          </Connect(TeamPermissionGate)>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c3"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c3"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c4"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c4"
-      />
-    </ul>
-    <ul
-      className="nav nav-pills nav-stacked"
-    >
-      <li>
-        <h4
-          id="directChannel"
+          </h4>
+        </li>
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c5"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c5"
+        />
+        <Connect(SidebarChannel)
+          active={false}
+          channelId="c6"
+          currentTeamName="test-team"
+          currentUserId="my-user-id"
+          key="c6"
+        />
+        <li
+          key="more"
         >
-          <FormattedMessage
-            defaultMessage="DIRECT MESSAGES"
-            id="sidebar.direct"
-            values={Object {}}
-          />
-          <OverlayTrigger
-            className="hidden-xs"
-            defaultOverlayShown={false}
-            delayShow={500}
-            overlay={
-              <Tooltip
-                bsClass="tooltip"
-                className="hidden-xs"
-                id="new-group-tooltip"
-                placement="right"
-              >
-                <FormattedMessage
-                  defaultMessage="Create new direct message"
-                  id="sidebar.createDirectMessage"
-                  values={Object {}}
-                />
-              </Tooltip>
-            }
-            placement="top"
-            trigger={
-              Array [
-                "hover",
-                "focus",
-              ]
-            }
+          <button
+            className="nav-more cursor--pointer style--none btn--block"
+            id="moreDirectMessage"
+            onClick={[Function]}
           >
-            <button
-              className="add-channel-btn cursor--pointer style--none"
-              onClick={[Function]}
-            >
-              +
-            </button>
-          </OverlayTrigger>
-        </h4>
-      </li>
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c5"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c5"
-      />
-      <Connect(SidebarChannel)
-        active={false}
-        channelId="c6"
-        currentTeamName="test-team"
-        currentUserId="my-user-id"
-        key="c6"
-      />
-      <li
-        key="more"
-      >
-        <button
-          className="nav-more cursor--pointer style--none btn--block"
-          id="moreDirectMessage"
-          onClick={[Function]}
-        >
-          <FormattedMessage
-            defaultMessage="More..."
-            id="sidebar.moreElips"
-            values={Object {}}
-          />
-        </button>
-      </li>
-    </ul>
+            <FormattedMessage
+              defaultMessage="More..."
+              id="sidebar.moreElips"
+              values={Object {}}
+            />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
   <div
     className="sidebar__switcher"

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -19,6 +19,10 @@ export function isSystemMessage(post) {
     return Boolean(post.type && (post.type.lastIndexOf(Constants.SYSTEM_MESSAGE_PREFIX) === 0));
 }
 
+export function isEphemeral(post) {
+    return Boolean(post.type && post.type === Constants.PostTypes.EPHEMERAL);
+}
+
 export function fromAutoResponder(post) {
     return Boolean(post.type && (post.type === Constants.AUTO_RESPONDER));
 }

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -19,10 +19,6 @@ export function isSystemMessage(post) {
     return Boolean(post.type && (post.type.lastIndexOf(Constants.SYSTEM_MESSAGE_PREFIX) === 0));
 }
 
-export function isEphemeral(post) {
-    return Boolean(post.type && post.type === Constants.PostTypes.EPHEMERAL);
-}
-
 export function fromAutoResponder(post) {
     return Boolean(post.type && (post.type === Constants.AUTO_RESPONDER));
 }


### PR DESCRIPTION
#### Summary
This PR does a bunch of things:
* Add two sidebar pluggable components
* Add a `deinitialize` function that plugins can implement, for removing event handlers and doing other clean-up. It's called just before a plugin is removed
* Allow ephemeral messages to have their icons overridden (this was a bug where only the name would get overridden)
* Fix new line separator not appearing for messages posted by a bot using your account
* Fixes to WS event handler registration to prevent collisions
* Add ability for plugins to register a reconnect handler, called when the app disconnects then reconnects to the internet

This should be the last webapp PR before we're ready to merge `plugins-2` to master.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)