### PR TITLE
MM-12153: Remove Default Server Language option from the config panel

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -362,7 +362,7 @@ export default {
                             label: 'admin.general.localization.serverLocaleTitle',
                             label_default: 'Default Server Language:',
                             help_text: 'admin.general.localization.serverLocaleDescription',
-                            help_text_default: 'Default language for system messages and logs. Changing this will require a server restart before taking effect.',
+                            help_text_default: 'Default language for system messages. Changing this will require a server restart before taking effect.',
                         },
                         {
                             type: Constants.SettingsTypes.TYPE_LANGUAGE,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -507,7 +507,7 @@
   "admin.general.localization.availableLocalesTitle": "Available Languages:",
   "admin.general.localization.clientLocaleDescription": "Default language for newly created users and pages where the user hasn't logged in.",
   "admin.general.localization.clientLocaleTitle": "Default Client Language:",
-  "admin.general.localization.serverLocaleDescription": "Default language for system messages and logs. Changing this will require a server restart before taking effect.",
+  "admin.general.localization.serverLocaleDescription": "Default language for system messages. Changing this will require a server restart before taking effect.",
   "admin.general.localization.serverLocaleTitle": "Default Server Language:",
   "admin.general.log": "Logging",
   "admin.general.privacy": "Privacy",


### PR DESCRIPTION
#### Summary
Remove Default Server Language option from the config panel

#### Ticket Link
[MM-12153](https://mattermost.atlassian.net/browse/MM-12153)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed