### PR TITLE
MM-12257 preserve extra on logout

### DIFF
--- a/components/login/login_controller/index.js
+++ b/components/login/login_controller/index.js
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {RequestStatus} from 'mattermost-redux/constants';
 
 import LoginController from './login_controller.jsx';
 
@@ -28,6 +29,7 @@ function mapStateToProps(state) {
     const ldapLoginFieldName = config.LdapLoginFieldName;
     const samlLoginButtonText = config.SamlLoginButtonText;
     const siteName = config.SiteName;
+    const initializing = state.requests.users.logout.status === RequestStatus.SUCCESS || !state.storage.initialized;
 
     return {
         isLicensed,
@@ -47,6 +49,7 @@ function mapStateToProps(state) {
         ldapLoginFieldName,
         samlLoginButtonText,
         siteName,
+        initializing,
     };
 }
 

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -28,6 +28,7 @@ import SiteNameAndDescription from 'components/common/site_name_and_description'
 import AnnouncementBar from 'components/announcement_bar';
 import FormError from 'components/form_error.jsx';
 import BackButton from 'components/common/back_button.jsx';
+import LoadingScreen from 'components/loading_screen.jsx';
 
 import LoginMfa from '../login_mfa.jsx';
 class LoginController extends React.Component {
@@ -54,6 +55,7 @@ class LoginController extends React.Component {
             ldapLoginFieldName: PropTypes.string,
             samlLoginButtonText: PropTypes.string,
             siteName: PropTypes.string,
+            initializing: PropTypes.bool,
         };
     }
 
@@ -764,7 +766,12 @@ class LoginController extends React.Component {
         const {
             customDescriptionText,
             siteName,
+            initializing,
         } = this.props;
+
+        if (initializing) {
+            return (<LoadingScreen/>);
+        }
 
         let content;
         let customContent;

--- a/store/index.js
+++ b/store/index.js
@@ -146,7 +146,18 @@ export default function configureStore(initialState) {
 
                         persistor.purge().then(() => {
                             document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-                            window.location.href = basePath;
+
+                            // Preserve any `extra` query string parameter on logout to trigger
+                            // the corresponding message on the login page. This would probably be
+                            // better modelled by persistent data in the Redux store, but we're
+                            // clearing that out here.
+                            const search = new URLSearchParams(window.location.search);
+                            const extra = search.get('extra');
+                            if (extra) {
+                                window.location.href = `${basePath}?extra=${extra}`;
+                            } else {
+                                window.location.href = basePath;
+                            }
 
                             store.dispatch({
                                 type: General.OFFLINE_STORE_RESET,

--- a/tests/components/login/login_controller/__snapshots__/login_controller.test.jsx.snap
+++ b/tests/components/login/login_controller/__snapshots__/login_controller.test.jsx.snap
@@ -110,3 +110,10 @@ exports[`components/login/LoginController should match snapshot when expired 1`]
   </div>
 </div>
 `;
+
+exports[`components/login/LoginController should match snapshot when initializing 1`] = `
+<LoadingScreen
+  position="relative"
+  style={Object {}}
+/>
+`;

--- a/tests/components/login/login_controller/login_controller.test.jsx
+++ b/tests/components/login/login_controller/login_controller.test.jsx
@@ -50,4 +50,16 @@ describe('components/login/LoginController', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should match snapshot when initializing', () => {
+        const props = {
+            ...baseProps,
+            initializing: true,
+        };
+        const wrapper = shallowWithIntl(
+            <LoginController {...props}/>
+        ).dive();
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Summary
This is related to https://github.com/mattermost/mattermost-webapp/pull/1735, in that that feature relies on the `?extra=<...>` parameter being preserved across logout. While I was in here, I fixed a longstanding issue with the login page "flashing" invalid content while the store was resetting. If we detect that we're logging out or the state is not initialized, we render the `<LoadingScreen />` until we are done.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12257

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)