### PR TITLE
MM-11631: s/Link/a/ for more external links

### DIFF
--- a/components/sidebar_right_menu/sidebar_right_menu.jsx
+++ b/components/sidebar_right_menu/sidebar_right_menu.jsx
@@ -414,7 +414,7 @@ export default class SidebarRightMenu extends React.Component {
                     <a
                         target='_blank'
                         rel='noopener noreferrer'
-                        href={this.props.helpLink}
+                        href={useSafeUrl(this.props.helpLink)}
                     >
                         <i className='icon fa fa-question'/>
                         <FormattedMessage
@@ -433,7 +433,7 @@ export default class SidebarRightMenu extends React.Component {
                     <a
                         target='_blank'
                         rel='noopener noreferrer'
-                        href={this.props.reportAProblemLink}
+                        href={useSafeUrl(this.props.reportAProblemLink)}
                     >
                         <i className='icon fa fa-phone'/>
                         <FormattedMessage

--- a/components/sidebar_right_menu/sidebar_right_menu.jsx
+++ b/components/sidebar_right_menu/sidebar_right_menu.jsx
@@ -411,17 +411,17 @@ export default class SidebarRightMenu extends React.Component {
         if (this.props.helpLink) {
             helpLink = (
                 <li>
-                    <Link
+                    <a
                         target='_blank'
                         rel='noopener noreferrer'
-                        to={this.props.helpLink}
+                        href={this.props.helpLink}
                     >
                         <i className='icon fa fa-question'/>
                         <FormattedMessage
                             id='sidebar_right_menu.help'
                             defaultMessage='Help'
                         />
-                    </Link>
+                    </a>
                 </li>
             );
         }
@@ -430,17 +430,17 @@ export default class SidebarRightMenu extends React.Component {
         if (this.props.reportAProblemLink) {
             reportLink = (
                 <li>
-                    <Link
+                    <a
                         target='_blank'
                         rel='noopener noreferrer'
-                        to={this.props.reportAProblemLink}
+                        href={this.props.reportAProblemLink}
                     >
                         <i className='icon fa fa-phone'/>
                         <FormattedMessage
                             id='sidebar_right_menu.report'
                             defaultMessage='Report a Problem'
                         />
-                    </Link>
+                    </a>
                 </li>
             );
         }
@@ -455,17 +455,17 @@ export default class SidebarRightMenu extends React.Component {
         if (this.props.appDownloadLink && !UserAgent.isMobileApp()) {
             nativeAppLink = (
                 <li>
-                    <Link
+                    <a
                         target='_blank'
                         rel='noopener noreferrer'
-                        to={useSafeUrl(this.props.appDownloadLink)}
+                        href={useSafeUrl(this.props.appDownloadLink)}
                     >
                         <i className='icon fa fa-mobile'/>
                         <FormattedMessage
                             id='sidebar_right_menu.nativeApps'
                             defaultMessage='Download Apps'
                         />
-                    </Link>
+                    </a>
                 </li>
             );
         }


### PR DESCRIPTION
#### Summary
More `<Link>` to `<a>` changes. I thought I had grepped for them successfully in the last commit, but failed to search for parameterized `to` values. Hopefully I've found them all this time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11631

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed