### PR TITLE
MM-11318: Waits for browser to follow location header.

### DIFF
--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -120,10 +120,10 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
     }
 
     // when image links are collapsed, check if the link is a valid image url and it is available
-    preCheckImageLink() {
+    async preCheckImageLink() {
         // check only if embedVisible is false i.e the image are by default hidden/collapsed
         // if embedVisible is true, the image is rendered, during which image load error is captured
-        if (!this.props.isEmbedVisible && this.isLinkImage(this.state.link)) {
+        if (!this.props.isEmbedVisible && await this.isLinkImage(this.state.link)) {
             const image = new Image();
             image.src = PostUtils.getImageSrc(this.state.link, this.props.hasImageProxy);
 
@@ -137,7 +137,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         }
     }
 
-    isLinkImage(link) {
+    async isLinkImage(link) {
         let linkWithoutQuery = link.toLowerCase();
         if (link.indexOf('?') !== -1) {
             linkWithoutQuery = linkWithoutQuery.split('?')[0];

--- a/tests/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
+++ b/tests/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
@@ -38,8 +38,9 @@ describe('components/post_view/PostBodyAdditionalContent', () => {
                 <div/>
             </PostBodyAdditionalContent>
         );
-        testCases.forEach((testCase) => {
-            expect(wrapper.instance().isLinkImage(testCase.link)).toEqual(testCase.result);
+        testCases.forEach(async (testCase) => {
+            const result = await wrapper.instance().isLinkImage(testCase.link);
+            expect(result).toEqual(testCase.result);
         });
     });
 });


### PR DESCRIPTION
#### Summary
Waits for the browser to follow the `302` + `Location` header combo. 

Tested on macOS in Chrome, Safari, and Firefox.

#### Ticket Link
[MM-11318](https://mattermost.atlassian.net/browse/MM-11318)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

<img width="809" alt="screen shot 2018-08-10 at 7 40 23 am" src="https://user-images.githubusercontent.com/1149597/43956069-b42ff322-9c70-11e8-97c1-d2ef72761fa0.png">