### PR TITLE
Added generic response for valid/invalid users

### DIFF
--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -211,7 +211,7 @@ export default class LoginController extends React.Component {
                         serverError: (
                             <FormattedMessage
                                 id='login.userNotFound'
-                                defaultMessage="We couldn't find an account matching your login credentials."
+                                defaultMessage="The credentials you provided are incorrect."
                             />
                         ),
                     });
@@ -222,7 +222,7 @@ export default class LoginController extends React.Component {
                         serverError: (
                             <FormattedMessage
                                 id='login.invalidPassword'
-                                defaultMessage='Your password is incorrect.'
+                                defaultMessage='The credentials you provided are incorrect.'
                             />
                         ),
                     });


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
User enumeration seems to be a design decision based on https://github.com/mattermost/docs/issues/885 . However, I think simply changing ALL instances of error messages that can be used to enumerate users could help. This can be mitigated by responding generic message such as "The credentials you provided are incorrect" instead of "We couldn't find an account matching the credentials provided" or "The password you provided is incorrect", which implies that the username is correct, and thus leads to user enumeration. A small change that could help other users who don't deploy in a private network

#### Ticket Link
https://github.com/mattermost/docs/issues/885
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
