### PR TITLE
MM-11982: Fix slack attachments permanlinks click

### DIFF
--- a/components/post_view/post_attachment.jsx
+++ b/components/post_view/post_attachment.jsx
@@ -8,6 +8,7 @@ import * as PostActions from 'actions/post_actions.jsx';
 import {postListScrollChange} from 'actions/global_actions';
 
 import {isUrlSafe} from 'utils/url.jsx';
+import * as Utils from 'utils/utils';
 
 import Markdown from 'components/markdown';
 
@@ -322,6 +323,7 @@ export default class PostAttachment extends React.PureComponent {
                         <div>
                             <div
                                 className={thumb ? 'attachment__body' : 'attachment__body attachment__body--no_thumb'}
+                                onClick={Utils.handleFormattedTextClick}
                             >
                                 {attachmentText}
                                 {image}

--- a/tests/components/post_view/__snapshots__/post_attachment.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/post_attachment.test.jsx.snap
@@ -56,6 +56,7 @@ exports[`components/post_view/PostAttachment should call PostActions.doPostActio
       <div>
         <div
           className="attachment__body"
+          onClick={[Function]}
         >
           <Connect(ShowMore)
             checkOverflow={0}
@@ -164,6 +165,7 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
       <div>
         <div
           className="attachment__body"
+          onClick={[Function]}
         >
           <Connect(ShowMore)
             checkOverflow={0}


### PR DESCRIPTION
#### Summary
Handling slack attachments links to do not reload on permalinks clicks.

#### Ticket Link
[MM-11982](https://mattermost.atlassian.net/browse/MM-11982)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed