### PR TITLE
MM-12455 Modifying webpack config to use contenthash instead of hash.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -147,8 +147,8 @@ var config = {
     output: {
         path: path.join(__dirname, 'dist'),
         publicPath,
-        filename: '[name].[hash].js',
-        chunkFilename: '[name].[chunkhash].js',
+        filename: '[name].[contenthash].js',
+        chunkFilename: '[name].[contenthash].js',
     },
     module: {
         rules: [


### PR DESCRIPTION
- Low entropy in the [hash] may be responsible for some of the issues regarding chunks not being able to be loaded.