### PR TITLE
Fix statistics in console when translation too long

### DIFF
--- a/components/analytics/statistic_count.jsx
+++ b/components/analytics/statistic_count.jsx
@@ -33,7 +33,7 @@ export default class StatisticCount extends React.PureComponent {
         );
 
         return (
-            <div className='col-md-3 col-sm-6'>
+            <div className='col-lg-3 col-md-4 col-sm-6'>
                 <div className='total-count'>
                     <div className='title'>
                         {this.props.title}

--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -111,7 +111,7 @@
     }
 
     .wrapper--fixed {
-        max-width: 800px;
+        max-width: 920px;
         margin-bottom: 70px;
     }
 

--- a/tests/components/analytics/__snapshots__/statistic_count.test.jsx.snap
+++ b/tests/components/analytics/__snapshots__/statistic_count.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`components/analytics/statistic_count.jsx should match snapshot, loaded 1`] = `
 <div
-  className="col-md-3 col-sm-6"
+  className="col-lg-3 col-md-4 col-sm-6"
 >
   <div
     className="total-count"
@@ -26,7 +26,7 @@ exports[`components/analytics/statistic_count.jsx should match snapshot, loaded 
 
 exports[`components/analytics/statistic_count.jsx should match snapshot, on loading 1`] = `
 <div
-  className="col-md-3 col-sm-6"
+  className="col-lg-3 col-md-4 col-sm-6"
 >
   <div
     className="total-count"


### PR DESCRIPTION
#### Summary
On languages other than English, this is impossible to have a translation that short (maybe in Chinese?) for daily users, etc. The only solution here is to make the squares larger.

Before:
![screenshot_20180716_105811](https://user-images.githubusercontent.com/2997662/42752942-bbf2e5d6-88ef-11e8-927d-2087f1b7c6c7.png)

After:
![screenshot_20180716_115552](https://user-images.githubusercontent.com/2997662/42752964-c14aa0be-88ef-11e8-80d0-435173ad0e72.png)

#### Ticket Link
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
