### PR TITLE
MM-12044 Add trailing $ to text formatting tokens

### DIFF
--- a/tests/utils/emoticons.test.jsx
+++ b/tests/utils/emoticons.test.jsx
@@ -7,22 +7,22 @@ describe('Emoticons', () => {
     describe('handleEmoticons', () => {
         test('should replace emoticons with tokens', () => {
             expect(Emoticons.handleEmoticons(':goat: :dash:', new Map())).
-                toEqual('$MM_EMOTICON0 $MM_EMOTICON1');
+                toEqual('$MM_EMOTICON0$ $MM_EMOTICON1$');
         });
 
         test('should replace emoticons not separated by whitespace', () => {
             expect(Emoticons.handleEmoticons(':goat::dash:', new Map())).
-                toEqual('$MM_EMOTICON0$MM_EMOTICON1');
+                toEqual('$MM_EMOTICON0$$MM_EMOTICON1$');
         });
 
         test('should replace emoticons separated by punctuation', () => {
             expect(Emoticons.handleEmoticons('/:goat:..:dash:)', new Map())).
-                toEqual('/$MM_EMOTICON0..$MM_EMOTICON1)');
+                toEqual('/$MM_EMOTICON0$..$MM_EMOTICON1$)');
         });
 
         test('should replace emoticons separated by text', () => {
             expect(Emoticons.handleEmoticons('asdf:goat:asdf:dash:asdf', new Map())).
-                toEqual('asdf$MM_EMOTICON0asdf$MM_EMOTICON1asdf');
+                toEqual('asdf$MM_EMOTICON0$asdf$MM_EMOTICON1$asdf');
         });
 
         test('shouldn\'t replace invalid emoticons', () => {

--- a/tests/utils/formatting_at_mentions.test.jsx
+++ b/tests/utils/formatting_at_mentions.test.jsx
@@ -9,37 +9,37 @@ describe('TextFormatting.AtMentions', function() {
     it('At mentions', function() {
         assert.equal(
             TextFormatting.autolinkAtMentions('@user', new Map()),
-            '$MM_ATMENTION0',
+            '$MM_ATMENTION0$',
             'should replace mention with token'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('abc"@user"def', new Map()),
-            'abc"$MM_ATMENTION0"def',
+            'abc"$MM_ATMENTION0$"def',
             'should replace mention surrounded by punctuation with token'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('@user1 @user2', new Map()),
-            '$MM_ATMENTION0 $MM_ATMENTION1',
+            '$MM_ATMENTION0$ $MM_ATMENTION1$',
             'should replace multiple mentions with tokens'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('@user1/@user2/@user3', new Map()),
-            '$MM_ATMENTION0/$MM_ATMENTION1/$MM_ATMENTION2',
+            '$MM_ATMENTION0$/$MM_ATMENTION1$/$MM_ATMENTION2$',
             'should replace multiple mentions with tokens'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('@us_-e.r', new Map()),
-            '$MM_ATMENTION0',
+            '$MM_ATMENTION0$',
             'should replace multiple mentions containing punctuation with token'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('@user.', new Map()),
-            '$MM_ATMENTION0',
+            '$MM_ATMENTION0$',
             'should capture trailing punctuation as part of mention'
         );
     });

--- a/utils/emoticons.jsx
+++ b/utils/emoticons.jsx
@@ -31,7 +31,7 @@ export function handleEmoticons(text, tokens) {
 
     function replaceEmoticonWithToken(fullMatch, prefix, matchText, name) {
         const index = tokens.size;
-        const alias = `$MM_EMOTICON${index}`;
+        const alias = `$MM_EMOTICON${index}$`;
 
         tokens.set(alias, {
             value: `<span data-emoticon="${name}">${matchText}</span>`,

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -150,7 +150,7 @@ var reEmail = XRegExp.cache('(^|[^\\pL\\d])(' + emailStartPattern + '[\\pL\\d.\\
 function autolinkEmails(text, tokens) {
     function replaceEmailWithToken(fullMatch, prefix, email) {
         const index = tokens.size;
-        const alias = `$MM_EMAIL${index}`;
+        const alias = `$MM_EMAIL${index}$`;
 
         tokens.set(alias, {
             value: `<a class="theme" href="mailto:${email}">${email}</a>`,
@@ -169,7 +169,7 @@ function autolinkEmails(text, tokens) {
 export function autolinkAtMentions(text, tokens) {
     function replaceAtMentionWithToken(fullMatch, username) {
         const index = tokens.size;
-        const alias = `$MM_ATMENTION${index}`;
+        const alias = `$MM_ATMENTION${index}$`;
 
         tokens.set(alias, {
             value: `<span data-mention="${username}">@${username}</span>`,
@@ -191,7 +191,7 @@ function autolinkChannelMentions(text, tokens, channelNamesMap, team) {
     }
     function addToken(channelName, mention, displayName) {
         const index = tokens.size;
-        const alias = `$MM_CHANNELMENTION${index}`;
+        const alias = `$MM_CHANNELMENTION${index}$`;
         let href = '#';
         if (team) {
             href = (window.basename || '') + '/' + team.name + '/channels/' + channelName;
@@ -276,7 +276,7 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
 
         if (mentionKeys.findIndex((key) => key.key.toLowerCase() === tokenTextLower) !== -1) {
             const index = tokens.size + newTokens.size;
-            const newAlias = `$MM_SELFMENTION${index}`;
+            const newAlias = `$MM_SELFMENTION${index}$`;
 
             newTokens.set(newAlias, {
                 value: `<span class='mention--highlight'>${alias}</span>`,
@@ -294,7 +294,7 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
     // look for self mentions in the text
     function replaceCurrentMentionWithToken(fullMatch, prefix, mention, suffix = '') {
         const index = tokens.size;
-        const alias = `$MM_SELFMENTION${index}`;
+        const alias = `$MM_SELFMENTION${index}$`;
 
         tokens.set(alias, {
             value: `<span class='mention--highlight'>${mention}</span>`,
@@ -329,7 +329,7 @@ function autolinkHashtags(text, tokens) {
     for (const [alias, token] of tokens) {
         if (token.originalText.lastIndexOf('#', 0) === 0) {
             const index = tokens.size + newTokens.size;
-            const newAlias = `$MM_HASHTAG${index}`;
+            const newAlias = `$MM_HASHTAG${index}$`;
 
             newTokens.set(newAlias, {
                 value: `<a class='mention-link' href='#' data-hashtag='${token.originalText}'>${token.originalText}</a>`,
@@ -349,7 +349,7 @@ function autolinkHashtags(text, tokens) {
     // look for hashtags in the text
     function replaceHashtagWithToken(fullMatch, prefix, originalText) {
         const index = tokens.size;
-        const alias = `$MM_HASHTAG${index}`;
+        const alias = `$MM_HASHTAG${index}$`;
 
         if (text.length < Constants.MIN_HASHTAG_LINK_LENGTH + 1) {
             // too short to be a hashtag
@@ -462,7 +462,7 @@ export function highlightSearchTerms(text, tokens, searchPatterns) {
 
     function replaceSearchTermWithToken(match, prefix, word) {
         const index = tokens.size;
-        const alias = `$MM_SEARCHTERM${index}`;
+        const alias = `$MM_SEARCHTERM${index}$`;
 
         tokens.set(alias, {
             value: `<span class='search-highlight'>${word}</span>`,
@@ -487,12 +487,12 @@ export function highlightSearchTerms(text, tokens, searchPatterns) {
                     term = term.substr(1);
                 }
 
-                if (alias.startsWith('$MM_HASHTAG') && originalText !== term) {
+                if (alias.startsWith('$MM_HASHTAG') && alias.endsWith('$') && originalText !== term) {
                     continue;
                 }
 
                 const index = tokens.size + newTokens.size;
-                const newAlias = `$MM_SEARCHTERM${index}`;
+                const newAlias = `$MM_SEARCHTERM${index}$`;
 
                 newTokens.set(newAlias, {
                     value: `<span class='search-highlight'>${alias}</span>`,


### PR DESCRIPTION
This bug boils down to it being possible for a token like `$MM_EMOTICON10` to accidentally replace `$MM_EMOTICON1` followed by a `0`. Adding a trailing `$` makes it much more difficult to accidentally break the text formatting that way.

Marking this as DO NOT MERGE in case the ticket gets triaged to 5.3

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12044

#### Checklist
- Added or updated unit tests (required for all new features)