### PR TITLE
MM-12260: don't close edit post modal on escape if emoji picker is open

### DIFF
--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -103,10 +103,16 @@ export default class EditPostModal extends React.PureComponent {
 
     toggleEmojiPicker = () => {
         this.setState({showEmojiPicker: !this.state.showEmojiPicker});
+        if (!this.state.showEmojiPicker && this.editbox) {
+            this.editbox.focus();
+        }
     }
 
     hideEmojiPicker = () => {
         this.setState({showEmojiPicker: false});
+        if (this.editbox) {
+            this.editbox.focus();
+        }
     }
 
     handleEmojiClick = (emoji) => {
@@ -225,7 +231,7 @@ export default class EditPostModal extends React.PureComponent {
     handleKeyDown = (e) => {
         if (this.props.ctrlSend && Utils.isKeyPressed(e, KeyCodes.ENTER) && e.ctrlKey === true) {
             this.handleEdit();
-        } else if (Utils.isKeyPressed(e, KeyCodes.ESCAPE)) {
+        } else if (Utils.isKeyPressed(e, KeyCodes.ESCAPE) && !this.state.showEmojiPicker) {
             this.handleHide();
         }
     }

--- a/tests/components/edit_post_modal.test.jsx
+++ b/tests/components/edit_post_modal.test.jsx
@@ -415,8 +415,8 @@ describe('components/EditPostModal', () => {
 
     it('should handle the escape key manually to hide the modal', () => {
         const options = new ReactRouterEnzymeContext();
-        var wrapper = shallow(createEditPost({ctrlSend: true}), {context: options.get()});
-        var instance = wrapper.instance();
+        const wrapper = mountWithIntl(createEditPost({ctrlSend: true}), options.get());
+        const instance = wrapper.instance();
         instance.handleHide = jest.fn();
         instance.handleExit = jest.fn();
 
@@ -425,5 +425,17 @@ describe('components/EditPostModal', () => {
 
         instance.handleKeyDown({key: Constants.KeyCodes.ESCAPE[0], keyCode: Constants.KeyCodes.ESCAPE[1]});
         expect(instance.handleHide).toBeCalled();
+    });
+
+    it('should handle the escape key manually to hide the modal, unless the emoji picker is shown', () => {
+        const wrapper = shallow(createEditPost({ctrlSend: true}));
+        const instance = wrapper.instance();
+        instance.handleHide = jest.fn();
+        instance.handleExit = jest.fn();
+
+        instance.setState({showEmojiPicker: true});
+
+        instance.handleKeyDown({key: Constants.KeyCodes.ESCAPE[0], keyCode: Constants.KeyCodes.ESCAPE[1]});
+        expect(instance.handleHide).not.toBeCalled();
     });
 });


### PR DESCRIPTION
#### Summary
Unlike the autocomplete overlays, the emoji picker's bootstrap component doesn't support /not/ handling the escape key -- it's hard coded. So if the emoji picker is open when an escape key is detected in the edit post modal, just dismiss the picker without closing the modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12260

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)