### PR TITLE
[MM-12054] Revert the missing footer--show CSS class

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -485,11 +485,17 @@
             }
 
             .modal-button-bar {
+                @include single-transition(opacity, .6s);
+                @include opacity(0);
                 overflow: hidden;
                 background-color: $black;
                 line-height: 40px;
                 max-width: 100%;
                 padding: 0 10px;
+
+                &.footer--show {
+                    @include opacity(1);
+                }
 
                 .image-links {
                     a,

--- a/sass/responsive/_tablet.scss
+++ b/sass/responsive/_tablet.scss
@@ -80,6 +80,7 @@
                 }
 
                 .modal-button-bar {
+                    @include opacity(1);
                     line-height: 30px;
                     padding: 5px 10px 5px 5px;
                     bottom: 20px;

--- a/tests/components/view_image_popover_bar.test.jsx
+++ b/tests/components/view_image_popover_bar.test.jsx
@@ -104,5 +104,14 @@ describe('components/view_image/popover_bar/PopoverBar', () => {
 
             expect(wrapper).toMatchSnapshot();
         });
+
+        test('should match CSS class on footer', () => {
+            const wrapper = shallow(<PopoverBar {...defaultProps}/>);
+            expect(wrapper.find('div').first().hasClass('modal-button-bar footer--show')).toEqual(true);
+
+            wrapper.setProps({show: false});
+            expect(wrapper.find('div').first().hasClass('modal-button-bar')).toEqual(true);
+            expect(wrapper.find('div').first().hasClass('modal-button-bar footer--show')).toEqual(false);
+        });
     });
 });


### PR DESCRIPTION
#### Summary
Revert the missing footer--show CSS class which was removed from https://github.com/mattermost/mattermost-webapp/pull/1646/files.

#### Ticket Link
Jira ticket: [MM-12054](https://mattermost.atlassian.net/browse/MM-12054)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
