### PR TITLE
MM-12447: stop tracking focus for session expiry

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -446,11 +446,12 @@ export function emitRemoteUserTypingEvent(channelId, userId, postParentId) {
     });
 }
 
-export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = true) {
-    // If the logout was intentional (as it should be if emitUserLoggedOutEvent is called),
-    // discard knowledge about having previously been logged in. This bit is otherwise used to
-    // detect session expirations on the login page.
-    LocalStorageStore.setWasLoggedIn(false);
+export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = true, userAction = true) {
+    // If the logout was intentional, discard knowledge about having previously been logged in.
+    // This bit is otherwise used to detect session expirations on the login page.
+    if (userAction) {
+        LocalStorageStore.setWasLoggedIn(false);
+    }
 
     dispatch(logout()).then(() => {
         if (shouldSignalLogout) {

--- a/components/logged_in/logged_in.jsx
+++ b/components/logged_in/logged_in.jsx
@@ -95,7 +95,7 @@ export default class LoggedIn extends React.Component {
 
         if (!this.state.user) {
             $('#root').attr('class', '');
-            GlobalActions.emitUserLoggedOutEvent('/login?redirect_to=' + encodeURIComponent(this.props.location.pathname));
+            GlobalActions.emitUserLoggedOutEvent('/login?redirect_to=' + encodeURIComponent(this.props.location.pathname), true, false);
         }
 
         if (this.props.showTermsOfService && this.props.location.pathname !== '/terms_of_service') {

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -84,7 +84,6 @@ class LoginController extends React.Component {
             password: '',
             showMfa: false,
             loading: false,
-            focused: document.hasFocus(),
             sessionExpired: false,
         };
     }
@@ -115,9 +114,6 @@ class LoginController extends React.Component {
         }
 
         this.showSessionExpiredNotificationIfNeeded();
-
-        window.addEventListener('focus', this.handleFocus);
-        window.addEventListener('blur', this.handleBlur);
     }
 
     componentDidUpdate() {
@@ -130,9 +126,6 @@ class LoginController extends React.Component {
             this.closeSessionExpiredNotification();
             this.closeSessionExpiredNotification = null;
         }
-
-        window.removeEventListener('focus', this.handleFocus);
-        window.removeEventListener('blur', this.handleBlur);
     }
 
     configureTitle() {
@@ -149,9 +142,7 @@ class LoginController extends React.Component {
     }
 
     showSessionExpiredNotificationIfNeeded = () => {
-        const show = this.state.sessionExpired && (!this.state.focused || this.closeSessionExpiredNotification);
-
-        if (show && !this.closeSessionExpiredNotification) {
+        if (this.state.sessionExpired && !this.closeSessionExpiredNotification) {
             Utils.showNotification({
                 title: this.props.siteName,
                 body: Utils.localizeMessage(
@@ -162,28 +153,20 @@ class LoginController extends React.Component {
                 silent: false,
                 onClick: () => {
                     window.focus();
+                    if (this.closeSessionExpiredNotification()) {
+                        this.closeSessionExpiredNotification();
+                        this.closeSessionExpiredNotification = null;
+                    }
                 },
             }).then((closeNotification) => {
                 this.closeSessionExpiredNotification = closeNotification;
             }).catch(() => {
                 // Ignore the failure to display the notification.
             });
-        } else if (!show && this.closeSessionExpiredNotification) {
+        } else if (!this.state.sessionExpired && this.closeSessionExpiredNotification) {
             this.closeSessionExpiredNotification();
             this.closeSessionExpiredNotification = null;
         }
-    }
-
-    handleFocus = () => {
-        this.setState({
-            focused: true,
-        });
-    }
-
-    handleBlur = () => {
-        this.setState({
-            focused: false,
-        });
     }
 
     preSubmit(e) {

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -112,7 +112,7 @@ export default class Root extends React.Component {
                 }
 
                 console.log('detected logout from a different tab'); //eslint-disable-line no-console
-                GlobalActions.emitUserLoggedOutEvent('/', false);
+                GlobalActions.emitUserLoggedOutEvent('/', false, false);
             }
 
             if (e.originalEvent.key === StoragePrefixes.LOGIN && e.originalEvent.storageArea === localStorage && e.originalEvent.newValue) {


### PR DESCRIPTION
#### Summary
Detecting focus after a page reload across various platforms proved to be unreliable. Better to show the notification even if focussed than miss showing it at all.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12447

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed