### PR TITLE
[MM-11280] Migrate activity_log_modal.jsx to use Redux

### DIFF
--- a/components/activity_log_modal/activity_log_modal.jsx
+++ b/components/activity_log_modal/activity_log_modal.jsx
@@ -6,9 +6,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
-import {General} from 'mattermost-redux/constants';
 
-import {localizeMessage, isMobile} from 'utils/utils.jsx';
+import {isMobile} from 'utils/utils.jsx';
 import ActivityLog from 'components/activity_log_modal/components/activity_log.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
@@ -55,7 +54,6 @@ export default class ActivityLogModal extends React.PureComponent {
         super(props);
 
         this.state = {
-            moreInfo: [],
             show: true,
         };
     }
@@ -87,112 +85,15 @@ export default class ActivityLogModal extends React.PureComponent {
         this.onShow();
     }
 
-    handleMoreInfo = (index) => {
-        const newMoreInfo = this.state.moreInfo;
-        newMoreInfo[index] = true;
-        this.setState({moreInfo: newMoreInfo});
-    }
-
-    isMobileSession = (session) => {
-        return session.device_id && (session.device_id.includes('apple') || session.device_id.includes('android'));
-    };
-
-    mobileSessionInfo = (session) => {
-        let deviceTypeId;
-        let deviceTypeMessage;
-        let devicePicture;
-        let deviceTitle;
-
-        if (session.device_id.includes('apple')) {
-            devicePicture = 'fa fa-apple';
-            deviceTitle = localizeMessage('device_icons.apple', 'Apple Icon');
-            deviceTypeId = 'activity_log_modal.iphoneNativeClassicApp';
-            deviceTypeMessage = 'iPhone Native Classic App';
-
-            if (session.device_id.includes(General.PUSH_NOTIFY_APPLE_REACT_NATIVE)) {
-                deviceTypeId = 'activity_log_modal.iphoneNativeApp';
-                deviceTypeMessage = 'iPhone Native App';
-            }
-        } else if (session.device_id.includes('android')) {
-            devicePicture = 'fa fa-android';
-            deviceTitle = localizeMessage('device_icons.android', 'Android Icon');
-            deviceTypeId = 'activity_log_modal.androidNativeClassicApp';
-            deviceTypeMessage = 'Android Native Classic App';
-
-            if (session.device_id.includes(General.PUSH_NOTIFY_ANDROID_REACT_NATIVE)) {
-                deviceTypeId = 'activity_log_modal.androidNativeApp';
-                deviceTypeMessage = 'Android Native App';
-            }
-        }
-
-        return {
-            devicePicture,
-            deviceTitle,
-            devicePlatform: (
-                <FormattedMessage
-                    id={deviceTypeId}
-                    defaultMessage={deviceTypeMessage}
-                />
-            ),
-        };
-    };
-
     render() {
         let content;
         if (this.props.sessions.loading) {
             content = <LoadingScreen/>;
         } else {
             const activityList = this.props.sessions.reduce((array, currentSession, index) => {
-                const lastAccessTime = new Date(currentSession.last_activity_at);
-                const firstAccessTime = new Date(currentSession.create_at);
-                let devicePlatform = currentSession.props.platform;
-                let devicePicture = '';
-                let deviceTitle = '';
-
                 if (currentSession.props.type === 'UserAccessToken') {
                     return array;
                 }
-
-                if (currentSession.props.platform === 'Windows') {
-                    devicePicture = 'fa fa-windows';
-                    deviceTitle = localizeMessage('device_icons.windows', 'Windows Icon');
-                } else if (this.isMobileSession(currentSession)) {
-                    const sessionInfo = this.mobileSessionInfo(currentSession);
-                    devicePicture = sessionInfo.devicePicture;
-                    devicePlatform = sessionInfo.devicePlatform;
-                } else if (currentSession.props.platform === 'Macintosh' ||
-                    currentSession.props.platform === 'iPhone') {
-                    devicePicture = 'fa fa-apple';
-                    deviceTitle = localizeMessage('device_icons.apple', 'Apple Icon');
-                } else if (currentSession.props.platform === 'Linux') {
-                    if (currentSession.props.os.indexOf('Android') >= 0) {
-                        devicePlatform = (
-                            <FormattedMessage
-                                id='activity_log_modal.android'
-                                defaultMessage='Android'
-                            />
-                        );
-                        devicePicture = 'fa fa-android';
-                        deviceTitle = localizeMessage('device_icons.android', 'Android Icon');
-                    } else {
-                        devicePicture = 'fa fa-linux';
-                        deviceTitle = localizeMessage('device_icons.linux', 'Linux Icon');
-                    }
-                } else if (currentSession.props.os.indexOf('Linux') !== -1) {
-                    devicePicture = 'fa fa-linux';
-                    deviceTitle = localizeMessage('device_icons.linux', 'Linux Icon');
-                }
-
-                if (currentSession.props.browser.indexOf('Desktop App') !== -1) {
-                    devicePlatform = (
-                        <FormattedMessage
-                            id='activity_log_modal.desktop'
-                            defaultMessage='Native Desktop App'
-                        />
-                    );
-                }
-
-                const moreInfo = typeof this.state.moreInfo[index] !== 'undefined';
 
                 array.push(
                     <ActivityLog
@@ -200,13 +101,6 @@ export default class ActivityLogModal extends React.PureComponent {
                         index={index}
                         locale={this.props.locale}
                         currentSession={currentSession}
-                        lastAccessTime={lastAccessTime}
-                        firstAccessTime={firstAccessTime}
-                        devicePlatform={devicePlatform}
-                        devicePicture={devicePicture}
-                        deviceTitle={deviceTitle}
-                        moreInfo={moreInfo}
-                        handleMoreInfo={this.handleMoreInfo}
                         submitRevoke={this.submitRevoke}
                     />
                 );

--- a/components/activity_log_modal/components/activity_log.jsx
+++ b/components/activity_log_modal/components/activity_log.jsx
@@ -1,0 +1,154 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedDate, FormattedMessage, FormattedTime} from 'react-intl';
+
+import {getMonthLong} from 'utils/i18n';
+
+import MoreInfo from './more_info.jsx';
+
+export default class ActivityLog extends React.PureComponent {
+    static propTypes = {
+
+        /**
+         * The index of this instance within the list
+         */
+        index: PropTypes.number.isRequired,
+
+        /**
+         * The current locale of the user
+         */
+        locale: PropTypes.string.isRequired,
+
+        /**
+         * The session that's to be displayed
+         */
+        currentSession: PropTypes.object.isRequired,
+
+        /**
+         * The session's last access time
+         */
+        lastAccessTime: PropTypes.instanceOf(Date).isRequired,
+
+        /**
+         * The session's first access time
+         */
+        firstAccessTime: PropTypes.instanceOf(Date).isRequired,
+
+        /**
+         * The session's device platform
+         */
+        devicePlatform: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.element,
+        ]),
+
+        /**
+         * The session's device picture
+         */
+        devicePicture: PropTypes.string.isRequired,
+
+        /**
+         * The session's last access time
+         */
+        deviceTitle: PropTypes.string.isRequired,
+
+        /**
+         * Boolean indicating whether to show more info about the session
+         */
+        moreInfo: PropTypes.bool.isRequired,
+
+        /**
+         * Function to show more info
+         */
+        handleMoreInfo: PropTypes.func.isRequired,
+
+        /**
+         * Function to revoke session
+         */
+        submitRevoke: PropTypes.func.isRequired,
+    }
+
+    handleMoreInfo = () => {
+        this.props.handleMoreInfo(this.props.index);
+    }
+
+    submitRevoke = (e) => {
+        this.props.submitRevoke(this.props.currentSession.id, e);
+    }
+
+    render() {
+        const {
+            index,
+            locale,
+            currentSession,
+            lastAccessTime,
+            firstAccessTime,
+            devicePlatform,
+            devicePicture,
+            deviceTitle,
+            moreInfo,
+        } = this.props;
+
+        return (
+            <div
+                key={'activityLogEntryKey' + index}
+                className='activity-log__table'
+            >
+                <div className='activity-log__report'>
+                    <div className='report__platform'>
+                        <i
+                            className={devicePicture}
+                            title={deviceTitle}
+                        />{devicePlatform}
+                    </div>
+                    <div className='report__info'>
+                        <div>
+                            <FormattedMessage
+                                id='activity_log.lastActivity'
+                                defaultMessage='Last activity: {date}, {time}'
+                                values={{
+                                    date: (
+                                        <FormattedDate
+                                            value={lastAccessTime}
+                                            day='2-digit'
+                                            month={getMonthLong(locale)}
+                                            year='numeric'
+                                        />
+                                    ),
+                                    time: (
+                                        <FormattedTime
+                                            value={lastAccessTime}
+                                            hour='2-digit'
+                                            minute='2-digit'
+                                        />
+                                    ),
+                                }}
+                            />
+                        </div>
+                        <MoreInfo
+                            locale={locale}
+                            currentSession={currentSession}
+                            firstAccessTime={firstAccessTime}
+                            moreInfo={moreInfo}
+                            handleMoreInfo={this.handleMoreInfo}
+                        />
+                    </div>
+                </div>
+                <div className='activity-log__action'>
+                    <button
+                        onClick={this.submitRevoke}
+                        className='btn btn-primary'
+                    >
+                        <FormattedMessage
+                            id='activity_log.logout'
+                            defaultMessage='Logout'
+                        />
+                    </button>
+                </div>
+            </div>
+        );
+    }
+}

--- a/components/activity_log_modal/components/more_info.jsx
+++ b/components/activity_log_modal/components/more_info.jsx
@@ -10,11 +10,12 @@ import {getMonthLong} from 'utils/i18n';
 export default function MoreInfo({
     locale,
     currentSession,
-    firstAccessTime,
     moreInfo,
     handleMoreInfo,
 }) {
     if (moreInfo) {
+        const firstAccessTime = new Date(currentSession.create_at);
+
         return (
             <div>
                 <div>
@@ -88,7 +89,6 @@ export default function MoreInfo({
 MoreInfo.propTypes = {
     locale: PropTypes.string.isRequired,
     currentSession: PropTypes.object.isRequired,
-    firstAccessTime: PropTypes.instanceOf(Date).isRequired,
     handleMoreInfo: PropTypes.func.isRequired,
     moreInfo: PropTypes.bool.isRequired,
 };

--- a/components/activity_log_modal/components/more_info.jsx
+++ b/components/activity_log_modal/components/more_info.jsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedDate, FormattedMessage, FormattedTime} from 'react-intl';
+
+import {getMonthLong} from 'utils/i18n';
+
+export default function MoreInfo({
+    locale,
+    currentSession,
+    firstAccessTime,
+    moreInfo,
+    handleMoreInfo,
+}) {
+    if (moreInfo) {
+        return (
+            <div>
+                <div>
+                    <FormattedMessage
+                        id='activity_log.firstTime'
+                        defaultMessage='First time active: {date}, {time}'
+                        values={{
+                            date: (
+                                <FormattedDate
+                                    value={firstAccessTime}
+                                    day='2-digit'
+                                    month={getMonthLong(locale)}
+                                    year='numeric'
+                                />
+                            ),
+                            time: (
+                                <FormattedTime
+                                    value={firstAccessTime}
+                                    hour='2-digit'
+                                    minute='2-digit'
+                                />
+                            ),
+                        }}
+                    />
+                </div>
+                <div>
+                    <FormattedMessage
+                        id='activity_log.os'
+                        defaultMessage='OS: {os}'
+                        values={{
+                            os: currentSession.props.os,
+                        }}
+                    />
+                </div>
+                <div>
+                    <FormattedMessage
+                        id='activity_log.browser'
+                        defaultMessage='Browser: {browser}'
+                        values={{
+                            browser: currentSession.props.browser,
+                        }}
+                    />
+                </div>
+                <div>
+                    <FormattedMessage
+                        id='activity_log.sessionId'
+                        defaultMessage='Session ID: {id}'
+                        values={{
+                            id: currentSession.id,
+                        }}
+                    />
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <a
+            className='theme'
+            href='#'
+            onClick={handleMoreInfo}
+        >
+            <FormattedMessage
+                id='activity_log.moreInfo'
+                defaultMessage='More info'
+            />
+        </a>
+    );
+}
+
+MoreInfo.propTypes = {
+    locale: PropTypes.string.isRequired,
+    currentSession: PropTypes.object.isRequired,
+    firstAccessTime: PropTypes.instanceOf(Date).isRequired,
+    handleMoreInfo: PropTypes.func.isRequired,
+    moreInfo: PropTypes.bool.isRequired,
+};

--- a/components/activity_log_modal/index.js
+++ b/components/activity_log_modal/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getSessions, revokeSession} from 'mattermost-redux/actions/users';
+import {getCurrentUserId, getUserSessions} from 'mattermost-redux/selectors/entities/users';
 
 import {getCurrentLocale} from 'selectors/i18n';
 
@@ -11,6 +12,8 @@ import ActivityLogModal from './activity_log_modal.jsx';
 
 function mapStateToProps(state) {
     return {
+        currentUserId: getCurrentUserId(state),
+        sessions: getUserSessions(state),
         locale: getCurrentLocale(state),
     };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10231,8 +10231,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#11902b0d530e5b3303e7fffe74ef8102d25a1893",
-      "from": "github:mattermost/mattermost-redux#11902b0d530e5b3303e7fffe74ef8102d25a1893",
+      "version": "github:mattermost/mattermost-redux#aface7335570589cbda39c71da06be7153f48ccb",
+      "from": "github:mattermost/mattermost-redux#aface7335570589cbda39c71da06be7153f48ccb",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",
@@ -13183,7 +13183,6 @@
     "redux-offline": {
       "version": "git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
       "from": "git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
-      "from": "redux-offline@git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
       "requires": {
         "redux-persist": "^4.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "localforage": "1.7.2",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#11902b0d530e5b3303e7fffe74ef8102d25a1893",
+    "mattermost-redux": "github:mattermost/mattermost-redux#aface7335570589cbda39c71da06be7153f48ccb",
     "moment-timezone": "0.5.21",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/tests/components/activity_log_modal.test.jsx
+++ b/tests/components/activity_log_modal.test.jsx
@@ -3,13 +3,11 @@
 
 import React from 'react';
 import {shallow} from 'enzyme';
-import {FormattedMessage} from 'react-intl';
 import $ from 'jquery';
 require('perfect-scrollbar/jquery')($);
 
 import {General} from 'mattermost-redux/constants';
 
-import {localizeMessage} from 'utils/utils.jsx';
 import ActivityLogModal from 'components/activity_log_modal/activity_log_modal.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
@@ -83,49 +81,5 @@ describe('components/ActivityLogModal', () => {
         wrapper.setState({show: true});
         wrapper.instance().onHide();
         expect(wrapper.state('show')).toEqual(false);
-    });
-
-    test('should match state when handleMoreInfo is called', () => {
-        const wrapper = shallow(
-            <ActivityLogModal {...baseProps}/>
-        );
-
-        const newProps = {sessions: [{props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'}, id: 'sessionId'}]};
-        const newState = {moreInfo: [false, false], show: true};
-        wrapper.setProps(newProps);
-        wrapper.setState(newState);
-        wrapper.instance().handleMoreInfo(1);
-        expect(wrapper.state()).toEqual({...newState, moreInfo: [false, true]});
-    });
-
-    test('should match when isMobileSession is called', () => {
-        const wrapper = shallow(
-            <ActivityLogModal {...baseProps}/>
-        );
-
-        const isMobileSession = wrapper.instance().isMobileSession;
-        expect(isMobileSession({device_id: 'apple'})).toEqual(true);
-        expect(isMobileSession({device_id: 'android'})).toEqual(true);
-        expect(isMobileSession({device_id: 'none'})).toEqual(false);
-    });
-
-    test('should match when mobileSessionInfo is called', () => {
-        const wrapper = shallow(
-            <ActivityLogModal {...baseProps}/>
-        );
-
-        const mobileSessionInfo = wrapper.instance().mobileSessionInfo;
-
-        const apple = {devicePicture: 'fa fa-apple', deviceTitle: localizeMessage('device_icons.apple', 'Apple Icon'), devicePlatform: <FormattedMessage defaultMessage='iPhone Native Classic App' id='activity_log_modal.iphoneNativeClassicApp' values={{}}/>}; //eslint-disable-line react/jsx-max-props-per-line
-        expect(mobileSessionInfo({device_id: 'apple'})).toEqual(apple);
-
-        const android = {devicePicture: 'fa fa-android', deviceTitle: localizeMessage('device_icons.android', 'Android Icon'), devicePlatform: <FormattedMessage defaultMessage='Android Native Classic App' id='activity_log_modal.androidNativeClassicApp' values={{}}/>}; //eslint-disable-line react/jsx-max-props-per-line
-        expect(mobileSessionInfo({device_id: 'android'})).toEqual(android);
-
-        const appleRN = {devicePicture: 'fa fa-apple', deviceTitle: localizeMessage('device_icons.apple', 'Apple Icon'), devicePlatform: <FormattedMessage defaultMessage='iPhone Native App' id='activity_log_modal.iphoneNativeApp' values={{}}/>}; //eslint-disable-line react/jsx-max-props-per-line
-        expect(mobileSessionInfo({device_id: 'apple_rn'})).toEqual(appleRN);
-
-        const androidRN = {devicePicture: 'fa fa-android', deviceTitle: localizeMessage('device_icons.android', 'Android Icon'), devicePlatform: <FormattedMessage defaultMessage='Android Native App' id='activity_log_modal.androidNativeApp' values={{}}/>}; //eslint-disable-line react/jsx-max-props-per-line
-        expect(mobileSessionInfo({device_id: 'android_rn'})).toEqual(androidRN);
     });
 });

--- a/tests/components/activity_log_modal.test.jsx
+++ b/tests/components/activity_log_modal.test.jsx
@@ -90,7 +90,7 @@ describe('components/ActivityLogModal', () => {
             <ActivityLogModal {...baseProps}/>
         );
 
-        const newProps = {sessions: [{props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'}}]};
+        const newProps = {sessions: [{props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'}, id: 'sessionId'}]};
         const newState = {moreInfo: [false, false], show: true};
         wrapper.setProps(newProps);
         wrapper.setState(newState);

--- a/tests/components/activity_log_modal.test.jsx
+++ b/tests/components/activity_log_modal.test.jsx
@@ -15,6 +15,8 @@ import LoadingScreen from 'components/loading_screen.jsx';
 
 describe('components/ActivityLogModal', () => {
     const baseProps = {
+        sessions: [],
+        currentUserId: '',
         onHide: jest.fn(),
         actions: {
             getSessions: jest.fn(),
@@ -30,7 +32,7 @@ describe('components/ActivityLogModal', () => {
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find(LoadingScreen).exists()).toBe(false);
 
-        wrapper.setState({sessions: {loading: true}});
+        wrapper.setProps({sessions: {loading: true}});
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find(LoadingScreen).exists()).toBe(true);
     });
@@ -83,23 +85,14 @@ describe('components/ActivityLogModal', () => {
         expect(wrapper.state('show')).toEqual(false);
     });
 
-    test('should match state when onListenerChange is called', () => {
-        const wrapper = shallow(
-            <ActivityLogModal {...baseProps}/>
-        );
-
-        const newState = {sessions: [{props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'}}], clientError: null, moreInfo: [false, false], show: true};
-        wrapper.setState(newState);
-        wrapper.instance().onListenerChange();
-        expect(wrapper.state()).toEqual({clientError: null, moreInfo: [false, false], sessions: [], show: true});
-    });
-
     test('should match state when handleMoreInfo is called', () => {
         const wrapper = shallow(
             <ActivityLogModal {...baseProps}/>
         );
 
-        const newState = {sessions: [{props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'}}], clientError: null, moreInfo: [false, false], show: true};
+        const newProps = {sessions: [{props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'}}]};
+        const newState = {moreInfo: [false, false], show: true};
+        wrapper.setProps(newProps);
         wrapper.setState(newState);
         wrapper.instance().handleMoreInfo(1);
         expect(wrapper.state()).toEqual({...newState, moreInfo: [false, true]});

--- a/tests/components/activity_log_modal/__snapshots__/activity_log.test.jsx.snap
+++ b/tests/components/activity_log_modal/__snapshots__/activity_log.test.jsx.snap
@@ -15,7 +15,11 @@ exports[`components/activity_log_modal/ActivityLog should match snapshot 1`] = `
         className="fa fa-linux"
         title="Linux Icon"
       />
-      Linux
+      <FormattedMessage
+        defaultMessage="Native Desktop App"
+        id="activity_log_modal.desktop"
+        values={Object {}}
+      />
     </div>
     <div
       className="report__info"
@@ -29,13 +33,13 @@ exports[`components/activity_log_modal/ActivityLog should match snapshot 1`] = `
               "date": <FormattedDate
                 day="2-digit"
                 month="long"
-                value={2018-09-20T12:15:00.000Z}
+                value={2018-08-22T06:00:43.890Z}
                 year="numeric"
               />,
               "time": <FormattedTime
                 hour="2-digit"
                 minute="2-digit"
-                value={2018-09-20T12:15:00.000Z}
+                value={2018-08-22T06:00:43.890Z}
               />,
             }
           }
@@ -44,7 +48,9 @@ exports[`components/activity_log_modal/ActivityLog should match snapshot 1`] = `
       <MoreInfo
         currentSession={
           Object {
+            "create_at": 1534917291042,
             "id": "sessionId",
+            "last_activity_at": 1534917643890,
             "props": Object {
               "browser": "Desktop App",
               "os": "Linux",
@@ -52,7 +58,6 @@ exports[`components/activity_log_modal/ActivityLog should match snapshot 1`] = `
             },
           }
         }
-        firstAccessTime={2018-07-20T12:15:00.000Z}
         handleMoreInfo={[Function]}
         locale="en"
         moreInfo={false}

--- a/tests/components/activity_log_modal/__snapshots__/activity_log.test.jsx.snap
+++ b/tests/components/activity_log_modal/__snapshots__/activity_log.test.jsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/activity_log_modal/ActivityLog should match snapshot 1`] = `
+<div
+  className="activity-log__table"
+  key="activityLogEntryKey0"
+>
+  <div
+    className="activity-log__report"
+  >
+    <div
+      className="report__platform"
+    >
+      <i
+        className="fa fa-linux"
+        title="Linux Icon"
+      />
+      Linux
+    </div>
+    <div
+      className="report__info"
+    >
+      <div>
+        <FormattedMessage
+          defaultMessage="Last activity: {date}, {time}"
+          id="activity_log.lastActivity"
+          values={
+            Object {
+              "date": <FormattedDate
+                day="2-digit"
+                month="long"
+                value={2018-09-20T12:15:00.000Z}
+                year="numeric"
+              />,
+              "time": <FormattedTime
+                hour="2-digit"
+                minute="2-digit"
+                value={2018-09-20T12:15:00.000Z}
+              />,
+            }
+          }
+        />
+      </div>
+      <MoreInfo
+        currentSession={
+          Object {
+            "id": "sessionId",
+            "props": Object {
+              "browser": "Desktop App",
+              "os": "Linux",
+              "platform": "Linux",
+            },
+          }
+        }
+        firstAccessTime={2018-07-20T12:15:00.000Z}
+        handleMoreInfo={[Function]}
+        locale="en"
+        moreInfo={false}
+      />
+    </div>
+  </div>
+  <div
+    className="activity-log__action"
+  >
+    <button
+      className="btn btn-primary"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Logout"
+        id="activity_log.logout"
+        values={Object {}}
+      />
+    </button>
+  </div>
+</div>
+`;

--- a/tests/components/activity_log_modal/__snapshots__/more_info.test.jsx.snap
+++ b/tests/components/activity_log_modal/__snapshots__/more_info.test.jsx.snap
@@ -25,13 +25,13 @@ exports[`components/activity_log_modal/MoreInfo should match snapshot, extra inf
           "date": <FormattedDate
             day="2-digit"
             month="long"
-            value={2018-07-20T12:15:00.000Z}
+            value={2018-08-22T05:54:51.042Z}
             year="numeric"
           />,
           "time": <FormattedTime
             hour="2-digit"
             minute="2-digit"
-            value={2018-07-20T12:15:00.000Z}
+            value={2018-08-22T05:54:51.042Z}
           />,
         }
       }

--- a/tests/components/activity_log_modal/__snapshots__/more_info.test.jsx.snap
+++ b/tests/components/activity_log_modal/__snapshots__/more_info.test.jsx.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/activity_log_modal/MoreInfo should match snapshot extra info toggled off 1`] = `
+<a
+  className="theme"
+  href="#"
+  onClick={[MockFunction]}
+>
+  <FormattedMessage
+    defaultMessage="More info"
+    id="activity_log.moreInfo"
+    values={Object {}}
+  />
+</a>
+`;
+
+exports[`components/activity_log_modal/MoreInfo should match snapshot, extra info toggled on 1`] = `
+<div>
+  <div>
+    <FormattedMessage
+      defaultMessage="First time active: {date}, {time}"
+      id="activity_log.firstTime"
+      values={
+        Object {
+          "date": <FormattedDate
+            day="2-digit"
+            month="long"
+            value={2018-07-20T12:15:00.000Z}
+            year="numeric"
+          />,
+          "time": <FormattedTime
+            hour="2-digit"
+            minute="2-digit"
+            value={2018-07-20T12:15:00.000Z}
+          />,
+        }
+      }
+    />
+  </div>
+  <div>
+    <FormattedMessage
+      defaultMessage="OS: {os}"
+      id="activity_log.os"
+      values={
+        Object {
+          "os": "Linux",
+        }
+      }
+    />
+  </div>
+  <div>
+    <FormattedMessage
+      defaultMessage="Browser: {browser}"
+      id="activity_log.browser"
+      values={
+        Object {
+          "browser": "Desktop App",
+        }
+      }
+    />
+  </div>
+  <div>
+    <FormattedMessage
+      defaultMessage="Session ID: {id}"
+      id="activity_log.sessionId"
+      values={
+        Object {
+          "id": "sessionId",
+        }
+      }
+    />
+  </div>
+</div>
+`;

--- a/tests/components/activity_log_modal/activity_log.test.jsx
+++ b/tests/components/activity_log_modal/activity_log.test.jsx
@@ -3,23 +3,23 @@
 
 import React from 'react';
 import {shallow} from 'enzyme';
+import {FormattedMessage} from 'react-intl';
 
 import {General} from 'mattermost-redux/constants';
 
+import {localizeMessage} from 'utils/utils.jsx';
 import ActivityLog from 'components/activity_log_modal/components/activity_log.jsx';
 
 describe('components/activity_log_modal/ActivityLog', () => {
     const baseProps = {
         index: 0,
         locale: General.DEFAULT_LOCALE,
-        currentSession: {props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'}, id: 'sessionId'},
-        lastAccessTime: new Date(Date.UTC(2018, 8, 20, 12, 15)),
-        firstAccessTime: new Date(Date.UTC(2018, 6, 20, 12, 15)),
-        devicePlatform: 'Linux',
-        devicePicture: 'fa fa-linux',
-        deviceTitle: 'Linux Icon',
-        moreInfo: false,
-        handleMoreInfo: jest.fn(),
+        currentSession: {
+            props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'},
+            id: 'sessionId',
+            create_at: 1534917291042,
+            last_activity_at: 1534917643890,
+        },
         submitRevoke: jest.fn(),
     };
 
@@ -31,19 +31,54 @@ describe('components/activity_log_modal/ActivityLog', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('functions are called correctly', () => {
+    test('submitRevoke is called correctly', () => {
         const wrapper = shallow(
             <ActivityLog {...baseProps}/>
         );
-
-        wrapper.instance().handleMoreInfo();
-        expect(baseProps.handleMoreInfo).toBeCalled();
-        expect(baseProps.handleMoreInfo).toHaveBeenCalledTimes(1);
-        expect(baseProps.handleMoreInfo).toBeCalledWith(0);
 
         wrapper.instance().submitRevoke('e');
         expect(baseProps.submitRevoke).toBeCalled();
         expect(baseProps.submitRevoke).toHaveBeenCalledTimes(1);
         expect(baseProps.submitRevoke).toBeCalledWith('sessionId', 'e');
+    });
+
+    test('handleMoreInfo updates state correctly', () => {
+        const wrapper = shallow(
+            <ActivityLog {...baseProps}/>
+        );
+
+        wrapper.instance().handleMoreInfo();
+        expect(wrapper.state()).toEqual({moreInfo: true});
+    });
+
+    test('should match when isMobileSession is called', () => {
+        const wrapper = shallow(
+            <ActivityLog {...baseProps}/>
+        );
+
+        const isMobileSession = wrapper.instance().isMobileSession;
+        expect(isMobileSession({device_id: 'apple'})).toEqual(true);
+        expect(isMobileSession({device_id: 'android'})).toEqual(true);
+        expect(isMobileSession({device_id: 'none'})).toEqual(false);
+    });
+
+    test('should match when mobileSessionInfo is called', () => {
+        const wrapper = shallow(
+            <ActivityLog {...baseProps}/>
+        );
+
+        const mobileSessionInfo = wrapper.instance().mobileSessionInfo;
+
+        const apple = {devicePicture: 'fa fa-apple', deviceTitle: localizeMessage('device_icons.apple', 'Apple Icon'), devicePlatform: <FormattedMessage defaultMessage='iPhone Native Classic App' id='activity_log_modal.iphoneNativeClassicApp' values={{}}/>}; //eslint-disable-line react/jsx-max-props-per-line
+        expect(mobileSessionInfo({device_id: 'apple'})).toEqual(apple);
+
+        const android = {devicePicture: 'fa fa-android', deviceTitle: localizeMessage('device_icons.android', 'Android Icon'), devicePlatform: <FormattedMessage defaultMessage='Android Native Classic App' id='activity_log_modal.androidNativeClassicApp' values={{}}/>}; //eslint-disable-line react/jsx-max-props-per-line
+        expect(mobileSessionInfo({device_id: 'android'})).toEqual(android);
+
+        const appleRN = {devicePicture: 'fa fa-apple', deviceTitle: localizeMessage('device_icons.apple', 'Apple Icon'), devicePlatform: <FormattedMessage defaultMessage='iPhone Native App' id='activity_log_modal.iphoneNativeApp' values={{}}/>}; //eslint-disable-line react/jsx-max-props-per-line
+        expect(mobileSessionInfo({device_id: 'apple_rn'})).toEqual(appleRN);
+
+        const androidRN = {devicePicture: 'fa fa-android', deviceTitle: localizeMessage('device_icons.android', 'Android Icon'), devicePlatform: <FormattedMessage defaultMessage='Android Native App' id='activity_log_modal.androidNativeApp' values={{}}/>}; //eslint-disable-line react/jsx-max-props-per-line
+        expect(mobileSessionInfo({device_id: 'android_rn'})).toEqual(androidRN);
     });
 });

--- a/tests/components/activity_log_modal/activity_log.test.jsx
+++ b/tests/components/activity_log_modal/activity_log.test.jsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {General} from 'mattermost-redux/constants';
+
+import ActivityLog from 'components/activity_log_modal/components/activity_log.jsx';
+
+describe('components/activity_log_modal/ActivityLog', () => {
+    const baseProps = {
+        index: 0,
+        locale: General.DEFAULT_LOCALE,
+        currentSession: {props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'}, id: 'sessionId'},
+        lastAccessTime: new Date(Date.UTC(2018, 8, 20, 12, 15)),
+        firstAccessTime: new Date(Date.UTC(2018, 6, 20, 12, 15)),
+        devicePlatform: 'Linux',
+        devicePicture: 'fa fa-linux',
+        deviceTitle: 'Linux Icon',
+        moreInfo: false,
+        handleMoreInfo: jest.fn(),
+        submitRevoke: jest.fn(),
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <ActivityLog {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('functions are called correctly', () => {
+        const wrapper = shallow(
+            <ActivityLog {...baseProps}/>
+        );
+
+        wrapper.instance().handleMoreInfo();
+        expect(baseProps.handleMoreInfo).toBeCalled();
+        expect(baseProps.handleMoreInfo).toHaveBeenCalledTimes(1);
+        expect(baseProps.handleMoreInfo).toBeCalledWith(0);
+
+        wrapper.instance().submitRevoke('e');
+        expect(baseProps.submitRevoke).toBeCalled();
+        expect(baseProps.submitRevoke).toHaveBeenCalledTimes(1);
+        expect(baseProps.submitRevoke).toBeCalledWith('sessionId', 'e');
+    });
+});

--- a/tests/components/activity_log_modal/more_info.test.jsx
+++ b/tests/components/activity_log_modal/more_info.test.jsx
@@ -11,8 +11,12 @@ import MoreInfo from 'components/activity_log_modal/components/more_info.jsx';
 describe('components/activity_log_modal/MoreInfo', () => {
     const baseProps = {
         locale: General.DEFAULT_LOCALE,
-        currentSession: {props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'}, id: 'sessionId'},
-        firstAccessTime: new Date(Date.UTC(2018, 6, 20, 12, 15)),
+        currentSession: {
+            props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'},
+            id: 'sessionId',
+            create_at: 1534917291042,
+            last_activity_at: 1534917643890,
+        },
         moreInfo: false,
         handleMoreInfo: jest.fn(),
     };

--- a/tests/components/activity_log_modal/more_info.test.jsx
+++ b/tests/components/activity_log_modal/more_info.test.jsx
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {General} from 'mattermost-redux/constants';
+
+import MoreInfo from 'components/activity_log_modal/components/more_info.jsx';
+
+describe('components/activity_log_modal/MoreInfo', () => {
+    const baseProps = {
+        locale: General.DEFAULT_LOCALE,
+        currentSession: {props: {os: 'Linux', platform: 'Linux', browser: 'Desktop App'}, id: 'sessionId'},
+        firstAccessTime: new Date(Date.UTC(2018, 6, 20, 12, 15)),
+        moreInfo: false,
+        handleMoreInfo: jest.fn(),
+    };
+
+    test('should match snapshot extra info toggled off', () => {
+        const wrapper = shallow(
+            <MoreInfo {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, extra info toggled on', () => {
+        const props = {...baseProps, moreInfo: true};
+        const wrapper = shallow(
+            <MoreInfo {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
Refactored `activity_log_modal.jsx` to use Redux and be pure. Also cleaned up the code to make use of ES6 style syntax. Tests have been updated as well.

#### Ticket Link
mattermost/mattermost-server#9092
https://mattermost.atlassian.net/browse/MM-11280


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has redux changes https://github.com/mattermost/mattermost-redux/pull/608