### PR TITLE
[MM-11856] Revert unit test of Sidebar by setting empty string to href whenever the favicon is not of type string

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -205,9 +205,9 @@ export default class Sidebar extends React.PureComponent {
             link.rel = 'shortcut icon';
             link.id = 'favicon';
             if (this.badgesActive) {
-                link.href = redFavicon;
+                link.href = typeof redFavicon === 'string' ? redFavicon : '';
             } else {
-                link.href = favicon;
+                link.href = typeof favicon === 'string' ? favicon : '';
             }
             var head = document.getElementsByTagName('head')[0];
             var oldLink = document.getElementById('favicon');

--- a/tests/components/sidebar/__snapshots__/sidebar.test.jsx.snap
+++ b/tests/components/sidebar/__snapshots__/sidebar.test.jsx.snap
@@ -1,0 +1,3192 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot, on sidebar show 1`] = `
+<div
+  className="sidebar--left"
+  id="sidebar-left"
+  key="sidebar-left"
+>
+  <NewChannelFlow
+    channelType=""
+    onModalDismissed={[Function]}
+    show={false}
+  />
+  <Connect(SidebarHeader)
+    currentUser={
+      Object {
+        "id": "my-user-id",
+      }
+    }
+    teamDescription="Test team description"
+    teamDisplayName="Test team display name"
+    teamId="team_id"
+    teamName="test-team"
+    teamType="team-type"
+  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <Scrollbars
+      autoHeight={false}
+      autoHeightMax={200}
+      autoHeightMin={0}
+      autoHide={true}
+      autoHideDuration={500}
+      autoHideTimeout={500}
+      hideTracksWhenNotNeeded={false}
+      onScroll={[Function]}
+      renderThumbHorizontal={[Function]}
+      renderThumbVertical={[Function]}
+      renderTrackHorizontal={[Function]}
+      renderTrackVertical={[Function]}
+      renderView={[Function]}
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }
+      tagName="div"
+      thumbMinSize={30}
+      universal={false}
+    >
+      <div
+        className="nav-pills__container"
+        id="sidebarChannelContainer"
+      >
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="publicChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PUBLIC CHANNELS"
+                id="sidebar.channels"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_public_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-channel-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new public channel"
+                        id="sidebar.createChannel"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPublicChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={true}
+            channelId="c1"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c1"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c2"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c2"
+          />
+          <li>
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="sidebarChannelsMore"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="privateChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PRIVATE CHANNELS"
+                id="sidebar.pg"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_private_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-group-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new private channel"
+                        id="sidebar.createGroup"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPrivateChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c4"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c4"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="directChannel"
+            >
+              <FormattedMessage
+                defaultMessage="DIRECT MESSAGES"
+                id="sidebar.direct"
+                values={Object {}}
+              />
+              <OverlayTrigger
+                className="hidden-xs"
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    className="hidden-xs"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new direct message"
+                      id="sidebar.createDirectMessage"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c6"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c6"
+          />
+          <li
+            key="more"
+          >
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="moreDirectMessage"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+      </div>
+    </Scrollbars>
+  </div>
+  <div
+    className="sidebar__switcher"
+  >
+    <button
+      className="btn btn-link"
+      id="sidebarSwitcherButton"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Switch Channels"
+        id="channel_switch_modal.title"
+        values={Object {}}
+      />
+      <span
+        className="switch__shortcut hidden-xs"
+      >
+        <FormattedMessage
+          defaultMessage="- CTRL+K"
+          id="quick_switch_modal.channelsShortcut.windows"
+          values={Object {}}
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot, on sidebar show with favorites 1`] = `
+<div
+  className="sidebar--left"
+  id="sidebar-left"
+  key="sidebar-left"
+>
+  <NewChannelFlow
+    channelType=""
+    onModalDismissed={[Function]}
+    show={false}
+  />
+  <Connect(SidebarHeader)
+    currentUser={
+      Object {
+        "id": "my-user-id",
+      }
+    }
+    teamDescription="Test team description"
+    teamDisplayName="Test team display name"
+    teamId="team_id"
+    teamName="test-team"
+    teamType="team-type"
+  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <Scrollbars
+      autoHeight={false}
+      autoHeightMax={200}
+      autoHeightMin={0}
+      autoHide={true}
+      autoHideDuration={500}
+      autoHideTimeout={500}
+      hideTracksWhenNotNeeded={false}
+      onScroll={[Function]}
+      renderThumbHorizontal={[Function]}
+      renderThumbVertical={[Function]}
+      renderTrackHorizontal={[Function]}
+      renderTrackVertical={[Function]}
+      renderView={[Function]}
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }
+      tagName="div"
+      thumbMinSize={30}
+      universal={false}
+    >
+      <div
+        className="nav-pills__container"
+        id="sidebarChannelContainer"
+      >
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="favoriteChannel"
+            >
+              <FormattedMessage
+                defaultMessage="FAVORITE CHANNELS"
+                id="sidebar.favorite"
+                values={Object {}}
+              />
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={true}
+            channelId="c1"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c1"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="publicChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PUBLIC CHANNELS"
+                id="sidebar.channels"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_public_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-channel-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new public channel"
+                        id="sidebar.createChannel"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPublicChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={true}
+            channelId="c1"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c1"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c2"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c2"
+          />
+          <li>
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="sidebarChannelsMore"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="privateChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PRIVATE CHANNELS"
+                id="sidebar.pg"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_private_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-group-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new private channel"
+                        id="sidebar.createGroup"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPrivateChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c4"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c4"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="directChannel"
+            >
+              <FormattedMessage
+                defaultMessage="DIRECT MESSAGES"
+                id="sidebar.direct"
+                values={Object {}}
+              />
+              <OverlayTrigger
+                className="hidden-xs"
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    className="hidden-xs"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new direct message"
+                      id="sidebar.createDirectMessage"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c6"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c6"
+          />
+          <li
+            key="more"
+          >
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="moreDirectMessage"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+      </div>
+    </Scrollbars>
+  </div>
+  <div
+    className="sidebar__switcher"
+  >
+    <button
+      className="btn btn-link"
+      id="sidebarSwitcherButton"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Switch Channels"
+        id="channel_switch_modal.title"
+        values={Object {}}
+      />
+      <span
+        className="switch__shortcut hidden-xs"
+      >
+        <FormattedMessage
+          defaultMessage="- CTRL+K"
+          id="quick_switch_modal.channelsShortcut.windows"
+          values={Object {}}
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot, on sidebar show with unreads 1`] = `
+<div
+  className="sidebar--left"
+  id="sidebar-left"
+  key="sidebar-left"
+>
+  <NewChannelFlow
+    channelType=""
+    onModalDismissed={[Function]}
+    show={false}
+  />
+  <Connect(SidebarHeader)
+    currentUser={
+      Object {
+        "id": "my-user-id",
+      }
+    }
+    teamDescription="Test team description"
+    teamDisplayName="Test team display name"
+    teamId="team_id"
+    teamName="test-team"
+    teamType="team-type"
+  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <Scrollbars
+      autoHeight={false}
+      autoHeightMax={200}
+      autoHeightMin={0}
+      autoHide={true}
+      autoHideDuration={500}
+      autoHideTimeout={500}
+      hideTracksWhenNotNeeded={false}
+      onScroll={[Function]}
+      renderThumbHorizontal={[Function]}
+      renderThumbVertical={[Function]}
+      renderTrackHorizontal={[Function]}
+      renderTrackVertical={[Function]}
+      renderView={[Function]}
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }
+      tagName="div"
+      thumbMinSize={30}
+      universal={false}
+    >
+      <div
+        className="nav-pills__container"
+        id="sidebarChannelContainer"
+      >
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="favoriteChannel"
+            >
+              <FormattedMessage
+                defaultMessage="UNREADS"
+                id="sidebar.unreadSection"
+                values={Object {}}
+              />
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="publicChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PUBLIC CHANNELS"
+                id="sidebar.channels"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_public_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-channel-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new public channel"
+                        id="sidebar.createChannel"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPublicChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={true}
+            channelId="c1"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c1"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c2"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c2"
+          />
+          <li>
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="sidebarChannelsMore"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="privateChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PRIVATE CHANNELS"
+                id="sidebar.pg"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_private_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-group-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new private channel"
+                        id="sidebar.createGroup"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPrivateChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c4"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c4"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="directChannel"
+            >
+              <FormattedMessage
+                defaultMessage="DIRECT MESSAGES"
+                id="sidebar.direct"
+                values={Object {}}
+              />
+              <OverlayTrigger
+                className="hidden-xs"
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    className="hidden-xs"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new direct message"
+                      id="sidebar.createDirectMessage"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c6"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c6"
+          />
+          <li
+            key="more"
+          >
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="moreDirectMessage"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+      </div>
+    </Scrollbars>
+  </div>
+  <div
+    className="sidebar__switcher"
+  >
+    <button
+      className="btn btn-link"
+      id="sidebarSwitcherButton"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Switch Channels"
+        id="channel_switch_modal.title"
+        values={Object {}}
+      />
+      <span
+        className="switch__shortcut hidden-xs"
+      >
+        <FormattedMessage
+          defaultMessage="- CTRL+K"
+          id="quick_switch_modal.channelsShortcut.windows"
+          values={Object {}}
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot, when render as an empty div because no have a team or a user 1`] = `<div />`;
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot, when render as an empty div because no have a team or a user 2`] = `<div />`;
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide correctly more channels modal 1`] = `
+<div
+  className="sidebar--left"
+  id="sidebar-left"
+  key="sidebar-left"
+>
+  <NewChannelFlow
+    channelType=""
+    onModalDismissed={[Function]}
+    show={false}
+  />
+  <Connect(MoreChannels)
+    handleNewChannel={[Function]}
+    onModalDismissed={[Function]}
+  />
+  <Connect(SidebarHeader)
+    currentUser={
+      Object {
+        "id": "my-user-id",
+      }
+    }
+    teamDescription="Test team description"
+    teamDisplayName="Test team display name"
+    teamId="team_id"
+    teamName="test-team"
+    teamType="team-type"
+  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <Scrollbars
+      autoHeight={false}
+      autoHeightMax={200}
+      autoHeightMin={0}
+      autoHide={true}
+      autoHideDuration={500}
+      autoHideTimeout={500}
+      hideTracksWhenNotNeeded={false}
+      onScroll={[Function]}
+      renderThumbHorizontal={[Function]}
+      renderThumbVertical={[Function]}
+      renderTrackHorizontal={[Function]}
+      renderTrackVertical={[Function]}
+      renderView={[Function]}
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }
+      tagName="div"
+      thumbMinSize={30}
+      universal={false}
+    >
+      <div
+        className="nav-pills__container"
+        id="sidebarChannelContainer"
+      >
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="publicChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PUBLIC CHANNELS"
+                id="sidebar.channels"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_public_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-channel-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new public channel"
+                        id="sidebar.createChannel"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPublicChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={true}
+            channelId="c1"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c1"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c2"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c2"
+          />
+          <li>
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="sidebarChannelsMore"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="privateChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PRIVATE CHANNELS"
+                id="sidebar.pg"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_private_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-group-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new private channel"
+                        id="sidebar.createGroup"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPrivateChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c4"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c4"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="directChannel"
+            >
+              <FormattedMessage
+                defaultMessage="DIRECT MESSAGES"
+                id="sidebar.direct"
+                values={Object {}}
+              />
+              <OverlayTrigger
+                className="hidden-xs"
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    className="hidden-xs"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new direct message"
+                      id="sidebar.createDirectMessage"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c6"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c6"
+          />
+          <li
+            key="more"
+          >
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="moreDirectMessage"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+      </div>
+    </Scrollbars>
+  </div>
+  <div
+    className="sidebar__switcher"
+  >
+    <button
+      className="btn btn-link"
+      id="sidebarSwitcherButton"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Switch Channels"
+        id="channel_switch_modal.title"
+        values={Object {}}
+      />
+      <span
+        className="switch__shortcut hidden-xs"
+      >
+        <FormattedMessage
+          defaultMessage="- CTRL+K"
+          id="quick_switch_modal.channelsShortcut.windows"
+          values={Object {}}
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide correctly more channels modal 2`] = `
+<div
+  className="sidebar--left"
+  id="sidebar-left"
+  key="sidebar-left"
+>
+  <NewChannelFlow
+    channelType=""
+    onModalDismissed={[Function]}
+    show={false}
+  />
+  <Connect(SidebarHeader)
+    currentUser={
+      Object {
+        "id": "my-user-id",
+      }
+    }
+    teamDescription="Test team description"
+    teamDisplayName="Test team display name"
+    teamId="team_id"
+    teamName="test-team"
+    teamType="team-type"
+  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <Scrollbars
+      autoHeight={false}
+      autoHeightMax={200}
+      autoHeightMin={0}
+      autoHide={true}
+      autoHideDuration={500}
+      autoHideTimeout={500}
+      hideTracksWhenNotNeeded={false}
+      onScroll={[Function]}
+      renderThumbHorizontal={[Function]}
+      renderThumbVertical={[Function]}
+      renderTrackHorizontal={[Function]}
+      renderTrackVertical={[Function]}
+      renderView={[Function]}
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }
+      tagName="div"
+      thumbMinSize={30}
+      universal={false}
+    >
+      <div
+        className="nav-pills__container"
+        id="sidebarChannelContainer"
+      >
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="publicChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PUBLIC CHANNELS"
+                id="sidebar.channels"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_public_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-channel-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new public channel"
+                        id="sidebar.createChannel"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPublicChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={true}
+            channelId="c1"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c1"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c2"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c2"
+          />
+          <li>
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="sidebarChannelsMore"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="privateChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PRIVATE CHANNELS"
+                id="sidebar.pg"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_private_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-group-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new private channel"
+                        id="sidebar.createGroup"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPrivateChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c4"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c4"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="directChannel"
+            >
+              <FormattedMessage
+                defaultMessage="DIRECT MESSAGES"
+                id="sidebar.direct"
+                values={Object {}}
+              />
+              <OverlayTrigger
+                className="hidden-xs"
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    className="hidden-xs"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new direct message"
+                      id="sidebar.createDirectMessage"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c6"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c6"
+          />
+          <li
+            key="more"
+          >
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="moreDirectMessage"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+      </div>
+    </Scrollbars>
+  </div>
+  <div
+    className="sidebar__switcher"
+  >
+    <button
+      className="btn btn-link"
+      id="sidebarSwitcherButton"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Switch Channels"
+        id="channel_switch_modal.title"
+        values={Object {}}
+      />
+      <span
+        className="switch__shortcut hidden-xs"
+      >
+        <FormattedMessage
+          defaultMessage="- CTRL+K"
+          id="quick_switch_modal.channelsShortcut.windows"
+          values={Object {}}
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide correctly more direct channels modal 1`] = `
+<div
+  className="sidebar--left"
+  id="sidebar-left"
+  key="sidebar-left"
+>
+  <NewChannelFlow
+    channelType=""
+    onModalDismissed={[Function]}
+    show={false}
+  />
+  <Connect(MoreDirectChannels)
+    isExistingChannel={false}
+    onModalDismissed={[Function]}
+  />
+  <Connect(SidebarHeader)
+    currentUser={
+      Object {
+        "id": "my-user-id",
+      }
+    }
+    teamDescription="Test team description"
+    teamDisplayName="Test team display name"
+    teamId="team_id"
+    teamName="test-team"
+    teamType="team-type"
+  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <Scrollbars
+      autoHeight={false}
+      autoHeightMax={200}
+      autoHeightMin={0}
+      autoHide={true}
+      autoHideDuration={500}
+      autoHideTimeout={500}
+      hideTracksWhenNotNeeded={false}
+      onScroll={[Function]}
+      renderThumbHorizontal={[Function]}
+      renderThumbVertical={[Function]}
+      renderTrackHorizontal={[Function]}
+      renderTrackVertical={[Function]}
+      renderView={[Function]}
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }
+      tagName="div"
+      thumbMinSize={30}
+      universal={false}
+    >
+      <div
+        className="nav-pills__container"
+        id="sidebarChannelContainer"
+      >
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="publicChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PUBLIC CHANNELS"
+                id="sidebar.channels"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_public_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-channel-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new public channel"
+                        id="sidebar.createChannel"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPublicChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={true}
+            channelId="c1"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c1"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c2"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c2"
+          />
+          <li>
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="sidebarChannelsMore"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="privateChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PRIVATE CHANNELS"
+                id="sidebar.pg"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_private_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-group-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new private channel"
+                        id="sidebar.createGroup"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPrivateChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c4"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c4"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="directChannel"
+            >
+              <FormattedMessage
+                defaultMessage="DIRECT MESSAGES"
+                id="sidebar.direct"
+                values={Object {}}
+              />
+              <OverlayTrigger
+                className="hidden-xs"
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    className="hidden-xs"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new direct message"
+                      id="sidebar.createDirectMessage"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c6"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c6"
+          />
+          <li
+            key="more"
+          >
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="moreDirectMessage"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+      </div>
+    </Scrollbars>
+  </div>
+  <div
+    className="sidebar__switcher"
+  >
+    <button
+      className="btn btn-link"
+      id="sidebarSwitcherButton"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Switch Channels"
+        id="channel_switch_modal.title"
+        values={Object {}}
+      />
+      <span
+        className="switch__shortcut hidden-xs"
+      >
+        <FormattedMessage
+          defaultMessage="- CTRL+K"
+          id="quick_switch_modal.channelsShortcut.windows"
+          values={Object {}}
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide correctly more direct channels modal 2`] = `
+<div
+  className="sidebar--left"
+  id="sidebar-left"
+  key="sidebar-left"
+>
+  <NewChannelFlow
+    channelType=""
+    onModalDismissed={[Function]}
+    show={false}
+  />
+  <Connect(SidebarHeader)
+    currentUser={
+      Object {
+        "id": "my-user-id",
+      }
+    }
+    teamDescription="Test team description"
+    teamDisplayName="Test team display name"
+    teamId="team_id"
+    teamName="test-team"
+    teamType="team-type"
+  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <Scrollbars
+      autoHeight={false}
+      autoHeightMax={200}
+      autoHeightMin={0}
+      autoHide={true}
+      autoHideDuration={500}
+      autoHideTimeout={500}
+      hideTracksWhenNotNeeded={false}
+      onScroll={[Function]}
+      renderThumbHorizontal={[Function]}
+      renderThumbVertical={[Function]}
+      renderTrackHorizontal={[Function]}
+      renderTrackVertical={[Function]}
+      renderView={[Function]}
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }
+      tagName="div"
+      thumbMinSize={30}
+      universal={false}
+    >
+      <div
+        className="nav-pills__container"
+        id="sidebarChannelContainer"
+      >
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="publicChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PUBLIC CHANNELS"
+                id="sidebar.channels"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_public_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-channel-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new public channel"
+                        id="sidebar.createChannel"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPublicChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={true}
+            channelId="c1"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c1"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c2"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c2"
+          />
+          <li>
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="sidebarChannelsMore"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="privateChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PRIVATE CHANNELS"
+                id="sidebar.pg"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_private_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-group-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new private channel"
+                        id="sidebar.createGroup"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPrivateChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c4"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c4"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="directChannel"
+            >
+              <FormattedMessage
+                defaultMessage="DIRECT MESSAGES"
+                id="sidebar.direct"
+                values={Object {}}
+              />
+              <OverlayTrigger
+                className="hidden-xs"
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    className="hidden-xs"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new direct message"
+                      id="sidebar.createDirectMessage"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c6"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c6"
+          />
+          <li
+            key="more"
+          >
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="moreDirectMessage"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+      </div>
+    </Scrollbars>
+  </div>
+  <div
+    className="sidebar__switcher"
+  >
+    <button
+      className="btn btn-link"
+      id="sidebarSwitcherButton"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Switch Channels"
+        id="channel_switch_modal.title"
+        values={Object {}}
+      />
+      <span
+        className="switch__shortcut hidden-xs"
+      >
+        <FormattedMessage
+          defaultMessage="- CTRL+K"
+          id="quick_switch_modal.channelsShortcut.windows"
+          values={Object {}}
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide correctly new channel modal 1`] = `
+<div
+  className="sidebar--left"
+  id="sidebar-left"
+  key="sidebar-left"
+>
+  <NewChannelFlow
+    channelType="P"
+    onModalDismissed={[Function]}
+    show={true}
+  />
+  <Connect(SidebarHeader)
+    currentUser={
+      Object {
+        "id": "my-user-id",
+      }
+    }
+    teamDescription="Test team description"
+    teamDisplayName="Test team display name"
+    teamId="team_id"
+    teamName="test-team"
+    teamType="team-type"
+  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <Scrollbars
+      autoHeight={false}
+      autoHeightMax={200}
+      autoHeightMin={0}
+      autoHide={true}
+      autoHideDuration={500}
+      autoHideTimeout={500}
+      hideTracksWhenNotNeeded={false}
+      onScroll={[Function]}
+      renderThumbHorizontal={[Function]}
+      renderThumbVertical={[Function]}
+      renderTrackHorizontal={[Function]}
+      renderTrackVertical={[Function]}
+      renderView={[Function]}
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }
+      tagName="div"
+      thumbMinSize={30}
+      universal={false}
+    >
+      <div
+        className="nav-pills__container"
+        id="sidebarChannelContainer"
+      >
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="publicChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PUBLIC CHANNELS"
+                id="sidebar.channels"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_public_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-channel-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new public channel"
+                        id="sidebar.createChannel"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPublicChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={true}
+            channelId="c1"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c1"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c2"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c2"
+          />
+          <li>
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="sidebarChannelsMore"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="privateChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PRIVATE CHANNELS"
+                id="sidebar.pg"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_private_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-group-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new private channel"
+                        id="sidebar.createGroup"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPrivateChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c4"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c4"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="directChannel"
+            >
+              <FormattedMessage
+                defaultMessage="DIRECT MESSAGES"
+                id="sidebar.direct"
+                values={Object {}}
+              />
+              <OverlayTrigger
+                className="hidden-xs"
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    className="hidden-xs"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new direct message"
+                      id="sidebar.createDirectMessage"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c6"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c6"
+          />
+          <li
+            key="more"
+          >
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="moreDirectMessage"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+      </div>
+    </Scrollbars>
+  </div>
+  <div
+    className="sidebar__switcher"
+  >
+    <button
+      className="btn btn-link"
+      id="sidebarSwitcherButton"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Switch Channels"
+        id="channel_switch_modal.title"
+        values={Object {}}
+      />
+      <span
+        className="switch__shortcut hidden-xs"
+      >
+        <FormattedMessage
+          defaultMessage="- CTRL+K"
+          id="quick_switch_modal.channelsShortcut.windows"
+          values={Object {}}
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide correctly new channel modal 2`] = `
+<div
+  className="sidebar--left"
+  id="sidebar-left"
+  key="sidebar-left"
+>
+  <NewChannelFlow
+    channelType=""
+    onModalDismissed={[Function]}
+    show={false}
+  />
+  <Connect(SidebarHeader)
+    currentUser={
+      Object {
+        "id": "my-user-id",
+      }
+    }
+    teamDescription="Test team description"
+    teamDisplayName="Test team display name"
+    teamId="team_id"
+    teamName="test-team"
+    teamType="team-type"
+  />
+  <div
+    className="sidebar--left__icons"
+  >
+    <Connect(Pluggable)
+      pluggableName="LeftSidebarHeader"
+    />
+  </div>
+  <div
+    className="sidebar--left__list"
+  >
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-top"
+      name="Top"
+      onClick={[Function]}
+      show={false}
+    />
+    <UnreadChannelIndicator
+      content={
+        <FormattedMessage
+          defaultMessage="More unreads"
+          id="sidebar.unreads"
+          values={Object {}}
+        />
+      }
+      extraClass="nav-pills__unread-indicator-bottom"
+      name="Bottom"
+      onClick={[Function]}
+      show={false}
+    />
+    <Scrollbars
+      autoHeight={false}
+      autoHeightMax={200}
+      autoHeightMin={0}
+      autoHide={true}
+      autoHideDuration={500}
+      autoHideTimeout={500}
+      hideTracksWhenNotNeeded={false}
+      onScroll={[Function]}
+      renderThumbHorizontal={[Function]}
+      renderThumbVertical={[Function]}
+      renderTrackHorizontal={[Function]}
+      renderTrackVertical={[Function]}
+      renderView={[Function]}
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }
+      tagName="div"
+      thumbMinSize={30}
+      universal={false}
+    >
+      <div
+        className="nav-pills__container"
+        id="sidebarChannelContainer"
+      >
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="publicChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PUBLIC CHANNELS"
+                id="sidebar.channels"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_public_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-channel-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new public channel"
+                        id="sidebar.createChannel"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPublicChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={true}
+            channelId="c1"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c1"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c2"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c2"
+          />
+          <li>
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="sidebarChannelsMore"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="privateChannel"
+            >
+              <FormattedMessage
+                defaultMessage="PRIVATE CHANNELS"
+                id="sidebar.pg"
+                values={Object {}}
+              />
+              <Connect(TeamPermissionGate)
+                permissions={
+                  Array [
+                    "create_private_channel",
+                  ]
+                }
+                teamId="team_id"
+              >
+                <OverlayTrigger
+                  defaultOverlayShown={false}
+                  delayShow={500}
+                  overlay={
+                    <Tooltip
+                      bsClass="tooltip"
+                      id="new-group-tooltip"
+                      placement="right"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Create new private channel"
+                        id="sidebar.createGroup"
+                        values={Object {}}
+                      />
+                    </Tooltip>
+                  }
+                  placement="top"
+                  trigger={
+                    Array [
+                      "hover",
+                      "focus",
+                    ]
+                  }
+                >
+                  <button
+                    className="add-channel-btn cursor--pointer style--none"
+                    id="createPrivateChannel"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </OverlayTrigger>
+              </Connect(TeamPermissionGate)>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c3"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c3"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c4"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c4"
+          />
+        </ul>
+        <ul
+          className="nav nav-pills nav-stacked"
+        >
+          <li>
+            <h4
+              id="directChannel"
+            >
+              <FormattedMessage
+                defaultMessage="DIRECT MESSAGES"
+                id="sidebar.direct"
+                values={Object {}}
+              />
+              <OverlayTrigger
+                className="hidden-xs"
+                defaultOverlayShown={false}
+                delayShow={500}
+                overlay={
+                  <Tooltip
+                    bsClass="tooltip"
+                    className="hidden-xs"
+                    id="new-group-tooltip"
+                    placement="right"
+                  >
+                    <FormattedMessage
+                      defaultMessage="Create new direct message"
+                      id="sidebar.createDirectMessage"
+                      values={Object {}}
+                    />
+                  </Tooltip>
+                }
+                placement="top"
+                trigger={
+                  Array [
+                    "hover",
+                    "focus",
+                  ]
+                }
+              >
+                <button
+                  className="add-channel-btn cursor--pointer style--none"
+                  onClick={[Function]}
+                >
+                  +
+                </button>
+              </OverlayTrigger>
+            </h4>
+          </li>
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c5"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c5"
+          />
+          <Connect(SidebarChannel)
+            active={false}
+            channelId="c6"
+            currentTeamName="test-team"
+            currentUserId="my-user-id"
+            key="c6"
+          />
+          <li
+            key="more"
+          >
+            <button
+              className="nav-more cursor--pointer style--none btn--block"
+              id="moreDirectMessage"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="More..."
+                id="sidebar.moreElips"
+                values={Object {}}
+              />
+            </button>
+          </li>
+        </ul>
+      </div>
+    </Scrollbars>
+  </div>
+  <div
+    className="sidebar__switcher"
+  >
+    <button
+      className="btn btn-link"
+      id="sidebarSwitcherButton"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="Switch Channels"
+        id="channel_switch_modal.title"
+        values={Object {}}
+      />
+      <span
+        className="switch__shortcut hidden-xs"
+      >
+        <FormattedMessage
+          defaultMessage="- CTRL+K"
+          id="quick_switch_modal.channelsShortcut.windows"
+          values={Object {}}
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;

--- a/tests/components/sidebar/sidebar.test.jsx
+++ b/tests/components/sidebar/sidebar.test.jsx
@@ -1,0 +1,478 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {Constants} from 'utils/constants.jsx';
+import Sidebar from 'components/sidebar/sidebar.jsx';
+
+jest.mock('utils/utils', () => {
+    const original = require.requireActual('utils/utils');
+    return {
+        ...original,
+        cmdOrCtrlPressed: jest.fn(),
+    };
+});
+
+jest.mock('actions/channel_actions', () => {
+    const original = require.requireActual('actions/channel_actions');
+    return {
+        ...original,
+        goToChannelById: jest.fn(),
+    };
+});
+
+describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
+    const allChannels = {
+        c1: {
+            id: 'c1',
+            display_name: 'Public test 1',
+            name: 'public-test-1',
+            type: Constants.OPEN_CHANNEL,
+        },
+        c2: {
+            id: 'c2',
+            display_name: 'Public test 2',
+            name: 'public-test-2',
+            type: Constants.OPEN_CHANNEL,
+        },
+        c3: {
+            id: 'c3',
+            display_name: 'Private test 1',
+            name: 'private-test-1',
+            type: Constants.PRIVATE_CHANNEL,
+        },
+        c4: {
+            id: 'c4',
+            display_name: 'Private test 2',
+            name: 'private-test-2',
+            type: Constants.PRIVATE_CHANNEL,
+        },
+        c5: {
+            id: 'c5',
+            display_name: 'Direct message test',
+            name: 'direct-message-test',
+            type: Constants.DM_CHANNEL,
+        },
+        c6: {
+            id: 'c6',
+            display_name: 'Group message test',
+            name: 'group-message-test',
+            type: Constants.GM_CHANNEL,
+        },
+    };
+
+    const defaultProps = {
+        config: {
+            EnableXToLeaveChannelsFromLHS: 'false',
+            SiteName: 'Test site',
+        },
+        isOpen: false,
+        showUnreadSection: false,
+        publicChannelIds: ['c1', 'c2'],
+        privateChannelIds: ['c3', 'c4'],
+        favoriteChannelIds: [],
+        directAndGroupChannelIds: ['c5', 'c6'],
+        unreadChannelIds: [],
+        currentChannel: {
+            id: 'c1',
+            display_name: 'Public test 1',
+            name: 'public-test-1',
+            type: Constants.OPEN_CHANNEL,
+        },
+        currentTeam: {
+            id: 'team_id',
+            name: 'test-team',
+            display_name: 'Test team display name',
+            description: 'Test team description',
+            type: 'team-type',
+        },
+        currentUser: {
+            id: 'my-user-id',
+        },
+        memberships: {
+            c1: {
+                name: 'Public test 1 membership',
+            },
+            c2: {
+                name: 'Public test 2 membership',
+            },
+            c3: {
+                name: 'Private test 1 membership',
+            },
+            c4: {
+                name: 'Private test 2 membership',
+            },
+            c5: {
+                name: 'Direct message test membership',
+            },
+            c6: {
+                name: 'Group message test membership',
+            },
+        },
+        unreads: {
+            messageCount: 0,
+            mentions: 0,
+        },
+        actions: {
+            close: jest.fn(),
+        },
+    };
+
+    test('should match snapshot, on sidebar show', () => {
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, on sidebar show with favorites', () => {
+        const wrapper = shallow(
+            <Sidebar
+                {...{
+                    ...defaultProps,
+                    favoriteChannelIds: ['c1', 'c3', 'c5'],
+                }}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, on sidebar show with unreads', () => {
+        const wrapper = shallow(
+            <Sidebar
+                {...{
+                    ...defaultProps,
+                    unreadChannelIds: ['c3', 'c5'],
+                    showUnreadSection: true,
+                }}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, when render as an empty div because no have a team or a user', () => {
+        let wrapper = shallow(
+            <Sidebar
+                {...{
+                    ...defaultProps,
+                    currentTeam: null,
+                }}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+        wrapper = shallow(
+            <Sidebar
+                {...{
+                    ...defaultProps,
+                    currentUser: null,
+                }}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('navigate to the next/prev channels', () => {
+        const channelActions = require.requireMock('actions/channel_actions');
+        const nextEvent = {
+            preventDefault: jest.fn(),
+            altKey: true,
+            shiftKey: false,
+            key: Constants.KeyCodes.DOWN[0],
+            keyCode: Constants.KeyCodes.DOWN[1],
+        };
+        const prevEvent = {
+            preventDefault: jest.fn(),
+            altKey: true,
+            shiftKey: false,
+            key: Constants.KeyCodes.UP[0],
+            keyCode: Constants.KeyCodes.UP[1],
+        };
+
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.updateScrollbarOnChannelChange = jest.fn();
+        instance.componentDidUpdate = jest.fn();
+        instance.navigateChannelShortcut({});
+        expect(instance.updateScrollbarOnChannelChange).not.toBeCalled();
+        expect(channelActions.goToChannelById).not.toBeCalled();
+
+        instance.isSwitchingChannel = true;
+        instance.navigateChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).not.toBeCalled();
+        expect(channelActions.goToChannelById).not.toBeCalled();
+        instance.isSwitchingChannel = false;
+
+        instance.navigateChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c2');
+        expect(channelActions.goToChannelById).lastCalledWith('c2');
+        wrapper.setProps({currentChannel: allChannels.c2});
+
+        instance.navigateChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c3');
+        expect(channelActions.goToChannelById).lastCalledWith('c3');
+        wrapper.setProps({currentChannel: allChannels.c3});
+
+        instance.navigateChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c4');
+        expect(channelActions.goToChannelById).lastCalledWith('c4');
+        wrapper.setProps({currentChannel: allChannels.c4});
+
+        instance.navigateChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c5');
+        expect(channelActions.goToChannelById).lastCalledWith('c5');
+        wrapper.setProps({currentChannel: allChannels.c5});
+
+        instance.navigateChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c6');
+        expect(channelActions.goToChannelById).lastCalledWith('c6');
+        wrapper.setProps({currentChannel: allChannels.c6});
+
+        instance.navigateChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c1');
+        expect(channelActions.goToChannelById).lastCalledWith('c1');
+        wrapper.setProps({currentChannel: allChannels.c1});
+
+        instance.navigateChannelShortcut(prevEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c6');
+        expect(channelActions.goToChannelById).lastCalledWith('c6');
+        wrapper.setProps({currentChannel: allChannels.c6});
+
+        instance.navigateChannelShortcut(prevEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c5');
+        expect(channelActions.goToChannelById).lastCalledWith('c5');
+        wrapper.setProps({currentChannel: allChannels.c5});
+
+        instance.navigateChannelShortcut(prevEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c4');
+        expect(channelActions.goToChannelById).lastCalledWith('c4');
+        wrapper.setProps({currentChannel: allChannels.c4});
+
+        instance.navigateChannelShortcut(prevEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c3');
+        expect(channelActions.goToChannelById).lastCalledWith('c3');
+        wrapper.setProps({currentChannel: allChannels.c3});
+
+        instance.navigateChannelShortcut(prevEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c2');
+        expect(channelActions.goToChannelById).lastCalledWith('c2');
+        wrapper.setProps({currentChannel: allChannels.c2});
+    });
+
+    test('navigate to the next/prev unread channels', () => {
+        const channelActions = require.requireMock('actions/channel_actions');
+        const nextEvent = {
+            preventDefault: jest.fn(),
+            altKey: true,
+            shiftKey: true,
+            key: Constants.KeyCodes.DOWN[0],
+            keyCode: Constants.KeyCodes.DOWN[1],
+        };
+        const prevEvent = {
+            preventDefault: jest.fn(),
+            altKey: true,
+            shiftKey: true,
+            key: Constants.KeyCodes.UP[0],
+            keyCode: Constants.KeyCodes.UP[1],
+        };
+
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.updateScrollbarOnChannelChange = jest.fn();
+        instance.updateUnreadIndicators = jest.fn();
+        instance.componentDidUpdate = jest.fn();
+        wrapper.setProps({unreadChannelIds: ['c3', 'c6']});
+
+        instance.navigateUnreadChannelShortcut({});
+        expect(instance.updateScrollbarOnChannelChange).not.toBeCalled();
+        expect(channelActions.goToChannelById).not.toBeCalled();
+
+        instance.isSwitchingChannel = true;
+        instance.navigateUnreadChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).not.toBeCalled();
+        expect(channelActions.goToChannelById).not.toBeCalled();
+        instance.isSwitchingChannel = false;
+
+        wrapper.setProps({unreadChannelIds: []});
+        instance.navigateUnreadChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).not.toBeCalled();
+        expect(channelActions.goToChannelById).not.toBeCalled();
+
+        wrapper.setProps({unreadChannelIds: ['c3', 'c6']});
+
+        instance.navigateUnreadChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c3');
+        expect(channelActions.goToChannelById).lastCalledWith('c3');
+        wrapper.setProps({currentChannel: allChannels.c3, unreadChannelIds: ['c6']});
+
+        instance.navigateUnreadChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c6');
+        expect(channelActions.goToChannelById).lastCalledWith('c6');
+        wrapper.setProps({currentChannel: allChannels.c6, unreadChannelIds: ['c3']});
+
+        instance.navigateUnreadChannelShortcut(nextEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c3');
+        expect(channelActions.goToChannelById).lastCalledWith('c3');
+        wrapper.setProps({currentChannel: allChannels.c1, unreadChannelIds: ['c3', 'c6']});
+
+        instance.navigateUnreadChannelShortcut(prevEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c6');
+        expect(channelActions.goToChannelById).lastCalledWith('c6');
+        wrapper.setProps({currentChannel: allChannels.c6, unreadChannelIds: ['c3']});
+
+        instance.navigateUnreadChannelShortcut(prevEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c3');
+        expect(channelActions.goToChannelById).lastCalledWith('c3');
+        wrapper.setProps({currentChannel: allChannels.c3, unreadChannelIds: ['c6']});
+
+        instance.navigateUnreadChannelShortcut(prevEvent);
+        expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c6');
+        expect(channelActions.goToChannelById).lastCalledWith('c6');
+    });
+
+    test('open direct channel selector on CTRL/CMD+SHIFT+K', () => {
+        const utils = require.requireMock('utils/utils');
+        utils.cmdOrCtrlPressed.mockImplementation(() => false);
+        const ctrlShiftK = {
+            preventDefault: jest.fn(),
+            altKey: false,
+            shiftKey: true,
+            ctrlKey: true,
+            key: Constants.KeyCodes.K[0],
+            keyCode: Constants.KeyCodes.K[1],
+        };
+        const cmdShiftK = {
+            preventDefault: jest.fn(),
+            altKey: false,
+            shiftKey: true,
+            metaKey: true,
+            key: Constants.KeyCodes.K[0],
+            keyCode: Constants.KeyCodes.K[1],
+        };
+
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.handleOpenMoreDirectChannelsModal = jest.fn();
+        expect(instance.handleOpenMoreDirectChannelsModal).not.toBeCalled();
+
+        instance.navigateChannelShortcut(ctrlShiftK);
+        expect(instance.handleOpenMoreDirectChannelsModal).not.toBeCalled();
+
+        utils.cmdOrCtrlPressed.mockImplementation(() => true);
+        instance.navigateChannelShortcut(cmdShiftK);
+        expect(instance.handleOpenMoreDirectChannelsModal).toBeCalled();
+
+        instance.navigateChannelShortcut(ctrlShiftK);
+        expect(instance.handleOpenMoreDirectChannelsModal).toHaveBeenCalledTimes(2);
+    });
+
+    test('set correctly the title when needed', () => {
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.updateTitle();
+        instance.componentDidUpdate = jest.fn();
+        instance.render = jest.fn();
+        expect(document.title).toBe('Public test 1 - Test team display name Test site');
+        wrapper.setProps({config: {SiteName: null}});
+        instance.updateTitle();
+        expect(document.title).toBe('Public test 1 - Test team display name');
+        wrapper.setProps({currentChannel: {type: Constants.DM_CHANNEL}, currentTeammate: {display_name: 'teammate'}});
+        instance.updateTitle();
+        expect(document.title).toBe('teammate - Test team display name');
+        wrapper.setProps({unreads: {mentionCount: 3, messageCount: 4}});
+        instance.updateTitle();
+        expect(document.title).toBe('(3) * teammate - Test team display name');
+    });
+
+    test('should show/hide correctly more channels modal', () => {
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.componentDidUpdate = jest.fn();
+        instance.showMoreChannelsModal();
+        wrapper.setState(instance.state);
+        expect(wrapper).toMatchSnapshot();
+        instance.hideMoreChannelsModal();
+        wrapper.setState(instance.state);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should show/hide correctly new channel modal', () => {
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.componentDidUpdate = jest.fn();
+        instance.showNewChannelModal(Constants.PRIVATE_CHANNEL);
+        wrapper.setState(instance.state);
+        expect(wrapper).toMatchSnapshot();
+        instance.hideNewChannelModal();
+        wrapper.setState(instance.state);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should show/hide correctly more direct channels modal', () => {
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.componentDidUpdate = jest.fn();
+        instance.showMoreDirectChannelsModal([]);
+        wrapper.setState(instance.state);
+        expect(wrapper).toMatchSnapshot();
+        instance.hideMoreDirectChannelsModal();
+        wrapper.setState(instance.state);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should verify if the channel is displayed for props', () => {
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        expect(instance.channelIdIsDisplayedForProps(instance.props, 'c1')).toBe(true);
+        expect(instance.channelIdIsDisplayedForProps(instance.props, 'c9')).toBe(false);
+    });
+
+    test('should handle correctly open more direct channels toggle', () => {
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.showMoreDirectChannelsModal = jest.fn();
+        instance.hideMoreDirectChannelsModal = jest.fn();
+
+        instance.setState({showDirectChannelsModal: true});
+        instance.handleOpenMoreDirectChannelsModal({preventDefault: jest.fn()});
+        expect(instance.hideMoreDirectChannelsModal).toBeCalled();
+        expect(instance.showMoreDirectChannelsModal).not.toBeCalled();
+
+        instance.setState({showDirectChannelsModal: false});
+        instance.handleOpenMoreDirectChannelsModal({preventDefault: jest.fn()});
+        expect(instance.showMoreDirectChannelsModal).toBeCalled();
+    });
+
+    test('should listen/unlisten keydown events', () => {
+        document.addEventListener = jest.fn();
+        document.removeEventListener = jest.fn();
+        const wrapper = shallow(
+            <Sidebar {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+
+        expect(document.addEventListener).toHaveBeenCalledTimes(2);
+        expect(document.removeEventListener).not.toBeCalled();
+        instance.componentWillUnmount();
+        expect(document.removeEventListener).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
#### Summary
The original error is:
```
TypeError: 'Symbol(Symbol.toPrimitive)' returned for property 'Symbol(Symbol.toPrimitive)' of object '[object Object]' is not a function
```
which I'm not sure what's causing that after the upgrade of dependencies.

Revert unit test of Sidebar by setting empty string to href whenever the favicon is not of type string.  It's a dirty hack and there might be a proper fix to this but this fix works.  I've tested it for normal favicon (blue icon) and "red" favicon and everything seems to work just fine.

#### Ticket Link
Jira ticket: [MM-11856](https://mattermost.atlassian.net/browse/MM-11856)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
