### PR TITLE
addSwitchToEENotification: don't assume there is a current user

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -42,6 +42,9 @@ export async function addSwitchToEENotification() {
     const USERS_THRESHOLD = 10000;
 
     const currentUser = Selectors.getCurrentUser(store.getState());
+    if (!currentUser) {
+        return;
+    }
 
     const isSystemAdmin = currentUser.roles.indexOf('system_admin') !== -1;
     if (!isSystemAdmin) {


### PR DESCRIPTION
#### Summary
This fixes a recently introduced regression in the `addSwitchToEENotification` function that resulted in the webapp breaking while logged out.

![image pasted at 2018-7-24 15-13](https://user-images.githubusercontent.com/1023171/43161224-7d00adba-8f55-11e8-9d57-57009253e8aa.png)

#### Ticket Link
None.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed