### PR TITLE
Re-Submitting: MM-11384: More customizable approach to the system notices

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -1,13 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
-
 import {getChannelAndMyMember} from 'mattermost-redux/actions/channels';
 import {getClientConfig, getLicenseConfig} from 'mattermost-redux/actions/general';
 import {deletePreferences as deletePreferencesRedux, savePreferences as savePreferencesRedux} from 'mattermost-redux/actions/preferences';
 import {getMyTeamMembers, getMyTeamUnreads, getTeamMembersByIds} from 'mattermost-redux/actions/teams';
-import {getStandardAnalytics} from 'mattermost-redux/actions/admin';
 import * as UserActions from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {Preferences as PreferencesRedux} from 'mattermost-redux/constants';
@@ -26,9 +23,6 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {Constants, Preferences, UserStatuses} from 'utils/constants.jsx';
-import notices from 'components/system_notice/notices';
-import FormattedMarkdownMessage from 'components/formatted_markdown_message';
-import mattermostIcon from 'images/icon50x50.png';
 
 const dispatch = store.dispatch;
 const getState = store.getState;
@@ -36,48 +30,6 @@ const getState = store.getState;
 export async function loadMe() {
     await UserActions.loadMe()(dispatch, getState);
     loadCurrentLocale();
-}
-
-export async function addSwitchToEENotification() {
-    const USERS_THRESHOLD = 10000;
-
-    const currentUser = Selectors.getCurrentUser(store.getState());
-    if (!currentUser) {
-        return;
-    }
-
-    const isSystemAdmin = currentUser.roles.indexOf('system_admin') !== -1;
-    if (!isSystemAdmin) {
-        return;
-    }
-
-    const {data: license} = await store.dispatch(getLicenseConfig());
-    if (license.IsLicensed === 'true' && license.Cluster === 'true') {
-        return;
-    }
-
-    await store.dispatch(getStandardAnalytics());
-    const analytics = store.getState().entities.admin.analytics;
-    if (analytics.TOTAL_USERS > USERS_THRESHOLD) {
-        notices.push({
-            name: 'ee_upgrade_advice',
-            adminOnly: true,
-            cantForget: true,
-            title: (
-                <FormattedMarkdownMessage
-                    id='system_notice.title'
-                    defaultMessage='**Notice**\nfrom Mattermost'
-                />
-            ),
-            icon: mattermostIcon,
-            body: (
-                <FormattedMarkdownMessage
-                    id='system_notice.body.ee_upgrade_advice'
-                    defaultMessage='Enterprise Edition is recommended to ensure optimal operation and reliability. [Learn more](!https://mattermost.com/performance).'
-                />
-            ),
-        });
-    }
 }
 
 export async function loadMeAndConfig(callback) {

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -10,7 +10,7 @@ import {Client4} from 'mattermost-redux/client';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {addUserToTeamFromInvite} from 'actions/team_actions.jsx';
-import {checkMfa, webLogin, addSwitchToEENotification} from 'actions/user_actions.jsx';
+import {checkMfa, webLogin} from 'actions/user_actions.jsx';
 import BrowserStore from 'stores/browser_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
@@ -234,7 +234,6 @@ export default class LoginController extends React.Component {
     }
 
     finishSignin(team) {
-        addSwitchToEENotification();
         const experimentalPrimaryTeam = this.props.experimentalPrimaryTeam;
         const primaryTeam = TeamStore.getByName(experimentalPrimaryTeam);
         const query = new URLSearchParams(this.props.location.search);

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -23,7 +23,7 @@ import BrowserStore from 'stores/browser_store.jsx';
 import ErrorStore from 'stores/error_store.jsx';
 import LocalizationStore from 'stores/localization_store.jsx';
 import UserStore from 'stores/user_store.jsx';
-import {loadMeAndConfig, addSwitchToEENotification} from 'actions/user_actions.jsx';
+import {loadMeAndConfig} from 'actions/user_actions.jsx';
 import {loadRecentlyUsedCustomEmojis} from 'actions/emoji_actions.jsx';
 import * as I18n from 'i18n/i18n.jsx';
 import {initializePlugins} from 'plugins';
@@ -222,7 +222,6 @@ export default class Root extends React.Component {
             this.props.history.push('/get_android_app');
             BrowserStore.setLandingPageSeen(true);
         }
-        addSwitchToEENotification();
     }
 
     localizationChanged = () => {

--- a/components/system_notice/index.js
+++ b/components/system_notice/index.js
@@ -5,9 +5,11 @@ import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
 import {bindActionCreators} from 'redux';
 import {makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
+import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {Permissions} from 'mattermost-redux/constants';
+import {getStandardAnalytics} from 'mattermost-redux/actions/admin';
 
 import {dismissNotice} from 'actions/views/notice';
 import {Preferences} from 'utils/constants.jsx';
@@ -30,12 +32,21 @@ function makeMapStateToProps() {
     );
 
     return function mapStateToProps(state) {
+        const license = getLicense(state);
+        const config = getConfig(state);
+        const serverVersion = state.entities.general.serverVersion;
+        const analytics = state.entities.admin.analytics;
+
         return {
             currentUserId: state.entities.users.currentUserId,
             preferences: getPreferenceNameMap(state, Preferences.CATEGORY_SYSTEM_NOTICE),
             dismissedNotices: state.views.notice.hasBeenDismissed,
             isSystemAdmin: haveISystemPermission(state, {permission: Permissions.MANAGE_SYSTEM}),
             notices: Notices,
+            config,
+            license,
+            serverVersion,
+            analytics,
         };
     };
 }
@@ -45,6 +56,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             savePreferences,
             dismissNotice,
+            getStandardAnalytics,
         }, dispatch),
     };
 }

--- a/components/system_notice/notices.jsx
+++ b/components/system_notice/notices.jsx
@@ -14,7 +14,7 @@ import mattermostIcon from 'images/icon50x50.png';
 //  - icon - the image to display for the notice icon
 //  - title - JSX node to display for the notice title
 //  - body - JSX node to display for the notice body
-//  - cantForget - boolean to allow forget the notice
+//  - allowForget - boolean to allow forget the notice
 //  - show - function that check if we need to show the notice
 //
 // Order is important! The notices at the top are shown first.
@@ -35,12 +35,12 @@ export default [
                 defaultMessage='If you’ve created or installed integrations in the last two years, find out how <a href="https://about.mattermost.com/default-apiv3-deprecation-guide" target="_blank">recent changes</a> may have affected them.'
             />
         ),
-        cantForget: false,
+        allowForget: true,
         show: (serverVersion, config) => {
-            if (config.InstallationDate < new Date(2018, 6, 16, 0, 0, 0, 0).getTime()) {
-                return true;
+            if (config.InstallationDate >= new Date(2018, 6, 16, 0, 0, 0, 0).getTime()) {
+                return false;
             }
-            return false;
+            return true;
         },
     },
     {
@@ -59,7 +59,7 @@ export default [
                 defaultMessage='Some policy and permission System Console settings have moved with the release of <a href="https://about.mattermost.com/default-advanced-permissions" target="_blank">advanced permissions</a> in Enterprise E10 and E20.'
             />
         ),
-        cantForget: false,
+        allowForget: true,
         show: (serverVersion, config, license) => {
             if (license.IsLicensed === 'false') {
                 return false;
@@ -89,7 +89,7 @@ export default [
                 defaultMessage='Enterprise Edition is recommended to ensure optimal operation and reliability. [Learn more](!https://mattermost.com/performance).'
             />
         ),
-        cantForget: true,
+        allowForget: false,
         show: (serverVersion, config, license, analytics) => {
             const USERS_THRESHOLD = 10000;
 

--- a/components/system_notice/notices.jsx
+++ b/components/system_notice/notices.jsx
@@ -14,6 +14,8 @@ import mattermostIcon from 'images/icon50x50.png';
 //  - icon - the image to display for the notice icon
 //  - title - JSX node to display for the notice title
 //  - body - JSX node to display for the notice body
+//  - cantForget - boolean to allow forget the notice
+//  - show - function that check if we need to show the notice
 //
 // Order is important! The notices at the top are shown first.
 export default [
@@ -33,6 +35,13 @@ export default [
                 defaultMessage='If you’ve created or installed integrations in the last two years, find out how <a href="https://about.mattermost.com/default-apiv3-deprecation-guide" target="_blank">recent changes</a> may have affected them.'
             />
         ),
+        cantForget: false,
+        show: (serverVersion, config) => {
+            if (config.InstallationDate < new Date(2018, 6, 16, 0, 0, 0, 0).getTime()) {
+                return true;
+            }
+            return false;
+        },
     },
     {
         name: 'advanced_permissions',
@@ -50,5 +59,48 @@ export default [
                 defaultMessage='Some policy and permission System Console settings have moved with the release of <a href="https://about.mattermost.com/default-advanced-permissions" target="_blank">advanced permissions</a> in Enterprise E10 and E20.'
             />
         ),
+        cantForget: false,
+        show: (serverVersion, config, license) => {
+            if (license.IsLicensed === 'false') {
+                return false;
+            }
+            if (config.InstallationDate > new Date(2018, 6, 16, 0, 0, 0, 0).getTime()) {
+                return false;
+            }
+            if (license.IsLicensed === 'true' && license.IssuedAt > new Date(2018, 6, 16, 0, 0, 0, 0).getTime()) {
+                return false;
+            }
+            return true;
+        },
+    },
+    {
+        name: 'ee_upgrade_advice',
+        adminOnly: true,
+        title: (
+            <FormattedMarkdownMessage
+                id='system_notice.title'
+                defaultMessage='**Notice**\nfrom Mattermost'
+            />
+        ),
+        icon: mattermostIcon,
+        body: (
+            <FormattedMarkdownMessage
+                id='system_notice.body.ee_upgrade_advice'
+                defaultMessage='Enterprise Edition is recommended to ensure optimal operation and reliability. [Learn more](!https://mattermost.com/performance).'
+            />
+        ),
+        cantForget: true,
+        show: (serverVersion, config, license, analytics) => {
+            const USERS_THRESHOLD = 10000;
+
+            if (analytics.TOTAL_USERS < USERS_THRESHOLD) {
+                return false;
+            }
+
+            if (license.IsLicensed === 'true' && license.Cluster === 'true') {
+                return false;
+            }
+            return true;
+        },
     },
 ];

--- a/components/system_notice/system_notice.jsx
+++ b/components/system_notice/system_notice.jsx
@@ -16,53 +16,56 @@ export default class SystemNotice extends React.PureComponent {
         preferences: PropTypes.object.isRequired,
         dismissedNotices: PropTypes.object.isRequired,
         isSystemAdmin: PropTypes.bool,
+        serverVersion: PropTypes.string.isRequired,
+        config: PropTypes.object.isRequired,
+        license: PropTypes.object.isRequired,
+        analytics: PropTypes.object,
         actions: PropTypes.shape({
             savePreferences: PropTypes.func.isRequired,
             dismissNotice: PropTypes.func.isRequired,
+            getStandardAnalytics: PropTypes.func.isRequired,
         }).isRequired,
     }
 
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            currentNotice: null,
-        };
-    }
-
     componentDidMount() {
-        this.setCurrentNotice();
+        if (this.props.isSystemAdmin) {
+            this.props.actions.getStandardAnalytics();
+        }
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        this.setCurrentNotice(nextProps);
+    componentDidUpdate(prevProps) {
+        if (prevProps.isSystemAdmin !== this.props.isSystemAdmin && this.props.isSystemAdmin) {
+            this.props.actions.getStandardAnalytics();
+        }
     }
 
-    setCurrentNotice = (props = this.props) => {
-        for (const notice of props.notices) {
+    getCurrentNotice = () => {
+        for (const notice of this.props.notices) {
             // Skip if dismissed previously this session
-            if (props.dismissedNotices[notice.name]) {
+            if (this.props.dismissedNotices[notice.name]) {
                 continue;
             }
 
             // Skip if dismissed forever
-            if (props.preferences[notice.name]) {
+            if (this.props.preferences[notice.name]) {
                 continue;
             }
 
-            if (notice.adminOnly && !props.isSystemAdmin) {
+            if (notice.adminOnly && !this.props.isSystemAdmin) {
                 continue;
             }
 
-            this.setState({currentNotice: notice});
-            return;
+            if (!notice.show(this.props.serverVersion, this.props.config, this.props.license, this.props.analytics)) {
+                continue;
+            }
+
+            return notice;
         }
-
-        this.setState({currentNotice: null});
+        return null;
     }
 
     hide = (remind = false) => {
-        const notice = this.state.currentNotice;
+        const notice = this.getCurrentNotice();
         if (!notice) {
             return;
         }
@@ -88,7 +91,7 @@ export default class SystemNotice extends React.PureComponent {
     }
 
     render() {
-        const notice = this.state.currentNotice;
+        const notice = this.getCurrentNotice();
 
         if (notice == null) {
             return null;

--- a/components/system_notice/system_notice.jsx
+++ b/components/system_notice/system_notice.jsx
@@ -140,7 +140,7 @@ export default class SystemNotice extends React.PureComponent {
                             defaultMessage='Remind me later'
                         />
                     </button>
-                    {!notice.cantForget &&
+                    {notice.allowForget &&
                         <button
                             id='systemnotice_dontshow'
                             className='btn btn-transparent'

--- a/tests/components/__snapshots__/system_notice.test.jsx.snap
+++ b/tests/components/__snapshots__/system_notice.test.jsx.snap
@@ -283,7 +283,7 @@ exports[`components/SystemNotice should match snapshot for show function returni
 </div>
 `;
 
-exports[`components/SystemNotice should match snapshot for with cantForget 1`] = `
+exports[`components/SystemNotice should match snapshot for with allowForget equal false 1`] = `
 <div
   className="system-notice bg--white shadow--2"
 >

--- a/tests/components/__snapshots__/system_notice.test.jsx.snap
+++ b/tests/components/__snapshots__/system_notice.test.jsx.snap
@@ -228,3 +228,98 @@ exports[`components/SystemNotice should match snapshot for regular user, regular
   </div>
 </div>
 `;
+
+exports[`components/SystemNotice should match snapshot for show function returning false 1`] = `""`;
+
+exports[`components/SystemNotice should match snapshot for show function returning true 1`] = `
+<div
+  className="system-notice bg--white shadow--2"
+>
+  <div
+    className="system-notice__header"
+  >
+    <div
+      className="system-notice__logo"
+    >
+      <MattermostLogo />
+    </div>
+    <div
+      className="system-notice__title"
+    >
+      some title
+    </div>
+  </div>
+  <div
+    className="system-notice__body"
+  >
+    some body
+  </div>
+  <div
+    className="system-notice__footer"
+  >
+    <button
+      className="btn btn-transparent"
+      id="systemnotice_remindme"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Remind me later"
+        id="system_notice.remind_me"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-transparent"
+      id="systemnotice_dontshow"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Don't show again"
+        id="system_notice.dont_show"
+        values={Object {}}
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`components/SystemNotice should match snapshot for with cantForget 1`] = `
+<div
+  className="system-notice bg--white shadow--2"
+>
+  <div
+    className="system-notice__header"
+  >
+    <div
+      className="system-notice__logo"
+    >
+      <MattermostLogo />
+    </div>
+    <div
+      className="system-notice__title"
+    >
+      some title
+    </div>
+  </div>
+  <div
+    className="system-notice__body"
+  >
+    some body
+  </div>
+  <div
+    className="system-notice__footer"
+  >
+    <button
+      className="btn btn-transparent"
+      id="systemnotice_remindme"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Remind me later"
+        id="system_notice.remind_me"
+        values={Object {}}
+      />
+    </button>
+  </div>
+</div>
+`;

--- a/tests/components/system_notice.test.jsx
+++ b/tests/components/system_notice.test.jsx
@@ -14,7 +14,7 @@ describe('components/SystemNotice', () => {
         preferences: {},
         dismissedNotices: {},
         isSystemAdmin: false,
-        notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', show: () => true}],
+        notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true, show: () => true}],
         serverVersion: '5.1',
         license: {IsLicensed: 'true'},
         config: {},
@@ -38,13 +38,13 @@ describe('components/SystemNotice', () => {
     });
 
     test('should match snapshot for regular user, admin notice', () => {
-        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body', show: () => true}]};
+        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true, show: () => true}]};
         const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for regular user, admin and regular notice', () => {
-        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body'}, {name: 'notice2', adminOnly: false, title: 'some title2', icon: mattermostIcon, body: 'some body2', show: () => true}]};
+        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true}, {name: 'notice2', adminOnly: false, title: 'some title2', icon: mattermostIcon, body: 'some body2', allowForget: true, show: () => true}]};
         const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
@@ -56,7 +56,7 @@ describe('components/SystemNotice', () => {
     });
 
     test('should match snapshot for admin, admin notice', () => {
-        const props = {...baseProps, isSystemAdmin: true, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body', show: () => true}]};
+        const props = {...baseProps, isSystemAdmin: true, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true, show: () => true}]};
         const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
@@ -74,19 +74,19 @@ describe('components/SystemNotice', () => {
     });
 
     test('should match snapshot for show function returning false', () => {
-        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', show: () => false}]};
+        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true, show: () => false}]};
         const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for show function returning true', () => {
-        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', show: () => true}]};
+        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true, show: () => true}]};
         const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should match snapshot for with cantForget', () => {
-        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', cantForget: true, show: () => true}]};
+    test('should match snapshot for with allowForget equal false', () => {
+        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: false, show: () => true}]};
         const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });

--- a/tests/components/system_notice.test.jsx
+++ b/tests/components/system_notice.test.jsx
@@ -14,10 +14,15 @@ describe('components/SystemNotice', () => {
         preferences: {},
         dismissedNotices: {},
         isSystemAdmin: false,
-        notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body'}],
+        notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', show: () => true}],
+        serverVersion: '5.1',
+        license: {IsLicensed: 'true'},
+        config: {},
+        analytics: {TOTAL_USERS: 300},
         actions: {
             savePreferences: jest.fn(),
             dismissNotice: jest.fn(),
+            getStandardAnalytics: jest.fn(),
         },
     };
 
@@ -33,13 +38,13 @@ describe('components/SystemNotice', () => {
     });
 
     test('should match snapshot for regular user, admin notice', () => {
-        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body'}]};
+        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body', show: () => true}]};
         const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for regular user, admin and regular notice', () => {
-        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body'}, {name: 'notice2', adminOnly: false, title: 'some title2', icon: mattermostIcon, body: 'some body2'}]};
+        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body'}, {name: 'notice2', adminOnly: false, title: 'some title2', icon: mattermostIcon, body: 'some body2', show: () => true}]};
         const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
@@ -51,7 +56,7 @@ describe('components/SystemNotice', () => {
     });
 
     test('should match snapshot for admin, admin notice', () => {
-        const props = {...baseProps, isSystemAdmin: true, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body'}]};
+        const props = {...baseProps, isSystemAdmin: true, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body', show: () => true}]};
         const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
@@ -64,6 +69,24 @@ describe('components/SystemNotice', () => {
 
     test('should match snapshot for regular user, dont show again notice', () => {
         const props = {...baseProps, preferences: {notice1: {}}};
+        const wrapper = shallow(<SystemNotice {...props}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot for show function returning false', () => {
+        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', show: () => false}]};
+        const wrapper = shallow(<SystemNotice {...props}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot for show function returning true', () => {
+        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', show: () => true}]};
+        const wrapper = shallow(<SystemNotice {...props}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot for with cantForget', () => {
+        const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', cantForget: true, show: () => true}]};
         const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });


### PR DESCRIPTION
####Summary
More customizable approach to the system notices.

Besides I've migrated the "Switch to EE" notification to the new system
of notifications.

#### Ticket Link
[MM-11384](https://mattermost.atlassian.net/browse/MM-11384)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has server changes (mattermost/mattermost-server#9218)