### PR TITLE
[MM-12582] Remove PostActions removeReaction and addReaction and use the ones from redux

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -152,14 +152,6 @@ export async function unflagPost(postId) {
     }
 }
 
-export function addReaction(channelId, postId, emojiName) {
-    PostActions.addReaction(postId, emojiName)(dispatch, getState);
-}
-
-export function removeReaction(channelId, postId, emojiName) {
-    PostActions.removeReaction(postId, emojiName)(dispatch, getState);
-}
-
 export async function createPost(post, files, success) {
     // parse message and emit emoji event
     const emojis = post.message.match(EMOJI_PATTERN);

--- a/components/post_view/reaction/reaction.jsx
+++ b/components/post_view/reaction/reaction.jsx
@@ -81,21 +81,14 @@ export default class Reaction extends React.PureComponent {
         }),
     }
 
-    constructor(props) {
-        super(props);
-
-        this.addReaction = this.addReaction.bind(this);
-        this.removeReaction = this.removeReaction.bind(this);
-    }
-
-    addReaction(e) {
+    handleAddReaction = (e) => {
         e.preventDefault();
         const {actions, post, emojiName} = this.props;
         actions.addReaction(post.id, emojiName);
         emitEmojiPosted(emojiName);
     }
 
-    removeReaction(e) {
+    handleRemoveReaction = (e) => {
         e.preventDefault();
         this.props.actions.removeReaction(this.props.post.id, this.props.emojiName);
     }
@@ -216,7 +209,7 @@ export default class Reaction extends React.PureComponent {
         let className = 'post-reaction';
         if (currentUserReacted) {
             if (this.props.canRemoveReaction) {
-                handleClick = this.removeReaction;
+                handleClick = this.handleRemoveReaction;
                 clickTooltip = (
                     <FormattedMessage
                         id='reaction.clickToRemove'
@@ -229,7 +222,7 @@ export default class Reaction extends React.PureComponent {
 
             className += ' post-reaction--current-user';
         } else if (!currentUserReacted && this.props.canAddReaction) {
-            handleClick = this.addReaction;
+            handleClick = this.handleAddReaction;
             clickTooltip = (
                 <FormattedMessage
                     id='reaction.clickToAdd'

--- a/components/rhs_comment/index.js
+++ b/components/rhs_comment/index.js
@@ -1,8 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {Posts} from 'mattermost-redux/constants';
+import {addReaction} from 'mattermost-redux/actions/posts';
 import {isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -53,4 +55,12 @@ function mapStateToProps(state, ownProps) {
     };
 }
 
-export default connect(mapStateToProps)(RhsComment);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            addReaction,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(RhsComment);

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -11,7 +11,7 @@ import {
 } from 'mattermost-redux/utils/post_utils';
 import Permissions from 'mattermost-redux/constants/permissions';
 
-import {addReaction, emitEmojiPosted} from 'actions/post_actions.jsx';
+import {emitEmojiPosted} from 'actions/post_actions.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
@@ -51,6 +51,9 @@ export default class RhsComment extends React.Component {
         pluginPostTypes: PropTypes.object,
         channelIsArchived: PropTypes.bool.isRequired,
         isConsecutivePost: PropTypes.bool,
+        actions: PropTypes.shape({
+            addReaction: PropTypes.func.isRequired,
+        }).isRequired,
     };
 
     constructor(props) {
@@ -165,11 +168,13 @@ export default class RhsComment extends React.Component {
     };
 
     reactEmojiClick = (emoji) => {
-        this.setState({showEmojiPicker: false});
+        this.setState({
+            dropdownOpened: false,
+            showEmojiPicker: false,
+        });
         const emojiName = emoji.name || emoji.aliases[0];
-        addReaction(this.props.post.channel_id, this.props.post.id, emojiName);
+        this.props.actions.addReaction(this.props.post.id, emojiName);
         emitEmojiPosted(emojiName);
-        this.handleDropdownOpened(false);
     };
 
     getClassName = (post, isSystemMessage) => {

--- a/components/rhs_root_post/index.js
+++ b/components/rhs_root_post/index.js
@@ -1,10 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {addReaction} from 'mattermost-redux/actions/posts';
 
 import RhsRootPost from './rhs_root_post.jsx';
 
@@ -25,4 +27,12 @@ function mapStateToProps(state, ownProps) {
     };
 }
 
-export default connect(mapStateToProps)(RhsRootPost);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            addReaction,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(RhsRootPost);

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -8,7 +8,7 @@ import {Posts} from 'mattermost-redux/constants';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
 import Permissions from 'mattermost-redux/constants/permissions';
 
-import {addReaction, emitEmojiPosted} from 'actions/post_actions.jsx';
+import {emitEmojiPosted} from 'actions/post_actions.jsx';
 import UserStore from 'stores/user_store.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
@@ -47,6 +47,9 @@ export default class RhsRootPost extends React.Component {
         isReadOnly: PropTypes.bool.isRequired,
         pluginPostTypes: PropTypes.object,
         channelIsArchived: PropTypes.bool.isRequired,
+        actions: PropTypes.shape({
+            addReaction: PropTypes.func.isRequired,
+        }).isRequired,
     };
 
     static defaultProps = {
@@ -150,11 +153,13 @@ export default class RhsRootPost extends React.Component {
     };
 
     reactEmojiClick = (emoji) => {
-        this.setState({showEmojiPicker: false});
+        this.setState({
+            dropdownOpened: false,
+            showEmojiPicker: false,
+        });
         const emojiName = emoji.name || emoji.aliases[0];
-        addReaction(this.props.post.channel_id, this.props.post.id, emojiName);
+        this.props.actions.addReaction(this.props.post.id, emojiName);
         emitEmojiPosted(emojiName);
-        this.handleDropdownOpened(false);
     };
 
     getClassName = (post, isSystemMessage) => {

--- a/tests/components/post_view/reaction.test.jsx
+++ b/tests/components/post_view/reaction.test.jsx
@@ -72,12 +72,12 @@ describe('components/post_view/Reaction', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should have called actions.addReaction and emitEmojiPosted when addReaction is called', () => {
+    test('should have called actions.addReaction and emitEmojiPosted when handleAddReaction is called', () => {
         const newActions = {...actions, addReaction: jest.fn()};
         const props = {...baseProps, actions: newActions};
 
         const wrapper = shallow(<Reaction {...props}/>);
-        wrapper.instance().addReaction({preventDefault: jest.fn()});
+        wrapper.instance().handleAddReaction({preventDefault: jest.fn()});
 
         expect(newActions.addReaction).toHaveBeenCalledTimes(1);
         expect(newActions.addReaction).toHaveBeenCalledWith(post.id, emojiName);
@@ -86,12 +86,12 @@ describe('components/post_view/Reaction', () => {
         expect(emitEmojiPosted).toHaveBeenCalledWith(emojiName);
     });
 
-    test('should have called actions.removeReaction when removeReaction is called', () => {
+    test('should have called actions.removeReaction when handleRemoveReaction is called', () => {
         const newActions = {...actions, removeReaction: jest.fn()};
         const props = {...baseProps, actions: newActions};
 
         const wrapper = shallow(<Reaction {...props}/>);
-        wrapper.instance().removeReaction({preventDefault: jest.fn()});
+        wrapper.instance().handleRemoveReaction({preventDefault: jest.fn()});
 
         expect(newActions.removeReaction).toHaveBeenCalledTimes(1);
         expect(newActions.removeReaction).toHaveBeenCalledWith(post.id, emojiName);


### PR DESCRIPTION
#### Summary
(1st PR)
Remove `removeReaction` and `addReaction` at PostActions and use the ones from redux.

#### Ticket Link
Jira ticket: [MM-12582](https://mattermost.atlassian.net/browse/MM-12582)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
