### PR TITLE
Remove the glich on User Settings open

### DIFF
--- a/components/user_settings/modal/user_settings_modal.jsx
+++ b/components/user_settings/modal/user_settings_modal.jsx
@@ -13,9 +13,8 @@ import UserStore from 'stores/user_store.jsx';
 import Constants, {GroupUnreadChannels} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import ConfirmModal from '../../confirm_modal.jsx';
-import {AsyncComponent} from 'components/async_load';
-import loadUserSettings from 'bundle-loader?lazy!../user_settings.jsx';
-import loadSettingsSidebar from 'bundle-loader?lazy!../../settings_sidebar.jsx';
+import UserSettings from '../user_settings.jsx';
+import SettingsSidebar from '../../settings_sidebar.jsx';
 
 const holders = defineMessages({
     general: {
@@ -272,16 +271,14 @@ class UserSettingsModal extends React.Component {
                 <Modal.Body ref='modalBody'>
                     <div className='settings-table'>
                         <div className='settings-links'>
-                            <AsyncComponent
-                                doLoad={loadSettingsSidebar}
+                            <SettingsSidebar
                                 tabs={tabs}
                                 activeTab={this.state.active_tab}
                                 updateTab={this.updateTab}
                             />
                         </div>
                         <div className='settings-content minimize-settings'>
-                            <AsyncComponent
-                                doLoad={loadUserSettings}
+                            <UserSettings
                                 ref='userSettings'
                                 activeTab={this.state.active_tab}
                                 activeSection={this.state.active_section}


### PR DESCRIPTION
#### Summary
The glich was generated by the lazy loading of the components. In this
case, the lazy loading generate a weird behavior when you open the
component for first time. Probably in the future if we want to keep this
as lazy load, we can try to do it at a higher level. The entire modal,
for example.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed