### PR TITLE
[MM-12454] fix formated message when have *** and improve the copy text button

### DIFF
--- a/components/integrations/installed_oauth_app.jsx
+++ b/components/integrations/installed_oauth_app.jsx
@@ -158,6 +158,7 @@ export default class InstalledOAuthApp extends React.PureComponent {
         }
 
         let showHide;
+        let clientSecret;
         if (this.state.clientSecret === FAKE_SECRET) {
             showHide = (
                 <button
@@ -171,6 +172,17 @@ export default class InstalledOAuthApp extends React.PureComponent {
                     />
                 </button>
             );
+            clientSecret = (
+                <span className='item-details__token'>
+                    <FormattedMessage
+                        id='installed_integrations.client_secret'
+                        defaultMessage='Client Secret: **{clientSecret}**'
+                        values={{
+                            clientSecret: this.state.clientSecret,
+                        }}
+                    />
+                </span>
+            );
         } else {
             showHide = (
                 <button
@@ -183,6 +195,22 @@ export default class InstalledOAuthApp extends React.PureComponent {
                         defaultMessage='Hide Secret'
                     />
                 </button>
+            );
+            clientSecret = (
+                <span className='item-details__token'>
+                    <FormattedMarkdownMessage
+                        id='installed_integrations.client_secret'
+                        defaultMessage='Client Secret: **{clientSecret}**'
+                        values={{
+                            clientSecret: this.state.clientSecret,
+                        }}
+                    />
+                    <CopyText
+                        idMessage='integrations.copy_client_secret'
+                        defaultMessage='Copy Client Secret'
+                        value={this.state.clientSecret}
+                    />
+                </span>
             );
         }
 
@@ -247,20 +275,7 @@ export default class InstalledOAuthApp extends React.PureComponent {
                         </span>
                     </div>
                     <div className='item-details__row'>
-                        <span className='item-details__token'>
-                            <FormattedMarkdownMessage
-                                id='installed_integrations.client_secret'
-                                defaultMessage='Client Secret: **{clientSecret}**'
-                                values={{
-                                    clientSecret: this.state.clientSecret,
-                                }}
-                            />
-                            <CopyText
-                                idMessage='integrations.copy_client_secret'
-                                defaultMessage='Copy Client Secret'
-                                value={this.state.clientSecret}
-                            />
-                        </span>
+                        {clientSecret}
                     </div>
                     {urls}
                     <div className='item-details__row'>

--- a/tests/components/integrations/__snapshots__/installed_oauth_app.test.jsx.snap
+++ b/tests/components/integrations/__snapshots__/installed_oauth_app.test.jsx.snap
@@ -79,7 +79,7 @@ exports[`components/integrations/InstalledOAuthApp should match snapshot 1`] = `
       <span
         className="item-details__token"
       >
-        <InjectIntl(FormattedMarkdownMessage)
+        <FormattedMessage
           defaultMessage="Client Secret: **{clientSecret}**"
           id="installed_integrations.client_secret"
           values={
@@ -87,11 +87,6 @@ exports[`components/integrations/InstalledOAuthApp should match snapshot 1`] = `
               "clientSecret": "***************",
             }
           }
-        />
-        <CopyText
-          defaultMessage="Copy Client Secret"
-          idMessage="integrations.copy_client_secret"
-          value="***************"
         />
       </span>
     </div>
@@ -262,7 +257,7 @@ exports[`components/integrations/InstalledOAuthApp should match snapshot, on err
       <span
         className="item-details__token"
       >
-        <InjectIntl(FormattedMarkdownMessage)
+        <FormattedMessage
           defaultMessage="Client Secret: **{clientSecret}**"
           id="installed_integrations.client_secret"
           values={
@@ -270,11 +265,6 @@ exports[`components/integrations/InstalledOAuthApp should match snapshot, on err
               "clientSecret": "***************",
             }
           }
-        />
-        <CopyText
-          defaultMessage="Copy Client Secret"
-          idMessage="integrations.copy_client_secret"
-          value="***************"
         />
       </span>
     </div>
@@ -441,7 +431,7 @@ exports[`components/integrations/InstalledOAuthApp should match snapshot, when o
       <span
         className="item-details__token"
       >
-        <InjectIntl(FormattedMarkdownMessage)
+        <FormattedMessage
           defaultMessage="Client Secret: **{clientSecret}**"
           id="installed_integrations.client_secret"
           values={
@@ -449,11 +439,6 @@ exports[`components/integrations/InstalledOAuthApp should match snapshot, when o
               "clientSecret": "***************",
             }
           }
-        />
-        <CopyText
-          defaultMessage="Copy Client Secret"
-          idMessage="integrations.copy_client_secret"
-          value="***************"
         />
       </span>
     </div>


### PR DESCRIPTION
#### Summary
the  `FormattedMarkdownMessage` was parsing the FAKE secret text so I update to use `FormattedMessage` when need to display the fake secret

Also, improve the copy button to show only when you click to show the secret.


#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-12454

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
