### PR TITLE
MM-12659: unify LoggedIn redirect handling to avoid races

### DIFF
--- a/components/logged_in/logged_in.jsx
+++ b/components/logged_in/logged_in.jsx
@@ -15,7 +15,6 @@ import ChannelStore from 'stores/channel_store.jsx';
 import ErrorStore from 'stores/error_store.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
-import {browserHistory} from 'utils/browser_history';
 import LoadingScreen from 'components/loading_screen.jsx';
 import {getBrowserTimezone} from 'utils/timezone.jsx';
 import store from 'stores/redux_store.jsx';
@@ -35,7 +34,10 @@ export default class LoggedIn extends React.Component {
             user: UserStore.getCurrentUser(),
         };
 
-        document.getElementById('root').className += ' channel-view';
+        const root = document.getElementById('root');
+        if (root) {
+            root.className += ' channel-view';
+        }
     }
 
     isValidState() {
@@ -98,10 +100,6 @@ export default class LoggedIn extends React.Component {
             GlobalActions.emitUserLoggedOutEvent('/login?redirect_to=' + encodeURIComponent(this.props.location.pathname), true, false);
         }
 
-        if (this.props.showTermsOfService && this.props.location.pathname !== '/terms_of_service') {
-            browserHistory.push('/terms_of_service?redirect_to=' + encodeURIComponent(this.props.location.pathname));
-        }
-
         $('body').on('mouseenter mouseleave', '.post', function mouseOver(ev) {
             if (ev.type === 'mouseenter') {
                 $(this).prev('.date-separator, .new-separator').addClass('hovered--after');
@@ -162,8 +160,16 @@ export default class LoggedIn extends React.Component {
             return <LoadingScreen/>;
         }
 
-        if (this.props.location.pathname !== '/mfa/setup' && this.props.mfaRequired) {
-            return <Redirect to={'/mfa/setup'}/>;
+        if (this.props.mfaRequired) {
+            if (this.props.location.pathname !== '/mfa/setup') {
+                return <Redirect to={'/mfa/setup'}/>;
+            }
+        } else if (this.props.location.pathname === '/mfa/confirm') {
+            // Nothing to do. Wait for MFA flow to complete before prompting TOS.
+        } else if (this.props.showTermsOfService) {
+            if (this.props.location.pathname !== '/terms_of_service') {
+                return <Redirect to={'/terms_of_service?redirect_to=' + encodeURIComponent(this.props.location.pathname)}/>;
+            }
         }
 
         return this.props.children;

--- a/tests/components/logged_in/logged_in.test.jsx
+++ b/tests/components/logged_in/logged_in.test.jsx
@@ -1,0 +1,170 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import LoggedIn from 'components/logged_in/logged_in.jsx';
+
+jest.mock('actions/websocket_actions.jsx', () => ({
+    initialize: jest.fn(),
+}));
+
+describe('components/logged_in/LoggedIn', () => {
+    const children = <span>{'Test'}</span>;
+    const baseProps = {
+        mfaRequired: false,
+        enableTimezone: false,
+        actions: {
+            autoUpdateTimezone: jest.fn(),
+        },
+        showTermsOfService: false,
+        location: {
+            pathname: '/',
+        },
+    };
+
+    it('should render loading state without user', () => {
+        const props = {
+            ...baseProps,
+        };
+
+        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
+
+        expect(wrapper).toMatchInlineSnapshot(`
+<LoadingScreen
+  position="relative"
+  style={Object {}}
+/>
+`
+        );
+    });
+
+    it('should redirect to mfa when required and not on /mfa/setup', () => {
+        const props = {
+            ...baseProps,
+            mfaRequired: true,
+        };
+
+        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
+        wrapper.setState({
+            user: {},
+        });
+
+        expect(wrapper).toMatchInlineSnapshot(`
+<Redirect
+  push={false}
+  to="/mfa/setup"
+/>
+`
+        );
+    });
+
+    it('should render children when mfa required and already on /mfa/setup', () => {
+        const props = {
+            ...baseProps,
+            mfaRequired: true,
+            location: {
+                pathname: '/mfa/setup',
+            },
+        };
+
+        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
+        wrapper.setState({
+            user: {},
+        });
+
+        expect(wrapper).toMatchInlineSnapshot(`
+<span>
+  Test
+</span>
+`
+        );
+    });
+
+    it('should render children when mfa is not required and on /mfa/confirm', () => {
+        const props = {
+            ...baseProps,
+            mfaRequired: false,
+            location: {
+                pathname: '/mfa/confirm',
+            },
+        };
+
+        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
+        wrapper.setState({
+            user: {},
+        });
+
+        expect(wrapper).toMatchInlineSnapshot(`
+<span>
+  Test
+</span>
+`
+        );
+    });
+
+    it('should redirect to terms of service when mfa not required and terms of service required but not on /terms_of_service', () => {
+        const props = {
+            ...baseProps,
+            mfaRequired: false,
+            showTermsOfService: true,
+        };
+
+        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
+        wrapper.setState({
+            user: {},
+        });
+
+        expect(wrapper).toMatchInlineSnapshot(`
+<Redirect
+  push={false}
+  to="/terms_of_service?redirect_to=%2F"
+/>
+`
+        );
+    });
+
+    it('should render children when mfa is not required and terms of service required and on /terms_of_service', () => {
+        const props = {
+            ...baseProps,
+            mfaRequired: false,
+            showTermsOfService: true,
+            location: {
+                pathname: '/terms_of_service',
+            },
+        };
+
+        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
+        wrapper.setState({
+            user: {},
+        });
+
+        expect(wrapper).toMatchInlineSnapshot(`
+<span>
+  Test
+</span>
+`
+        );
+    });
+
+    it('should render children when neither mfa nor terms of service required', () => {
+        const props = {
+            ...baseProps,
+            mfaRequired: false,
+            showTermsOfService: false,
+        };
+
+        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
+        wrapper.setState({
+            user: {},
+        });
+
+        expect(wrapper).toMatchInlineSnapshot(`
+<span>
+  Test
+</span>
+`
+        );
+    });
+});


### PR DESCRIPTION
#### Summary
If MFA is required and custom TOS is enabled, a user who needs to enter both flows gets bounced back and forth between the two in a tight loop. Unify the redirect handling into one code block to ensure the cases are handled correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12674

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)