### PR TITLE
MM-12513: fix copy link on desktop

### DIFF
--- a/components/copy_url_context_menu/copy_url_context_menu.jsx
+++ b/components/copy_url_context_menu/copy_url_context_menu.jsx
@@ -6,11 +6,11 @@ import React from 'react';
 import {ContextMenu, ContextMenuTrigger, MenuItem} from 'react-contextmenu';
 import {FormattedMessage} from 'react-intl';
 
-import * as Utils from '../utils/utils';
+import * as Utils from 'utils/utils';
+import {getSiteURL} from 'utils/url';
 
 export default class CopyUrlContextMenu extends React.Component {
     static propTypes = {
-
         /**
          * The child component that will be right-clicked on to show the context menu
          */
@@ -22,17 +22,31 @@ export default class CopyUrlContextMenu extends React.Component {
         link: PropTypes.string.isRequired,
 
         /**
-         * A unique id differentiating this instance of context menu from others on the page. Will be set to a random value if not provided.
+         * A unique id differentiating this instance of context menu from others on the page.
          */
         menuId: PropTypes.string.isRequired,
+
+        actions: PropTypes.shape({
+            copyToClipboard: PropTypes.func.isRequired,
+        }),
     };
+
+    copy = () => {
+        let link = this.props.link;
+
+        // Transform relative links to absolute ones for copy and paste.
+        if (link.indexOf('http://') === -1 && link.indexOf('https://') === -1) {
+            link = this.props.siteURL + link;
+        }
+
+        this.props.actions.copyToClipboard(link);
+    }
 
     render() {
         const contextMenu = (
             <ContextMenu id={'copy-url-context-menu' + this.props.menuId}>
                 <MenuItem
-                    data={{link: this.props.link}}
-                    onClick={Utils.copyToClipboard}
+                    onClick={this.copy}
                 >
                     <FormattedMessage
                         id='copy_url_context_menu.getChannelLink'

--- a/components/copy_url_context_menu/copy_url_context_menu.jsx
+++ b/components/copy_url_context_menu/copy_url_context_menu.jsx
@@ -6,25 +6,19 @@ import React from 'react';
 import {ContextMenu, ContextMenuTrigger, MenuItem} from 'react-contextmenu';
 import {FormattedMessage} from 'react-intl';
 
-import * as Utils from 'utils/utils';
-import {getSiteURL} from 'utils/url';
-
 export default class CopyUrlContextMenu extends React.Component {
     static propTypes = {
-        /**
-         * The child component that will be right-clicked on to show the context menu
-         */
+
+        // The child component that will be right-clicked on to show the context menu
         children: PropTypes.element,
 
-        /**
-         * The link to copy to the user's clipboard when the 'Copy' option is selected from the context menu
-         */
+        // The link to copy to the user's clipboard when the 'Copy' option is selected from the context menu
         link: PropTypes.string.isRequired,
 
-        /**
-         * A unique id differentiating this instance of context menu from others on the page.
-         */
+        // A unique id differentiating this instance of context menu from others on the page.
         menuId: PropTypes.string.isRequired,
+
+        siteURL: PropTypes.string.isRequired,
 
         actions: PropTypes.shape({
             copyToClipboard: PropTypes.func.isRequired,

--- a/components/copy_url_context_menu/index.js
+++ b/components/copy_url_context_menu/index.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {copyToClipboard} from 'utils/utils';
+
+import CopyUrlContextMenu from './copy_url_context_menu.jsx';
+
+function mapStateToProps(state) {
+    const config = getConfig(state);
+
+    return {
+        siteURL: config.SiteURL,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: {
+            copyToClipboard,
+        },
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CopyUrlContextMenu);

--- a/components/copy_url_context_menu/index.js
+++ b/components/copy_url_context_menu/index.js
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
 import {copyToClipboard} from 'utils/utils';
 
 import CopyUrlContextMenu from './copy_url_context_menu.jsx';
@@ -15,7 +16,7 @@ function mapStateToProps(state) {
     };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps() {
     return {
         actions: {
             copyToClipboard,

--- a/tests/components/__snapshots__/copy_url_context_menu.test.jsx.snap
+++ b/tests/components/__snapshots__/copy_url_context_menu.test.jsx.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/CopyUrlContextMenu should copy absolute url on click 1`] = `
+<span>
+  <ContextMenu
+    className=""
+    data={Object {}}
+    hideOnLeave={false}
+    id="copy-url-context-menuresource"
+    onHide={[Function]}
+    onMouseLeave={[Function]}
+    onShow={[Function]}
+    style={Object {}}
+  >
+    <MenuItem
+      attributes={Object {}}
+      data={Object {}}
+      disabled={false}
+      divider={false}
+      onClick={[Function]}
+      onMouseLeave={[Function]}
+      onMouseMove={[Function]}
+      preventClose={false}
+      selected={false}
+    >
+      <FormattedMessage
+        defaultMessage="Copy Link"
+        id="copy_url_context_menu.getChannelLink"
+        values={Object {}}
+      />
+    </MenuItem>
+  </ContextMenu>
+  <ContextMenuTrigger
+    attributes={Object {}}
+    collect={[Function]}
+    disable={false}
+    holdToDisplay={1000}
+    id="copy-url-context-menuresource"
+    posX={0}
+    posY={0}
+    renderTag="div"
+  >
+    <span>
+      Click
+    </span>
+  </ContextMenuTrigger>
+</span>
+`;
+
+exports[`components/CopyUrlContextMenu should copy relative url on click 1`] = `
+<span>
+  <ContextMenu
+    className=""
+    data={Object {}}
+    hideOnLeave={false}
+    id="copy-url-context-menuresource"
+    onHide={[Function]}
+    onMouseLeave={[Function]}
+    onShow={[Function]}
+    style={Object {}}
+  >
+    <MenuItem
+      attributes={Object {}}
+      data={Object {}}
+      disabled={false}
+      divider={false}
+      onClick={[Function]}
+      onMouseLeave={[Function]}
+      onMouseMove={[Function]}
+      preventClose={false}
+      selected={false}
+    >
+      <FormattedMessage
+        defaultMessage="Copy Link"
+        id="copy_url_context_menu.getChannelLink"
+        values={Object {}}
+      />
+    </MenuItem>
+  </ContextMenu>
+  <ContextMenuTrigger
+    attributes={Object {}}
+    collect={[Function]}
+    disable={false}
+    holdToDisplay={1000}
+    id="copy-url-context-menuresource"
+    posX={0}
+    posY={0}
+    renderTag="div"
+  >
+    <span>
+      Click
+    </span>
+  </ContextMenuTrigger>
+</span>
+`;

--- a/tests/components/copy_url_context_menu.test.jsx
+++ b/tests/components/copy_url_context_menu.test.jsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import CopyUrlContextMenu from 'components/copy_url_context_menu/copy_url_context_menu.jsx';
+
+describe('components/CopyUrlContextMenu', () => {
+    test('should copy relative url on click', () => {
+        const props = {
+            siteURL: 'http://example.com',
+            link: '/path/to/resource',
+            menuId: 'resource',
+            actions: {
+                copyToClipboard: jest.fn(),
+            },
+        }
+
+        const wrapper = shallow(
+            <CopyUrlContextMenu {...props}>
+                <span>Click</span>
+            </CopyUrlContextMenu>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        wrapper.find('MenuItem').simulate('click');
+        expect(props.actions.copyToClipboard).toBeCalledWith("http://example.com/path/to/resource");
+    });
+
+    test('should copy absolute url on click', () => {
+        const props = {
+            siteURL: 'http://example.com',
+            link: 'http://site.example.com/path/to/resource',
+            menuId: 'resource',
+            actions: {
+                copyToClipboard: jest.fn(),
+            },
+        }
+
+        const wrapper = shallow(
+            <CopyUrlContextMenu {...props}>
+                <span>Click</span>
+            </CopyUrlContextMenu>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        wrapper.find('MenuItem').simulate('click');
+        expect(props.actions.copyToClipboard).toBeCalledWith("http://site.example.com/path/to/resource");
+    });
+});

--- a/tests/components/copy_url_context_menu.test.jsx
+++ b/tests/components/copy_url_context_menu.test.jsx
@@ -15,17 +15,17 @@ describe('components/CopyUrlContextMenu', () => {
             actions: {
                 copyToClipboard: jest.fn(),
             },
-        }
+        };
 
         const wrapper = shallow(
             <CopyUrlContextMenu {...props}>
-                <span>Click</span>
+                <span>{'Click'}</span>
             </CopyUrlContextMenu>
         );
 
         expect(wrapper).toMatchSnapshot();
         wrapper.find('MenuItem').simulate('click');
-        expect(props.actions.copyToClipboard).toBeCalledWith("http://example.com/path/to/resource");
+        expect(props.actions.copyToClipboard).toBeCalledWith('http://example.com/path/to/resource');
     });
 
     test('should copy absolute url on click', () => {
@@ -36,16 +36,16 @@ describe('components/CopyUrlContextMenu', () => {
             actions: {
                 copyToClipboard: jest.fn(),
             },
-        }
+        };
 
         const wrapper = shallow(
             <CopyUrlContextMenu {...props}>
-                <span>Click</span>
+                <span>{'Click'}</span>
             </CopyUrlContextMenu>
         );
 
         expect(wrapper).toMatchSnapshot();
         wrapper.find('MenuItem').simulate('click');
-        expect(props.actions.copyToClipboard).toBeCalledWith("http://site.example.com/path/to/resource");
+        expect(props.actions.copyToClipboard).toBeCalledWith('http://site.example.com/path/to/resource');
     });
 });

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -24,7 +24,6 @@ import TeamStore from 'stores/team_store.jsx';
 import Constants, {FileTypes, UserStatuses} from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import bing from 'images/bing.mp3';
-import {getSiteURL} from 'utils/url';
 import {t} from 'utils/i18n';
 import store from 'stores/redux_store.jsx';
 import {showNotification} from 'utils/notifications.jsx';
@@ -1633,11 +1632,7 @@ export function copyToClipboard(data) {
     textArea.style.outline = 'none';
     textArea.style.boxShadow = 'none';
     textArea.style.background = 'transparent';
-    if (typeof data === 'string') {
-        textArea.value = data;
-    } else {
-        textArea.value = getSiteURL() + data.link;
-    }
+    textArea.value = data;
     document.body.appendChild(textArea);
     textArea.select();
     document.execCommand('copy');


### PR DESCRIPTION
#### Summary
Fix "Copy link" (a Desktop-specific feature), removing the magic from `copyToClipboard` that ultimately broke the feature.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12513

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)