### PR TITLE
MM-11812 Improve positioning of emoji picker

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -17,10 +17,13 @@ import EmojiPickerPreview from './components/emoji_picker_preview';
 
 const CATEGORY_SEARCH_RESULTS = 'searchResults';
 const EMOJI_HEIGHT = 27;
+
+// If this changes, the spaceRequiredAbove and spaceRequiredBelow props passed to the EmojiPickerOverlay must be updated
 const EMOJI_CONTAINER_HEIGHT = 290;
 const EMOJI_CONTAINER_STYLE = {
     height: EMOJI_CONTAINER_HEIGHT,
 };
+
 const EMOJI_LAZY_LOAD_BUFFER = 75;
 const EMOJI_PER_ROW = 9;
 const EMOJI_TO_LOAD_PER_UPDATE = 135;

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -109,11 +109,7 @@ const LOAD_MORE_AT_PIXELS_FROM_BOTTOM = 500;
 
 export default class EmojiPicker extends React.PureComponent {
     static propTypes = {
-        style: PropTypes.object,
-        rightOffset: PropTypes.number,
-        topOffset: PropTypes.number,
         listHeight: PropTypes.number,
-        placement: PropTypes.oneOf(['top', 'bottom', 'left']),
         onEmojiClick: PropTypes.func.isRequired,
         customEmojisEnabled: PropTypes.bool,
         emojiMap: PropTypes.object.isRequired,
@@ -127,8 +123,6 @@ export default class EmojiPicker extends React.PureComponent {
 
     static defaultProps = {
         listHeight: 245,
-        rightOffset: 0,
-        topOffset: 0,
         customEmojiPage: 0,
         customEmojisEnabled: false,
     };
@@ -572,26 +566,8 @@ export default class EmojiPicker extends React.PureComponent {
     }
 
     render() {
-        let pickerStyle;
-        if (this.props.style && !(this.props.style.left === 0 || this.props.style.top === 0)) {
-            if (this.props.placement === 'top' || this.props.placement === 'bottom') {
-                // Only take the top/bottom position passed by React Bootstrap since we want to be right-aligned
-                pickerStyle = {
-                    top: this.props.style.top,
-                    bottom: this.props.style.bottom,
-                    right: this.props.rightOffset,
-                };
-            } else {
-                pickerStyle = {...this.props.style};
-            }
-        }
-        if (pickerStyle && pickerStyle.top) {
-            pickerStyle.top += this.props.topOffset;
-        }
         return (
-            <div
-                style={pickerStyle}
-            >
+            <div>
                 {this.emojiSearch()}
                 {this.emojiCategories()}
                 {this.emojiCurrentResults()}

--- a/components/emoji_picker/emoji_picker_overlay.jsx
+++ b/components/emoji_picker/emoji_picker_overlay.jsx
@@ -8,6 +8,16 @@ import {Overlay} from 'react-bootstrap';
 import EmojiPickerTabs from './emoji_picker_tabs.jsx';
 
 export default class EmojiPickerOverlay extends React.PureComponent {
+    // An emoji picker in the center channel is contained within the post list, so it needs space
+    // above for the channel header and below for the post textbox
+    static CENTER_SPACE_REQUIRED_ABOVE = 476;
+    static CENTER_SPACE_REQUIRED_BELOW = 497;
+
+    // An emoji picker in the RHS isn't constrained by the RHS, so it just needs space to fit
+    // the emoji picker itself
+    static RHS_SPACE_REQUIRED_ABOVE = 420;
+    static RHS_SPACE_REQUIRED_BELOW = 420;
+
     static propTypes = {
         show: PropTypes.bool.isRequired,
         container: PropTypes.func,
@@ -20,14 +30,14 @@ export default class EmojiPickerOverlay extends React.PureComponent {
         spaceRequiredAbove: PropTypes.number,
         spaceRequiredBelow: PropTypes.number,
         enableGifPicker: PropTypes.bool,
-    }
+    };
 
     // Reasonable defaults calculated from from the center channel
     static defaultProps = {
-        spaceRequiredAbove: 422,
-        spaceRequiredBelow: 436,
+        spaceRequiredAbove: EmojiPickerOverlay.CENTER_SPACE_REQUIRED_ABOVE,
+        spaceRequiredBelow: EmojiPickerOverlay.CENTER_SPACE_REQUIRED_BELOW,
         enableGifPicker: false,
-    }
+    };
 
     constructor(props) {
         super(props);

--- a/components/emoji_picker/emoji_picker_tabs.jsx
+++ b/components/emoji_picker/emoji_picker_tabs.jsx
@@ -68,9 +68,6 @@ export default class EmojiPickerTabs extends PureComponent {
                         <EmojiPicker
                             style={this.props.style}
                             onEmojiClick={this.props.onEmojiClick}
-                            rightOffset={this.props.rightOffset}
-                            topOffset={this.props.topOffset}
-                            placement={this.props.placement}
                             customEmojis={this.props.customEmojis}
                         />
                     </Tab>
@@ -82,8 +79,6 @@ export default class EmojiPickerTabs extends PureComponent {
                     >
                         <GifPicker
                             onGifClick={this.props.onGifClick}
-                            rightOffset={this.props.rightOffset}
-                            topOffset={this.props.topOffset}
                         />
                     </Tab>
                 </Tabs>
@@ -97,9 +92,6 @@ export default class EmojiPickerTabs extends PureComponent {
                 <EmojiPicker
                     style={this.props.style}
                     onEmojiClick={this.props.onEmojiClick}
-                    rightOffset={this.props.rightOffset}
-                    topOffset={this.props.topOffset}
-                    placement={this.props.placement}
                     customEmojis={this.props.customEmojis}
                 />
             </div>

--- a/components/emoji_picker/emoji_picker_tabs.jsx
+++ b/components/emoji_picker/emoji_picker_tabs.jsx
@@ -30,7 +30,7 @@ export default class EmojiPickerTabs extends PureComponent {
 
     render() {
         let pickerStyle;
-        if (this.props.style && !(this.props.style.left === 0 || this.props.style.top === 0)) {
+        if (this.props.style && !(this.props.style.left === 0 && this.props.style.top === 0)) {
             if (this.props.placement === 'top' || this.props.placement === 'bottom') {
                 // Only take the top/bottom position passed by React Bootstrap since we want to be right-aligned
                 pickerStyle = {
@@ -41,10 +41,10 @@ export default class EmojiPickerTabs extends PureComponent {
             } else {
                 pickerStyle = {...this.props.style};
             }
-        }
 
-        if (pickerStyle && pickerStyle.top) {
-            pickerStyle.top += this.props.topOffset;
+            if (pickerStyle.top) {
+                pickerStyle.top += this.props.topOffset;
+            }
         }
 
         let pickerClass = 'emoji-picker';

--- a/components/gif_picker/gif_picker.jsx
+++ b/components/gif_picker/gif_picker.jsx
@@ -28,17 +28,8 @@ export const appProps = {
 
 export default class GifPicker extends React.Component {
     static propTypes = {
-        style: PropTypes.object,
-        rightOffset: PropTypes.number,
-        topOffset: PropTypes.number,
-        placement: PropTypes.oneOf(['top', 'bottom', 'left']),
         onGifClick: PropTypes.func.isRequired,
     }
-
-    static defaultProps = {
-        rightOffset: 0,
-        topOffset: 0,
-    };
 
     constructor(props) {
         super(props);

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -341,8 +341,8 @@ export default class RhsComment extends React.Component {
                             target={this.getDotMenuRef}
                             onEmojiClick={this.reactEmojiClick}
                             rightOffset={15}
-                            spaceRequiredAbove={342}
-                            spaceRequiredBelow={342}
+                            spaceRequiredAbove={EmojiPickerOverlay.RHS_SPACE_REQUIRED_ABOVE}
+                            spaceRequiredBelow={EmojiPickerOverlay.RHS_SPACE_REQUIRED_BELOW}
                         />
                         <button
                             className='reacticon__container reaction color--link style--none'

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -229,8 +229,8 @@ export default class RhsRootPost extends React.Component {
                             target={this.getDotMenuRef}
                             onEmojiClick={this.reactEmojiClick}
                             rightOffset={15}
-                            spaceRequiredAbove={342}
-                            spaceRequiredBelow={342}
+                            spaceRequiredAbove={EmojiPickerOverlay.RHS_SPACE_REQUIRED_ABOVE}
+                            spaceRequiredBelow={EmojiPickerOverlay.RHS_SPACE_REQUIRED_BELOW}
                         />
                         <button
                             className='reacticon__container reaction color--link style--none'

--- a/tests/components/__snapshots__/edit_post_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/edit_post_modal.test.jsx.snap
@@ -85,8 +85,8 @@ exports[`components/EditPostModal should match with default config 1`] = `
           onHide={[Function]}
           rightOffset={50}
           show={false}
-          spaceRequiredAbove={422}
-          spaceRequiredBelow={436}
+          spaceRequiredAbove={476}
+          spaceRequiredBelow={497}
           target={[Function]}
           topOffset={-20}
         />
@@ -323,8 +323,8 @@ exports[`components/EditPostModal should show emojis on emojis click 1`] = `
           onHide={[Function]}
           rightOffset={50}
           show={true}
-          spaceRequiredAbove={422}
-          spaceRequiredBelow={436}
+          spaceRequiredAbove={476}
+          spaceRequiredBelow={497}
           target={[Function]}
           topOffset={-20}
         />
@@ -453,8 +453,8 @@ exports[`components/EditPostModal should show errors when it is set in the state
           onHide={[Function]}
           rightOffset={50}
           show={false}
-          spaceRequiredAbove={422}
-          spaceRequiredBelow={436}
+          spaceRequiredAbove={476}
+          spaceRequiredBelow={497}
           target={[Function]}
           topOffset={-20}
         />

--- a/tests/components/create_comment/__snapshots__/create_comment.test.jsx.snap
+++ b/tests/components/create_comment/__snapshots__/create_comment.test.jsx.snap
@@ -146,8 +146,8 @@ exports[`components/CreateComment should match snapshot, comment with message 1`
               onHide={[Function]}
               rightOffset={15}
               show={false}
-              spaceRequiredAbove={422}
-              spaceRequiredBelow={436}
+              spaceRequiredAbove={476}
+              spaceRequiredBelow={497}
               target={[Function]}
               topOffset={55}
             />
@@ -380,8 +380,8 @@ exports[`components/CreateComment should match snapshot, empty comment 1`] = `
               onHide={[Function]}
               rightOffset={15}
               show={false}
-              spaceRequiredAbove={422}
-              spaceRequiredBelow={436}
+              spaceRequiredAbove={476}
+              spaceRequiredBelow={497}
               target={[Function]}
               topOffset={55}
             />
@@ -502,8 +502,8 @@ exports[`components/CreateComment should match snapshot, non-empty message and u
               onHide={[Function]}
               rightOffset={15}
               show={false}
-              spaceRequiredAbove={422}
-              spaceRequiredBelow={436}
+              spaceRequiredAbove={476}
+              spaceRequiredBelow={497}
               target={[Function]}
               topOffset={55}
             />

--- a/tests/components/create_post/__snapshots__/create_post.test.jsx.snap
+++ b/tests/components/create_post/__snapshots__/create_post.test.jsx.snap
@@ -55,8 +55,8 @@ exports[`components/create_post Show tutorial 1`] = `
               onHide={[Function]}
               rightOffset={15}
               show={false}
-              spaceRequiredAbove={422}
-              spaceRequiredBelow={436}
+              spaceRequiredAbove={476}
+              spaceRequiredBelow={497}
               target={[Function]}
               topOffset={-7}
             />
@@ -199,8 +199,8 @@ exports[`components/create_post should match snapshot for center textbox 1`] = `
               onHide={[Function]}
               rightOffset={15}
               show={false}
-              spaceRequiredAbove={422}
-              spaceRequiredBelow={436}
+              spaceRequiredAbove={476}
+              spaceRequiredBelow={497}
               target={[Function]}
               topOffset={-7}
             />
@@ -423,8 +423,8 @@ exports[`components/create_post should match snapshot when file upload disabled 
               onHide={[Function]}
               rightOffset={15}
               show={false}
-              spaceRequiredAbove={422}
-              spaceRequiredBelow={436}
+              spaceRequiredAbove={476}
+              spaceRequiredBelow={497}
               target={[Function]}
               topOffset={-7}
             />
@@ -550,8 +550,8 @@ exports[`components/create_post should match snapshot, init 1`] = `
               onHide={[Function]}
               rightOffset={15}
               show={false}
-              spaceRequiredAbove={422}
-              spaceRequiredBelow={436}
+              spaceRequiredAbove={476}
+              spaceRequiredBelow={497}
               target={[Function]}
               topOffset={-7}
             />

--- a/tests/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
+++ b/tests/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
@@ -322,8 +322,8 @@ exports[`components/post_view/PostInfo toggleEmojiPicker, should have called pro
           onHide={[Function]}
           rightOffset={7}
           show={true}
-          spaceRequiredAbove={422}
-          spaceRequiredBelow={436}
+          spaceRequiredAbove={476}
+          spaceRequiredBelow={497}
           target={[Function]}
         />
         <button


### PR DESCRIPTION
This makes 3 main changes to improve the position of the emoji picker:
1. When the gif picker was added, some of the layout code was duplicated, causing some odd issues like larger-than-intended margins between the picker and the component that controlled it due to having it ran in two different places.
2. Fixed a bug that's existed for a long time where the emoji picker would appear somewhere on the left side of the screen whenever react-bootstrap tried to position the picker along the top of the screen. This is the main fix for this issue and almost every other similar layout issue that we've had in the past.
3. The logic for positioning the emoji picker above or below the [...] menu in a post was updated since it relied on the height of the emoji picker which was changed at some point.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11812

#### Checklist
- Added or updated unit tests (required for all new features)
- Has UI changes