### PR TITLE
MM-12263 Add plugin FilesWillUpload hook

### DIFF
--- a/components/file_upload/index.js
+++ b/components/file_upload/index.js
@@ -21,6 +21,7 @@ function mapStateToProps(state) {
         maxFileSize,
         canUploadFiles: canUploadFiles(config),
         pluginFileUploadMethods: state.plugins.components.FileUploadMethod,
+        pluginFilesWillUploadHooks: state.plugins.components.FilesWillUploadHook,
     };
 }
 

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -210,7 +210,30 @@ export default class PluginRegistry {
         return id;
     }
 
-    // Unregister a component using the unique identifier returned after registration.
+    // Register a hook to intercept file uploads before they take place.
+    // Accepts a function to run before files get uploaded. Receives an array of
+    // files and a function to upload files at a later time as arguments. Must
+    // return an object that can contain two properties:
+    // - message - An error message to display, leave blank or null to display no message
+    // - files - Modified array of files to upload, set to null to reject all files
+    // Returns a unique identifier.
+    registerFilesWillUploadHook(hook) {
+        const id = generateId();
+
+        store.dispatch({
+            type: ActionTypes.RECEIVED_PLUGIN_COMPONENT,
+            name: 'FilesWillUploadHook',
+            data: {
+                id,
+                pluginId: this.id,
+                hook,
+            },
+        });
+
+        return id;
+    }
+
+    // Unregister a component, action or hook using the unique identifier returned after registration.
     // Accepts a string id.
     // Returns undefined in all cases.
     unregisterComponent(componentId) {

--- a/tests/components/file_upload/file_upload.test.jsx
+++ b/tests/components/file_upload/file_upload.test.jsx
@@ -147,7 +147,7 @@ describe('components/FileUpload', () => {
             <FileUpload {...props}/>
         );
 
-        wrapper.instance().uploadFiles(files);
+        wrapper.instance().checkPluginHooksAndUploadFiles(files);
 
         expect(uploadFile).toHaveBeenCalledTimes(2);
 
@@ -170,7 +170,7 @@ describe('components/FileUpload', () => {
             <FileUpload {...props}/>
         );
 
-        wrapper.instance().uploadFiles(files);
+        wrapper.instance().checkPluginHooksAndUploadFiles(files);
 
         expect(uploadFile).not.toBeCalled();
 
@@ -192,7 +192,7 @@ describe('components/FileUpload', () => {
             <FileUpload {...props}/>
         );
 
-        wrapper.instance().uploadFiles(files);
+        wrapper.instance().checkPluginHooksAndUploadFiles(files);
 
         expect(uploadFile).not.toBeCalled();
 
@@ -213,7 +213,7 @@ describe('components/FileUpload', () => {
             <FileUpload {...props}/>
         );
 
-        wrapper.instance().uploadFiles(files);
+        wrapper.instance().checkPluginHooksAndUploadFiles(files);
 
         expect(uploadFile).not.toBeCalled();
 
@@ -268,5 +268,54 @@ describe('components/FileUpload', () => {
 
         expect(onFileUploadChange).toBeCalled();
         expect(onFileUploadChange).toHaveBeenCalledWith();
+    });
+
+    test('FilesWillUploadHook - should reject all files', () => {
+        const onUploadError = jest.fn();
+        const uploadFile = jest.fn();
+        const onUploadStart = jest.fn();
+        const pluginHook = () => {
+            return {files: null};
+        };
+        const props = {...baseProps, onUploadError, uploadFile, onUploadStart, pluginFilesWillUploadHooks: [{hook: pluginHook}]};
+        const files = [{name: 'file1.pdf'}, {name: 'file2.jpg'}];
+
+        const wrapper = shallowWithIntl(
+            <FileUpload {...props}/>
+        );
+
+        wrapper.instance().checkPluginHooksAndUploadFiles(files);
+
+        expect(uploadFile).toHaveBeenCalledTimes(0);
+
+        expect(onUploadStart).toHaveBeenCalledTimes(0);
+
+        expect(onUploadError).toHaveBeenCalledTimes(1);
+        expect(onUploadError).toHaveBeenCalledWith(null);
+    });
+
+    test('FilesWillUploadHook - should reject one file and allow one file', () => {
+        const onUploadError = jest.fn();
+        const uploadFile = jest.fn();
+        const onUploadStart = jest.fn();
+        const pluginHook = (files) => {
+            return {files: files.filter((f) => f.name === 'file1.pdf')};
+        };
+        const props = {...baseProps, onUploadError, uploadFile, onUploadStart, pluginFilesWillUploadHooks: [{hook: pluginHook}]};
+        const files = [{name: 'file1.pdf'}, {name: 'file2.jpg'}];
+
+        const wrapper = shallowWithIntl(
+            <FileUpload {...props}/>
+        );
+
+        wrapper.instance().checkPluginHooksAndUploadFiles(files);
+
+        expect(uploadFile).toHaveBeenCalledTimes(1);
+
+        expect(onUploadStart).toHaveBeenCalledTimes(1);
+        expect(onUploadStart).toHaveBeenCalledWith(['generated_id_1'], props.currentChannelId);
+
+        expect(onUploadError).toHaveBeenCalledTimes(1);
+        expect(onUploadError).toHaveBeenCalledWith(null);
     });
 });


### PR DESCRIPTION
#### Summary
Adds a plugin hook `FilesWillUpload` that allows web app plugins to reject or modify file uploads before they happen.

Example usage that filters out PNGs:
```javascript
registry.registerFilesWillUploadHook(
        (files) => {
            const newFiles = files.filter((file) => file.type !== 'image/png');

            let message;
            if (newFiles.length < files.length) {
                message = 'One or more of the files was a PNG. These files were rejected by the demo plugin.';
            }

            return {message, files: newFiles};
        }
);
```

I also performed a small amount of refactoring with how we handled pasting images to remove some duplicate code and make it easier to implement the hook. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12263

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)