### PR TITLE
MM-11794: Don't keep highlighting search terms on flag/pin view.

### DIFF
--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -364,7 +364,7 @@ export default class SearchResults extends React.PureComponent {
                         matches={this.props.matches[post.id]}
                         lastPostCount={(reverseCount >= 0 && reverseCount < Constants.TEST_ID_COUNT) ? reverseCount : -1}
                         user={profile}
-                        term={searchTerms}
+                        term={(!this.props.isFlaggedPosts && !this.props.isPinnedPosts && !this.props.isMentionSearch) ? searchTerms : ''}
                         isMentionSearch={this.props.isMentionSearch}
                         isFlagged={isFlagged}
                         isBusy={this.state.isBusy}


### PR DESCRIPTION
#### Summary
Don't show search highlights when switching to pin/flag/mention views.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11794

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed