### PR TITLE
MM-11469: Create a telemetry event for telemetry config changed.

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -8,6 +8,7 @@ import {Constants} from 'utils/constants';
 import {ldapTest, invalidateAllCaches, reloadConfig, testS3Connection} from 'actions/admin_actions';
 import SystemAnalytics from 'components/analytics/system_analytics';
 import TeamAnalytics from 'components/analytics/team_analytics';
+import {trackEvent} from 'actions/diagnostics_actions.jsx';
 
 import Audits from './audits';
 import CustomUrlSchemesSetting from './custom_url_schemes_setting.jsx';
@@ -533,6 +534,12 @@ export default {
                             help_text: 'admin.log.enableDiagnosticsDescription',
                             help_text_default: 'Enable this feature to improve the quality and performance of Mattermost by sending error reporting and diagnostic information to Mattermost, Inc. Read our [privacy policy](!https://about.mattermost.com/default-privacy-policy/) to learn more.',
                             help_text_markdown: true,
+                            onConfigSave: (displayVal, previousVal) => {
+                                if (previousVal && previousVal !== displayVal) {
+                                    trackEvent('ui', 'diagnostics_disabled');
+                                }
+                                return displayVal;
+                            },
                         },
                     ],
                 },

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -62,9 +62,10 @@ export default class SchemaAdminSettings extends AdminSettings {
                 }
 
                 let value = this.getSettingValue(setting);
+                const previousValue = this.getConfigValue(config, setting.key);
 
                 if (setting.onConfigSave) {
-                    value = setting.onConfigSave(value);
+                    value = setting.onConfigSave(value, previousValue);
                 }
 
                 this.setConfigValue(config, setting.key, value);


### PR DESCRIPTION
#### Summary
Sends a client-side telemetry event when telemetry config setting changed in system console.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11469

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed