### PR TITLE
[MM-12639] Not allow edit for pending post

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -281,6 +281,11 @@ export function doPostAction(postId, actionId) {
 export function setEditingPost(postId = '', commentCount = 0, refocusId = '', title = '', isRHS = false) {
     return async (doDispatch, doGetState) => {
         const state = doGetState();
+        const post = Selectors.getPost(state, postId);
+
+        if (!post || post.pending_post_id === postId) {
+            return {data: false};
+        }
 
         let canEditNow = true;
 
@@ -291,8 +296,6 @@ export function setEditingPost(postId = '', commentCount = 0, refocusId = '', ti
             if (config.AllowEditPost === Constants.ALLOW_EDIT_POST_NEVER) {
                 canEditNow = false;
             } else if (config.AllowEditPost === Constants.ALLOW_EDIT_POST_TIME_LIMIT) {
-                const post = Selectors.getPost(state, postId);
-
                 if ((post.create_at + (config.PostEditTimeLimit * 1000)) < Date.now()) {
                     canEditNow = false;
                 }


### PR DESCRIPTION
#### Summary
The issue of periodically can't save edited post is due to the nature of such stale post (or postId) when doing `setEditingPost`.  During post and then quick edit, setEditingPost is getting the pending post ID and after doing the edit, such pending post ID in store is already gone and replaced by the real post ID from the server.  The post will be null since it's no longer available at the store.  There are also some cases depending on timing that the server is logging error like:
```
{"id":"api.context.404.app_error","message":"Sorry, we could not find the page.","detailed_error":"There doesn't appear to be an api call for the url='/api/v4/posts/5gm4ygap7t8qdpjtcaz46ztkzy:1539347243754/patch'.  Typo? are you missing a team_id or user_id as part of the url?","status_code":404}
``` 

This fix prevent editing a post if it's still a pending post.

#### Ticket Link
Jira ticket: [MM-12639](https://mattermost.atlassian.net/browse/MM-12639)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
