### PR TITLE
Add postId to the PostDropDownMenuAction and Component for plugins

### DIFF
--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -273,7 +273,7 @@ export default class DotMenu extends Component {
                     menuItemText={item.text}
                     handleMenuItemActivated={() => {
                         if (item.action) {
-                            item.action();
+                            item.action(this.props.post.id);
                         }
                     }}
                 />
@@ -305,7 +305,10 @@ export default class DotMenu extends Component {
                         >
                             {menuItems}
                             {pluginItems}
-                            <Pluggable pluggableName='PostDropdownMenuItem'/>
+                            <Pluggable
+                                postId={this.props.post.id}
+                                pluggableName='PostDropdownMenuItem'
+                            />
                         </ul>
                     </div>
                 </div>

--- a/components/dot_menu/dot_menu_item.jsx
+++ b/components/dot_menu/dot_menu_item.jsx
@@ -7,10 +7,10 @@ import React from 'react';
 export default class DotMenuItem extends React.PureComponent {
     static propTypes = {
         handleMenuItemActivated: PropTypes.func.isRequired,
-        menuItemText: PropTypes.oneOfType(
+        menuItemText: PropTypes.oneOfType([
             PropTypes.element,
-            PropTypes.string
-        ),
+            PropTypes.string,
+        ]),
     };
 
     render() {

--- a/components/dot_menu/dot_menu_item.jsx
+++ b/components/dot_menu/dot_menu_item.jsx
@@ -7,7 +7,10 @@ import React from 'react';
 export default class DotMenuItem extends React.PureComponent {
     static propTypes = {
         handleMenuItemActivated: PropTypes.func.isRequired,
-        menuItemText: PropTypes.element,
+        menuItemText: PropTypes.oneOfType(
+            PropTypes.element,
+            PropTypes.string
+        ),
     };
 
     render() {

--- a/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
@@ -55,6 +55,7 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
         />
         <Connect(Pluggable)
           pluggableName="PostDropdownMenuItem"
+          postId="post_id_1"
         />
       </ul>
     </div>
@@ -117,6 +118,7 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
         />
         <Connect(Pluggable)
           pluggableName="PostDropdownMenuItem"
+          postId="post_id_1"
         />
       </ul>
     </div>


### PR DESCRIPTION
#### Summary
Adds the correspondent postId as a prop for the `PostDropDownMenuComponent` and as an parameter to `PostDropDownMenuAction` function.

Without the postId the action or the component are basically useless

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
