### PR TITLE
Fix JS error on local dev when opening ViewImageModal

### DIFF
--- a/components/view_image/view_image.jsx
+++ b/components/view_image/view_image.jsx
@@ -302,10 +302,7 @@ export default class ViewImageModal extends React.PureComponent {
                 className='modal-image'
                 dialogClassName='modal-image'
             >
-                <Modal.Body
-                    modalClassName='modal-image__body'
-                    onClick={this.props.onModalDismissed}
-                >
+                <Modal.Body>
                     <div
                         className={'modal-image__wrapper'}
                         onClick={this.props.onModalDismissed}

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -439,16 +439,6 @@
                 width: 100%;
             }
 
-            .modal-image__body {
-                display: table-cell;
-                height: 100%;
-                overflow: visible;
-                padding: 0;
-                position: relative;
-                text-align: center;
-                vertical-align: middle;
-            }
-
             .image-control {
                 background: url('../images/prev.png') left no-repeat;
                 float: left;

--- a/tests/components/__snapshots__/view_image.test.jsx.snap
+++ b/tests/components/__snapshots__/view_image.test.jsx.snap
@@ -31,8 +31,6 @@ exports[`components/ViewImageModal should match snapshot for external file 1`] =
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -104,8 +102,6 @@ exports[`components/ViewImageModal should match snapshot on onModalShown and onM
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -201,8 +197,6 @@ exports[`components/ViewImageModal should match snapshot on onModalShown and onM
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -298,8 +292,6 @@ exports[`components/ViewImageModal should match snapshot, loaded 1`] = `
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -375,8 +367,6 @@ exports[`components/ViewImageModal should match snapshot, loaded and showing foo
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -452,8 +442,6 @@ exports[`components/ViewImageModal should match snapshot, loaded with .js file 1
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -529,8 +517,6 @@ exports[`components/ViewImageModal should match snapshot, loaded with .m4a file 
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -606,8 +592,6 @@ exports[`components/ViewImageModal should match snapshot, loaded with .mov file 
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -683,8 +667,6 @@ exports[`components/ViewImageModal should match snapshot, loaded with footer 1`]
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -780,8 +762,6 @@ exports[`components/ViewImageModal should match snapshot, loaded with image 1`] 
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -857,8 +837,6 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -954,8 +932,6 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -1051,8 +1027,6 @@ exports[`components/ViewImageModal should match snapshot, loaded with left and r
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -1148,8 +1122,6 @@ exports[`components/ViewImageModal should match snapshot, loaded with other file
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -1225,8 +1197,6 @@ exports[`components/ViewImageModal should match snapshot, loading 1`] = `
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"
@@ -1298,8 +1268,6 @@ exports[`components/ViewImageModal should match snapshot, modal not shown 1`] = 
   <ModalBody
     bsClass="modal-body"
     componentClass="div"
-    modalClassName="modal-image__body"
-    onClick={[MockFunction]}
   >
     <div
       className="modal-image__wrapper"


### PR DESCRIPTION
#### Summary
Fix JS error on local dev when opening ViewImageModal.

Have seen this while working on https://github.com/mattermost/mattermost-webapp/pull/1683 and I don't see any difference after removing such `modalClassName`.  The className `modal-image__wrapper` on div container seems to be enough for modal body.

![screen shot 2018-09-11 at 5 35 06 pm](https://user-images.githubusercontent.com/5334504/45353487-7f27ee00-b5ed-11e8-9d2d-b5e3d21f67cf.png)

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed

