### PR TITLE
MM-11247: fix ldap port saving

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -628,7 +628,7 @@ export default {
                             ),
                         },
                         {
-                            type: Constants.SettingsTypes.TYPE_TEXT,
+                            type: Constants.SettingsTypes.TYPE_NUMBER,
                             key: 'LdapSettings.LdapPort',
                             label: 'admin.ldap.portTitle',
                             label_default: 'AD/LDAP Port:',


### PR DESCRIPTION
#### Summary
If changed from the default, the LDAP port was being discarded by the server as it was sent up as a string and not a number.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11247

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed