### PR TITLE
[MM-12639] On thread view, remove pending post or failed post from user's last message and revert focus to comment textbox when no post to edit

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -455,7 +455,11 @@ export default class CreateComment extends React.PureComponent {
             if (this.refs.textbox) {
                 this.refs.textbox.blur();
             }
-            this.props.onEditLatestPost();
+
+            const {data: canEditNow} = this.props.onEditLatestPost();
+            if (!canEditNow) {
+                this.focusTextbox(true);
+            }
         }
 
         if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey) {

--- a/tests/components/create_comment/create_comment.test.jsx
+++ b/tests/components/create_comment/create_comment.test.jsx
@@ -599,7 +599,7 @@ describe('components/CreateComment', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    it('check for handleFileUploadChange callback for focus', () => {
+    test('check for handleFileUploadChange callback for focus', () => {
         const wrapper = shallow(
             <CreateComment {...baseProps}/>
         );
@@ -608,5 +608,73 @@ describe('components/CreateComment', () => {
 
         instance.handleFileUploadChange();
         expect(instance.focusTextbox).toHaveBeenCalledTimes(1);
+    });
+
+    test('should call functions on handleKeyDown', () => {
+        const onMoveHistoryIndexBack = jest.fn();
+        const onMoveHistoryIndexForward = jest.fn();
+        const onEditLatestPost = jest.fn().
+            mockImplementationOnce(() => ({data: true})).
+            mockImplementationOnce(() => ({data: false}));
+        const wrapper = shallow(
+            <CreateComment
+                {...baseProps}
+                ctrlSend={true}
+                onMoveHistoryIndexBack={onMoveHistoryIndexBack}
+                onMoveHistoryIndexForward={onMoveHistoryIndexForward}
+                onEditLatestPost={onEditLatestPost}
+            />
+        );
+        const instance = wrapper.instance();
+        instance.commentMsgKeyPress = jest.fn();
+        instance.focusTextbox = jest.fn();
+        instance.refs = {textbox: {blur: jest.fn(), focus: jest.fn()}};
+
+        const commentMsgKey = {
+            preventDefault: jest.fn(),
+            ctrlKey: true,
+            key: Constants.KeyCodes.ENTER[0],
+            keyCode: Constants.KeyCodes.ENTER[1],
+        };
+        instance.handleKeyDown(commentMsgKey);
+        expect(instance.commentMsgKeyPress).toHaveBeenCalledTimes(1);
+
+        const upKey = {
+            preventDefault: jest.fn(),
+            ctrlKey: true,
+            key: Constants.KeyCodes.UP[0],
+            keyCode: Constants.KeyCodes.UP[1],
+        };
+        instance.handleKeyDown(upKey);
+        expect(upKey.preventDefault).toHaveBeenCalledTimes(1);
+        expect(onMoveHistoryIndexBack).toHaveBeenCalledTimes(1);
+
+        const downKey = {
+            preventDefault: jest.fn(),
+            ctrlKey: true,
+            key: Constants.KeyCodes.DOWN[0],
+            keyCode: Constants.KeyCodes.DOWN[1],
+        };
+        instance.handleKeyDown(downKey);
+        expect(downKey.preventDefault).toHaveBeenCalledTimes(1);
+        expect(onMoveHistoryIndexForward).toHaveBeenCalledTimes(1);
+
+        wrapper.setState({draft: {message: '', fileInfos: [], uploadsInProgress: []}});
+        const upKeyForEdit = {
+            preventDefault: jest.fn(),
+            ctrlKey: false,
+            key: Constants.KeyCodes.UP[0],
+            keyCode: Constants.KeyCodes.UP[1],
+        };
+        instance.handleKeyDown(upKeyForEdit);
+        expect(upKeyForEdit.preventDefault).toHaveBeenCalledTimes(1);
+        expect(onEditLatestPost).toHaveBeenCalledTimes(1);
+        expect(instance.refs.textbox.blur).toHaveBeenCalledTimes(1);
+
+        instance.handleKeyDown(upKeyForEdit);
+        expect(upKeyForEdit.preventDefault).toHaveBeenCalledTimes(2);
+        expect(onEditLatestPost).toHaveBeenCalledTimes(2);
+        expect(instance.focusTextbox).toHaveBeenCalledTimes(1);
+        expect(instance.focusTextbox).toHaveBeenCalledWith(true);
     });
 });


### PR DESCRIPTION
#### Summary
On thread view, remove pending post or failed post from user's last editable message and revert focus to comment textbox when no post to edit

#### Ticket Link
Jira ticket: [MM-12639](https://mattermost.atlassian.net/browse/MM-12639)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
