### PR TITLE
[MM-11422] Fix rendering of embedded images with long URLs in message attachment

### DIFF
--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import * as PostActions from 'actions/post_actions.jsx';
+import {postListScrollChange} from 'actions/global_actions';
 
 import Markdown from 'components/markdown';
 
@@ -40,6 +41,10 @@ export default class PostAttachment extends React.PureComponent {
             collapsed: true,
             hasOverflow: false,
         };
+
+        this.imageProps = {
+            onHeightReceived: this.handleImageHeightReceived,
+        };
     }
 
     componentDidMount() {
@@ -70,6 +75,12 @@ export default class PostAttachment extends React.PureComponent {
                 hasOverflow,
             });
         }
+    };
+
+    handleImageHeightReceived = () => {
+        postListScrollChange();
+
+        this.checkAttachmentTextOverflow();
     };
 
     handleResize = () => {
@@ -322,6 +333,7 @@ export default class PostAttachment extends React.PureComponent {
                         <Markdown
                             message={attachment.text || ''}
                             options={options}
+                            imageProps={this.imageProps}
                         />
                     </div>
                     {textOverflow}

--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -11,6 +11,9 @@ import Markdown from 'components/markdown';
 import {isUrlSafe} from 'utils/url.jsx';
 import {localizeMessage} from 'utils/utils.jsx';
 
+// This must match the max-height defined in CSS for the collapsed attachmentText div
+const MAX_ATTACHMENT_TEXT_HEIGHT = 600;
+
 export default class PostAttachment extends React.PureComponent {
     static propTypes = {
 
@@ -35,8 +38,43 @@ export default class PostAttachment extends React.PureComponent {
 
         this.state = {
             collapsed: true,
+            hasOverflow: false,
         };
     }
+
+    componentDidMount() {
+        this.checkAttachmentTextOverflow();
+
+        window.addEventListener('resize', this.handleResize);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.attachment.text !== prevProps.attachment.text) {
+            this.checkAttachmentTextOverflow();
+        }
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.handleResize);
+    }
+
+    checkAttachmentTextOverflow = () => {
+        const attachmentText = this.refs.attachmentText;
+        let hasOverflow = false;
+        if (attachmentText && attachmentText.scrollHeight > MAX_ATTACHMENT_TEXT_HEIGHT) {
+            hasOverflow = true;
+        }
+
+        if (hasOverflow !== this.state.hasOverflow) {
+            this.setState({
+                hasOverflow,
+            });
+        }
+    };
+
+    handleResize = () => {
+        this.checkAttachmentTextOverflow();
+    };
 
     toggleCollapseState = (e) => {
         e.preventDefault();
@@ -45,25 +83,6 @@ export default class PostAttachment extends React.PureComponent {
                 collapsed: !prevState.collapsed,
             };
         });
-    };
-
-    shouldCollapse = () => {
-        const text = this.props.attachment.text || '';
-        return (text.match(/\n/g) || []).length >= 5 || text.length > 700;
-    };
-
-    getCollapsedText = () => {
-        // TODO: this breaks markdown formatting when it e.g. cuts a ``` block terminator
-        // Should be collapsed using another method.
-        let text = this.props.attachment.text || '';
-        if ((text.match(/\n/g) || []).length >= 5) {
-            text = text.split('\n').splice(0, 5).join('\n');
-        }
-        if (text.length > 300) {
-            text = text.substr(0, 300);
-        }
-
-        return text;
     };
 
     getActionView = () => {
@@ -191,47 +210,51 @@ export default class PostAttachment extends React.PureComponent {
     };
 
     render() {
-        const data = this.props.attachment;
+        const {
+            collapsed,
+            hasOverflow,
+        } = this.state;
+        const {attachment, options} = this.props;
         let preTextClass = '';
 
         let preText;
-        if (data.pretext) {
+        if (attachment.pretext) {
             preTextClass = 'attachment--pretext';
             preText = (
                 <div className='attachment__thumb-pretext'>
-                    <Markdown message={data.pretext}/>
+                    <Markdown message={attachment.pretext}/>
                 </div>
             );
         }
 
         let author = [];
-        if (data.author_name || data.author_icon) {
-            if (data.author_icon) {
+        if (attachment.author_name || attachment.author_icon) {
+            if (attachment.author_icon) {
                 author.push(
                     <img
                         className='attachment__author-icon'
-                        src={data.author_icon}
+                        src={attachment.author_icon}
                         key={'attachment__author-icon'}
                         height='14'
                         width='14'
                     />
                 );
             }
-            if (data.author_name) {
+            if (attachment.author_name) {
                 author.push(
                     <span
                         className='attachment__author-name'
                         key={'attachment__author-name'}
                     >
-                        {data.author_name}
+                        {attachment.author_name}
                     </span>
                 );
             }
         }
-        if (data.author_link && isUrlSafe(data.author_link)) {
+        if (attachment.author_link && isUrlSafe(attachment.author_link)) {
             author = (
                 <a
-                    href={data.author_link}
+                    href={attachment.author_link}
                     target='_blank'
                     rel='noopener noreferrer'
                 >
@@ -241,79 +264,89 @@ export default class PostAttachment extends React.PureComponent {
         }
 
         let title;
-        if (data.title) {
-            if (data.title_link && isUrlSafe(data.title_link)) {
+        if (attachment.title) {
+            if (attachment.title_link && isUrlSafe(attachment.title_link)) {
                 title = (
-                    <h1
-                        className='attachment__title'
-                    >
+                    <h1 className='attachment__title'>
                         <a
                             className='attachment__title-link'
-                            href={data.title_link}
+                            href={attachment.title_link}
                             target='_blank'
                             rel='noopener noreferrer'
                         >
-                            {data.title}
+                            {attachment.title}
                         </a>
                     </h1>
                 );
             } else {
                 title = (
-                    <h1
-                        className='attachment__title'
-                    >
-                        {data.title}
+                    <h1 className='attachment__title'>
+                        {attachment.title}
                     </h1>
                 );
             }
         }
 
         let text;
-        if (data.text) {
-            const shouldCollapse = this.shouldCollapse();
-            const collapsed = shouldCollapse && this.state.collapsed;
-            const attachmentText = collapsed ? this.getCollapsedText() : this.props.attachment.text;
-            const collapseMessage = collapsed ? localizeMessage('post_attachment.more', 'Show more...') : localizeMessage('post_attachment.collapse', 'Show less...');
+        if (attachment.text) {
+            let collapseMessage = localizeMessage('post_attachment.more', 'Show more...');
+            let textClass = 'attachment__text';
+            if (collapsed) {
+                collapseMessage = localizeMessage('post_attachment.collapse', 'Show less...');
+                textClass += ' attachment__text--collapsed';
+            }
 
-            text = (
-                <div className='attachment__text'>
-                    <Markdown
-                        message={attachmentText || ''}
-                        options={this.props.options}
-                    />
-                    {shouldCollapse &&
-                        <div>
+            let textOverflow = null;
+            if (hasOverflow) {
+                textOverflow = (
+                    <div className='attachment__text-collapse'>
+                        <div className='attachment__text-collapse__link-more'>
                             <a
-                                className='attachment-link-more'
+                                className='attachment__text-link-more'
                                 href='#'
                                 onClick={this.toggleCollapseState}
                             >
                                 {collapseMessage}
                             </a>
                         </div>
-                    }
+                    </div>
+                );
+            }
+
+            text = (
+                <div className={textClass}>
+                    <div
+                        className='attachment__text-container'
+                        ref='attachmentText'
+                    >
+                        <Markdown
+                            message={attachment.text || ''}
+                            options={options}
+                        />
+                    </div>
+                    {textOverflow}
                 </div>
             );
         }
 
         let image;
-        if (data.image_url) {
+        if (attachment.image_url) {
             image = (
                 <img
                     className='attachment__image'
-                    src={data.image_url}
+                    src={attachment.image_url}
                 />
             );
         }
 
         let thumb;
-        if (data.thumb_url) {
+        if (attachment.thumb_url) {
             thumb = (
                 <div
                     className='attachment__thumb-container'
                 >
                     <img
-                        src={data.thumb_url}
+                        src={attachment.thumb_url}
                     />
                 </div>
             );
@@ -323,8 +356,8 @@ export default class PostAttachment extends React.PureComponent {
         const actions = this.getActionView();
 
         let useBorderStyle;
-        if (data.color && data.color[0] === '#') {
-            useBorderStyle = {borderLeftColor: data.color};
+        if (attachment.color && attachment.color[0] === '#') {
+            useBorderStyle = {borderLeftColor: attachment.color};
         }
 
         return (
@@ -335,7 +368,7 @@ export default class PostAttachment extends React.PureComponent {
                 {preText}
                 <div className='attachment__content'>
                     <div
-                        className={useBorderStyle ? 'clearfix attachment__container' : 'clearfix attachment__container attachment__container--' + data.color}
+                        className={useBorderStyle ? 'clearfix attachment__container' : 'clearfix attachment__container attachment__container--' + attachment.color}
                         style={useBorderStyle}
                     >
                         {author}

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -178,7 +178,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
     wrapInSmallImageContainer(imageElement) {
         return (
             <div
-                className='attachment__image__container--openraph'
+                className='attachment__image__container--opengraph'
                 ref={this.getSmallImageContainer}
             >
                 {imageElement}

--- a/sass/layout/_webhooks.scss
+++ b/sass/layout/_webhooks.scss
@@ -177,11 +177,29 @@
             }
         }
 
+        .attachment__text {
+            .attachment__text-collapse {
+                position: relative;
+            }
+
+            .attachment__text-collapse__link-more {
+                position: relative;
+            }
+        }
+
         .attachment__text p:last-of-type {
             display: inline-block;
         }
 
-        .attachment__image__container--openraph {
+        .attachment__text--collapsed {
+            .attachment__text-container {
+                // "max-height" should match MAX_ATTACHMENT_TEXT_HEIGHT constant in
+                // components/post_view/post_attachment.jsx.
+                max-height: 600px;
+            }
+        }
+
+        .attachment__image__container--opengraph {
             display: table-cell;
             padding-left: 15px;
             padding-top: 3px;
@@ -245,7 +263,7 @@
             }
         }
 
-        .attachment-link-more {
+        .attachment__text-link-more {
             display: inline-block;
             font-size: .9em;
             margin: 5px 0;

--- a/tests/components/post_view/__snapshots__/post_attachment.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/post_attachment.test.jsx.snap
@@ -58,11 +58,15 @@ exports[`components/post_view/PostAttachment should call PostActions.doPostActio
           className="attachment__body"
         >
           <div
-            className="attachment__text"
+            className="attachment__text attachment__text--collapsed"
           >
-            <Connect(Markdown)
-              message="short text"
-            />
+            <div
+              className="attachment__text-container"
+            >
+              <Connect(Markdown)
+                message="short text"
+              />
+            </div>
           </div>
           <img
             className="attachment__image"
@@ -158,11 +162,15 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
           className="attachment__body"
         >
           <div
-            className="attachment__text"
+            className="attachment__text attachment__text--collapsed"
           >
-            <Connect(Markdown)
-              message="short text"
-            />
+            <div
+              className="attachment__text-container"
+            >
+              <Connect(Markdown)
+                message="short text"
+              />
+            </div>
           </div>
           <img
             className="attachment__image"

--- a/tests/components/post_view/__snapshots__/post_attachment.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/post_attachment.test.jsx.snap
@@ -64,6 +64,11 @@ exports[`components/post_view/PostAttachment should call PostActions.doPostActio
               className="attachment__text-container"
             >
               <Connect(Markdown)
+                imageProps={
+                  Object {
+                    "onHeightReceived": [Function],
+                  }
+                }
                 message="short text"
               />
             </div>
@@ -168,6 +173,11 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
               className="attachment__text-container"
             >
               <Connect(Markdown)
+                imageProps={
+                  Object {
+                    "onHeightReceived": [Function],
+                  }
+                }
                 message="short text"
               />
             </div>

--- a/tests/components/post_view/post_attachment.test.jsx
+++ b/tests/components/post_view/post_attachment.test.jsx
@@ -5,11 +5,16 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import {doPostAction} from 'actions/post_actions.jsx';
+import {postListScrollChange} from 'actions/global_actions';
 
 import PostAttachment from 'components/post_view/post_attachment.jsx';
 
 jest.mock('actions/post_actions.jsx', () => ({
     doPostAction: jest.fn(),
+}));
+
+jest.mock('actions/global_actions.jsx', () => ({
+    postListScrollChange: jest.fn(),
 }));
 
 describe('components/post_view/PostAttachment', () => {
@@ -49,6 +54,16 @@ describe('components/post_view/PostAttachment', () => {
         const newAttachment = {...attachment, text: 'new text'};
         wrapper.setProps({attachment: newAttachment});
         expect(instance.checkAttachmentTextOverflow).toHaveBeenCalledTimes(2);
+    });
+
+    test('should have called postListScrollChange and checkAttachmentTextOverflow on handleImageHeightReceived', () => {
+        const wrapper = shallow(<PostAttachment {...baseProps}/>);
+        const instance = wrapper.instance();
+        instance.checkAttachmentTextOverflow = jest.fn();
+
+        instance.handleImageHeightReceived();
+        expect(instance.checkAttachmentTextOverflow).toHaveBeenCalledTimes(1);
+        expect(postListScrollChange).toHaveBeenCalledTimes(1);
     });
 
     test('should match collapsed state on toggleCollapseState', () => {

--- a/tests/components/post_view/post_attachment.test.jsx
+++ b/tests/components/post_view/post_attachment.test.jsx
@@ -36,6 +36,21 @@ describe('components/post_view/PostAttachment', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should have called checkAttachmentTextOverflow on handleResize and on componentDidUpdate', () => {
+        const wrapper = shallow(<PostAttachment {...baseProps}/>);
+        const instance = wrapper.instance();
+        instance.checkAttachmentTextOverflow = jest.fn();
+
+        // on handleResize
+        instance.handleResize();
+        expect(instance.checkAttachmentTextOverflow).toHaveBeenCalledTimes(1);
+
+        // on componentDidUpdate
+        const newAttachment = {...attachment, text: 'new text'};
+        wrapper.setProps({attachment: newAttachment});
+        expect(instance.checkAttachmentTextOverflow).toHaveBeenCalledTimes(2);
+    });
+
     test('should match collapsed state on toggleCollapseState', () => {
         const wrapper = shallow(<PostAttachment {...baseProps}/>);
 
@@ -45,48 +60,6 @@ describe('components/post_view/PostAttachment', () => {
 
         wrapper.instance().toggleCollapseState({preventDefault: () => {}}); // eslint-disable-line no-empty-function
         expect(wrapper.state('collapsed')).toEqual(true);
-    });
-
-    test('should match value on shouldCollapse', () => {
-        const wrapper = shallow(<PostAttachment {...baseProps}/>);
-
-        expect(wrapper.instance().shouldCollapse()).toEqual(false);
-
-        let text = 'a'.repeat(701);
-        wrapper.setProps({attachment: {text}});
-        expect(wrapper.instance().shouldCollapse()).toEqual(true);
-
-        text = 'a'.repeat(700);
-        wrapper.setProps({attachment: {text}});
-        expect(wrapper.instance().shouldCollapse()).toEqual(false);
-
-        text = 'a\n'.repeat(5);
-        wrapper.setProps({attachment: {text}});
-        expect(wrapper.instance().shouldCollapse()).toEqual(true);
-
-        text = 'a\n'.repeat(4);
-        wrapper.setProps({attachment: {text}});
-        expect(wrapper.instance().shouldCollapse()).toEqual(false);
-    });
-
-    test('getCollapsedText should return correct results', () => {
-        const wrapper = shallow(<PostAttachment {...baseProps}/>);
-        wrapper.setState({collapsed: true});
-
-        let text = 'b'.repeat(30);
-        wrapper.setProps({attachment: {text}});
-        let actual = wrapper.instance().getCollapsedText();
-        expect(actual).toBe(text);
-
-        text = 'c'.repeat(701);
-        wrapper.setProps({attachment: {text}});
-        actual = wrapper.instance().getCollapsedText();
-        expect(actual).toBe('c'.repeat(300));
-
-        text = 'd\n'.repeat(5);
-        wrapper.setProps({attachment: {text}});
-        actual = wrapper.instance().getCollapsedText();
-        expect(actual).toBe('d\nd\nd\nd\nd');
     });
 
     test('should match value on getActionView', () => {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -662,8 +662,9 @@ export function applyTheme(theme) {
             '.app__body .sidebar-right__body .post.post--compact .post-collapse__show-more',
             `background-color:${theme.centerChannelBg}`,
         );
-        changeCss('.app__body .post-collapse__show-more-button', `background:${theme.centerChannelBg}`);
+        changeCss('.app__body .attachment__text-collapse__link-more', `background:${theme.centerChannelBg}`);
         changeCss('.app__body .post-collapse__show-more-button:hover', `color:${theme.centerChannelBg}`);
+        changeCss('.app__body .post-collapse__show-more-button', `background:${theme.centerChannelBg}`);
     }
 
     if (theme.centerChannelColor) {


### PR DESCRIPTION
#### Summary
Fix rendering of embedded images with long URLs in message attachment.
Found this bug while working on related bug on RN (MM-11145).

It happened when attachment.text is partially forwarded to Markdown component.  So instead of slicing the attachment.text when it's greater than the cap multilines or text' length, such text is fully rendered on Markdown component and just hide/show when it has overflow (depends on height).  Implementation is similar to long post feature.

See screen capture: 
BEFORE (Broken)
- https://youtu.be/JjcNwIQN8oE

AFTER (Fixed)
- https://youtu.be/6itK3sDsD2w

#### Ticket Link
Jira ticket: [MM-11422](https://mattermost.atlassian.net/browse/MM-11145)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
