### PR TITLE
MM-11805: Fix strange behavior on exit channel creation modal

### DIFF
--- a/components/new_channel_flow.jsx
+++ b/components/new_channel_flow.jsx
@@ -124,6 +124,7 @@ export default class NewChannelFlow extends React.Component {
     onModalExited = () => {
         if (this.doOnModalExited) {
             this.doOnModalExited();
+            this.doOnModalExited = null;
         }
     };
 

--- a/tests/components/new_channel_flow.test.jsx
+++ b/tests/components/new_channel_flow.test.jsx
@@ -145,10 +145,12 @@ describe('components/NewChannelFlow', () => {
             <NewChannelFlow {...baseProps}/>
         );
 
-        wrapper.instance().doOnModalExited = jest.fn();
-        wrapper.instance().onModalExited();
-        expect(typeof wrapper.instance().doOnModalExited).not.toEqual('undefined');
-        expect(wrapper.instance().doOnModalExited).toHaveBeenCalledTimes(1);
+        const instance = wrapper.instance();
+        const doOnModalExited = jest.fn();
+        instance.doOnModalExited = doOnModalExited;
+        instance.onModalExited();
+        expect(instance.doOnModalExited).toEqual(null);
+        expect(doOnModalExited).toHaveBeenCalledTimes(1);
     });
 
     test('call onModalDismissed after successfully creating channel', () => {


### PR DESCRIPTION
#### Summary
When you create a new channel is set a function to be run when the modal
is closed, which redirects you to the new channel. That function wasn't
removed, so it redirects you to the last created channel every time you
cancel a channel creation.

#### Ticket Link
[MM-11805](https://mattermost.atlassian.net/browse/11805)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed