### PR TITLE
MM-12642: handle callback-style notification API

### DIFF
--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -20,6 +20,7 @@ import Constants from 'utils/constants.jsx';
 import messageHtmlToComponent from 'utils/message_html_to_component';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 import * as Utils from 'utils/utils.jsx';
+import {showNotification} from 'utils/notifications.jsx';
 import {t} from 'utils/i18n.jsx';
 
 import logoImage from 'images/logo.png';
@@ -143,7 +144,7 @@ class LoginController extends React.Component {
 
     showSessionExpiredNotificationIfNeeded = () => {
         if (this.state.sessionExpired && !this.closeSessionExpiredNotification) {
-            Utils.showNotification({
+            showNotification({
                 title: this.props.siteName,
                 body: Utils.localizeMessage(
                     'login.session_expired.notification',

--- a/tests/utils/notifications.jsx
+++ b/tests/utils/notifications.jsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+describe('Notifications.showNotification', () => {
+    let Notifications;
+
+    beforeEach(() => {
+        jest.resetModules();
+        Notifications = require('utils/notifications.jsx');
+    });
+
+    it('should throw an exception if Notification is not defined on window', async () => {
+        await expect(Notifications.showNotification()).rejects.toThrow('Notification not supported');
+    });
+
+    it('should throw an exception if Notification.requestPermission is not defined', async () => {
+        window.Notification = {};
+        await expect(Notifications.showNotification()).rejects.toThrow('Notification.requestPermission not supported');
+    });
+
+    it('should throw an exception if Notification.requestPermission is not a function', async () => {
+        window.Notification = {
+            requestPermission: true,
+        };
+        await expect(Notifications.showNotification()).rejects.toThrow('Notification.requestPermission not supported');
+    });
+
+    it('should request permissions, promise style, if not previously requested, handling rejection', async () => {
+        window.Notification = {
+            requestPermission: () => Promise.resolve('denied'),
+            permission: 'denied',
+        };
+        await expect(Notifications.showNotification()).rejects.toThrow('Notifications not granted');
+    });
+
+    it('should request permissions, callback style, if not previously requested, handling rejection', async () => {
+        window.Notification = {
+            requestPermission: (callback) => {
+                if (callback) {
+                    callback('denied');
+                }
+            },
+            permission: 'denied',
+        };
+        await expect(Notifications.showNotification()).rejects.toThrow('Notifications not granted');
+    });
+
+    it('should request permissions, promise style, if not previously requested, handling success', async () => {
+        window.Notification = jest.fn();
+        window.Notification.requestPermission = () => Promise.resolve('granted');
+        window.Notification.permission = 'denied';
+
+        const n = {};
+        window.Notification.mockReturnValueOnce(n);
+
+        await expect(Notifications.showNotification({
+            body: 'body',
+            requireInteraction: true,
+            silent: false,
+        })).resolves.toBeTruthy();
+        await expect(window.Notification.mock.calls.length).toBe(1);
+        const call = window.Notification.mock.calls[0];
+        expect(call[1]).toEqual({
+            body: 'body',
+            tag: 'body',
+            icon: {},
+            requireInteraction: true,
+            silent: false,
+        });
+    });
+
+    it('should request permissions, callback style, if not previously requested, handling success', async () => {
+        window.Notification = jest.fn();
+        window.Notification.requestPermission = (callback) => {
+            if (callback) {
+                callback('granted');
+            }
+        };
+        window.Notification.permission = 'denied';
+
+        const n = {};
+        window.Notification.mockReturnValueOnce(n);
+
+        await expect(Notifications.showNotification({
+            body: 'body',
+            requireInteraction: true,
+            silent: false,
+        })).resolves.toBeTruthy();
+        await expect(window.Notification.mock.calls.length).toBe(1);
+        const call = window.Notification.mock.calls[0];
+        expect(call[1]).toEqual({
+            body: 'body',
+            tag: 'body',
+            icon: {},
+            requireInteraction: true,
+            silent: false,
+        });
+    });
+
+    it('should do nothing if permissions previously requested but not granted', async () => {
+        window.Notification = {
+            requestPermission: () => Promise.resolve('denied'),
+            permission: 'denied',
+        };
+
+        // Call one to deny and mark as already requested
+        Notifications.showNotification();
+
+        // Try again
+        await expect(Notifications.showNotification()).rejects.toThrow('Notifications already requested but not granted');
+    });
+});

--- a/utils/notifications.jsx
+++ b/utils/notifications.jsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import * as UserAgent from 'utils/user_agent.jsx';
+import Constants from 'utils/constants.jsx';
+import icon50 from 'images/icon50x50.png';
+import iconWS from 'images/icon_WS.png';
+
+let requestedNotificationPermission = false;
+
+// showNotification displays a platform notification with the configured parameters.
+//
+// If successful in showing a notification, it resolves with a callback to manually close the
+// notification. Notifications that do not require interaction will be closed automatically after
+// the Constants.DEFAULT_NOTIFICATION_DURATION. Not all platforms support all features, and may
+// choose different semantics for the notifications.
+export async function showNotification({title, body, requireInteraction, silent, onClick} = {}) {
+    let icon = icon50;
+    if (UserAgent.isEdge()) {
+        icon = iconWS;
+    }
+
+    if (!('Notification' in window)) {
+        throw new Error('Notification not supported');
+    }
+
+    if (typeof Notification.requestPermission !== 'function') {
+        throw new Error('Notification.requestPermission not supported');
+    }
+
+    if (Notification.permission !== 'granted' && requestedNotificationPermission) {
+        throw new Error('Notifications already requested but not granted');
+    }
+
+    requestedNotificationPermission = true;
+
+    let permission = await Notification.requestPermission();
+    if (typeof permission === 'undefined') {
+        // Handle browsers that don't support the promise-based syntax.
+        permission = await new Promise((resolve) => {
+            Notification.requestPermission(resolve);
+        });
+    }
+
+    if (permission !== 'granted') {
+        throw new Error('Notifications not granted');
+    }
+
+    const notification = new Notification(title, {
+        body,
+        tag: body,
+        icon,
+        requireInteraction,
+        silent,
+    });
+
+    if (onClick) {
+        notification.onclick = onClick;
+    }
+
+    if (!requireInteraction) {
+        setTimeout(() => {
+            notification.close();
+        }, Constants.DEFAULT_NOTIFICATION_DURATION);
+    }
+
+    return () => {
+        notification.close();
+    };
+}

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -24,11 +24,10 @@ import TeamStore from 'stores/team_store.jsx';
 import Constants, {FileTypes, UserStatuses} from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import bing from 'images/bing.mp3';
-import icon50 from 'images/icon50x50.png';
-import iconWS from 'images/icon_WS.png';
 import {getSiteURL} from 'utils/url';
 import {t} from 'utils/i18n';
 import store from 'stores/redux_store.jsx';
+import {showNotification} from 'utils/notifications.jsx';
 
 export function isMac() {
     return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
@@ -121,62 +120,6 @@ export function isSystemAdmin(roles) {
     }
 
     return false;
-}
-
-let requestedNotificationPermission = false;
-
-// showNotification displays a platform notification with the configured parameters.
-//
-// If successful in showing a notification, it resolves with a callback to manually close the
-// notification. Notifications that do not require interaction will be closed automatically after
-// the Constants.DEFAULT_NOTIFICATION_DURATION. Not all platforms support all features, and may
-// choose different semantics for the notifications.
-export async function showNotification({title, body, requireInteraction, silent, onClick}) {
-    let icon = icon50;
-    if (UserAgent.isEdge()) {
-        icon = iconWS;
-    }
-
-    if (!('Notification' in window)) {
-        throw new Error('Notification not supported');
-    }
-
-    if (typeof Notification.requestPermission !== 'function') {
-        throw new Error('Notifications.requestPermission not supported');
-    }
-
-    if (Notification.permission !== 'granted' && requestedNotificationPermission) {
-        throw new Error('Notifications already requested but not granted');
-    }
-
-    requestedNotificationPermission = true;
-
-    const permission = await Notification.requestPermission();
-    if (permission !== 'granted') {
-        throw new Error('Notifications not granted');
-    }
-
-    const notification = new Notification(title, {
-        body,
-        tag: body,
-        icon,
-        requireInteraction,
-        silent,
-    });
-
-    if (onClick) {
-        notification.onclick = onClick;
-    }
-
-    if (!requireInteraction) {
-        setTimeout(() => {
-            notification.close();
-        }, Constants.DEFAULT_NOTIFICATION_DURATION);
-    }
-
-    return () => {
-        notification.close();
-    };
 }
 
 export function notifyMe(title, body, channel, teamId, silent) {


### PR DESCRIPTION
#### Summary
My recent changes to notifications broke support for Safari, which doesn't yet support the promise style. Fix this, relocating the code so as to enable unit tests that can reset the module and thus clear the internal state. Oh, and get a smiley face for the team ;p

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12642

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)