### PR TITLE
MM-12556 Fix autocomplete staying open when deleting mention character at beginning of textbox

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -268,10 +268,7 @@ export default class SuggestionBox extends React.Component {
         const textbox = this.getTextbox();
         const pretext = textbox.value.substring(0, textbox.selectionEnd);
 
-        if (!this.composing &&
-            SuggestionStore.getPretext(this.suggestionId) !== pretext &&
-            (this.props.openWhenEmpty || pretext.length >= this.props.requiredCharacters)
-        ) {
+        if (!this.composing && SuggestionStore.getPretext(this.suggestionId) !== pretext) {
             this.doEmitSuggestionPretextChanged(pretext);
         }
 


### PR DESCRIPTION
#### Summary
Fix autocomplete staying open when deleting mention character at beginning of textbox while there is other text present in the textbox.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12256

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed