### PR TITLE
MM-12620/MM-12619 login issues

### DIFF
--- a/actions/storage.js
+++ b/actions/storage.js
@@ -48,7 +48,7 @@ export function removeGlobalItem(name) {
     };
 }
 
-export function clear(options) {
+export function clear(options = {exclude: []}) {
     return (dispatch, getState) => {
         dispatch({
             type: StorageTypes.CLEAR,

--- a/components/claim/components/email_to_ldap.jsx
+++ b/components/claim/components/email_to_ldap.jsx
@@ -9,6 +9,7 @@ import {emailToLdap} from 'actions/admin_actions.jsx';
 import {checkMfa} from 'actions/user_actions.jsx';
 import * as Utils from 'utils/utils.jsx';
 import LoginMfa from 'components/login/login_mfa.jsx';
+import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 
 export default class EmailToLDAP extends React.Component {
     constructor(props) {
@@ -85,9 +86,7 @@ export default class EmailToLDAP extends React.Component {
             ldapId || this.state.ldapId,
             ldapPassword || this.state.ldapPassword,
             (data) => {
-                if (data.follow_link) {
-                    window.location.href = data.follow_link;
-                }
+                emitUserLoggedOutEvent(data.follow_link, false, true);
             },
             (err) => {
                 switch (err.id) {

--- a/components/claim/components/email_to_oauth.jsx
+++ b/components/claim/components/email_to_oauth.jsx
@@ -11,6 +11,7 @@ import {checkMfa} from 'actions/user_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import LoginMfa from 'components/login/login_mfa.jsx';
+import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 
 export default class EmailToOAuth extends React.Component {
     constructor(props) {
@@ -60,9 +61,7 @@ export default class EmailToOAuth extends React.Component {
             token,
             this.props.newType,
             (data) => {
-                if (data.follow_link) {
-                    window.location.href = data.follow_link;
-                }
+                emitUserLoggedOutEvent(data.follow_link, false, true);
             },
             (err) => {
                 this.setState({error: err.message, showMfa: false});

--- a/components/claim/components/ldap_to_email.jsx
+++ b/components/claim/components/ldap_to_email.jsx
@@ -8,6 +8,7 @@ import {FormattedMessage} from 'react-intl';
 import {checkMfa, switchFromLdapToEmail} from 'actions/user_actions.jsx';
 import * as Utils from 'utils/utils.jsx';
 import LoginMfa from 'components/login/login_mfa.jsx';
+import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 
 export default class LDAPToEmail extends React.Component {
     constructor(props) {
@@ -89,9 +90,7 @@ export default class LDAPToEmail extends React.Component {
             token,
             ldapPassword || this.state.ldapPassword,
             (data) => {
-                if (data.follow_link) {
-                    window.location.href = data.follow_link;
-                }
+                emitUserLoggedOutEvent(data.follow_link, false, true);
             },
             (err) => {
                 if (err.id.startsWith('model.user.is_valid.pwd')) {

--- a/components/claim/components/oauth_to_email.jsx
+++ b/components/claim/components/oauth_to_email.jsx
@@ -9,6 +9,7 @@ import {FormattedMessage} from 'react-intl';
 import {oauthToEmail} from 'actions/admin_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
+import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 
 export default class OAuthToEmail extends React.Component {
     constructor(props) {
@@ -50,7 +51,9 @@ export default class OAuthToEmail extends React.Component {
             this.props.currentType,
             this.props.email,
             password,
-            null,
+            () => {
+                emitUserLoggedOutEvent('/', false, true);
+            },
             (err) => {
                 this.setState({error: err.message});
             }

--- a/reducers/storage.js
+++ b/reducers/storage.js
@@ -49,12 +49,14 @@ function storage(state = {}, action) {
         return nextState;
     }
     case StorageTypes.CLEAR: {
-        var cleanState = {};
-        action.data.exclude.forEach((excluded) => {
-            if (state[excluded]) {
-                cleanState[excluded] = state[excluded];
-            }
-        });
+        const cleanState = {};
+        if (action.data && action.data.exclude && action.data.exclude.forEach) {
+            action.data.exclude.forEach((excluded) => {
+                if (state[excluded]) {
+                    cleanState[excluded] = state[excluded];
+                }
+            });
+        }
         return cleanState;
     }
     case StorageTypes.ACTION_ON_GLOBAL_ITEMS_WITH_PREFIX: {

--- a/store/index.js
+++ b/store/index.js
@@ -147,17 +147,9 @@ export default function configureStore(initialState) {
                         persistor.purge().then(() => {
                             document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
 
-                            // Preserve any `extra` query string parameter on logout to trigger
-                            // the corresponding message on the login page. This would probably be
-                            // better modelled by persistent data in the Redux store, but we're
-                            // clearing that out here.
-                            const search = new URLSearchParams(window.location.search);
-                            const extra = search.get('extra');
-                            if (extra) {
-                                window.location.href = `${basePath}?extra=${extra}`;
-                            } else {
-                                window.location.href = basePath;
-                            }
+                            // Preserve any query string parameters on logout, including parameters
+                            // used by the application such as extra and redirect_to.
+                            window.location.href = `${basePath}${window.location.search}`;
 
                             store.dispatch({
                                 type: General.OFFLINE_STORE_RESET,


### PR DESCRIPTION
#### Summary
This addresses two login/logout related bugs that are best reviewed in context:
* Ensure authentication flows explicitly logout to avoid triggering the session expiry flow that clobbers the success message displayed on the login page.
* Preserve all query string parameters on logout, to avoid stripping the `redirect_to` parameter. This became an issue in v5.4 due to the act of dispatching the logout (and triggering all the Redux stores) vs. just calling `Client4.logout()` in the past and effecting a different logout flow.

It's ultimately more explicit now, and thus hopefully simpler in the long run. While in here, I ran into an issue with a reducer assuming a particular action data payload structure connected with logout, and fixed it to handle same.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12619
https://mattermost.atlassian.net/browse/MM-12620

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)