### PR TITLE
Added Admin Badge to Profile Popover

### DIFF
--- a/actions/views/profile_popover.js
+++ b/actions/views/profile_popover.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getTeamMember} from 'mattermost-redux/actions/teams';
+import {getChannelMember} from 'mattermost-redux/actions/channels';
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+
+import {getSelectedPost} from 'selectors/rhs';
+
+export function getMembershipForCurrentEntities(userId) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const currentTeamId = getCurrentTeamId(state);
+
+        const selectedPost = getSelectedPost(state);
+        const currentChannel = getCurrentChannel(state);
+
+        let channelId;
+        if (selectedPost.exists === false) {
+            channelId = currentChannel.id;
+        } else {
+            channelId = selectedPost.channel_id;
+        }
+
+        return Promise.all([dispatch(getTeamMember(currentTeamId, userId)), dispatch(getChannelMember(channelId, userId))]);
+    };
+}

--- a/plugins/pluggable/__snapshots__/pluggable.test.jsx.snap
+++ b/plugins/pluggable/__snapshots__/pluggable.test.jsx.snap
@@ -233,6 +233,7 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
       theme={Object {}}
       user={
         Object {
+          "id": "someid",
           "name": "name",
         }
       }
@@ -240,19 +241,23 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
       <ProfilePopover
         actions={
           Object {
+            "getMembershipForCurrentEntities": [Function],
             "openDirectChannelToUserId": [Function],
             "openModal": [Function],
           }
         }
-        currentUserId=""
+        currentUserId="someid"
         enableTimezone={false}
         hasMention={false}
+        isChannelAdmin={false}
         isRHS={false}
+        isTeamAdmin={false}
         src="src"
         teamUrl="/somename"
         theme={Object {}}
         user={
           Object {
+            "id": "someid",
             "name": "name",
           }
         }
@@ -262,7 +267,16 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
           id="user-profile-popover"
           placement="right"
           theme={Object {}}
-          title="@undefined"
+          title={
+            <span>
+              <span
+                className="user-popover__username"
+              >
+                @undefined
+              </span>
+               
+            </span>
+          }
         >
           <div
             className="popover right"
@@ -289,7 +303,14 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
             <h3
               className="popover-title"
             >
-              @undefined
+              <span>
+                <span
+                  className="user-popover__username"
+                >
+                  @undefined
+                </span>
+                 
+              </span>
             </h3>
             <div
               className="popover-content"
@@ -307,6 +328,7 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
                 pluggableName="PopoverUserAttributes"
                 user={
                   Object {
+                    "id": "someid",
                     "name": "name",
                   }
                 }
@@ -346,6 +368,7 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
                   }
                   user={
                     Object {
+                      "id": "someid",
                       "name": "name",
                     }
                   }
@@ -354,24 +377,23 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
               <div
                 className="popover__row first"
                 data-toggle="tooltip"
-                key="user-popover-dm"
+                key="user-popover-settings"
               >
                 <a
-                  className="text-nowrap user-popover__email"
                   href="#"
                   onClick={[Function]}
                 >
                   <i
-                    className="fa fa-paper-plane"
-                    title="Send Message Icon"
+                    className="fa fa-pencil-square-o"
+                    title="Edit Icon"
                   />
                   <FormattedMessage
-                    defaultMessage="Send Message"
-                    id="user_profile.send.dm"
+                    defaultMessage="Edit Account Settings"
+                    id="user_profile.account.editSettings"
                     values={Object {}}
                   >
                     <span>
-                      Send Message
+                      Edit Account Settings
                     </span>
                   </FormattedMessage>
                 </a>
@@ -381,6 +403,7 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
                 pluggableName="PopoverUserActions"
                 user={
                   Object {
+                    "id": "someid",
                     "name": "name",
                   }
                 }
@@ -420,6 +443,7 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
                   }
                   user={
                     Object {
+                      "id": "someid",
                       "name": "name",
                     }
                   }
@@ -473,6 +497,7 @@ exports[`plugins/Pluggable should match snapshot with overridden component 1`] =
       }
       user={
         Object {
+          "id": "someid",
           "name": "name",
         }
       }

--- a/plugins/pluggable/pluggable.test.jsx
+++ b/plugins/pluggable/pluggable.test.jsx
@@ -6,6 +6,8 @@ import {mount, shallow} from 'enzyme';
 import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux';
 
+import {getMembershipForCurrentEntities} from 'actions/views/profile_popover';
+
 import Pluggable from 'plugins/pluggable/pluggable.jsx';
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 import ProfilePopover from 'components/profile_popover';
@@ -16,27 +18,58 @@ class ProfilePopoverPlugin extends React.PureComponent {
     }
 }
 
+jest.mock('actions/views/profile_popover');
+
 describe('plugins/Pluggable', () => {
     const mockStore = configureStore();
+
+    const membersInTeam = {};
+    membersInTeam.someid = {};
+    membersInTeam.someid.someid = {team_id: 'someid', user_id: 'someid', roles: 'team_user'};
+
+    const membersInChannel = {};
+    membersInChannel.someid = {};
+    membersInChannel.someid.someid = {channel_id: 'someid', user_id: 'someid', roles: 'channel_user'};
+
     const store = mockStore({
         entities: {
+            channels: {
+                currentChannelId: 'someid',
+                channels: {
+                    someid: {team_id: 'someid', id: 'someid'},
+                },
+                membersInChannel,
+            },
             general: {
+                license: {IsLicensed: 'false'},
                 config: {
                 },
             },
             teams: {
                 currentTeamId: 'someid',
-                teams: {someid: {name: 'somename'}},
+                teams: {someid: {id: 'someid', name: 'somename'}},
+                membersInTeam,
             },
             preferences: {
                 myPreferences: {},
             },
+            posts: {
+                posts: {},
+            },
             users: {
-                currentUserId: '',
+                currentUserId: 'someid',
+                users: {someid: {id: 'someid', name: 'somename'}},
             },
         },
         plugins: {
             components: {},
+        },
+        views: {
+            posts: {
+            },
+            channel: {
+            },
+            rhs: {},
         },
     });
 
@@ -104,6 +137,10 @@ describe('plugins/Pluggable', () => {
     });
 
     test('should match snapshot with no overridden component', () => {
+        getMembershipForCurrentEntities.mockImplementation((...args) => {
+            return {type: 'MOCK_GET_MEMBERSHIP_FOR_CURRENT_ENTITIES', args};
+        });
+
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Pluggable
@@ -111,7 +148,7 @@ describe('plugins/Pluggable', () => {
                     theme={{}}
                 >
                     <ProfilePopover
-                        user={{name: 'name'}}
+                        user={{id: 'someid', name: 'name'}}
                         src='src'
                     />
                 </Pluggable>
@@ -128,7 +165,7 @@ describe('plugins/Pluggable', () => {
                     theme={{id: 'theme_id'}}
                 >
                     <ProfilePopover
-                        user={{name: 'name'}}
+                        user={{id: 'someid', name: 'name'}}
                         src='src'
                     />
                 </Pluggable>

--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -98,14 +98,42 @@
     }
 }
 
+.user-popover__username,
+.user-popover__username > a {
+    display: inline-block;
+    max-width: 150px;
+    height: 17px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+#user-profile-popover .user-popover__username:only-child,
+#user-profile-popover .user-popover__username:only-child > a{
+    max-width: 100%;
+}
+
+.user-popover__role {
+    display: inline-block;
+    float: right;
+    padding: 3px 5px;
+    margin-left: 10px;
+    background-color: $gray;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 0.8em;
+    color: $white;
+}
+
 .user-popover__image {
     @include border-radius(128px);
-    margin: 5px 0;
+    margin: 5px auto;
+    display: block;
 }
 
 .user-popover__email {
     display: block;
-    max-width: 200px;
+    max-width: 300px;
     overflow: hidden;
     text-overflow: ellipsis;
 }


### PR DESCRIPTION
#### Summary
This PR adds an admin badge to the profile popover show whether an user is an channel / team / system admin using a shield icon on the right side. The title of the icon shows the admin level of the user.

Preview:
![Example Image](https://i.imgur.com/9NPrc3q.png)

#### Ticket Link
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes