### PR TITLE
MM-12656: fix racey ref access

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -189,6 +189,10 @@ export default class SuggestionBox extends React.Component {
     }
 
     getTextbox() {
+        if (!this.refs.input) {
+            return null;
+        }
+
         const input = this.refs.input.getInput();
 
         if (input.getDOMNode) {

--- a/tests/components/suggestion/suggestion_box.test.jsx
+++ b/tests/components/suggestion/suggestion_box.test.jsx
@@ -1,7 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import React from 'react';
+import {mount} from 'enzyme';
+
 import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
+import SuggestionList from 'components/suggestion/suggestion_list.jsx';
 
 describe('components/SuggestionBox', function() {
     test('findOverlap', () => {
@@ -12,5 +16,22 @@ describe('components/SuggestionBox', function() {
         expect(SuggestionBox.findOverlap('red', 'education')).toBe('ed');
         expect(SuggestionBox.findOverlap('red', 'reduce')).toBe('red');
         expect(SuggestionBox.findOverlap('black', 'ack')).toBe('ack');
+    });
+
+    it('should avoid ref access on unmount race', (done) => {
+        const props = {
+            listComponent: SuggestionList,
+            value: 'value',
+            containerClass: 'test',
+            openOnFocus: true,
+        };
+
+        const wrapper = mount(
+            <SuggestionBox {...props}/>
+        );
+        wrapper.instance().handleFocusIn({});
+        wrapper.unmount();
+
+        setTimeout(done, 100);
     });
 });


### PR DESCRIPTION
#### Summary
We indirectly attempt to dereference a ref inside a setTimeout, which won't be valid on an unmount race. We correctly handle the return value being undefined from the caller, but not the ref being undefined in the accessor.

Oh, and smiley face for the team ;P

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12656

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)