### PR TITLE
Getting error in resolving mattermost-redux, bump it to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10234,8 +10234,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#3acb868e99b4327279e6bb5dabf0a6d407fc12ec",
-      "from": "github:mattermost/mattermost-redux#3acb868e99b4327279e6bb5dabf0a6d407fc12ec",
+      "version": "github:mattermost/mattermost-redux#9d47dbf86762982a474f162a46fa532c69070213",
+      "from": "github:mattermost/mattermost-redux#9d47dbf86762982a474f162a46fa532c69070213",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "localforage": "1.7.2",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#3acb868e99b4327279e6bb5dabf0a6d407fc12ec",
+    "mattermost-redux": "github:mattermost/mattermost-redux#9d47dbf86762982a474f162a46fa532c69070213",
     "moment-timezone": "0.5.21",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
Getting error in resolving mattermost-redux, bump it to latest

Repro steps:
- delete node_modules or just the mattermost-redux module
- do the `make run`
- observe that the mattermost-redux is not being installed and built accordingly

#### Ticket Link
none

![screen shot 2018-09-18 at 3 42 32 pm](https://user-images.githubusercontent.com/5334504/45671973-830dc000-bb59-11e8-8b1f-b79aca88263e.png)
