### PR TITLE
Swap order between Romanian and Turkish

### DIFF
--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -20,9 +20,9 @@ const pl = require('./pl.json');
 
 const ptBR = require('./pt-BR.json');
 
-const tr = require('./tr.json');
-
 const ro = require('./ro.json');
+
+const tr = require('./tr.json');
 
 const ru = require('./ru.json');
 
@@ -41,8 +41,8 @@ import koLocaleData from 'react-intl/locale-data/ko';
 import nlLocaleData from 'react-intl/locale-data/nl';
 import plLocaleData from 'react-intl/locale-data/pl';
 import ptLocaleData from 'react-intl/locale-data/pt';
-import trLocaleData from 'react-intl/locale-data/tr';
 import roLocaleData from 'react-intl/locale-data/ro';
+import trLocaleData from 'react-intl/locale-data/tr';
 import ruLocaleData from 'react-intl/locale-data/ru';
 import zhLocaleData from 'react-intl/locale-data/zh';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -111,17 +111,17 @@ const languages = {
         order: 7,
         url: ptBR,
     },
-    tr: {
-        value: 'tr',
-        name: 'Türkçe',
-        order: 8,
-        url: tr,
-    },
     ro: {
         value: 'ro',
         name: 'Română (Beta)',
         order: 9,
         url: ro,
+    },
+    tr: {
+        value: 'tr',
+        name: 'Türkçe',
+        order: 8,
+        url: tr,
     },
     ru: {
         value: 'ru',
@@ -177,8 +177,8 @@ export function safariFix(callback) {
         'intl/locale-data/jsonp/nl.js',
         'intl/locale-data/jsonp/pl.js',
         'intl/locale-data/jsonp/pt.js',
-        'intl/locale-data/jsonp/tr.js',
         'intl/locale-data/jsonp/ro.js',
+        'intl/locale-data/jsonp/tr.js',
         'intl/locale-data/jsonp/ru.js',
         'intl/locale-data/jsonp/zh.js',
     ], (require) => {
@@ -193,8 +193,8 @@ export function safariFix(callback) {
         require('intl/locale-data/jsonp/nl.js');
         require('intl/locale-data/jsonp/pl.js');
         require('intl/locale-data/jsonp/pt.js');
-        require('intl/locale-data/jsonp/tr.js');
         require('intl/locale-data/jsonp/ro.js');
+        require('intl/locale-data/jsonp/tr.js');
         require('intl/locale-data/jsonp/ru.js');
         require('intl/locale-data/jsonp/zh.js');
         callback();
@@ -212,8 +212,8 @@ export function doAddLocaleData() {
     addLocaleData(nlLocaleData);
     addLocaleData(plLocaleData);
     addLocaleData(ptLocaleData);
-    addLocaleData(trLocaleData);
     addLocaleData(roLocaleData);
+    addLocaleData(trLocaleData);
     addLocaleData(ruLocaleData);
     addLocaleData(zhLocaleData);
 }

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -22,9 +22,9 @@ const ptBR = require('./pt-BR.json');
 
 const ro = require('./ro.json');
 
-const tr = require('./tr.json');
-
 const ru = require('./ru.json');
+
+const tr = require('./tr.json');
 
 const zhTW = require('./zh-TW.json');
 
@@ -42,8 +42,8 @@ import nlLocaleData from 'react-intl/locale-data/nl';
 import plLocaleData from 'react-intl/locale-data/pl';
 import ptLocaleData from 'react-intl/locale-data/pt';
 import roLocaleData from 'react-intl/locale-data/ro';
-import trLocaleData from 'react-intl/locale-data/tr';
 import ruLocaleData from 'react-intl/locale-data/ru';
+import trLocaleData from 'react-intl/locale-data/tr';
 import zhLocaleData from 'react-intl/locale-data/zh';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
@@ -117,17 +117,17 @@ const languages = {
         order: 8,
         url: ro,
     },
-    tr: {
-        value: 'tr',
-        name: 'Türkçe',
-        order: 9,
-        url: tr,
-    },
     ru: {
         value: 'ru',
         name: 'Pусский (Alpha)',
-        order: 10,
+        order: 9,
         url: ru,
+    },
+    tr: {
+        value: 'tr',
+        name: 'Türkçe',
+        order: 10,
+        url: tr,
     },
     'zh-TW': {
         value: 'zh-TW',
@@ -178,8 +178,8 @@ export function safariFix(callback) {
         'intl/locale-data/jsonp/pl.js',
         'intl/locale-data/jsonp/pt.js',
         'intl/locale-data/jsonp/ro.js',
-        'intl/locale-data/jsonp/tr.js',
         'intl/locale-data/jsonp/ru.js',
+        'intl/locale-data/jsonp/tr.js',
         'intl/locale-data/jsonp/zh.js',
     ], (require) => {
         require('intl');
@@ -194,8 +194,8 @@ export function safariFix(callback) {
         require('intl/locale-data/jsonp/pl.js');
         require('intl/locale-data/jsonp/pt.js');
         require('intl/locale-data/jsonp/ro.js');
-        require('intl/locale-data/jsonp/tr.js');
         require('intl/locale-data/jsonp/ru.js');
+        require('intl/locale-data/jsonp/tr.js');
         require('intl/locale-data/jsonp/zh.js');
         callback();
     });
@@ -213,7 +213,7 @@ export function doAddLocaleData() {
     addLocaleData(plLocaleData);
     addLocaleData(ptLocaleData);
     addLocaleData(roLocaleData);
-    addLocaleData(trLocaleData);
     addLocaleData(ruLocaleData);
+    addLocaleData(trLocaleData);
     addLocaleData(zhLocaleData);
 }

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -114,13 +114,13 @@ const languages = {
     ro: {
         value: 'ro',
         name: 'Română (Beta)',
-        order: 9,
+        order: 8,
         url: ro,
     },
     tr: {
         value: 'tr',
         name: 'Türkçe',
-        order: 8,
+        order: 9,
         url: tr,
     },
     ru: {

--- a/tests/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/tests/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -323,18 +323,18 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
             },
             Object {
               "order": 8,
-              "text": "Türkçe",
-              "value": "tr",
-            },
-            Object {
-              "order": 9,
               "text": "Română (Beta)",
               "value": "ro",
             },
             Object {
-              "order": 10,
+              "order": 9,
               "text": "Pусский (Alpha)",
               "value": "ru",
+            },
+            Object {
+              "order": 10,
+              "text": "Türkçe",
+              "value": "tr",
             },
             Object {
               "order": 11,
@@ -432,18 +432,18 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
             },
             Object {
               "order": 8,
-              "text": "Türkçe",
-              "value": "tr",
-            },
-            Object {
-              "order": 9,
               "text": "Română (Beta)",
               "value": "ro",
             },
             Object {
-              "order": 10,
+              "order": 9,
               "text": "Pусский (Alpha)",
               "value": "ru",
+            },
+            Object {
+              "order": 10,
+              "text": "Türkçe",
+              "value": "tr",
             },
             Object {
               "order": 11,


### PR DESCRIPTION
Romanian should be below Portuguese, above Turkish