### PR TITLE
[MM-11282] Migrate audit_table to use redux and be pure

### DIFF
--- a/components/access_history_modal/access_history_modal.jsx
+++ b/components/access_history_modal/access_history_modal.jsx
@@ -8,7 +8,7 @@ import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import {isMobile} from 'utils/utils.jsx';
-import AuditTable from 'components/audit_table.jsx';
+import AuditTable from 'components/audit_table';
 import LoadingScreen from 'components/loading_screen.jsx';
 
 export default class AccessHistoryModal extends React.PureComponent {

--- a/components/admin_console/audits/audits.jsx
+++ b/components/admin_console/audits/audits.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import ComplianceReports from 'components/admin_console/compliance_reports';
 import {localizeMessage} from 'utils/utils.jsx';
-import AuditTable from 'components/audit_table.jsx';
+import AuditTable from 'components/audit_table';
 import LoadingScreen from 'components/loading_screen.jsx';
 
 export default class Audits extends React.PureComponent {

--- a/components/audit_table/index.js
+++ b/components/audit_table/index.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {getUser, getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {getChannelByName} from 'mattermost-redux/selectors/entities/channels';
+
+import AuditTable from './audit_table.jsx';
+
+function mapStateToProps(state) {
+    return {
+        currentUser: getCurrentUser(state),
+        getUser: (userId) => getUser(state, userId),
+        getByName: (channelName) => getChannelByName(state, channelName),
+    };
+}
+
+export default connect(mapStateToProps)(AuditTable);

--- a/tests/components/__snapshots__/access_history_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/access_history_modal.test.jsx.snap
@@ -49,7 +49,7 @@ exports[`components/AccessHistoryModal should match snapshot when audits exist 1
     bsClass="modal-body"
     componentClass="div"
   >
-    <InjectIntl(AuditTable)
+    <Connect(InjectIntl(AuditTable))
       audits={
         Array [
           "audit1",

--- a/tests/components/access_history_modal.test.jsx
+++ b/tests/components/access_history_modal.test.jsx
@@ -7,7 +7,7 @@ import $ from 'jquery';
 require('perfect-scrollbar/jquery')($);
 
 import AccessHistoryModal from 'components/access_history_modal/access_history_modal.jsx';
-import AuditTable from 'components/audit_table.jsx';
+import AuditTable from 'components/audit_table';
 import LoadingScreen from 'components/loading_screen.jsx';
 
 describe('components/AccessHistoryModal', () => {

--- a/tests/components/audit_table/__snapshots__/audit_table.test.jsx.snap
+++ b/tests/components/audit_table/__snapshots__/audit_table.test.jsx.snap
@@ -1,0 +1,508 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/audit_table/AuditTable should match snapshot with audits 1`] = `
+<InjectIntl(AuditTable)
+  audits={
+    Array [
+      Object {
+        "action": "/api/v4/channels",
+        "create_at": 50778112674,
+        "extra_info": "name=yeye",
+        "id": "id_2",
+        "ip_address": "::1",
+        "session_id": "hb8febm9ytdiz8zqaxj18efqhy",
+        "user_id": "user_id_1",
+      },
+      Object {
+        "action": "/api/v4/users/login",
+        "create_at": 51053522355,
+        "extra_info": "success",
+        "id": "id_1",
+        "ip_address": "::1",
+        "session_id": "",
+        "user_id": "user_id_1",
+      },
+    ]
+  }
+  currentUser={
+    Object {
+      "id": "test_user",
+    }
+  }
+  getByName={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "yeye",
+        ],
+      ],
+      "results": Array [
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  getUser={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "user_id_1",
+        ],
+        Array [
+          "user_id_1",
+        ],
+      ],
+      "results": Array [
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  showIp={true}
+  showSession={true}
+  showUserId={true}
+>
+  <AuditTable
+    audits={
+      Array [
+        Object {
+          "action": "/api/v4/channels",
+          "create_at": 50778112674,
+          "extra_info": "name=yeye",
+          "id": "id_2",
+          "ip_address": "::1",
+          "session_id": "hb8febm9ytdiz8zqaxj18efqhy",
+          "user_id": "user_id_1",
+        },
+        Object {
+          "action": "/api/v4/users/login",
+          "create_at": 51053522355,
+          "extra_info": "success",
+          "id": "id_1",
+          "ip_address": "::1",
+          "session_id": "",
+          "user_id": "user_id_1",
+        },
+      ]
+    }
+    currentUser={
+      Object {
+        "id": "test_user",
+      }
+    }
+    getByName={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "yeye",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      }
+    }
+    getUser={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "user_id_1",
+          ],
+          Array [
+            "user_id_1",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      }
+    }
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "textComponent": "span",
+      }
+    }
+    showIp={true}
+    showSession={true}
+    showUserId={true}
+  >
+    <table
+      className="table"
+    >
+      <thead>
+        <tr>
+          <th>
+            <FormattedMessage
+              defaultMessage="Timestamp"
+              id="audit_table.timestamp"
+              values={Object {}}
+            >
+              <span>
+                Timestamp
+              </span>
+            </FormattedMessage>
+          </th>
+          <th>
+            <FormattedMessage
+              defaultMessage="User ID"
+              id="audit_table.userId"
+              values={Object {}}
+            >
+              <span>
+                User ID
+              </span>
+            </FormattedMessage>
+          </th>
+          <th>
+            <FormattedMessage
+              defaultMessage="Action"
+              id="audit_table.action"
+              values={Object {}}
+            >
+              <span>
+                Action
+              </span>
+            </FormattedMessage>
+          </th>
+          <th>
+            <FormattedMessage
+              defaultMessage="IP Address"
+              id="audit_table.ip"
+              values={Object {}}
+            >
+              <span>
+                IP Address
+              </span>
+            </FormattedMessage>
+          </th>
+          <th>
+            <FormattedMessage
+              defaultMessage="Session ID"
+              id="audit_table.session"
+              values={Object {}}
+            >
+              <span>
+                Session ID
+              </span>
+            </FormattedMessage>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          key="id_2"
+        >
+          <td
+            className="whitespace--nowrap word-break--all"
+          >
+            <div>
+              <div>
+                <FormattedDate
+                  day="2-digit"
+                  month="short"
+                  value={1971-08-11T17:01:52.674Z}
+                  year="numeric"
+                >
+                  <span>
+                    Aug 11, 1971
+                  </span>
+                </FormattedDate>
+              </div>
+              <div>
+                <FormattedTime
+                  hour="2-digit"
+                  minute="2-digit"
+                  value={1971-08-11T17:01:52.674Z}
+                >
+                  <span>
+                    5:01 PM
+                  </span>
+                </FormattedTime>
+              </div>
+            </div>
+          </td>
+          <td
+            className="word-break--all"
+          >
+            user_id_1
+          </td>
+          <td
+            className="word-break--all"
+          >
+            Channels yeye
+          </td>
+          <td
+            className="whitespace--nowrap word-break--all"
+          >
+            ::1
+          </td>
+          <td
+            className="whitespace--nowrap word-break--all"
+          >
+            hb8febm9ytdiz8zqaxj18efqhy
+          </td>
+        </tr>
+        <tr
+          key="id_1"
+        >
+          <td
+            className="whitespace--nowrap word-break--all"
+          >
+            <div>
+              <div>
+                <FormattedDate
+                  day="2-digit"
+                  month="short"
+                  value={1971-08-14T21:32:02.355Z}
+                  year="numeric"
+                >
+                  <span>
+                    Aug 14, 1971
+                  </span>
+                </FormattedDate>
+              </div>
+              <div>
+                <FormattedTime
+                  hour="2-digit"
+                  minute="2-digit"
+                  value={1971-08-14T21:32:02.355Z}
+                >
+                  <span>
+                    9:32 PM
+                  </span>
+                </FormattedTime>
+              </div>
+            </div>
+          </td>
+          <td
+            className="word-break--all"
+          >
+            user_id_1
+          </td>
+          <td
+            className="word-break--all"
+          >
+            Successfully logged in
+          </td>
+          <td
+            className="whitespace--nowrap word-break--all"
+          >
+            ::1
+          </td>
+          <td
+            className="whitespace--nowrap word-break--all"
+          />
+        </tr>
+      </tbody>
+    </table>
+  </AuditTable>
+</InjectIntl(AuditTable)>
+`;
+
+exports[`components/audit_table/AuditTable should match snapshot with no audits 1`] = `
+<InjectIntl(AuditTable)
+  audits={Array []}
+  currentUser={
+    Object {
+      "id": "test_user",
+    }
+  }
+  getByName={[MockFunction]}
+  getUser={[MockFunction]}
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "textComponent": "span",
+    }
+  }
+  showIp={true}
+  showSession={true}
+  showUserId={true}
+>
+  <AuditTable
+    audits={Array []}
+    currentUser={
+      Object {
+        "id": "test_user",
+      }
+    }
+    getByName={[MockFunction]}
+    getUser={[MockFunction]}
+    intl={
+      Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
+        "formatDate": [Function],
+        "formatHTMLMessage": [Function],
+        "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "textComponent": "span",
+      }
+    }
+    showIp={true}
+    showSession={true}
+    showUserId={true}
+  >
+    <table
+      className="table"
+    >
+      <thead>
+        <tr>
+          <th>
+            <FormattedMessage
+              defaultMessage="Timestamp"
+              id="audit_table.timestamp"
+              values={Object {}}
+            >
+              <span>
+                Timestamp
+              </span>
+            </FormattedMessage>
+          </th>
+          <th>
+            <FormattedMessage
+              defaultMessage="User ID"
+              id="audit_table.userId"
+              values={Object {}}
+            >
+              <span>
+                User ID
+              </span>
+            </FormattedMessage>
+          </th>
+          <th>
+            <FormattedMessage
+              defaultMessage="Action"
+              id="audit_table.action"
+              values={Object {}}
+            >
+              <span>
+                Action
+              </span>
+            </FormattedMessage>
+          </th>
+          <th>
+            <FormattedMessage
+              defaultMessage="IP Address"
+              id="audit_table.ip"
+              values={Object {}}
+            >
+              <span>
+                IP Address
+              </span>
+            </FormattedMessage>
+          </th>
+          <th>
+            <FormattedMessage
+              defaultMessage="Session ID"
+              id="audit_table.session"
+              values={Object {}}
+            >
+              <span>
+                Session ID
+              </span>
+            </FormattedMessage>
+          </th>
+        </tr>
+      </thead>
+      <tbody />
+    </table>
+  </AuditTable>
+</InjectIntl(AuditTable)>
+`;

--- a/tests/components/audit_table/audit_table.test.jsx
+++ b/tests/components/audit_table/audit_table.test.jsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+import AuditTable from 'components/audit_table/audit_table.jsx';
+
+describe('components/audit_table/AuditTable', () => {
+    const baseProps = {
+        audits: [],
+        showUserId: true,
+        showIp: true,
+        showSession: true,
+        currentUser: {id: 'test_user'},
+        getUser: jest.fn(),
+        getByName: jest.fn(),
+    };
+
+    test('should match snapshot with no audits', () => {
+        const wrapper = mountWithIntl(
+            <AuditTable {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot with audits', () => {
+        const audits = [
+            {
+                action: '/api/v4/channels',
+                create_at: 50778112674,
+                extra_info: 'name=yeye',
+                id: 'id_2',
+                ip_address: '::1',
+                session_id: 'hb8febm9ytdiz8zqaxj18efqhy',
+                user_id: 'user_id_1',
+            },
+            {
+                action: '/api/v4/users/login',
+                create_at: 51053522355,
+                extra_info: 'success',
+                id: 'id_1',
+                ip_address: '::1',
+                session_id: '',
+                user_id: 'user_id_1',
+            },
+        ];
+
+        const props = {...baseProps, audits};
+        const wrapper = mountWithIntl(
+            <AuditTable {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
Changes necessary to make `audit_table.jsx` use redux and be pure. New tests have been added as well.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9090
https://mattermost.atlassian.net/browse/MM-11282

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has redux changes (https://github.com/mattermost/mattermost-redux/pull/628)