### PR TITLE
Change SuggestionBox to use focusin and focusout events

### DIFF
--- a/components/admin_console/user_autocomplete_setting.jsx
+++ b/components/admin_console/user_autocomplete_setting.jsx
@@ -39,6 +39,7 @@ class UserSuggestion extends Suggestion {
             <div
                 className={className}
                 onClick={this.handleClick}
+                {...Suggestion.baseProps}
             >
                 <div className='pull-left'>
                     <img

--- a/components/suggestion/at_mention_provider.jsx
+++ b/components/suggestion/at_mention_provider.jsx
@@ -92,6 +92,7 @@ class AtMentionSuggestion extends Suggestion {
             <div
                 className={className}
                 onClick={this.handleClick}
+                {...Suggestion.baseProps}
             >
                 <div className='pull-left'>
                     {icon}

--- a/components/suggestion/channel_mention_provider.jsx
+++ b/components/suggestion/channel_mention_provider.jsx
@@ -33,6 +33,7 @@ class ChannelMentionSuggestion extends Suggestion {
             <div
                 className={className}
                 onClick={this.handleClick}
+                {...Suggestion.baseProps}
             >
                 <div className='mention__align'>
                     <span>

--- a/components/suggestion/command_provider.jsx
+++ b/components/suggestion/command_provider.jsx
@@ -20,6 +20,7 @@ class CommandSuggestion extends Suggestion {
             <div
                 className={className}
                 onClick={this.handleClick}
+                {...Suggestion.baseProps}
             >
                 <div className='command__title'>
                     <string>{item.suggestion} {item.hint}</string>

--- a/components/suggestion/emoticon_provider.jsx
+++ b/components/suggestion/emoticon_provider.jsx
@@ -34,6 +34,7 @@ class EmoticonSuggestion extends Suggestion {
             <div
                 className={className}
                 onClick={this.handleClick}
+                {...Suggestion.baseProps}
             >
                 <div className='pull-left'>
                     <img

--- a/components/suggestion/search_channel_provider.jsx
+++ b/components/suggestion/search_channel_provider.jsx
@@ -26,6 +26,7 @@ class SearchChannelSuggestion extends Suggestion {
             <div
                 onClick={this.handleClick}
                 className={className}
+                {...Suggestion.baseProps}
             >
                 <i
                     className='fa fa fa-plus-square'

--- a/components/suggestion/search_user_provider.jsx
+++ b/components/suggestion/search_user_provider.jsx
@@ -35,6 +35,7 @@ class SearchUserSuggestion extends Suggestion {
             <div
                 className={className}
                 onClick={this.handleClick}
+                {...Suggestion.baseProps}
             >
                 <i
                     className='fa fa fa-plus-square'

--- a/components/suggestion/suggestion.jsx
+++ b/components/suggestion/suggestion.jsx
@@ -18,6 +18,11 @@ export default class Suggestion extends React.Component {
         };
     }
 
+    static baseProps = {
+        role: 'button',
+        tabIndex: 0,
+    };
+
     constructor(props) {
         super(props);
 

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -8,6 +8,7 @@ import * as GlobalActions from 'actions/global_actions.jsx';
 import QuickInput from 'components/quick_input.jsx';
 import SuggestionStore from 'stores/suggestion_store.jsx';
 import Constants from 'utils/constants.jsx';
+import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 const KeyCodes = Constants.KeyCodes;
@@ -182,7 +183,15 @@ export default class SuggestionBox extends React.Component {
             return;
         }
 
-        GlobalActions.emitClearSuggestions(this.suggestionId);
+        if (UserAgent.isIos() && !e.relatedTarget) {
+            // iOS doesn't support e.relatedTarget, so we need to use the old method of just delaying the
+            // blur so that click handlers on the list items still register
+            setTimeout(() => {
+                GlobalActions.emitClearSuggestions(this.suggestionId);
+            }, 200);
+        } else {
+            GlobalActions.emitClearSuggestions(this.suggestionId);
+        }
 
         if (this.props.onBlur) {
             this.props.onBlur();

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -114,9 +114,6 @@ export default class SuggestionBox extends React.Component {
     constructor(props) {
         super(props);
 
-        this.handleBlur = this.handleBlur.bind(this);
-        this.handleFocus = this.handleFocus.bind(this);
-
         this.handlePopoverMentionKeyClick = this.handlePopoverMentionKeyClick.bind(this);
         this.handleCompleteWord = this.handleCompleteWord.bind(this);
         this.handleChange = this.handleChange.bind(this);
@@ -178,18 +175,27 @@ export default class SuggestionBox extends React.Component {
         }
     }
 
-    handleBlur() {
-        setTimeout(() => {
-            // Delay this slightly so that we don't clear the suggestions before we run click handlers on SuggestionList
-            GlobalActions.emitClearSuggestions(this.suggestionId);
-        }, 200);
+    handleFocusOut = (e) => {
+        // Focus is switching TO e.relatedTarget, so only treat this as a blur event if we're not switching
+        // between children (like from the textbox to the suggestion list)
+        if (this.container.contains(e.relatedTarget)) {
+            return;
+        }
+
+        GlobalActions.emitClearSuggestions(this.suggestionId);
 
         if (this.props.onBlur) {
             this.props.onBlur();
         }
-    }
+    };
 
-    handleFocus() {
+    handleFocusIn = (e) => {
+        // Focus is switching FROM e.relatedTarget, so only treat this as a focus event if we're not switching
+        // between children (like from the textbox to the suggestion list)
+        if (this.container.contains(e.relatedTarget)) {
+            return;
+        }
+
         if (this.props.openOnFocus || this.props.openWhenEmpty) {
             setTimeout(() => {
                 const textbox = this.getTextbox();
@@ -205,7 +211,7 @@ export default class SuggestionBox extends React.Component {
         if (this.props.onFocus) {
             this.props.onFocus();
         }
-    }
+    };
 
     handleChange(e) {
         const textbox = this.getTextbox();
@@ -374,6 +380,22 @@ export default class SuggestionBox extends React.Component {
         this.refs.input.blur();
     }
 
+    setContainerRef = (container) => {
+        // Attach/detach event listeners that aren't supported by React
+        if (this.container) {
+            this.container.removeEventListener('focusin', this.handleFocusIn);
+            this.container.removeEventListener('focusout', this.handleFocusOut);
+        }
+
+        if (container) {
+            container.addEventListener('focusin', this.handleFocusIn);
+            container.addEventListener('focusout', this.handleFocusOut);
+        }
+
+        // Save ref
+        this.container = container;
+    };
+
     render() {
         const {
             listComponent,
@@ -392,18 +414,18 @@ export default class SuggestionBox extends React.Component {
         Reflect.deleteProperty(props, 'requiredCharacters');
         Reflect.deleteProperty(props, 'openOnFocus');
         Reflect.deleteProperty(props, 'openWhenEmpty');
+        Reflect.deleteProperty(props, 'onFocus');
+        Reflect.deleteProperty(props, 'onBlur');
 
         // This needs to be upper case so React doesn't think it's an html tag
         const SuggestionListComponent = listComponent;
 
         return (
-            <div>
+            <div ref={this.setContainerRef}>
                 <QuickInput
                     ref='input'
                     autoComplete='off'
                     {...props}
-                    onBlur={this.handleBlur}
-                    onFocus={this.handleFocus}
                     onInput={this.handleChange}
                     onCompositionStart={this.handleCompositionStart}
                     onCompositionUpdate={this.handleCompositionUpdate}

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -97,6 +97,7 @@ class SwitchChannelSuggestion extends Suggestion {
             <div
                 onClick={this.handleClick}
                 className={className}
+                {...Suggestion.baseProps}
             >
                 {icon}
                 {displayName}

--- a/components/suggestion/switch_team_provider.jsx
+++ b/components/suggestion/switch_team_provider.jsx
@@ -28,6 +28,7 @@ class SwitchTeamSuggestion extends Suggestion {
             <div
                 onClick={this.handleClick}
                 className={className}
+                {...Suggestion.baseProps}
             >
                 <div className='status'>
                     <i

--- a/components/suggestion/timezone_provider.jsx
+++ b/components/suggestion/timezone_provider.jsx
@@ -26,6 +26,7 @@ class TimezoneSuggestion extends Suggestion {
             <div
                 onClick={this.handleClick}
                 className={className}
+                {...Suggestion.baseProps}
             >
                 {timezone}
             </div>


### PR DESCRIPTION
The reason to use focusin and focusout events is that unlike React's focus and blur events, focusin events are called with the element that you switched from and focusout events are called with the element that you switched to. This lets us actually detect when you switch from, for example, the search box to the suggestion list by clicking on it without the whole SuggestionBox component losing focus.

The reason that we need this is because we clear and close the suggestion list when the SuggestionBox loses focus, but that doesn't work when the suggestion list itself gains focus since it would disappear when you click onto it. Previously, it just needed to stay visible for long enough for the click handler on the list item to fire and actually autocomplete a suggestion, and a `setTimeout` on the clearing was enough to accomplish that, but that doesn't work when the suggestion list needs to remain open like the date picker in https://github.com/mattermost/mattermost-webapp/pull/1574 does.

A couple implementation details:
- For the `e.relatedTarget` to contain the element you're switching from/to, it needs to be able to grab focus, so we need to set `tabIndex=0` and `aria='button'` on the suggestion list items which we were previously missing.
- React wraps the native event handler to assure it works the same on all platforms, but it doesn't offer focusin and focusout events, so we have to bypass it for those events using the ref to add the event handler manually.

I've tested this on Chrome/Firefox/IE11/Edge on Windows 10 and Chrome/Firefox/Safari on OS X where it works fine. I also tested on iOS Safari and the Classic App where it does not work, but I've chatted with @esethna, and he said that was acceptable. I also made sure to test all of the places where autocompletes show up in the app (post textbox, edit box, searchbox, channel switcher, timezone settings, jira plugin settings)

#### Checklist
- Touches critical sections of the codebase (auth, posting, etc.)
