### PR TITLE
MM-12403 Fix uploads fail for last attachment

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -498,7 +498,6 @@ export default class CreateComment extends React.PureComponent {
         });
 
         this.draftsTimeout = setTimeout(() => {
-            clearTimeout(this.draftsTimeout);
             this.props.onUpdateCommentDraft({...draft, fileInfos: newFileInfos, uploadsInProgress});
             this.setState({draft: {...draft, fileInfos: newFileInfos, uploadsInProgress}});
         }, 500);

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -585,7 +585,6 @@ export default class CreatePost extends React.Component {
 
         this.draftsForChannel[channelId] = draft;
         this.draftsTimeout = setTimeout(() => {
-            clearTimeout(this.draftsTimeout);
             this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, draft);
 
             if (channelId === this.props.currentChannel.id) {


### PR DESCRIPTION
#### Summary
Fixes upload for last attachment staying in progress state.
This removes an unneeded clear timeout as this is handled by clearing in unmount of the component.

#### Ticket Link
[MM-12403](https://mattermost.atlassian.net/browse/MM-12403)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
![oct-02-2018 21-44-14](https://user-images.githubusercontent.com/4973621/46362068-ed138280-c68c-11e8-85df-570ec9fd3838.gif)
