### PR TITLE
[MM-9577] Update pinned posts list on channel switch

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -24,10 +24,11 @@ import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
 import {handleNewPost} from 'actions/post_actions.jsx';
 import {stopPeriodicStatusUpdates} from 'actions/status_actions.jsx';
 import {loadNewDMIfNeeded, loadNewGMIfNeeded, loadProfilesForSidebar} from 'actions/user_actions.jsx';
-import {closeRightHandSide, closeMenu as closeRhsMenu} from 'actions/views/rhs';
+import {closeRightHandSide, closeMenu as closeRhsMenu, updateRhsState} from 'actions/views/rhs';
 import {close as closeLhs} from 'actions/views/lhs';
 import * as WebsocketActions from 'actions/websocket_actions.jsx';
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
+import {getIsRhsOpen, getRhsState} from 'selectors/rhs';
 import BrowserStore from 'stores/browser_store.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 import ErrorStore from 'stores/error_store.jsx';
@@ -36,7 +37,7 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import WebSocketClient from 'client/web_websocket_client.jsx';
 
-import {ActionTypes, Constants, ErrorPageTypes, PostTypes} from 'utils/constants.jsx';
+import {ActionTypes, Constants, ErrorPageTypes, PostTypes, RHSStates} from 'utils/constants.jsx';
 import EventTypes from 'utils/event_types.jsx';
 import {filterAndSortTeamsByDisplayName} from 'utils/team_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -59,12 +60,15 @@ export function emitChannelClickEvent(channel) {
         }
     }
     function switchToChannel(chan) {
-        const getMyChannelMemberPromise = getMyChannelMember(chan.id)(dispatch, getState);
+        const state = getState();
+        const getMyChannelMemberPromise = dispatch(getMyChannelMember(chan.id));
         const oldChannelId = ChannelStore.getCurrentId();
-        const teamId = chan.team_id || getCurrentTeamId(getState());
+        const teamId = chan.team_id || getCurrentTeamId(state);
+        const isRHSOpened = getIsRhsOpen(state);
+        const isPinnedPostsShowing = getRhsState(state) === RHSStates.PIN;
 
         getMyChannelMemberPromise.then(() => {
-            getChannelStats(chan.id)(dispatch, getState);
+            dispatch(getChannelStats(chan.id));
 
             // Mark previous and next channel as read
             dispatch(markChannelAsRead(chan.id, oldChannelId));
@@ -73,6 +77,12 @@ export function emitChannelClickEvent(channel) {
 
         if (chan.delete_at === 0) {
             BrowserStore.setGlobalItem(Constants.PREV_CHANNEL_KEY + teamId, chan.name);
+        }
+
+        // When switching to a different channel if the pinned posts is showing
+        // Update the RHS state to reflect the pinned post of the selected channel
+        if (isRHSOpened && isPinnedPostsShowing) {
+            dispatch(updateRhsState(RHSStates.PIN, chan.id));
         }
 
         loadProfilesForSidebar();

--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -21,7 +21,7 @@ import * as Utils from 'utils/utils';
 
 import {getBrowserUtcOffset, getUtcOffsetForTimeZone} from 'utils/timezone';
 
-export function updateRhsState(rhsState) {
+export function updateRhsState(rhsState, channelId) {
     return (dispatch, getState) => {
         const action = {
             type: ActionTypes.UPDATE_RHS_STATE,
@@ -29,7 +29,7 @@ export function updateRhsState(rhsState) {
         };
 
         if (rhsState === RHSStates.PIN) {
-            action.channelId = getCurrentChannelId(getState());
+            action.channelId = channelId || getCurrentChannelId(getState());
         }
 
         dispatch(action);

--- a/components/sidebar_right/index.js
+++ b/components/sidebar_right/index.js
@@ -8,7 +8,7 @@ import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
 import PostStore from 'stores/post_store';
-import {getPinnedPosts, getFlaggedPosts, setRhsExpanded} from 'actions/views/rhs';
+import {getPinnedPosts, getFlaggedPosts, setRhsExpanded, showPinnedPosts} from 'actions/views/rhs';
 import {
     getIsRhsExpanded,
     getIsRhsOpen,
@@ -61,6 +61,7 @@ function mapDispatchToProps(dispatch) {
             getPinnedPosts,
             getFlaggedPosts,
             setRhsExpanded,
+            showPinnedPosts,
         }, dispatch),
     };
 }

--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -32,8 +32,9 @@ export default class SidebarRight extends React.Component {
             getPinnedPosts: PropTypes.func.isRequired,
             getFlaggedPosts: PropTypes.func.isRequired,
             setRhsExpanded: PropTypes.func.isRequired,
+            showPinnedPosts: PropTypes.func.isRequired,
         }),
-    }
+    };
 
     constructor(props) {
         super(props);
@@ -56,6 +57,12 @@ export default class SidebarRight extends React.Component {
         if (!isOpen && willOpen) {
             trackEvent('ui', 'ui_rhs_opened');
         }
+
+        if (nextProps.isPinnedPosts && nextProps.channel &&
+            this.props.isPinnedPosts === nextProps.isPinnedPosts &&
+            this.props.channel !== nextProps.channel) {
+            this.props.actions.showPinnedPosts(nextProps.channel.id);
+        }
     }
 
     componentDidUpdate(prevProps) {
@@ -72,7 +79,7 @@ export default class SidebarRight extends React.Component {
         if (this.props.channel && this.props.isPinnedPosts) {
             this.props.actions.getPinnedPosts(this.props.channel.id);
         }
-    }
+    };
 
     onShrink = () => {
         this.props.actions.setRhsExpanded(false);


### PR DESCRIPTION
#### Summary
If the RHS is opened and showing pinned posts and we switch channels then the pinned post in the RHS are updated to show the pinned posts of the selected channel

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9577

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
