### PR TITLE
[MM-12336 && MM-12299] Add cursor pointer to mobile view plugin button and add tests

### DIFF
--- a/plugins/mobile_channel_header_plug/mobile_channel_header_plug.jsx
+++ b/plugins/mobile_channel_header_plug/mobile_channel_header_plug.jsx
@@ -28,14 +28,14 @@ export default class MobileChannelHeaderPlug extends React.PureComponent {
 
     createButton(plug) {
         return (
-            <div
+            <button
                 className='navbar-toggle navbar-right__icon pull-right'
                 onClick={() => this.fireAction(plug)}
             >
                 <span className='icon navbar-plugin-button'>
                     {plug.icon}
                 </span>
-            </div>
+            </button>
         );
     }
 

--- a/tests/plugins/__snapshots__/mobile_channel_header_plug.test.jsx.snap
+++ b/tests/plugins/__snapshots__/mobile_channel_header_plug.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`plugins/MobileChannelHeaderPlug should match snapshot with one extended
   isDropdown={false}
   theme={Object {}}
 >
-  <div
+  <button
     className="navbar-toggle navbar-right__icon pull-right"
     onClick={[Function]}
   >
@@ -51,7 +51,7 @@ exports[`plugins/MobileChannelHeaderPlug should match snapshot with one extended
         className="fa fa-anchor"
       />
     </span>
-  </div>
+  </button>
 </MobileChannelHeaderPlug>
 `;
 
@@ -75,7 +75,7 @@ exports[`plugins/MobileChannelHeaderPlug should match snapshot with one extended
   isDropdown={true}
   theme={Object {}}
 >
-  <div
+  <button
     className="navbar-toggle navbar-right__icon pull-right"
     onClick={[Function]}
   >
@@ -86,7 +86,7 @@ exports[`plugins/MobileChannelHeaderPlug should match snapshot with one extended
         className="fa fa-anchor"
       />
     </span>
-  </div>
+  </button>
 </MobileChannelHeaderPlug>
 `;
 

--- a/tests/plugins/mobile_channel_header_plug.test.jsx
+++ b/tests/plugins/mobile_channel_header_plug.test.jsx
@@ -39,6 +39,14 @@ describe('plugins/MobileChannelHeaderPlug', () => {
             />
         );
         expect(wrapper).toMatchSnapshot();
+
+        wrapper.instance().fireAction = jest.fn();
+        expect(wrapper.find('button').exists()).toEqual(true);
+        expect(wrapper.find('li').exists()).toEqual(false);
+
+        wrapper.find('button').first().simulate('click');
+        expect(wrapper.instance().fireAction).toHaveBeenCalledTimes(1);
+        expect(wrapper.instance().fireAction).toBeCalledWith(testPlug);
     });
 
     test('should match snapshot with two extended components', () => {
@@ -78,6 +86,10 @@ describe('plugins/MobileChannelHeaderPlug', () => {
             />
         );
         expect(wrapper).toMatchSnapshot();
+
+        wrapper.instance().fireAction = jest.fn();
+        expect(wrapper.find('button').exists()).toEqual(true);
+        expect(wrapper.find('li').exists()).toEqual(false);
     });
 
     test('should match snapshot with two extended components, in dropdown', () => {
@@ -91,5 +103,13 @@ describe('plugins/MobileChannelHeaderPlug', () => {
             />
         );
         expect(wrapper).toMatchSnapshot();
+
+        wrapper.instance().fireAction = jest.fn();
+        expect(wrapper.find('button').exists()).toEqual(false);
+        expect(wrapper.find('li').exists()).toEqual(true);
+
+        wrapper.find('a').first().simulate('click');
+        expect(wrapper.instance().fireAction).toHaveBeenCalledTimes(1);
+        expect(wrapper.instance().fireAction).toBeCalledWith(testPlug);
     });
 });


### PR DESCRIPTION
#### Summary
MM-12336 - Add cursor pointer to mobile view plugin button by changing div to button.  This is just a follow up PR based on the comment on Jira ticket.
MM-12299 - The test added here satisfy the requirement of this ticket. (separate PR seems to be unnecessary)

#### Ticket Link
Jire tickets: [MM-12336](https://mattermost.atlassian.net/browse/MM-12336) && [MM-12299](https://mattermost.atlassian.net/browse/MM-12299)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
