### PR TITLE
MM-10958: Fix elasticsearch settings interdependencies in system console

### DIFF
--- a/components/admin_console/elasticsearch_settings.jsx
+++ b/components/admin_console/elasticsearch_settings.jsx
@@ -22,7 +22,7 @@ export default class ElasticsearchSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.doTestConfig = this.doTestConfig.bind(this);
-        this.handleChange = this.handleChange.bind(this);
+        this.handleSettingChanged = this.handleSettingChanged.bind(this);
         this.handleSaved = this.handleSaved.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
@@ -53,7 +53,7 @@ export default class ElasticsearchSettings extends AdminSettings {
         };
     }
 
-    handleChange(id, value) {
+    handleSettingChanged(id, value) {
         if (id === 'enableIndexing') {
             if (value === false) {
                 this.setState({
@@ -80,7 +80,7 @@ export default class ElasticsearchSettings extends AdminSettings {
             });
         }
 
-        super.handleChange(id, value);
+        this.handleChange(id, value);
     }
 
     handleSaved() {
@@ -180,7 +180,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                         />
                     }
                     value={this.state.enableIndexing}
-                    onChange={this.handleChange}
+                    onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.EnableIndexing')}
                 />
                 <TextSetting
@@ -214,7 +214,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                     }
                     value={this.state.connectionUrl}
                     disabled={!this.state.enableIndexing}
-                    onChange={this.handleChange}
+                    onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.ConnectionUrl')}
                 />
                 <TextSetting
@@ -234,7 +234,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                     }
                     value={this.state.username}
                     disabled={!this.state.enableIndexing}
-                    onChange={this.handleChange}
+                    onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.Username')}
                 />
                 <TextSetting
@@ -254,7 +254,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                     }
                     value={this.state.password}
                     disabled={!this.state.enableIndexing}
-                    onChange={this.handleChange}
+                    onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.Password')}
                 />
                 <BooleanSetting
@@ -273,7 +273,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                     }
                     value={this.state.sniff}
                     disabled={!this.state.enableIndexing}
-                    onChange={this.handleChange}
+                    onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.Sniff')}
                 />
                 <RequestButton
@@ -373,7 +373,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                     }
                     value={this.state.enableSearching}
                     disabled={!this.state.enableIndexing || !this.state.configTested}
-                    onChange={this.handleChange}
+                    onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.EnableSearching')}
                 />
             </SettingsGroup>


### PR DESCRIPTION
#### Summary
For some reason I don't entirely understand, this method was not getting called when it had the same name as the method in the parent class - the parent class method was getting called instead. By renaming it, it is now called as expected and the logic that covers this ticket runs again as it used to.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10958

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed