### PR TITLE
Add check for mobile implementation in the PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@ When filling in a section please remove the help text and the above text.
 - [ ] Ran `make check-style` to check for style errors (required for all pull requests)
 - [ ] Ran `make test` to ensure unit and component tests passed
 - [ ] Added or updated unit tests (required for all new features)
+- [ ] Needs to be implemented in mobile (link to PR or User Story)
 - [ ] Has server changes (please link)
 - [ ] Has redux changes (please link)
 - [ ] Has UI changes


### PR DESCRIPTION
#### Summary
As we decide in the Developers meeting, we add to the PR template the
check for "Need to be implemented in mobile" to be sure we don't forget
to do or enqueue it.