### PR TITLE
MM-11053: improve group channel name subsetting

### DIFF
--- a/tests/utils/channel_utils.test.jsx
+++ b/tests/utils/channel_utils.test.jsx
@@ -1,7 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+let mockedCurrentUser;
+jest.mock('../../stores/user_store.jsx', () => ({
+    getCurrentUser: () => {
+        return mockedCurrentUser;
+    },
+}));
+
 import * as Utils from 'utils/channel_utils.jsx';
+import Constants from 'utils/constants.jsx';
 
 describe('Channel Utils', () => {
     describe('findNextUnreadChannelId', () => {
@@ -51,6 +59,96 @@ describe('Channel Utils', () => {
             const unreadChannelIds = ['3', '4', '5'];
 
             expect(Utils.findNextUnreadChannelId(curChannelId, allChannelIds, unreadChannelIds, -1)).toEqual(4);
+        });
+    });
+
+    describe('getChannelDisplayName', () => {
+        describe('should return display name unmodified', () => {
+            [Constants.DM_CHANNEL, Constants.OPEN_CHANNEL, Constants.PRIVATE_CHANNEL].forEach((type) => {
+                it(`for channels of type ${type}`, () => {
+                    mockedCurrentUser = {username: 'Display Name'};
+
+                    const channel = {
+                        type,
+                        display_name: 'Display Name, with a comma!',
+                    };
+                    expect(Utils.getChannelDisplayName(channel)).toEqual(channel.display_name);
+                });
+            });
+
+            it('if there is no current user', () => {
+                mockedCurrentUser = null;
+
+                const channel = {
+                    type: Constants.GM_CHANNEL,
+                    display_name: 'Display Name, with a comma!',
+                };
+                expect(Utils.getChannelDisplayName(channel)).toEqual(channel.display_name);
+            });
+        });
+
+        describe('should splice out current username with three users', () => {
+            const expectedChannelName = 'jason-4, jason-admin';
+
+            beforeEach(() => {
+                mockedCurrentUser = {username: 'jason'};
+            });
+
+            it('when at the beginning', () => {
+                const channel = {
+                    type: Constants.GM_CHANNEL,
+                    display_name: 'jason, jason-4, jason-admin',
+                };
+                expect(Utils.getChannelDisplayName(channel)).toEqual(expectedChannelName);
+            });
+
+            it('when in the middle', () => {
+                const channel = {
+                    type: Constants.GM_CHANNEL,
+                    display_name: 'jason-4, jason, jason-admin',
+                };
+                expect(Utils.getChannelDisplayName(channel)).toEqual(expectedChannelName);
+            });
+
+            it('when at the end', () => {
+                const channel = {
+                    type: Constants.GM_CHANNEL,
+                    display_name: 'jason-4, jason-admin, jason',
+                };
+                expect(Utils.getChannelDisplayName(channel)).toEqual(expectedChannelName);
+            });
+        });
+
+        describe('should splice out current username with four users', () => {
+            const expectedChannelName = 'test, test2, test3';
+
+            beforeEach(() => {
+                mockedCurrentUser = {username: 'test1'};
+            });
+
+            it('when at the beginning', () => {
+                const channel = {
+                    type: Constants.GM_CHANNEL,
+                    display_name: 'test1, test, test2, test3',
+                };
+                expect(Utils.getChannelDisplayName(channel)).toEqual(expectedChannelName);
+            });
+
+            it('when in the middle', () => {
+                const channel = {
+                    type: Constants.GM_CHANNEL,
+                    display_name: 'test, test2, test1, test3',
+                };
+                expect(Utils.getChannelDisplayName(channel)).toEqual(expectedChannelName);
+            });
+
+            it('when at the end', () => {
+                const channel = {
+                    type: Constants.GM_CHANNEL,
+                    display_name: 'test, test2, test3, test1',
+                };
+                expect(Utils.getChannelDisplayName(channel)).toEqual(expectedChannelName);
+            });
         });
     });
 });

--- a/utils/channel_utils.jsx
+++ b/utils/channel_utils.jsx
@@ -28,8 +28,6 @@ export function sortChannelsByDisplayName(a, b) {
     return ChannelUtilsRedux.sortChannelsByTypeAndDisplayName(locale, a, b);
 }
 
-const MAX_CHANNEL_NAME_LENGTH = 64;
-
 export function getChannelDisplayName(channel) {
     if (channel.type !== Constants.GM_CHANNEL) {
         return channel.display_name;
@@ -38,17 +36,11 @@ export function getChannelDisplayName(channel) {
     const currentUser = UserStore.getCurrentUser();
 
     if (currentUser) {
-        let displayName = channel.display_name.
+        return channel.display_name.
             split(',').
             map((username) => username.trim()).
             filter((username) => username !== currentUser.username).
             join(', ');
-
-        if (displayName.length >= MAX_CHANNEL_NAME_LENGTH) {
-            displayName += '...';
-        }
-
-        return displayName;
     }
 
     return channel.display_name;

--- a/utils/channel_utils.jsx
+++ b/utils/channel_utils.jsx
@@ -38,14 +38,16 @@ export function getChannelDisplayName(channel) {
     const currentUser = UserStore.getCurrentUser();
 
     if (currentUser) {
-        let displayName = channel.display_name;
+        let displayName = channel.display_name.
+            split(',').
+            map((username) => username.trim()).
+            filter((username) => username !== currentUser.username).
+            join(', ');
+
         if (displayName.length >= MAX_CHANNEL_NAME_LENGTH) {
             displayName += '...';
         }
-        displayName = displayName.replace(currentUser.username + ', ', '').replace(currentUser.username, '').trim();
-        if (displayName[displayName.length - 1] === ',') {
-            return displayName.slice(0, -1);
-        }
+
         return displayName;
     }
 


### PR DESCRIPTION
#### Summary
Channel names displayed in the quick switcher have the current user "subtracted" out of the channel name. Fix the code that does this for group messages to avoid removing parts of other usernames.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11053

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)