### PR TITLE
[MM-11798] Change landingPageSeen flag to localStorage

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -447,7 +447,7 @@ export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = tr
 }
 
 export function clientLogout(redirectTo = '/') {
-    BrowserStore.clear({exclude: [Constants.RECENT_EMOJI_KEY, '__landingPageSeen__', 'selected_teams']});
+    BrowserStore.clear({exclude: [Constants.RECENT_EMOJI_KEY, 'selected_teams']});
     ErrorStore.clearLastError();
     ChannelStore.clear();
     stopPeriodicStatusUpdates();

--- a/stores/browser_store.jsx
+++ b/stores/browser_store.jsx
@@ -115,11 +115,11 @@ class BrowserStoreClass {
     }
 
     hasSeenLandingPage() {
-        return this.getItem('__landingPageSeen__', false);
+        return localStorage.getItem(StoragePrefixes.LANDING_PAGE_SEEN);
     }
 
     setLandingPageSeen(landingPageSeen) {
-        return this.setItem('__landingPageSeen__', landingPageSeen);
+        localStorage.setItem(StoragePrefixes.LANDING_PAGE_SEEN, landingPageSeen);
     }
 }
 

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -438,6 +438,7 @@ export const StoragePrefixes = {
     LOGOUT: '__logout__',
     LOGIN: '__login__',
     ANNOUNCEMENT: '__announcement__',
+    LANDING_PAGE_SEEN: '__landingPageSeen__',
 };
 
 export const ErrorPageTypes = {


### PR DESCRIPTION
#### Summary
Fixes the issue of showing getApp screen in different scenarios.

At present the way we store the flag for showing app srceen is odd as it store the flag in couple of ways
1. `_unknow___landingPageSeen__`(when user is not logged)
2. `_userId___landingPageSeen__`(when user is logged)

so first time when the skip though it sets the flag(with unknow id) once after logging and refreash webapp checks for flag with userId showing the getApp screen again.

The other problem is how we purge stores on logout in couple of places so the flag is removed from indexDB after logout showing the screen again.

So moving this flag to localStorage similar to other app flags like bannerAnouncement so it is persisted even after logout.

#### Ticket Link
[MM-11798](https://mattermost.atlassian.net/browse/MM-11798)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
