### PR TITLE
MM-11418: Channging the admin console banners related to compliance exports

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -396,9 +396,18 @@ export default {
                         {
                             type: Constants.SettingsTypes.TYPE_BANNER,
                             label: 'admin.compliance.noLicense',
+                            label_html: true,
                             label_default: '<h4 class="banner__heading">Note:</h4><p>Compliance is an enterprise feature. Your current license does not support Compliance. Click <a href="http://mattermost.com"target="_blank">here</a> for information and pricing on enterprise licenses.</p>',
                             isHidden: needsUtils.hasLicense,
                             banner_type: 'warning',
+                        },
+                        {
+                            type: Constants.SettingsTypes.TYPE_BANNER,
+                            label: 'admin.compliance.newComplianceExportBanner',
+                            label_html: true,
+                            label_default: 'This feature is replaced by a new <a href="../../admin_console/compliance/message_export">Compliance Export</a> feature, and will be removed in a future release. We recommend migrating to the new system.',
+                            isHidden: needsUtils.not(needsUtils.hasLicense),
+                            banner_type: 'info',
                         },
                         {
                             type: Constants.SettingsTypes.TYPE_BOOL,

--- a/components/admin_console/message_export_settings.jsx
+++ b/components/admin_console/message_export_settings.jsx
@@ -208,15 +208,6 @@ export default class MessageExportSettings extends AdminSettings {
 
         return (
             <SettingsGroup>
-                <div className='banner'>
-                    <div className='banner__content'>
-                        <FormattedHTMLMessage
-                            id='admin.complianceExport.description'
-                            defaultMessage='This feature supports compliance exports to the Actiance XML and GlobalRelay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\"/admin_console/general/compliance\">Compliance</a> feature.'
-                        />
-                    </div>
-                </div>
-
                 <BooleanSetting
                     id='enableComplianceExport'
                     label={

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -223,6 +223,7 @@
   "admin.compliance.enableTitle": "Enable Compliance Reporting:",
   "admin.compliance.false": "false",
   "admin.compliance.noLicense": "<h4 class=\"banner__heading\">Note:</h4><p>Compliance is an enterprise feature. Your current license does not support Compliance. Click <a href=\"http://mattermost.com\" target='_blank'>here</a> for information and pricing on enterprise licenses.</p>",
+  "admin.compliance.newComplianceExportBanner": "This feature is replaced by a new <a href=\"../../admin_console/compliance/message_export\">Compliance Export</a> feature, and will be removed in a future release. We recommend migrating to the new system.",
   "admin.compliance.save": "Save",
   "admin.compliance.saving": "Saving Config...",
   "admin.compliance.title": "Compliance Settings",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -230,7 +230,6 @@
   "admin.compliance.true": "true",
   "admin.complianceExport.createJob.help": "Initiates a Compliance Export job immediately.",
   "admin.complianceExport.createJob.title": "Run Compliance Export Job Now",
-  "admin.complianceExport.description": "This feature supports compliance exports to the Actiance XML and Global Relay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\"/admin_console/general/compliance\">Compliance</a> feature.",
   "admin.complianceExport.exportFormat.actiance": "Actiance XML",
   "admin.complianceExport.exportFormat.csv": "CSV",
   "admin.complianceExport.exportFormat.description": "Format of the compliance export. Corresponds to the system that you want to import the data into.<br><br>For Actiance XML or CSV, compliance export files are written to the \"exports\" subdirectory of the configured <a href=\"/admin_console/files/storage\">Local Storage Directory</a>. For Global Relay EML, they are emailed to the configured email address.",

--- a/tests/components/admin_console/__snapshots__/message_export_settings.test.jsx.snap
+++ b/tests/components/admin_console/__snapshots__/message_export_settings.test.jsx.snap
@@ -21,19 +21,6 @@ exports[`components/MessageExportSettings should match snapshot, disabled, actia
     <SettingsGroup
       show={true}
     >
-      <div
-        className="banner"
-      >
-        <div
-          className="banner__content"
-        >
-          <FormattedHTMLMessage
-            defaultMessage="This feature supports compliance exports to the Actiance XML and GlobalRelay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\\\\\\"/admin_console/general/compliance\\\\\\">Compliance</a> feature."
-            id="admin.complianceExport.description"
-            values={Object {}}
-          />
-        </div>
-      </div>
       <BooleanSetting
         disabled={false}
         falseText={
@@ -212,19 +199,6 @@ exports[`components/MessageExportSettings should match snapshot, disabled, globa
     <SettingsGroup
       show={true}
     >
-      <div
-        className="banner"
-      >
-        <div
-          className="banner__content"
-        >
-          <FormattedHTMLMessage
-            defaultMessage="This feature supports compliance exports to the Actiance XML and GlobalRelay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\\\\\\"/admin_console/general/compliance\\\\\\">Compliance</a> feature."
-            id="admin.complianceExport.description"
-            values={Object {}}
-          />
-        </div>
-      </div>
       <BooleanSetting
         disabled={false}
         falseText={
@@ -513,19 +487,6 @@ exports[`components/MessageExportSettings should match snapshot, enabled, actian
     <SettingsGroup
       show={true}
     >
-      <div
-        className="banner"
-      >
-        <div
-          className="banner__content"
-        >
-          <FormattedHTMLMessage
-            defaultMessage="This feature supports compliance exports to the Actiance XML and GlobalRelay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\\\\\\"/admin_console/general/compliance\\\\\\">Compliance</a> feature."
-            id="admin.complianceExport.description"
-            values={Object {}}
-          />
-        </div>
-      </div>
       <BooleanSetting
         disabled={false}
         falseText={
@@ -704,19 +665,6 @@ exports[`components/MessageExportSettings should match snapshot, enabled, global
     <SettingsGroup
       show={true}
     >
-      <div
-        className="banner"
-      >
-        <div
-          className="banner__content"
-        >
-          <FormattedHTMLMessage
-            defaultMessage="This feature supports compliance exports to the Actiance XML and GlobalRelay EML formats, and is currently in beta. Support for the Mattermost CSV format is scheduled for a future release, and will replace the existing <a href=\\\\\\"/admin_console/general/compliance\\\\\\">Compliance</a> feature."
-            id="admin.complianceExport.description"
-            values={Object {}}
-          />
-        </div>
-      </div>
       <BooleanSetting
         disabled={false}
         falseText={


### PR DESCRIPTION
#### Summary
Removing the banner text on admin console for new compliance exports
system, and adding a new banner in the old compliance exports system.

#### Ticket Link
[MM-11418](https://mattermost.atlassian.net/browse/MM-11418)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates