### PR TITLE
[MM-12264] do not load redirect_location if enablelinkpreview is disabled

### DIFF
--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -91,7 +91,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
     }
 
     async loadShortenedImageLink() {
-        if (!this.isLinkImage(this.state.link) && !YoutubeVideo.isYoutubeLink(this.state.link)) {
+        if (!this.isLinkImage(this.state.link) && !YoutubeVideo.isYoutubeLink(this.state.link) && this.props.enableLinkPreviews) {
             const {data} = await this.props.actions.getRedirectLocation(this.state.link);
             const {link} = this.state;
             if (data && data.location && this.mounted) {


### PR DESCRIPTION
#### Summary
Currently if enablelinkpreview is disabled, the redirect_location url is still called

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12264
https://github.com/mattermost/mattermost-server/issues/9457
https://github.com/mattermost/mattermost-server/issues/9437

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has server changes (please link)
- [x] Has UI changes

server changes https://github.com/mattermost/mattermost-server/pull/9461