### PR TITLE
MM-11584: fix system console links

### DIFF
--- a/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
+++ b/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
-import {Link} from 'react-router-dom';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import TeamStore from 'stores/team_store.jsx';
@@ -173,8 +172,8 @@ export default class AdminNavbarDropdown extends React.Component {
                             className='divider'
                         />
                         <li>
-                            <Link
-                                to='https://about.mattermost.com/administrators-guide/'
+                            <a
+                                href='https://about.mattermost.com/administrators-guide/'
                                 rel='noopener noreferrer'
                                 target='_blank'
                             >
@@ -182,11 +181,11 @@ export default class AdminNavbarDropdown extends React.Component {
                                     id='admin.nav.administratorsGuide'
                                     defaultMessage='Administrator Guide'
                                 />
-                            </Link>
+                            </a>
                         </li>
                         <li>
-                            <Link
-                                to='https://about.mattermost.com/troubleshooting-forum/'
+                            <a
+                                href='https://about.mattermost.com/troubleshooting-forum/'
                                 rel='noopener noreferrer'
                                 target='_blank'
                             >
@@ -194,11 +193,11 @@ export default class AdminNavbarDropdown extends React.Component {
                                     id='admin.nav.troubleshootingForum'
                                     defaultMessage='Troubleshooting Forum'
                                 />
-                            </Link>
+                            </a>
                         </li>
                         <li>
-                            <Link
-                                to='https://about.mattermost.com/commercial-support/'
+                            <a
+                                href='https://about.mattermost.com/commercial-support/'
                                 rel='noopener noreferrer'
                                 target='_blank'
                             >
@@ -206,23 +205,23 @@ export default class AdminNavbarDropdown extends React.Component {
                                     id='admin.nav.commercialSupport'
                                     defaultMessage='Commercial Support'
                                 />
-                            </Link>
+                            </a>
                         </li>
                         <li>
-                            <a
-                                href='#'
+                            <button
+                                className='style--none'
                                 onClick={this.handleAboutModal}
                             >
                                 <FormattedMessage
                                     id='navbar_dropdown.about'
                                     defaultMessage='About Mattermost'
                                 />
-                            </a>
+                            </button>
                         </li>
                         <li className='divider'/>
                         <li>
-                            <a
-                                href='#'
+                            <button
+                                className='style--none'
                                 id='logout'
                                 onClick={this.handleLogout}
                             >
@@ -230,7 +229,7 @@ export default class AdminNavbarDropdown extends React.Component {
                                     id='admin.nav.logout'
                                     defaultMessage='Logout'
                                 />
-                            </a>
+                            </button>
                         </li>
                         <AboutBuildModal
                             show={this.state.showAboutModal}

--- a/components/admin_console/permission_schemes_settings/permission_schemes_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_schemes_settings.jsx
@@ -81,15 +81,15 @@ export default class PermissionSchemesSettings extends React.PureComponent {
         }
 
         const docLink = (
-            <Link
-                to='https://docs.mattermost.com/administration/config-settings.html#jobs'
+            <a
+                href='https://docs.mattermost.com/administration/config-settings.html#jobs'
                 target='_blank'
             >
                 <FormattedMessage
                     id='admin.permissions.documentationLinkText'
                     defaultMessage='documentation'
                 />
-            </Link>
+            </a>
         );
 
         if (this.props.jobsAreEnabled && !this.props.clusterIsEnabled) {

--- a/components/admin_console/permission_schemes_settings/permission_schemes_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_schemes_settings.jsx
@@ -83,6 +83,7 @@ export default class PermissionSchemesSettings extends React.PureComponent {
         const docLink = (
             <a
                 href='https://docs.mattermost.com/administration/config-settings.html#jobs'
+                rel='noopener noreferrer'
                 target='_blank'
             >
                 <FormattedMessage

--- a/tests/components/admin_console/permission_schemes_settings/__snapshots__/permission_schemes_settings.test.jsx.snap
+++ b/tests/components/admin_console/permission_schemes_settings/__snapshots__/permission_schemes_settings.test.jsx.snap
@@ -377,17 +377,17 @@ exports[`components/admin_console/permission_schemes_settings/permission_schemes
           id="admin.permissions.teamOverrideSchemesInProgress"
           values={
             Object {
-              "documentationLink": <Link
-                replace={false}
+              "documentationLink": <a
+                href="https://docs.mattermost.com/administration/config-settings.html#jobs"
+                rel="noopener noreferrer"
                 target="_blank"
-                to="https://docs.mattermost.com/administration/config-settings.html#jobs"
               >
                 <FormattedMessage
                   defaultMessage="documentation"
                   id="admin.permissions.documentationLinkText"
                   values={Object {}}
                 />
-              </Link>,
+              </a>,
             }
           }
         />
@@ -542,17 +542,17 @@ exports[`components/admin_console/permission_schemes_settings/permission_schemes
           id="admin.permissions.teamOverrideSchemesNoJobsEnabled"
           values={
             Object {
-              "documentationLink": <Link
-                replace={false}
+              "documentationLink": <a
+                href="https://docs.mattermost.com/administration/config-settings.html#jobs"
+                rel="noopener noreferrer"
                 target="_blank"
-                to="https://docs.mattermost.com/administration/config-settings.html#jobs"
               >
                 <FormattedMessage
                   defaultMessage="documentation"
                   id="admin.permissions.documentationLinkText"
                   values={Object {}}
                 />
-              </Link>,
+              </a>,
             }
           }
         />


### PR DESCRIPTION
#### Summary
* use `<a>` instead of `<Link>` for external links
* use `<button>` instead of `<a href="#">` for onClick handlers

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11584

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed