### PR TITLE
Fix key for orderedChannelSections component

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -479,7 +479,7 @@ export default class Sidebar extends React.PureComponent {
             >
                 {orderedChannelSections.map((section) => {
                     if (section.items.length === 0) {
-                        return (<div/>);
+                        return (<div key={section.type}/>);
                     }
 
                     return (


### PR DESCRIPTION
#### Summary
when multiple sections are not present for sidebar it returns div without a key throwing an error

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
