### PR TITLE
Fix dev mode warnings caused by Markdown tables

### DIFF
--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -209,6 +209,14 @@ export default class Renderer extends marked.Renderer {
         return `<div class="table-responsive"><table class="markdown__table"><thead>${header}</thead><tbody>${body}</tbody></table></div>`;
     }
 
+    tablerow(content) {
+        return `<tr>${content}</tr>`;
+    }
+
+    tablecell(content, flags) {
+        return marked.Renderer.prototype.tablecell(content, flags).trim();
+    }
+
     listitem(text, bullet) {
         const taskListReg = /^\[([ |xX])] /;
         const isTaskList = taskListReg.exec(text);


### PR DESCRIPTION
The default implementations of the functions that render table rows and cells pad the HTML with new lines for some reason ([link](https://github.com/mattermost/marked/blob/master/lib/marked.js#L1002)), causing React to complain about the invalid whitespace.
