### PR TITLE
Fix TypeError of handleMaxUploadReached()

### DIFF
--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -469,14 +469,14 @@ export default class FileUpload extends PureComponent {
         this.setState({menuOpen: open});
     }
 
-    handleLocalFileUploaded = () => {
+    handleLocalFileUploaded = (e) => {
         const uploadsRemaining = Constants.MAX_UPLOAD_FILES - this.props.fileCount;
         if (uploadsRemaining > 0) {
             if (this.props.onClick) {
                 this.props.onClick();
             }
         } else {
-            this.handleMaxUploadReached();
+            this.handleMaxUploadReached(e);
         }
         this.setState({menuOpen: false});
     }


### PR DESCRIPTION
#### Summary
When handleMaxUploadReached() is called from handleLocalFileUploaded(),
event is not passed so e.preventDefault() triggers a TypeError resulting not to invoke onUploadError().
So fix to pass an event argument simply :)

I found it from:
https://deepscan.io/dashboard/#view=project&pid=3171&bid=26245&subview=issues&status=%5B%22fixed%22%5D

#### Ticket Link
N/A

#### Checklist
- [ ] Ran `make test` to ensure unit and component tests passed