### PR TITLE
Pass the post object to the dots menu plugins

### DIFF
--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -305,7 +305,10 @@ export default class DotMenu extends Component {
                         >
                             {menuItems}
                             {pluginItems}
-                            <Pluggable pluggableName='PostDropdownMenuItem'/>
+                            <Pluggable
+                                pluggableName='PostDropdownMenuItem'
+                                post={this.props.post}
+                            />
                         </ul>
                     </div>
                 </div>

--- a/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
+++ b/tests/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
@@ -55,6 +55,12 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
         />
         <Connect(Pluggable)
           pluggableName="PostDropdownMenuItem"
+          post={
+            Object {
+              "id": "post_id_1",
+              "is_pinned": false,
+            }
+          }
         />
       </ul>
     </div>
@@ -117,6 +123,12 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
         />
         <Connect(Pluggable)
           pluggableName="PostDropdownMenuItem"
+          post={
+            Object {
+              "id": "post_id_1",
+              "is_pinned": false,
+            }
+          }
         />
       </ul>
     </div>


### PR DESCRIPTION
#### Summary
The dots menu items probably will need the post itself to make
decisions.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed