### PR TITLE
MM-11782: Make archived channels experimental and off by default.

### DIFF
--- a/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
+++ b/components/admin_console/users_and_teams_settings/users_and_teams_settings.jsx
@@ -101,7 +101,7 @@ export class UsersAndTeamsSettings extends AdminSettings {
                 this.state.edited.maxChannelsPerTeam ||
                 this.state.edited.maxNotificationsPerChannel ||
                 this.state.edited.enableConfirmNotificationsToChannel ||
-                this.state.edited.viewArchivedChannels
+                this.state.edited.experimentalViewArchivedChannels
             );
 
             if (configFieldEdited) {
@@ -169,7 +169,7 @@ export class UsersAndTeamsSettings extends AdminSettings {
                                     this.state.edited.maxChannelsPerTeam,
                                     this.state.edited.maxNotificationsPerChannel,
                                     this.state.edited.enableConfirmNotificationsToChannel,
-                                    this.state.edited.viewArchivedChannels,
+                                    this.state.edited.experimentalViewArchivedChannels,
                                 ].filter((v) => v).join(', '),
                             }}
                         />
@@ -211,7 +211,7 @@ export class UsersAndTeamsSettings extends AdminSettings {
         config.TeamSettings.MaxChannelsPerTeam = this.parseIntNonZero(this.state.maxChannelsPerTeam, Constants.DEFAULT_MAX_CHANNELS_PER_TEAM);
         config.TeamSettings.MaxNotificationsPerChannel = this.parseIntNonZero(this.state.maxNotificationsPerChannel, Constants.DEFAULT_MAX_NOTIFICATIONS_PER_CHANNEL);
         config.TeamSettings.EnableConfirmNotificationsToChannel = this.state.enableConfirmNotificationsToChannel;
-        config.TeamSettings.ViewArchivedChannels = this.state.viewArchivedChannels;
+        config.TeamSettings.ExperimentalViewArchivedChannels = this.state.experimentalViewArchivedChannels;
         return config;
     };
 
@@ -225,7 +225,7 @@ export class UsersAndTeamsSettings extends AdminSettings {
             maxChannelsPerTeam: config.TeamSettings.MaxChannelsPerTeam,
             maxNotificationsPerChannel: config.TeamSettings.MaxNotificationsPerChannel,
             enableConfirmNotificationsToChannel: config.TeamSettings.EnableConfirmNotificationsToChannel,
-            viewArchivedChannels: config.TeamSettings.ViewArchivedChannels,
+            experimentalViewArchivedChannels: config.TeamSettings.ExperimentalViewArchivedChannels,
         };
     }
 
@@ -421,7 +421,7 @@ export class UsersAndTeamsSettings extends AdminSettings {
                     setByEnv={this.isSetByEnv('TeamSetting.TeammateNameDisplay')}
                 />
                 <BooleanSetting
-                    id='viewArchivedChannels'
+                    id='experimentalViewArchivedChannels'
                     label={
                         <FormattedMessage
                             id='admin.viewArchivedChannelsTitle'
@@ -431,12 +431,12 @@ export class UsersAndTeamsSettings extends AdminSettings {
                     helpText={
                         <FormattedMessage
                             id='admin.viewArchivedChannelsHelpText'
-                            defaultMessage='When true, allows users to share permalinks and search for content of channels that have been archived. Users can only view the content in channels of which they were a member before the channel was archived.'
+                            defaultMessage='(Experimental) When true, allows users to share permalinks and search for content of channels that have been archived. Users can only view the content in channels of which they were a member before the channel was archived.'
                         />
                     }
-                    value={this.state.viewArchivedChannels}
+                    value={this.state.experimentalViewArchivedChannels}
                     onChange={this.handleChange}
-                    setByEnv={this.isSetByEnv('TeamSetting.ViewArchivedChannels')}
+                    setByEnv={this.isSetByEnv('TeamSetting.ExperimentalViewArchivedChannels')}
                 />
             </SettingsGroup>
         );

--- a/components/delete_channel_modal/index.js
+++ b/components/delete_channel_modal/index.js
@@ -13,7 +13,7 @@ function mapStateToProps(state) {
     const config = getConfig(state);
 
     return {
-        canViewArchivedChannels: config.ViewArchivedChannels === 'true',
+        canViewArchivedChannels: config.ExperimentalViewArchivedChannels === 'true',
         currentTeamDetails: getCurrentTeam(state),
     };
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1369,7 +1369,7 @@
   "admin.user_item.userAccessTokenPostAll": "(with post:all personal access tokens)",
   "admin.user_item.userAccessTokenPostAllPublic": "(with post:channels personal access tokens)",
   "admin.user_item.userAccessTokenYes": "(with personal access tokens)",
-  "admin.viewArchivedChannelsHelpText": "When true, allows users to share permalinks and search for content of channels that have been archived. Users can only view the content in channels of which they were a member before the channel was archived.",
+  "admin.viewArchivedChannelsHelpText": "(Experimental) When true, allows users to share permalinks and search for content of channels that have been archived. Users can only view the content in channels of which they were a member before the channel was archived.",
   "admin.viewArchivedChannelsTitle": "Allow users to view archived channels:",
   "admin.webrtc.enableDescription": "When true, Mattermost allows making **one-on-one** video calls. WebRTC calls are available on Chrome, Firefox and Mattermost Desktop Apps.",
   "admin.webrtc.enableTitle": "Enable Mattermost WebRTC: ",


### PR DESCRIPTION
#### Summary
Change View Archive Channels to a new config setting that's off by default.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11782

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes

Webapp Changes: https://github.com/mattermost/mattermost-server/pull/9281