### PR TITLE
MM-11725: Fix some cases where we show archived channels

### DIFF
--- a/components/suggestion/search_channel_provider.jsx
+++ b/components/suggestion/search_channel_provider.jsx
@@ -55,6 +55,7 @@ export default class SearchChannelProvider extends Provider {
                     const publicChannels = data;
 
                     const localChannels = ChannelStore.getAll();
+                    const membershipsForChannels = new Set(Object.keys(ChannelStore.getMyMembers()));
                     let privateChannels = [];
 
                     for (const id of Object.keys(localChannels)) {
@@ -67,7 +68,11 @@ export default class SearchChannelProvider extends Provider {
                     let filteredPublicChannels = [];
                     publicChannels.forEach((item) => {
                         if (item.name.startsWith(channelPrefix)) {
-                            filteredPublicChannels.push(item);
+                            if (item.delete_at === 0) {
+                                filteredPublicChannels.push(item);
+                            } else if (membershipsForChannels.has(item.id)) {
+                                filteredPublicChannels.push(item);
+                            }
                         }
                     });
 

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -320,7 +320,7 @@ export default class SwitchChannelProvider extends Provider {
                 continue;
             }
 
-            if (channelFilter(channel)) {
+            if (channelFilter(channel) && channel.delete_at === 0) {
                 const newChannel = Object.assign({}, channel);
                 const channelIsArchived = channel.delete_at !== 0;
 


### PR DESCRIPTION
#### Summary

**Note:** This is the "Quick fix" version of the other MM-11725 PRs. I going to make a similar one for RN.

We show archived channels in the Channel Switch modal (and we don't want
that, so this commit filter archived channels there).

In the search `in:` filter autocompletion, we show all open channels
including archived channels (If archived channels are enabled), with
this PR we only show the archived channels if we are members of them.

#### Ticket Link
[MM-11725](https://mattermost.atlassian.net/browse/11725)

#### Checklist
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [x] Needs to be implemented in mobile (link to PR or User Story)