### PR TITLE
MM-12057: Only show my own archived channels in the channel switcher

### DIFF
--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -313,6 +313,10 @@ export default class SwitchChannelProvider extends Provider {
 
         const channelFilter = makeChannelSearchFilter(channelPrefix);
 
+        const state = getState();
+        const config = getConfig(state);
+        const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
+
         for (const id of Object.keys(allChannels)) {
             const channel = allChannels[id];
 
@@ -320,13 +324,17 @@ export default class SwitchChannelProvider extends Provider {
                 continue;
             }
 
-            if (channelFilter(channel) && channel.delete_at === 0) {
+            if (channelFilter(channel)) {
                 const newChannel = Object.assign({}, channel);
                 const channelIsArchived = channel.delete_at !== 0;
 
                 let wrappedChannel = {channel: newChannel, name: newChannel.name, deactivated: false};
-                if (channelIsArchived) {
+                if (!viewArchivedChannels && channelIsArchived) {
+                    continue;
+                } else if (channelIsArchived && members[channel.id]) {
                     wrappedChannel.type = Constants.ARCHIVED_CHANNEL;
+                } else if (channelIsArchived && !members[channel.id]) {
+                    continue;
                 } else if (newChannel.type === Constants.GM_CHANNEL) {
                     newChannel.name = getChannelDisplayName(newChannel);
                     wrappedChannel.name = newChannel.name;


### PR DESCRIPTION
#### Summary
Only show my own archived channels in the channel switcher. When the
viewArchivedChannels settings is active.

#### Ticket Link
[MM-12057](https://mattermost.atlassian.net/browse/MM-12057)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed