### PR TITLE
Update plugin based on hackathon observation - working on translate plugin

### DIFF
--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -266,19 +266,23 @@ export default class DotMenu extends Component {
             );
         }
 
-        const pluginItems = this.props.pluginMenuItems.map((item) => {
-            return (
-                <DotMenuItem
-                    key={item.id + '_pluginmenuitem'}
-                    menuItemText={item.text}
-                    handleMenuItemActivated={() => {
-                        if (item.action) {
-                            item.action(this.props.post.id);
-                        }
-                    }}
-                />
-            );
-        });
+        const pluginItems = this.props.pluginMenuItems.
+            filter((item) => {
+                return item.filter ? item.filter(this.props.post.id) : item;
+            }).
+            map((item) => {
+                return (
+                    <DotMenuItem
+                        key={item.id + '_pluginmenuitem'}
+                        menuItemText={item.text}
+                        handleMenuItemActivated={() => {
+                            if (item.action) {
+                                item.action(this.props.post.id);
+                            }
+                        }}
+                    />
+                );
+            });
 
         if (menuItems.length === 0 && pluginItems.length === 0) {
             return null;

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -13,7 +13,6 @@ import * as Utils from 'utils/utils';
 
 import PostMarkdown from 'components/post_markdown';
 import Pluggable from 'plugins/pluggable';
-
 import ShowMore from 'components/post_view/show_more';
 
 const MAX_POST_HEIGHT = 600;
@@ -197,7 +196,7 @@ export default class PostMessageView extends React.PureComponent {
                 </div>
                 {this.renderEditedIndicator()}
                 <Pluggable
-                    pluggableName='PostMessage'
+                    pluggableName='PostMessageAttachment'
                     postId={post.id}
                     onHeightChange={this.handleHeightReceived}
                 />

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -12,8 +12,9 @@ import * as PostUtils from 'utils/post_utils';
 import * as Utils from 'utils/utils';
 
 import PostMarkdown from 'components/post_markdown';
+import Pluggable from 'plugins/pluggable';
 
-import ShowMore from '../show_more';
+import ShowMore from 'components/post_view/show_more';
 
 const MAX_POST_HEIGHT = 600;
 
@@ -195,6 +196,11 @@ export default class PostMessageView extends React.PureComponent {
                     />
                 </div>
                 {this.renderEditedIndicator()}
+                <Pluggable
+                    pluggableName='PostMessage'
+                    postId={post.id}
+                    onHeightChange={this.handleHeightReceived}
+                />
             </ShowMore>
         );
     }

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -76,7 +76,7 @@ export default class PluginRegistry {
 
     // Register a component fixed to the bottom of the post message.
     // Accepts a React component. Returns a unique identifier.
-    registerPostMessageComponentAttachment(component) {
+    registerPostMessageAttachmentComponent(component) {
         return dispatchPluginComponentAction('PostMessageAttachment', this.id, component);
     }
 

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -76,7 +76,7 @@ export default class PluginRegistry {
 
     // Register a component fixed to the bottom of the post message.
     // Accepts a React component. Returns a unique identifier.
-    registerPostMessageComponent(component) {
+    registerPostMessageComponentAttachment(component) {
         return dispatchPluginComponentAction('PostMessageAttachment', this.id, component);
     }
 

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -77,7 +77,7 @@ export default class PluginRegistry {
     // Register a component fixed to the bottom of the post message.
     // Accepts a React component. Returns a unique identifier.
     registerPostMessageComponent(component) {
-        return dispatchPluginComponentAction('PostMessage', this.id, component);
+        return dispatchPluginComponentAction('PostMessageAttachment', this.id, component);
     }
 
     // Add a button to the channel header. If there are more than one buttons registered by any
@@ -160,6 +160,7 @@ export default class PluginRegistry {
     // Accepts the following:
     // - text - A string or React element to display in the menu
     // - action - A function to trigger when component is clicked on
+    // - filter - A function whether to apply the plugin into the post' dropdown menu
     // Returns a unique identifier.
     registerPostDropdownMenuAction(text, action, filter) {
         const id = generateId();

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -74,6 +74,12 @@ export default class PluginRegistry {
         return dispatchPluginComponentAction('BottomTeamSidebar', this.id, component);
     }
 
+    // Register a component fixed to the bottom of the post message.
+    // Accepts a React component. Returns a unique identifier.
+    registerPostMessageComponent(component) {
+        return dispatchPluginComponentAction('PostMessage', this.id, component);
+    }
+
     // Add a button to the channel header. If there are more than one buttons registered by any
     // plugin, a dropdown menu is created to contain all the plugin buttons.
     // Accepts the following:
@@ -155,7 +161,7 @@ export default class PluginRegistry {
     // - text - A string or React element to display in the menu
     // - action - A function to trigger when component is clicked on
     // Returns a unique identifier.
-    registerPostDropdownMenuAction(text, action) {
+    registerPostDropdownMenuAction(text, action, filter) {
         const id = generateId();
 
         store.dispatch({
@@ -166,6 +172,7 @@ export default class PluginRegistry {
                 pluginId: this.id,
                 text: resolveReactElement(text),
                 action,
+                filter,
             },
         });
 

--- a/tests/components/post_view/__snapshots__/post_message_view.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/post_message_view.test.jsx.snap
@@ -31,6 +31,7 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
     />
   </div>
   <Connect(Pluggable)
+    onHeightChange={[Function]}
     pluggableName="PostMessage"
     postId="post_id"
   />
@@ -68,6 +69,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show Less
     />
   </div>
   <Connect(Pluggable)
+    onHeightChange={[Function]}
     pluggableName="PostMessage"
     postId="post_id"
   />
@@ -105,6 +107,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show More
     />
   </div>
   <Connect(Pluggable)
+    onHeightChange={[Function]}
     pluggableName="PostMessage"
     postId="post_id"
   />
@@ -172,6 +175,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on edited po
     />
   </span>
   <Connect(Pluggable)
+    onHeightChange={[Function]}
     pluggableName="PostMessage"
     postId="post_id"
   />
@@ -221,6 +225,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on ephemeral
     />
   </div>
   <Connect(Pluggable)
+    onHeightChange={[Function]}
     pluggableName="PostMessage"
     postId="post_id"
   />

--- a/tests/components/post_view/__snapshots__/post_message_view.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/post_message_view.test.jsx.snap
@@ -30,6 +30,10 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
       }
     />
   </div>
+  <Connect(Pluggable)
+    pluggableName="PostMessage"
+    postId="post_id"
+  />
 </Connect(ShowMore)>
 `;
 
@@ -63,6 +67,10 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show Less
       }
     />
   </div>
+  <Connect(Pluggable)
+    pluggableName="PostMessage"
+    postId="post_id"
+  />
 </Connect(ShowMore)>
 `;
 
@@ -96,6 +104,10 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show More
       }
     />
   </div>
+  <Connect(Pluggable)
+    pluggableName="PostMessage"
+    postId="post_id"
+  />
 </Connect(ShowMore)>
 `;
 
@@ -159,6 +171,10 @@ exports[`components/post_view/PostAttachment should match snapshot, on edited po
       values={Object {}}
     />
   </span>
+  <Connect(Pluggable)
+    pluggableName="PostMessage"
+    postId="post_id"
+  />
 </Connect(ShowMore)>
 `;
 
@@ -204,5 +220,9 @@ exports[`components/post_view/PostAttachment should match snapshot, on ephemeral
       }
     />
   </div>
+  <Connect(Pluggable)
+    pluggableName="PostMessage"
+    postId="post_id"
+  />
 </Connect(ShowMore)>
 `;

--- a/tests/components/post_view/__snapshots__/post_message_view.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/post_message_view.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
   </div>
   <Connect(Pluggable)
     onHeightChange={[Function]}
-    pluggableName="PostMessage"
+    pluggableName="PostMessageAttachment"
     postId="post_id"
   />
 </Connect(ShowMore)>
@@ -70,7 +70,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show Less
   </div>
   <Connect(Pluggable)
     onHeightChange={[Function]}
-    pluggableName="PostMessage"
+    pluggableName="PostMessageAttachment"
     postId="post_id"
   />
 </Connect(ShowMore)>
@@ -108,7 +108,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show More
   </div>
   <Connect(Pluggable)
     onHeightChange={[Function]}
-    pluggableName="PostMessage"
+    pluggableName="PostMessageAttachment"
     postId="post_id"
   />
 </Connect(ShowMore)>
@@ -176,7 +176,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on edited po
   </span>
   <Connect(Pluggable)
     onHeightChange={[Function]}
-    pluggableName="PostMessage"
+    pluggableName="PostMessageAttachment"
     postId="post_id"
   />
 </Connect(ShowMore)>
@@ -226,7 +226,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on ephemeral
   </div>
   <Connect(Pluggable)
     onHeightChange={[Function]}
-    pluggableName="PostMessage"
+    pluggableName="PostMessageAttachment"
     postId="post_id"
   />
 </Connect(ShowMore)>

--- a/tests/components/post_view/post_message_view.test.jsx
+++ b/tests/components/post_view/post_message_view.test.jsx
@@ -77,7 +77,7 @@ describe('components/post_view/PostAttachment', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should match state and call GlobalActions.postListScrollChange on handleImageHeightReceived', () => {
+    test('should match state and call GlobalActions.postListScrollChange on handleHeightChange', () => {
         const wrapper = shallow(<PostMessageView {...baseProps}/>);
         const instance = wrapper.instance();
         instance.checkOverflow = jest.fn();

--- a/tests/plugins/__snapshots__/post_type.test.jsx.snap
+++ b/tests/plugins/__snapshots__/post_type.test.jsx.snap
@@ -91,6 +91,7 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
     />
   </div>
   <Connect(Pluggable)
+    onHeightChange={[Function]}
     pluggableName="PostMessage"
   />
 </Connect(ShowMore)>

--- a/tests/plugins/__snapshots__/post_type.test.jsx.snap
+++ b/tests/plugins/__snapshots__/post_type.test.jsx.snap
@@ -92,7 +92,7 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
   </div>
   <Connect(Pluggable)
     onHeightChange={[Function]}
-    pluggableName="PostMessage"
+    pluggableName="PostMessageAttachment"
   />
 </Connect(ShowMore)>
 `;

--- a/tests/plugins/__snapshots__/post_type.test.jsx.snap
+++ b/tests/plugins/__snapshots__/post_type.test.jsx.snap
@@ -90,5 +90,8 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
       }
     />
   </div>
+  <Connect(Pluggable)
+    pluggableName="PostMessage"
+  />
 </Connect(ShowMore)>
 `;


### PR DESCRIPTION
#### Summary
Update plugin based on hackathon observation - working on [mattermost-plugin-autotranslate](https://github.com/mattermost/mattermost-plugin-autotranslate).
- add PostMessage pluggable at PostMessageView to add an inline message to a post without worrying about formatting/styles of existing post
-  add filter to PostDropdownMenuAction to easily filter out which post to take effect with that action.

~~Note that I've submitted this on top of https://github.com/mattermost/mattermost-webapp/pull/1606 since it's partly related.  Will rebase after it's merged.~~ Said PR is merged and this change has been rebased to master.

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Plugin architecture