### PR TITLE
[MM-11279] Migrate access_history_modal to be pure and use redux

### DIFF
--- a/components/access_history_modal/access_history_modal.jsx
+++ b/components/access_history_modal/access_history_modal.jsx
@@ -7,74 +7,67 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
-import UserStore from 'stores/user_store.jsx';
-import * as Utils from 'utils/utils.jsx';
+import {isMobile} from 'utils/utils.jsx';
 import AuditTable from 'components/audit_table.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
-export default class AccessHistoryModal extends React.Component {
+export default class AccessHistoryModal extends React.PureComponent {
     static propTypes = {
+
+        /**
+         * Function that's called when modal is closed
+         */
         onHide: PropTypes.func.isRequired,
         actions: PropTypes.shape({
+
+            /**
+             * Function to fetch the user's audits
+             */
             getUserAudits: PropTypes.func.isRequired,
         }).isRequired,
+
+        /**
+         * The current user's audits
+         */
+        userAudits: PropTypes.array.isRequired,
+
+        /**
+         * The current user id
+         */
+        currentUserId: PropTypes.string.isRequired,
     }
 
     constructor(props) {
         super(props);
 
-        this.onAuditChange = this.onAuditChange.bind(this);
-        this.onShow = this.onShow.bind(this);
-        this.onHide = this.onHide.bind(this);
-
-        const state = this.getStateFromStoresForAudits();
-        state.moreInfo = [];
-        state.show = true;
-
-        this.state = state;
-    }
-
-    getStateFromStoresForAudits() {
-        return {
-            audits: UserStore.getAudits(),
+        this.state = {
+            show: true,
         };
     }
 
-    onShow() {
-        this.props.actions.getUserAudits(UserStore.getCurrentId(), 0, 200);
-        if (!Utils.isMobile()) {
+    onShow = () => {
+        this.props.actions.getUserAudits(this.props.currentUserId, 0, 200);
+        if (!isMobile()) {
             $('.modal-body').perfectScrollbar();
         }
     }
 
-    onHide() {
+    onHide = () => {
         this.setState({show: false});
     }
 
     componentDidMount() {
-        UserStore.addAuditsChangeListener(this.onAuditChange);
         this.onShow();
-    }
-
-    componentWillUnmount() {
-        UserStore.removeAuditsChangeListener(this.onAuditChange);
-    }
-
-    onAuditChange() {
-        const newState = this.getStateFromStoresForAudits();
-        if (!Utils.areObjectsEqual(newState.audits, this.state.audits)) {
-            this.setState(newState);
-        }
     }
 
     render() {
         let content;
-        if (this.state.audits.length === 0) {
+        if (this.props.userAudits.length === 0) {
             content = (<LoadingScreen/>);
         } else {
             content = (
                 <AuditTable
-                    audits={this.state.audits}
+                    audits={this.props.userAudits}
                     showIp={true}
                     showSession={true}
                 />

--- a/components/access_history_modal/index.js
+++ b/components/access_history_modal/index.js
@@ -4,8 +4,17 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getUserAudits} from 'mattermost-redux/actions/users';
+import {getCurrentUserId, getUserAudits as getCurrentUserAudits} from 'mattermost-redux/selectors/entities/users';
 
 import AccessHistoryModal from './access_history_modal.jsx';
+
+function mapStateToProps(state, ownProps) {
+    return {
+        ...ownProps,
+        currentUserId: getCurrentUserId(state),
+        userAudits: getCurrentUserAudits(state),
+    };
+}
 
 function mapDispatchToProps(dispatch) {
     return {
@@ -15,4 +24,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(null, mapDispatchToProps)(AccessHistoryModal);
+export default connect(mapStateToProps, mapDispatchToProps)(AccessHistoryModal);

--- a/components/access_history_modal/index.js
+++ b/components/access_history_modal/index.js
@@ -8,11 +8,10 @@ import {getCurrentUserId, getUserAudits as getCurrentUserAudits} from 'mattermos
 
 import AccessHistoryModal from './access_history_modal.jsx';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
     return {
-        ...ownProps,
         currentUserId: getCurrentUserId(state),
-        userAudits: getCurrentUserAudits(state),
+        userAudits: getCurrentUserAudits(state) || [],
     };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10230,7 +10230,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#91049bd643b5fb78bd9fc8760adfdd0a4a013183",
+      "version": "github:mattermost/mattermost-redux#1c381497e539c074a4d5ef54ef4353462736316f",
+      "from": "github:mattermost/mattermost-redux#1c381497e539c074a4d5ef54ef4353462736316f",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "localforage": "1.7.2",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#91049bd643b5fb78bd9fc8760adfdd0a4a013183",
+    "mattermost-redux": "github:mattermost/mattermost-redux#1c381497e539c074a4d5ef54ef4353462736316f",
     "moment-timezone": "0.5.21",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/tests/components/access_history_modal.test.jsx
+++ b/tests/components/access_history_modal.test.jsx
@@ -16,6 +16,8 @@ describe('components/AccessHistoryModal', () => {
         actions: {
             getUserAudits: jest.fn(),
         },
+        userAudits: [],
+        currentUserId: '',
     };
 
     test('should match snapshot when no audits exist', () => {
@@ -32,7 +34,7 @@ describe('components/AccessHistoryModal', () => {
             <AccessHistoryModal {...baseProps}/>
         );
 
-        wrapper.setState({audits: ['audit1', 'audit2']});
+        wrapper.setProps({userAudits: ['audit1', 'audit2']});
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find(LoadingScreen).exists()).toBe(false);
         expect(wrapper.find(AuditTable).exists()).toBe(true);
@@ -59,16 +61,5 @@ describe('components/AccessHistoryModal', () => {
         wrapper.setState({show: true});
         wrapper.instance().onHide();
         expect(wrapper.state('show')).toEqual(false);
-    });
-
-    test('should match state when onAuditChange is called', () => {
-        const wrapper = shallow(
-            <AccessHistoryModal {...baseProps}/>
-        );
-
-        const newState = {show: true, audits: ['audit1', 'audit2'], moreInfo: 'moreInfo'};
-        wrapper.setState(newState);
-        wrapper.instance().onAuditChange();
-        expect(wrapper.state()).toEqual({...newState, audits: []});
     });
 });


### PR DESCRIPTION
#### Summary
Refactored `access_history_modal.jsx` to use Redux and be pure. Also cleaned up the code to make use of ES6 style syntax. Tests have been updated as well.

#### Ticket Link
mattermost/mattermost-server#9089
https://mattermost.atlassian.net/browse/MM-11279

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has redux changes https://github.com/mattermost/mattermost-redux/pull/614