### PR TITLE
Fix dev mode warning on login screen

### DIFF
--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -571,7 +571,7 @@ class LoginController extends React.Component {
                                 placeholder={this.createLoginPlaceholder()}
                                 spellCheck='false'
                                 autoCapitalize='off'
-                                autoFocus='true'
+                                autoFocus={true}
                             />
                         </div>
                         <div className={'form-group' + errorClass}>


### PR DESCRIPTION
autoFocus expects a boolean value. Setting it to `'true'` still works since it's a truthy value, but it causes React to print a warning