### PR TITLE
MM-11649: Don't disable channel name field if set to town-square.

### DIFF
--- a/components/rename_channel_modal/rename_channel_modal.jsx
+++ b/components/rename_channel_modal/rename_channel_modal.jsx
@@ -258,7 +258,7 @@ export class RenameChannelModal extends React.PureComponent {
         let urlInputLabel = formatMessage(holders.url);
         const handleInputClass = 'form-control';
         let readOnlyHandleInput = false;
-        if (this.state.channelName === Constants.DEFAULT_CHANNEL) {
+        if (this.props.channel.name === Constants.DEFAULT_CHANNEL) {
             urlInputLabel += formatMessage(holders.defaultError);
             readOnlyHandleInput = true;
         }


### PR DESCRIPTION
#### Summary
Don't disable channel name field if set to town-square.

In the Channel Rename modal, this should only be disabled if
the name is *already*  town-square before starting to rename
it, not if it gets set to town-square by the user prior to
saving.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11649

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed