### PR TITLE
MM-11854 Commented on message for different webhook props

### DIFF
--- a/components/post_view/commented_on/commented_on.jsx
+++ b/components/post_view/commented_on/commented_on.jsx
@@ -32,24 +32,33 @@ export default class CommentedOn extends PureComponent {
     makeUsername = () => {
         const postProps = this.props.post.props;
         let username = this.props.displayName;
-        if (
-            this.props.enablePostUsernameOverride &&
-            postProps &&
-            postProps.from_webhook === 'true' &&
-            postProps.override_username
-        ) {
+        if (this.props.enablePostUsernameOverride && postProps && postProps.from_webhook === 'true' && postProps.override_username) {
             username = postProps.override_username;
         }
         return username;
     }
 
+    makeCommentedOnMessage = () => {
+        const {post} = this.props;
+        let message = '';
+        if (post.message) {
+            message = Utils.replaceHtmlEntities(post.message);
+        } else if (post.file_ids && post.file_ids.length > 0) {
+            message = (
+                <CommentedOnFilesMessage parentPostId={post.id}/>
+            );
+        } else {
+            const attachment = post.props.attachments[0];
+            const webhookMessage = attachment.pretext || attachment.title || attachment.text || attachment.fallback;
+            message = Utils.replaceHtmlEntities(webhookMessage);
+        }
+
+        return message;
+    }
+
     render() {
-        const {
-            post,
-        } = this.props;
-
         const username = this.makeUsername();
-
+        const message = this.makeCommentedOnMessage();
         let apostrophe = '\'s';
         if (username.slice(-1) === 's') {
             apostrophe = '\'';
@@ -63,19 +72,6 @@ export default class CommentedOn extends PureComponent {
                 {username}
             </a>
         );
-
-        let message = '';
-        if (post.message === '' && post.props && post.props.attachments) {
-            const attachment = post.props.attachments[0];
-            const webhookMessage = attachment.pretext || attachment.title || attachment.text || attachment.fallback;
-            message = Utils.replaceHtmlEntities(webhookMessage);
-        } else if (post.file_ids && post.file_ids.length > 0) {
-            message = (
-                <CommentedOnFilesMessage parentPostId={post.id}/>
-            );
-        } else {
-            message = Utils.replaceHtmlEntities(post.message);
-        }
 
         return (
             <div className='post__link'>

--- a/components/post_view/commented_on/commented_on.jsx
+++ b/components/post_view/commented_on/commented_on.jsx
@@ -47,9 +47,9 @@ export default class CommentedOn extends PureComponent {
             message = (
                 <CommentedOnFilesMessage parentPostId={post.id}/>
             );
-        } else {
+        } else if (post.props && post.props.attachments && post.props.attachments.length > 0) {
             const attachment = post.props.attachments[0];
-            const webhookMessage = attachment.pretext || attachment.title || attachment.text || attachment.fallback;
+            const webhookMessage = attachment.pretext || attachment.title || attachment.text || attachment.fallback || '';
             message = Utils.replaceHtmlEntities(webhookMessage);
         }
 

--- a/tests/components/post_view/__snapshots__/commented_on.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/commented_on.test.jsx.snap
@@ -91,3 +91,123 @@ exports[`components/post_view/CommentedOn should match snapshot 3`] = `
   </span>
 </div>
 `;
+
+exports[`components/post_view/CommentedOn should match snapshots for post with props.fallback as message 1`] = `
+<div
+  className="post__link"
+>
+  <span>
+    <FormattedMessage
+      defaultMessage="Commented on {name}{apostrophe} message: "
+      id="post_body.commentedOn"
+      values={
+        Object {
+          "apostrophe": "'s",
+          "name": <a
+            className="theme"
+            onClick={[Function]}
+          >
+            override_username
+          </a>,
+        }
+      }
+    />
+    <a
+      className="theme"
+      onClick={[MockFunction]}
+    >
+      This is fallback message
+    </a>
+  </span>
+</div>
+`;
+
+exports[`components/post_view/CommentedOn should match snapshots for post with props.pretext as message 1`] = `
+<div
+  className="post__link"
+>
+  <span>
+    <FormattedMessage
+      defaultMessage="Commented on {name}{apostrophe} message: "
+      id="post_body.commentedOn"
+      values={
+        Object {
+          "apostrophe": "'s",
+          "name": <a
+            className="theme"
+            onClick={[Function]}
+          >
+            override_username
+          </a>,
+        }
+      }
+    />
+    <a
+      className="theme"
+      onClick={[MockFunction]}
+    >
+      This is a pretext
+    </a>
+  </span>
+</div>
+`;
+
+exports[`components/post_view/CommentedOn should match snapshots for post with props.text as message 1`] = `
+<div
+  className="post__link"
+>
+  <span>
+    <FormattedMessage
+      defaultMessage="Commented on {name}{apostrophe} message: "
+      id="post_body.commentedOn"
+      values={
+        Object {
+          "apostrophe": "'s",
+          "name": <a
+            className="theme"
+            onClick={[Function]}
+          >
+            override_username
+          </a>,
+        }
+      }
+    />
+    <a
+      className="theme"
+      onClick={[MockFunction]}
+    >
+      This is a text
+    </a>
+  </span>
+</div>
+`;
+
+exports[`components/post_view/CommentedOn should match snapshots for post with props.title as message 1`] = `
+<div
+  className="post__link"
+>
+  <span>
+    <FormattedMessage
+      defaultMessage="Commented on {name}{apostrophe} message: "
+      id="post_body.commentedOn"
+      values={
+        Object {
+          "apostrophe": "'s",
+          "name": <a
+            className="theme"
+            onClick={[Function]}
+          >
+            override_username
+          </a>,
+        }
+      }
+    />
+    <a
+      className="theme"
+      onClick={[MockFunction]}
+    >
+      This is a title
+    </a>
+  </span>
+</div>
+`;

--- a/tests/components/post_view/commented_on.test.jsx
+++ b/tests/components/post_view/commented_on.test.jsx
@@ -165,7 +165,7 @@ describe('components/post_view/CommentedOn', () => {
         expect(baseProps.actions.showSearchResults).toHaveBeenCalledTimes(1);
     });
 
-    test('Should trigger search with ', () => {
+    test('Should trigger search with override_username', () => {
         const wrapper = shallow(<CommentedOn {...baseProps}/>);
         wrapper.setProps({enablePostUsernameOverride: true});
 

--- a/tests/components/post_view/commented_on.test.jsx
+++ b/tests/components/post_view/commented_on.test.jsx
@@ -16,7 +16,7 @@ describe('components/post_view/CommentedOn', () => {
             id: 'post_id',
             message: 'text message',
             props: {
-                from_webhook: true,
+                from_webhook: 'true',
                 override_username: 'override_username',
             },
         },
@@ -44,6 +44,110 @@ describe('components/post_view/CommentedOn', () => {
         expect(wrapper.find(CommentedOnFilesMessage).exists()).toBe(true);
     });
 
+    test('should match snapshots for post with props.pretext as message', () => {
+        const newPost = {
+            id: 'post_id',
+            message: '',
+            props: {
+                from_webhook: 'true',
+                override_username: 'override_username',
+                attachments: [{
+                    pretext: 'This is a pretext',
+                }],
+            },
+        };
+        const newProps = {
+            ...baseProps,
+            post: {
+                ...newPost,
+            },
+            enablePostUsernameOverride: true,
+        };
+
+        const wrapper = shallow(<CommentedOn {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshots for post with props.title as message', () => {
+        const newPost = {
+            id: 'post_id',
+            message: '',
+            props: {
+                from_webhook: 'true',
+                override_username: 'override_username',
+                attachments: [{
+                    pretext: '',
+                    title: 'This is a title',
+                }],
+            },
+        };
+        const newProps = {
+            ...baseProps,
+            post: {
+                ...newPost,
+            },
+            enablePostUsernameOverride: true,
+        };
+
+        const wrapper = shallow(<CommentedOn {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshots for post with props.text as message', () => {
+        const newPost = {
+            id: 'post_id',
+            message: '',
+            props: {
+                from_webhook: 'true',
+                override_username: 'override_username',
+                attachments: [{
+                    pretext: '',
+                    title: '',
+                    text: 'This is a text',
+                }],
+            },
+        };
+
+        const newProps = {
+            ...baseProps,
+            post: {
+                ...newPost,
+            },
+            enablePostUsernameOverride: true,
+        };
+
+        const wrapper = shallow(<CommentedOn {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshots for post with props.fallback as message', () => {
+        const newPost = {
+            id: 'post_id',
+            message: '',
+            props: {
+                from_webhook: 'true',
+                override_username: 'override_username',
+                attachments: [{
+                    pretext: '',
+                    title: '',
+                    text: '',
+                    fallback: 'This is fallback message',
+                }],
+            },
+        };
+
+        const newProps = {
+            ...baseProps,
+            post: {
+                ...newPost,
+            },
+            enablePostUsernameOverride: true,
+        };
+
+        const wrapper = shallow(<CommentedOn {...newProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should call onCommentClick on click of text message', () => {
         const wrapper = shallow(<CommentedOn {...baseProps}/>);
 
@@ -58,6 +162,17 @@ describe('components/post_view/CommentedOn', () => {
 
         expect(baseProps.actions.updateSearchTerms).toHaveBeenCalledTimes(1);
         expect(baseProps.actions.updateSearchTerms).toHaveBeenCalledWith(baseProps.displayName);
+        expect(baseProps.actions.showSearchResults).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should trigger search with ', () => {
+        const wrapper = shallow(<CommentedOn {...baseProps}/>);
+        wrapper.setProps({enablePostUsernameOverride: true});
+
+        wrapper.instance().handleOnClick();
+
+        expect(baseProps.actions.updateSearchTerms).toHaveBeenCalledTimes(1);
+        expect(baseProps.actions.updateSearchTerms).toHaveBeenCalledWith(baseProps.post.props.override_username);
 
         expect(baseProps.actions.showSearchResults).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
#### Summary
  * Change from_webhook to string true as that is how API responds
  * Use enablePostUsernameOverride for searchTerm
  * Use pretext > title > text > falllback for commented on
    message

#### Ticket Link
[MM-11854](https://mattermost.atlassian.net/browse/MM-11854)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
