### PR TITLE
Recalculate textContainer height for each image height received

### DIFF
--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -38,18 +38,25 @@ export default class PostAttachment extends React.PureComponent {
         super(props);
 
         this.state = {
-            checkOverflow: false,
+            checkOverflow: 0,
         };
 
         this.imageProps = {
-            onHeightReceived: this.handleImageHeightReceived,
+            onHeightReceived: this.handleHeightReceived,
         };
     }
 
-    handleImageHeightReceived = () => {
-        postListScrollChange();
+    handleHeightReceived = (height) => {
+        if (height > 0) {
+            // Increment checkOverflow to indicate change in height
+            // and recompute textContainer height at ShowMore component
+            // and see whether overflow text of show more/less is necessary or not.
+            this.setState((prevState) => {
+                return {checkOverflow: prevState.checkOverflow + 1};
+            });
 
-        this.setState({checkOverflow: true});
+            postListScrollChange();
+        }
     };
 
     getActionView = () => {

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -83,17 +83,25 @@ export default class PostMessageView extends React.PureComponent {
         this.state = {
             collapse: true,
             hasOverflow: false,
+            checkOverflow: 0,
         };
 
         this.imageProps = {
-            onHeightReceived: this.handleImageHeightReceived,
+            onHeightReceived: this.handleHeightReceived,
         };
     }
 
-    handleImageHeightReceived = () => {
-        GlobalActions.postListScrollChange();
+    handleHeightReceived = (height) => {
+        if (height > 0) {
+            // Increment checkOverflow to indicate change in height
+            // and recompute textContainer height at ShowMore component
+            // and see whether overflow text of show more/less is necessary or not.
+            this.setState((prevState) => {
+                return {checkOverflow: prevState.checkOverflow + 1};
+            });
 
-        this.setState({checkOverflow: true});
+            GlobalActions.postListScrollChange();
+        }
     };
 
     renderDeletedPost() {

--- a/components/post_view/show_more/show_more.jsx
+++ b/components/post_view/show_more/show_more.jsx
@@ -9,7 +9,7 @@ import {localizeMessage} from 'utils/utils.jsx';
 export default class ShowMore extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node,
-        checkOverflow: PropTypes.bool,
+        checkOverflow: PropTypes.number,
         isAttachmentText: PropTypes.bool,
         isRHSExpanded: PropTypes.bool.isRequired,
         isRHSOpen: PropTypes.bool.isRequired,
@@ -33,7 +33,7 @@ export default class ShowMore extends React.PureComponent {
             this.props.text !== prevProps.text ||
             this.props.isRHSExpanded !== prevProps.isRHSExpanded ||
             this.props.isRHSOpen !== prevProps.isRHSOpen ||
-            this.props.checkOverflow
+            this.props.checkOverflow !== prevProps.checkOverflow
         ) {
             this.checkTextOverflow();
         }

--- a/tests/components/post_view/__snapshots__/post_attachment.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/post_attachment.test.jsx.snap
@@ -58,7 +58,7 @@ exports[`components/post_view/PostAttachment should call PostActions.doPostActio
           className="attachment__body"
         >
           <Connect(ShowMore)
-            checkOverflow={false}
+            checkOverflow={0}
             isAttachmentText={true}
             maxHeight={200}
             text="short text"
@@ -166,7 +166,7 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
           className="attachment__body"
         >
           <Connect(ShowMore)
-            checkOverflow={false}
+            checkOverflow={0}
             isAttachmentText={true}
             maxHeight={200}
             text="short text"

--- a/tests/components/post_view/__snapshots__/post_message_view.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/post_message_view.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`components/post_view/PostAttachment should match snapshot 1`] = `
 <Connect(ShowMore)
+  checkOverflow={0}
   maxHeight={600}
   text="post message"
 >
@@ -34,6 +35,7 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
 
 exports[`components/post_view/PostAttachment should match snapshot, on Show Less 1`] = `
 <Connect(ShowMore)
+  checkOverflow={0}
   maxHeight={600}
   text="post message"
 >
@@ -66,6 +68,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show Less
 
 exports[`components/post_view/PostAttachment should match snapshot, on Show More 1`] = `
 <Connect(ShowMore)
+  checkOverflow={0}
   maxHeight={600}
   text="post message"
 >
@@ -118,6 +121,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on deleted p
 
 exports[`components/post_view/PostAttachment should match snapshot, on edited post 1`] = `
 <Connect(ShowMore)
+  checkOverflow={0}
   maxHeight={600}
   text="post message"
 >
@@ -172,6 +176,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on edited po
 
 exports[`components/post_view/PostAttachment should match snapshot, on ephemeral post 1`] = `
 <Connect(ShowMore)
+  checkOverflow={0}
   maxHeight={600}
   text="post message"
 >

--- a/tests/components/post_view/post_attachment.test.jsx
+++ b/tests/components/post_view/post_attachment.test.jsx
@@ -46,10 +46,14 @@ describe('components/post_view/PostAttachment', () => {
         const instance = wrapper.instance();
         instance.checkAttachmentTextOverflow = jest.fn();
 
-        wrapper.setState({checkOverflow: false});
-        instance.handleImageHeightReceived();
+        wrapper.setState({checkOverflow: 0});
+        instance.handleHeightReceived(1);
         expect(postListScrollChange).toHaveBeenCalledTimes(1);
-        expect(wrapper.state('checkOverflow')).toEqual(true);
+        expect(wrapper.state('checkOverflow')).toEqual(1);
+
+        instance.handleHeightReceived(0);
+        expect(postListScrollChange).toHaveBeenCalledTimes(1);
+        expect(wrapper.state('checkOverflow')).toEqual(1);
     });
 
     test('should match value on getActionView', () => {

--- a/tests/components/post_view/post_message_view.test.jsx
+++ b/tests/components/post_view/post_message_view.test.jsx
@@ -82,9 +82,13 @@ describe('components/post_view/PostAttachment', () => {
         const instance = wrapper.instance();
         instance.checkOverflow = jest.fn();
 
-        wrapper.setState({checkOverflow: false});
-        instance.handleImageHeightReceived();
+        wrapper.setState({checkOverflow: 0});
+        instance.handleHeightReceived(1);
         expect(postListScrollChange).toHaveBeenCalledTimes(1);
-        expect(wrapper.state('checkOverflow')).toEqual(true);
+        expect(wrapper.state('checkOverflow')).toEqual(1);
+
+        instance.handleHeightReceived(0);
+        expect(postListScrollChange).toHaveBeenCalledTimes(1);
+        expect(wrapper.state('checkOverflow')).toEqual(1);
     });
 });

--- a/tests/components/post_view/show_more.test.jsx
+++ b/tests/components/post_view/show_more.test.jsx
@@ -9,7 +9,7 @@ import ShowMore from 'components/post_view/show_more/show_more.jsx';
 describe('components/post_view/ShowMore', () => {
     const children = (<div><p>{'text'}</p></div>);
     const baseProps = {
-        checkOverflow: false,
+        checkOverflow: 0,
         isAttachmentText: false,
         isRHSExpanded: false,
         isRHSOpen: false,
@@ -81,10 +81,10 @@ describe('components/post_view/ShowMore', () => {
         wrapper.setProps({text: 'text another change'});
         expect(instance.checkTextOverflow).toBeCalledTimes(6);
 
-        wrapper.setProps({checkOverflow: true});
+        wrapper.setProps({checkOverflow: 1});
         expect(instance.checkTextOverflow).toBeCalledTimes(7);
 
-        wrapper.setProps({checkOverflow: false});
+        wrapper.setProps({checkOverflow: 1});
         expect(instance.checkTextOverflow).toBeCalledTimes(7);
     });
 });

--- a/tests/plugins/__snapshots__/post_type.test.jsx.snap
+++ b/tests/plugins/__snapshots__/post_type.test.jsx.snap
@@ -64,6 +64,7 @@ exports[`plugins/PostMessageView should match snapshot with extended post type 1
 
 exports[`plugins/PostMessageView should match snapshot with no extended post type 1`] = `
 <Connect(ShowMore)
+  checkOverflow={0}
   maxHeight={600}
   text="this is some text"
 >


### PR DESCRIPTION
#### Summary
This is a follow up change to https://github.com/mattermost/mattermost-webapp/pull/1520 where I missed to consider cases like multiple images.  Thanks @hmhealey for checking! 😄 

#### Ticket Link
Jira ticket: [MM-11422](https://mattermost.atlassian.net/browse/MM-11422)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

