### PR TITLE
MM-12416: Adds boolean config for 'memberOf' overlay.

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -1288,6 +1288,15 @@ export default {
                             ),
                         },
                         {
+                            type: Constants.SettingsTypes.TYPE_BOOL,
+                            key: 'LdapSettings.UseMemberOfOverlay',
+                            label: t('admin.ldap.memberOverlayTitle'),
+                            label_default: 'Use \'memberOf\' Overlay:',
+                            help_text: t('admin.ldap.memberOverlayDesc'),
+                            help_text_default: 'Set this to false only if the AD/LDAP instance does not support [reverse group membership maintenance](!https://www.openldap.org/doc/admin24/overlays.html#Reverse%20Group%20Membership%20Maintenance) using the \'memberOf\' overlay or if there is a known reason not to use it. Setting this to false will make group syncs slower.',
+                            help_text_markdown: true,
+                        },
+                        {
                             type: Constants.SettingsTypes.TYPE_TEXT,
                             key: 'LdapSettings.FirstNameAttribute',
                             label: t('admin.ldap.firstnameAttrTitle'),

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -1293,7 +1293,7 @@ export default {
                             label: t('admin.ldap.memberOverlayTitle'),
                             label_default: 'Use \'memberOf\' Overlay:',
                             help_text: t('admin.ldap.memberOverlayDesc'),
-                            help_text_default: 'Set this to false only if the AD/LDAP instance does not support [reverse group membership maintenance](!https://www.openldap.org/doc/admin24/overlays.html#Reverse%20Group%20Membership%20Maintenance) using the \'memberOf\' overlay or if there is a known reason not to use it. Setting this to false will make group syncs slower.',
+                            help_text_default: '(Optional) This setting is used with the Group Filter to determine if group membership changes are updated on the user \'memberOf\' attribute or by modification of the group object members attribute. Set this to false only if the AD/LDAP instance does not support reverse group membership maintenance using the \'memberOf\' overlay or if there is a known reason not to use it. Setting this to false will make group syncs slower.',
                             help_text_markdown: true,
                         },
                         {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -595,6 +595,8 @@
   "admin.ldap.groupFilterTitle": "Group Filter:",
   "admin.ldap.groupFilterFilterDesc": "(Optional) Enter an AD/LDAP Filter to use when searching for group objects.",
   "admin.ldap.groupFilterEx": "E.g.: \"(objectClass=group)\"",
+  "admin.ldap.memberOverlayTitle": "Use 'memberOf' Overlay:",
+  "admin.ldap.memberOverlayTitleDesc": "Set this to false only if the AD/LDAP instance does not support [reverse group membership maintenance](!https://www.openldap.org/doc/admin24/overlays.html#Reverse%20Group%20Membership%20Maintenance) using the 'memberOf' overlay or if there is a known reason not to use it. Setting this to false will make group syncs slower.",
   "admin.ldap.idAttrDesc": "The attribute in the AD/LDAP server used as a unique identifier in Mattermost. It should be an AD/LDAP attribute with a value that does not change. If a user's ID Attribute changes, it will create a new Mattermost account unassociated with their old one.\n \nIf you need to change this field after users have already logged in, use the [mattermost ldap idmigrate](!https://about.mattermost.com/default-platform-ldap-idmigrate) CLI tool.",
   "admin.ldap.idAttrEx": "E.g.: \"objectGUID\"",
   "admin.ldap.idAttrTitle": "ID Attribute: ",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -596,7 +596,7 @@
   "admin.ldap.groupFilterFilterDesc": "(Optional) Enter an AD/LDAP Filter to use when searching for group objects.",
   "admin.ldap.groupFilterEx": "E.g.: \"(objectClass=group)\"",
   "admin.ldap.memberOverlayTitle": "Use 'memberOf' Overlay:",
-  "admin.ldap.memberOverlayTitleDesc": "Set this to false only if the AD/LDAP instance does not support [reverse group membership maintenance](!https://www.openldap.org/doc/admin24/overlays.html#Reverse%20Group%20Membership%20Maintenance) using the 'memberOf' overlay or if there is a known reason not to use it. Setting this to false will make group syncs slower.",
+  "admin.ldap.memberOverlayTitleDesc": "(Optional) This setting is used with the Group Filter to determine if group membership changes are updated on the user 'memberOf' attribute or by modification of the group object members attribute. Set this to false only if the AD/LDAP instance does not support reverse group membership maintenance using the 'memberOf' overlay or if there is a known reason not to use it. Setting this to false will make group syncs slower.",
   "admin.ldap.idAttrDesc": "The attribute in the AD/LDAP server used as a unique identifier in Mattermost. It should be an AD/LDAP attribute with a value that does not change. If a user's ID Attribute changes, it will create a new Mattermost account unassociated with their old one.\n \nIf you need to change this field after users have already logged in, use the [mattermost ldap idmigrate](!https://about.mattermost.com/default-platform-ldap-idmigrate) CLI tool.",
   "admin.ldap.idAttrEx": "E.g.: \"objectGUID\"",
   "admin.ldap.idAttrTitle": "ID Attribute: ",


### PR DESCRIPTION
#### Summary
Adds ability to determine group membership retrieval strategy. Defaults to the faster strategy, using the `memberOf` overlay. If that overlay is not available on the LDAP instance it can be disabled at a cost of slower syncs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12416

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [x] Has server changes (https://github.com/mattermost/mattermost-server/commit/b06b3fef0351d6848e62fefb5953663a0cb4ecde)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)

<img width="1431" alt="screen shot 2018-10-03 at 8 10 18 am" src="https://user-images.githubusercontent.com/1149597/46409636-4ce94800-c6e4-11e8-93f1-0b1dbfa1ce00.png">
