### PR TITLE
MM-11473: Ignore the not-so-error "ResizeObserver loop limit exceeded"

### DIFF
--- a/root.jsx
+++ b/root.jsx
@@ -31,6 +31,9 @@ PDFJS.disableWorker = true;
 // This runs before we start to render anything.
 function preRenderSetup(callwhendone) {
     window.onerror = (msg, url, line, column, stack) => {
+        if (msg === 'ResizeObserver loop limit exceeded') {
+            return;
+        }
         var l = {};
         l.level = 'ERROR';
         l.message = 'msg: ' + msg + ' row: ' + line + ' col: ' + column + ' stack: ' + stack + ' url: ' + url;


### PR DESCRIPTION
#### Summary
Ignore the "ResizeObserver loop limit exceeded" error, because is not a
real error. Happens only in Chrome and makes not sense to show to the
user in Developer mode.

Here is a short explanation: https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded

#### Ticket Link
[MM-11473](https://mattermost.atlassian.net/browse/11473)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed