### PR TITLE
Stop saving user's ID to their NotifyProps

### DIFF
--- a/components/user_settings/notifications/user_settings_notifications.jsx
+++ b/components/user_settings/notifications/user_settings_notifications.jsx
@@ -126,7 +126,6 @@ export default class NotificationsTab extends React.Component {
 
     handleSubmit = (enableEmail = this.state.enableEmail) => {
         const data = {};
-        data.user_id = this.props.user.id;
         data.email = enableEmail;
         data.desktop_sound = this.state.desktopSound;
         data.desktop = this.state.desktopActivity;


### PR DESCRIPTION
When we changed the notification settings to use API v4 and the /api/v4/users/patch endpoint, we never removed the old user_id field that was needed for the /api/v3/users/update_notify route, so we've been writing their ID back into their notify_props for no reason.