### PR TITLE
MM-11176: Show the banner for licenses without clustering support (E10)

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -52,7 +52,7 @@ export async function addSwitchToEENotification() {
     }
 
     const {data: license} = await store.dispatch(getLicenseConfig());
-    if (license.IsLicensed === 'true') {
+    if (license.IsLicensed === 'true' && license.Cluster === 'true') {
         return;
     }
 


### PR DESCRIPTION
#### Summary
Show the banner for licenses without clustering support (E10). The idea
is show it for any not E20 license, I detect the license using the
"Cluster" support, because makes sense in the context of support more
than 10K users.

#### Ticket Link
[MM-11176](https://mattermost.atlassian.net/browse/MM-11176)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed