### PR TITLE
MM-12685 Do not restore focus to previous components when closing channel switcher

### DIFF
--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -314,6 +314,7 @@ export default class QuickSwitchModal extends React.PureComponent {
                 show={this.props.show}
                 onHide={this.onHide}
                 enforceFocus={false}
+                restoreFocus={false}
             >
                 <Modal.Header closeButton={true}/>
                 <Modal.Body>

--- a/tests/components/__snapshots__/quick_switch_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/quick_switch_modal.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`components/QuickSwitchModal should match snapshot 1`] = `
   }
   onHide={[Function]}
   renderBackdrop={[Function]}
-  restoreFocus={true}
+  restoreFocus={false}
   show={true}
 >
   <ModalHeader


### PR DESCRIPTION
#### Summary
Do not restore focus to previous components when closing channel switcher as focus should always go to the main post box.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12685