### PR TITLE
[MM-11289] Fixes app crashing when adding a user to the channel via at-mention

### DIFF
--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -92,6 +92,10 @@ export default class Post extends React.PureComponent {
         getPostList: PropTypes.func.isRequired,
     }
 
+    static defaultProps = {
+        post: {},
+    };
+
     constructor(props) {
         super(props);
 
@@ -218,7 +222,10 @@ export default class Post extends React.PureComponent {
     }
 
     render() {
-        const post = this.props.post || {};
+        const {post} = this.props;
+        if (!post.id) {
+            return null;
+        }
 
         const isSystemMessage = PostUtils.isSystemMessage(post);
         const fromAutoResponder = PostUtils.fromAutoResponder(post);


### PR DESCRIPTION
#### Summary
Fixes app crashing when adding a user to the channel via at-mention.  It happened when undefined post is passed into `Post` component.
I'm not particularly sure why but it should have been caught by this [line](https://github.com/mattermost/mattermost-webapp/blob/master/components/post_view/post_list.jsx#L519).
It's very confusing but it's introduced in this commit - https://github.com/mattermost/mattermost-webapp/commit/4cf32681087b86fa4068a5b0921593b36674d2b2

#### Ticket Link
Jira ticket: [MM-11289](https://mattermost.atlassian.net/browse/MM-11289)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
