### PR TITLE
MM-11707: Removes edit_others_posts permission from the Reset Default…

### DIFF
--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -611,7 +611,6 @@ export const DefaultRolePermissions = {
         Permissions.MANAGE_CHANNEL_ROLES,
     ],
     team_admin: [
-        Permissions.EDIT_OTHERS_POSTS,
         Permissions.REMOVE_USER_FROM_TEAM,
         Permissions.MANAGE_TEAM,
         Permissions.IMPORT_TEAM,


### PR DESCRIPTION
… Permissions button.

#### Summary
Removes `edit_others_posts` permissions when one resets the default permissions.

#### Ticket Link
[MM-11707](https://mattermost.atlassian.net/browse/MM-11707)

#### Checklist
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [x] Has server changes (https://github.com/mattermost/mattermost-server/pull/9259)