### PR TITLE
MM-3762 Focus textbox immediately when opening edit modal

### DIFF
--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -129,7 +129,7 @@ export default class EditPostModal extends React.PureComponent {
 
         this.setState({showEmojiPicker: false});
 
-        this.refs.editbox.focus();
+        this.editbox.focus();
     }
 
     handleGifClick = (gif) => {
@@ -140,7 +140,7 @@ export default class EditPostModal extends React.PureComponent {
             this.setState({editText: newMessage});
         }
         this.setState({showEmojiPicker: false});
-        this.refs.editbox.focus();
+        this.editbox.focus();
     }
 
     getEditPostControls = () => {
@@ -213,11 +213,11 @@ export default class EditPostModal extends React.PureComponent {
     handleEditKeyPress = (e) => {
         if (!UserAgent.isMobile() && !this.props.ctrlSend && Utils.isKeyPressed(e, KeyCodes.ENTER) && !e.shiftKey && !e.altKey) {
             e.preventDefault();
-            this.refs.editbox.blur();
+            this.editbox.blur();
             this.handleEdit();
         } else if (this.props.ctrlSend && e.ctrlKey && Utils.isKeyPressed(e, KeyCodes.ENTER)) {
             e.preventDefault();
-            this.refs.editbox.blur();
+            this.editbox.blur();
             this.handleEdit();
         }
     }
@@ -234,12 +234,12 @@ export default class EditPostModal extends React.PureComponent {
     }
 
     handleEntered = () => {
-        this.refs.editbox.focus();
-        this.refs.editbox.recalculateSize();
+        this.editbox.focus();
+        this.editbox.recalculateSize();
     }
 
     handleExit = () => {
-        this.refs.editbox.hidePreview();
+        this.editbox.hidePreview();
     }
 
     handleExited = () => {
@@ -255,6 +255,13 @@ export default class EditPostModal extends React.PureComponent {
 
         this.refocusId = null;
         this.setState({editText: '', postError: '', errorClass: null, showEmojiPicker: false});
+    }
+
+    setEditboxRef = (ref) => {
+        this.editbox = ref;
+        if (this.editbox) {
+            this.editbox.focus();
+        }
     }
 
     render() {
@@ -325,7 +332,7 @@ export default class EditPostModal extends React.PureComponent {
                         supportsCommands={false}
                         suggestionListStyle='bottom'
                         id='edit_textbox'
-                        ref='editbox'
+                        ref={this.setEditboxRef}
                         characterLimit={this.props.maxPostSize}
                     />
                     <span

--- a/tests/components/edit_post_modal.test.jsx
+++ b/tests/components/edit_post_modal.test.jsx
@@ -199,7 +199,7 @@ describe('components/EditPostModal', () => {
         const options = new ReactRouterEnzymeContext();
         const wrapper = mountWithIntl(createEditPost(), options.get());
         const instance = wrapper.instance();
-        const ref = wrapper.ref('editbox');
+        const ref = instance.editbox;
         ref.focus = jest.fn();
         ref.recalculateSize = jest.fn();
         expect(ref.focus).not.toBeCalled();
@@ -213,7 +213,7 @@ describe('components/EditPostModal', () => {
         const options = new ReactRouterEnzymeContext();
         const wrapper = mountWithIntl(createEditPost(), options.get());
         const instance = wrapper.instance();
-        const ref = wrapper.ref('editbox');
+        const ref = instance.editbox;
         ref.hidePreview = jest.fn();
         expect(ref.hidePreview).not.toBeCalled();
         instance.handleExit();


### PR DESCRIPTION
#### Summary
Focus the textbox as soon as the ref is set so that typing is picked up faster.

QA if you want to give it a quick test that'd be great.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-3762
Fixes https://github.com/mattermost/platform/issues/4593

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes