### PR TITLE
[MM-12433] Fix expand/collapse of image at RHS root post

### DIFF
--- a/components/rhs_root_post/index.js
+++ b/components/rhs_root_post/index.js
@@ -2,9 +2,12 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+
 import {isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import {isEmbedVisible} from 'selectors/posts';
 
 import RhsRootPost from './rhs_root_post.jsx';
 
@@ -18,6 +21,7 @@ function mapStateToProps(state, ownProps) {
     return {
         enableEmojiPicker,
         enablePostUsernameOverride,
+        isEmbedVisible: isEmbedVisible(state, ownProps.post.id),
         isReadOnly: isChannelReadOnlyById(state, ownProps.post.channel_id),
         teamId,
         pluginPostTypes: state.plugins.postTypes,

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -20,7 +20,7 @@ import DateSeparator from 'components/post_view/date_separator.jsx';
 import FloatingTimestamp from 'components/post_view/floating_timestamp.jsx';
 import RhsComment from 'components/rhs_comment';
 import RhsHeaderPost from 'components/rhs_header_post';
-import RootPost from 'components/rhs_root_post';
+import RhsRootPost from 'components/rhs_root_post';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 const Preferences = Constants.Preferences;
@@ -445,7 +445,7 @@ export default class RhsThread extends React.Component {
                 >
                     <div className='post-right__scroll'>
                         {!isFakeDeletedPost && <DateSeparator date={rootPostDay}/>}
-                        <RootPost
+                        <RhsRootPost
                             ref={selected.id}
                             post={selected}
                             commentCount={postsLength}


### PR DESCRIPTION
#### Summary
Fix expand/collapse of image URL at RHS root post by adding the missing `isEmbedVisible` as props from store at the container component.

#### Ticket Link
Jira ticket: [MM-12433](https://mattermost.atlassian.net/browse/MM-12433)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
