### PR TITLE
Fix JS error on posts.order where posts is undefined

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -244,7 +244,7 @@ export function increasePostVisibility(channelId, focusedPostId) {
             channelId,
         });
 
-        return posts.order.length >= POST_INCREASE_AMOUNT;
+        return posts ? posts.order.length >= POST_INCREASE_AMOUNT : false;
     };
 }
 


### PR DESCRIPTION
#### Summary
Fix JS error on posts.order where posts is undefined
- `PostActions.getPostsBefore` and `PostActions.getPosts` may return a server error (`results.error`) which in that case will make `posts` to be undefined.

Error encountered on pre-release:
![screen shot 2018-08-03 at 11 50 52 pm](https://user-images.githubusercontent.com/5334504/43654266-39891e8e-977d-11e8-99bc-0f215f1ae37c.png)
![screen shot 2018-08-03 at 11 51 04 pm](https://user-images.githubusercontent.com/5334504/43654283-467c2e10-977d-11e8-909a-2402ffbdebbb.png)


#### Ticket Link
none

