### PR TITLE
MM-11395: Opens docs to slash commands in new tab.

### DIFF
--- a/components/integrations/confirm_integration/confirm_integration.jsx
+++ b/components/integrations/confirm_integration/confirm_integration.jsx
@@ -10,6 +10,7 @@ import {browserHistory} from 'utils/browser_history';
 import Constants from 'utils/constants.jsx';
 import BackstageHeader from 'components/backstage/components/backstage_header.jsx';
 import {getSiteURL} from 'utils/url.jsx';
+import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 export default class ConfirmIntegration extends React.Component {
     static get propTypes() {
@@ -61,9 +62,9 @@ export default class ConfirmIntegration extends React.Component {
                 );
                 helpText = (
                     <p>
-                        <FormattedHTMLMessage
+                        <FormattedMarkdownMessage
                             id='add_command.doneHelp'
-                            defaultMessage='Your slash command has been set up. The following token will be sent in the outgoing payload. Please use it to verify the request came from your Mattermost team (see <a href="https://docs.mattermost.com/developer/slash-commands.html">documentation</a> for further details).'
+                            defaultMessage='Your slash command has been set up. The following token will be sent in the outgoing payload. Please use it to verify the request came from your Mattermost team (see [documentation](!https://docs.mattermost.com/developer/slash-commands.html) for further details).'
                         />
                     </p>
                 );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -49,7 +49,7 @@
   "add_command.description.help": "Description for your incoming webhook.",
   "add_command.displayName": "Title",
   "add_command.displayName.help": "Choose a title to be displayed on the slash command settings page. Maximum 64 characters.",
-  "add_command.doneHelp": "Your slash command has been set up. The following token will be sent in the outgoing payload. Please use it to verify the request came from your Mattermost team (see <a href=\"https://docs.mattermost.com/developer/slash-commands.html\">documentation</a> for further details).",
+  "add_command.doneHelp": "Your slash command has been set up. The following token will be sent in the outgoing payload. Please use it to verify the request came from your Mattermost team (see [documentation](!https://docs.mattermost.com/developer/slash-commands.html) for further details).",
   "add_command.iconUrl": "Response Icon",
   "add_command.iconUrl.help": "(Optional) Choose a profile picture override for the post responses to this slash command. Enter the URL of a .png or .jpg file at least 128 pixels by 128 pixels.",
   "add_command.iconUrl.placeholder": "https://www.example.com/myicon.png",


### PR DESCRIPTION
#### Summary
Opens docs to slash commands in new tab/window.

#### Ticket Link
[MM-11395](https://mattermost.atlassian.net/browse/MM-11395)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates