### PR TITLE
Set the react configuration for eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
-  "extends": "eslint:recommended",
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ],
   "parserOptions": {
     "ecmaVersion": 8,
     "sourceType": "module",
@@ -33,7 +36,11 @@
     "beforeEach": true
   },
   "settings": {
-    "import/resolver": "webpack"
+    "import/resolver": "webpack",
+    "react": {
+        "pragma": "React",
+        "version": "16.4"
+    }
   },
   "rules": {
     "array-bracket-spacing": [

--- a/tests/utils/markdown/remove_markdown.test.jsx
+++ b/tests/utils/markdown/remove_markdown.test.jsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import React from 'react';
+
 import {stripMarkdown} from 'utils/markdown';
 
 describe('stripMarkdown | RemoveMarkdown', () => {


### PR DESCRIPTION
#### Summary
After updating the dependency for eslint it is expected to have the `plugin:react/recommended` configured in `.eslintrc` and set the specific minor version of React

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12157

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
