### PR TITLE
MM-11172: Apply read only town square rules to reactions as posts.

### DIFF
--- a/components/post_view/reaction/index.js
+++ b/components/post_view/reaction/index.js
@@ -5,11 +5,13 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {addReaction, removeReaction} from 'mattermost-redux/actions/posts';
 import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
-import {getCurrentUserId, makeGetProfilesForReactions} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUserId, makeGetProfilesForReactions, getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import Permissions from 'mattermost-redux/constants/permissions';
+import Constants from 'mattermost-redux/constants/general';
+import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 
 import * as Emoji from 'utils/emoji.jsx';
 
@@ -19,6 +21,10 @@ function makeMapStateToProps() {
     const getProfilesForReactions = makeGetProfilesForReactions();
 
     return function mapStateToProps(state, ownProps) {
+        const config = getConfig(state);
+        const license = getLicense(state);
+        const me = getCurrentUser(state);
+
         const profiles = getProfilesForReactions(state, ownProps.reactions);
         let emoji;
         if (Emoji.EmojiIndicesByAlias.has(ownProps.emojiName)) {
@@ -31,10 +37,11 @@ function makeMapStateToProps() {
         if (emoji) {
             emojiImageUrl = getEmojiImageUrl(emoji);
         }
-        const channel = getChannel(state, {id: ownProps.post.channel_id}) || {};
+        const channel = getChannel(state, ownProps.post.channel_id) || {};
         const teamId = channel.team_id;
-        const canAddReaction = haveIChannelPermission(state, {team: teamId, channel: ownProps.post.channel_id, permission: Permissions.ADD_REACTION});
-        const canRemoveReaction = haveIChannelPermission(state, {team: teamId, channel: ownProps.post.channel_id, permission: Permissions.REMOVE_REACTION});
+
+        const canAddReaction = checkReactionAction(state, teamId, ownProps.post.channel_id, channel.name, config, license, me, Permissions.REMOVE_REACTION);
+        const canRemoveReaction = checkReactionAction(state, teamId, ownProps.post.channel_id, channel.name, config, license, me, Permissions.ADD_REACTION);
 
         return {
             profiles,
@@ -56,6 +63,18 @@ function mapDispatchToProps(dispatch) {
             getMissingProfilesByIds,
         }, dispatch),
     };
+}
+
+function checkReactionAction(state, teamId, channelId, channelName, config, license, user, permission) {
+    if (!haveIChannelPermission(state, {team: teamId, channel: channelId, permission})) {
+        return false;
+    }
+
+    if (channelName === Constants.DEFAULT_CHANNEL && config.ExperimentalTownSquareIsReadOnly === 'true' && license.IsLicensed === 'true' && !user.roles.includes('system_admin')) {
+        return false;
+    }
+
+    return true;
 }
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(Reaction);

--- a/components/post_view/reaction/reaction.jsx
+++ b/components/post_view/reaction/reaction.jsx
@@ -223,6 +223,8 @@ export default class Reaction extends React.PureComponent {
                         defaultMessage='(click to remove)'
                     />
                 );
+            } else {
+                className += ' post-reaction--read-only';
             }
 
             className += ' post-reaction--current-user';
@@ -234,6 +236,8 @@ export default class Reaction extends React.PureComponent {
                     defaultMessage='(click to add)'
                 />
             );
+        } else {
+            className += ' post-reaction--read-only';
         }
 
         return (

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1572,6 +1572,10 @@
                     font-weight: 600;
                 }
             }
+
+            &--read-only {
+                cursor: default;
+            }
         }
     }
 

--- a/tests/components/post_view/__snapshots__/reaction.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/reaction.test.jsx.snap
@@ -52,7 +52,7 @@ exports[`components/post_view/Reaction should disable add reaction when you do n
   }
 >
   <div
-    className="post-reaction"
+    className="post-reaction post-reaction--read-only"
   >
     <span
       className="post-reaction__emoji emoticon"
@@ -123,7 +123,7 @@ exports[`components/post_view/Reaction should disable remove reaction when you d
   }
 >
   <div
-    className="post-reaction post-reaction--current-user"
+    className="post-reaction post-reaction--read-only post-reaction--current-user"
   >
     <span
       className="post-reaction__emoji emoticon"


### PR DESCRIPTION
#### Summary
Apply read only town square rules to reactions in the same way as posts.

Makes the UI behaviour the exact same as for when you don't have permissions to react, which we already support.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11172

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)