### PR TITLE
MM-11444 Add default theming to icons in the team sidebar

### DIFF
--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -6,6 +6,10 @@
     width: 65px;
     z-index: 12;
 
+    .fa {
+        color: $white;
+    }
+
     .team-sidebar-bottom-plugin {
         position: absolute;
         bottom: 0;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -589,6 +589,7 @@ export function applyTheme(theme) {
         changeCss('.app__body .navbar-right__icon:hover, .app__body .navbar-right__icon:focus', 'background:' + changeOpacity(theme.sidebarHeaderTextColor, 0.3));
         changeCss('.app__body .navbar-right__icon svg', 'fill:' + theme.sidebarHeaderTextColor);
         changeCss('.app__body .navbar-right__icon svg', 'stroke:' + theme.sidebarHeaderTextColor);
+        changeCss('.team-sidebar .fa', 'color:' + theme.sidebarHeaderTextColor);
     }
 
     if (theme.onlineIndicator) {


### PR DESCRIPTION
#### Summary
So when a plugin adds a font-awesome icon, default to the correct theme color.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11444

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes