### PR TITLE
[MM-10924] Use reset password screen on web irrespective of device

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -212,11 +212,13 @@ export default class Root extends React.Component {
         const iosDownloadLink = getConfig(store.getState()).IosAppDownloadLink;
         const androidDownloadLink = getConfig(store.getState()).AndroidAppDownloadLink;
 
+        const toResetPasswordScreen = this.props.location.pathname === '/reset_password_complete';
+
         // redirect to the mobile landing page if the user hasn't seen it before
-        if (iosDownloadLink && UserAgent.isIosWeb() && !BrowserStore.hasSeenLandingPage()) {
+        if (iosDownloadLink && UserAgent.isIosWeb() && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen) {
             this.props.history.push('/get_ios_app');
             BrowserStore.setLandingPageSeen(true);
-        } else if (androidDownloadLink && UserAgent.isAndroidWeb() && !BrowserStore.hasSeenLandingPage()) {
+        } else if (androidDownloadLink && UserAgent.isAndroidWeb() && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen) {
             this.props.history.push('/get_android_app');
             BrowserStore.setLandingPageSeen(true);
         }


### PR DESCRIPTION
#### Summary
Allow users to go to reset password screen on mobile devices as well as there is no way to do it from mobile app

#### Ticket Link
[MM-10924](https://mattermost.atlassian.net/browse/MM-10924)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
