### PR TITLE
Draft channel indicator to ignore message with whitespaces only

### DIFF
--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -109,7 +109,7 @@ function makeMapStateToProps() {
             channelTeammateId,
             channelTeammateUsername,
             channelTeammateDeletedAt,
-            hasDraft: Boolean(draft.message || draft.fileInfos.length || draft.uploadsInProgress.length) && currentChannelId !== channel.id,
+            hasDraft: Boolean(draft.message.trim() || draft.fileInfos.length || draft.uploadsInProgress.length) && currentChannelId !== channel.id,
             showTutorialTip: enableTutorial && tutorialStep === Constants.TutorialSteps.CHANNEL_POPOVER,
             townSquareDisplayName: channelsByName[Constants.DEFAULT_CHANNEL] && channelsByName[Constants.DEFAULT_CHANNEL].display_name,
             offTopicDisplayName: channelsByName[Constants.OFFTOPIC_CHANNEL] && channelsByName[Constants.OFFTOPIC_CHANNEL].display_name,

--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -109,7 +109,7 @@ function makeMapStateToProps() {
             channelTeammateId,
             channelTeammateUsername,
             channelTeammateDeletedAt,
-            hasDraft: Boolean(draft.message.trim() || draft.fileInfos.length || draft.uploadsInProgress.length) && currentChannelId !== channel.id,
+            hasDraft: draft && Boolean(draft.message.trim() || draft.fileInfos.length || draft.uploadsInProgress.length) && currentChannelId !== channel.id,
             showTutorialTip: enableTutorial && tutorialStep === Constants.TutorialSteps.CHANNEL_POPOVER,
             townSquareDisplayName: channelsByName[Constants.DEFAULT_CHANNEL] && channelsByName[Constants.DEFAULT_CHANNEL].display_name,
             offTopicDisplayName: channelsByName[Constants.OFFTOPIC_CHANNEL] && channelsByName[Constants.OFFTOPIC_CHANNEL].display_name,

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -120,7 +120,7 @@ function mapStateToPropsForSwitchChannelSuggestion(state, ownProps) {
 
     return {
         channelMember: getMyChannelMemberships(state)[channelId],
-        hasDraft: Boolean(draft.message || draft.fileInfos.length || draft.uploadsInProgress.length),
+        hasDraft: Boolean(draft.message.trim() || draft.fileInfos.length || draft.uploadsInProgress.length),
     };
 }
 

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -116,11 +116,11 @@ class SwitchChannelSuggestion extends Suggestion {
 
 function mapStateToPropsForSwitchChannelSuggestion(state, ownProps) {
     const channelId = ownProps.item && ownProps.item.channel ? ownProps.item.channel.id : '';
-    const draft = getPostDraft(state, StoragePrefixes.DRAFT, channelId);
+    const draft = channelId ? getPostDraft(state, StoragePrefixes.DRAFT, channelId) : false;
 
     return {
         channelMember: getMyChannelMemberships(state)[channelId],
-        hasDraft: Boolean(draft.message.trim() || draft.fileInfos.length || draft.uploadsInProgress.length),
+        hasDraft: draft && Boolean(draft.message.trim() || draft.fileInfos.length || draft.uploadsInProgress.length),
     };
 }
 


### PR DESCRIPTION
#### Summary
The draft indicator should not be present if the draft only contains whitespaces

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12337

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Needs to be implemented in mobile (https://github.com/mattermost/mattermost-mobile/pull/2209)