### PR TITLE
Adding Permissions setting to declarative admin console

### DIFF
--- a/components/admin_console/admin_console.jsx
+++ b/components/admin_console/admin_console.jsx
@@ -50,63 +50,24 @@ const SCRoute = ({component: Component, extraProps, ...rest}) => ( //eslint-disa
 
 export default class AdminConsole extends React.Component {
     static propTypes = {
-
-        /*
-         * Object representing the config file
-         */
         config: PropTypes.object.isRequired,
-
-        /*
-         * Object containing config fields that have been set through environment variables
-         */
         environmentConfig: PropTypes.object,
-
-        /*
-         * Object representing the license
-         */
         license: PropTypes.object.isRequired,
-
-        /*
-         * Object from react-router
-         */
+        roles: PropTypes.object.isRequired,
         match: PropTypes.shape({
             url: PropTypes.string.isRequired,
         }).isRequired,
-
-        /*
-         * String whether to show prompt to navigate away
-         * from unsaved changes
-         */
         showNavigationPrompt: PropTypes.bool.isRequired,
-
         isCurrentUserSystemAdmin: PropTypes.bool.isRequired,
 
         actions: PropTypes.shape({
-
-            /*
-             * Function to get the config file
-             */
             getConfig: PropTypes.func.isRequired,
-
-            /*
-             * Function to get the environment config
-             */
             getEnvironmentConfig: PropTypes.func.isRequired,
-
-            /*
-             * Function to block navigation when there are unsaved changes
-             */
             setNavigationBlocked: PropTypes.func.isRequired,
-
-            /*
-             * Function to confirm navigation
-             */
             confirmNavigation: PropTypes.func.isRequired,
-
-            /*
-             * Function to cancel navigation away from unsaved changes
-             */
             cancelNavigation: PropTypes.func.isRequired,
+            loadRolesIfNeeded: PropTypes.func.isRequired,
+            editRole: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -387,6 +348,9 @@ export default class AdminConsole extends React.Component {
                                         component={SchemaAdminSettings}
                                         extraProps={{
                                             ...extraProps,
+                                            roles: this.props.roles,
+                                            loadRolesIfNeeded: this.props.actions.loadRolesIfNeeded,
+                                            editRole: this.props.actions.editRole,
                                             schema: AdminDefinition.settings.integrations.custom_integrations.schema,
                                         }}
                                     />

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -81,6 +81,9 @@ const MEBIBYTE = Math.pow(1024, 2);
 //
 // Dropdown Widget (extends from Setting Widget)
 //   - options: List of options of the dropdown (each options has value, display_name and display_name_default fields).
+//
+// Permissions Flag (extends from Setting Widget)
+//   - permissions_mapping_name: A permission name in the utils/policy_roles_adapter.js file.
 
 export const needsUtils = {
     not: (func) => (config, state, license) => !func(config, state, license),
@@ -104,7 +107,7 @@ export const needsUtils = {
     stateValueEqual: (key, value) => (config, state) => state[key] === value,
     stateValueTrue: (key) => (config, state) => Boolean(state[key]),
     stateValueFalse: (key) => (config, state) => !state[key],
-    hasLicense: (config, state, license) => license.IsLicensed,
+    hasLicense: (config, state, license) => license.IsLicensed === 'true',
 };
 
 export default {
@@ -1180,6 +1183,16 @@ export default {
                             help_text: 'admin.oauth.providerDescription',
                             help_text_default: 'When true, Mattermost can act as an OAuth 2.0 service provider allowing Mattermost to authorize API requests from external applications. See [documentation](!https://docs.mattermost.com/developer/oauth-2-0-applications.html) to learn more.',
                             help_text_markdown: true,
+                        },
+                        {
+                            type: Constants.SettingsTypes.TYPE_PERMISSION,
+                            key: 'ServiceSettings.EnableOnlyAdminIntegrations',
+                            label: 'admin.service.integrationAdmin',
+                            label_default: 'Restrict managing integrations to Admins:',
+                            help_text: 'admin.service.integrationAdminDesc',
+                            help_text_default: 'When true, webhooks and slash commands can only be created, edited and viewed by Team and System Admins, and OAuth 2.0 applications by System Admins. Integrations are available to all users after they have been created by the Admin.',
+                            permissions_mapping_name: 'enableOnlyAdminIntegrations',
+                            isHidden: needsUtils.hasLicense,
                         },
                         {
                             type: Constants.SettingsTypes.TYPE_BOOL,

--- a/components/admin_console/index.js
+++ b/components/admin_console/index.js
@@ -4,9 +4,11 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getConfig, getEnvironmentConfig} from 'mattermost-redux/actions/admin';
+import {loadRolesIfNeeded, editRole} from 'mattermost-redux/actions/roles';
 import * as Selectors from 'mattermost-redux/selectors/entities/admin';
 import {withRouter} from 'react-router-dom';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getRoles} from 'mattermost-redux/selectors/entities/roles';
 import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 
 import {setNavigationBlocked, deferNavigation, cancelNavigation, confirmNavigation} from 'actions/admin_actions.jsx';
@@ -22,6 +24,7 @@ function mapStateToProps(state) {
         navigationBlocked: getNavigationBlocked(state),
         showNavigationPrompt: showNavigationPrompt(state),
         isCurrentUserSystemAdmin: isCurrentUserSystemAdmin(state),
+        roles: getRoles(state),
     };
 }
 
@@ -34,6 +37,8 @@ function mapDispatchToProps(dispatch) {
             deferNavigation,
             cancelNavigation,
             confirmNavigation,
+            loadRolesIfNeeded,
+            editRole,
         }, dispatch),
     };
 }

--- a/tests/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/tests/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -572,6 +572,36 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         jobType="test"
         key="Config_userautocomplete_undefined"
       />
+      <BooleanSetting
+        disabled={false}
+        falseText={
+          <FormattedMessage
+            defaultMessage="false"
+            id="admin.false"
+            values={Object {}}
+          />
+        }
+        helpText={
+          <FormattedMessage
+            defaultMessage="This is some help text for the permissions field."
+            id="help-text-o"
+            values={Object {}}
+          />
+        }
+        id="settingo"
+        key="Config_bool_settingo"
+        label="Setting Fourteen"
+        onChange={[Function]}
+        setByEnv={false}
+        trueText={
+          <FormattedMessage
+            defaultMessage="true"
+            id="admin.true"
+            values={Object {}}
+          />
+        }
+        value={false}
+      />
     </SettingsGroup>
     <div
       className="admin-console-save"

--- a/tests/components/admin_console/admin_console.test.jsx
+++ b/tests/components/admin_console/admin_console.test.jsx
@@ -13,6 +13,7 @@ describe('components/AdminConsole', () => {
         match: {
             url: '',
         },
+        roles: {},
         showNavigationPrompt: false,
         isCurrentUserSystemAdmin: false,
         actions: {
@@ -21,6 +22,8 @@ describe('components/AdminConsole', () => {
             setNavigationBlocked: jest.fn(),
             confirmNavigation: jest.fn(),
             cancelNavigation: jest.fn(),
+            loadRolesIfNeeded: jest.fn(),
+            editRole: jest.fn(),
         },
     };
 

--- a/tests/components/admin_console/schema_admin_settings.test.jsx
+++ b/tests/components/admin_console/schema_admin_settings.test.jsx
@@ -189,6 +189,15 @@ describe('components/admin_console/SchemaAdminSettings', () => {
                     job_type: 'test',
                     render_job: () => <p>{'Test'}</p>,
                 },
+                {
+                    type: 'permission',
+                    key: 'settingo',
+                    label: 'label-o',
+                    label_default: 'Setting Fourteen',
+                    help_text: 'help-text-o',
+                    help_text_default: 'This is some help text for the permissions field.',
+                    permissions_mapping_name: 'enableOnlyAdminIntegrations',
+                },
             ],
         };
 

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -42,6 +42,7 @@ export const SettingsTypes = {
     TYPE_NUMBER: 'number',
     TYPE_COLOR: 'color',
     TYPE_BOOL: 'bool',
+    TYPE_PERMISSION: 'permission',
     TYPE_RADIO: 'radio',
     TYPE_BANNER: 'banner',
     TYPE_DROPDOWN: 'dropdown',


### PR DESCRIPTION
#### Summary
Adding Permissions setting to declarative admin console, and using this
new thing to reintroduce the "EnableAdminOnlyIntegrations" setting in
the "Integrations" config panel.

#### Ticket Link
[MM-11920](https://mattermost.atlassian.net/browse/11920)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates