### PR TITLE
MM-12031: ignore loading channel mentions

### DIFF
--- a/stores/suggestion_store.jsx
+++ b/stores/suggestion_store.jsx
@@ -121,8 +121,13 @@ class SuggestionStore extends EventEmitter {
         return this.suggestions.has(id);
     }
 
+    // hasSuggestions returns true if the given suggestion box has selectable items.
+    //
+    // This adopts a convention introduced by a particular suggestion provider tagging a loading
+    // item with a flag indicating same. Ideally, this would be modelled as a concept within the
+    // suggestion store itself.
     hasSuggestions(id) {
-        return this.getSuggestions(id).terms.length > 0;
+        return this.getSuggestions(id).items.some((item) => !item.loading);
     }
 
     setPretext(id, pretext) {

--- a/tests/stores/suggestion_store.test.jsx
+++ b/tests/stores/suggestion_store.test.jsx
@@ -49,4 +49,23 @@ describe('stores/SuggestionStore', () => {
         });
         assert.equal(SuggestionStore.suggestions.has(id), false);
     });
+
+    test('hasSuggestions should ignore loading items', () => {
+        const id = 'id1';
+        const suggestion = {render: () => null};
+
+        SuggestionStore.registerSuggestionBox(id);
+        assert.equal(SuggestionStore.hasSuggestions(id), false);
+
+        SuggestionStore.addSuggestion(id, '', {
+            type: 'type',
+            loading: true,
+        }, suggestion, 'captured');
+        assert.equal(SuggestionStore.hasSuggestions(id), false);
+
+        SuggestionStore.addSuggestion(id, 'a', {
+            type: 'type',
+        }, suggestion, 'captured');
+        assert.equal(SuggestionStore.hasSuggestions(id), true);
+    });
 });


### PR DESCRIPTION
#### Summary
The channel mention provider renders a fake "loading" item while waiting for results from the server. If there are no matches, the corresponding empty term ("") incorrectly causes the suggestion box to believe there are terms, and thus attempt to replace the typed text with nothing at all.

See https://github.com/mattermost/mattermost-webapp/blob/047cdb8a0f3b73c650d24cd4f1dc7d2a6ab4be28/components/suggestion/channel_mention_provider.jsx#L140-L143 for the code in question that triggered this behaviour. I opted not to do a wholesale refactoring to model this concept more cleanly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12031

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)