### PR TITLE
MM-12066 Typing when not focused on an input goes to post textbox

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -218,6 +218,13 @@ export default class CreateComment extends React.PureComponent {
             return;
         }
 
+        // Bit of a hack to not steal focus from the channel switch modal if it's open
+        // This is a special case as the channel switch modal does not enforce focus like
+        // most modals do
+        if (document.getElementsByClassName('channel-switch-modal').length) {
+            return;
+        }
+
         if (PostUtils.shouldFocusMainTextbox(e, document.activeElement)) {
             this.focusTextbox();
         }

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -153,6 +153,7 @@ export default class CreateComment extends React.PureComponent {
          * The maximum length of a post
          */
         maxPostSize: PropTypes.number.isRequired,
+        rhsExpanded: PropTypes.bool.isRequired,
     }
 
     constructor(props) {
@@ -180,10 +181,12 @@ export default class CreateComment extends React.PureComponent {
 
     componentDidMount() {
         this.focusTextbox();
+        document.addEventListener('keydown', this.focusTextboxIfNecessary);
     }
 
     componentWillUnmount() {
         this.props.resetCreatePostRequest();
+        document.removeEventListener('keydown', this.focusTextboxIfNecessary);
     }
 
     UNSAFE_componentWillReceiveProps(newProps) { // eslint-disable-line camelcase
@@ -205,6 +208,17 @@ export default class CreateComment extends React.PureComponent {
         }
 
         if (prevProps.rootId !== this.props.rootId) {
+            this.focusTextbox();
+        }
+    }
+
+    focusTextboxIfNecessary = (e) => {
+        // Should only focus if RHS is expanded
+        if (!this.props.rhsExpanded) {
+            return;
+        }
+
+        if (PostUtils.shouldFocusMainTextbox(e, document.activeElement)) {
             this.focusTextbox();
         }
     }

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -21,7 +21,7 @@ import {
     makeOnSubmit,
     makeOnEditLatestPost,
 } from 'actions/views/create_comment';
-import {getPostDraft} from 'selectors/rhs';
+import {getPostDraft, getIsRhsExpanded} from 'selectors/rhs';
 
 import CreateComment from './create_comment.jsx';
 
@@ -54,6 +54,7 @@ function mapStateToProps(state, ownProps) {
         enableGifPicker,
         locale: getCurrentLocale(state),
         maxPostSize: parseInt(config.MaxPostSize, 10) || Constants.DEFAULT_CHARACTER_LIMIT,
+        rhsExpanded: getIsRhsExpanded(state),
     };
 }
 

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -146,6 +146,7 @@ export default class CreatePost extends React.Component {
          * Whether to display a confirmation modal to reset status.
          */
         userIsOutOfOffice: PropTypes.bool.isRequired,
+        rhsExpanded: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
 
             /**
@@ -240,7 +241,7 @@ export default class CreatePost extends React.Component {
 
     componentDidMount() {
         this.focusTextbox();
-        document.addEventListener('keydown', this.showShortcuts);
+        document.addEventListener('keydown', this.documentKeyHandler);
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
@@ -262,7 +263,7 @@ export default class CreatePost extends React.Component {
     }
 
     componentWillUnmount() {
-        document.removeEventListener('keydown', this.showShortcuts);
+        document.removeEventListener('keydown', this.documentKeyHandler);
     }
 
     handlePostError = (postError) => {
@@ -623,12 +624,26 @@ export default class CreatePost extends React.Component {
         this.handleFileUploadChange();
     }
 
-    showShortcuts(e) {
+    focusTextboxIfNecessary = (e) => {
+        // Focus should go to the RHS when it is expanded
+        if (this.props.rhsExpanded) {
+            return;
+        }
+
+        if (PostUtils.shouldFocusMainTextbox(e, document.activeElement)) {
+            this.focusTextbox();
+        }
+    }
+
+    documentKeyHandler = (e) => {
         if ((e.ctrlKey || e.metaKey) && Utils.isKeyPressed(e, KeyCodes.FORWARD_SLASH)) {
             e.preventDefault();
 
             GlobalActions.toggleShortcutsModal();
+            return;
         }
+
+        this.focusTextboxIfNecessary(e);
     }
 
     getFileCount = () => {

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -630,6 +630,13 @@ export default class CreatePost extends React.Component {
             return;
         }
 
+        // Bit of a hack to not steal focus from the channel switch modal if it's open
+        // This is a special case as the channel switch modal does not enforce focus like
+        // most modals do
+        if (document.getElementsByClassName('channel-switch-modal').length) {
+            return;
+        }
+
         if (PostUtils.shouldFocusMainTextbox(e, document.activeElement)) {
             this.focusTextbox();
         }

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -28,7 +28,7 @@ import {Posts} from 'mattermost-redux/constants';
 import {emitUserPostedEvent, postListScrollChangeToBottom} from 'actions/global_actions.jsx';
 import {createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
-import {getPostDraft} from 'selectors/rhs';
+import {getPostDraft, getIsRhsExpanded} from 'selectors/rhs';
 import {getCurrentLocale} from 'selectors/i18n';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import {openModal} from 'actions/views/modals';
@@ -77,6 +77,7 @@ function mapStateToProps() {
             enableConfirmNotificationsToChannel,
             maxPostSize: parseInt(config.MaxPostSize, 10) || Constants.DEFAULT_CHARACTER_LIMIT,
             userIsOutOfOffice,
+            rhsExpanded: getIsRhsExpanded(state),
         };
     };
 }

--- a/tests/components/create_comment/create_comment.test.jsx
+++ b/tests/components/create_comment/create_comment.test.jsx
@@ -45,6 +45,7 @@ describe('components/CreateComment', () => {
         enableGifPicker: true,
         enableConfirmNotificationsToChannel: true,
         maxPostSize: Constants.DEFAULT_CHARACTER_LIMIT,
+        rhsExpanded: false,
     };
 
     test('should match snapshot, empty comment', () => {

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -119,6 +119,7 @@ function createPost({
             enableGifPicker={true}
             maxPostSize={Constants.DEFAULT_CHARACTER_LIMIT}
             userIsOutOfOffice={false}
+            rhsExpanded={false}
         />
     );
 }
@@ -527,13 +528,13 @@ describe('components/create_post', () => {
     it('Should call Shortcut modal on FORWARD_SLASH+cntrl/meta', () => {
         const wrapper = shallow(createPost());
         const instance = wrapper.instance();
-        instance.showShortcuts({ctrlKey: true, key: Constants.KeyCodes.BACK_SLASH[0], keyCode: Constants.KeyCodes.BACK_SLASH[1], preventDefault: jest.fn});
+        instance.documentKeyHandler({ctrlKey: true, key: Constants.KeyCodes.BACK_SLASH[0], keyCode: Constants.KeyCodes.BACK_SLASH[1], preventDefault: jest.fn});
         expect(GlobalActions.toggleShortcutsModal).not.toHaveBeenCalled();
-        instance.showShortcuts({ctrlKey: true, key: 'ù', keyCode: Constants.KeyCodes.FORWARD_SLASH[1], preventDefault: jest.fn});
+        instance.documentKeyHandler({ctrlKey: true, key: 'ù', keyCode: Constants.KeyCodes.FORWARD_SLASH[1], preventDefault: jest.fn});
         expect(GlobalActions.toggleShortcutsModal).toHaveBeenCalled();
-        instance.showShortcuts({ctrlKey: true, key: '/', keyCode: Constants.KeyCodes.SEVEN[1], preventDefault: jest.fn});
+        instance.documentKeyHandler({ctrlKey: true, key: '/', keyCode: Constants.KeyCodes.SEVEN[1], preventDefault: jest.fn});
         expect(GlobalActions.toggleShortcutsModal).toHaveBeenCalled();
-        instance.showShortcuts({ctrlKey: true, key: Constants.KeyCodes.FORWARD_SLASH[0], keyCode: Constants.KeyCodes.FORWARD_SLASH[1], preventDefault: jest.fn});
+        instance.documentKeyHandler({ctrlKey: true, key: Constants.KeyCodes.FORWARD_SLASH[0], keyCode: Constants.KeyCodes.FORWARD_SLASH[1], preventDefault: jest.fn});
         expect(GlobalActions.toggleShortcutsModal).toHaveBeenCalled();
     });
 

--- a/tests/utils/post_utils.test.jsx
+++ b/tests/utils/post_utils.test.jsx
@@ -171,3 +171,76 @@ describe('PostUtils.containsAtChannel', function() {
         }
     });
 });
+
+describe('PostUtils.shouldFocusMainTextbox', function() {
+    test('basic cases', function() {
+        for (const data of [
+            {
+                event: null,
+                expected: false,
+            },
+            {
+                event: {},
+                expected: false,
+            },
+            {
+                event: {ctrlKey: true},
+                activeElement: {tagName: 'BODY'},
+                expected: false,
+            },
+            {
+                event: {metaKey: true},
+                activeElement: {tagName: 'BODY'},
+                expected: false,
+            },
+            {
+                event: {altKey: true},
+                activeElement: {tagName: 'BODY'},
+                expected: false,
+            },
+            {
+                event: {},
+                activeElement: {tagName: 'BODY'},
+                expected: false,
+            },
+            {
+                event: {key: 'a'},
+                activeElement: {tagName: 'BODY'},
+                expected: true,
+            },
+            {
+                event: {key: 'a'},
+                activeElement: {tagName: 'INPUT'},
+                expected: false,
+            },
+            {
+                event: {key: 'a'},
+                activeElement: {tagName: 'TEXTAREA'},
+                expected: false,
+            },
+            {
+                event: {key: '0'},
+                activeElement: {tagName: 'BODY'},
+                expected: true,
+            },
+            {
+                event: {key: '!'},
+                activeElement: {tagName: 'BODY'},
+                expected: true,
+            },
+            {
+                event: {key: ' '},
+                activeElement: {tagName: 'BODY'},
+                expected: true,
+            },
+            {
+                event: {key: 'BACKSPACE'},
+                activeElement: {tagName: 'BODY'},
+                expected: false,
+            },
+        ]) {
+            const shouldFocus = PostUtils.shouldFocusMainTextbox(data.event, data.activeElement);
+            assert.equal(shouldFocus, data.expected);
+        }
+    });
+});

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -157,8 +157,7 @@ export function shouldFocusMainTextbox(e, activeElement) {
     }
 
     // Do not focus for non-character or non-number keys
-    // Note this does not work for some non-English characters
-    if (e.key.length !== 1 || !e.key.match(/[a-zA-ZÀ-ÿ0-9!@#$%^&*()-=+[\]{}\\|;:'",.<>/?`~ ]/i)) {
+    if (e.key.length !== 1 || !e.key.match(/./)) {
         return false;
     }
 

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -129,3 +129,38 @@ export function containsAtChannel(text) {
 
     return (/\B@(all|channel)\b/i).test(mentionableText);
 }
+
+export function shouldFocusMainTextbox(e, activeElement) {
+    if (!e) {
+        return false;
+    }
+
+    // Do not focus if we're currently focused on a textarea or input
+    const keepFocusTags = ['TEXTAREA', 'INPUT'];
+    if (!activeElement || keepFocusTags.includes(activeElement.tagName)) {
+        return false;
+    }
+
+    // Focus if it is an attempted paste
+    if (Utils.cmdOrCtrlPressed(e) && Utils.isKeyPressed(e, Constants.KeyCodes.V)) {
+        return true;
+    }
+
+    // Do not focus if a modifier key is pressed
+    if (e.ctrlKey || e.metaKey || e.altKey) {
+        return false;
+    }
+
+    // Do not focus if the key is undefined or null
+    if (e.key == null) {
+        return false;
+    }
+
+    // Do not focus for non-character or non-number keys
+    // Note this does not work for some non-English characters
+    if (e.key.length !== 1 || !e.key.match(/[a-zA-ZÀ-ÿ0-9!@#$%^&*()-=+[\]{}\\|;:'",.<>/?`~ ]/i)) {
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
#### Summary
Typing when not focused on an input goes to post textbox.

Note that this doesn't work for all non-English characters, though it will work for some.

QA this one is going to need some fairly thorough testing as we want to make sure this isn't going to steal the focus away from the user in situations where it doesn't make sense to. In addition, the linked ticket has a list of common cases to test.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12066

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Touches critical sections of the codebase (steals focus)
