### PR TITLE
MM-11331 Autocomplete all users for system console username setting

### DIFF
--- a/components/admin_console/user_autocomplete_setting.jsx
+++ b/components/admin_console/user_autocomplete_setting.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {Client4} from 'mattermost-redux/client';
 
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
-import {autocompleteUsersInTeam} from 'actions/user_actions.jsx';
+import {autocompleteUsers} from 'actions/user_actions.jsx';
 import {ActionTypes} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import Setting from 'components/admin_console/setting.jsx';
@@ -65,7 +65,7 @@ class UserProvider extends Provider {
         const normalizedPretext = pretext.toLowerCase();
         this.startNewRequest(suggestionId, normalizedPretext);
 
-        autocompleteUsersInTeam(
+        autocompleteUsers(
             normalizedPretext,
             (data) => {
                 if (this.shouldCancelDispatch(normalizedPretext)) {


### PR DESCRIPTION
#### Summary
Autocomplete all users for system console username setting instead of whatever the previous current team was.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11331