### PR TITLE
[MM-11442] Strip markdown on desktop notification and "commented on"

### DIFF
--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -15,7 +15,9 @@ import store from 'stores/redux_store.jsx';
 
 import {formatWithRenderer} from 'utils/markdown';
 import RemoveMarkdown from 'utils/markdown/remove_markdown';
+
 const removeMarkdown = new RemoveMarkdown();
+const NOTIFY_TEXT_MAX_LENGTH = 50;
 
 export function sendDesktopNotification(post, msgProps) {
     if ((UserStore.getCurrentId() === post.user_id && post.props.from_webhook !== 'true')) {
@@ -97,12 +99,10 @@ export function sendDesktopNotification(post, msgProps) {
         image |= attachment.image_url.length > 0;
     });
 
-    notifyText = notifyText.replace(/\n+/g, ' ');
-    if (notifyText.length > 50) {
-        notifyText = notifyText.substring(0, 49) + '...';
+    let strippedMarkdownNotifyText = formatWithRenderer(notifyText, removeMarkdown);
+    if (strippedMarkdownNotifyText.length > NOTIFY_TEXT_MAX_LENGTH) {
+        strippedMarkdownNotifyText = strippedMarkdownNotifyText.substring(0, NOTIFY_TEXT_MAX_LENGTH - 1) + '...';
     }
-
-    const strippedMarkdownNotifyText = formatWithRenderer(notifyText, removeMarkdown);
 
     let body = '';
     if (strippedMarkdownNotifyText.length === 0) {

--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -15,6 +15,7 @@ import store from 'stores/redux_store.jsx';
 
 import {formatWithRenderer} from 'utils/markdown';
 import RemoveMarkdown from 'utils/markdown/remove_markdown';
+const removeMarkdown = new RemoveMarkdown();
 
 export function sendDesktopNotification(post, msgProps) {
     if ((UserStore.getCurrentId() === post.user_id && post.props.from_webhook !== 'true')) {
@@ -101,7 +102,7 @@ export function sendDesktopNotification(post, msgProps) {
         notifyText = notifyText.substring(0, 49) + '...';
     }
 
-    const strippedMarkdownNotifyText = formatWithRenderer(notifyText, new RemoveMarkdown());
+    const strippedMarkdownNotifyText = formatWithRenderer(notifyText, removeMarkdown);
 
     let body = '';
     if (strippedMarkdownNotifyText.length === 0) {

--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -13,6 +13,9 @@ import {isMacApp, isMobileApp, isWindowsApp} from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 import store from 'stores/redux_store.jsx';
 
+import {formatWithRenderer} from 'utils/markdown';
+import RemoveMarkdown from 'utils/markdown/remove_markdown';
+
 export function sendDesktopNotification(post, msgProps) {
     if ((UserStore.getCurrentId() === post.user_id && post.props.from_webhook !== 'true')) {
         return;
@@ -98,8 +101,10 @@ export function sendDesktopNotification(post, msgProps) {
         notifyText = notifyText.substring(0, 49) + '...';
     }
 
+    const strippedMarkdownNotifyText = formatWithRenderer(notifyText, new RemoveMarkdown());
+
     let body = '';
-    if (notifyText.length === 0) {
+    if (strippedMarkdownNotifyText.length === 0) {
         if (msgProps.image) {
             body = username + Utils.localizeMessage('channel_loader.uploadedImage', ' uploaded an image');
         } else if (msgProps.otherFile) {
@@ -110,7 +115,7 @@ export function sendDesktopNotification(post, msgProps) {
             body = username + Utils.localizeMessage('channel_loader.something', ' did something new');
         }
     } else {
-        body = username + Utils.localizeMessage('channel_loader.wrote', ' wrote: ') + notifyText;
+        body = username + Utils.localizeMessage('channel_loader.wrote', ' wrote: ') + strippedMarkdownNotifyText;
     }
 
     //Play a sound if explicitly set in settings

--- a/components/post_view/post_body/post_body.jsx
+++ b/components/post_view/post_body/post_body.jsx
@@ -202,6 +202,8 @@ export default class PostBody extends React.PureComponent {
                         <span
                             className='theme color--link'
                             onClick={this.props.handleCommentClick}
+                            role='button'
+                            tabIndex='0'
                         >
                             <Markdown
                                 message={message}

--- a/components/post_view/post_body/post_body.jsx
+++ b/components/post_view/post_body/post_body.jsx
@@ -10,8 +10,6 @@ import * as PostActions from 'actions/post_actions.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 import DelayedAction from 'utils/delayed_action.jsx';
-import {formatWithRenderer} from 'utils/markdown';
-import RemoveMarkdown from 'utils/markdown/remove_markdown';
 
 import CommentedOnFilesMessage from 'components/post_view/commented_on_files_message';
 import FileAttachmentListContainer from 'components/file_attachment_list';
@@ -24,7 +22,12 @@ import ReactionListContainer from 'components/post_view/reaction_list';
 import loadingGif from 'images/load.gif';
 
 const SENDING_ANIMATION_DELAY = 3000;
-const commentedMarkdownOptions = {singleline: true, mentionHighlight: false, atMentions: true};
+const commentedMarkdownOptions = {
+    atMentions: true,
+    mentionHighlight: false,
+    removeMarkdown: true,
+    singleline: true,
+};
 
 export default class PostBody extends React.PureComponent {
     static propTypes = {
@@ -196,15 +199,15 @@ export default class PostBody extends React.PureComponent {
                                 apostrophe,
                             }}
                         />
-                        <a
-                            className='theme'
+                        <span
+                            className='theme color--link'
                             onClick={this.props.handleCommentClick}
                         >
                             <Markdown
-                                message={formatWithRenderer(message, new RemoveMarkdown())}
+                                message={message}
                                 options={commentedMarkdownOptions}
                             />
-                        </a>
+                        </span>
                     </span>
                 </div>
             );

--- a/components/post_view/post_body/post_body.jsx
+++ b/components/post_view/post_body/post_body.jsx
@@ -10,15 +10,21 @@ import * as PostActions from 'actions/post_actions.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 import DelayedAction from 'utils/delayed_action.jsx';
-import FileAttachmentListContainer from 'components/file_attachment_list';
+import {formatWithRenderer} from 'utils/markdown';
+import RemoveMarkdown from 'utils/markdown/remove_markdown';
+
 import CommentedOnFilesMessage from 'components/post_view/commented_on_files_message';
+import FileAttachmentListContainer from 'components/file_attachment_list';
 import FailedPostOptions from 'components/post_view/failed_post_options';
+import Markdown from 'components/markdown';
 import PostBodyAdditionalContent from 'components/post_view/post_body_additional_content';
 import PostMessageView from 'components/post_view/post_message_view';
 import ReactionListContainer from 'components/post_view/reaction_list';
+
 import loadingGif from 'images/load.gif';
 
 const SENDING_ANIMATION_DELAY = 3000;
+const commentedMarkdownOptions = {singleline: true, mentionHighlight: false, atMentions: true};
 
 export default class PostBody extends React.PureComponent {
     static propTypes = {
@@ -194,7 +200,10 @@ export default class PostBody extends React.PureComponent {
                             className='theme'
                             onClick={this.props.handleCommentClick}
                         >
-                            {message}
+                            <Markdown
+                                message={formatWithRenderer(message, new RemoveMarkdown())}
+                                options={commentedMarkdownOptions}
+                            />
                         </a>
                     </span>
                 </div>

--- a/tests/utils/markdown/remove_markdown.test.jsx
+++ b/tests/utils/markdown/remove_markdown.test.jsx
@@ -3,6 +3,7 @@
 
 import {formatWithRenderer} from 'utils/markdown';
 import RemoveMarkdown from 'utils/markdown/remove_markdown';
+const removeMarkdown = new RemoveMarkdown();
 
 describe('RemoveMarkdown', () => {
     const testCases = [
@@ -186,6 +187,6 @@ describe('RemoveMarkdown', () => {
     ];
 
     testCases.forEach((testCase) => it(testCase.description, () => {
-        expect(formatWithRenderer(testCase.inputText, new RemoveMarkdown())).toEqual(testCase.outputText);
+        expect(formatWithRenderer(testCase.inputText, removeMarkdown)).toEqual(testCase.outputText);
     }));
 });

--- a/tests/utils/markdown/remove_markdown.test.jsx
+++ b/tests/utils/markdown/remove_markdown.test.jsx
@@ -1,0 +1,191 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {formatWithRenderer} from 'utils/markdown';
+import RemoveMarkdown from 'utils/markdown/remove_markdown';
+
+describe('RemoveMarkdown', () => {
+    const testCases = [
+        {
+            description: 'emoji: same',
+            inputText: 'Hey :smile: :+1: :)',
+            outputText: 'Hey :smile: :+1: :)',
+        },
+        {
+            description: 'at-mention: same',
+            inputText: 'Hey @user and @test',
+            outputText: 'Hey @user and @test',
+        },
+        {
+            description: 'channel-link: same',
+            inputText: 'join ~channelname',
+            outputText: 'join ~channelname',
+        },
+        {
+            description: 'codespan: single backtick',
+            inputText: '`single backtick`',
+            outputText: 'single backtick',
+        },
+        {
+            description: 'codespan: double backtick',
+            inputText: '``double backtick``',
+            outputText: 'double backtick',
+        },
+        {
+            description: 'codespan: triple backtick',
+            inputText: '```triple backtick```',
+            outputText: 'triple backtick',
+        },
+        {
+            description: 'codespan: inline code',
+            inputText: 'Inline `code` has ``double backtick`` and ```triple backtick``` around it.',
+            outputText: 'Inline code has double backtick and triple backtick around it.',
+        },
+        {
+            description: 'codespan: multiline codespan',
+            inputText: 'Multiline ```\ncodespan\n```',
+            outputText: 'Multiline codespan',
+        },
+        {
+            description: 'codespan: language highlighting',
+            inputText: '```javascript\nvar s = "JavaScript syntax highlighting";\nalert(s);\n```',
+            outputText: ' var s = "JavaScript syntax highlighting"; alert(s); ',
+        },
+        {
+            description: 'blockquote:',
+            inputText: '> Hey quote',
+            outputText: 'Hey quote',
+        },
+        {
+            description: 'blockquote: multiline',
+            inputText: '> Hey quote.\n> Hello quote.',
+            outputText: 'Hey quote. Hello quote.',
+        },
+        {
+            description: 'heading: # H1 header',
+            inputText: '# H1 header',
+            outputText: 'H1 header',
+        },
+        {
+            description: 'heading: heading with @user',
+            inputText: '# H1 @user',
+            outputText: 'H1 @user',
+        },
+        {
+            description: 'heading: ## H2 header',
+            inputText: '## H2 header',
+            outputText: 'H2 header',
+        },
+        {
+            description: 'heading: ### H3 header',
+            inputText: '### H3 header',
+            outputText: 'H3 header',
+        },
+        {
+            description: 'heading: #### H4 header',
+            inputText: '#### H4 header',
+            outputText: 'H4 header',
+        },
+        {
+            description: 'heading: ##### H5 header',
+            inputText: '##### H5 header',
+            outputText: 'H5 header',
+        },
+        {
+            description: 'heading: ###### H6 header',
+            inputText: '###### H6 header',
+            outputText: 'H6 header',
+        },
+        {
+            description: 'list: 1. First ordered list item',
+            inputText: '1. First ordered list item',
+            outputText: 'First ordered list item',
+        },
+        {
+            description: 'list: 2. Another item',
+            inputText: '1. 2. Another item',
+            outputText: 'Another item',
+        },
+        {
+            description: 'list: * Unordered sub-list.',
+            inputText: '* Unordered sub-list.',
+            outputText: 'Unordered sub-list.',
+        },
+        {
+            description: 'list: - Or minuses',
+            inputText: '- Or minuses',
+            outputText: 'Or minuses',
+        },
+        {
+            description: 'list: + Or pluses',
+            inputText: '+ Or pluses',
+            outputText: 'Or pluses',
+        },
+        {
+            description: 'list: multiline',
+            inputText: '1. First ordered list item\n2. Another item',
+            outputText: 'First ordered list itemAnother item',
+        },
+        {
+            description: 'tablerow:)',
+            inputText: 'Markdown | Less | Pretty\n' +
+            '--- | --- | ---\n' +
+            '*Still* | `renders` | **nicely**\n' +
+            '1 | 2 | 3\n',
+            outputText: '',
+        },
+        {
+            description: 'table:',
+            inputText: '| Tables        | Are           | Cool  |\n' +
+                '| ------------- |:-------------:| -----:|\n' +
+                '| col 3 is      | right-aligned | $1600 |\n' +
+                '| col 2 is      | centered      |   $12 |\n' +
+                '| zebra stripes | are neat      |    $1 |\n',
+            outputText: '',
+        },
+        {
+            description: 'strong: Bold with **asterisks** or __underscores__.',
+            inputText: 'Bold with **asterisks** or __underscores__.',
+            outputText: 'Bold with asterisks or underscores.',
+        },
+        {
+            description: 'strong & em: Bold and italics with **asterisks and _underscores_**.',
+            inputText: 'Bold and italics with **asterisks and _underscores_**.',
+            outputText: 'Bold and italics with asterisks and underscores.',
+        },
+        {
+            description: 'em: Italics with *asterisks* or _underscores_.',
+            inputText: 'Italics with *asterisks* or _underscores_.',
+            outputText: 'Italics with asterisks or underscores.',
+        },
+        {
+            description: 'del: Strikethrough ~~strike this.~~',
+            inputText: 'Strikethrough ~~strike this.~~',
+            outputText: 'Strikethrough strike this.',
+        },
+        {
+            description: 'links: [inline-style link](http://localhost:8065)',
+            inputText: '[inline-style link](http://localhost:8065)',
+            outputText: 'inline-style link',
+        },
+        {
+            description: 'image: ![image link](http://localhost:8065/image)',
+            inputText: '![image link](http://localhost:8065/image)',
+            outputText: 'image link',
+        },
+        {
+            description: 'text: plain',
+            inputText: 'This is plain text.',
+            outputText: 'This is plain text.',
+        },
+        {
+            description: 'text: multiline',
+            inputText: 'This is multiline text.\nHere is the next line.\n',
+            outputText: 'This is multiline text. Here is the next line.',
+        },
+    ];
+
+    testCases.forEach((testCase) => it(testCase.description, () => {
+        expect(formatWithRenderer(testCase.inputText, new RemoveMarkdown())).toEqual(testCase.outputText);
+    }));
+});

--- a/utils/markdown/remove_markdown.js
+++ b/utils/markdown/remove_markdown.js
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import marked from 'marked';
+
+export default class RemoveMarkdown extends marked.Renderer {
+    code(text) {
+        return ' ' + text.split('\n').join(' ');
+    }
+
+    blockquote(text) {
+        return text.split('\n').join(' ');
+    }
+
+    heading(text) {
+        return text;
+    }
+
+    hr() {
+        return '';
+    }
+
+    list(body) {
+        return body;
+    }
+
+    listitem(text) {
+        return text;
+    }
+
+    paragraph(text) {
+        return text;
+    }
+
+    table() {
+        return '';
+    }
+
+    tablerow() {
+        return '';
+    }
+
+    tablecell() {
+        return '';
+    }
+
+    strong(text) {
+        return text;
+    }
+
+    em(text) {
+        return text;
+    }
+
+    codespan(text) {
+        return text;
+    }
+
+    br() {
+        return ' ';
+    }
+
+    del(text) {
+        return text;
+    }
+
+    link(href, title, text) {
+        return text;
+    }
+
+    image(href, title, text) {
+        return text;
+    }
+
+    text(text) {
+        return text.replace('\n', ' ');
+    }
+}

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -6,10 +6,14 @@ import XRegExp from 'xregexp';
 
 import EmojiStore from 'stores/emoji_store.jsx';
 
+import {formatWithRenderer} from 'utils/markdown';
+import RemoveMarkdown from 'utils/markdown/remove_markdown';
+
 import Constants from './constants.jsx';
 import * as Emoticons from './emoticons.jsx';
 import * as Markdown from './markdown';
 
+const removeMarkdown = new RemoveMarkdown();
 const punctuation = XRegExp.cache('[^\\pL\\d]');
 
 // pattern to detect the existence of a Chinese, Japanese, or Korean character in a string
@@ -50,7 +54,11 @@ export function formatText(text, inputOptions) {
         options.searchPatterns = parseSearchTerms(options.searchTerm).map(convertSearchTermToRegex);
     }
 
-    if (!('markdown' in options) || options.markdown) {
+    if (options.removeMarkdown) {
+        output = formatWithRenderer(output, removeMarkdown);
+        output = sanitizeHtml(output);
+        output = doFormatText(output, options);
+    } else if (!('markdown' in options) || options.markdown) {
         // the markdown renderer will call doFormatText as necessary
         output = Markdown.format(output, options);
     } else {


### PR DESCRIPTION
#### Summary
Stripped markdown on push notification and "commented on".

On "commented on", it's not specified on the ticket but I let it render with emoji and profile pop-over (can easily remove if not expected)
- https://youtu.be/Sg36Gkx4y5w
- https://youtu.be/-VOCC1WwAm4

#### Ticket Link
Jira ticket: [MM-11442](https://mattermost.atlassian.net/browse/MM-11442)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
