### PR TITLE
MM-11503 Stopped trying to highlight empty search strings

### DIFF
--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -380,10 +380,13 @@ function parseSearchTerms(searchTerm) {
         let captured;
 
         // check for a quoted string
-        captured = (/^"(.*?)"/).exec(termString);
+        captured = (/^"([^"]*)"/).exec(termString);
         if (captured) {
             termString = termString.substring(captured[0].length);
-            terms.push(captured[1]);
+
+            if (captured[1].length > 0) {
+                terms.push(captured[1]);
+            }
             continue;
         }
 


### PR DESCRIPTION
I don't know if this is at all possible any more since I couldn't get my local server to return the correct results, but I can certainly see how it would've happened if the server sent back those results. Funnily enough, I'm surprised it didn't fully error when you do this because apparently it's totally fine to call `''.charAt(-1)` in JavaScript (it returns the empty string)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11503