### PR TITLE
[MM-12024] Fix state of channel notification preference modal on hide/exit based from props

### DIFF
--- a/components/channel_notifications_modal/channel_notifications_modal.jsx
+++ b/components/channel_notifications_modal/channel_notifications_modal.jsx
@@ -38,20 +38,26 @@ export default class ChannelNotificationsModal extends React.Component {
         };
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        if (!Utils.areObjectsEqual(this.props.channelMember.notify_props, nextProps.channelMember.notify_props)) {
-            this.setState({
-                desktopNotifyLevel: nextProps.channelMember.notify_props.desktop,
-                markUnreadNotifyLevel: nextProps.channelMember.notify_props.mark_unread,
-                pushNotifyLevel: nextProps.channelMember.notify_props.push || NotificationLevels.DEFAULT,
-            });
+    componentDidUpdate(prevProps) {
+        if (!Utils.areObjectsEqual(this.props.channelMember.notify_props, prevProps.channelMember.notify_props)) {
+            this.setStateFromNotifyProps(this.props.channelMember.notify_props);
         }
+    }
+
+    setStateFromNotifyProps(notifyProps) {
+        this.setState({
+            desktopNotifyLevel: notifyProps.desktop,
+            markUnreadNotifyLevel: notifyProps.mark_unread,
+            pushNotifyLevel: notifyProps.push || NotificationLevels.DEFAULT,
+        });
     }
 
     handleOnHide = () => {
         this.setState({
             activeSection: NotificationSections.NONE,
         });
+
+        this.setStateFromNotifyProps(this.props.channelMember.notify_props);
 
         this.props.onHide();
     }

--- a/tests/components/channel_notifications_modal.test.jsx
+++ b/tests/components/channel_notifications_modal.test.jsx
@@ -45,10 +45,23 @@ describe('components/channel_notifications_modal/ChannelNotificationsModal', () 
             <ChannelNotificationsModal {...props}/>
         );
 
-        wrapper.setState({activeSection: NotificationSections.DESKTOP});
+        wrapper.setState({activeSection: NotificationSections.DESKTOP, desktopNotifyLevel: NotificationLevels.NONE});
         wrapper.instance().handleOnHide();
         expect(onHide).toHaveBeenCalledTimes(1);
         expect(wrapper.state('activeSection')).toEqual(NotificationSections.NONE);
+        expect(wrapper.state('desktopNotifyLevel')).toEqual(NotificationLevels.ALL);
+
+        wrapper.setState({activeSection: NotificationSections.MARK_UNREAD, markUnreadNotifyLevel: NotificationLevels.NONE});
+        wrapper.instance().handleOnHide();
+        expect(onHide).toHaveBeenCalledTimes(2);
+        expect(wrapper.state('activeSection')).toEqual(NotificationSections.NONE);
+        expect(wrapper.state('markUnreadNotifyLevel')).toEqual(NotificationLevels.ALL);
+
+        wrapper.setState({activeSection: NotificationSections.PUSH, pushNotifyLevel: NotificationLevels.NONE});
+        wrapper.instance().handleOnHide();
+        expect(onHide).toHaveBeenCalledTimes(3);
+        expect(wrapper.state('activeSection')).toEqual(NotificationSections.NONE);
+        expect(wrapper.state('pushNotifyLevel')).toEqual(NotificationLevels.DEFAULT);
     });
 
     test('should match state on updateSection', () => {
@@ -252,5 +265,31 @@ describe('components/channel_notifications_modal/ChannelNotificationsModal', () 
         instance.handleUpdatePushSection(NotificationSections.PUSH);
         expect(instance.updateSection).toHaveBeenCalledTimes(2);
         expect(instance.updateSection).toBeCalledWith(NotificationSections.PUSH);
+    });
+
+    test('should match state on setStateFromNotifyProps', () => {
+        const notifyProps = {
+            desktop: NotificationLevels.NONE,
+            mark_unread: NotificationLevels.NONE,
+            push: NotificationLevels.ALL,
+        };
+
+        const wrapper = shallow(
+            <ChannelNotificationsModal {...baseProps}/>
+        );
+
+        wrapper.instance().setStateFromNotifyProps(notifyProps);
+        expect(wrapper.state('desktopNotifyLevel')).toEqual(NotificationLevels.NONE);
+        expect(wrapper.state('markUnreadNotifyLevel')).toEqual(NotificationLevels.NONE);
+        expect(wrapper.state('pushNotifyLevel')).toEqual(NotificationLevels.ALL);
+
+        wrapper.instance().setStateFromNotifyProps({...notifyProps, desktop: NotificationLevels.ALL});
+        expect(wrapper.state('desktopNotifyLevel')).toEqual(NotificationLevels.ALL);
+
+        wrapper.instance().setStateFromNotifyProps({...notifyProps, mark_unread: NotificationLevels.ALL});
+        expect(wrapper.state('markUnreadNotifyLevel')).toEqual(NotificationLevels.ALL);
+
+        wrapper.instance().setStateFromNotifyProps({...notifyProps, push: NotificationLevels.NONE});
+        expect(wrapper.state('pushNotifyLevel')).toEqual(NotificationLevels.NONE);
     });
 });


### PR DESCRIPTION
#### Summary
Fix state of channel notification preference modal on hide/exit based from props

#### Ticket Link
Jira ticket: [MM-12024](https://mattermost.atlassian.net/browse/MM-12024)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
