### PR TITLE
MM-12579 Migration of team_actions to be pure redux

### DIFF
--- a/actions/team_actions.jsx
+++ b/actions/team_actions.jsx
@@ -15,33 +15,6 @@ import store from 'stores/redux_store.jsx';
 const dispatch = store.dispatch;
 const getState = store.getState;
 
-export async function checkIfTeamExists(teamName, onSuccess, onError) {
-    const {data: exists, error: err} = await TeamActions.checkIfTeamExists(teamName)(dispatch, getState);
-    if (exists != null && onSuccess) {
-        onSuccess(exists);
-    } else if (err && onError) {
-        onError({id: err.server_error_id, ...err});
-    }
-}
-
-export async function createTeam(team, onSuccess, onError) {
-    const {data: rteam, error: err} = await TeamActions.createTeam(team)(dispatch, getState);
-    if (rteam && onSuccess) {
-        onSuccess(rteam);
-    } else if (err && onError) {
-        onError({id: err.server_error_id, ...err});
-    }
-}
-
-export async function updateTeam(team, onSuccess, onError) {
-    const {data: rteam, error: err} = await TeamActions.updateTeam(team)(dispatch, getState);
-    if (rteam && onSuccess) {
-        onSuccess(rteam);
-    } else if (err && onError) {
-        onError({id: err.server_error_id, ...err});
-    }
-}
-
 export async function removeUserFromTeam(teamId, userId, success, error) {
     const {data, error: err} = await dispatch(TeamActions.removeUserFromTeam(teamId, userId));
     dispatch(getUser(userId));
@@ -131,22 +104,4 @@ export async function inviteMembers(data, success, error) {
 export function switchTeams(url) {
     dispatch(viewChannel(getCurrentChannelId(getState())));
     browserHistory.push(url);
-}
-
-export async function getTeamsForUser(userId, success, error) {
-    const {data, error: err} = await TeamActions.getTeamsForUser(userId)(dispatch, getState);
-    if (data && success) {
-        success(data);
-    } else if (err && error) {
-        error({id: err.server_error_id, ...err});
-    }
-}
-
-export async function getTeamMembersForUser(userId, success, error) {
-    const {data, error: err} = await TeamActions.getTeamMembersForUser(userId)(dispatch, getState);
-    if (data && success) {
-        success(data);
-    } else if (err && error) {
-        error({id: err.server_error_id, ...err});
-    }
 }

--- a/components/admin_console/manage_teams_modal/index.jsx
+++ b/components/admin_console/manage_teams_modal/index.jsx
@@ -2,6 +2,9 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {updateTeamMemberSchemeRoles, getTeamMembersForUser, getTeamsForUser} from 'mattermost-redux/actions/teams';
 
 import {getCurrentLocale} from 'selectors/i18n';
 
@@ -13,4 +16,14 @@ function mapStateToProps(state) {
     };
 }
 
-export default connect(mapStateToProps)(ManageTeamsModal);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getTeamMembersForUser,
+            getTeamsForUser,
+            updateTeamMemberSchemeRoles,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ManageTeamsModal);

--- a/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
+++ b/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
@@ -7,8 +7,6 @@ import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import {Client4} from 'mattermost-redux/client';
 
-import * as TeamActions from 'actions/team_actions.jsx';
-
 import {filterAndSortTeamsByDisplayName} from 'utils/team_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
@@ -23,6 +21,8 @@ export default class ManageTeamsModal extends React.Component {
         show: PropTypes.bool.isRequired,
         user: PropTypes.object,
         updateTeamMemberSchemeRoles: PropTypes.func.isRequired,
+        getTeamMembersForUser: PropTypes.func.isRequired,
+        getTeamsForUser: PropTypes.func.isRequired,
     };
 
     constructor(props) {
@@ -57,17 +57,11 @@ export default class ManageTeamsModal extends React.Component {
         }
     }
 
-    loadTeamsAndTeamMembers = (user = this.props.user) => {
-        TeamActions.getTeamsForUser(user.id, (teams) => {
-            this.setState({
-                teams: filterAndSortTeamsByDisplayName(teams, this.props.locale),
-            });
-        });
-
-        TeamActions.getTeamMembersForUser(user.id, (teamMembers) => {
-            this.setState({
-                teamMembers,
-            });
+    loadTeamsAndTeamMembers = async (user = this.props.user) => {
+        this.getTeamMembers(user.id);
+        const {data} = await this.props.getTeamsForUser(user.id);
+        this.setState({
+            teams: filterAndSortTeamsByDisplayName(data, this.props.locale),
         });
     }
 
@@ -77,12 +71,13 @@ export default class ManageTeamsModal extends React.Component {
         });
     }
 
-    handleMemberChange = () => {
-        TeamActions.getTeamMembersForUser(this.props.user.id, (teamMembers) => {
+    getTeamMembers = async (userId = this.props.user.id) => {
+        const {data} = await this.props.getTeamMembersForUser(userId);
+        if (data) {
             this.setState({
-                teamMembers,
+                teamMembers: data,
             });
-        });
+        }
     }
 
     handleMemberRemove = (teamId) => {
@@ -134,7 +129,7 @@ export default class ManageTeamsModal extends React.Component {
                             team={team}
                             teamMember={teamMember}
                             onError={this.handleError}
-                            onMemberChange={this.handleMemberChange}
+                            onMemberChange={this.getTeamMembers}
                             onMemberRemove={this.handleMemberRemove}
                             updateTeamMemberSchemeRoles={this.props.updateTeamMemberSchemeRoles}
                         />

--- a/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
+++ b/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
@@ -20,9 +20,11 @@ export default class ManageTeamsModal extends React.Component {
         onModalDismissed: PropTypes.func.isRequired,
         show: PropTypes.bool.isRequired,
         user: PropTypes.object,
-        updateTeamMemberSchemeRoles: PropTypes.func.isRequired,
-        getTeamMembersForUser: PropTypes.func.isRequired,
-        getTeamsForUser: PropTypes.func.isRequired,
+        actions: PropTypes.shape({
+            getTeamMembersForUser: PropTypes.func.isRequired,
+            getTeamsForUser: PropTypes.func.isRequired,
+            updateTeamMemberSchemeRoles: PropTypes.func.isRequired,
+        }).isRequired,
     };
 
     constructor(props) {
@@ -59,7 +61,7 @@ export default class ManageTeamsModal extends React.Component {
 
     loadTeamsAndTeamMembers = async (user = this.props.user) => {
         this.getTeamMembers(user.id);
-        const {data} = await this.props.getTeamsForUser(user.id);
+        const {data} = await this.props.actions.getTeamsForUser(user.id);
         this.setState({
             teams: filterAndSortTeamsByDisplayName(data, this.props.locale),
         });
@@ -72,7 +74,7 @@ export default class ManageTeamsModal extends React.Component {
     }
 
     getTeamMembers = async (userId = this.props.user.id) => {
-        const {data} = await this.props.getTeamMembersForUser(userId);
+        const {data} = await this.props.actions.getTeamMembersForUser(userId);
         if (data) {
             this.setState({
                 teamMembers: data,
@@ -131,7 +133,7 @@ export default class ManageTeamsModal extends React.Component {
                             onError={this.handleError}
                             onMemberChange={this.getTeamMembers}
                             onMemberRemove={this.handleMemberRemove}
-                            updateTeamMemberSchemeRoles={this.props.updateTeamMemberSchemeRoles}
+                            updateTeamMemberSchemeRoles={this.props.actions.updateTeamMemberSchemeRoles}
                         />
                     );
                 }

--- a/components/admin_console/system_users/list/index.js
+++ b/components/admin_console/system_users/list/index.js
@@ -5,7 +5,6 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getUser} from 'mattermost-redux/actions/users';
-import {updateTeamMemberSchemeRoles, getTeamMembersForUser, getTeamsForUser} from 'mattermost-redux/actions/teams';
 
 import SystemUsersList from './system_users_list.jsx';
 import {getUsers} from './selectors.jsx';
@@ -20,9 +19,6 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             getUser,
-            updateTeamMemberSchemeRoles,
-            getTeamMembersForUser,
-            getTeamsForUser,
         }, dispatch),
     };
 }

--- a/components/admin_console/system_users/list/index.js
+++ b/components/admin_console/system_users/list/index.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getUser} from 'mattermost-redux/actions/users';
-import {updateTeamMemberSchemeRoles} from 'mattermost-redux/actions/teams';
+import {updateTeamMemberSchemeRoles, getTeamMembersForUser, getTeamsForUser} from 'mattermost-redux/actions/teams';
 
 import SystemUsersList from './system_users_list.jsx';
 import {getUsers} from './selectors.jsx';
@@ -21,6 +21,8 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             getUser,
             updateTeamMemberSchemeRoles,
+            getTeamMembersForUser,
+            getTeamsForUser,
         }, dispatch),
     };
 }

--- a/components/admin_console/system_users/list/system_users_list.jsx
+++ b/components/admin_console/system_users/list/system_users_list.jsx
@@ -50,6 +50,8 @@ export default class SystemUsersList extends React.Component {
         actions: PropTypes.shape({
             getUser: PropTypes.func.isRequired,
             updateTeamMemberSchemeRoles: PropTypes.func.isRequired,
+            getTeamMembersForUser: PropTypes.func.isRequired,
+            getTeamsForUser: PropTypes.func.isRequired,
         }).isRequired,
     };
 
@@ -316,6 +318,8 @@ export default class SystemUsersList extends React.Component {
                     show={this.state.showManageTeamsModal}
                     onModalDismissed={this.doManageTeamsDismiss}
                     updateTeamMemberSchemeRoles={this.props.actions.updateTeamMemberSchemeRoles}
+                    getTeamsForUser={this.props.actions.getTeamsForUser}
+                    getTeamMembersForUser={this.props.actions.getTeamMembersForUser}
                 />
                 <ManageRolesModal
                     user={this.state.user}

--- a/components/admin_console/system_users/list/system_users_list.jsx
+++ b/components/admin_console/system_users/list/system_users_list.jsx
@@ -49,9 +49,6 @@ export default class SystemUsersList extends React.Component {
 
         actions: PropTypes.shape({
             getUser: PropTypes.func.isRequired,
-            updateTeamMemberSchemeRoles: PropTypes.func.isRequired,
-            getTeamMembersForUser: PropTypes.func.isRequired,
-            getTeamsForUser: PropTypes.func.isRequired,
         }).isRequired,
     };
 
@@ -317,9 +314,6 @@ export default class SystemUsersList extends React.Component {
                     user={this.state.user}
                     show={this.state.showManageTeamsModal}
                     onModalDismissed={this.doManageTeamsDismiss}
-                    updateTeamMemberSchemeRoles={this.props.actions.updateTeamMemberSchemeRoles}
-                    getTeamsForUser={this.props.actions.getTeamsForUser}
-                    getTeamMembersForUser={this.props.actions.getTeamMembersForUser}
                 />
                 <ManageRolesModal
                     user={this.state.user}

--- a/tests/components/admin_console/manage_teams_modal/__snapshots__/manage_teams_modal.test.jsx.snap
+++ b/tests/components/admin_console/manage_teams_modal/__snapshots__/manage_teams_modal.test.jsx.snap
@@ -1,0 +1,205 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ManageTeamsModal should match snapshot init 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="manage-teams"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Manage Teams"
+        id="admin.user_item.manageTeams"
+        values={Object {}}
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <div>
+      <div
+        className="manage-teams__user"
+      >
+        <img
+          className="manage-teams__profile-picture"
+          src="/api/v4/users/currentUserId/image?_=1234"
+        />
+        <div
+          className="manage-teams__info"
+        >
+          <div
+            className="manage-teams__name"
+          >
+            @currentUsername
+          </div>
+          <div
+            className="manage-teams__email"
+          >
+            currentUser@test.com
+          </div>
+        </div>
+      </div>
+      <div
+        className="manage-teams__teams"
+      >
+        <LoadingScreen
+          position="relative"
+          style={Object {}}
+        />
+      </div>
+    </div>
+  </ModalBody>
+</Modal>
+`;
+
+exports[`ManageTeamsModal should save data in state from api calls 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="manage-teams"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Manage Teams"
+        id="admin.user_item.manageTeams"
+        values={Object {}}
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <div>
+      <div
+        className="manage-teams__user"
+      >
+        <img
+          className="manage-teams__profile-picture"
+          src="/api/v4/users/currentUserId/image?_=1234"
+        />
+        <div
+          className="manage-teams__info"
+        >
+          <div
+            className="manage-teams__name"
+          >
+            @currentUsername
+          </div>
+          <div
+            className="manage-teams__email"
+          >
+            currentUser@test.com
+          </div>
+        </div>
+      </div>
+      <div
+        className="manage-teams__teams"
+      >
+        <div
+          className="manage-teams__team"
+          key="123test"
+        >
+          <div
+            className="manage-teams__team-name"
+          >
+            testTeam
+          </div>
+          <div
+            className="manage-teams__team-actions"
+          >
+            <ManageTeamsDropdown
+              onError={[Function]}
+              onMemberChange={[Function]}
+              onMemberRemove={[Function]}
+              team={
+                Object {
+                  "delete_at": 0,
+                  "display_name": "testTeam",
+                  "id": "123test",
+                  "name": "testTeam",
+                }
+              }
+              teamMember={
+                Object {
+                  "team_id": "123test",
+                }
+              }
+              updateTeamMemberSchemeRoles={[Function]}
+              user={
+                Object {
+                  "email": "currentUser@test.com",
+                  "id": "currentUserId",
+                  "last_picture_update": "1234",
+                  "roles": "system_user",
+                  "username": "currentUsername",
+                }
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </ModalBody>
+</Modal>
+`;

--- a/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
+++ b/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
@@ -47,7 +47,7 @@ describe('ManageTeamsModal', () => {
         expect(baseProps.actions.getTeamsForUser).toHaveBeenCalledWith('currentUserId');
     });
 
-    test('should save data in state from api calls', async () => {
+    test('should save data in state from api calls', (done) => {
         const mockTeamData = {
             id: '123test',
             name: 'testTeam',
@@ -55,13 +55,13 @@ describe('ManageTeamsModal', () => {
             delete_at: 0,
         };
 
-        const getTeamMembersForUser = async () => {
+        const getTeamMembersForUser = () => {
             return {
                 data: [{team_id: '123test'}],
             };
         };
 
-        const getTeamsForUser = async () => {
+        const getTeamsForUser = () => {
             return {
                 data: [mockTeamData],
             };
@@ -80,10 +80,11 @@ describe('ManageTeamsModal', () => {
             <ManageTeamsModal {...props}/>
         );
 
-        await getTeamMembersForUser();
-
-        expect(wrapper.state('teams')).toEqual([mockTeamData]);
-        expect(wrapper.state('teamMembers')).toEqual([{team_id: '123test'}]);
-        expect(wrapper).toMatchSnapshot();
+        process.nextTick(() => {
+            expect(wrapper.state('teams')).toEqual([mockTeamData]);
+            expect(wrapper.state('teamMembers')).toEqual([{team_id: '123test'}]);
+            expect(wrapper).toMatchSnapshot();
+            done();
+        });
     });
 });

--- a/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
+++ b/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import {shallow} from 'enzyme';
+import {General} from 'mattermost-redux/constants';
 
 import ManageTeamsModal from 'components/admin_console/manage_teams_modal/manage_teams_modal.jsx';
 
@@ -10,6 +11,7 @@ describe('ManageTeamsModal', () => {
     function emptyFunc() {} // eslint-disable-line no-empty-function
 
     const baseProps = {
+        locale: General.DEFAULT_LOCALE,
         onModalDismissed: emptyFunc,
         show: true,
         user: {
@@ -19,9 +21,11 @@ describe('ManageTeamsModal', () => {
             roles: 'system_user',
             username: 'currentUsername',
         },
-        updateTeamMemberSchemeRoles: emptyFunc,
-        getTeamMembersForUser: jest.fn(),
-        getTeamsForUser: jest.fn(),
+        actions: {
+            getTeamMembersForUser: jest.fn(),
+            getTeamsForUser: jest.fn(),
+            updateTeamMemberSchemeRoles: emptyFunc,
+        },
     };
 
     test('should match snapshot init', () => {
@@ -37,10 +41,10 @@ describe('ManageTeamsModal', () => {
             <ManageTeamsModal {...baseProps}/>
         );
 
-        expect(baseProps.getTeamMembersForUser).toHaveBeenCalledTimes(1);
-        expect(baseProps.getTeamMembersForUser).toHaveBeenCalledWith('currentUserId');
-        expect(baseProps.getTeamsForUser).toHaveBeenCalledTimes(1);
-        expect(baseProps.getTeamsForUser).toHaveBeenCalledWith('currentUserId');
+        expect(baseProps.actions.getTeamMembersForUser).toHaveBeenCalledTimes(1);
+        expect(baseProps.actions.getTeamMembersForUser).toHaveBeenCalledWith('currentUserId');
+        expect(baseProps.actions.getTeamsForUser).toHaveBeenCalledTimes(1);
+        expect(baseProps.actions.getTeamsForUser).toHaveBeenCalledWith('currentUserId');
     });
 
     test('should save data in state from api calls', async () => {
@@ -61,12 +65,17 @@ describe('ManageTeamsModal', () => {
             return Promise.resolve({data: [mockTeamData]});
         });
 
+        const props = {
+            ...baseProps,
+            actions: {
+                ...baseProps.actions,
+                getTeamMembersForUser,
+                getTeamsForUser,
+            },
+        };
+
         const wrapper = shallow(
-            <ManageTeamsModal
-                {...baseProps}
-                getTeamMembersForUser={getTeamMembersForUser}
-                getTeamsForUser={getTeamsForUser}
-            />
+            <ManageTeamsModal {...props}/>
         );
 
         process.nextTick(() => {

--- a/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
+++ b/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
@@ -55,15 +55,17 @@ describe('ManageTeamsModal', () => {
             delete_at: 0,
         };
 
-        const getTeamMembersForUser = jest.fn(() => {
-            return Promise.resolve({
+        const getTeamMembersForUser = async () => {
+            return {
                 data: [{team_id: '123test'}],
-            });
-        });
+            };
+        };
 
-        const getTeamsForUser = jest.fn(() => {
-            return Promise.resolve({data: [mockTeamData]});
-        });
+        const getTeamsForUser = async () => {
+            return {
+                data: [mockTeamData],
+            };
+        };
 
         const props = {
             ...baseProps,
@@ -78,10 +80,10 @@ describe('ManageTeamsModal', () => {
             <ManageTeamsModal {...props}/>
         );
 
-        process.nextTick(() => {
-            expect(wrapper.state('teams')).toEqual([mockTeamData]);
-            expect(wrapper.state('teamMembers')).toEqual([{team_id: '123test'}]);
-            expect(wrapper).toMatchSnapshot();
-        });
+        await getTeamMembersForUser();
+
+        expect(wrapper.state('teams')).toEqual([mockTeamData]);
+        expect(wrapper.state('teamMembers')).toEqual([{team_id: '123test'}]);
+        expect(wrapper).toMatchSnapshot();
     });
 });

--- a/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
+++ b/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
@@ -74,7 +74,6 @@ describe('ManageTeamsModal', () => {
         await getTeamsForUser();
         await getTeamMembersForUser();
 
-        wrapper.update();
         expect(wrapper.state('teams')).toEqual([mockTeamData]);
         expect(wrapper.state('teamMembers')).toEqual([{team_id: '123test'}]);
 

--- a/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
+++ b/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
@@ -1,0 +1,83 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import ManageTeamsModal from 'components/admin_console/manage_teams_modal/manage_teams_modal.jsx';
+
+describe('ManageTeamsModal', () => {
+    function emptyFunc() {} // eslint-disable-line no-empty-function
+
+    const baseProps = {
+        onModalDismissed: emptyFunc,
+        show: true,
+        user: {
+            id: 'currentUserId',
+            last_picture_update: '1234',
+            email: 'currentUser@test.com',
+            roles: 'system_user',
+            username: 'currentUsername',
+        },
+        updateTeamMemberSchemeRoles: emptyFunc,
+        getTeamMembersForUser: emptyFunc,
+        getTeamsForUser: emptyFunc,
+    };
+
+    test('should match snapshot init', () => {
+        const getTeamMembersForUser = jest.fn();
+        const getTeamsForUser = jest.fn();
+
+        const wrapper = shallow(
+            <ManageTeamsModal
+                {...baseProps}
+                getTeamMembersForUser={getTeamMembersForUser}
+                getTeamsForUser={getTeamsForUser}
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(getTeamMembersForUser).toHaveBeenCalledTimes(1);
+        expect(getTeamMembersForUser).toHaveBeenCalledWith('currentUserId');
+        expect(getTeamsForUser).toHaveBeenCalledTimes(1);
+        expect(getTeamsForUser).toHaveBeenCalledWith('currentUserId');
+    });
+
+    test('should save data in state from api calls', async () => {
+        const mockTeamData = {
+            id: '123test',
+            name: 'testTeam',
+            display_name: 'testTeam',
+            delete_at: 0,
+        };
+
+        const getTeamMembersForUser = async () => {
+            return {
+                data: [{team_id: '123test'}],
+            };
+        };
+
+        const getTeamsForUser = async () => {
+            return {
+                data: [mockTeamData],
+            };
+        };
+
+        const wrapper = shallow(
+            <ManageTeamsModal
+                {...baseProps}
+                getTeamMembersForUser={getTeamMembersForUser}
+                getTeamsForUser={getTeamsForUser}
+            />
+        );
+
+        await getTeamsForUser();
+        await getTeamMembersForUser();
+
+        wrapper.update();
+        expect(wrapper.state('teams')).toEqual([mockTeamData]);
+        expect(wrapper.state('teamMembers')).toEqual([{team_id: '123test'}]);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
+++ b/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
@@ -20,27 +20,27 @@ describe('ManageTeamsModal', () => {
             username: 'currentUsername',
         },
         updateTeamMemberSchemeRoles: emptyFunc,
-        getTeamMembersForUser: emptyFunc,
-        getTeamsForUser: emptyFunc,
+        getTeamMembersForUser: jest.fn(),
+        getTeamsForUser: jest.fn(),
     };
 
     test('should match snapshot init', () => {
-        const getTeamMembersForUser = jest.fn();
-        const getTeamsForUser = jest.fn();
-
         const wrapper = shallow(
-            <ManageTeamsModal
-                {...baseProps}
-                getTeamMembersForUser={getTeamMembersForUser}
-                getTeamsForUser={getTeamsForUser}
-            />
+            <ManageTeamsModal {...baseProps}/>
         );
 
         expect(wrapper).toMatchSnapshot();
-        expect(getTeamMembersForUser).toHaveBeenCalledTimes(1);
-        expect(getTeamMembersForUser).toHaveBeenCalledWith('currentUserId');
-        expect(getTeamsForUser).toHaveBeenCalledTimes(1);
-        expect(getTeamsForUser).toHaveBeenCalledWith('currentUserId');
+    });
+
+    test('should call api calls on mount', () => {
+        shallow(
+            <ManageTeamsModal {...baseProps}/>
+        );
+
+        expect(baseProps.getTeamMembersForUser).toHaveBeenCalledTimes(1);
+        expect(baseProps.getTeamMembersForUser).toHaveBeenCalledWith('currentUserId');
+        expect(baseProps.getTeamsForUser).toHaveBeenCalledTimes(1);
+        expect(baseProps.getTeamsForUser).toHaveBeenCalledWith('currentUserId');
     });
 
     test('should save data in state from api calls', async () => {
@@ -51,17 +51,15 @@ describe('ManageTeamsModal', () => {
             delete_at: 0,
         };
 
-        const getTeamMembersForUser = async () => {
-            return {
+        const getTeamMembersForUser = jest.fn(() => {
+            return Promise.resolve({
                 data: [{team_id: '123test'}],
-            };
-        };
+            });
+        });
 
-        const getTeamsForUser = async () => {
-            return {
-                data: [mockTeamData],
-            };
-        };
+        const getTeamsForUser = jest.fn(() => {
+            return Promise.resolve({data: [mockTeamData]});
+        });
 
         const wrapper = shallow(
             <ManageTeamsModal
@@ -71,7 +69,7 @@ describe('ManageTeamsModal', () => {
             />
         );
 
-        await getTeamsForUser();
+        getTeamsForUser();
         await getTeamMembersForUser();
 
         expect(wrapper.state('teams')).toEqual([mockTeamData]);

--- a/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
+++ b/tests/components/admin_console/manage_teams_modal/manage_teams_modal.test.jsx
@@ -69,12 +69,10 @@ describe('ManageTeamsModal', () => {
             />
         );
 
-        getTeamsForUser();
-        await getTeamMembersForUser();
-
-        expect(wrapper.state('teams')).toEqual([mockTeamData]);
-        expect(wrapper.state('teamMembers')).toEqual([{team_id: '123test'}]);
-
-        expect(wrapper).toMatchSnapshot();
+        process.nextTick(() => {
+            expect(wrapper.state('teams')).toEqual([mockTeamData]);
+            expect(wrapper.state('teamMembers')).toEqual([{team_id: '123test'}]);
+            expect(wrapper).toMatchSnapshot();
+        });
     });
 });

--- a/tests/components/admin_console/system_users/__snapshots__/system_users_list.test.jsx.snap
+++ b/tests/components/admin_console/system_users/__snapshots__/system_users_list.test.jsx.snap
@@ -42,6 +42,8 @@ exports[`components/admin_console/system_users/list should match default snapsho
     usersPerPage={0}
   />
   <Connect(ManageTeamsModal)
+    getTeamMembersForUser={[MockFunction]}
+    getTeamsForUser={[MockFunction]}
     onModalDismissed={[Function]}
     show={false}
     updateTeamMemberSchemeRoles={[MockFunction]}
@@ -183,6 +185,8 @@ exports[`components/admin_console/system_users/list should match default snapsho
     usersPerPage={0}
   />
   <Connect(ManageTeamsModal)
+    getTeamMembersForUser={[MockFunction]}
+    getTeamsForUser={[MockFunction]}
     onModalDismissed={[Function]}
     show={false}
     updateTeamMemberSchemeRoles={[MockFunction]}
@@ -349,6 +353,8 @@ exports[`components/admin_console/system_users/list should match default snapsho
     usersPerPage={0}
   />
   <Connect(ManageTeamsModal)
+    getTeamMembersForUser={[MockFunction]}
+    getTeamsForUser={[MockFunction]}
     onModalDismissed={[Function]}
     show={false}
     updateTeamMemberSchemeRoles={[MockFunction]}

--- a/tests/components/admin_console/system_users/__snapshots__/system_users_list.test.jsx.snap
+++ b/tests/components/admin_console/system_users/__snapshots__/system_users_list.test.jsx.snap
@@ -42,11 +42,8 @@ exports[`components/admin_console/system_users/list should match default snapsho
     usersPerPage={0}
   />
   <Connect(ManageTeamsModal)
-    getTeamMembersForUser={[MockFunction]}
-    getTeamsForUser={[MockFunction]}
     onModalDismissed={[Function]}
     show={false}
-    updateTeamMemberSchemeRoles={[MockFunction]}
     user={null}
   />
   <Connect(ManageRolesModal)
@@ -185,11 +182,8 @@ exports[`components/admin_console/system_users/list should match default snapsho
     usersPerPage={0}
   />
   <Connect(ManageTeamsModal)
-    getTeamMembersForUser={[MockFunction]}
-    getTeamsForUser={[MockFunction]}
     onModalDismissed={[Function]}
     show={false}
-    updateTeamMemberSchemeRoles={[MockFunction]}
     user={null}
   />
   <Connect(ManageRolesModal)
@@ -353,11 +347,8 @@ exports[`components/admin_console/system_users/list should match default snapsho
     usersPerPage={0}
   />
   <Connect(ManageTeamsModal)
-    getTeamMembersForUser={[MockFunction]}
-    getTeamsForUser={[MockFunction]}
     onModalDismissed={[Function]}
     show={false}
-    updateTeamMemberSchemeRoles={[MockFunction]}
     user={null}
   />
   <Connect(ManageRolesModal)

--- a/tests/components/admin_console/system_users/system_users_list.test.jsx
+++ b/tests/components/admin_console/system_users/system_users_list.test.jsx
@@ -26,6 +26,8 @@ describe('components/admin_console/system_users/list', () => {
         actions: {
             getUser: jest.fn(),
             updateTeamMemberSchemeRoles: jest.fn(),
+            getTeamMembersForUser: jest.fn(),
+            getTeamsForUser: jest.fn(),
         },
     };
 


### PR DESCRIPTION
#### Summary
Remove updateTeam legacy actions
Remove createTeam legacy action
Remove getTeamMembersForUser legacy action
Remove getTeamsForUser legacy action

Affected areas:
Manage teams sections in system console for users.

#### Ticket Link
[12579](https://mattermost.atlassian.net/browse/MM-12579)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
