### PR TITLE
Fixing scrollbar on Firefox by removing it.

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -242,7 +242,7 @@
 #post-list {
     @include flex(1 1 auto);
     height: 100%;
-    overflow-y: hidden;
+    overflow: hidden;
     position: relative;
 
     .inactive {
@@ -273,7 +273,8 @@
         -webkit-overflow-scrolling: touch;
         height: 100%;
         overflow-y: scroll;
-        padding: 1em 0 0;
+        box-sizing: content-box;
+        padding-right: 17px;
         position: absolute;
         width: 100%;
 


### PR DESCRIPTION
The scrollbar on Firefox looks terrible. It can't be styled because of a missing feature in FF that looks like it will never be implemented: https://bugzilla.mozilla.org/show_bug.cgi?id=77790 ` Reported: 18 years ago`

This PR removes it.
Before:
![before](https://user-images.githubusercontent.com/3191642/45191296-40fa8b00-b1f7-11e8-80d4-249272d22baf.png)
After:
![after](https://user-images.githubusercontent.com/3191642/45191301-435ce500-b1f7-11e8-81ab-2a8cdd81eed3.png)

