### PR TITLE
MM-11248: fix custom emoij on subpath

### DIFF
--- a/stores/emoji_store.jsx
+++ b/stores/emoji_store.jsx
@@ -207,7 +207,7 @@ class EmojiStore extends EventEmitter {
 
     getEmojiImageUrl(emoji) {
         if (emoji.id) {
-            return Client4.getUrlVersion() + '/emoji/' + emoji.id + '/image';
+            return Client4.getBaseRoute() + '/emoji/' + emoji.id + '/image';
         }
 
         const filename = emoji.filename || emoji.aliases[0];


### PR DESCRIPTION
#### Summary
Another casualty of my testing subpath with an incorrect root redirect (that redirected the subpath-less path back into the subpath).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11248

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed