### PR TITLE
change to keydown

### DIFF
--- a/components/confirm_modal.jsx
+++ b/components/confirm_modal.jsx
@@ -85,19 +85,19 @@ export default class ConfirmModal extends React.Component {
 
     componentDidMount() {
         if (this.props.show) {
-            document.addEventListener('keypress', this.handleKeypress);
+            document.addEventListener('keydown', this.handleKeypress);
         }
     }
 
     componentWillUnmount() {
-        document.removeEventListener('keypress', this.handleKeypress);
+        document.removeEventListener('keydown', this.handleKeypress);
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
         if (this.props.show && !nextProps.show) {
-            document.removeEventListener('keypress', this.handleKeypress);
+            document.removeEventListener('keydown', this.handleKeypress);
         } else if (!this.props.show && nextProps.show) {
-            document.addEventListener('keypress', this.handleKeypress);
+            document.addEventListener('keydown', this.handleKeypress);
         }
     }
 


### PR DESCRIPTION
#### Summary
So the modal can intercept and can use the enter key to accept the
changes.
follow up of https://github.com/mattermost/mattermost-webapp/pull/1152

