### PR TITLE
MM-11554: Redirects user to last viewed non-archived channel when clo…

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -72,7 +72,9 @@ export function emitChannelClickEvent(channel) {
             reloadIfServerVersionChanged();
         });
 
-        BrowserStore.setGlobalItem(Constants.PREV_CHANNEL_KEY + teamId, chan.name);
+        if (chan.delete_at === 0) {
+            BrowserStore.setGlobalItem(Storage.PREV_CHANNEL_KEY + teamId, chan.name);
+        }
 
         loadProfilesForSidebar();
 
@@ -392,7 +394,7 @@ export function newLocalizationSelected(locale) {
                 });
             }
         ).catch(
-            () => {} //eslint-disable-line no-empty-function
+            () => { } //eslint-disable-line no-empty-function
         );
     }
 }

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -79,6 +79,7 @@ export default class ChannelHeader extends React.Component {
         rhsState: PropTypes.oneOf(
             Object.values(RHSStates)
         ),
+        lastViewedChannelName: PropTypes.string.isRequired,
         enableWebrtc: PropTypes.bool.isRequired,
     };
 
@@ -153,7 +154,8 @@ export default class ChannelHeader extends React.Component {
     };
 
     handleClose = () => {
-        browserHistory.push(`${TeamStore.getCurrentTeamRelativeUrl()}/channels/${Constants.DEFAULT_CHANNEL}`);
+        const {lastViewedChannelName} = this.props;
+        browserHistory.push(`${TeamStore.getCurrentTeamRelativeUrl()}/channels/${lastViewedChannelName}`);
     };
 
     toggleFavorite = () => {

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -14,6 +14,9 @@ import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general
 
 import {withRouter} from 'react-router-dom';
 
+import {getLastViewedChannelName} from 'selectors/storage';
+import {Constants} from 'utils/constants.jsx';
+
 import {
     showFlaggedPosts,
     showPinnedPosts,
@@ -42,6 +45,11 @@ function mapStateToProps(state, ownProps) {
     const license = getLicense(state);
     const config = getConfig(state);
 
+    let lastViewedChannelName = getLastViewedChannelName(state);
+    if (!lastViewedChannelName) {
+        lastViewedChannelName = Constants.DEFAULT_CHANNEL;
+    }
+
     return {
         channel,
         channelMember: getMyChannelMember(state, ownProps.channelId),
@@ -55,6 +63,7 @@ function mapStateToProps(state, ownProps) {
         isLicensed: license.IsLicensed === 'true',
         enableWebrtc: config.EnableWebrtc === 'true',
         isReadOnly: isCurrentChannelReadOnly(state),
+        lastViewedChannelName,
     };
 }
 

--- a/components/channel_view/channel_view.jsx
+++ b/components/channel_view/channel_view.jsx
@@ -17,7 +17,6 @@ import {clearMarks, mark, measure, trackEvent} from 'actions/diagnostics_actions
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 import {browserHistory} from 'utils/browser_history';
 import TeamStore from 'stores/team_store.jsx';
-import {Constants} from '../../utils/constants';
 
 export default class ChannelView extends React.PureComponent {
     static propTypes = {
@@ -48,6 +47,8 @@ export default class ChannelView extends React.PureComponent {
          * Whether the channel is archived
          */
         channelIsArchived: PropTypes.bool.isRequired,
+
+        lastViewedChannelName: PropTypes.string.isRequired,
     };
 
     constructor(props) {
@@ -87,7 +88,8 @@ export default class ChannelView extends React.PureComponent {
     }
 
     onClickCloseChannel = () => {
-        browserHistory.push(`${TeamStore.getCurrentTeamRelativeUrl()}/channels/${Constants.DEFAULT_CHANNEL}`);
+        const {lastViewedChannelName} = this.props;
+        browserHistory.push(`${TeamStore.getCurrentTeamRelativeUrl()}/channels/${lastViewedChannelName}`);
     }
 
     componentDidUpdate(prevProps) {

--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -9,7 +9,9 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {withRouter} from 'react-router-dom';
 
 import {getDirectTeammate} from 'utils/utils.jsx';
-import {TutorialSteps, Preferences} from 'utils/constants.jsx';
+import {TutorialSteps, Preferences, Constants} from 'utils/constants.jsx';
+
+import {getLastViewedChannelName} from 'selectors/storage';
 
 import ChannelView from './channel_view.jsx';
 
@@ -30,11 +32,17 @@ function mapStateToProps(state) {
     const enableTutorial = config.EnableTutorial === 'true';
     const tutorialStep = getInt(state, Preferences.TUTORIAL_STEP, getCurrentUserId(state), TutorialSteps.FINISHED);
 
+    let lastViewedChannelName = getLastViewedChannelName(state);
+    if (!lastViewedChannelName) {
+        lastViewedChannelName = Constants.DEFAULT_CHANNEL;
+    }
+
     return {
         channelId: channel ? channel.id : '',
         deactivatedChannel: channel ? getDeactivatedChannel(state, channel.id) : false,
         showTutorial: enableTutorial && tutorialStep <= TutorialSteps.INTRO_SCREENS,
         channelIsArchived: channel ? channel.delete_at !== 0 : false,
+        lastViewedChannelName,
     };
 }
 

--- a/selectors/storage.js
+++ b/selectors/storage.js
@@ -1,6 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {createSelector} from 'reselect';
+
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+
 import {getPrefix} from 'utils/storage_utils';
 
 export const getGlobalItem = (state, name, defaultValue) => {
@@ -32,3 +36,14 @@ export const getItemFromStorage = (storage, name, defaultValue) => {
 
     return defaultValue;
 };
+
+export const getStorage = (state) => state.storage;
+
+export const getLastViewedChannelName = createSelector(
+    getStorage,
+    getCurrentTeamId,
+    (storage, currentTeamId) => {
+        const entry = storage.storage[`${Storage.PREV_CHANNEL_KEY}${currentTeamId}`];
+        return entry ? entry.value : null;
+    }
+);

--- a/tests/components/channel_header.test.jsx
+++ b/tests/components/channel_header.test.jsx
@@ -25,6 +25,7 @@ describe('components/ChannelHeader', () => {
         channelMember: {},
         currentUser: {},
         enableWebrtc: false,
+        lastViewedChannelName: '',
     };
 
     const populatedProps = {


### PR DESCRIPTION
#### Summary
Redirects to last non-archived channel when closing an archived channel.

#### Ticket Link
[MM-11554](https://mattermost.atlassian.net/browse/MM-11554)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed