### PR TITLE
MM-11662 Enforce 500 character limit on branding text

### DIFF
--- a/components/admin_console/custom_brand_settings.jsx
+++ b/components/admin_console/custom_brand_settings.jsx
@@ -111,6 +111,7 @@ export default class CustomBrandSettings extends AdminSettings {
                     key='customBrandText'
                     id='customBrandText'
                     type='textarea'
+                    maxLength={500}
                     label={
                         <FormattedMessage
                             id='admin.team.brandTextTitle'


### PR DESCRIPTION
#### Summary
Enforce 500 character limit on branding text.

Cause: Old bug, either the help text was updated without changing the functionality or some refactoring in the system console accidentally broke this more than a year ago.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11662

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed