### PR TITLE
Ensuring CJK characters can fallback to sans-serif in IE11

### DIFF
--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -147,5 +147,5 @@ body {
 }
 
 .app__body.font--open_sans {
-    font-family: 'Open Sans', 'sans-serif';
+    font-family: 'Open Sans', sans-serif;
 }


### PR DESCRIPTION
#### Summary
Ensuring that CJK characters on IE11 can fallback to `sans-serif`, as the single quotation marks were not recognized by the browser.

Image of occurence can be seen below:
![ie_font_before](https://user-images.githubusercontent.com/29700158/45085037-ac325780-b13a-11e8-9eed-c97c20cd4cdb.png)

And once single quotation marks were removed:
![ie_font_after](https://user-images.githubusercontent.com/29700158/45085682-3b8c3a80-b13c-11e8-8ec2-78a78ae3ba38.png)


Note: Japanese characters still look about the same, and whether or not `sans-serif` looks better than the browser default with Chinese characters is questionable, but Korean characters look much sharper and easier to read (It's been an unanimous feedback that the font in the second image looks better than the first for Korean users).

There may be a need to review whether you'd like to add default fonts that are displayed well in each language, or if `sans-serif` is acceptable as seen on the second image shown above.

#### Ticket Link
No open tickets for this.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests