### PR TITLE
MM-11444 (part 2) Change default plugin sidebar icons opacity

### DIFF
--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -7,6 +7,7 @@
     z-index: 12;
 
     .fa {
+        @include opacity(.6);
         color: $white;
     }
 

--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -7,8 +7,13 @@
     z-index: 12;
 
     .fa {
+        @include single-transition(all, .15s, ease);
         @include opacity(.6);
         color: $white;
+
+        &:hover {
+            @include opacity(1);
+        }
     }
 
     .team-sidebar-bottom-plugin {


### PR DESCRIPTION
#### Summary
Follow-up to #1611 to set the opacity to 60% by default.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11444