### PR TITLE
[MM-10621] Update file preview to have the fileInfos sorted by "create_at" (if not created at the same time) or by "name"

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -6,7 +6,15 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
+import {sortFileInfos} from 'mattermost-redux/utils/file_utils';
+
 import * as GlobalActions from 'actions/global_actions.jsx';
+
+import Constants from 'utils/constants.jsx';
+import * as UserAgent from 'utils/user_agent.jsx';
+import * as Utils from 'utils/utils.jsx';
+import * as PostUtils from 'utils/post_utils.jsx';
+
 import ConfirmModal from 'components/confirm_modal.jsx';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
 import FilePreview from 'components/file_preview.jsx';
@@ -15,10 +23,6 @@ import MsgTyping from 'components/msg_typing';
 import PostDeletedModal from 'components/post_deleted_modal.jsx';
 import EmojiIcon from 'components/svg/emoji_icon';
 import Textbox from 'components/textbox.jsx';
-import Constants from 'utils/constants.jsx';
-import * as UserAgent from 'utils/user_agent.jsx';
-import * as Utils from 'utils/utils.jsx';
-import * as PostUtils from 'utils/post_utils.jsx';
 
 const KeyCodes = Constants.KeyCodes;
 
@@ -73,6 +77,7 @@ export default class CreateComment extends React.PureComponent {
          * The id of the latest post in this channel
          */
         latestPostId: PropTypes.string,
+        locale: PropTypes.string.isRequired,
 
         /**
          * A function returning a ref to the sidebar
@@ -420,7 +425,7 @@ export default class CreateComment extends React.PureComponent {
     handleFileUploadComplete = (fileInfos, clientIds) => {
         const {draft} = this.state;
         const uploadsInProgress = [...draft.uploadsInProgress];
-        const newFileInfos = [...draft.fileInfos, ...fileInfos];
+        const newFileInfos = sortFileInfos([...draft.fileInfos, ...fileInfos], this.props.locale);
 
         // remove each finished file from uploads
         for (let i = 0; i < clientIds.length; i++) {

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -12,6 +12,7 @@ import {resetCreatePostRequest, resetHistoryIndex} from 'mattermost-redux/action
 import {Preferences, Posts} from 'mattermost-redux/constants';
 
 import {Constants, StoragePrefixes} from 'utils/constants.jsx';
+import {getCurrentLocale} from 'selectors/i18n';
 
 import {
     clearCommentDraftUploads,
@@ -51,6 +52,7 @@ function mapStateToProps(state, ownProps) {
         enableConfirmNotificationsToChannel,
         enableEmojiPicker,
         enableGifPicker,
+        locale: getCurrentLocale(state),
         maxPostSize: parseInt(config.MaxPostSize, 10) || Constants.DEFAULT_CHARACTER_LIMIT,
     };
 }

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -5,7 +5,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
+
 import {Posts} from 'mattermost-redux/constants';
+import {sortFileInfos} from 'mattermost-redux/utils/file_utils';
 
 import * as ChannelActions from 'actions/channel_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
@@ -15,6 +17,7 @@ import Constants, {StoragePrefixes, ModalIdentifiers} from 'utils/constants.jsx'
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
+
 import ConfirmModal from 'components/confirm_modal.jsx';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
 import FilePreview from 'components/file_preview.jsx';
@@ -99,6 +102,7 @@ export default class CreatePost extends React.Component {
         *  Data used dispatching handleViewAction ex: edit post
         */
         latestReplyablePostId: PropTypes.string,
+        locale: PropTypes.string.isRequired,
 
         /**
         *  Data used for calling edit of post
@@ -533,7 +537,7 @@ export default class CreatePost extends React.Component {
             }
         }
 
-        draft.fileInfos = draft.fileInfos.concat(fileInfos);
+        draft.fileInfos = sortFileInfos(draft.fileInfos.concat(fileInfos), this.props.locale);
         this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, draft);
 
         if (channelId === this.props.currentChannel.id) {

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -29,6 +29,7 @@ import {emitUserPostedEvent, postListScrollChangeToBottom} from 'actions/global_
 import {createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
 import {getPostDraft} from 'selectors/rhs';
+import {getCurrentLocale} from 'selectors/i18n';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import {openModal} from 'actions/views/modals';
 import {Constants, Preferences, StoragePrefixes, TutorialSteps, UserStatuses} from 'utils/constants.jsx';
@@ -67,6 +68,7 @@ function mapStateToProps() {
             recentPostIdInChannel,
             commentCountForPost: getCommentCountForPost(state, {post}),
             latestReplyablePostId,
+            locale: getCurrentLocale(state),
             currentUsersLatestPost: getCurrentUsersLatestPost(state),
             readOnlyChannel: !isCurrentUserSystemAdmin(state) && config.ExperimentalTownSquareIsReadOnly === 'true' && currentChannel.name === Constants.DEFAULT_CHANNEL,
             canUploadFiles: canUploadFiles(config),

--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -25,7 +25,7 @@ export default class FileAttachmentList extends React.Component {
         fileCount: PropTypes.number.isRequired,
 
         /*
-         * Array of metadata for each file attached to the post
+         * Sorted array of metadata for each file attached to the post
          */
         fileInfos: PropTypes.arrayOf(PropTypes.object),
 
@@ -91,17 +91,14 @@ export default class FileAttachmentList extends React.Component {
         }
 
         const postFiles = [];
-        let sortedFileInfos = [];
-
         if (fileInfos && fileInfos.length > 0) {
-            sortedFileInfos = fileInfos.sort((a, b) => a.create_at - b.create_at);
-            for (let i = 0; i < Math.min(sortedFileInfos.length, Constants.MAX_DISPLAY_FILES); i++) {
-                const fileInfo = sortedFileInfos[i];
+            for (let i = 0; i < Math.min(fileInfos.length, Constants.MAX_DISPLAY_FILES); i++) {
+                const fileInfo = fileInfos[i];
 
                 postFiles.push(
                     <FileAttachment
                         key={fileInfo.id}
-                        fileInfo={sortedFileInfos[i]}
+                        fileInfo={fileInfos[i]}
                         index={i}
                         handleImageClick={this.handleImageClick}
                         compactDisplay={compactDisplay}
@@ -129,7 +126,7 @@ export default class FileAttachmentList extends React.Component {
                     show={this.state.showPreviewModal}
                     onModalDismissed={this.hidePreviewModal}
                     startIndex={this.state.startImgIndex}
-                    fileInfos={sortedFileInfos}
+                    fileInfos={fileInfos}
                 />
             </React.Fragment>
         );

--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Constants, {FileTypes} from 'utils/constants.jsx';
+import {FileTypes} from 'utils/constants.jsx';
 import {getFileType} from 'utils/utils';
 
 import FileAttachment from 'components/file_attachment';
@@ -92,7 +92,7 @@ export default class FileAttachmentList extends React.Component {
 
         const postFiles = [];
         if (fileInfos && fileInfos.length > 0) {
-            for (let i = 0; i < Math.min(fileInfos.length, Constants.MAX_DISPLAY_FILES); i++) {
+            for (let i = 0; i < fileInfos.length; i++) {
                 const fileInfo = fileInfos[i];
 
                 postFiles.push(
@@ -106,7 +106,7 @@ export default class FileAttachmentList extends React.Component {
                 );
             }
         } else if (fileCount > 0) {
-            for (let i = 0; i < Math.min(fileCount, Constants.MAX_DISPLAY_FILES); i++) {
+            for (let i = 0; i < fileCount; i++) {
                 // Add a placeholder to avoid pop-in once we get the file infos for this post
                 postFiles.push(
                     <div

--- a/components/file_preview.jsx
+++ b/components/file_preview.jsx
@@ -77,7 +77,7 @@ export default class FilePreview extends React.PureComponent {
 
             previews.push(
                 <div
-                    key={info.id + idx}
+                    key={info.id}
                     className={className}
                 >
                     <div className='post-image__thumbnail'>

--- a/components/file_preview.jsx
+++ b/components/file_preview.jsx
@@ -8,6 +8,7 @@ import {getFileThumbnailUrl, getFileUrl} from 'mattermost-redux/utils/file_utils
 import FilenameOverlay from 'components/file_attachment/filename_overlay.jsx';
 import Constants, {FileTypes} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
+
 import loadingGif from 'images/load.gif';
 
 export default class FilePreview extends React.PureComponent {
@@ -22,37 +23,19 @@ export default class FilePreview extends React.PureComponent {
         uploadsInProgress: [],
     };
 
-    constructor(props) {
-        super(props);
-
-        this.handleRemove = this.handleRemove.bind(this);
-        this.state = {
-            fileInfos: [...this.props.fileInfos],
-        };
-    }
-
     componentDidUpdate() {
         if (this.props.uploadsInProgress.length > 0) {
             this.refs[this.props.uploadsInProgress[0]].scrollIntoView();
         }
     }
 
-    UNSAFE_componentWillReceiveProps(newProps) { // eslint-disable-line camelcase
-        if (!Utils.areObjectsEqual(this.props.fileInfos, newProps.fileInfos)) {
-            this.setState({
-                fileInfos: [...newProps.fileInfos],
-            });
-        }
-    }
-
-    handleRemove(id) {
+    handleRemove = (id) => {
         this.props.onRemove(id);
     }
 
     render() {
         const previews = [];
-        const fileInfos = this.state.fileInfos.sort((a, b) => a.create_at - b.create_at);
-        fileInfos.forEach((info, idx) => {
+        this.props.fileInfos.forEach((info, idx) => {
             const type = Utils.getFileType(info.extension);
 
             let className = 'file-preview post-image__column';
@@ -94,7 +77,7 @@ export default class FilePreview extends React.PureComponent {
 
             previews.push(
                 <div
-                    key={info.id}
+                    key={info.id + idx}
                     className={className}
                 >
                     <div className='post-image__thumbnail'>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10202,8 +10202,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#a634d4157d60b99c0302ce08826982fa2a94f3df",
-      "from": "mattermost-redux@github:mattermost/mattermost-redux#a634d4157d60b99c0302ce08826982fa2a94f3df",
+      "version": "github:mattermost/mattermost-redux#10108a3d0d0c5fab658fe78bf66936fa6934745b",
+      "from": "github:mattermost/mattermost-redux#10108a3d0d0c5fab658fe78bf66936fa6934745b",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "localforage": "1.7.2",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#a634d4157d60b99c0302ce08826982fa2a94f3df",
+    "mattermost-redux": "github:mattermost/mattermost-redux#10108a3d0d0c5fab658fe78bf66936fa6934745b",
     "moment-timezone": "0.5.21",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/tests/components/__snapshots__/file_preview.test.jsx.snap
+++ b/tests/components/__snapshots__/file_preview.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`component/FilePreview should match snapshot 1`] = `
 >
   <div
     className="file-preview post-image__column"
-    key="file_id_10"
+    key="file_id_1"
   >
     <div
       className="post-image__thumbnail"
@@ -98,7 +98,7 @@ exports[`component/FilePreview should match snapshot when props are changed 1`] 
 >
   <div
     className="file-preview post-image__column"
-    key="file_id_10"
+    key="file_id_1"
   >
     <div
       className="post-image__thumbnail"
@@ -190,7 +190,7 @@ exports[`component/FilePreview should match snapshot when props are changed 2`] 
 >
   <div
     className="file-preview post-image__column"
-    key="file_id_10"
+    key="file_id_1"
   >
     <div
       className="post-image__thumbnail"
@@ -256,7 +256,7 @@ exports[`component/FilePreview should match snapshot when props are changed 2`] 
   </div>
   <div
     className="file-preview post-image__column"
-    key="file_id_21"
+    key="file_id_2"
   >
     <div
       className="post-image__thumbnail"

--- a/tests/components/__snapshots__/file_preview.test.jsx.snap
+++ b/tests/components/__snapshots__/file_preview.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`component/FilePreview should match snapshot 1`] = `
 >
   <div
     className="file-preview post-image__column"
-    key="file_id_1"
+    key="file_id_10"
   >
     <div
       className="post-image__thumbnail"
@@ -98,7 +98,7 @@ exports[`component/FilePreview should match snapshot when props are changed 1`] 
 >
   <div
     className="file-preview post-image__column"
-    key="file_id_1"
+    key="file_id_10"
   >
     <div
       className="post-image__thumbnail"
@@ -190,7 +190,7 @@ exports[`component/FilePreview should match snapshot when props are changed 2`] 
 >
   <div
     className="file-preview post-image__column"
-    key="file_id_1"
+    key="file_id_10"
   >
     <div
       className="post-image__thumbnail"
@@ -256,7 +256,7 @@ exports[`component/FilePreview should match snapshot when props are changed 2`] 
   </div>
   <div
     className="file-preview post-image__column"
-    key="file_id_2"
+    key="file_id_21"
   >
     <div
       className="post-image__thumbnail"

--- a/tests/components/create_comment/create_comment.test.jsx
+++ b/tests/components/create_comment/create_comment.test.jsx
@@ -30,6 +30,7 @@ describe('components/CreateComment', () => {
         enableAddButton: true,
         ctrlSend: false,
         latestPostId,
+        locale: 'en',
         getSidebarBody: jest.fn(),
         clearCommentDraftUploads: jest.fn(),
         onUpdateCommentDraft: jest.fn(),
@@ -276,10 +277,11 @@ describe('components/CreateComment', () => {
 
     test('handleFileUploadComplete should update comment draft correctly', () => {
         const onUpdateCommentDraft = jest.fn();
+        const fileInfos = [{id: '1', name: 'aaa', create_at: 100}, {id: '2', name: 'bbb', create_at: 200}];
         const draft = {
             message: 'Test message',
             uploadsInProgress: [1, 2, 3],
-            fileInfos: [{test: 1}, {test: 2}],
+            fileInfos,
         };
         const props = {...baseProps, onUpdateCommentDraft, draft};
 
@@ -289,14 +291,16 @@ describe('components/CreateComment', () => {
 
         wrapper.setState({draft});
 
-        wrapper.instance().handleFileUploadComplete([{test: 3}], [3]);
+        const uploadCompleteFileInfo = [{id: '3', name: 'ccc', create_at: 300}];
+        const expectedNewFileInfos = fileInfos.concat(uploadCompleteFileInfo);
+        wrapper.instance().handleFileUploadComplete(uploadCompleteFileInfo, [3]);
         expect(onUpdateCommentDraft).toHaveBeenCalled();
         expect(onUpdateCommentDraft.mock.calls[0][0]).toEqual(
-            expect.objectContaining({uploadsInProgress: [1, 2], fileInfos: [{test: 1}, {test: 2}, {test: 3}]})
+            expect.objectContaining({uploadsInProgress: [1, 2], fileInfos: expectedNewFileInfos})
         );
 
         expect(wrapper.state().draft.uploadsInProgress).toEqual([1, 2]);
-        expect(wrapper.state().draft.fileInfos).toEqual([{test: 1}, {test: 2}, {test: 3}]);
+        expect(wrapper.state().draft.fileInfos).toEqual(expectedNewFileInfos);
     });
 
     test('calls showPostDeletedModal when createPostErrorId === api.post.create_post.root_id.app_error', () => {
@@ -304,7 +308,7 @@ describe('components/CreateComment', () => {
         const draft = {
             message: 'Test message',
             uploadsInProgress: [1, 2, 3],
-            fileInfos: [{test: 1}, {test: 2}],
+            fileInfos: [{id: '1', name: 'aaa', create_at: 100}, {id: '2', name: 'bbb', create_at: 200}],
         };
         const props = {...baseProps, onUpdateCommentDraft, draft};
 
@@ -322,7 +326,7 @@ describe('components/CreateComment', () => {
         const draft = {
             message: 'Test message',
             uploadsInProgress: [1, 2, 3],
-            fileInfos: [{test: 1}, {test: 2}],
+            fileInfos: [{id: '1', name: 'aaa', create_at: 100}, {id: '2', name: 'bbb', create_at: 200}],
         };
         const props = {...baseProps, draft};
 

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -44,6 +44,7 @@ const showTutorialTipProp = false;
 const fullWidthTextBoxProp = true;
 const recentPostIdInChannelProp = 'a';
 const latestReplyablePostIdProp = 'a';
+const localeProp = 'en';
 
 const currentChannelProp = {
     id: 'owsyt8n43jfxjpzh9np93mx1wa',
@@ -87,6 +88,7 @@ function createPost({
     draft = draftProp,
     recentPostIdInChannel = recentPostIdInChannelProp,
     latestReplyablePostId = latestReplyablePostIdProp,
+    locale = localeProp,
     actions = actionsProp,
     ctrlSend = ctrlSendProp,
     currentUsersLatestPost = currentUsersLatestPostProp,
@@ -105,6 +107,7 @@ function createPost({
             draft={draft}
             recentPostIdInChannel={recentPostIdInChannel}
             latestReplyablePostId={latestReplyablePostId}
+            locale={locale}
             ctrlSend={ctrlSend}
             currentUsersLatestPost={currentUsersLatestPost}
             commentCountForPost={commentCountForPost}

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -698,7 +698,6 @@ export const Constants = {
         patch: 'patch',
         other: 'generic',
     },
-    MAX_DISPLAY_FILES: 5,
     MAX_UPLOAD_FILES: 5,
     MAX_FILENAME_LENGTH: 35,
     THUMBNAIL_WIDTH: 128,


### PR DESCRIPTION
#### Ticket Link
- Update file preview to have the fileInfos sorted by "create_at" (if not created at the same time) or by "name"
- sorting of files on FileAttachmentList component is handled by redux store/utility (`makeGetFilesForPost`) so no need to handle the sorting on the component itself  

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has server changes (https://github.com/mattermost/mattermost-server/pull/9170)
- [x] Has redux changes (https://github.com/mattermost/mattermost-redux/pull/582)

