### PR TITLE
[MM-12582 & MM-12745] Migrate PostActions.handleNewPost to redux actions

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -343,7 +343,7 @@ export function sendEphemeralPost(message, channelId, parentId) {
         props: {},
     };
 
-    handleNewPost(post);
+    dispatch(handleNewPost(post));
 }
 
 export function sendAddToChannelEphemeralPost(user, addedUsername, addedUserId, channelId, postRootId = '', timestamp) {
@@ -364,7 +364,7 @@ export function sendAddToChannelEphemeralPost(user, addedUsername, addedUserId, 
         },
     };
 
-    handleNewPost(post);
+    dispatch(handleNewPost(post));
 }
 
 export function newLocalizationSelected(locale) {

--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -39,11 +39,12 @@ export function handleNewPost(post, msg) {
             websocketMessageProps = msg.data;
         }
 
-        if (getMyChannelMemberSelector(doGetState(), post.channel_id)) {
-            doDispatch(completePostReceive(post, websocketMessageProps));
-        } else {
-            doDispatch(getMyChannelMember(post.channel_id)).then(() => doDispatch(completePostReceive(post, websocketMessageProps)));
+        const myChannelMember = getMyChannelMemberSelector(doGetState(), post.channel_id);
+        if (myChannelMember && Object.keys(myChannelMember).length === 0 && myChannelMember.constructor === 'Object') {
+            await doDispatch(getMyChannelMember(post.channel_id));
         }
+
+        doDispatch(completePostReceive(post, websocketMessageProps));
 
         if (msg && msg.data) {
             if (msg.data.channel_type === Constants.DM_CHANNEL) {

--- a/actions/post_utils.js
+++ b/actions/post_utils.js
@@ -1,0 +1,105 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {PostTypes} from 'mattermost-redux/action_types';
+import {
+    markChannelAsRead,
+    markChannelAsUnread,
+    markChannelAsViewed,
+} from 'mattermost-redux/actions/channels';
+import * as PostActions from 'mattermost-redux/actions/posts';
+import * as PostSelectors from 'mattermost-redux/selectors/entities/posts';
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {
+    isFromWebhook,
+    isSystemMessage,
+    shouldIgnorePost,
+} from 'mattermost-redux/utils/post_utils';
+
+import {sendDesktopNotification} from 'actions/notification_actions.jsx';
+
+import {ActionTypes} from 'utils/constants';
+
+export function completePostReceive(post, websocketMessageProps) {
+    return async (dispatch, getState) => {
+        const state = getState();
+
+        const rootPost = PostSelectors.getPost(state, post.root_id);
+        if (post.root_id && !rootPost) {
+            const {data: posts} = await dispatch(PostActions.getPostThread(post.root_id));
+            if (posts) {
+                dispatch(lastPostActions(post, websocketMessageProps));
+            }
+
+            return;
+        }
+
+        dispatch(lastPostActions(post, websocketMessageProps));
+    };
+}
+
+export function lastPostActions(post, websocketMessageProps) {
+    return (dispatch, getState) => {
+        const {currentChannelId} = getCurrentChannelId(getState());
+
+        if (post.channel_id === currentChannelId) {
+            dispatch({
+                type: ActionTypes.INCREASE_POST_VISIBILITY,
+                data: post.channel_id,
+                amount: 1,
+            });
+        }
+
+        // Need manual dispatch to remove pending post
+        dispatch({
+            type: PostTypes.RECEIVED_POSTS,
+            data: {
+                order: [],
+                posts: {
+                    [post.id]: post,
+                },
+            },
+            channelId: post.channel_id,
+        });
+
+        // Still needed to update unreads
+
+        dispatch(setChannelReadAndView(post, websocketMessageProps));
+
+        dispatch(sendDesktopNotification(post, websocketMessageProps));
+    };
+}
+
+export function setChannelReadAndView(post, websocketMessageProps) {
+    return (dispatch, getState) => {
+        const state = getState();
+        if (shouldIgnorePost(post)) {
+            return;
+        }
+
+        let markAsRead = false;
+        let markAsReadOnServer = false;
+        if (
+            post.user_id === getCurrentUserId(state) &&
+            !isSystemMessage(post) &&
+            !isFromWebhook(post)
+        ) {
+            markAsRead = true;
+            markAsReadOnServer = false;
+        } else if (
+            post.channel_id === getCurrentChannelId(state) &&
+            window.isActive
+        ) {
+            markAsRead = true;
+            markAsReadOnServer = true;
+        }
+
+        if (markAsRead) {
+            dispatch(markChannelAsRead(post.channel_id, null, markAsReadOnServer));
+            dispatch(markChannelAsViewed(post.channel_id));
+        } else {
+            dispatch(markChannelAsUnread(websocketMessageProps.team_id, post.channel_id, websocketMessageProps.mentions));
+        }
+    };
+}

--- a/actions/post_utils.js
+++ b/actions/post_utils.js
@@ -41,7 +41,7 @@ export function completePostReceive(post, websocketMessageProps) {
 
 export function lastPostActions(post, websocketMessageProps) {
     return (dispatch, getState) => {
-        const {currentChannelId} = getCurrentChannelId(getState());
+        const currentChannelId = getCurrentChannelId(getState());
 
         if (post.channel_id === currentChannelId) {
             dispatch({

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -386,7 +386,7 @@ function handleChannelMemberUpdatedEvent(msg) {
 
 function handleNewPostEvent(msg) {
     const post = JSON.parse(msg.data.post);
-    handleNewPost(post, msg);
+    dispatch(handleNewPost(post, msg));
 
     getProfilesAndStatusesForPosts([post], dispatch, getState);
 

--- a/stores/channel_store.jsx
+++ b/stores/channel_store.jsx
@@ -5,10 +5,8 @@ import EventEmitter from 'events';
 
 import {batchActions} from 'redux-batched-actions';
 import {ChannelTypes} from 'mattermost-redux/action_types';
-import {markChannelAsRead, markChannelAsUnread, markChannelAsViewed} from 'mattermost-redux/actions/channels';
 import * as Selectors from 'mattermost-redux/selectors/entities/channels';
 import {getMyChannelMemberships} from 'mattermost-redux/selectors/entities/common';
-import {isFromWebhook, isSystemMessage, shouldIgnorePost} from 'mattermost-redux/utils/post_utils';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
 
 import UserStore from 'stores/user_store.jsx';
@@ -557,31 +555,6 @@ ChannelStore.dispatchToken = AppDispatcher.register((payload) => {
         });
         break;
 
-    case ActionTypes.RECEIVED_POST: {
-        const {post, websocketMessageProps: data} = action;
-        const {dispatch} = store;
-        if (shouldIgnorePost(post)) {
-            return;
-        }
-
-        let markAsRead = false;
-        let markAsReadOnServer = false;
-        if (post.user_id === UserStore.getCurrentId() && !isSystemMessage(post) && !isFromWebhook(post)) {
-            markAsRead = true;
-            markAsReadOnServer = false;
-        } else if (action.post.channel_id === ChannelStore.getCurrentId() && window.isActive) {
-            markAsRead = true;
-            markAsReadOnServer = true;
-        }
-
-        if (markAsRead) {
-            dispatch(markChannelAsRead(post.channel_id, null, markAsReadOnServer));
-            dispatch(markChannelAsViewed(post.channel_id));
-        } else {
-            dispatch(markChannelAsUnread(data.team_id, post.channel_id, data.mentions));
-        }
-        break;
-    }
     case ActionTypes.CREATE_POST:
         ChannelStore.incrementMessages(action.post.channel_id, true);
         break;

--- a/tests/redux/actions/post_actions.test.js
+++ b/tests/redux/actions/post_actions.test.js
@@ -16,6 +16,7 @@ const RECEIVED_POSTS = {
     data: {order: [], posts: {new_post_id: {channel_id: 'current_channel_id', id: 'new_post_id', message: 'new message', type: ''}}},
     type: 'RECEIVED_POSTS',
 };
+const INCREASED_POST_VISIBILITY = {amount: 1, data: 'current_channel_id', type: 'INCREASE_POST_VISIBILITY'};
 
 function getReceivedPosts(post) {
     const receivedPosts = {...RECEIVED_POSTS};
@@ -82,7 +83,7 @@ describe('Actions.Posts', () => {
         const msg = {data: {team_id: 'team_id', mentions: ['current_user_id']}};
 
         await testStore.dispatch(Actions.handleNewPost(newPost, msg));
-        expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
+        expect(testStore.getActions()).toEqual([INCREASED_POST_VISIBILITY, getReceivedPosts(newPost)]);
     });
 
     test('setEditingPost', async () => {

--- a/tests/redux/actions/post_actions.test.js
+++ b/tests/redux/actions/post_actions.test.js
@@ -11,25 +11,6 @@ import {Constants, ActionTypes} from 'utils/constants';
 
 const mockStore = configureStore([thunk]);
 
-jest.mock('mattermost-redux/actions/channels', () => ({
-    markChannelAsUnread: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_UNREAD', args}),
-    markChannelAsRead: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_READ', args}),
-    markChannelAsViewed: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_VIEWED', args}),
-}));
-
-const EMPTY_ACTION = [];
-const MARK_CHANNEL_AS_UNREAD = {
-    args: ['team_id', 'current_channel_id', ['current_user_id']],
-    type: 'MOCK_MARK_CHANNEL_AS_UNREAD',
-};
-const MARK_CHANNEL_AS_READ = {
-    args: ['current_channel_id', null, false],
-    type: 'MOCK_MARK_CHANNEL_AS_READ',
-};
-const MARK_CHANNEL_AS_VIEWED = {
-    args: ['current_channel_id'],
-    type: 'MOCK_MARK_CHANNEL_AS_VIEWED',
-};
 const RECEIVED_POSTS = {
     channelId: 'current_channel_id',
     data: {order: [], posts: {new_post_id: {channel_id: 'current_channel_id', id: 'new_post_id', message: 'new message', type: ''}}},
@@ -102,43 +83,6 @@ describe('Actions.Posts', () => {
 
         await testStore.dispatch(Actions.handleNewPost(newPost, msg));
         expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
-    });
-
-    test('completePostReceive', async () => {
-        const testStore = await mockStore(initialState);
-        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
-        const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
-
-        await testStore.dispatch(Actions.completePostReceive(newPost, websocketProps));
-        expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
-    });
-
-    test('lastPostActions', async () => {
-        const testStore = await mockStore(initialState);
-        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
-        const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
-
-        await testStore.dispatch(Actions.lastPostActions(newPost, websocketProps));
-        expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
-    });
-
-    test('setChannelReadAndView', async () => {
-        let testStore = await mockStore(initialState);
-        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
-        const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
-
-        await testStore.dispatch(Actions.setChannelReadAndView(newPost, websocketProps));
-        expect(testStore.getActions()).toEqual(EMPTY_ACTION);
-
-        testStore = await mockStore(initialState);
-        newPost.type = '';
-        await testStore.dispatch(Actions.setChannelReadAndView(newPost, websocketProps));
-        expect(testStore.getActions()).toEqual([MARK_CHANNEL_AS_UNREAD]);
-
-        testStore = await mockStore(initialState);
-        newPost.user_id = 'current_user_id';
-        await testStore.dispatch(Actions.setChannelReadAndView(newPost, websocketProps));
-        expect(testStore.getActions()).toEqual([MARK_CHANNEL_AS_READ, MARK_CHANNEL_AS_VIEWED]);
     });
 
     test('setEditingPost', async () => {

--- a/tests/redux/actions/post_utils.test.js
+++ b/tests/redux/actions/post_utils.test.js
@@ -1,0 +1,134 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+
+import {Posts} from 'mattermost-redux/constants';
+
+import * as PostActionsUtils from 'actions/post_utils';
+import {Constants} from 'utils/constants';
+
+const mockStore = configureStore([thunk]);
+
+jest.mock('mattermost-redux/actions/channels', () => ({
+    markChannelAsUnread: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_UNREAD', args}),
+    markChannelAsRead: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_READ', args}),
+    markChannelAsViewed: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_VIEWED', args}),
+}));
+
+const EMPTY_ACTION = [];
+const MARK_CHANNEL_AS_UNREAD = {
+    args: ['team_id', 'current_channel_id', ['current_user_id']],
+    type: 'MOCK_MARK_CHANNEL_AS_UNREAD',
+};
+const MARK_CHANNEL_AS_READ = {
+    args: ['current_channel_id', null, false],
+    type: 'MOCK_MARK_CHANNEL_AS_READ',
+};
+const MARK_CHANNEL_AS_VIEWED = {
+    args: ['current_channel_id'],
+    type: 'MOCK_MARK_CHANNEL_AS_VIEWED',
+};
+const RECEIVED_POSTS = {
+    channelId: 'current_channel_id',
+    data: {order: [], posts: {new_post_id: {channel_id: 'current_channel_id', id: 'new_post_id', message: 'new message', type: ''}}},
+    type: 'RECEIVED_POSTS',
+};
+
+function getReceivedPosts(post) {
+    const receivedPosts = {...RECEIVED_POSTS};
+    if (post) {
+        receivedPosts.data.posts[post.id] = post;
+    }
+
+    return receivedPosts;
+}
+
+describe('actions/post_utils', () => {
+    const latestPost = {
+        id: 'latest_post_id',
+        user_id: 'current_user_id',
+        message: 'test msg',
+        channel_id: 'current_channel_id',
+    };
+    const initialState = {
+        entities: {
+            posts: {
+                posts: {
+                    [latestPost.id]: latestPost,
+                },
+                postsInChannel: {
+                    current_channel_id: [latestPost.id],
+                },
+                postsInThread: {},
+                messagesHistory: {
+                    index: {
+                        [Posts.MESSAGE_TYPES.COMMENT]: 0,
+                    },
+                    messages: ['test message'],
+                },
+            },
+            channels: {
+                currentChannelId: 'current_channel_id',
+                myMembers: {[latestPost.channel_id]: {channel_id: 'current_channel_id', user_id: 'current_user_id'}},
+            },
+            teams: {
+                currentTeamId: 'team-1',
+                teams: {
+                    team_id: {
+                        id: 'team_id',
+                        name: 'team-1',
+                        displayName: 'Team 1',
+                    },
+                },
+            },
+            users: {
+                currentUserId: 'current_user_id',
+            },
+            general: {license: {IsLicensed: 'false'}},
+        },
+        views: {
+            posts: {
+                editingPost: {},
+            },
+        },
+    };
+
+    test('completePostReceive', async () => {
+        const testStore = await mockStore(initialState);
+        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
+        const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
+
+        await testStore.dispatch(PostActionsUtils.completePostReceive(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
+    });
+
+    test('lastPostActions', async () => {
+        const testStore = await mockStore(initialState);
+        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
+        const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
+
+        await testStore.dispatch(PostActionsUtils.lastPostActions(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
+    });
+
+    test('setChannelReadAndView', async () => {
+        let testStore = await mockStore(initialState);
+        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
+        const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
+
+        await testStore.dispatch(PostActionsUtils.setChannelReadAndView(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual(EMPTY_ACTION);
+
+        testStore = await mockStore(initialState);
+        newPost.type = '';
+        await testStore.dispatch(PostActionsUtils.setChannelReadAndView(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual([MARK_CHANNEL_AS_UNREAD]);
+
+        testStore = await mockStore(initialState);
+        newPost.user_id = 'current_user_id';
+        await testStore.dispatch(PostActionsUtils.setChannelReadAndView(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual([MARK_CHANNEL_AS_READ, MARK_CHANNEL_AS_VIEWED]);
+    });
+});

--- a/tests/redux/actions/post_utils.test.js
+++ b/tests/redux/actions/post_utils.test.js
@@ -35,6 +35,7 @@ const RECEIVED_POSTS = {
     data: {order: [], posts: {new_post_id: {channel_id: 'current_channel_id', id: 'new_post_id', message: 'new message', type: ''}}},
     type: 'RECEIVED_POSTS',
 };
+const INCREASED_POST_VISIBILITY = {amount: 1, data: 'current_channel_id', type: 'INCREASE_POST_VISIBILITY'};
 
 function getReceivedPosts(post) {
     const receivedPosts = {...RECEIVED_POSTS};
@@ -101,7 +102,7 @@ describe('actions/post_utils', () => {
         const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
 
         await testStore.dispatch(PostActionsUtils.completePostReceive(newPost, websocketProps));
-        expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
+        expect(testStore.getActions()).toEqual([INCREASED_POST_VISIBILITY, getReceivedPosts(newPost)]);
     });
 
     test('lastPostActions', async () => {
@@ -110,7 +111,7 @@ describe('actions/post_utils', () => {
         const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
 
         await testStore.dispatch(PostActionsUtils.lastPostActions(newPost, websocketProps));
-        expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
+        expect(testStore.getActions()).toEqual([INCREASED_POST_VISIBILITY, getReceivedPosts(newPost)]);
     });
 
     test('setChannelReadAndView', async () => {

--- a/tests/redux/actions/posts.test.js
+++ b/tests/redux/actions/posts.test.js
@@ -11,6 +11,40 @@ import {Constants, ActionTypes} from 'utils/constants';
 
 const mockStore = configureStore([thunk]);
 
+jest.mock('mattermost-redux/actions/channels', () => ({
+    markChannelAsUnread: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_UNREAD', args}),
+    markChannelAsRead: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_READ', args}),
+    markChannelAsViewed: (...args) => ({type: 'MOCK_MARK_CHANNEL_AS_VIEWED', args}),
+}));
+
+const EMPTY_ACTION = [];
+const MARK_CHANNEL_AS_UNREAD = {
+    args: ['team_id', 'current_channel_id', ['current_user_id']],
+    type: 'MOCK_MARK_CHANNEL_AS_UNREAD',
+};
+const MARK_CHANNEL_AS_READ = {
+    args: ['current_channel_id', null, false],
+    type: 'MOCK_MARK_CHANNEL_AS_READ',
+};
+const MARK_CHANNEL_AS_VIEWED = {
+    args: ['current_channel_id'],
+    type: 'MOCK_MARK_CHANNEL_AS_VIEWED',
+};
+const RECEIVED_POSTS = {
+    channelId: 'current_channel_id',
+    data: {order: [], posts: {new_post_id: {channel_id: 'current_channel_id', id: 'new_post_id', message: 'new message', type: ''}}},
+    type: 'RECEIVED_POSTS',
+};
+
+function getReceivedPosts(post) {
+    const receivedPosts = {...RECEIVED_POSTS};
+    if (post) {
+        receivedPosts.data.posts[post.id] = post;
+    }
+
+    return receivedPosts;
+}
+
 describe('Actions.Posts', () => {
     const latestPost = {
         id: 'latest_post_id',
@@ -35,6 +69,23 @@ describe('Actions.Posts', () => {
                     messages: ['test message'],
                 },
             },
+            channels: {
+                currentChannelId: 'current_channel_id',
+                myMembers: {[latestPost.channel_id]: {channel_id: 'current_channel_id', user_id: 'current_user_id'}},
+            },
+            teams: {
+                currentTeamId: 'team-1',
+                teams: {
+                    team_id: {
+                        id: 'team_id',
+                        name: 'team-1',
+                        displayName: 'Team 1',
+                    },
+                },
+            },
+            users: {
+                currentUserId: 'current_user_id',
+            },
             general: {license: {IsLicensed: 'false'}},
         },
         views: {
@@ -43,6 +94,52 @@ describe('Actions.Posts', () => {
             },
         },
     };
+
+    test('handleNewPost', async () => {
+        const testStore = await mockStore(initialState);
+        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
+        const msg = {data: {team_id: 'team_id', mentions: ['current_user_id']}};
+
+        await testStore.dispatch(Actions.handleNewPost(newPost, msg));
+        expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
+    });
+
+    test('completePostReceive', async () => {
+        const testStore = await mockStore(initialState);
+        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
+        const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
+
+        await testStore.dispatch(Actions.completePostReceive(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
+    });
+
+    test('lastPostActions', async () => {
+        const testStore = await mockStore(initialState);
+        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
+        const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
+
+        await testStore.dispatch(Actions.lastPostActions(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual([getReceivedPosts(newPost)]);
+    });
+
+    test('setChannelReadAndView', async () => {
+        let testStore = await mockStore(initialState);
+        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
+        const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
+
+        await testStore.dispatch(Actions.setChannelReadAndView(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual(EMPTY_ACTION);
+
+        testStore = await mockStore(initialState);
+        newPost.type = '';
+        await testStore.dispatch(Actions.setChannelReadAndView(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual([MARK_CHANNEL_AS_UNREAD]);
+
+        testStore = await mockStore(initialState);
+        newPost.user_id = 'current_user_id';
+        await testStore.dispatch(Actions.setChannelReadAndView(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual([MARK_CHANNEL_AS_READ, MARK_CHANNEL_AS_VIEWED]);
+    });
 
     test('setEditingPost', async () => {
         // should allow to edit and should fire an action

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -113,7 +113,6 @@ export const ActionTypes = keyMirror({
     FOCUS_POST: null,
     RECEIVED_POSTS: null,
     RECEIVED_FOCUSED_POST: null,
-    RECEIVED_POST: null,
     RECEIVED_EDIT_POST: null,
     EDIT_POST: null,
     SELECT_POST: null,


### PR DESCRIPTION
#### Summary
Migrate PostActions.handleNewPost to redux actions.

Affected Areas:
Receiving new post via websocket, send ephemeral post.

@DHaussermann @lindy65 May I request for your smoke tests? This could be tested by:
- sending `/leave` command at reply thread --> should see ephemeral post that such command is not supported on thread view
- at-mention a user that's not member of a channel --> should see ephemeral post to add that use to a channel
- have 2 users on different browser, viewing different channel or team.  If user A post, user B should see dot (*) on team name if it's posted on different team, or see a mention badge if it's a at-mention.

#### Ticket Link
Jira ticket: [MM-12582](https://mattermost.atlassian.net/browse/MM-12582) && [MM-12745](https://mattermost.atlassian.net/browse/MM-12745)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
