### PR TITLE
[MM-11498] Use event.key as well to support different english keyboard layouts

### DIFF
--- a/tests/utils/utils.test.jsx
+++ b/tests/utils/utils.test.jsx
@@ -489,4 +489,12 @@ describe('Utils.isKeyPressed', function() {
             expect(Utils.isKeyPressed(data.event, data.key)).toEqual(data.valid);
         }
     });
+
+    test('key should be tested as fallback for different layout of english keyboards', function() {
+        //key will be k for keyboards like dvorak but code will be keyV as `v` is pressed
+        const event = {key: 'k', code: 'KeyV'};
+        const key = ['k', 2221, 'KeyK'];
+        expect(Utils.isKeyPressed(event, key)).toEqual(true);
+    });
+
 });

--- a/tests/utils/utils.test.jsx
+++ b/tests/utils/utils.test.jsx
@@ -496,5 +496,4 @@ describe('Utils.isKeyPressed', function() {
         const key = ['k', 2221, 'KeyK'];
         expect(Utils.isKeyPressed(event, key)).toEqual(true);
     });
-
 });

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -59,13 +59,14 @@ export function cmdOrCtrlPressed(e, allowAlt = false) {
 export function isKeyPressed(event, key) {
     // There are two types of keyboards
     // 1. English with different layouts(Ex: Dvorak)
-    // 2. Different language keyboards(Ex: Russain)
+    // 2. Different language keyboards(Ex: Russian)
 
     if (event.keyCode === Constants.KeyCodes.COMPOSING[1]) {
         return false;
     }
     if (typeof event.code !== 'undefined' && event.code !== 'Unidentified' && key[2]) {
         const isPressedByCode = typeof key[2] === 'function' ? key[2](event.code) : event.code === key[2];
+
         // Returns true if the position of the key is validated. i.e Key K position irrespective of language.
         // Works consistently across different languages keyboards.
         // Do not return false because Layouts such as Dvorak will have Key k will be in different position.

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -57,12 +57,24 @@ export function cmdOrCtrlPressed(e, allowAlt = false) {
 }
 
 export function isKeyPressed(event, key) {
+    // There are two types of keyboards
+    // 1. English with different layouts(Ex: Dvorak)
+    // 2. Different language keyboards(Ex: Russain)
+
     if (event.keyCode === Constants.KeyCodes.COMPOSING[1]) {
         return false;
     }
     if (typeof event.code !== 'undefined' && event.code !== 'Unidentified' && key[2]) {
-        return typeof key[2] === 'function' ? key[2](event.code) : event.code === key[2];
+        const isPressedByCode = typeof key[2] === 'function' ? key[2](event.code) : event.code === key[2];
+        // Returns true if the position of the key is validated. i.e Key K position irrespective of language.
+        // Works consistently across different languages keyboards.
+        // Do not return false because Layouts such as Dvorak will have Key k will be in different position.
+        if (isPressedByCode) {
+            return true;
+        }
     }
+
+    // checks for event.key for older browsers and also for the case of different English layout keyboards.
     if (typeof event.key !== 'undefined' && event.key !== 'Unidentified' && event.key !== 'Dead') {
         return event.key === key[0] || event.key === key[0].toUpperCase();
     }


### PR DESCRIPTION
#### Summary
Use event.key to check as well even if event.code fails so it can support different layouts of English keyboards 
#### Ticket Link
[MM-11498](https://mattermost.atlassian.net/browse/MM-11498)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
