### PR TITLE
[MM-12639] Remove not required channel_id when editing a post

### DIFF
--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -164,7 +164,6 @@ export default class EditPostModal extends React.PureComponent {
         const updatedPost = {
             message: this.state.editText,
             id: editingPost.postId,
-            channel_id: editingPost.post.channel_id,
         };
 
         if (this.state.postError) {

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -160,12 +160,6 @@ export default class EditPostModal extends React.PureComponent {
     }
 
     handleEdit = async () => {
-        const {actions, editingPost} = this.props;
-        const updatedPost = {
-            message: this.state.editText,
-            id: editingPost.postId,
-        };
-
         if (this.state.postError) {
             this.setState({errorClass: 'animation--highlight'});
             setTimeout(() => {
@@ -174,35 +168,43 @@ export default class EditPostModal extends React.PureComponent {
             return;
         }
 
-        if (updatedPost.message === (editingPost.post.message_source || editingPost.post.message)) {
-            // no changes so just close the modal
-            this.handleHide();
-            return;
-        }
-
-        const hasAttachment = editingPost.post.file_ids && editingPost.post.file_ids.length > 0;
-        if (updatedPost.message.trim().length === 0 && !hasAttachment) {
-            this.handleHide(false);
-
-            const deletePostModalData = {
-                ModalId: ModalIdentifiers.DELETE_POST,
-                dialogType: DeletePostModal,
-                dialogProps: {
-                    post: editingPost.post,
-                    commentCount: editingPost.commentCount,
-                    isRHS: editingPost.isRHS,
-                },
+        const {actions, editingPost} = this.props;
+        if (editingPost.post) {
+            const updatedPost = {
+                message: this.state.editText,
+                id: editingPost.postId,
             };
 
-            this.props.actions.openModal(deletePostModalData);
-            return;
-        }
+            if (updatedPost.message === (editingPost.post.message_source || editingPost.post.message)) {
+                // no changes so just close the modal
+                this.handleHide();
+                return;
+            }
 
-        actions.addMessageIntoHistory(updatedPost.message);
+            const hasAttachment = editingPost.post.file_ids && editingPost.post.file_ids.length > 0;
+            if (updatedPost.message.trim().length === 0 && !hasAttachment) {
+                this.handleHide(false);
 
-        const data = await actions.editPost(updatedPost);
-        if (data) {
-            window.scrollTo(0, 0);
+                const deletePostModalData = {
+                    ModalId: ModalIdentifiers.DELETE_POST,
+                    dialogType: DeletePostModal,
+                    dialogProps: {
+                        post: editingPost.post,
+                        commentCount: editingPost.commentCount,
+                        isRHS: editingPost.isRHS,
+                    },
+                };
+
+                this.props.actions.openModal(deletePostModalData);
+                return;
+            }
+
+            actions.addMessageIntoHistory(updatedPost.message);
+
+            const data = await actions.editPost(updatedPost);
+            if (data) {
+                window.scrollTo(0, 0);
+            }
         }
 
         this.handleHide();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2269,7 +2269,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
@@ -2311,7 +2311,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -14727,7 +14727,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -14992,7 +14992,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -15027,7 +15027,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serialize-javascript": {
@@ -15860,7 +15860,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -16864,7 +16864,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -18144,7 +18144,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {

--- a/tests/components/edit_post_modal.test.jsx
+++ b/tests/components/edit_post_modal.test.jsx
@@ -121,7 +121,6 @@ describe('components/EditPostModal', () => {
         expect(actions.editPost).toBeCalledWith({
             message: 'new message',
             id: '123',
-            channel_id: '5',
         });
         expect(actions.hideEditPostModal).toBeCalled();
     });


### PR DESCRIPTION
#### Summary
Remove not required channel_id when editing a post.

I was not able to replicate the issue but such unnecessary `channel_id` might be the source of it since post (or `editingPost.post`) can be null at some point - https://github.com/mattermost/mattermost-webapp/blob/e991a851edaa534bf04e556f9b27f017f50f2e00/selectors/posts.js#L18.

```
[pre-release] Uncaught (in promise) TypeError: Cannot read property 'channel_id' of undefined
webview.addEventListener.e @ index_bundle.js:45185
13:09:41.828 index_bundle.js:45185 [pre-release] Uncaught (in promise) TypeError: Cannot read property 'channel_id' of undefined
webview.addEventListener.e @ index_bundle.js:45185
``` 

#### Ticket Link
Jira ticket: [MM-12639](https://mattermost.atlassian.net/browse/MM-12639)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
