### PR TITLE
MM-12493 Fix channel names are bolded when you hover over them

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -443,3 +443,8 @@
         outline: none;
     }
 }
+
+/* Fix for https://mattermost.atlassian.net/browse/MM-12493 */
+.react-contextmenu:not(.react-contextmenu--visible) {
+    z-index: -1 !important;
+}


### PR DESCRIPTION
#### Summary
Fixes the issues of having channel names bolded when marking unread.

#### Ticket Link
[MM-12493](https://mattermost.atlassian.net/browse/MM-12493)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes

Before:
![oct-11-2018 00-45-36](https://user-images.githubusercontent.com/4973621/46760236-26806980-ccef-11e8-8e8b-4b5852076282.gif)

After:
![oct-11-2018 00-46-21](https://user-images.githubusercontent.com/4973621/46760258-3435ef00-ccef-11e8-820f-0d07c6494b88.gif)
