### PR TITLE
Modify the ESLint config to allow .js ext for React component file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,12 @@
         "detectObjects": true
       }
     ],
-    "react/jsx-filename-extension": 2,
+    "react/jsx-filename-extension": [
+      1,
+      {
+        "extensions": [".js"]
+      }
+    ],
     "react/prop-types": [
       2,
       {


### PR DESCRIPTION
#### Summary
Modify the ESLint setups to allow .js ext for React component file.

@saturninoabril noticed me change about JavaScript filename extensions in https://github.com/mattermost/mattermost-webapp/pull/1666#pullrequestreview-163366241, but the ESLint settings does not allow `.js` for react yet. 