### PR TITLE
MM-11369: Hide 'Invite others to this team' link from channel intro w…

### DIFF
--- a/components/post_view/channel_intro_message/channel_intro_message.jsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.jsx
@@ -30,6 +30,7 @@ export default class ChannelIntroMessage extends React.PureComponent {
         channel: PropTypes.object.isRequired,
         fullWidth: PropTypes.bool.isRequired,
         locale: PropTypes.string.isRequired,
+        enableUserCreation: PropTypes.bool,
     };
 
     render() {
@@ -49,7 +50,7 @@ export default class ChannelIntroMessage extends React.PureComponent {
         } else if (channel.type === Constants.GM_CHANNEL) {
             return createGMIntroMessage(channel, centeredIntro);
         } else if (ChannelStore.isDefault(channel)) {
-            return createDefaultIntroMessage(channel, centeredIntro);
+            return createDefaultIntroMessage(channel, centeredIntro, this.props.enableUserCreation);
         } else if (channel.name === Constants.OFFTOPIC_CHANNEL) {
             return createOffTopicIntroMessage(channel, centeredIntro);
         } else if (channel.type === Constants.OPEN_CHANNEL || channel.type === Constants.PRIVATE_CHANNEL) {
@@ -227,10 +228,10 @@ function createOffTopicIntroMessage(channel, centeredIntro) {
     );
 }
 
-export function createDefaultIntroMessage(channel, centeredIntro) {
+export function createDefaultIntroMessage(channel, centeredIntro, enableUserCreation) {
     let teamInviteLink = null;
     const isReadOnly = isCurrentChannelReadOnly(store.getState());
-    if (!isReadOnly) {
+    if (!isReadOnly && enableUserCreation) {
         teamInviteLink = (
             <TeamPermissionGate
                 teamId={channel.team_id}

--- a/components/post_view/channel_intro_message/channel_intro_message.jsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.jsx
@@ -6,7 +6,6 @@ import {FormattedDate, FormattedHTMLMessage, FormattedMessage} from 'react-intl'
 import PropTypes from 'prop-types';
 
 import {Permissions} from 'mattermost-redux/constants';
-import {isCurrentChannelReadOnly} from 'mattermost-redux/selectors/entities/channels';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
@@ -23,7 +22,6 @@ import TeamPermissionGate from 'components/permissions_gates/team_permission_gat
 
 import {getMonthLong} from 'utils/i18n.jsx';
 import * as Utils from 'utils/utils.jsx';
-import store from 'stores/redux_store.jsx';
 
 export default class ChannelIntroMessage extends React.PureComponent {
     static propTypes = {
@@ -31,6 +29,7 @@ export default class ChannelIntroMessage extends React.PureComponent {
         fullWidth: PropTypes.bool.isRequired,
         locale: PropTypes.string.isRequired,
         enableUserCreation: PropTypes.bool,
+        isReadOnly: PropTypes.bool,
     };
 
     render() {
@@ -38,6 +37,8 @@ export default class ChannelIntroMessage extends React.PureComponent {
             channel,
             fullWidth,
             locale,
+            enableUserCreation,
+            isReadOnly,
         } = this.props;
 
         let centeredIntro = '';
@@ -50,7 +51,7 @@ export default class ChannelIntroMessage extends React.PureComponent {
         } else if (channel.type === Constants.GM_CHANNEL) {
             return createGMIntroMessage(channel, centeredIntro);
         } else if (ChannelStore.isDefault(channel)) {
-            return createDefaultIntroMessage(channel, centeredIntro, this.props.enableUserCreation);
+            return createDefaultIntroMessage(channel, centeredIntro, enableUserCreation, isReadOnly);
         } else if (channel.name === Constants.OFFTOPIC_CHANNEL) {
             return createOffTopicIntroMessage(channel, centeredIntro);
         } else if (channel.type === Constants.OPEN_CHANNEL || channel.type === Constants.PRIVATE_CHANNEL) {
@@ -228,9 +229,9 @@ function createOffTopicIntroMessage(channel, centeredIntro) {
     );
 }
 
-export function createDefaultIntroMessage(channel, centeredIntro, enableUserCreation) {
+export function createDefaultIntroMessage(channel, centeredIntro, enableUserCreation, isReadOnly) {
     let teamInviteLink = null;
-    const isReadOnly = isCurrentChannelReadOnly(store.getState());
+
     if (!isReadOnly && enableUserCreation) {
         teamInviteLink = (
             <TeamPermissionGate

--- a/components/post_view/channel_intro_message/index.js
+++ b/components/post_view/channel_intro_message/index.js
@@ -3,13 +3,19 @@
 
 import {connect} from 'react-redux';
 
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
 import {getCurrentLocale} from 'selectors/i18n';
 
 import ChannelIntroMessage from './channel_intro_message.jsx';
 
 function mapStateToProps(state) {
+    const config = getConfig(state);
+    const enableUserCreation = config.EnableUserCreation === 'true';
+
     return {
         locale: getCurrentLocale(state),
+        enableUserCreation,
     };
 }
 

--- a/components/post_view/channel_intro_message/index.js
+++ b/components/post_view/channel_intro_message/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {isCurrentChannelReadOnly} from 'mattermost-redux/selectors/entities/channels';
 
 import {getCurrentLocale} from 'selectors/i18n';
 
@@ -12,10 +13,12 @@ import ChannelIntroMessage from './channel_intro_message.jsx';
 function mapStateToProps(state) {
     const config = getConfig(state);
     const enableUserCreation = config.EnableUserCreation === 'true';
+    const isReadOnly = isCurrentChannelReadOnly(state);
 
     return {
         locale: getCurrentLocale(state),
         enableUserCreation,
+        isReadOnly,
     };
 }
 


### PR DESCRIPTION
…hen 'Enable Account Creation' config setting is false.

#### Summary
Hides invite link in channel intro when `EnableUserCreation` config is `false`.

#### Ticket Link
[MM-11369](https://mattermost.atlassian.net/browse/MM-11369)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed