### PR TITLE
MM-11786: Loads shortened link previews.

### DIFF
--- a/components/post_view/post_body_additional_content/index.js
+++ b/components/post_view/post_body_additional_content/index.js
@@ -2,7 +2,10 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import {getRedirectLocation} from 'mattermost-redux/actions/general';
 
 import PostBodyAdditionalContent from './post_body_additional_content.jsx';
 
@@ -17,4 +20,12 @@ function mapStateToProps(state) {
     };
 }
 
-export default connect(mapStateToProps)(PostBodyAdditionalContent);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getRedirectLocation,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PostBodyAdditionalContent);

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -90,13 +90,24 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         // check the availability of the image rendered(if any) in the first render.
         this.loadShortenedImageLink();
         this.preCheckImageLink();
+        this.mounted = true;
+    }
+
+    componentWillUnmount() {
+        this.mounted = false;
     }
 
     async loadShortenedImageLink() {
-        if (!this.isLinkImage(this.state.link)) {
+        if (!this.isLinkImage(this.state.link) && !YoutubeVideo.isYoutubeLink(this.state.link)) {
             const {data} = await this.props.actions.getRedirectLocation(this.state.link);
-            if (data && data.location) {
-                this.setState({link: data.location});
+            const {link} = this.state;
+            if (data && data.location && this.mounted) {
+                this.setState((state) => {
+                    if (state.link !== link) {
+                        return {};
+                    }
+                    return {link: data.location};
+                });
                 this.preCheckImageLink();
             }
         }

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -58,6 +58,10 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
          * Options specific to text formatting
          */
         options: PropTypes.object,
+
+        actions: PropTypes.shape({
+            getRedirectLocation: PropTypes.func.isRequired,
+        }).isRequired,
     }
 
     static defaultProps = {
@@ -84,7 +88,18 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
 
     componentDidMount() {
         // check the availability of the image rendered(if any) in the first render.
+        this.loadShortenedImageLink();
         this.preCheckImageLink();
+    }
+
+    async loadShortenedImageLink() {
+        if (!this.isLinkImage(this.state.link)) {
+            const {data} = await this.props.actions.getRedirectLocation(this.state.link);
+            if (data && data.location) {
+                this.setState({link: data.location});
+                this.preCheckImageLink();
+            }
+        }
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
@@ -93,6 +108,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
                 link: Utils.extractFirstLink(nextProps.post.message),
             }, () => {
                 // check the availability of the image link
+                this.loadShortenedImageLink();
                 this.preCheckImageLink();
             });
         }

--- a/tests/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
+++ b/tests/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
@@ -21,6 +21,9 @@ describe('components/post_view/PostBodyAdditionalContent', () => {
         isEmbedVisible: true,
         enableLinkPreviews: true,
         hasImageProxy: true,
+        actions: {
+            getRedirectLocation: () => null,
+        },
     };
 
     test('isLinkImage, should return true for valid image URLs', () => {


### PR DESCRIPTION
#### Summary
Adds ability to preview shortened (ex bitly) links for previewable content including images and youtube links.

#### Ticket Link
[MM-11786](https://mattermost.atlassian.net/browse/MM-11786)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has server changes (https://github.com/mattermost/mattermost-server/pull/9284/files)
- [x] Has redux changes (https://github.com/mattermost/mattermost-redux/pull/611)

<img width="705" alt="screen shot 2018-08-22 at 5 37 22 pm" src="https://user-images.githubusercontent.com/1149597/44492322-1377e400-a632-11e8-9fd1-7f61412608bc.png">