### PR TITLE
MM-12680: fix switching email to oauth

### DIFF
--- a/components/claim/components/email_to_oauth.jsx
+++ b/components/claim/components/email_to_oauth.jsx
@@ -11,7 +11,6 @@ import {checkMfa} from 'actions/user_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import LoginMfa from 'components/login/login_mfa.jsx';
-import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 
 export default class EmailToOAuth extends React.Component {
     constructor(props) {
@@ -61,7 +60,8 @@ export default class EmailToOAuth extends React.Component {
             token,
             this.props.newType,
             (data) => {
-                emitUserLoggedOutEvent(data.follow_link, false, true);
+                // Stay logged in and just redirect to the OAuth provider.
+                window.location.href = data.follow_link;
             },
             (err) => {
                 this.setState({error: err.message, showMfa: false});

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -104,7 +104,9 @@ class LoginController extends React.Component {
         if (extra === Constants.SIGNIN_VERIFIED && email) {
             this.refs.password.focus();
         }
-        if (LocalStorageStore.getWasLoggedIn()) {
+
+        // Determine if the user was unexpectedly logged out.
+        if (LocalStorageStore.getWasLoggedIn() && extra !== Constants.SIGNIN_CHANGE) {
             // Although the authority remains the local sessionExpired bit on the state, set this
             // extra field in the querystring to signal the desktop app. And although eslint
             // complains about this, it is allowed: https://reactjs.org/docs/react-component.html#componentdidmount.


### PR DESCRIPTION
#### Summary
My fix for [MM-12619](https://mattermost.atlassian.net/browse/MM-12619) regressed the OAuth redirect behaviour and prematurely logged the user out instead of keeping them logged in during the flow. To continue to suppress the session expiry notice when changing the auth method, the login controller now handles this transition instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12680

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)