### PR TITLE
MM7676 - Migrated removed_from_channel_modal to be pure and use Redux

### DIFF
--- a/components/channel_layout/channel_controller.jsx
+++ b/components/channel_layout/channel_controller.jsx
@@ -14,7 +14,6 @@ import GetTeamInviteLinkModal from 'components/get_team_invite_link_modal';
 import GetPublicLinkModal from 'components/get_public_link_modal';
 import InviteMemberModal from 'components/invite_member_modal';
 import LeavePrivateChannelModal from 'components/leave_private_channel_modal';
-import RemovedFromChannelModal from 'components/removed_from_channel_modal';
 import ResetStatusModal from 'components/reset_status_modal';
 import ShortcutsModal from 'components/shortcuts_modal.jsx';
 import SidebarRight from 'components/sidebar_right';
@@ -57,7 +56,6 @@ export default class ChannelController extends React.Component {
                     <ImportThemeModal/>
                     <TeamSettingsModal/>
                     <EditPostModal/>
-                    <RemovedFromChannelModal/>
                     <ResetStatusModal/>
                     <LeavePrivateChannelModal/>
                     <ShortcutsModal isMac={Utils.isMac()}/>

--- a/components/removed_from_channel_modal/index.js
+++ b/components/removed_from_channel_modal/index.js
@@ -3,23 +3,22 @@
 
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/common';
 
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {closeModal} from 'actions/views/modals';
 
-import {goToLastViewedChannel} from 'actions/views/channel';
-
-import RemovedFromChannelModal from './removed_from_channel_modal.jsx';
+import RemovedFromChannelModal from './removed_from_channel_modal';
 
 function mapStateToProps(state) {
     return {
-        currentUserId: getCurrentUserId(state),
+        currentUser: getCurrentUser(state),
     };
 }
 
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            goToLastViewedChannel,
+            closeModal,
         }, dispatch),
     };
 }

--- a/components/removed_from_channel_modal/removed_from_channel_modal.jsx
+++ b/components/removed_from_channel_modal/removed_from_channel_modal.jsx
@@ -1,69 +1,70 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
-import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
+import {Modal} from 'react-bootstrap';
 
-import BrowserStore from 'stores/browser_store.jsx';
+import {ModalIdentifiers} from 'utils/constants.jsx';
 
-export default class RemovedFromChannelModal extends React.Component {
+export default class RemovedFromChannelModal extends React.PureComponent {
     static propTypes = {
-        currentUserId: PropTypes.string.isRequired,
+
+        /**
+         * Object with info about townsquare
+         */
+        currentUser: PropTypes.object.isRequired,
+
+        /**
+         * String with name of currently selected channel
+         */
+        channelName: PropTypes.string,
+
+        /**
+         * String with name of admin who removed currentUser from channel
+         */
+        remover: PropTypes.string,
+
+        /*
+         * Object with redux action creators
+         */
         actions: PropTypes.shape({
-            goToLastViewedChannel: PropTypes.func.isRequired,
-        }),
-    };
+
+            /*
+             * Action creator to close modal
+             */
+            closeModal: PropTypes.func.isRequired,
+        }).isRequired,
+    }
 
     constructor(props) {
         super(props);
-
-        this.handleShow = this.handleShow.bind(this);
-        this.handleClose = this.handleClose.bind(this);
-
         this.state = {
-            channelName: '',
-            remover: '',
+            show: true,
         };
     }
 
-    handleShow() {
-        var newState = {};
-        if (BrowserStore.getItem('channel-removed-state')) {
-            newState = BrowserStore.getItem('channel-removed-state');
-            BrowserStore.removeItem('channel-removed-state');
-        }
-
-        setTimeout(this.props.actions.goToLastViewedChannel, 1);
-
-        this.setState(newState);
+    handleClose = () => {
+        this.setState({show: false});
     }
 
-    handleClose() {
-        this.setState({channelName: '', remover: ''});
-    }
-
-    componentDidMount() {
-        $(ReactDOM.findDOMNode(this)).on('show.bs.modal', this.handleShow);
-        $(ReactDOM.findDOMNode(this)).on('hidden.bs.modal', this.handleClose);
-    }
-
-    componentWillUnmount() {
-        $(ReactDOM.findDOMNode(this)).off('show.bs.modal', this.handleShow);
-        $(ReactDOM.findDOMNode(this)).off('hidden.bs.modal', this.handleClose);
+    handleExited = () => {
+        this.props.actions.closeModal(ModalIdentifiers.REMOVED_FROM_CHANNEL);
     }
 
     render() {
+        const {currentUser} = this.props;
+
         var channelName = (
             <FormattedMessage
                 id='removed_channel.channelName'
                 defaultMessage='the channel'
             />
         );
-        if (this.state.channelName) {
-            channelName = this.state.channelName;
+
+        if (this.props.channelName) {
+            channelName = this.props.channelName;
         }
 
         var remover = (
@@ -72,70 +73,57 @@ export default class RemovedFromChannelModal extends React.Component {
                 defaultMessage='Someone'
             />
         );
-        if (this.state.remover) {
-            remover = this.state.remover;
+
+        if (this.props.remover) {
+            remover = this.props.remover;
         }
 
-        if (this.props.currentUserId !== '') {
-            return (
-                <div
-                    className='modal fade'
-                    ref='modal'
-                    id='removed_from_channel'
-                    tabIndex='-1'
-                    role='dialog'
-                    aria-hidden='true'
-                >
-                    <div className='modal-dialog'>
-                        <div className='modal-content'>
-                            <div className='modal-header'>
-                                <button
-                                    type='button'
-                                    className='close'
-                                    data-dismiss='modal'
-                                    aria-label='Close'
-                                >
-                                    <span aria-hidden='true'>
-                                        {'×'}
-                                    </span>
-                                </button>
-                                <h4 className='modal-title'>
-                                    <FormattedMessage
-                                        id='removed_channel.from'
-                                        defaultMessage='Removed from '
-                                    />
-                                    <span className='name'>{channelName}</span></h4>
-                            </div>
-                            <div className='modal-body'>
-                                <p>
-                                    <FormattedMessage
-                                        id='removed_channel.remover'
-                                        defaultMessage='{remover} removed you from {channel}'
-                                        values={{
-                                            remover,
-                                            channel: (channelName),
-                                        }}
-                                    />
-                                </p>
-                            </div>
-                            <div className='modal-footer'>
-                                <button
-                                    type='button'
-                                    className='btn btn-primary'
-                                    data-dismiss='modal'
-                                >
-                                    <FormattedMessage
-                                        id='removed_channel.okay'
-                                        defaultMessage='Okay'
-                                    />
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            );
+        if (!currentUser) {
+            return null;
         }
 
-        return <div/>;
+        return (
+            <Modal
+                show={this.state.show}
+                onHide={this.handleClose}
+                onExited={this.handleExited}
+                id={ModalIdentifiers.REMOVED_FROM_CHANNEL}
+            >
+                <Modal.Header closeButton={true}>
+                    <Modal.Title>
+                        <FormattedMessage
+                            id='removed_channel.from'
+                            defaultMessage='Removed from '
+                        />
+                        <span className='name'>{channelName}</span>
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <p>
+                        <FormattedMessage
+                            id='removed_channel.remover'
+                            defaultMessage='{remover} removed you from {channel}'
+                            values={{
+                                remover,
+                                channel: (channelName),
+                            }}
+                        />
+                    </p>
+                </Modal.Body>
+                <Modal.Footer>
+                    <button
+                        type='button'
+                        className='btn btn-primary'
+                        data-dismiss='modal'
+                        onClick={this.handleClose}
+                    >
+                        <FormattedMessage
+                            id='removed_channel.okay'
+                            defaultMessage='Okay'
+                        />
+                    </button>
+                </Modal.Footer>
+            </Modal>
+        );
     }
 }

--- a/tests/components/removed_from_channel_modal/__snapshots__/removed_from_channel_modal.test.jsx.snap
+++ b/tests/components/removed_from_channel_modal/__snapshots__/removed_from_channel_modal.test.jsx.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/AddUsersToTeam should match snapshot 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  id="removed_from_channel"
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onExited={[Function]}
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Removed from "
+        id="removed_channel.from"
+        values={Object {}}
+      />
+      <span
+        className="name"
+      >
+        test-channel
+      </span>
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <p>
+      <FormattedMessage
+        defaultMessage="{remover} removed you from {channel}"
+        id="removed_channel.remover"
+        values={
+          Object {
+            "channel": "test-channel",
+            "remover": "Administrator",
+          }
+        }
+      />
+    </p>
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-primary"
+      data-dismiss="modal"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Okay"
+        id="removed_channel.okay"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;

--- a/tests/components/removed_from_channel_modal/removed_from_channel_modal.test.jsx
+++ b/tests/components/removed_from_channel_modal/removed_from_channel_modal.test.jsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+import {Modal} from 'react-bootstrap';
+
+import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+
+import RemovedFromChannelModal from 'components/removed_from_channel_modal/removed_from_channel_modal';
+
+describe('components/AddUsersToTeam', () => {
+    const baseProps = {
+        defaultChannel: {
+            name: 'town-square',
+        },
+        currentUser: {
+            id: 'current_user_id',
+        },
+        channelName: 'test-channel',
+        remover: 'Administrator',
+        actions: {
+            closeModal: jest.fn(),
+        },
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <RemovedFromChannelModal {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should have state "show" equals true on mount', () => {
+        const wrapper = shallow(
+            <RemovedFromChannelModal {...baseProps}/>
+        );
+
+        expect(wrapper.state('show')).toBe(true);
+    });
+
+    test('should run handleClose on exit', () => {
+        const wrapper = shallow(
+            <RemovedFromChannelModal {...baseProps}/>
+        );
+        wrapper.find('#removed_from_channel button.btn-primary').simulate('click');
+        expect(wrapper.state('show')).toBe(false);
+    });
+
+    test('should display correct props on Modal.Title and Modal.Body', () => {
+        const wrapper = mountWithIntl(
+            <RemovedFromChannelModal {...baseProps}/>
+        );
+
+        expect(wrapper.find('.modal-title').text()).toBe('Removed from test-channel');
+        expect(wrapper.find('.modal-body').text()).toBe('Administrator removed you from test-channel');
+    });
+
+    test('should fallback to default text on Modal.Body', () => {
+        baseProps.channelName = null;
+        baseProps.remover = null;
+
+        const wrapper = mountWithIntl(
+            <RemovedFromChannelModal {...baseProps}/>
+        );
+
+        expect(wrapper.find('.modal-title').text()).toBe('Removed from the channel');
+        expect(wrapper.find('.modal-body').text()).toBe('Someone removed you from the channel');
+    });
+
+    test('should run closeModal after modal exited', () => {
+        const wrapper = shallow(
+            <RemovedFromChannelModal {...baseProps}/>
+        );
+
+        wrapper.find(Modal).first().props().onExited();
+        expect(baseProps.actions.closeModal).toHaveBeenCalledTimes(1);
+    });
+});

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -282,6 +282,7 @@ export const ModalIdentifiers = {
     RESET_STATUS: 'reset_status',
     LEAVE_TEAM: 'leave_team',
     USER_SETTINGS: 'user_settings',
+    REMOVED_FROM_CHANNEL: 'removed_from_channel',
 };
 
 export const UserStatuses = {


### PR DESCRIPTION
#### Summary
* Migrated to redux
* Removed usage of BrowserStore and jQuery
* Added usage of react-bootstrap's Modal and openModal action

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7676

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
