### PR TITLE
[MM-11912] ~~Add (revert)~~ Set zero delay before calling emitClearSuggestions

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -185,6 +185,12 @@ export default class SuggestionBox extends React.Component {
         }
     }
 
+    handleEmitClearSuggestions = (suggestionId) => {
+        setTimeout(() => {
+            GlobalActions.emitClearSuggestions(suggestionId);
+        }, 200);
+    }
+
     handleFocusOut = (e) => {
         // Focus is switching TO e.relatedTarget, so only treat this as a blur event if we're not switching
         // between children (like from the textbox to the suggestion list)
@@ -196,12 +202,10 @@ export default class SuggestionBox extends React.Component {
             // iOS doesn't support e.relatedTarget, so we need to use the old method of just delaying the
             // blur so that click handlers on the list items still register
             if (this.presentationType !== 'date' || this.props.value.length === 0) {
-                setTimeout(() => {
-                    GlobalActions.emitClearSuggestions(this.suggestionId);
-                }, 200);
+                this.handleEmitClearSuggestions(this.suggestionId);
             }
         } else {
-            GlobalActions.emitClearSuggestions(this.suggestionId);
+            this.handleEmitClearSuggestions(this.suggestionId);
         }
 
         if (this.props.onBlur) {

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -188,7 +188,7 @@ export default class SuggestionBox extends React.Component {
     handleEmitClearSuggestions = (suggestionId) => {
         setTimeout(() => {
             GlobalActions.emitClearSuggestions(suggestionId);
-        }, 200);
+        }, 0);
     }
 
     handleFocusOut = (e) => {

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -13,6 +13,7 @@ import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 const KeyCodes = Constants.KeyCodes;
+const MIN_TIME_BEFORE_CLICK = 200;
 
 export default class SuggestionBox extends React.Component {
     static propTypes = {
@@ -185,10 +186,10 @@ export default class SuggestionBox extends React.Component {
         }
     }
 
-    handleEmitClearSuggestions = (suggestionId) => {
+    handleEmitClearSuggestions = (suggestionId, delay = 0) => {
         setTimeout(() => {
             GlobalActions.emitClearSuggestions(suggestionId);
-        }, 0);
+        }, delay);
     }
 
     handleFocusOut = (e) => {
@@ -202,7 +203,7 @@ export default class SuggestionBox extends React.Component {
             // iOS doesn't support e.relatedTarget, so we need to use the old method of just delaying the
             // blur so that click handlers on the list items still register
             if (this.presentationType !== 'date' || this.props.value.length === 0) {
-                this.handleEmitClearSuggestions(this.suggestionId);
+                this.handleEmitClearSuggestions(this.suggestionId, MIN_TIME_BEFORE_CLICK);
             }
         } else {
             this.handleEmitClearSuggestions(this.suggestionId);


### PR DESCRIPTION
#### Summary
Fix JS error when opening keyboard shortcuts modal via CTRL+/ by adding (reverting) delay before calling emitClearSuggestions.

#### Ticket Link
Jira ticket: [MM-11912](https://mattermost.atlassian.net/browse/MM-11912)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
