### PR TITLE
MM-12523: fix announcement bar styling

### DIFF
--- a/components/announcement_bar/announcement_bar.jsx
+++ b/components/announcement_bar/announcement_bar.jsx
@@ -213,7 +213,7 @@ export default class AnnouncementBar extends React.PureComponent {
     }
 
     componentDidMount() {
-        if (this.props.isLoggedIn && !this.state.allowDismissal) {
+        if (this.shouldRender()) {
             document.body.classList.add('announcement-bar--fixed');
         }
 
@@ -234,15 +234,15 @@ export default class AnnouncementBar extends React.PureComponent {
         AnalyticsStore.removeChangeListener(this.onAnalyticsChange);
     }
 
-    componentDidUpdate(prevProps, prevState) {
+    componentDidUpdate() {
         if (!this.props.isLoggedIn) {
             return;
         }
 
-        if (!prevState.allowDismissal && this.state.allowDismissal) {
-            document.body.classList.remove('announcement-bar--fixed');
-        } else if (prevState.allowDismissal && !this.state.allowDismissal) {
+        if (this.shouldRender()) {
             document.body.classList.add('announcement-bar--fixed');
+        } else {
+            document.body.classList.remove('announcement-bar--fixed');
         }
     }
 
@@ -284,12 +284,20 @@ export default class AnnouncementBar extends React.PureComponent {
         this.setState(this.getState());
     }
 
-    render() {
+    shouldRender() {
         if (!this.isValidState(this.state)) {
-            return <div/>;
+            return false;
         }
 
         if (!this.props.isLoggedIn && this.state.type === AnnouncementBarTypes.ANNOUNCEMENT) {
+            return false;
+        }
+
+        return true;
+    }
+
+    render() {
+        if (!this.shouldRender()) {
             return <div/>;
         }
 

--- a/sass/base/_structure.scss
+++ b/sass/base/_structure.scss
@@ -15,8 +15,8 @@ body {
     position: relative;
     width: 100%;
 
-    &.error-bar--fixed {
-        padding-top: 22px;
+    &.announcement-bar--fixed {
+        padding-top: $announcement-bar-height;
     }
 }
 

--- a/sass/components/_announcement-bar.scss
+++ b/sass/components/_announcement-bar.scss
@@ -4,6 +4,7 @@
     background-color: darken($primary-color, 5%);
     color: $white;
     padding: 5px 30px;
+    height: calc($announcement-bar-height - 10px);
     position: fixed;
     text-align: center;
     top: 0;

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -10,8 +10,8 @@
     width: 220px;
     z-index: 10;
 
-    .error-bar--fixed & {
-        height: calc(100% - 22px);
+    body.announcement-bar--fixed & {
+        height: calc(100% - $announcement-bar-height);
     }
 
     &.sidebar--padded {

--- a/sass/layout/_sidebar-right.scss
+++ b/sass/layout/_sidebar-right.scss
@@ -10,8 +10,8 @@
     width: 400px;
     z-index: 8;
 
-    .error-bar--fixed & {
-        height: calc(100% - 22px);
+    body.announcement-bar--fixed & {
+        height: calc(100% - $announcement-bar-height);
     }
 
     &.webrtc {

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -969,7 +969,7 @@
                 @include translate3d(0, 100%, 0);
                 background: alpha-color($black, .9);
                 display: block;
-                height: calc(100% - 48px);
+                height: calc(100% - 26px);
                 left: 0;
                 overflow: auto;
                 padding: 2.5em 0 0;
@@ -978,9 +978,9 @@
                 visibility: hidden;
                 width: 100%;
 
-                .error-bar--fixed & {
-                    height: calc(100% - 70px);
-                    top: 70px;
+                body.announcement-bar--fixed & {
+                    height: calc(100% - 48px - $announcement-bar-height);
+                    top: 48px + $announcement-bar-height;
                 }
 
                 .close {
@@ -1503,9 +1503,9 @@
     }
 
     .app__body {
-        &.error-bar--fixed {
+        &.announcement-bar--fixed {
             .modal {
-                padding-top: 21px;
+                padding-top: $announcement-bar-height;
             }
         }
 

--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -521,6 +521,10 @@
     width: 220px;
     z-index: 10;
 
+    body.announcement-bar--fixed & {
+        top: $announcement-bar-height;
+    }
+
     .dropdown-menu {
         max-height: 80vh;
         max-width: 200px;

--- a/sass/utils/_variables.scss
+++ b/sass/utils/_variables.scss
@@ -16,7 +16,7 @@ $transparent: rgba(0, 0, 0, 0);
 
 // Page Variables
 $border-gray: 1px solid #ddd;
-$announcement-bar-height: 30px;
+$announcement-bar-height: 22px;
 
 // Random variables
 $border-rad: 2px;

--- a/sass/utils/_variables.scss
+++ b/sass/utils/_variables.scss
@@ -16,6 +16,7 @@ $transparent: rgba(0, 0, 0, 0);
 
 // Page Variables
 $border-gray: 1px solid #ddd;
+$announcement-bar-height: 30px;
 
 // Random variables
 $border-rad: 2px;


### PR DESCRIPTION
#### Summary
Over the past two releases, the announcement bar was renamed from error bar, disconnecting some styling rules. Further, the rules themselves seemed not to have been updated when we dropped `position: fixed` styling to properly shift all the affected components. These styling changes now effectively push down all content when the announcement bar is displayed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12523

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed