### PR TITLE
MM-12539: Fix formatting user setting help text.

### DIFF
--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -250,7 +250,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
                                 <br/>
                                 <FormattedMessage
                                     id='user.settings.advance.formattingDesc'
-                                    defaultMessage='If enabled, posts will be formatted to create links, show emoji, style the text, and add line breaks. By default, this setting is enabled. Changing this setting requires the page to be refreshed.'
+                                    defaultMessage='If enabled, posts will be formatted to create links, show emoji, style the text, and add line breaks. By default, this setting is enabled.'
                                 />
                             </div>
                         </div>,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2679,7 +2679,7 @@
   "user.settings.advance.deactivateDesc": "Deactivating your account removes your ability to log in to this server and disables all email and mobile notifications. To reactivate your account, contact your System Administrator.",
   "user.settings.advance.deactivateDescShort": "Click 'Edit' to deactivate your account",
   "user.settings.advance.enabledFeatures": "{count, number} {count, plural, one {Feature} other {Features}} Enabled",
-  "user.settings.advance.formattingDesc": "If enabled, posts will be formatted to create links, show emoji, style the text, and add line breaks. By default, this setting is enabled. Changing this setting requires the page to be refreshed.",
+  "user.settings.advance.formattingDesc": "If enabled, posts will be formatted to create links, show emoji, style the text, and add line breaks. By default, this setting is enabled.",
   "user.settings.advance.formattingTitle": "Enable Post Formatting",
   "user.settings.advance.icon": "Advanced Settings Icon",
   "user.settings.advance.joinLeaveDesc": "When \"On\", System Messages saying a user has joined or left a channel will be visible. When \"Off\", the System Messages about joining or leaving a channel will be hidden. A message will still show up when you are added to a channel, so you can receive a notification.",


### PR DESCRIPTION
#### Summary
Fix formatting user setting help text to remove "refresh" requirement since it appears to be no longer required.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12539