### PR TITLE
MM-12020: Removing explicit action to close channel menu

### DIFF
--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -332,12 +332,6 @@ export default class Navbar extends React.Component {
         );
     }
 
-    hideHeaderOverlay = () => {
-        if (this.refs.headerOverlay) {
-            this.refs.headerOverlay.hide();
-        }
-    }
-
     renderEditChannelHeaderOption = (channel) => {
         if (!channel || !channel.id) {
             return null;
@@ -721,7 +715,6 @@ export default class Navbar extends React.Component {
                             />
                             <div
                                 className='close visible-xs-block'
-                                onClick={this.hideHeaderOverlay}
                             >
                                 {'×'}
                             </div>

--- a/tests/components/navbar/__snapshots__/navbar.test.jsx.snap
+++ b/tests/components/navbar/__snapshots__/navbar.test.jsx.snap
@@ -298,7 +298,6 @@ exports[`components/navbar/Navbar should match snapshot, for default channel 1`]
               />
               <div
                 className="close visible-xs-block"
-                onClick={[Function]}
               >
                 ×
               </div>
@@ -760,7 +759,6 @@ exports[`components/navbar/Navbar should match snapshot, for private channel 1`]
               />
               <div
                 className="close visible-xs-block"
-                onClick={[Function]}
               >
                 ×
               </div>
@@ -1250,7 +1248,6 @@ exports[`components/navbar/Navbar should match snapshot, if WebRTC is not enable
               />
               <div
                 className="close visible-xs-block"
-                onClick={[Function]}
               >
                 ×
               </div>
@@ -1467,7 +1464,6 @@ exports[`components/navbar/Navbar should match snapshot, if enabled WebRTC and D
               />
               <div
                 className="close visible-xs-block"
-                onClick={[Function]}
               >
                 ×
               </div>
@@ -1959,7 +1955,6 @@ exports[`components/navbar/Navbar should match snapshot, if not licensed 1`] = `
               />
               <div
                 className="close visible-xs-block"
-                onClick={[Function]}
               >
                 ×
               </div>
@@ -2453,7 +2448,6 @@ exports[`components/navbar/Navbar should match snapshot, valid state 1`] = `
               />
               <div
                 className="close visible-xs-block"
-                onClick={[Function]}
               >
                 ×
               </div>


### PR DESCRIPTION
#### Summary
Removing explicit action to close channel menu. The menu "X" icon still
works because behave exactly like if you click anywhere any not-button
part of the menu.

Would be nice to test it in Iphone browser, and IE browser using mobile
mode.

#### Ticket Link
[MM-12020](https://mattermost.atlassian.net/browse/12020)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed