### PR TITLE
[MM-11658] Move hiding join/leave messages to TE

### DIFF
--- a/components/user_settings/advanced/index.js
+++ b/components/user_settings/advanced/index.js
@@ -2,23 +2,19 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import AdvancedSettingsDisplay from './user_settings_advanced.jsx';
 
 function mapStateToProps(state) {
     const config = getConfig(state);
-    const license = getLicense(state);
 
     const enablePreviewFeatures = config.EnablePreviewFeatures === 'true';
-    const buildEnterpriseReady = config.BuildEnterpriseReady === 'true';
-    const isLicensed = license && license.IsLicensed === 'true';
     const enableUserDeactivation = config.EnableUserDeactivation === 'true';
 
     return {
         enablePreviewFeatures,
-        buildEnterpriseReady,
-        isLicensed,
         enableUserDeactivation,
     };
 }

--- a/components/user_settings/advanced/join_leave_section/index.js
+++ b/components/user_settings/advanced/join_leave_section/index.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+
+import {savePreferences} from 'mattermost-redux/actions/preferences';
+import {Preferences} from 'mattermost-redux/constants';
+import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+import JoinLeaveSection from './join_leave_section.jsx';
+
+function mapStateToProps(state) {
+    const joinLeave = getPreference(
+        state,
+        Preferences.CATEGORY_ADVANCED_SETTINGS,
+        'join_leave',
+        'true'
+    );
+
+    return {
+        currentUserId: getCurrentUserId(state),
+        joinLeave,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            savePreferences,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(JoinLeaveSection);

--- a/components/user_settings/advanced/join_leave_section/index.js
+++ b/components/user_settings/advanced/join_leave_section/index.js
@@ -15,7 +15,7 @@ function mapStateToProps(state) {
     const joinLeave = getPreference(
         state,
         Preferences.CATEGORY_ADVANCED_SETTINGS,
-        'join_leave',
+        Preferences.ADVANCED_FILTER_JOIN_LEAVE,
         'true'
     );
 

--- a/components/user_settings/advanced/join_leave_section/join_leave_section.jsx
+++ b/components/user_settings/advanced/join_leave_section/join_leave_section.jsx
@@ -1,0 +1,130 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import {Preferences} from 'mattermost-redux/constants';
+
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min.jsx';
+
+import {AdvancedSections} from 'utils/constants.jsx';
+
+export default class JoinLeaveSection extends React.PureComponent {
+    static propTypes = {
+        activeSection: PropTypes.string,
+        currentUserId: PropTypes.string.isRequired,
+        joinLeave: PropTypes.string,
+        onUpdateSection: PropTypes.func.isRequired,
+        prevActiveSection: PropTypes.string,
+        renderOnOffLabel: PropTypes.func.isRequired,
+        actions: PropTypes.shape({
+            savePreferences: PropTypes.func.isRequired,
+        }).isRequired,
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            joinLeaveState: props.joinLeave,
+        };
+    }
+
+    handleOnChange = (e) => {
+        const value = e.currentTarget.value;
+
+        this.setState({joinLeaveState: value});
+    }
+
+    handleSubmit = () => {
+        const {actions, currentUserId, onUpdateSection} = this.props;
+        const joinLeavePreference = {category: Preferences.CATEGORY_ADVANCED_SETTINGS, user_id: currentUserId, name: 'join_leave', value: this.state.joinLeaveState};
+        actions.savePreferences(currentUserId, [joinLeavePreference]);
+
+        onUpdateSection();
+    }
+
+    render() {
+        const {joinLeaveState} = this.state;
+        if (this.props.activeSection === AdvancedSections.JOIN_LEAVE) {
+            return (
+                <SettingItemMax
+                    title={
+                        <FormattedMessage
+                            id='user.settings.advance.joinLeaveTitle'
+                            defaultMessage='Enable Join/Leave Messages'
+                        />
+                    }
+                    inputs={[
+                        <div key='joinLeaveSetting'>
+                            <div className='radio'>
+                                <label>
+                                    <input
+                                        id='joinLeaveOn'
+                                        type='radio'
+                                        value={'true'}
+                                        name={AdvancedSections.JOIN_LEAVE}
+                                        checked={joinLeaveState === 'true'}
+                                        onChange={this.handleOnChange}
+                                    />
+                                    <FormattedMessage
+                                        id='user.settings.advance.on'
+                                        defaultMessage='On'
+                                    />
+                                </label>
+                                <br/>
+                            </div>
+                            <div className='radio'>
+                                <label>
+                                    <input
+                                        id='joinLeaveOff'
+                                        type='radio'
+                                        value={'false'}
+                                        name={AdvancedSections.JOIN_LEAVE}
+                                        checked={joinLeaveState === 'false'}
+                                        onChange={this.handleOnChange}
+                                    />
+                                    <FormattedMessage
+                                        id='user.settings.advance.off'
+                                        defaultMessage='Off'
+                                    />
+                                </label>
+                                <br/>
+                            </div>
+                            <div>
+                                <br/>
+                                <FormattedMessage
+                                    id='user.settings.advance.joinLeaveDesc'
+                                    defaultMessage='When "On", System Messages saying a user has joined or left a channel will be visible. When "Off", the System Messages about joining or leaving a channel will be hidden. A message will still show up when you are added to a channel, so you can receive a notification.'
+                                />
+                            </div>
+                        </div>,
+                    ]}
+                    setting={AdvancedSections.JOIN_LEAVE}
+                    submit={this.handleSubmit}
+                    saving={this.state.isSaving}
+                    server_error={this.state.serverError}
+                    updateSection={this.props.onUpdateSection}
+                />
+            );
+        }
+
+        return (
+            <SettingItemMin
+                title={
+                    <FormattedMessage
+                        id='user.settings.advance.joinLeaveTitle'
+                        defaultMessage='Enable Join/Leave Messages'
+                    />
+                }
+                describe={this.props.renderOnOffLabel(joinLeaveState)}
+                focused={this.props.prevActiveSection === AdvancedSections.JOIN_LEAVE}
+                section={AdvancedSections.JOIN_LEAVE}
+                updateSection={this.props.onUpdateSection}
+            />
+        );
+    }
+}

--- a/components/user_settings/advanced/join_leave_section/join_leave_section.jsx
+++ b/components/user_settings/advanced/join_leave_section/join_leave_section.jsx
@@ -41,7 +41,7 @@ export default class JoinLeaveSection extends React.PureComponent {
 
     handleSubmit = () => {
         const {actions, currentUserId, onUpdateSection} = this.props;
-        const joinLeavePreference = {category: Preferences.CATEGORY_ADVANCED_SETTINGS, user_id: currentUserId, name: 'join_leave', value: this.state.joinLeaveState};
+        const joinLeavePreference = {category: Preferences.CATEGORY_ADVANCED_SETTINGS, user_id: currentUserId, name: Preferences.ADVANCED_FILTER_JOIN_LEAVE, value: this.state.joinLeaveState};
         actions.savePreferences(currentUserId, [joinLeavePreference]);
 
         onUpdateSection();

--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -13,7 +13,9 @@ import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min.jsx';
-import ConfirmModal from '../../confirm_modal.jsx';
+import ConfirmModal from 'components/confirm_modal.jsx';
+
+import JoinLeaveSection from './join_leave_section';
 
 const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
@@ -277,88 +279,6 @@ export default class AdvancedSettingsDisplay extends React.Component {
         );
     }
 
-    renderJoinLeaveSection = () => {
-        if (this.props.buildEnterpriseReady && this.props.isLicensed) {
-            if (this.props.activeSection === 'join_leave') {
-                return (
-                    <SettingItemMax
-                        title={
-                            <FormattedMessage
-                                id='user.settings.advance.joinLeaveTitle'
-                                defaultMessage='Enable Join/Leave Messages'
-                            />
-                        }
-                        inputs={[
-                            <div key='joinLeaveSetting'>
-                                <div className='radio'>
-                                    <label>
-                                        <input
-                                            id='joinLeaveOn'
-                                            type='radio'
-                                            name='join_leave'
-                                            checked={this.state.settings.join_leave !== 'false'}
-                                            onChange={this.updateSetting.bind(this, 'join_leave', 'true')}
-                                        />
-                                        <FormattedMessage
-                                            id='user.settings.advance.on'
-                                            defaultMessage='On'
-                                        />
-                                    </label>
-                                    <br/>
-                                </div>
-                                <div className='radio'>
-                                    <label>
-                                        <input
-                                            id='joinLeaveOff'
-                                            type='radio'
-                                            name='join_leave'
-                                            checked={this.state.settings.join_leave === 'false'}
-                                            onChange={this.updateSetting.bind(this, 'join_leave', 'false')}
-                                        />
-                                        <FormattedMessage
-                                            id='user.settings.advance.off'
-                                            defaultMessage='Off'
-                                        />
-                                    </label>
-                                    <br/>
-                                </div>
-                                <div>
-                                    <br/>
-                                    <FormattedMessage
-                                        id='user.settings.advance.joinLeaveDesc'
-                                        defaultMessage='When "On", System Messages saying a user has joined or left a channel will be visible. When "Off", the System Messages about joining or leaving a channel will be hidden. A message will still show up when you are added to a channel, so you can receive a notification.'
-                                    />
-                                </div>
-                            </div>,
-                        ]}
-                        setting={'join_leave'}
-                        submit={this.handleSubmit}
-                        saving={this.state.isSaving}
-                        server_error={this.state.serverError}
-                        updateSection={this.handleUpdateSection}
-                    />
-                );
-            }
-
-            return (
-                <SettingItemMin
-                    title={
-                        <FormattedMessage
-                            id='user.settings.advance.joinLeaveTitle'
-                            defaultMessage='Enable Join/Leave Messages'
-                        />
-                    }
-                    describe={this.renderOnOffLabel(this.state.settings.join_leave)}
-                    focused={this.props.prevActiveSection === this.prevSections.join_leave}
-                    section={'join_leave'}
-                    updateSection={this.handleUpdateSection}
-                />
-            );
-        }
-
-        return null;
-    }
-
     renderFeatureLabel(feature) {
         switch (feature) {
         case 'MARKDOWN_PREVIEW':
@@ -463,15 +383,6 @@ export default class AdvancedSettingsDisplay extends React.Component {
         let formattingSectionDivider = null;
         if (formattingSection) {
             formattingSectionDivider = <div className='divider-light'/>;
-        }
-
-        const displayJoinLeaveSection = this.renderJoinLeaveSection();
-        let displayJoinLeaveSectionDivider = null;
-        if (displayJoinLeaveSection) {
-            displayJoinLeaveSectionDivider = <div className='divider-light'/>;
-            this.prevSections.advancedPreviewFeatures = 'join_leave';
-        } else {
-            this.prevSections.advancedPreviewFeatures = this.prevSections.join_leave;
         }
 
         let previewFeaturesSection;
@@ -675,8 +586,13 @@ export default class AdvancedSettingsDisplay extends React.Component {
                     {ctrlSendSection}
                     {formattingSectionDivider}
                     {formattingSection}
-                    {displayJoinLeaveSectionDivider}
-                    {displayJoinLeaveSection}
+                    <div className='divider-light'/>
+                    <JoinLeaveSection
+                        activeSection={this.props.activeSection}
+                        onUpdateSection={this.handleUpdateSection}
+                        prevActiveSection={this.props.prevActiveSection}
+                        renderOnOffLabel={this.renderOnOffLabel}
+                    />
                     {previewFeaturesSectionDivider}
                     {previewFeaturesSection}
                     {formattingSectionDivider}
@@ -696,7 +612,5 @@ AdvancedSettingsDisplay.propTypes = {
     closeModal: PropTypes.func.isRequired,
     collapseModal: PropTypes.func.isRequired,
     enablePreviewFeatures: PropTypes.bool,
-    buildEnterpriseReady: PropTypes.bool,
-    isLicensed: PropTypes.bool,
     enableUserDeactivation: PropTypes.bool,
 };

--- a/tests/components/user_settings/advanced_tab/__snapshots__/join_leave_section.test.jsx.snap
+++ b/tests/components/user_settings/advanced_tab/__snapshots__/join_leave_section.test.jsx.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/user_settings/advanced/JoinLeaveSection should match snapshot 1`] = `
+<SettingItemMin
+  focused={false}
+  section="joinLeave"
+  title={
+    <FormattedMessage
+      defaultMessage="Enable Join/Leave Messages"
+      id="user.settings.advance.joinLeaveTitle"
+      values={Object {}}
+    />
+  }
+  updateSection={[MockFunction]}
+/>
+`;
+
+exports[`components/user_settings/advanced/JoinLeaveSection should match snapshot 2`] = `
+<SettingItemMax
+  containerStyle=""
+  infoPosition="bottom"
+  inputs={
+    Array [
+      <div>
+        <div
+          className="radio"
+        >
+          <label>
+            <input
+              checked={true}
+              id="joinLeaveOn"
+              name="joinLeave"
+              onChange={[Function]}
+              type="radio"
+              value="true"
+            />
+            <FormattedMessage
+              defaultMessage="On"
+              id="user.settings.advance.on"
+              values={Object {}}
+            />
+          </label>
+          <br />
+        </div>
+        <div
+          className="radio"
+        >
+          <label>
+            <input
+              checked={false}
+              id="joinLeaveOff"
+              name="joinLeave"
+              onChange={[Function]}
+              type="radio"
+              value="false"
+            />
+            <FormattedMessage
+              defaultMessage="Off"
+              id="user.settings.advance.off"
+              values={Object {}}
+            />
+          </label>
+          <br />
+        </div>
+        <div>
+          <br />
+          <FormattedMessage
+            defaultMessage="When \\"On\\", System Messages saying a user has joined or left a channel will be visible. When \\"Off\\", the System Messages about joining or leaving a channel will be hidden. A message will still show up when you are added to a channel, so you can receive a notification."
+            id="user.settings.advance.joinLeaveDesc"
+            values={Object {}}
+          />
+        </div>
+      </div>,
+    ]
+  }
+  saving={false}
+  section=""
+  setting="joinLeave"
+  submit={[Function]}
+  title={
+    <FormattedMessage
+      defaultMessage="Enable Join/Leave Messages"
+      id="user.settings.advance.joinLeaveTitle"
+      values={Object {}}
+    />
+  }
+  updateSection={[MockFunction]}
+/>
+`;

--- a/tests/components/user_settings/advanced_tab/join_leave_section.test.jsx
+++ b/tests/components/user_settings/advanced_tab/join_leave_section.test.jsx
@@ -1,0 +1,86 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {AdvancedSections} from 'utils/constants.jsx';
+
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min.jsx';
+
+import JoinLeaveSection from 'components/user_settings/advanced/join_leave_section/join_leave_section.jsx';
+
+describe('components/user_settings/advanced/JoinLeaveSection', () => {
+    const defaultProps = {
+        activeSection: '',
+        currentUserId: 'current_user_id',
+        joinLeave: 'true',
+        onUpdateSection: jest.fn(),
+        prevActiveSection: AdvancedSections.FORMATTING,
+        renderOnOffLabel: jest.fn(),
+        actions: {
+            savePreferences: jest.fn(),
+        },
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <JoinLeaveSection {...defaultProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(SettingItemMax).exists()).toEqual(false);
+        expect(wrapper.find(SettingItemMin).exists()).toEqual(true);
+
+        wrapper.setProps({activeSection: AdvancedSections.JOIN_LEAVE});
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(SettingItemMax).exists()).toEqual(true);
+        expect(wrapper.find(SettingItemMin).exists()).toEqual(false);
+    });
+
+    test('should match state on handleOnChange', () => {
+        const wrapper = shallow(
+            <JoinLeaveSection {...defaultProps}/>
+        );
+
+        let value = 'false';
+        wrapper.setState({joinLeaveState: 'true'});
+        wrapper.instance().handleOnChange({currentTarget: {value}});
+        expect(wrapper.state('joinLeaveState')).toEqual(value);
+
+        value = 'true';
+        wrapper.instance().handleOnChange({currentTarget: {value}});
+        expect(wrapper.state('joinLeaveState')).toEqual(value);
+    });
+
+    test('should call props.actions.savePreferences and props.onUpdateSection on handleSubmit', () => {
+        const actions = {savePreferences: jest.fn()};
+        const onUpdateSection = jest.fn();
+        const wrapper = shallow(
+            <JoinLeaveSection
+                {...defaultProps}
+                actions={actions}
+                onUpdateSection={onUpdateSection}
+            />
+        );
+
+        const joinLeavePreference = {
+            category: 'advanced_settings',
+            name: 'join_leave',
+            user_id: 'current_user_id',
+            value: 'true',
+        };
+
+        wrapper.instance().handleSubmit();
+        expect(actions.savePreferences).toHaveBeenCalledTimes(1);
+        expect(actions.savePreferences).toHaveBeenCalledWith('current_user_id', [joinLeavePreference]);
+        expect(onUpdateSection).toHaveBeenCalledTimes(1);
+
+        wrapper.setState({joinLeaveState: 'false'});
+        joinLeavePreference.value = 'false';
+        wrapper.instance().handleSubmit();
+        expect(actions.savePreferences).toHaveBeenCalledTimes(2);
+        expect(actions.savePreferences).toHaveBeenCalledWith('current_user_id', [joinLeavePreference]);
+    });
+});

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -504,6 +504,13 @@ export const NotificationSections = {
     NONE: '',
 };
 
+export const AdvancedSections = {
+    CONTROL_SEND: 'advancedCtrlSend',
+    FORMATTING: 'formatting',
+    JOIN_LEAVE: 'joinLeave',
+    PREVIEW_FEATURES: 'advancedPreviewFeatures',
+};
+
 export const RHSStates = {
     MENTION: 'mention',
     SEARCH: 'search',


### PR DESCRIPTION
#### Summary
Move hiding join/leave messages to TE
- remove licensed and EE build check
- add JoinLeaveSection component. (I should submit this to separate PR but it's hard to break it since `AdvancedSettingsDisplay` is not a pure component and is hard to provide necessary tests.)

Note: I'll create separate ticket to refactor the `AdvancedSettingsDisplay` component following this pattern. [UPDATE] --> https://mattermost.atlassian.net/browse/MM-12155

#### Ticket Link
Jira ticket: [MM-11658](https://mattermost.atlassian.net/browse/MM-11658)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
