### PR TITLE
[MM-11959] Add feature to send code block on CTRL + ENTER

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -13,7 +13,7 @@ import * as GlobalActions from 'actions/global_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
-import * as PostUtils from 'utils/post_utils.jsx';
+import {containsAtChannel, postMessageOnKeyPress, shouldFocusMainTextbox} from 'utils/post_utils.jsx';
 
 import ConfirmModal from 'components/confirm_modal.jsx';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
@@ -23,8 +23,6 @@ import MsgTyping from 'components/msg_typing';
 import PostDeletedModal from 'components/post_deleted_modal.jsx';
 import EmojiIcon from 'components/svg/emoji_icon';
 import Textbox from 'components/textbox.jsx';
-
-const KeyCodes = Constants.KeyCodes;
 
 export default class CreateComment extends React.PureComponent {
     static propTypes = {
@@ -67,6 +65,11 @@ export default class CreateComment extends React.PureComponent {
          * Whether the submit button is enabled
          */
         enableAddButton: PropTypes.bool.isRequired,
+
+        /**
+         * Force message submission on CTRL/CMD + ENTER
+         */
+        codeBlockOnCtrlEnter: PropTypes.bool,
 
         /**
          * Set to force form submission on CTRL/CMD + ENTER instead of ENTER
@@ -225,7 +228,7 @@ export default class CreateComment extends React.PureComponent {
             return;
         }
 
-        if (PostUtils.shouldFocusMainTextbox(e, document.activeElement)) {
+        if (shouldFocusMainTextbox(e, document.activeElement)) {
             this.focusTextbox();
         }
     }
@@ -313,7 +316,7 @@ export default class CreateComment extends React.PureComponent {
 
         if (this.props.enableConfirmNotificationsToChannel &&
             this.props.channelMembersCount > Constants.NOTIFY_ALL_MEMBERS &&
-            PostUtils.containsAtChannel(this.state.draft.message)) {
+            containsAtChannel(this.state.draft.message)) {
             this.showNotifyAllModal();
             return;
         }
@@ -370,15 +373,30 @@ export default class CreateComment extends React.PureComponent {
     }
 
     commentMsgKeyPress = (e) => {
-        if (!UserAgent.isMobile() && ((this.props.ctrlSend && (e.ctrlKey || e.metaKey)) || !this.props.ctrlSend)) {
-            if (Utils.isKeyPressed(e, KeyCodes.ENTER) && !e.shiftKey && !e.altKey) {
-                e.preventDefault();
-                this.refs.textbox.blur();
+        const {
+            ctrlSend,
+            codeBlockOnCtrlEnter,
+            channelId,
+            rootId,
+        } = this.props;
+
+        const {allowSending, withClosedCodeBlock, message} = postMessageOnKeyPress(e, this.state.draft.message, ctrlSend, codeBlockOnCtrlEnter);
+
+        if (allowSending) {
+            e.persist();
+            this.refs.textbox.blur();
+
+            if (withClosedCodeBlock && message) {
+                const {draft} = this.state;
+                const updatedDraft = {...draft, message};
+                this.props.onUpdateCommentDraft(updatedDraft);
+                this.setState({draft: updatedDraft}, () => this.handleSubmit(e));
+            } else {
                 this.handleSubmit(e);
             }
         }
 
-        GlobalActions.emitLocalUserTypingEvent(this.props.channelId, this.props.rootId);
+        GlobalActions.emitLocalUserTypingEvent(channelId, rootId);
     }
 
     scrollToBottom = () => {
@@ -400,7 +418,11 @@ export default class CreateComment extends React.PureComponent {
     }
 
     handleKeyDown = (e) => {
-        if (this.props.ctrlSend && Utils.isKeyPressed(e, Constants.KeyCodes.ENTER) && (e.ctrlKey || e.metaKey)) {
+        if (
+            (this.props.ctrlSend || this.props.codeBlockOnCtrlEnter) &&
+            Utils.isKeyPressed(e, Constants.KeyCodes.ENTER) &&
+            (e.ctrlKey || e.metaKey)
+        ) {
             this.commentMsgKeyPress(e);
             return;
         }

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -46,6 +46,7 @@ function mapStateToProps(state, ownProps) {
         messageInHistory,
         enableAddButton,
         channelMembersCount,
+        codeBlockOnCtrlEnter: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'code_block_ctrl_enter', true),
         ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
         createPostErrorId: err.server_error_id,
         readOnlyChannel: !isCurrentUserSystemAdmin(state) && config.ExperimentalTownSquareIsReadOnly === 'true' && channel.name === Constants.DEFAULT_CHANNEL,

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -23,7 +23,7 @@ import {
     addReaction,
     removeReaction,
 } from 'mattermost-redux/actions/posts';
-import {Posts} from 'mattermost-redux/constants';
+import {Posts, Preferences as PreferencesRedux} from 'mattermost-redux/constants';
 
 import {emitUserPostedEvent, postListScrollChangeToBottom} from 'actions/global_actions.jsx';
 import {createPost, setEditingPost} from 'actions/post_actions.jsx';
@@ -60,6 +60,7 @@ function mapStateToProps() {
             currentChannel,
             currentChannelMembersCount,
             currentUserId,
+            codeBlockOnCtrlEnter: getBool(state, PreferencesRedux.CATEGORY_ADVANCED_SETTINGS, 'code_block_ctrl_enter', true),
             ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
             fullWidthTextBox: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
             showTutorialTip: enableTutorial && tutorialStep === TutorialSteps.POST_POPOVER,

--- a/components/user_settings/advanced/code_block_ctrl_enter_section/code_block_ctrl_enter_section.jsx
+++ b/components/user_settings/advanced/code_block_ctrl_enter_section/code_block_ctrl_enter_section.jsx
@@ -1,0 +1,147 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import {Preferences} from 'mattermost-redux/constants';
+
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min.jsx';
+
+import {AdvancedSections} from 'utils/constants.jsx';
+
+export default class CodeBlockCtrlEnterSection extends React.PureComponent {
+    static propTypes = {
+        activeSection: PropTypes.string,
+        currentUserId: PropTypes.string.isRequired,
+        codeBlockOnCtrlEnter: PropTypes.string,
+        sendMessageOnCtrlEnter: PropTypes.bool,
+        onUpdateSection: PropTypes.func.isRequired,
+        prevActiveSection: PropTypes.string,
+        renderOnOffLabel: PropTypes.func.isRequired,
+        actions: PropTypes.shape({
+            savePreferences: PropTypes.func.isRequired,
+        }).isRequired,
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            codeBlockOnCtrlEnterState: props.codeBlockOnCtrlEnter,
+        };
+    }
+
+    handleOnChange = (e) => {
+        const value = e.currentTarget.value;
+
+        this.setState({codeBlockOnCtrlEnterState: value});
+    }
+
+    handleSubmit = () => {
+        const {actions, currentUserId, onUpdateSection} = this.props;
+        const codeBlockOnCtrlEnterPreference = {
+            user_id: currentUserId,
+            category: Preferences.CATEGORY_ADVANCED_SETTINGS,
+            name: 'code_block_ctrl_enter',
+            value: this.state.codeBlockOnCtrlEnterState,
+        };
+
+        actions.savePreferences(currentUserId, [codeBlockOnCtrlEnterPreference]);
+        onUpdateSection();
+    }
+
+    render() {
+        if (this.props.sendMessageOnCtrlEnter) {
+            return null;
+        }
+
+        const {codeBlockOnCtrlEnterState} = this.state;
+
+        let codeBlockOnCtrlEnterSection = (
+            <SettingItemMin
+                title={
+                    <FormattedMessage
+                        id='user.settings.advance.codeBlockOnCtrlEnterSendTitle'
+                        defaultMessage='Send code block messages on CTRL + ENTER'
+                    />
+                }
+                describe={this.props.renderOnOffLabel(codeBlockOnCtrlEnterState)}
+                focused={this.props.prevActiveSection === AdvancedSections.CODE_BLOCK_ON_CTRL_ENTER}
+                section={AdvancedSections.CODE_BLOCK_ON_CTRL_ENTER}
+                updateSection={this.props.onUpdateSection}
+            />
+        );
+        if (this.props.activeSection === AdvancedSections.CODE_BLOCK_ON_CTRL_ENTER) {
+            codeBlockOnCtrlEnterSection = (
+                <SettingItemMax
+                    title={
+                        <FormattedMessage
+                            id='user.settings.advance.codeBlockOnCtrlEnterSendTitle'
+                            defaultMessage='Send code block messages on CTRL + ENTER'
+                        />
+                    }
+                    inputs={[
+                        <div key='codeBlockOnCtrlEnterSetting'>
+                            <div className='radio'>
+                                <label>
+                                    <input
+                                        id='codeBlockOnCtrlEnterOn'
+                                        type='radio'
+                                        value={'true'}
+                                        name={AdvancedSections.CODE_BLOCK_ON_CTRL_ENTER}
+                                        checked={codeBlockOnCtrlEnterState === 'true'}
+                                        onChange={this.handleOnChange}
+                                    />
+                                    <FormattedMessage
+                                        id='user.settings.advance.on'
+                                        defaultMessage='On'
+                                    />
+                                </label>
+                                <br/>
+                            </div>
+                            <div className='radio'>
+                                <label>
+                                    <input
+                                        id='codeBlockOnCtrlEnterOff'
+                                        type='radio'
+                                        value={'false'}
+                                        name={AdvancedSections.CODE_BLOCK_ON_CTRL_ENTER}
+                                        checked={codeBlockOnCtrlEnterState === 'false'}
+                                        onChange={this.handleOnChange}
+                                    />
+                                    <FormattedMessage
+                                        id='user.settings.advance.off'
+                                        defaultMessage='Off'
+                                    />
+                                </label>
+                                <br/>
+                            </div>
+                            <div>
+                                <br/>
+                                <FormattedMessage
+                                    id='user.settings.advance.codeBlockOnCtrlEnterSendDesc'
+                                    defaultMessage='If enabled, ENTER inserts a new line within messages formatted as code starting with ```. CTRL + ENTER submits the message.'
+                                />
+                            </div>
+                        </div>,
+                    ]}
+                    setting={AdvancedSections.CODE_BLOCK_ON_CTRL_ENTER}
+                    submit={this.handleSubmit}
+                    saving={this.state.isSaving}
+                    server_error={this.state.serverError}
+                    updateSection={this.props.onUpdateSection}
+                />
+            );
+        }
+
+        return (
+            <React.Fragment>
+                <div className='divider-light'/>
+                {codeBlockOnCtrlEnterSection}
+            </React.Fragment>
+        );
+    }
+}

--- a/components/user_settings/advanced/code_block_ctrl_enter_section/index.js
+++ b/components/user_settings/advanced/code_block_ctrl_enter_section/index.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+
+import {savePreferences} from 'mattermost-redux/actions/preferences';
+import {Preferences} from 'mattermost-redux/constants';
+import {get as getPreference, getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+import CodeBlockCtrlEnterSection from './code_block_ctrl_enter_section';
+
+function mapStateToProps(state) {
+    return {
+        currentUserId: getCurrentUserId(state),
+        codeBlockOnCtrlEnter: getPreference(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'code_block_ctrl_enter', 'true'),
+        sendMessageOnCtrlEnter: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            savePreferences,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CodeBlockCtrlEnterSection);

--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -16,6 +16,7 @@ import SettingItemMin from 'components/setting_item_min.jsx';
 import ConfirmModal from 'components/confirm_modal.jsx';
 
 import JoinLeaveSection from './join_leave_section';
+import CodeBlockCtrlEnterSection from './code_block_ctrl_enter_section';
 
 const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
@@ -584,6 +585,12 @@ export default class AdvancedSettingsDisplay extends React.Component {
                     </h3>
                     <div className='divider-dark first'/>
                     {ctrlSendSection}
+                    <CodeBlockCtrlEnterSection
+                        activeSection={this.props.activeSection}
+                        onUpdateSection={this.handleUpdateSection}
+                        prevActiveSection={this.props.prevActiveSection}
+                        renderOnOffLabel={this.renderOnOffLabel}
+                    />
                     {formattingSectionDivider}
                     {formattingSection}
                     <div className='divider-light'/>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2661,6 +2661,8 @@
   "user_profile.webrtc.call": "Start Video Call",
   "user_profile.webrtc.offline": "The user is offline",
   "user_profile.webrtc.unavailable": "New call unavailable until your existing call ends",
+  "user.settings.advance.codeBlockOnCtrlEnterSendDesc": "If enabled, ENTER inserts a new line within messages formatted as code starting with ```. CTRL + ENTER submits the message.",
+  "user.settings.advance.codeBlockOnCtrlEnterSendTitle": "Send code block messages on CTRL + ENTER",
   "user.settings.advance.confirmDeactivateAccountTitle": "Confirm Deactivation",
   "user.settings.advance.confirmDeactivateDesc": "Are you sure you want to deactivate your account? This can only be reversed by your System Administrator.",
   "user.settings.advance.deactivate_member_modal.deactivateButton": "Yes, deactivate my account",

--- a/tests/components/user_settings/advanced_tab/__snapshots__/code_block_ctrl_enter_section.test.jsx.snap
+++ b/tests/components/user_settings/advanced_tab/__snapshots__/code_block_ctrl_enter_section.test.jsx.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/user_settings/advanced/JoinLeaveSection should match snapshot 1`] = `
+<Fragment>
+  <div
+    className="divider-light"
+  />
+  <SettingItemMin
+    focused={false}
+    section="codeBlockOnCtrlEnter"
+    title={
+      <FormattedMessage
+        defaultMessage="Send code block messages on CTRL + ENTER"
+        id="user.settings.advance.codeBlockOnCtrlEnterSendTitle"
+        values={Object {}}
+      />
+    }
+    updateSection={[MockFunction]}
+  />
+</Fragment>
+`;
+
+exports[`components/user_settings/advanced/JoinLeaveSection should match snapshot 2`] = `
+<Fragment>
+  <div
+    className="divider-light"
+  />
+  <SettingItemMax
+    containerStyle=""
+    infoPosition="bottom"
+    inputs={
+      Array [
+        <div>
+          <div
+            className="radio"
+          >
+            <label>
+              <input
+                checked={true}
+                id="codeBlockOnCtrlEnterOn"
+                name="codeBlockOnCtrlEnter"
+                onChange={[Function]}
+                type="radio"
+                value="true"
+              />
+              <FormattedMessage
+                defaultMessage="On"
+                id="user.settings.advance.on"
+                values={Object {}}
+              />
+            </label>
+            <br />
+          </div>
+          <div
+            className="radio"
+          >
+            <label>
+              <input
+                checked={false}
+                id="codeBlockOnCtrlEnterOff"
+                name="codeBlockOnCtrlEnter"
+                onChange={[Function]}
+                type="radio"
+                value="false"
+              />
+              <FormattedMessage
+                defaultMessage="Off"
+                id="user.settings.advance.off"
+                values={Object {}}
+              />
+            </label>
+            <br />
+          </div>
+          <div>
+            <br />
+            <FormattedMessage
+              defaultMessage="If enabled, ENTER inserts a new line within messages formatted as code starting with \`\`\`. CTRL + ENTER submits the message."
+              id="user.settings.advance.codeBlockOnCtrlEnterSendDesc"
+              values={Object {}}
+            />
+          </div>
+        </div>,
+      ]
+    }
+    saving={false}
+    section=""
+    setting="codeBlockOnCtrlEnter"
+    submit={[Function]}
+    title={
+      <FormattedMessage
+        defaultMessage="Send code block messages on CTRL + ENTER"
+        id="user.settings.advance.codeBlockOnCtrlEnterSendTitle"
+        values={Object {}}
+      />
+    }
+    updateSection={[MockFunction]}
+  />
+</Fragment>
+`;

--- a/tests/components/user_settings/advanced_tab/code_block_ctrl_enter_section.test.jsx
+++ b/tests/components/user_settings/advanced_tab/code_block_ctrl_enter_section.test.jsx
@@ -1,0 +1,88 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {Preferences} from 'mattermost-redux/constants';
+
+import {AdvancedSections} from 'utils/constants.jsx';
+
+import SettingItemMax from 'components/setting_item_max.jsx';
+import SettingItemMin from 'components/setting_item_min.jsx';
+
+import CodeBlockCtrlEnterSection from 'components/user_settings/advanced/code_block_ctrl_enter_section/code_block_ctrl_enter_section';
+
+describe('components/user_settings/advanced/JoinLeaveSection', () => {
+    const defaultProps = {
+        activeSection: '',
+        currentUserId: 'current_user_id',
+        codeBlockOnCtrlEnter: 'true',
+        onUpdateSection: jest.fn(),
+        prevActiveSection: AdvancedSections.CONTROL_SEND,
+        renderOnOffLabel: jest.fn(),
+        actions: {
+            savePreferences: jest.fn(),
+        },
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <CodeBlockCtrlEnterSection {...defaultProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(SettingItemMax).exists()).toEqual(false);
+        expect(wrapper.find(SettingItemMin).exists()).toEqual(true);
+
+        wrapper.setProps({activeSection: AdvancedSections.CODE_BLOCK_ON_CTRL_ENTER});
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(SettingItemMax).exists()).toEqual(true);
+        expect(wrapper.find(SettingItemMin).exists()).toEqual(false);
+    });
+
+    test('should match state on handleOnChange', () => {
+        const wrapper = shallow(
+            <CodeBlockCtrlEnterSection {...defaultProps}/>
+        );
+
+        let value = 'false';
+        wrapper.setState({codeBlockOnCtrlEnterState: 'true'});
+        wrapper.instance().handleOnChange({currentTarget: {value}});
+        expect(wrapper.state('codeBlockOnCtrlEnterState')).toEqual(value);
+
+        value = 'true';
+        wrapper.instance().handleOnChange({currentTarget: {value}});
+        expect(wrapper.state('codeBlockOnCtrlEnterState')).toEqual(value);
+    });
+
+    test('should call props.actions.savePreferences and props.onUpdateSection on handleSubmit', () => {
+        const actions = {savePreferences: jest.fn()};
+        const onUpdateSection = jest.fn();
+        const wrapper = shallow(
+            <CodeBlockCtrlEnterSection
+                {...defaultProps}
+                actions={actions}
+                onUpdateSection={onUpdateSection}
+            />
+        );
+
+        const codeBlockOnCtrlEnterPreference = {
+            category: Preferences.CATEGORY_ADVANCED_SETTINGS,
+            name: 'code_block_ctrl_enter',
+            user_id: defaultProps.currentUserId,
+            value: 'true',
+        };
+
+        wrapper.instance().handleSubmit();
+        expect(actions.savePreferences).toHaveBeenCalledTimes(1);
+        expect(actions.savePreferences).toHaveBeenCalledWith(defaultProps.currentUserId, [codeBlockOnCtrlEnterPreference]);
+        expect(onUpdateSection).toHaveBeenCalledTimes(1);
+
+        wrapper.setState({codeBlockOnCtrlEnterState: 'false'});
+        codeBlockOnCtrlEnterPreference.value = 'false';
+        wrapper.instance().handleSubmit();
+        expect(actions.savePreferences).toHaveBeenCalledTimes(2);
+        expect(actions.savePreferences).toHaveBeenCalledWith(defaultProps.currentUserId, [codeBlockOnCtrlEnterPreference]);
+    });
+});

--- a/tests/utils/post_utils.test.jsx
+++ b/tests/utils/post_utils.test.jsx
@@ -244,3 +244,173 @@ describe('PostUtils.shouldFocusMainTextbox', function() {
         }
     });
 });
+
+describe('PostUtils.postMessageOnKeyPress', function() {
+    // null/empty cases
+    const emptyCases = [{
+        name: 'null/empty: Test for null event',
+        input: {event: null, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
+        name: 'null/empty: Test for empty message',
+        input: {event: {}, message: '', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
+        name: 'null/empty: Test for shiftKey event',
+        input: {event: {shiftKey: true}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
+        name: 'null/empty: Test for altKey event',
+        input: {event: {altKey: true}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }];
+
+    for (const testCase of emptyCases) {
+        it(testCase.name, () => {
+            const output = PostUtils.postMessageOnKeyPress(
+                testCase.input.event,
+                testCase.input.message,
+                testCase.input.sendMessageOnCtrlEnter,
+                testCase.input.sendCodeBlockOnCtrlEnter
+            );
+
+            expect(output).toEqual(testCase.expected);
+        });
+    }
+
+    // no override case
+    const noOverrideCases = [{
+        name: 'no override: Test no override setting',
+        input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: true},
+    }];
+
+    for (const testCase of noOverrideCases) {
+        it(testCase.name, () => {
+            const output = PostUtils.postMessageOnKeyPress(
+                testCase.input.event,
+                testCase.input.message,
+                testCase.input.sendMessageOnCtrlEnter,
+                testCase.input.sendCodeBlockOnCtrlEnter
+            );
+
+            expect(output).toEqual(testCase.expected);
+        });
+    }
+
+    // on sending of message on Ctrl + Enter
+    const sendMessageOnCtrlEnterCases = [{
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, no ctrlKey|metaKey',
+        input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with ctrlKey',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: 'message', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: true},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with metaKey',
+        input: {event: {keyCode: 13, metaKey: true}, message: 'message', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: true},
+    }];
+
+    for (const testCase of sendMessageOnCtrlEnterCases) {
+        it(testCase.name, () => {
+            const output = PostUtils.postMessageOnKeyPress(
+                testCase.input.event,
+                testCase.input.message,
+                testCase.input.sendMessageOnCtrlEnter,
+                testCase.input.sendCodeBlockOnCtrlEnter
+            );
+
+            expect(output).toEqual(testCase.expected);
+        });
+    }
+
+    // on sending and/or closing of code block on Ctrl + Enter
+    const sendCodeBlockOnCtrlEnterCases = [{
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, no ctrlKey|metaKey, without opening backticks',
+        input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: true},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, no ctrlKey|metaKey, with opening backticks',
+        input: {event: {keyCode: 13}, message: '```', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, no ctrlKey|metaKey, with opening backticks',
+        input: {event: {keyCode: 13}, message: '```javascript', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, no ctrlKey|metaKey, with opening backticks',
+        input: {event: {keyCode: 13}, message: '```javascript\n', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, no ctrlKey|metaKey, with opening backticks',
+        input: {event: {keyCode: 13}, message: '```javascript\n    function(){}', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, without opening backticks',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: true},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with metaKey, without opening backticks',
+        input: {event: {keyCode: 13, metaKey: true}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: true},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with line break',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '\n', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with multiple line breaks',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '\n\n\n', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening backticks',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening backticks, with language set',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening and closing backticks, with language set',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript\n    function(){}\n```', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: true},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening and closing backticks',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript\n    function(){}\n```', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: true},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening backticks, with last line of empty spaces',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript\n    function(){}\n    ', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: true, message: '```javascript\n    function(){}\n    \n```', withClosedCodeBlock: true},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening backticks, with empty line break on last line',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript\n    function(){}\n', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: true, message: '```javascript\n    function(){}\n```', withClosedCodeBlock: true},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening backticks, with multiple empty line breaks on last lines',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript\n    function(){}\n\n\n', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: true, message: '```javascript\n    function(){}\n\n\n```', withClosedCodeBlock: true},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening backticks, with multiple empty line breaks and spaces on last lines',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript\n    function(){}\n    \n\n    ', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: true, message: '```javascript\n    function(){}\n    \n\n    \n```', withClosedCodeBlock: true},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening backticks, without line break on last line',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript\n    function(){}', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        expected: {allowSending: true, message: '```javascript\n    function(){}\n```', withClosedCodeBlock: true},
+    }];
+
+    for (const testCase of sendCodeBlockOnCtrlEnterCases) {
+        it(testCase.name, () => {
+            const output = PostUtils.postMessageOnKeyPress(
+                testCase.input.event,
+                testCase.input.message,
+                testCase.input.sendMessageOnCtrlEnter,
+                testCase.input.sendCodeBlockOnCtrlEnter
+            );
+
+            expect(output).toEqual(testCase.expected);
+        });
+    }
+});

--- a/tests/utils/post_utils.test.jsx
+++ b/tests/utils/post_utils.test.jsx
@@ -304,12 +304,60 @@ describe('PostUtils.postMessageOnKeyPress', function() {
         input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
         expected: {allowSending: false},
     }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, no ctrlKey|metaKey, with opening backticks',
+        input: {event: {keyCode: 13}, message: '```', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, no ctrlKey|metaKey, with opening backticks',
+        input: {event: {keyCode: 13}, message: '```\nfunc(){}', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, no ctrlKey|metaKey, with opening backticks',
+        input: {event: {keyCode: 13}, message: '```\nfunc(){}\n', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, no ctrlKey|metaKey, with opening and closing backticks',
+        input: {event: {keyCode: 13}, message: '```\nfunc(){}\n```', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
         name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with ctrlKey',
         input: {event: {keyCode: 13, ctrlKey: true}, message: 'message', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
         expected: {allowSending: true},
     }, {
         name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with metaKey',
         input: {event: {keyCode: 13, metaKey: true}, message: 'message', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: true},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with ctrlKey, with opening backticks',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with ctrlKey, with opening backticks, with language set',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with ctrlKey, with opening backticks',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```\n', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: false},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with ctrlKey, with opening backticks',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```\nfunction(){}', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: true, message: '```\nfunction(){}\n```', withClosedCodeBlock: true},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with ctrlKey, with opening backticks, with line break on last line',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```\nfunction(){}\n', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: true, message: '```\nfunction(){}\n```', withClosedCodeBlock: true},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with ctrlKey, with opening backticks, with multiple line breaks on last lines',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```\nfunction(){}\n\n\n', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: true, message: '```\nfunction(){}\n\n\n```', withClosedCodeBlock: true},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with ctrlKey, with opening and closing backticks',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```\nfunction(){}\n```', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
+        expected: {allowSending: true},
+    }, {
+        name: 'sendMessageOnCtrlEnter: Test for overriding sending of message on CTRL+ENTER, with ctrlKey, with opening and closing backticks, with language set',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript\nfunction(){}\n```', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
         expected: {allowSending: true},
     }];
 
@@ -377,7 +425,7 @@ describe('PostUtils.postMessageOnKeyPress', function() {
         expected: {allowSending: true},
     }, {
         name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening and closing backticks',
-        input: {event: {keyCode: 13, ctrlKey: true}, message: '```javascript\n    function(){}\n```', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '```\n    function(){}\n```', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true},
         expected: {allowSending: true},
     }, {
         name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with opening backticks, with last line of empty spaces',

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -526,6 +526,7 @@ export const NotificationSections = {
 
 export const AdvancedSections = {
     CONTROL_SEND: 'advancedCtrlSend',
+    CODE_BLOCK_ON_CTRL_ENTER: 'codeBlockOnCtrlEnter',
     FORMATTING: 'formatting',
     JOIN_LEAVE: 'joinLeave',
     PREVIEW_FEATURES: 'advancedPreviewFeatures',
@@ -1307,6 +1308,7 @@ export const Constants = {
     SEARCH_POST: 'searchpost',
     CHANNEL_ID_LENGTH: 26,
     TRANSPARENT_PIXEL: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+    TRIPLE_BACK_TICKS: /```/g,
 };
 
 t('suggestion.mention.channels');

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -14,6 +14,7 @@ import Constants from 'utils/constants.jsx';
 import {formatWithRenderer} from 'utils/markdown';
 import MentionableRenderer from 'utils/markdown/mentionable_renderer';
 import * as Utils from 'utils/utils.jsx';
+import {isMobile} from 'utils/user_agent.jsx';
 
 export function isSystemMessage(post) {
     return Boolean(post.type && (post.type.lastIndexOf(Constants.SYSTEM_MESSAGE_PREFIX) === 0));
@@ -162,4 +163,55 @@ export function shouldFocusMainTextbox(e, activeElement) {
     }
 
     return true;
+}
+
+export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, sendCodeBlockOnCtrlEnter) {
+    if (
+        !event ||
+        message.trim() === '' ||
+        isMobile() ||
+        !Utils.isKeyPressed(event, Constants.KeyCodes.ENTER) ||
+        event.shiftKey ||
+        event.altKey
+    ) {
+        return {allowSending: false};
+    }
+
+    // no override setting
+    if (!(sendMessageOnCtrlEnter || sendCodeBlockOnCtrlEnter)) {
+        return {allowSending: true};
+    }
+
+    const ctrlOrMetaKeyPressed = event.ctrlKey || event.metaKey;
+
+    if (sendMessageOnCtrlEnter) { // override sending of message on CTRL+ENTER
+        if (ctrlOrMetaKeyPressed) {
+            return {allowSending: true};
+        }
+    } else if (sendCodeBlockOnCtrlEnter) { // override sending of and/or closing code block on CTRL+ENTER
+        const match = message.match(Constants.TRIPLE_BACK_TICKS);
+        if (!match || match.length % 2 === 0) {
+            return {allowSending: true};
+        } else if (ctrlOrMetaKeyPressed && match && match.length % 2 !== 0) {
+            const splitMessage = message.split('\n');
+            let lastLineMessage = splitMessage[splitMessage.length - 1];
+
+            if (splitMessage.length > 1 && !lastLineMessage.includes('```')) {
+                while (splitMessage.length > 1 && !lastLineMessage.includes('```')) {
+                    if (lastLineMessage.trim() !== '') {
+                        return {
+                            allowSending: true,
+                            message: message.endsWith('\n') ? message.concat('```') : message.concat('\n```'),
+                            withClosedCodeBlock: true,
+                        };
+                    }
+
+                    splitMessage.splice(splitMessage.length - 1);
+                    lastLineMessage = splitMessage[splitMessage.length - 1];
+                }
+            }
+        }
+    }
+
+    return {allowSending: false};
 }


### PR DESCRIPTION
#### Summary
Add feature to send code block on CTRL + ENTER.

@esethna Could you please give this a smoke test if feature is according to specs?  Thanks!

(Note:  Constants will be updated as soon as mattermost-redux PR is merged.)

#### Ticket Link
Jira ticket: [MM-11959](https://mattermost.atlassian.net/browse/MM-11959)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
