### PR TITLE
Allow duplicate terms for suggestion box

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -310,8 +310,10 @@ export default class SuggestionBox extends React.Component {
         if (this.props.onItemSelected) {
             const items = SuggestionStore.getItems(this.suggestionId);
             const terms = SuggestionStore.getTerms(this.suggestionId);
+            const selection = SuggestionStore.getSelectionWithIndex(this.suggestionId);
+
             for (let i = 0; i < terms.length; i++) {
-                if (terms[i] === term) {
+                if (`${terms[i]}|${i}` === selection) {
                     this.props.onItemSelected(items[i]);
                     break;
                 }

--- a/components/suggestion/suggestion_list.jsx
+++ b/components/suggestion/suggestion_list.jsx
@@ -136,7 +136,7 @@ export default class SuggestionList extends React.Component {
         for (let i = 0; i < this.state.items.length; i++) {
             const item = this.state.items[i];
             const term = this.state.terms[i];
-            const isSelection = term === this.state.selection;
+            const isSelection = `${term}|${i}` === this.state.selection;
 
             // ReactComponent names need to be upper case when used in JSX
             const Component = this.state.components[i];
@@ -153,13 +153,16 @@ export default class SuggestionList extends React.Component {
 
             items.push(
                 <Component
-                    key={term}
-                    ref={term}
+                    key={`${term}|${i}`}
+                    ref={`${term}|${i}`}
                     item={this.state.items[i]}
                     term={term}
                     matchedPretext={this.state.matchedPretext[i]}
                     isSelection={isSelection}
-                    onClick={this.props.onCompleteWord}
+                    onClick={(selectedTerm, matchedPretext) => {
+                        SuggestionStore.setSelectionWithIndex(this.props.suggestionId, i);
+                        this.props.onCompleteWord(selectedTerm, matchedPretext);
+                    }}
                 />
             );
         }

--- a/stores/suggestion_store.jsx
+++ b/stores/suggestion_store.jsx
@@ -159,7 +159,7 @@ class SuggestionStore extends EventEmitter {
         if (suggestion.terms.length > 0) {
             // if the current selection is no longer in the map, select the first term in the list
             if (!suggestion.selection || suggestion.terms.indexOf(suggestion.selection) === -1) {
-                suggestion.selection = suggestion.terms[0];
+                suggestion.selection = `${suggestion.terms[0]}|0`;
 
                 return true;
             }
@@ -205,6 +205,10 @@ class SuggestionStore extends EventEmitter {
     }
 
     getSelection(id) {
+        return this.getSuggestions(id).selection.split('|')[0];
+    }
+
+    getSelectionWithIndex(id) {
         return this.getSuggestions(id).selection;
     }
 
@@ -219,7 +223,7 @@ class SuggestionStore extends EventEmitter {
     setSelectionByDelta(id, delta) {
         const suggestion = this.suggestions.get(id);
 
-        let selectionIndex = suggestion.terms.indexOf(suggestion.selection);
+        let selectionIndex = suggestion.terms.indexOf(suggestion.selection.split('|')[0]);
 
         if (selectionIndex === -1) {
             // this should never happen since selection should always be in terms
@@ -234,7 +238,12 @@ class SuggestionStore extends EventEmitter {
             selectionIndex = suggestion.terms.length - 1;
         }
 
-        suggestion.selection = suggestion.terms[selectionIndex];
+        suggestion.selection = `${suggestion.terms[selectionIndex]}|${selectionIndex}`;
+    }
+
+    setSelectionWithIndex(id, index) {
+        const suggestion = this.suggestions.get(id);
+        suggestion.selection = `${suggestion.terms[index]}|${index}`;
     }
 
     checkIfPretextMatches(id, matchedPretext) {


### PR DESCRIPTION
#### Summary
When having more than one result that matches the term in any suggestion box the selection highlighting was considering all of them but the selection was picking the first match.

This PR aims to allow different results with the same term and pick the selected one.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11193

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Touches critical sections of the codebase (autocompletes)
