### PR TITLE
MM-12482: Fallback to the default channel view when the archived chan…

### DIFF
--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -46,7 +46,7 @@ function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
 
     let lastViewedChannelName = getLastViewedChannelName(state);
-    if (!lastViewedChannelName) {
+    if (!lastViewedChannelName || (channel && lastViewedChannelName === channel.name)) {
         lastViewedChannelName = Constants.DEFAULT_CHANNEL;
     }
 

--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -34,7 +34,8 @@ function mapStateToProps(state) {
     const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
 
     let lastViewedChannelName = getLastViewedChannelName(state);
-    if (!lastViewedChannelName) {
+
+    if (!lastViewedChannelName || (channel && lastViewedChannelName === channel.name)) {
         lastViewedChannelName = Constants.DEFAULT_CHANNEL;
     }
 


### PR DESCRIPTION
#### Summary
There's a new feature to "redirect to archived view upon archiving" a channel. In that case the archived view *is* the last viewed channel so the close button does nothing. In this case redirect to the default channel (ex Town Square).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12482

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)