### PR TITLE
MM-12285: Migrate Admin Console Plugins screens to declarative

### DIFF
--- a/components/admin_console/admin_console.jsx
+++ b/components/admin_console/admin_console.jsx
@@ -20,8 +20,6 @@ import EmailSettings from 'components/admin_console/email_settings.jsx';
 import GitLabSettings from 'components/admin_console/gitlab_settings.jsx';
 import MessageExportSettings from 'components/admin_console/message_export_settings';
 import PasswordSettings from 'components/admin_console/password_settings.jsx';
-import PluginManagement from 'components/admin_console/plugin_management';
-import CustomPluginSettings from 'components/admin_console/custom_plugin_settings';
 
 import SchemaAdminSettings from 'components/admin_console/schema_admin_settings';
 import PushSettings from 'components/admin_console/push_settings.jsx';
@@ -415,13 +413,19 @@ export default class AdminConsole extends React.Component {
                                     />
                                     <SCRoute
                                         path={`${props.match.url}/management`}
-                                        component={PluginManagement}
-                                        extraProps={extraProps}
+                                        component={SchemaAdminSettings}
+                                        extraProps={{
+                                            ...extraProps,
+                                            schema: AdminDefinition.settings.plugins.management.schema,
+                                        }}
                                     />
                                     <SCRoute
                                         path={`${props.match.url}/custom/:plugin_id`}
-                                        component={CustomPluginSettings}
-                                        extraProps={extraProps}
+                                        component={SchemaAdminSettings}
+                                        extraProps={{
+                                            ...extraProps,
+                                            schema: AdminDefinition.settings.plugins.custom.schema,
+                                        }}
                                     />
                                     <Redirect to={`${props.match.url}/configuration`}/>
                                 </Switch>

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -15,6 +15,9 @@ import {
 } from 'actions/admin_actions';
 import SystemAnalytics from 'components/analytics/system_analytics';
 import TeamAnalytics from 'components/analytics/team_analytics';
+import PluginManagement from 'components/admin_console/plugin_management';
+import CustomPluginSettings from 'components/admin_console/custom_plugin_settings';
+
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 
 import Audits from './audits';
@@ -2188,6 +2191,18 @@ export default {
                             help_text_markdown: true,
                         },
                     ],
+                },
+            },
+            management: {
+                schema: {
+                    id: 'PluginManagementSettings',
+                    component: PluginManagement,
+                },
+            },
+            custom: {
+                schema: {
+                    id: 'CustomPluginSettings',
+                    component: CustomPluginSettings,
                 },
             },
         },


### PR DESCRIPTION
#### Summary
Migrate Admin Console Plugins screens to declarative

#### Ticket Link
[MM-12285](https://mattermost.atlassian.net/browse/MM-12285)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed