### PR TITLE
Migrate ChannelActions favorite and unfavorite channel to redux

### DIFF
--- a/actions/channel_actions.jsx
+++ b/actions/channel_actions.jsx
@@ -329,19 +329,6 @@ export async function getChannelMembersForUserIds(channelId, userIds, success, e
     }
 }
 
-export async function leaveChannel(channelId, success) {
-    const townsquare = ChannelStore.getByName('town-square');
-    browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + townsquare.name);
-
-    await dispatch(ChannelActions.leaveChannel(channelId));
-    if (isFavoriteChannel(channelId)) {
-        dispatch(ChannelActions.unfavoriteChannel(channelId));
-    }
-    if (success) {
-        success();
-    }
-}
-
 export async function deleteChannel(channelId, success, error) {
     const {data, error: err} = await ChannelActions.deleteChannel(channelId)(dispatch, getState);
 

--- a/actions/channel_actions.jsx
+++ b/actions/channel_actions.jsx
@@ -329,6 +329,19 @@ export async function getChannelMembersForUserIds(channelId, userIds, success, e
     }
 }
 
+export async function leaveChannel(channelId, success) {
+    const townsquare = ChannelStore.getByName('town-square');
+    browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + townsquare.name);
+
+    await dispatch(ChannelActions.leaveChannel(channelId));
+    if (isFavoriteChannel(channelId)) {
+        dispatch(ChannelActions.unfavoriteChannel(channelId));
+    }
+    if (success) {
+        success();
+    }
+}
+
 export async function deleteChannel(channelId, success, error) {
     const {data, error: err} = await ChannelActions.deleteChannel(channelId)(dispatch, getState);
 

--- a/components/navbar/index.js
+++ b/components/navbar/index.js
@@ -4,12 +4,11 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {updateChannelNotifyProps, favoriteChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
+import {updateChannelNotifyProps, favoriteChannel, unfavoriteChannel, leaveChannel} from 'mattermost-redux/actions/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {isCurrentChannelReadOnly, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {isFavoriteChannel} from 'mattermost-redux/utils/channel_utils';
 
-import {leaveChannel} from 'actions/views/channel';
 import {
     closeRightHandSide as closeRhs,
     updateRhsState,

--- a/tests/components/navbar/navbar.test.jsx
+++ b/tests/components/navbar/navbar.test.jsx
@@ -171,6 +171,7 @@ describe('components/navbar/Navbar', () => {
             preventDefault: jest.fn(),
         };
 
+        wrapper.setState(validState);
         wrapper.instance().toggleFavorite(event);
         expect(wrapper.instance().props.actions.markFavorite).toBeCalled();
 

--- a/tests/components/navbar/navbar.test.jsx
+++ b/tests/components/navbar/navbar.test.jsx
@@ -6,16 +6,6 @@ import {shallow} from 'enzyme';
 
 import Navbar from 'components/navbar/navbar.jsx';
 
-jest.mock('utils/browser_history', () => {
-    const original = require.requireActual('utils/browser_history');
-    return {
-        ...original,
-        browserHistory: {
-            push: jest.fn(),
-        },
-    };
-});
-
 describe('components/navbar/Navbar', () => {
     const baseProps = {
         teamDisplayName: 'team_display_name',
@@ -24,8 +14,8 @@ describe('components/navbar/Navbar', () => {
             closeLhs: jest.fn(),
             closeRhs: jest.fn(),
             closeRhsMenu: jest.fn(),
-            leaveChannel: jest.fn(),
             markFavorite: jest.fn(),
+            leaveChannel: jest.fn(),
             showPinnedPosts: jest.fn(),
             toggleLhs: jest.fn(),
             toggleRhsMenu: jest.fn(),
@@ -181,7 +171,6 @@ describe('components/navbar/Navbar', () => {
             preventDefault: jest.fn(),
         };
 
-        wrapper.setState(validState);
         wrapper.instance().toggleFavorite(event);
         expect(wrapper.instance().props.actions.markFavorite).toBeCalled();
 


### PR DESCRIPTION
#### Summary
Migrate favorite and unfavorite channel actions to redux

Affected Areas:
* Mark and unmark channels as favorite

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12692

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
