### PR TITLE
MM-11502 Switch focus to post textbox immediately when hiding channel switcher

### DIFF
--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -58,7 +58,6 @@ export default class QuickSwitchModal extends React.PureComponent {
         this.onChange = this.onChange.bind(this);
         this.onShow = this.onShow.bind(this);
         this.onHide = this.onHide.bind(this);
-        this.onExited = this.onExited.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
         this.switchToChannel = this.switchToChannel.bind(this);
@@ -108,13 +107,14 @@ export default class QuickSwitchModal extends React.PureComponent {
     }
 
     onHide() {
+        this.focusPostTextbox();
         this.setState({
             text: '',
         });
         this.props.onHide();
     }
 
-    onExited() {
+    focusPostTextbox = () => {
         if (!UserAgent.isMobile()) {
             setTimeout(() => {
                 const textbox = document.querySelector('#post_textbox');
@@ -312,7 +312,7 @@ export default class QuickSwitchModal extends React.PureComponent {
                 ref='modal'
                 show={this.props.show}
                 onHide={this.onHide}
-                onExited={this.onExited}
+                enforceFocus={false}
             >
                 <Modal.Header closeButton={true}/>
                 <Modal.Body>

--- a/tests/components/__snapshots__/quick_switch_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/quick_switch_modal.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`components/QuickSwitchModal should match snapshot 1`] = `
   bsClass="modal"
   dialogClassName="channel-switch-modal modal--overflow"
   dialogComponentClass={[Function]}
-  enforceFocus={true}
+  enforceFocus={false}
   keyboard={true}
   manager={
     ModalManager {
@@ -22,7 +22,6 @@ exports[`components/QuickSwitchModal should match snapshot 1`] = `
       "remove": [Function],
     }
   }
-  onExited={[Function]}
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}


### PR DESCRIPTION
#### Summary
Moved the focus to get set even sooner after selecting a channel to switch to. Tested on Chrome, FF, desktop app.

QA if someone could try this out and confirm that it improves the experience that'd be great.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11502