### PR TITLE
Refactor "commented on..." into its separate component and be tested

### DIFF
--- a/components/post_view/commented_on/commented_on.jsx
+++ b/components/post_view/commented_on/commented_on.jsx
@@ -1,0 +1,93 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import * as Utils from 'utils/utils.jsx';
+import {stripMarkdown} from 'utils/markdown';
+
+import CommentedOnFilesMessage from 'components/post_view/commented_on_files_message';
+
+export default class CommentedOn extends PureComponent {
+    static propTypes = {
+        displayName: PropTypes.string,
+        enablePostUsernameOverride: PropTypes.bool,
+        onCommentClick: PropTypes.func.isRequired,
+        post: PropTypes.object.isRequired,
+        actions: PropTypes.shape({
+            showSearchResults: PropTypes.func.isRequired,
+            updateSearchTerms: PropTypes.func.isRequired,
+        }).isRequired,
+    }
+
+    handleOnClick = () => {
+        const {actions, displayName} = this.props;
+
+        actions.updateSearchTerms(displayName);
+        actions.showSearchResults();
+    }
+
+    render() {
+        const {
+            displayName,
+            enablePostUsernameOverride,
+            post,
+        } = this.props;
+
+        let username = displayName;
+        if (
+            enablePostUsernameOverride &&
+            post.props &&
+            post.props.from_webhook &&
+            post.props.override_username
+        ) {
+            username = post.props.override_username;
+        }
+
+        let apostrophe = '\'s';
+        if (username.slice(-1) === 's') {
+            apostrophe = '\'';
+        }
+
+        const name = (
+            <a
+                className='theme'
+                onClick={this.handleOnClick}
+            >
+                {username}
+            </a>
+        );
+
+        let message = '';
+        if (post.message) {
+            message = Utils.replaceHtmlEntities(post.message);
+        } else if (post.file_ids && post.file_ids.length > 0) {
+            message = (
+                <CommentedOnFilesMessage parentPostId={post.id}/>
+            );
+        }
+
+        return (
+            <div className='post__link'>
+                <span>
+                    <FormattedMessage
+                        id='post_body.commentedOn'
+                        defaultMessage='Commented on {name}{apostrophe} message: '
+                        values={{
+                            name,
+                            apostrophe,
+                        }}
+                    />
+                    <a
+                        className='theme'
+                        onClick={this.props.onCommentClick}
+                    >
+                        {stripMarkdown(message)}
+                    </a>
+                </span>
+            </div>
+        );
+    }
+}

--- a/components/post_view/commented_on/index.js
+++ b/components/post_view/commented_on/index.js
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getUser} from 'mattermost-redux/selectors/entities/users';
+
+import {showSearchResults, updateSearchTerms} from 'actions/views/rhs';
+
+import {getDisplayNameByUser} from 'utils/utils.jsx';
+
+import CommentedOn from './commented_on.jsx';
+
+function mapStateToProps(state, ownProps) {
+    let displayName = '';
+    if (ownProps.post) {
+        const user = getUser(state, ownProps.post.user_id);
+        displayName = getDisplayNameByUser(user);
+    }
+
+    const config = getConfig(state);
+    const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
+
+    return {
+        displayName,
+        enablePostUsernameOverride,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            showSearchResults,
+            updateSearchTerms,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CommentedOn);

--- a/components/post_view/post_body/post_body.jsx
+++ b/components/post_view/post_body/post_body.jsx
@@ -3,16 +3,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
 import {Posts} from 'mattermost-redux/constants';
 
-import * as PostActions from 'actions/post_actions.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 import DelayedAction from 'utils/delayed_action.jsx';
-import {stripMarkdown} from 'utils/markdown';
 
-import CommentedOnFilesMessage from 'components/post_view/commented_on_files_message';
+import CommentedOn from 'components/post_view/commented_on';
 import FileAttachmentListContainer from 'components/file_attachment_list';
 import FailedPostOptions from 'components/post_view/failed_post_options';
 import PostBodyAdditionalContent from 'components/post_view/post_body_additional_content';
@@ -139,68 +136,15 @@ export default class PostBody extends React.PureComponent {
         const post = this.props.post;
         const parentPost = this.props.parentPost;
 
-        let comment = '';
+        let comment;
         let postClass = '';
         const isEphemeral = Utils.isPostEphemeral(post);
         if (this.props.isFirstReply && parentPost && !isEphemeral) {
-            const profile = this.props.parentPostUser;
-
-            let apostrophe = '';
-            let name = '...';
-            if (profile != null) {
-                let username = Utils.getDisplayNameByUser(profile);
-                if (parentPost.props &&
-                        parentPost.props.from_webhook &&
-                        parentPost.props.override_username &&
-                        this.props.enablePostUsernameOverride) {
-                    username = parentPost.props.override_username;
-                }
-
-                if (username.slice(-1) === 's') {
-                    apostrophe = '\'';
-                } else {
-                    apostrophe = '\'s';
-                }
-                name = (
-                    <a
-                        className='theme'
-                        onClick={PostActions.searchForTerm.bind(null, username)}
-                    >
-                        {username}
-                    </a>
-                );
-            }
-
-            let message = '';
-            if (parentPost.message) {
-                message = Utils.replaceHtmlEntities(parentPost.message);
-            } else if (parentPost.file_ids && parentPost.file_ids.length > 0) {
-                message = (
-                    <CommentedOnFilesMessage
-                        parentPostId={parentPost.id}
-                    />
-                );
-            }
-
             comment = (
-                <div className='post__link'>
-                    <span>
-                        <FormattedMessage
-                            id='post_body.commentedOn'
-                            defaultMessage='Commented on {name}{apostrophe} message: '
-                            values={{
-                                name,
-                                apostrophe,
-                            }}
-                        />
-                        <a
-                            className='theme'
-                            onClick={this.props.handleCommentClick}
-                        >
-                            {stripMarkdown(message)}
-                        </a>
-                    </span>
-                </div>
+                <CommentedOn
+                    post={parentPost}
+                    onCommentClick={this.props.handleCommentClick}
+                />
             );
         }
 

--- a/tests/components/post_view/__snapshots__/commented_on.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/commented_on.test.jsx.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/post_view/CommentedOn should match snapshot 1`] = `
+<div
+  className="post__link"
+>
+  <span>
+    <FormattedMessage
+      defaultMessage="Commented on {name}{apostrophe} message: "
+      id="post_body.commentedOn"
+      values={
+        Object {
+          "apostrophe": "'s",
+          "name": <a
+            className="theme"
+            onClick={[Function]}
+          >
+            user_displayName
+          </a>,
+        }
+      }
+    />
+    <a
+      className="theme"
+      onClick={[MockFunction]}
+    >
+      text message
+    </a>
+  </span>
+</div>
+`;
+
+exports[`components/post_view/CommentedOn should match snapshot 2`] = `
+<div
+  className="post__link"
+>
+  <span>
+    <FormattedMessage
+      defaultMessage="Commented on {name}{apostrophe} message: "
+      id="post_body.commentedOn"
+      values={
+        Object {
+          "apostrophe": "'s",
+          "name": <a
+            className="theme"
+            onClick={[Function]}
+          >
+            override_username
+          </a>,
+        }
+      }
+    />
+    <a
+      className="theme"
+      onClick={[MockFunction]}
+    >
+      text message
+    </a>
+  </span>
+</div>
+`;
+
+exports[`components/post_view/CommentedOn should match snapshot 3`] = `
+<div
+  className="post__link"
+>
+  <span>
+    <FormattedMessage
+      defaultMessage="Commented on {name}{apostrophe} message: "
+      id="post_body.commentedOn"
+      values={
+        Object {
+          "apostrophe": "'s",
+          "name": <a
+            className="theme"
+            onClick={[Function]}
+          >
+            user_displayName
+          </a>,
+        }
+      }
+    />
+    <a
+      className="theme"
+      onClick={[MockFunction]}
+    >
+      <Connect(CommentedOnFilesMessage)
+        parentPostId="post_id"
+      />
+    </a>
+  </span>
+</div>
+`;

--- a/tests/components/post_view/commented_on.test.jsx
+++ b/tests/components/post_view/commented_on.test.jsx
@@ -1,0 +1,64 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import CommentedOn from 'components/post_view/commented_on/commented_on.jsx';
+import CommentedOnFilesMessage from 'components/post_view/commented_on_files_message';
+
+describe('components/post_view/CommentedOn', () => {
+    const baseProps = {
+        displayName: 'user_displayName',
+        enablePostUsernameOverride: false,
+        onCommentClick: jest.fn(),
+        post: {
+            id: 'post_id',
+            message: 'text message',
+            props: {
+                from_webhook: true,
+                override_username: 'override_username',
+            },
+        },
+        actions: {
+            showSearchResults: jest.fn(),
+            updateSearchTerms: jest.fn(),
+        },
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(<CommentedOn {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+
+        wrapper.setProps({enablePostUsernameOverride: true});
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(CommentedOnFilesMessage).exists()).toBe(false);
+
+        const newPost = {
+            id: 'post_id',
+            message: '',
+            file_ids: ['file_id_1', 'file_id_2'],
+        };
+        wrapper.setProps({post: newPost, enablePostUsernameOverride: false});
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(CommentedOnFilesMessage).exists()).toBe(true);
+    });
+
+    test('should call onCommentClick on click of text message', () => {
+        const wrapper = shallow(<CommentedOn {...baseProps}/>);
+
+        wrapper.find('a').first().simulate('click');
+        expect(baseProps.onCommentClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('should call actions.updateSearchTerms and actions.showSearchResults on handleOnClick', () => {
+        const wrapper = shallow(<CommentedOn {...baseProps}/>);
+
+        wrapper.instance().handleOnClick();
+
+        expect(baseProps.actions.updateSearchTerms).toHaveBeenCalledTimes(1);
+        expect(baseProps.actions.updateSearchTerms).toHaveBeenCalledWith(baseProps.displayName);
+
+        expect(baseProps.actions.showSearchResults).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
#### Summary
Refactor "commented on..." into its separate component and be tested.  I find it necessary while working on https://github.com/mattermost/mattermost-webapp/pull/1657 where I'd like to test a smaller unit but cannot do it without testing the entire `PostBody`.

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

