### PR TITLE
Remove .npminstall and don't explicitly build mattermost-redux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,23 +3,20 @@
 BUILD_SERVER_DIR = ../mattermost-server
 EMOJI_TOOLS_DIR = ./build/emoji
 
-check-style: .npminstall ## Checks JS file for ESLint confirmity
+check-style: node_modules ## Checks JS file for ESLint confirmity
 	@echo Checking for style guide compliance
 
 	npm run check
 
-test: .npminstall ## Runs tests
+test: node_modules ## Runs tests
 	@echo Running jest unit/component testing
 
 	npm run test
 
-.npminstall: package.json package-lock.json
+node_modules: package.json package-lock.json
 	@echo Getting dependencies using npm
 
 	npm install
-	cd node_modules/mattermost-redux; npm run build
-
-	touch $@
 
 package: build ## Packages app
 	@echo Packaging webapp
@@ -30,19 +27,19 @@ package: build ## Packages app
 	mv tmp/client dist
 	rmdir tmp
 
-build: .npminstall ## Builds the app
+build: node_modules ## Builds the app
 	@echo Building mattermost Webapp
 
 	rm -rf dist
 
 	npm run build
 
-run: .npminstall ## Runs app
+run: node_modules ## Runs app
 	@echo Running mattermost Webapp for development
 
 	npm run run &
 
-run-fullmap: .npminstall ## Runs the app with the JS mapped to source (good for debugger)
+run-fullmap: node_modules ## Runs the app with the JS mapped to source (good for debugger)
 	@echo FULL SOURCE MAP Running mattermost Webapp for development FULL SOURCE MAP
 
 	npm run run-fullmap &
@@ -66,7 +63,6 @@ clean: ## Clears cached; deletes node_modules and dist directories
 
 	rm -rf dist
 	rm -rf node_modules
-	rm -f .npminstall
 
 emojis: ## Creates emoji JSX file and extracts emoji images from the system font
 	gem install bundler

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@ test: node_modules ## Runs tests
 
 	npm run test
 
-# TODO remove this once Jenkins has been updated to no longer run `make .npminstall` manually
-.PHONY: .npmisntall
-.npminstall: ;
-
 node_modules: package.json package-lock.json
 	@echo Getting dependencies using npm
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ test: node_modules ## Runs tests
 
 	npm run test
 
+# TODO remove this once Jenkins has been updated to no longer run `make .npminstall` manually
+.PHONY: .npmisntall
+.npminstall: ;
+
 node_modules: package.json package-lock.json
 	@echo Getting dependencies using npm
 

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     stages {
         stage('Install') {
             steps {
-                sh 'make .npminstall'
+                sh 'make node_modules'
             }
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10234,8 +10234,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#9d47dbf86762982a474f162a46fa532c69070213",
-      "from": "github:mattermost/mattermost-redux#9d47dbf86762982a474f162a46fa532c69070213",
+      "version": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
+      "from": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10234,8 +10234,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
-      "from": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
+      "version": "github:mattermost/mattermost-redux#a10b6c7f67a5163c15d029defbcd9bccf0eb0412",
+      "from": "github:mattermost/mattermost-redux#a10b6c7f67a5163c15d029defbcd9bccf0eb0412",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "localforage": "1.7.2",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#9d47dbf86762982a474f162a46fa532c69070213",
+    "mattermost-redux": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
     "moment-timezone": "0.5.21",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "localforage": "1.7.2",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#ee1310472165b9720478446a10d028f59f7992d8",
+    "mattermost-redux": "github:mattermost/mattermost-redux#a10b6c7f67a5163c15d029defbcd9bccf0eb0412",
     "moment-timezone": "0.5.21",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
I've always found the fact that you can't just `npm install mattermost/mattermost-redux` kind of annoying, but moving the build step to `prepublish` or `prepare` (both are very similar, but `prepare` happens after `prepublish`) instead of `prepublishOnly` so that it triggers automatically on `npm install` should fix that.

This also lets us remove the `.npminstall` files on each repo since we can just check if `node_modules` is up to date rather than creating a new file.

Redux PR: https://github.com/mattermost/mattermost-redux/pull/635
Mobile PR: https://github.com/mattermost/mattermost-mobile/pull/2135