### PR TITLE
[MM-11675] Username popover on all system messages

### DIFF
--- a/components/post_markdown/system_message_helpers.jsx
+++ b/components/post_markdown/system_message_helpers.jsx
@@ -16,14 +16,25 @@ import CombinedSystemMessage from 'components/post_view/combined_system_message'
 import PostAddChannelMember from 'components/post_view/post_add_channel_member';
 
 function renderUsername(value) {
-    return renderFormattedText(value, {markdown: false});
+    const username = (value[0] === '@') ? value : `@${value}`;
+
+    const options = {
+        atMentions: true,
+        mentionKeys: [{key: username}],
+        mentionHighlight: false,
+        markdown: false,
+    };
+
+    return renderFormattedText(username, options);
 }
 
 function renderUsernameForUserIdAndUsername(userId, username) {
     const displayUsername = Utils.getDisplayNameByUserId(userId);
+
     if (displayUsername && displayUsername.trim() !== '') {
         return renderUsername(displayUsername);
     }
+
     return renderUsername(username);
 }
 

--- a/components/post_markdown/system_message_helpers.jsx
+++ b/components/post_markdown/system_message_helpers.jsx
@@ -19,23 +19,12 @@ function renderUsername(value) {
     const username = (value[0] === '@') ? value : `@${value}`;
 
     const options = {
-        atMentions: true,
         mentionKeys: [{key: username}],
         mentionHighlight: false,
         markdown: false,
     };
 
     return renderFormattedText(username, options);
-}
-
-function renderUsernameForUserIdAndUsername(userId, username) {
-    const displayUsername = Utils.getDisplayNameByUserId(userId);
-
-    if (displayUsername && displayUsername.trim() !== '') {
-        return renderUsername(displayUsername);
-    }
-
-    return renderUsername(username);
 }
 
 function renderFormattedText(value, options) {
@@ -48,7 +37,7 @@ function renderFormattedText(value, options) {
 }
 
 function renderJoinChannelMessage(post) {
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
+    const username = renderUsername(post.props.username);
 
     return (
         <FormattedMessage
@@ -60,7 +49,7 @@ function renderJoinChannelMessage(post) {
 }
 
 function renderLeaveChannelMessage(post) {
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
+    const username = renderUsername(post.props.username);
 
     return (
         <FormattedMessage
@@ -72,8 +61,8 @@ function renderLeaveChannelMessage(post) {
 }
 
 function renderAddToChannelMessage(post) {
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
-    const addedUsername = renderUsernameForUserIdAndUsername(post.props.addedUserId, post.props.addedUsername);
+    const username = renderUsername(post.props.username);
+    const addedUsername = renderUsername(post.props.addedUsername);
 
     return (
         <FormattedMessage
@@ -88,7 +77,7 @@ function renderAddToChannelMessage(post) {
 }
 
 function renderRemoveFromChannelMessage(post) {
-    const removedUsername = renderUsernameForUserIdAndUsername(post.props.removedUserId, post.props.removedUsername);
+    const removedUsername = renderUsername(post.props.removedUsername);
 
     return (
         <FormattedMessage
@@ -102,7 +91,7 @@ function renderRemoveFromChannelMessage(post) {
 }
 
 function renderJoinTeamMessage(post) {
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
+    const username = renderUsername(post.props.username);
 
     return (
         <FormattedMessage
@@ -114,7 +103,7 @@ function renderJoinTeamMessage(post) {
 }
 
 function renderLeaveTeamMessage(post) {
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
+    const username = renderUsername(post.props.username);
 
     return (
         <FormattedMessage
@@ -126,8 +115,8 @@ function renderLeaveTeamMessage(post) {
 }
 
 function renderAddToTeamMessage(post) {
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
-    const addedUsername = renderUsernameForUserIdAndUsername(post.props.addedUserId, post.props.addedUsername);
+    const username = renderUsername(post.props.username);
+    const addedUsername = renderUsername(post.props.addedUsername);
 
     return (
         <FormattedMessage
@@ -142,7 +131,7 @@ function renderAddToTeamMessage(post) {
 }
 
 function renderRemoveFromTeamMessage(post) {
-    const removedUsername = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
+    const removedUsername = renderUsername(post.props.username);
 
     return (
         <FormattedMessage
@@ -165,7 +154,7 @@ function renderHeaderChangeMessage(post) {
         channelNamesMap: post.props && post.props.channel_mentions,
     };
 
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
+    const username = renderUsername(post.props.username);
     const oldHeader = post.props.old_header ? renderFormattedText(post.props.old_header, headerOptions) : null;
     const newHeader = post.props.new_header ? renderFormattedText(post.props.new_header, headerOptions) : null;
 
@@ -215,7 +204,7 @@ function renderDisplayNameChangeMessage(post) {
         return null;
     }
 
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
+    const username = renderUsername(post.props.username);
     const oldDisplayName = post.props.old_displayname;
     const newDisplayName = post.props.new_displayname;
 
@@ -237,7 +226,7 @@ function renderConvertChannelToPrivateMessage(post) {
         return null;
     }
 
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
+    const username = renderUsername(post.props.username);
 
     return (
         <FormattedMessage
@@ -255,7 +244,7 @@ function renderPurposeChangeMessage(post) {
         return null;
     }
 
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
+    const username = renderUsername(post.props.username);
     const oldPurpose = post.props.old_purpose;
     const newPurpose = post.props.new_purpose;
 
@@ -305,7 +294,7 @@ function renderChannelDeletedMessage(post) {
         return null;
     }
 
-    const username = renderUsernameForUserIdAndUsername(post.user_id, post.props.username);
+    const username = renderUsername(post.props.username);
 
     return (
         <FormattedMessage

--- a/components/post_markdown/system_message_helpers.jsx
+++ b/components/post_markdown/system_message_helpers.jsx
@@ -19,8 +19,6 @@ function renderUsername(value) {
     const username = (value[0] === '@') ? value : `@${value}`;
 
     const options = {
-        mentionKeys: [{key: username}],
-        mentionHighlight: false,
         markdown: false,
     };
 

--- a/tests/components/__snapshots__/post_markdown.test.jsx.snap
+++ b/tests/components/__snapshots__/post_markdown.test.jsx.snap
@@ -69,7 +69,6 @@ exports[`components/PostMarkdown should render header change properly 1`] = `
           message="@user"
           options={
             Object {
-              "atMentions": true,
               "markdown": false,
               "mentionHighlight": false,
               "mentionKeys": Array [

--- a/tests/components/__snapshots__/post_markdown.test.jsx.snap
+++ b/tests/components/__snapshots__/post_markdown.test.jsx.snap
@@ -70,12 +70,6 @@ exports[`components/PostMarkdown should render header change properly 1`] = `
           options={
             Object {
               "markdown": false,
-              "mentionHighlight": false,
-              "mentionKeys": Array [
-                Object {
-                  "key": "@user",
-                },
-              ],
             }
           }
         />,

--- a/tests/components/__snapshots__/post_markdown.test.jsx.snap
+++ b/tests/components/__snapshots__/post_markdown.test.jsx.snap
@@ -66,10 +66,17 @@ exports[`components/PostMarkdown should render header change properly 1`] = `
           }
         />,
         "username": <Connect(Markdown)
-          message="user"
+          message="@user"
           options={
             Object {
+              "atMentions": true,
               "markdown": false,
+              "mentionHighlight": false,
+              "mentionKeys": Array [
+                Object {
+                  "key": "@user",
+                },
+              ],
             }
           }
         />,


### PR DESCRIPTION
#### Summary
This PR ensures that system messages will render `@{username}` so that you can click the username and see the username popover.

From what I can tell, the check for the `@` symbol might be overkill but I thought it would be better to have it than not.

#### Ticket Link
[JIRA](https://mattermost.atlassian.net/browse/MM-11675) / [#9503](https://github.com/mattermost/mattermost-server/issues/9503)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
