### PR TITLE
MM-11375: fix period in channel purpose issue

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "Dies ist der Start von {type} {name}, erstellt am {date}.",
   "intro_messages.offTopic": "Dies ist der Beginn von {display_name}, einem Kanal für nicht arbeitsbezogene Konversationen.",
   "intro_messages.onlyInvited": " Nur eingeladene Mitglieder können diesen privaten Kanal sehen.",
-  "intro_messages.purpose": " Der Zweck der/des {type} ist: {purpose}.",
+  "intro_messages.purpose": " Der Zweck der/des {type} ist: {purpose}",
   "intro_messages.readonly.default": "**Wilkommen bei {display_name}!**\n \nSenden Sie Nachrichten hier, die jeder sehen können soll. Jeder wird automatisch ein permanentes Mitglied in diesem Kanal, wenn Sie dem Team beitreten.",
   "intro_messages.setHeader": "Eine Überschrift setzen",
   "intro_messages.teammate": "Dies ist der Start Ihres Privatnachrichtenverlaufs mit diesem Teammitglied. Privatnachrichten und hier geteilte Dateien sind für Personen außerhalb dieses Bereichs nicht sichtbar.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2198,7 +2198,7 @@
   "intro_messages.noCreator": "This is the start of the {name} {type}, created on {date}.",
   "intro_messages.offTopic": "This is the start of {display_name}, a channel for non-work-related conversations.",
   "intro_messages.onlyInvited": " Only invited members can see this private channel.",
-  "intro_messages.purpose": " This {type}'s purpose is: {purpose}.",
+  "intro_messages.purpose": " This {type}'s purpose is: {purpose}",
   "intro_messages.readonly.default": "**Welcome to {display_name}!**\n \nMessages can only be posted by system admins. Everyone automatically becomes a permanent member of this channel when they join the team.",
   "intro_messages.setHeader": "Set a Header",
   "intro_messages.teammate": "This is the start of your direct message history with this teammate. Direct messages and files shared here are not shown to people outside this area.",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "Este es el inicio del {type} {name}, creado el  {date}.",
   "intro_messages.offTopic": "Este es el inicio de {display_name}, un canal para conversaciones no relacionadas con el trabajo.",
   "intro_messages.onlyInvited": " Sólo miembros invitados pueden ver este canal privado.",
-  "intro_messages.purpose": " El propósito de este {type} es: {purpose}.",
+  "intro_messages.purpose": " El propósito de este {type} es: {purpose}",
   "intro_messages.readonly.default": "**¡Bienvenido a {display_name}!**\n\nPublica mensajes aquí que quieras que todos vean. Todo el mundo se convierte automáticamente en un miembro permanente de este canal cuando se unan al equipo.",
   "intro_messages.setHeader": "Asignar un Encabezado",
   "intro_messages.teammate": "Este es el inicio de tu historial de mensajes directos con este compañero. Los mensajes directos y archivos que se comparten aquí no son mostrados a personas fuera de esta área.",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "Ceci est le début de {name} {type}, créé le {date}.",
   "intro_messages.offTopic": "Ceci est le début de {display_name}, un canal dédié aux conversations extra-professionnelles.",
   "intro_messages.onlyInvited": " Seuls les membres invités peuvent voir ce canal privé.",
-  "intro_messages.purpose": " L'objectif de {type} est : {purpose}.",
+  "intro_messages.purpose": " L'objectif de {type} est : {purpose}",
   "intro_messages.readonly.default": "**Bienvenue dans {display_name}**\n\nPubliez ici les messages que vous souhaitez que tout le monde voie. Chaque utilisateur devient un membre permanent de ce canal lorsqu'il rejoint l'équipe.",
   "intro_messages.setHeader": "Définir l'entête",
   "intro_messages.teammate": "Vous êtes au début de votre historique de messages avec cet utilisateur. Les messages personnels et les fichiers partagés ici ne sont pas visibles par les autres utilisateurs.",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "Questo è l'inizio di {name} {type}, creato il {date}.",
   "intro_messages.offTopic": "Questo è l'inizio di {display_name}, un canale per le conversazioni non legate al lavoro.",
   "intro_messages.onlyInvited": " Invita solo i membri che possono vedere questo canale privato.",
-  "intro_messages.purpose": " Lo scopo di {type} è: {purpose}.",
+  "intro_messages.purpose": " Lo scopo di {type} è: {purpose}",
   "intro_messages.readonly.default": "**Benvenuto in {display_name}!**\n \nI messaggi possono essre pubblicati solo dagli amministratori di sistema. Tutti diventeranno automaticamente membri permanenti di questo canale quando si uniranno al gruppo.",
   "intro_messages.setHeader": "Imposta un intestazione",
   "intro_messages.teammate": "Questo è l'inizio della tua conversazione privata con questi colleghi. Messaggi privati e file condivisi qui non sono accessibili ad altre persone.",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "{name} {type}입니다. 만들어진 날짜: {date}.",
   "intro_messages.offTopic": "This is the start of {display_name}, a channel for non-work-related conversations.",
   "intro_messages.onlyInvited": " 초대받은 회원만 이 비공개 그룹을 볼 수 있습니다.",
-  "intro_messages.purpose": "이 {type}의 설명: {purpose}.",
+  "intro_messages.purpose": "이 {type}의 설명: {purpose}",
   "intro_messages.readonly.default": "모든사람이 볼 수 있도록 메시지를 게시하세요. 모든 사람들이 팀에 가입되면 자동으로 이 채널에 가입됩니다.",
   "intro_messages.setHeader": "헤더 설정",
   "intro_messages.teammate": "개인 메시지의 시작입니다. 개인 메세지와 여기서 공유된 파일들은 외부에서 보여지지 않습니다.",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "Dit is de start van {name} {type}, gemaakt op {date}.",
   "intro_messages.offTopic": "This is the start of {display_name}, a channel for non-work-related conversations.",
   "intro_messages.onlyInvited": " Alleen uitgenodigde deelnemers kunnen deze privé groep bekijken.",
-  "intro_messages.purpose": " This {type}'s purpose is: {purpose}.",
+  "intro_messages.purpose": " This {type}'s purpose is: {purpose}",
   "intro_messages.readonly.default": "**Welcome to {display_name}!**\n \nMessages can only be posted by system admins. Everyone automatically becomes a permanent member of this channel when they join the team.",
   "intro_messages.setHeader": "Stel een koptekst in",
   "intro_messages.teammate": "Dit is de start van uw privé berichten historiek met dit teamlid. Privé berichten en bestanden die hier gedeeld worden zijn niet zichtbaar voor anderen.",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "To początek {type} {name}, utworzony {date}.",
   "intro_messages.offTopic": "This is the start of {display_name}, a channel for non-work-related conversations.",
   "intro_messages.onlyInvited": " Tylko zaproszeni użytkownicy mogą zobaczyć ten prywatny kanał.",
-  "intro_messages.purpose": " Celem tego {type} jest: {purpose}.",
+  "intro_messages.purpose": " Celem tego {type} jest: {purpose}",
   "intro_messages.readonly.default": "Wyślij tutaj wiadomości które chcesz aby każdy zobaczył. Każdy automatycznie zostaje stałym uczestnikiem tego kanału gdy dołączają do zespołu.",
   "intro_messages.setHeader": "Ustaw tytuł",
   "intro_messages.teammate": "To początek historii wiadomości z użytkownikiem. Bezpośrednie wiadomości i wysłane w nich pliki nie są widoczne dla osób spoza tego obszaru.",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "Este é o início do {name} {type}, criado em {date}.",
   "intro_messages.offTopic": "Este é o início de {display_name}, um canal para conversas não relacionadas ao trabalho.",
   "intro_messages.onlyInvited": " Somente membros convidados podem ver este canal privado.",
-  "intro_messages.purpose": " O propósito deste {type} é: {purpose}.",
+  "intro_messages.purpose": " O propósito deste {type} é: {purpose}",
   "intro_messages.readonly.default": "**Bem vindo a {display_name}!**\n \nPublique mensagens aqui que você quer que todos vejam. Todos se tornam automaticamente membros permanentes deste canal quando entram na equipe.",
   "intro_messages.setHeader": "Definir um Cabeçalho",
   "intro_messages.teammate": "Este é o início de seu histórico de mensagens com esta equipe. Mensagens diretas e arquivos compartilhados aqui não são mostrados para pessoas fora dessa área.",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "{name} - {type}, созданный {date}",
   "intro_messages.offTopic": "This is the start of {display_name}, a channel for non-work-related conversations.",
   "intro_messages.onlyInvited": " Только приглашенные пользователи могут видеть этот приватный канал.",
-  "intro_messages.purpose": " Назначение для {type}: {purpose}.",
+  "intro_messages.purpose": " Назначение для {type}: {purpose}",
   "intro_messages.readonly.default": "**Welcome to {display_name}!**\n \nMessages can only be posted by system admins. Everyone automatically becomes a permanent member of this channel when they join the team.",
   "intro_messages.setHeader": "Изменить заголовок",
   "intro_messages.teammate": "Начало истории личных сообщений с участником. Личные сообщения и файлы доступны здесь и не видны за пределами этой области.",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "{name} {type} başlangıcı, oluşturulma tarihi: {date}.",
   "intro_messages.offTopic": "İş ile ilgili olmayan sohbetlerin bulunduğu {display_name} kanalının başlangıcı.",
   "intro_messages.onlyInvited": "Bu özel kanalı yalnız çağrılmış üyeler görüntüleyebilir.",
-  "intro_messages.purpose": " Bu {type} için amaç: {purpose}.",
+  "intro_messages.purpose": " Bu {type} için amaç: {purpose}",
   "intro_messages.readonly.default": "**Hoş geldiniz {display_name}!**\n\nBu kanala yalnız sistem yöneticileri ileti gönderebilir. Takıma katılan herkes otomatik olarak bu kanalın kalıcı üyesi olur.",
   "intro_messages.setHeader": "Bir Başlık Yazın",
   "intro_messages.teammate": "Takım arkadaşınız ile doğrudan ileti geçmişinizin başlangıcı. Bu bölüm dışındaki kişiler burada paylaşılan doğrudan ileti ve dosyaları göremez.",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "这是{name}{type}的开端，于{date}建立。",
   "intro_messages.offTopic": "这是{display_name}的开端，一个非工作有关的会话。",
   "intro_messages.onlyInvited": "只有受邀的成员才能看到这个私有频道。",
-  "intro_messages.purpose": "此{type}的用途是：{purpose}。",
+  "intro_messages.purpose": "此{type}的用途是：{purpose}",
   "intro_messages.readonly.default": "**欢迎来到{display_name}！**\n \n发表您想所有人看到的消息。所有人在加入团队时候自动成员此频道的永久成员。",
   "intro_messages.setHeader": "设置标题",
   "intro_messages.teammate": "这是您与此团队成员私信记录的开端。在这里的直接消息和文件共享除了在此的人外无法看到。",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -2193,7 +2193,7 @@
   "intro_messages.noCreator": "這是{name}{type}的開頭，建立於{date}。",
   "intro_messages.offTopic": "這是{display_name}的起頭，此頻道用以進行跟工作無關的對話。",
   "intro_messages.onlyInvited": " 只有受邀請的成員能看見此私人頻道",
-  "intro_messages.purpose": "此{type}的用途為：{purpose}。",
+  "intro_messages.purpose": "此{type}的用途為：{purpose}",
   "intro_messages.readonly.default": "**歡迎來到{display_name}！** 在此張貼希望所有人都可以看到的訊息。每個人在加入團隊的時候會自動成為此頻道的永久成員。",
   "intro_messages.setHeader": "設定標題",
   "intro_messages.teammate": "這是您跟這位團隊成員之間直接訊息的起頭。直接訊息跟在這邊分享的檔案除了在此處以外的人都看不到。",


### PR DESCRIPTION
#### Summary
Remove trailing period from the channel purpose when displaying the formatted message in the channel chat. This message is shown when a channel is first created. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11375

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Includes text changes
