### PR TITLE
Added HtmlToReact processing for text nodes to wrap them in a span.

### DIFF
--- a/tests/utils/__snapshots__/message_html_to_component.test.jsx.snap
+++ b/tests/utils/__snapshots__/message_html_to_component.test.jsx.snap
@@ -3,7 +3,9 @@
 exports[`messageHtmlToComponent latex 1`] = `
 Array [
   <p>
-    This is some latex!
+    <span>
+      This is some latex!
+    </span>
   </p>,
   "
 ",
@@ -16,7 +18,9 @@ Array [
 "
   />,
   <p>
-    That was some latex!
+    <span>
+      That was some latex!
+    </span>
   </p>,
   "
 ",
@@ -26,7 +30,9 @@ Array [
 exports[`messageHtmlToComponent plain text 1`] = `
 Array [
   <p>
-    Hello, world!
+    <span>
+      Hello, world!
+    </span>
   </p>,
   "
 ",

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -102,6 +102,15 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
     }
 
     processingInstructions.push({
+        shouldProcessNode: (node) => node.type === 'text',
+        processNode: (node) => {
+            return (
+                <span>
+                    {node.data}
+                </span>
+            );
+        },
+    }, {
         shouldProcessNode: () => true,
         processNode: processNodeDefinitions.processDefaultNode,
     });

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -102,7 +102,7 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
     }
 
     processingInstructions.push({
-        shouldProcessNode: (node) => node.type === 'text',
+        shouldProcessNode: (node) => node.type === 'text' && node.data.trim().length,
         processNode: (node) => {
             return (
                 <span>


### PR DESCRIPTION
For various reasons I find it to be very cumbersome that normal text appears in the DOM of messages as HTML text nodes, one of them is that this doesn't allow custom styling (treats the HTML node after an initial text node as `:first-child` for example) or further custom processing. Additionally I personally have always seen it as bad practice having text nodes next to HTML tag nodes.

#### Summary
This pull request adds a processing instruction to the HTML to React utility to wrap text - that would otherwise appear in the DOM as a HTML text node - with a span HTML tag.

A message like `Hello! :smile:` would render with the following difference:
```diff
<p>
---	Hello! 
+++	<span>Hello!</span>
	<span data-emoticon="smile">
		<span alt=":smile:" class="emoticon" title=":smile:" style="background-image: url(&quot;/static/emoji/1f604.png&quot;);"></span>
	</span>
</p>
```

Though, if there's any objections about any kind of semantic attribute on the span tag, I'd be happy to add that aswell.

#### Ticket Link
_does not apply_

#### Checklist
- [X] Ran `make check-style` to check for style errors (required for all pull requests)
- [X] Ran `make test` to ensure unit and component tests passed
- [X] Added or updated unit tests

#### Personal note
I hope my proposed change does not collide with any kind of views regarding integrity of DOM nodes and is acceptable.