### PR TITLE
bug fix: use user's timezone setting for search date flags

### DIFF
--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -16,7 +16,9 @@ import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import {getSearchTerms, getRhsState} from 'selectors/rhs';
 import {ActionTypes, RHSStates} from 'utils/constants';
 import * as Utils from 'utils/utils';
-import {getBrowserUtcOffset} from 'utils/timezone.jsx';
+import {getBrowserUtcOffset, getUtcOffsetForTimeZone} from 'utils/timezone.jsx';
+import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
+import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
 
 export function updateRhsState(rhsState) {
     return (dispatch, getState) => {
@@ -64,10 +66,12 @@ export function performSearch(terms, isMentionSearch) {
     return (dispatch, getState) => {
         const teamId = getCurrentTeamId(getState());
 
-        // timezone offset in seconds
-        const timeZoneOffset = getBrowserUtcOffset() * 60;
-
-        return dispatch(searchPostsWithParams(teamId, {terms, is_or_search: isMentionSearch, time_zone_offset: timeZoneOffset}, true));
+        // timezone offset in seconds        
+        const userId = getCurrentUserId(getState());
+        const userTimezone = getUserTimezone(getState(), userId);
+        let userCurrentTimezone = getUserCurrentTimezone(userTimezone);
+        const timezoneOffset = (userCurrentTimezone.length > 0 ? getUtcOffsetForTimeZone(userCurrentTimezone) : getBrowserUtcOffset()) * 60;
+        return dispatch(searchPostsWithParams(teamId, {terms, is_or_search: isMentionSearch, time_zone_offset: timezoneOffset}, true));
     };
 }
 

--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -11,14 +11,15 @@ import {getCurrentUserId, getCurrentUserMentionKeys} from 'mattermost-redux/sele
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
+import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
 
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import {getSearchTerms, getRhsState} from 'selectors/rhs';
 import {ActionTypes, RHSStates} from 'utils/constants';
 import * as Utils from 'utils/utils';
-import {getBrowserUtcOffset, getUtcOffsetForTimeZone} from 'utils/timezone.jsx';
-import {getUserTimezone} from 'mattermost-redux/selectors/entities/timezone';
-import {getUserCurrentTimezone} from 'mattermost-redux/utils/timezone_utils';
+
+import {getBrowserUtcOffset, getUtcOffsetForTimeZone} from 'utils/timezone';
 
 export function updateRhsState(rhsState) {
     return (dispatch, getState) => {
@@ -66,10 +67,10 @@ export function performSearch(terms, isMentionSearch) {
     return (dispatch, getState) => {
         const teamId = getCurrentTeamId(getState());
 
-        // timezone offset in seconds        
+        // timezone offset in seconds
         const userId = getCurrentUserId(getState());
         const userTimezone = getUserTimezone(getState(), userId);
-        let userCurrentTimezone = getUserCurrentTimezone(userTimezone);
+        const userCurrentTimezone = getUserCurrentTimezone(userTimezone);
         const timezoneOffset = (userCurrentTimezone.length > 0 ? getUtcOffsetForTimeZone(userCurrentTimezone) : getBrowserUtcOffset()) * 60;
         return dispatch(searchPostsWithParams(teamId, {terms, is_or_search: isMentionSearch, time_zone_offset: timezoneOffset}, true));
     };

--- a/tests/redux/actions/views/rhs.test.js
+++ b/tests/redux/actions/views/rhs.test.js
@@ -81,6 +81,15 @@ describe('rhs view actions', () => {
             },
             users: {
                 currentUserId,
+                profiles: {
+                    user123: {
+                        timezone: {
+                            useAutomaticTimezone: true,
+                            automaticTimezone: '',
+                            manualTimezone: '',
+                        }    
+                    }
+                }
             },
         },
         views: {

--- a/tests/redux/actions/views/rhs.test.js
+++ b/tests/redux/actions/views/rhs.test.js
@@ -87,9 +87,9 @@ describe('rhs view actions', () => {
                             useAutomaticTimezone: true,
                             automaticTimezone: '',
                             manualTimezone: '',
-                        }    
-                    }
-                }
+                        },
+                    },
+                },
             },
         },
         views: {

--- a/utils/timezone.jsx
+++ b/utils/timezone.jsx
@@ -17,3 +17,7 @@ export function getBrowserTimezone() {
 export function getBrowserUtcOffset() {
     return moment().utcOffset();
 }
+
+export function getUtcOffsetForTimeZone(timezone) {
+    return moment.tz(timezone).utcOffset();
+}


### PR DESCRIPTION
#### Summary
when retrieving the timezone to pass to the server during a date flag search (on: before: after:) check user's settings and use their selected timezone if present instead of the browser's timezone

#### Ticket Link
N/A

#### Checklist
N/A