### PR TITLE
MM-12056: Improve the state management for schema admin settings

### DIFF
--- a/components/admin_console/admin_console.jsx
+++ b/components/admin_console/admin_console.jsx
@@ -71,7 +71,20 @@ export default class AdminConsole extends React.Component {
     UNSAFE_componentWillMount() { // eslint-disable-line camelcase
         this.props.actions.getConfig();
         this.props.actions.getEnvironmentConfig();
+        this.props.actions.loadRolesIfNeeded(['channel_user', 'team_user', 'system_user', 'channel_admin', 'team_admin', 'system_admin']);
         reloadIfServerVersionChanged();
+    }
+
+    mainRolesLoaded(roles) {
+        return (
+            roles &&
+            roles.channel_admin &&
+            roles.channel_user &&
+            roles.team_admin &&
+            roles.team_user &&
+            roles.system_admin &&
+            roles.system_user
+        );
     }
 
     render() {
@@ -87,6 +100,10 @@ export default class AdminConsole extends React.Component {
             return (
                 <Redirect to='/'/>
             );
+        }
+
+        if (!this.mainRolesLoaded(this.props.roles)) {
+            return null;
         }
 
         if (Object.keys(config).length === 0) {
@@ -352,7 +369,6 @@ export default class AdminConsole extends React.Component {
                                         extraProps={{
                                             ...extraProps,
                                             roles: this.props.roles,
-                                            loadRolesIfNeeded: this.props.actions.loadRolesIfNeeded,
                                             editRole: this.props.actions.editRole,
                                             schema: AdminDefinition.settings.integrations.custom_integrations.schema,
                                         }}

--- a/components/admin_console/custom_plugin_settings/custom_plugin_settings.jsx
+++ b/components/admin_console/custom_plugin_settings/custom_plugin_settings.jsx
@@ -7,15 +7,21 @@ export default class CustomPluginSettings extends SchemaAdminSettings {
     constructor(props) {
         super(props);
         this.isPlugin = true;
+        this.getStateFromConfig = CustomPluginSettings.getStateFromConfig;
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        const id = this.props.schema ? this.props.schema.id : '';
-        const nextId = nextProps.schema ? nextProps.schema.id : '';
-
-        if ((!this.props.schema && nextProps.schema) || (id !== nextId)) {
-            this.setState(this.getStateFromConfig(nextProps.config, nextProps.schema));
+    static getDerivedStateFromProps(props, state) {
+        if (props.schema && props.schema.id !== state.prevSchemaId) {
+            return {
+                prevSchemaId: props.schema.id,
+                saveNeeded: false,
+                saving: false,
+                serverError: null,
+                errorTooltip: false,
+                ...CustomPluginSettings.getStateFromConfig(props.config, props.schema, props.roles),
+            };
         }
+        return null;
     }
 
     getConfigFromState(config) {
@@ -43,7 +49,7 @@ export default class CustomPluginSettings extends SchemaAdminSettings {
         return config;
     }
 
-    getStateFromConfig(config, schema = this.props.schema) {
+    static getStateFromConfig(config, schema) {
         const state = {};
 
         if (schema) {

--- a/components/admin_console/custom_plugin_settings/index.js
+++ b/components/admin_console/custom_plugin_settings/index.js
@@ -3,6 +3,8 @@
 
 import {connect} from 'react-redux';
 
+import {getRoles} from 'mattermost-redux/selectors/entities/roles';
+
 import CustomPluginSettings from './custom_plugin_settings.jsx';
 
 function mapStateToProps(state, ownProps) {
@@ -14,6 +16,7 @@ function mapStateToProps(state, ownProps) {
     const translate = (plugin && plugin.translate) || false;
     return {
         schema: plugin ? {...plugin.settings_schema, id: plugin.id, name: plugin.name, settings, translate} : null,
+        roles: getRoles(state),
     };
 }
 


### PR DESCRIPTION
#### Summary
Improve the state management for schema admin settings.

Based on the fix of MM-12056, I decide to simplify how
schema_admin_settings work, removing inheritance, and removing the
UNSAFE_complenteWillUpdate method.

In the future the AdminSettings class will be removed, when every single admin panel is using the declarative interface. So the code duplication will be temporary only.

#### Ticket Link
[MM-12056](https://mattermost.atlassian.net/browse/12056)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed