### PR TITLE
MM-6950: restore last viewed on logout

### DIFF
--- a/actions/admin_actions.jsx
+++ b/actions/admin_actions.jsx
@@ -5,7 +5,7 @@ import * as AdminActions from 'mattermost-redux/actions/admin';
 import * as UserActions from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 
-import {clientLogout} from 'actions/global_actions.jsx';
+import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 import {getOnNavigationConfirmed} from 'selectors/views/admin';
 import store from 'stores/redux_store.jsx';
 import {ActionTypes} from 'utils/constants.jsx';
@@ -165,7 +165,7 @@ export async function oauthToEmail(currentService, email, password, success, err
     const {data, error: err} = await UserActions.switchOAuthToEmail(currentService, email, password)(dispatch, getState);
     if (data) {
         if (data.follow_link) {
-            clientLogout(data.follow_link);
+            emitUserLoggedOutEvent(data.follow_link);
         }
         if (success) {
             success(data);

--- a/actions/channel_actions.jsx
+++ b/actions/channel_actions.jsx
@@ -122,7 +122,7 @@ export function executeCommand(message, args, success, error) {
             const hasGotoLocation = data.goto_location && isUrlSafe(data.goto_location);
 
             if (msg.trim() === '/logout') {
-                GlobalActions.clientLogout(hasGotoLocation ? data.goto_location : '/');
+                GlobalActions.emitUserLoggedOutEvent(hasGotoLocation ? data.goto_location : '/');
                 return;
             }
 

--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -437,23 +437,22 @@ export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = tr
                 BrowserStore.signalLogout();
             }
 
-            clientLogout(redirectTo);
+            BrowserStore.clear({exclude: [
+                Constants.RECENT_EMOJI_KEY,
+                'selected_teams',
+            ]});
+            ErrorStore.clearLastError();
+            ChannelStore.clear();
+            stopPeriodicStatusUpdates();
+            WebsocketActions.close();
+            document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+            browserHistory.push(redirectTo);
         }
     ).catch(
         () => {
             browserHistory.push(redirectTo);
         }
     );
-}
-
-export function clientLogout(redirectTo = '/') {
-    BrowserStore.clear({exclude: [Constants.RECENT_EMOJI_KEY, 'selected_teams']});
-    ErrorStore.clearLastError();
-    ChannelStore.clear();
-    stopPeriodicStatusUpdates();
-    WebsocketActions.close();
-    document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-    browserHistory.push(redirectTo);
 }
 
 export function toggleSideBarRightMenuAction() {

--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -437,10 +437,7 @@ export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = tr
                 BrowserStore.signalLogout();
             }
 
-            BrowserStore.clear({exclude: [
-                Constants.RECENT_EMOJI_KEY,
-                'selected_teams',
-            ]});
+            BrowserStore.clear();
             ErrorStore.clearLastError();
             ChannelStore.clear();
             stopPeriodicStatusUpdates();

--- a/actions/local_storage.jsx
+++ b/actions/local_storage.jsx
@@ -1,0 +1,20 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+import LocalStorageStore from 'stores/local_storage_store';
+
+// setPreviousTeamId is a pseudo-action that writes not to the Redux store, but back to local
+// storage.
+//
+// See LocalStorageStore for context.
+export function setPreviousTeamId(teamId) {
+    return (dispatch, getState) => {
+        const userId = getCurrentUserId(getState());
+
+        LocalStorageStore.setPreviousTeamId(userId, teamId);
+
+        return {data: true};
+    };
+}

--- a/components/admin_console/system_users/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown.jsx
@@ -14,7 +14,7 @@ import UserStore from 'stores/user_store.jsx';
 import {Constants} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
-import {clientLogout} from 'actions/global_actions.jsx';
+import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 import ConfirmModal from 'components/confirm_modal.jsx';
 import SystemPermissionGate from 'components/permissions_gates/system_permission_gate';
 import {browserHistory} from 'utils/browser_history';
@@ -239,7 +239,7 @@ export default class SystemUsersDropdown extends React.Component {
         revokeAllSessions(this.props.user.id,
             () => {
                 if (this.props.user.id === me.id) {
-                    clientLogout();
+                    emitUserLoggedOutEvent();
                 }
             },
             this.props.onError

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -14,7 +14,7 @@ import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general
 
 import {withRouter} from 'react-router-dom';
 
-import {getLastViewedChannelName} from 'selectors/storage';
+import {getLastViewedChannelName} from 'selectors/local_storage';
 import {Constants} from 'utils/constants.jsx';
 
 import {

--- a/components/channel_layout/center_channel/index.js
+++ b/components/channel_layout/center_channel/index.js
@@ -2,27 +2,16 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-import {getTeamByName} from 'mattermost-redux/selectors/entities/teams';
 
-import Constants from 'utils/constants';
-import {getGlobalItem} from 'selectors/storage';
 import {getIsRhsOpen, getIsRhsMenuOpen} from 'selectors/rhs';
 import {getIsLhsOpen} from 'selectors/lhs';
 import {getIsWebrtcOpen} from 'selectors/webrtc';
+import {getLastViewedChannelNameByTeamName} from 'selectors/local_storage';
 
 import CenterChannel from './center_channel';
 
-const getLastChannelPath = (state, teamName) => {
-    const team = getTeamByName(state, teamName);
-
-    if (team) {
-        return getGlobalItem(state, Constants.PREV_CHANNEL_KEY + team.id, Constants.DEFAULT_CHANNEL);
-    }
-    return Constants.DEFAULT_CHANNEL;
-};
-
 const mapStateToProps = (state, ownProps) => ({
-    lastChannelPath: `${ownProps.match.url}/channels/${getLastChannelPath(state, ownProps.match.params.team)}`,
+    lastChannelPath: `${ownProps.match.url}/channels/${getLastViewedChannelNameByTeamName(state, ownProps.match.params.team)}`,
     lhsOpen: getIsLhsOpen(state),
     rhsOpen: getIsRhsOpen(state),
     rhsMenuOpen: getIsRhsMenuOpen(state),

--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -11,7 +11,7 @@ import {withRouter} from 'react-router-dom';
 import {getDirectTeammate} from 'utils/utils.jsx';
 import {TutorialSteps, Preferences, Constants} from 'utils/constants.jsx';
 
-import {getLastViewedChannelName} from 'selectors/storage';
+import {getLastViewedChannelName} from 'selectors/local_storage';
 
 import ChannelView from './channel_view.jsx';
 

--- a/components/needs_team/index.js
+++ b/components/needs_team/index.js
@@ -13,7 +13,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
-import {setGlobalItem} from 'actions/storage';
+import {setPreviousTeamId} from 'actions/local_storage';
 import {checkIfMFARequired} from 'utils/route';
 
 import NeedsTeam from './needs_team.jsx';
@@ -41,7 +41,7 @@ function mapDispatchToProps(dispatch) {
             markChannelAsRead,
             getTeams,
             joinTeam,
-            setGlobalItem,
+            setPreviousTeamId,
             selectTeam,
         }, dispatch),
     };

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -41,7 +41,7 @@ export default class NeedsTeam extends React.Component {
             getTeams: PropTypes.func.isRequired,
             joinTeam: PropTypes.func.isRequired,
             selectTeam: PropTypes.func.isRequired,
-            setGlobalItem: PropTypes.func.isRequired,
+            setPreviousTeamId: PropTypes.func.isRequired,
         }).isRequired,
         theme: PropTypes.object.isRequired,
         mfaRequired: PropTypes.bool.isRequired,
@@ -178,7 +178,7 @@ export default class NeedsTeam extends React.Component {
         // The first load action pulls team unreads
         this.props.actions.getMyTeamUnreads();
         this.props.actions.selectTeam(team);
-        this.props.actions.setGlobalItem('team', team.id);
+        this.props.actions.setPreviousTeamId(team.id);
         GlobalActions.emitCloseRightHandSide();
 
         this.props.actions.fetchMyChannelsAndMembers(team.id).then(

--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {savePreferences, updateActive, revokeAllSessions} from 'actions/user_actions.jsx';
-import {clientLogout} from 'actions/global_actions.jsx';
+import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import Constants from 'utils/constants.jsx';
@@ -155,7 +155,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
 
         revokeAllSessions(userId,
             () => {
-                clientLogout();
+                emitUserLoggedOutEvent();
             },
             (err) => {
                 this.setState({serverError: err.message});

--- a/selectors/local_storage.js
+++ b/selectors/local_storage.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getCurrentTeamId, getTeamByName} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+import localStorageStore from 'stores/local_storage_store';
+
+// getLastViewedChannelName combines data from the Redux store and localStorage to return the
+// previously selected channel name, returning the default channel if none exists.
+//
+// See LocalStorageStore for context.
+export const getLastViewedChannelName = (state) => {
+    const userId = getCurrentUserId(state);
+    const teamId = getCurrentTeamId(state);
+
+    return localStorageStore.getPreviousChannelName(userId, teamId);
+};
+
+// getLastViewedChannelNameByTeamName combines data from the Redux store and localStorage to return
+// the url to the previously selected channel, returning the path to the default channel if none
+// exists.
+//
+// See LocalStorageStore for context.
+export const getLastViewedChannelNameByTeamName = (state, teamName) => {
+    const userId = getCurrentUserId(state);
+    const team = getTeamByName(state, teamName);
+    const teamId = team && team.id;
+
+    return localStorageStore.getPreviousChannelName(userId, teamId);
+};

--- a/selectors/storage.js
+++ b/selectors/storage.js
@@ -1,13 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {createSelector} from 'reselect';
-
-import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-
 import {getPrefix} from 'utils/storage_utils';
-
-import Constants from 'utils/constants';
 
 export const getGlobalItem = (state, name, defaultValue) => {
     const storage = state && state.storage && state.storage.storage;
@@ -38,14 +32,3 @@ export const getItemFromStorage = (storage, name, defaultValue) => {
 
     return defaultValue;
 };
-
-export const getStorage = (state) => state.storage;
-
-export const getLastViewedChannelName = createSelector(
-    getStorage,
-    getCurrentTeamId,
-    (storage, currentTeamId) => {
-        const entry = storage.storage[`${Constants.PREV_CHANNEL_KEY}${currentTeamId}`];
-        return entry ? entry.value : null;
-    }
-);

--- a/stores/local_storage_store.jsx
+++ b/stores/local_storage_store.jsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {Constants} from 'utils/constants.jsx';
+
+const getPreviousTeamIdKey = (userId) => ['user_prev_team', userId].join(':');
+const getPreviousChannelNameKey = (userId, teamId) => ['user_team_prev_channel', userId, teamId].join(':');
+
+// LocalStorageStore exposes an interface for accessing entries in the localStorage.
+//
+// Note that this excludes keys managed by redux-persist. The latter cannot currently be used for
+// key/value storage that persists beyond logout. Ideally, we could purge all but certain parts
+// of the Redux store so as to allow them to be used on re-login.
+class LocalStorageStoreClass {
+    getPreviousChannelName(userId, teamId) {
+        return localStorage.getItem(getPreviousChannelNameKey(userId, teamId)) || Constants.DEFAULT_CHANNEL;
+    }
+
+    setPreviousChannelName(userId, teamId, channelName) {
+        localStorage.setItem(getPreviousChannelNameKey(userId, teamId), channelName);
+    }
+
+    getPreviousTeamId(userId) {
+        return localStorage.getItem(getPreviousTeamIdKey(userId));
+    }
+
+    setPreviousTeamId(userId, teamId) {
+        localStorage.setItem(getPreviousTeamIdKey(userId), teamId);
+    }
+}
+
+const LocalStorageStore = new LocalStorageStoreClass();
+
+export default LocalStorageStore;

--- a/tests/components/needs_team.test.jsx
+++ b/tests/components/needs_team.test.jsx
@@ -42,7 +42,7 @@ const actionsProp = {
     getTeams: emptyFunction,
     joinTeam: emptyFunction,
     selectTeam: emptyFunction,
-    setGlobalItem: emptyFunction,
+    setPreviousTeamId: emptyFunction,
 };
 
 const teamsList = [{
@@ -164,7 +164,7 @@ describe('components/needs_team', () => {
 
         const getMyTeamUnreads = jest.fn();
         const selectTeam = jest.fn();
-        const setGlobalItem = jest.fn();
+        const setPreviousTeamId = jest.fn();
 
         const wrapper = shallow(
             <NeedsTeam
@@ -174,7 +174,7 @@ describe('components/needs_team', () => {
                     joinTeam,
                     getMyTeamUnreads,
                     selectTeam,
-                    setGlobalItem,
+                    setPreviousTeamId,
                 }}
                 theme={{}}
                 mfaRequired={false}
@@ -192,7 +192,7 @@ describe('components/needs_team', () => {
         expect(wrapper.state().team.name).toEqual('new');
         expect(selectTeam).toBeCalledWith(wrapper.state().team);
         expect(getMyTeamUnreads).toHaveBeenCalledTimes(1);
-        expect(setGlobalItem).toBeCalledWith('team', wrapper.state().team.id);
+        expect(setPreviousTeamId).toBeCalledWith(wrapper.state().team.id);
 
         const existingTeamMatch = {
             params: {

--- a/tests/stores/local_storage_store.test.jsx
+++ b/tests/stores/local_storage_store.test.jsx
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+
+import LocalStorageStore from 'stores/local_storage_store';
+
+describe('stores/LocalStorageStore', () => {
+    test('should persist previous team id per user', () => {
+        const userId1 = 'userId1';
+        const userId2 = 'userId2';
+        const teamId1 = 'teamId1';
+        const teamId2 = 'teamId2';
+        LocalStorageStore.setPreviousTeamId(userId1, teamId1);
+        LocalStorageStore.setPreviousTeamId(userId2, teamId2);
+        assert.equal(LocalStorageStore.getPreviousTeamId(userId1), teamId1);
+        assert.equal(LocalStorageStore.getPreviousTeamId(userId2), teamId2);
+    });
+
+    test('should persist previous channel name per team and user', () => {
+        const userId1 = 'userId1';
+        const userId2 = 'userId2';
+        const teamId1 = 'teamId1';
+        const teamId2 = 'teamId2';
+        const channel1 = 'channel1';
+        const channel2 = 'channel2';
+        const channel3 = 'channel3';
+        LocalStorageStore.setPreviousChannelName(userId1, teamId1, channel1);
+        LocalStorageStore.setPreviousChannelName(userId2, teamId1, channel2);
+        LocalStorageStore.setPreviousChannelName(userId2, teamId2, channel3);
+        assert.equal(LocalStorageStore.getPreviousChannelName(userId1, teamId1), channel1);
+        assert.equal(LocalStorageStore.getPreviousChannelName(userId2, teamId1), channel2);
+        assert.equal(LocalStorageStore.getPreviousChannelName(userId2, teamId2), channel3);
+    });
+});

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1305,7 +1305,6 @@ export const Constants = {
     SEARCH_POST: 'searchpost',
     CHANNEL_ID_LENGTH: 26,
     TRANSPARENT_PIXEL: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
-    PREV_CHANNEL_KEY: 'team_prev_channel:',
 };
 
 t('suggestion.mention.channels');


### PR DESCRIPTION
#### Summary
These changes persist the last viewed team and channel to localStorage to be reused on login. The values persisted to local storage are keyed by user id to disambiguate multiple users using the same useragent.

I'm not super happy with these changes. A better approach would be to leverage the existing redux-persist subsystem, write these values to Redux, and have it manage the persistence. Unfortunately, on logout we `purge` everything redux-persist manages, so a solution to keep some values around would have to be crafted. One option might be to manually expunge keys, but then we'd want to be extra certain to have cleaned everything up. Another approach might be to persist different roots with whitelisted keys for the persistor that keeps data around after logout.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-6950

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)