### PR TITLE
[MM-12259] Remove one of two tooltips of unmute icon and replace with aria-label

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -1085,11 +1085,9 @@ export default class ChannelHeader extends React.Component {
                         id='toggleMute'
                         onClick={this.unmute}
                         className={'style--none color--link channel-header__mute inactive'}
+                        aria-label={Utils.localizeMessage('generic_icons.muted', 'Muted Icon')}
                     >
-                        <i
-                            className={'icon fa fa-bell-slash-o'}
-                            title={Utils.localizeMessage('generic_icons.muted', 'Muted Icon')}
-                        />
+                        <i className={'icon fa fa-bell-slash-o'}/>
                     </button>
                 </OverlayTrigger>
             );

--- a/tests/components/__snapshots__/channel_header.test.jsx.snap
+++ b/tests/components/__snapshots__/channel_header.test.jsx.snap
@@ -501,13 +501,13 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
             }
           >
             <button
+              aria-label="Muted Icon"
               className="style--none color--link channel-header__mute inactive"
               id="toggleMute"
               onClick={[Function]}
             >
               <i
                 className="icon fa fa-bell-slash-o"
-                title="Muted Icon"
               />
             </button>
           </OverlayTrigger>


### PR DESCRIPTION
#### Summary
Remove one of two tooltips of unmute icon and replace with aria-label.

Fix:
![unmute_one_tooltip_fix](https://user-images.githubusercontent.com/5334504/46132024-a4fcf600-c26f-11e8-9a0f-9213382f6cb9.gif)

#### Ticket Link
Jira ticket: [MM-12259](https://mattermost.atlassian.net/browse/MM-12259)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

