### PR TITLE
[MM-10621] Fix order of files in viewing file attachments

### DIFF
--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -4,6 +4,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {sortFileInfos} from 'mattermost-redux/utils/file_utils';
+
 import {FileTypes} from 'utils/constants.jsx';
 import {getFileType} from 'utils/utils';
 
@@ -35,6 +37,8 @@ export default class FileAttachmentList extends React.Component {
         compactDisplay: PropTypes.bool,
 
         isEmbedVisible: PropTypes.bool,
+
+        locale: PropTypes.string.isRequired,
 
         actions: PropTypes.shape({
 
@@ -68,7 +72,12 @@ export default class FileAttachmentList extends React.Component {
     }
 
     render() {
-        const {fileInfos, fileCount, compactDisplay} = this.props;
+        const {
+            compactDisplay,
+            fileInfos,
+            fileCount,
+            locale,
+        } = this.props;
 
         if (compactDisplay === false) {
             if (fileInfos && fileInfos.length === 1) {
@@ -90,15 +99,15 @@ export default class FileAttachmentList extends React.Component {
             }
         }
 
+        const sortedFileInfos = sortFileInfos(fileInfos, locale);
         const postFiles = [];
-        if (fileInfos && fileInfos.length > 0) {
-            for (let i = 0; i < fileInfos.length; i++) {
-                const fileInfo = fileInfos[i];
-
+        if (sortedFileInfos && sortedFileInfos.length > 0) {
+            for (let i = 0; i < sortedFileInfos.length; i++) {
+                const fileInfo = sortedFileInfos[i];
                 postFiles.push(
                     <FileAttachment
                         key={fileInfo.id}
-                        fileInfo={fileInfos[i]}
+                        fileInfo={sortedFileInfos[i]}
                         index={i}
                         handleImageClick={this.handleImageClick}
                         compactDisplay={compactDisplay}
@@ -126,7 +135,7 @@ export default class FileAttachmentList extends React.Component {
                     show={this.state.showPreviewModal}
                     onModalDismissed={this.hidePreviewModal}
                     startIndex={this.state.startImgIndex}
-                    fileInfos={fileInfos}
+                    fileInfos={sortedFileInfos}
                 />
             </React.Fragment>
         );

--- a/components/file_attachment_list/index.js
+++ b/components/file_attachment_list/index.js
@@ -5,9 +5,9 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getMissingFilesForPost} from 'mattermost-redux/actions/files';
 import {makeGetFilesForPost} from 'mattermost-redux/selectors/entities/files';
-
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 
+import {getCurrentLocale} from 'selectors/i18n';
 import {makeGetGlobalItem} from 'selectors/storage';
 
 import {Preferences, StoragePrefixes} from 'utils/constants.jsx';
@@ -35,6 +35,7 @@ function makeMapStateToProps() {
             fileInfos,
             fileCount,
             isEmbedVisible,
+            locale: getCurrentLocale(state),
         };
     };
 }

--- a/tests/components/__snapshots__/file_attachment_list.test.jsx.snap
+++ b/tests/components/__snapshots__/file_attachment_list.test.jsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/FileAttachmentList should match snapshot, multiple files ordered 1-2-3 1`] = `
+<Fragment>
+  <div
+    className="post-image__columns clearfix"
+  >
+    <Connect(FileAttachment)
+      compactDisplay={false}
+      fileInfo={
+        Object {
+          "create_at": 1,
+          "extension": "png",
+          "id": "file_id_1",
+          "name": "image_1.png",
+        }
+      }
+      handleImageClick={[Function]}
+      index={0}
+      key="file_id_1"
+    />
+    <Connect(FileAttachment)
+      compactDisplay={false}
+      fileInfo={
+        Object {
+          "create_at": 2,
+          "extension": "png",
+          "id": "file_id_2",
+          "name": "image_2.png",
+        }
+      }
+      handleImageClick={[Function]}
+      index={1}
+      key="file_id_2"
+    />
+    <Connect(FileAttachment)
+      compactDisplay={false}
+      fileInfo={
+        Object {
+          "create_at": 3,
+          "extension": "png",
+          "id": "file_id_3",
+          "name": "image_3.png",
+        }
+      }
+      handleImageClick={[Function]}
+      index={2}
+      key="file_id_3"
+    />
+  </div>
+  <Connect(ViewImageModal)
+    fileInfos={
+      Array [
+        Object {
+          "create_at": 1,
+          "extension": "png",
+          "id": "file_id_1",
+          "name": "image_1.png",
+        },
+        Object {
+          "create_at": 2,
+          "extension": "png",
+          "id": "file_id_2",
+          "name": "image_2.png",
+        },
+        Object {
+          "create_at": 3,
+          "extension": "png",
+          "id": "file_id_3",
+          "name": "image_3.png",
+        },
+      ]
+    }
+    onModalDismissed={[Function]}
+    show={false}
+    startIndex={0}
+  />
+</Fragment>
+`;
+
+exports[`components/FileAttachmentList should match snapshot, single image view 1`] = `
+<Connect(SingleImageView)
+  fileInfo={
+    Object {
+      "create_at": 1,
+      "extension": "png",
+      "id": "file_id_1",
+      "name": "image_1.png",
+    }
+  }
+  isEmbedVisible={false}
+  post={
+    Object {
+      "file_ids": Array [
+        "file_id_1",
+      ],
+      "id": "post_id",
+    }
+  }
+/>
+`;

--- a/tests/components/file_attachment_list.test.jsx
+++ b/tests/components/file_attachment_list.test.jsx
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import FileAttachmentList from 'components/file_attachment_list/file_attachment_list.jsx';
+
+describe('components/FileAttachmentList', () => {
+    const post = {id: 'post_id', file_ids: ['file_id_1', 'file_id_2', 'file_id_3']};
+    const fileInfos = [
+        {id: 'file_id_3', name: 'image_3.png', extension: 'png', create_at: 3},
+        {id: 'file_id_2', name: 'image_2.png', extension: 'png', create_at: 2},
+        {id: 'file_id_1', name: 'image_1.png', extension: 'png', create_at: 1},
+    ];
+    const baseProps = {
+        post,
+        fileCount: 3,
+        fileInfos,
+        compactDisplay: false,
+        isEmbedVisible: false,
+        locale: 'en',
+        actions: {getMissingFilesForPost: jest.fn()},
+    };
+
+    test('should match snapshot, multiple files ordered 1-2-3', () => {
+        const wrapper = shallow(
+            <FileAttachmentList {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, single image view', () => {
+        const newPost = {...post, file_ids: ['file_id_1']};
+        const wrapper = shallow(
+            <FileAttachmentList
+                {...baseProps}
+                post={newPost}
+                fileInfos={[{id: 'file_id_1', name: 'image_1.png', extension: 'png', create_at: 1}]}
+                fileCount={1}
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match state on handleImageClick', () => {
+        const wrapper = shallow(
+            <FileAttachmentList {...baseProps}/>
+        );
+
+        wrapper.setState({showPreviewModal: false, startImgIndex: 0});
+        const newImageIndex = 1;
+        wrapper.instance().handleImageClick(newImageIndex);
+
+        expect(wrapper.state('showPreviewModal')).toEqual(true);
+        expect(wrapper.state('startImgIndex')).toEqual(newImageIndex);
+    });
+
+    test('should match state on hidePreviewModal', () => {
+        const wrapper = shallow(
+            <FileAttachmentList {...baseProps}/>
+        );
+
+        wrapper.setState({showPreviewModal: true});
+        wrapper.instance().hidePreviewModal();
+
+        expect(wrapper.state('showPreviewModal')).toEqual(false);
+    });
+});


### PR DESCRIPTION
#### Summary
Fix order of files in viewing file attachments.

(Previous PRs for this ticket adressed order of file on upload and previews.)

#### Ticket Link
Jira ticket: [MM-10621](https://mattermost.atlassian.net/browse/MM-10621).

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

