### PR TITLE
MM-11792 Make emoji picker search box regain focus when switching tabs

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -118,6 +118,7 @@ export default class EmojiPicker extends React.PureComponent {
         customEmojisEnabled: PropTypes.bool,
         emojiMap: PropTypes.object.isRequired,
         customEmojiPage: PropTypes.number.isRequired,
+        visible: PropTypes.bool,
         actions: PropTypes.shape({
             getCustomEmojis: PropTypes.func.isRequired,
             searchCustomEmojis: PropTypes.func.isRequired,
@@ -227,6 +228,12 @@ export default class EmojiPicker extends React.PureComponent {
         await this.props.actions.incrementEmojiPickerPage();
 
         this.loadingMoreEmojis = false;
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.visible && !prevProps.visible) {
+            this.searchInput.focus();
+        }
     }
 
     lastVisibleEmojiRef = (lastVisibleEmoji) => {

--- a/components/emoji_picker/emoji_picker_tabs.jsx
+++ b/components/emoji_picker/emoji_picker_tabs.jsx
@@ -28,6 +28,26 @@ export default class EmojiPickerTabs extends PureComponent {
         topOffset: 0,
     };
 
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            emojiTabVisible: true,
+        };
+    }
+
+    handleEnterEmojiTab = () => {
+        this.setState({
+            emojiTabVisible: true,
+        });
+    };
+
+    handleExitEmojiTab = () => {
+        this.setState({
+            emojiTabVisible: false,
+        });
+    };
+
     render() {
         let pickerStyle;
         if (this.props.style && !(this.props.style.left === 0 && this.props.style.top === 0)) {
@@ -63,12 +83,15 @@ export default class EmojiPickerTabs extends PureComponent {
                 >
                     <Tab
                         eventKey={1}
+                        onEnter={this.handleEnterEmojiTab}
+                        onExit={this.handleExitEmojiTab}
                         title={<EmojiIcon/>}
                     >
                         <EmojiPicker
                             style={this.props.style}
                             onEmojiClick={this.props.onEmojiClick}
                             customEmojis={this.props.customEmojis}
+                            visible={this.state.emojiTabVisible}
                         />
                     </Tab>
                     <Tab


### PR DESCRIPTION
A couple things to note about this:
1. The gif picker tab doesn't need this since it is mounted/unmounted when switching tabs. The emoji picker can't do that because it takes too long to remount
2. I couldn't hook into the activeKey used for the Tabs component since the value for that switches before the emoji picker can gain focus

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11792