### PR TITLE
Fixing freeze warning.

### DIFF
--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -285,7 +285,7 @@ const PluginItem = ({
         />
     );
 
-    const instances = pluginStatus.instances;
+    const instances = pluginStatus.instances.slice();
     instances.sort((a, b) => {
         if (a.cluster_id < b.cluster_id) {
             return -1;


### PR DESCRIPTION
Freeze crashes the page in dev mode if you open the plugin settings with HA enabled. 