### PR TITLE
Fix JS error/warning on MobileChannelHeaderPlug by not requiring props.components

### DIFF
--- a/plugins/mobile_channel_header_plug/mobile_channel_header_plug.jsx
+++ b/plugins/mobile_channel_header_plug/mobile_channel_header_plug.jsx
@@ -10,7 +10,7 @@ export default class MobileChannelHeaderPlug extends React.PureComponent {
         /*
          * Components or actions to add as channel header buttons
          */
-        components: PropTypes.array.isRequired,
+        components: PropTypes.array,
 
         /*
          * Set to true if the plug is in the dropdown


### PR DESCRIPTION
#### Summary
Fix JS error/warning on MobileChannelHeaderPlug by not requiring props.components.

The error occurred on local dev whenever no plugin component is set for `MobileChannelHeaderButton`.

![screen shot 2018-07-27 at 7 00 25 pm](https://user-images.githubusercontent.com/5334504/43317620-15b5ef58-91d0-11e8-8a25-4d569cb6e7e6.png)

#### Ticket Link
n/a

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
