### PR TITLE
Migrate ChannelActions joinChannel and leaveChannel to redux

### DIFF
--- a/actions/channel_actions.jsx
+++ b/actions/channel_actions.jsx
@@ -240,16 +240,6 @@ export function loadDMsAndGMsForUnreads() {
     }
 }
 
-export async function joinChannel(channel, success, error) {
-    const {data, err} = await ChannelActions.joinChannel(UserStore.getCurrentId(), null, channel.id)(dispatch, getState);
-
-    if (data && success) {
-        success(data);
-    } else if (err && error) {
-        error({id: err.server_error_id, ...err});
-    }
-}
-
 export async function updateChannel(channel, success, error) {
     const {data, error: err} = await ChannelActions.updateChannel(channel)(dispatch, getState);
     if (data && success) {
@@ -336,19 +326,6 @@ export async function getChannelMembersForUserIds(channelId, userIds, success, e
         success(data);
     } else if (err && error) {
         error({id: err.server_error_id, ...err});
-    }
-}
-
-export async function leaveChannel(channelId, success) {
-    const townsquare = ChannelStore.getByName('town-square');
-    browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + townsquare.name);
-
-    await dispatch(ChannelActions.leaveChannel(channelId));
-    if (isFavoriteChannel(channelId)) {
-        dispatch(ChannelActions.unfavoriteChannel(channelId));
-    }
-    if (success) {
-        success();
     }
 }
 

--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -130,7 +130,7 @@ export async function doFocusPost(channelId, postId, data) {
 
     const member = getState().entities.channels.myMembers[channelId];
     if (member == null) {
-        await joinChannel(UserStore.getCurrentId(), null, channelId)(dispatch, getState);
+        await dispatch(joinChannel(UserStore.getCurrentId(), null, channelId));
     }
 
     loadChannelsForCurrentUser();

--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -1,13 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {selectChannel} from 'mattermost-redux/actions/channels';
+import {leaveChannel as leaveChannelRedux, selectChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import {getChannelByName} from 'mattermost-redux/selectors/entities/channels';
+import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
+import {isFavoriteChannel} from 'mattermost-redux/utils/channel_utils';
 
 import {getLastViewedChannelName} from 'selectors/local_storage';
 
-import {isMobile} from 'utils/utils.jsx';
 import {ActionTypes} from 'utils/constants.jsx';
+import {isMobile} from 'utils/utils.jsx';
 
 export function checkAndSetMobileView() {
     return (dispatch) => {
@@ -20,7 +22,28 @@ export function checkAndSetMobileView() {
 
 export function goToLastViewedChannel() {
     return async (dispatch, getState) => {
-        const lastViewedChannel = getChannelByName(getState(), getLastViewedChannelName(getState()));
+        const state = getState();
+        const lastViewedChannel = getChannelByName(state, getLastViewedChannelName(state));
         dispatch(selectChannel(lastViewedChannel.id));
+    };
+}
+
+export function leaveChannel(channelId) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const myPreferences = getMyPreferences(state);
+
+        if (isFavoriteChannel(myPreferences, channelId)) {
+            dispatch(unfavoriteChannel(channelId));
+        }
+
+        const {error} = await dispatch(leaveChannelRedux(channelId));
+        if (error) {
+            return {error};
+        }
+
+        return {
+            data: true,
+        };
     };
 }

--- a/components/channel_layout/channel_identifier_router/channel_identifier_router.jsx
+++ b/components/channel_layout/channel_identifier_router/channel_identifier_router.jsx
@@ -70,7 +70,7 @@ async function goToChannelByChannelId(match, history) {
     let channel = ChannelStore.get(channelId);
     const teamObj = TeamStore.getByName(team);
     if (!channel) {
-        const {data, error} = await joinChannel(UserStore.getCurrentId(), teamObj.id, channelId, null)(dispatch, getState);
+        const {data, error} = await dispatch(joinChannel(UserStore.getCurrentId(), teamObj.id, channelId, null));
         if (error) {
             handleChannelJoinError(match, history);
             return;
@@ -94,7 +94,7 @@ async function goToChannelByChannelName(match, history) {
     let channel = ChannelStore.getByName(channelName);
     const teamObj = TeamStore.getByName(team);
     if (!channel) {
-        const {data, error: joinError} = await joinChannel(UserStore.getCurrentId(), teamObj.id, null, channelName)(dispatch, getState);
+        const {data, error: joinError} = await dispatch(joinChannel(UserStore.getCurrentId(), teamObj.id, null, channelName));
         if (joinError) {
             const {data: data2, error: getChannelError} = await dispatch(getChannelByNameAndTeamName(team, channelName, true));
             if (getChannelError || data2.delete_at === 0) {
@@ -198,7 +198,7 @@ async function goToGroupChannelByGroupId(match, history) {
     let channel = ChannelStore.getByName(groupId);
     const teamObj = TeamStore.getByName(team);
     if (!channel) {
-        const {data, error} = await joinChannel(UserStore.getCurrentId(), teamObj.id, null, groupId)(dispatch, getState);
+        const {data, error} = await dispatch(joinChannel(UserStore.getCurrentId(), teamObj.id, null, groupId));
         if (error) {
             handleError(match, history);
             return;

--- a/components/leave_private_channel_modal/index.js
+++ b/components/leave_private_channel_modal/index.js
@@ -4,14 +4,9 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {leaveChannel} from 'mattermost-redux/actions/channels';
+import {leaveChannel} from 'actions/views/channel';
 
 import LeavePrivateChannelModal from './leave_private_channel_modal.jsx';
-
-function mapStateToProps() {
-    return {
-    };
-}
 
 function mapDispatchToProps(dispatch) {
     return {
@@ -21,4 +16,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(LeavePrivateChannelModal);
+export default connect(null, mapDispatchToProps)(LeavePrivateChannelModal);

--- a/components/leave_private_channel_modal/leave_private_channel_modal.jsx
+++ b/components/leave_private_channel_modal/leave_private_channel_modal.jsx
@@ -2,8 +2,8 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedMessage, injectIntl, intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
+import {FormattedMessage, injectIntl, intlShape} from 'react-intl';
 
 import ModalStore from 'stores/modal_store.jsx';
 import Constants from 'utils/constants.jsx';
@@ -14,60 +14,59 @@ class LeavePrivateChannelModal extends React.Component {
         actions: PropTypes.shape({
             leaveChannel: PropTypes.func.isRequired,
         }).isRequired,
-    }
+        intl: intlShape.isRequired,
+    };
 
     constructor(props) {
         super(props);
-
-        this.handleToggle = this.handleToggle.bind(this);
-        this.handleSubmit = this.handleSubmit.bind(this);
-        this.handleHide = this.handleHide.bind(this);
-        this.handleKeyPress = this.handleKeyPress.bind(this);
 
         this.state = {
             show: false,
             channel: null,
         };
-        this.mounted = false;
     }
 
     componentDidMount() {
-        this.mounted = true;
         ModalStore.addModalListener(Constants.ActionTypes.TOGGLE_LEAVE_PRIVATE_CHANNEL_MODAL, this.handleToggle);
     }
 
     componentWillUnmount() {
-        this.mounted = false;
         ModalStore.removeModalListener(Constants.ActionTypes.TOGGLE_LEAVE_PRIVATE_CHANNEL_MODAL, this.handleToggle);
     }
 
-    handleKeyPress(e) {
+    handleKeyPress = (e) => {
         if (e.key === 'Enter' && this.state.show) {
             this.handleSubmit();
         }
-    }
+    };
 
-    handleSubmit() {
-        const channelId = this.state.channel.id;
-        this.setState({
-            show: false,
-            channel: null,
-        });
-        this.props.actions.leaveChannel(channelId);
-    }
+    handleSubmit = () => {
+        const {actions} = this.props;
+        const {channel} = this.state;
 
-    handleToggle(value) {
+        if (channel) {
+            const channelId = channel.id;
+            actions.leaveChannel(channelId).then((result) => {
+                if (result.data) {
+                    this.handleHide();
+                }
+            });
+        }
+    };
+
+    handleToggle = (value) => {
         this.setState({
             channel: value,
             show: value !== null,
         });
-    }
+    };
 
-    handleHide() {
+    handleHide = () => {
         this.setState({
             show: false,
+            channel: null,
         });
-    }
+    };
 
     render() {
         let title = '';
@@ -115,9 +114,5 @@ class LeavePrivateChannelModal extends React.Component {
         );
     }
 }
-
-LeavePrivateChannelModal.propTypes = {
-    intl: intlShape.isRequired,
-};
 
 export default injectIntl(LeavePrivateChannelModal);

--- a/components/more_channels/index.js
+++ b/components/more_channels/index.js
@@ -5,9 +5,10 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {createSelector} from 'reselect';
 
-import {getChannels} from 'mattermost-redux/actions/channels';
+import {getChannels, joinChannel} from 'mattermost-redux/actions/channels';
 import {getOtherChannels} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {RequestStatus} from 'mattermost-redux/constants';
 
 import MoreChannels from './more_channels.jsx';
@@ -22,6 +23,7 @@ function mapStateToProps(state) {
 
     return {
         channels: getNotArchivedOtherChannels(state) || [],
+        currentUserId: getCurrentUserId(state),
         teamId: team.id,
         teamName: team.name,
         channelsRequestStarted: state.requests.channels.getChannels.status === RequestStatus.STARTED,
@@ -32,6 +34,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             getChannels,
+            joinChannel,
         }, dispatch),
     };
 }

--- a/components/navbar/index.js
+++ b/components/navbar/index.js
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {updateChannelNotifyProps, leaveChannel} from 'mattermost-redux/actions/channels';
+import {updateChannelNotifyProps, favoriteChannel, unfavoriteChannel, leaveChannel} from 'mattermost-redux/actions/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {isCurrentChannelReadOnly, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {isFavoriteChannel} from 'mattermost-redux/utils/channel_utils';
@@ -41,14 +41,16 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            updateRhsState,
-            showPinnedPosts,
-            toggleLhs,
             closeLhs,
             closeRhs,
-            toggleRhsMenu,
             closeRhsMenu,
+            markFavorite: favoriteChannel,
+            showPinnedPosts,
+            toggleLhs,
+            toggleRhsMenu,
+            unmarkFavorite: unfavoriteChannel,
             updateChannelNotifyProps,
+            updateRhsState,
             leaveChannel,
         }, dispatch),
     };

--- a/components/navbar/index.js
+++ b/components/navbar/index.js
@@ -4,11 +4,12 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {updateChannelNotifyProps, favoriteChannel, unfavoriteChannel, leaveChannel} from 'mattermost-redux/actions/channels';
+import {updateChannelNotifyProps, favoriteChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {isCurrentChannelReadOnly, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {isFavoriteChannel} from 'mattermost-redux/utils/channel_utils';
 
+import {leaveChannel} from 'actions/views/channel';
 import {
     closeRightHandSide as closeRhs,
     updateRhsState,
@@ -44,6 +45,7 @@ function mapDispatchToProps(dispatch) {
             closeLhs,
             closeRhs,
             closeRhsMenu,
+            leaveChannel,
             markFavorite: favoriteChannel,
             showPinnedPosts,
             toggleLhs,
@@ -51,7 +53,6 @@ function mapDispatchToProps(dispatch) {
             unmarkFavorite: unfavoriteChannel,
             updateChannelNotifyProps,
             updateRhsState,
-            leaveChannel,
         }, dispatch),
     };
 }

--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -12,7 +12,6 @@ import {isChannelMuted} from 'mattermost-redux/utils/channel_utils';
 
 import EditChannelHeaderModal from 'components/edit_channel_header_modal';
 import EditChannelPurposeModal from 'components/edit_channel_purpose_modal';
-import * as ChannelActions from 'actions/channel_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import * as WebrtcActions from 'actions/webrtc_actions.jsx';
 import ChannelStore from 'stores/channel_store.jsx';

--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -146,10 +146,11 @@ export default class Navbar extends React.Component {
     }
 
     handleLeave = () => {
+        const {actions} = this.props;
         if (this.state.channel.type === Constants.PRIVATE_CHANNEL) {
             GlobalActions.showLeavePrivateChannelModal(this.state.channel);
         } else {
-            this.props.actions.leaveChannel(this.state.channel.id);
+            actions.leaveChannel(this.state.channel.id);
         }
     }
 

--- a/components/navbar/navbar.jsx
+++ b/components/navbar/navbar.jsx
@@ -61,16 +61,18 @@ export default class Navbar extends React.Component {
         isReadOnly: PropTypes.bool,
         isFavoriteChannel: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
-            updateRhsState: PropTypes.func,
-            showPinnedPosts: PropTypes.func,
-            toggleLhs: PropTypes.func.isRequired,
             closeLhs: PropTypes.func.isRequired,
             closeRhs: PropTypes.func.isRequired,
-            toggleRhsMenu: PropTypes.func.isRequired,
             closeRhsMenu: PropTypes.func.isRequired,
-            updateChannelNotifyProps: PropTypes.func.isRequired,
             leaveChannel: PropTypes.func.isRequired,
-        }),
+            markFavorite: PropTypes.func.isRequired,
+            showPinnedPosts: PropTypes.func,
+            toggleLhs: PropTypes.func.isRequired,
+            toggleRhsMenu: PropTypes.func.isRequired,
+            unmarkFavorite: PropTypes.func.isRequired,
+            updateChannelNotifyProps: PropTypes.func.isRequired,
+            updateRhsState: PropTypes.func.isRequired,
+        }).isRequired,
     };
 
     static defaultProps = {
@@ -263,12 +265,13 @@ export default class Navbar extends React.Component {
     }
 
     toggleFavorite = (e) => {
+        const {markFavorite, unmarkFavorite} = this.props.actions;
         e.preventDefault();
 
         if (this.props.isFavoriteChannel) {
-            ChannelActions.unmarkFavorite(this.state.channel.id);
+            unmarkFavorite(this.state.channel.id);
         } else {
-            ChannelActions.markFavorite(this.state.channel.id);
+            markFavorite(this.state.channel.id);
         }
     };
 

--- a/tests/components/__snapshots__/leave_private_channel_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/leave_private_channel_modal.test.jsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/LeavePrivateChannelModal should match snapshot, init 1`] = `
+<ConfirmModal
+  confirmButtonClass="btn btn-danger"
+  confirmButtonText={
+    <FormattedMessage
+      defaultMessage="Yes, leave channel"
+      id="leave_private_channel_modal.leave"
+      values={Object {}}
+    />
+  }
+  message=""
+  modalClass=""
+  onCancel={[Function]}
+  onConfirm={[Function]}
+  show={false}
+  title=""
+/>
+`;

--- a/tests/components/__snapshots__/more_channels.test.jsx.snap
+++ b/tests/components/__snapshots__/more_channels.test.jsx.snap
@@ -54,7 +54,7 @@ exports[`components/MoreChannels should match snapshot and state 1`] = `
       <button
         className="btn btn-primary channel-create-btn"
         id="createNewChannel"
-        onClick={[Function]}
+        onClick={[MockFunction]}
         type="button"
       >
         <FormattedMessage
@@ -75,6 +75,7 @@ exports[`components/MoreChannels should match snapshot and state 1`] = `
           Object {
             "delete_at": 0,
             "id": "channel_id_1",
+            "name": "channel-1",
           },
         ]
       }

--- a/tests/components/leave_private_channel_modal.test.jsx
+++ b/tests/components/leave_private_channel_modal.test.jsx
@@ -1,0 +1,138 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+
+import LeavePrivateChannelModal from 'components/leave_private_channel_modal/leave_private_channel_modal.jsx';
+import Constants from 'utils/constants';
+
+describe('components/LeavePrivateChannelModal', () => {
+    const channels = {
+        'channel-1': {
+            id: 'channel-1',
+            name: 'test-channel-1',
+            display_name: 'Test Channel 1',
+            type: 'P',
+            team_id: 'team-1',
+        },
+        'channel-2': {
+            id: 'channel-2',
+            name: 'test-channel-2',
+            display_name: 'Test Channel 2',
+            type: 'P',
+            team_id: 'team-1',
+        },
+        'town-square': {
+            id: 'town-square-id',
+            name: 'town-square',
+            display_name: 'Town Square',
+            type: 'O',
+            team_id: 'team-1',
+        },
+    };
+
+    const baseProps = {
+        actions: {
+            leaveChannel: jest.fn(),
+        },
+    };
+
+    test('should match snapshot, init', () => {
+        const wrapper = shallowWithIntl(
+            <LeavePrivateChannelModal
+                {...baseProps}
+            />
+        ).dive({disableLifecycleMethods: true});
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should show and hide the modal dialog', () => {
+        const wrapper = shallowWithIntl(
+            <LeavePrivateChannelModal
+                {...baseProps}
+            />
+        ).dive({disableLifecycleMethods: true});
+
+        wrapper.instance().handleToggle(channels['channel-2']);
+        expect(wrapper.state('show')).toEqual(true);
+        expect(wrapper.state('channel')).toHaveProperty('id', 'channel-2');
+
+        wrapper.instance().handleHide();
+        expect(wrapper.state('show')).toEqual(false);
+        expect(wrapper.state('channel')).toBeNull();
+    });
+
+    test('should fail to leave channel', (done) => {
+        const props = {
+            actions: {
+                leaveChannel: jest.fn().mockImplementation(() => {
+                    const error = {
+                        message: 'error leaving channel',
+                    };
+
+                    return Promise.resolve({error});
+                }),
+            },
+        };
+        const wrapper = shallowWithIntl(
+            <LeavePrivateChannelModal
+                {...props}
+            />
+        ).dive({disableLifecycleMethods: true});
+
+        wrapper.setState({
+            show: true,
+            channel: channels['channel-2'],
+        });
+
+        const instance = wrapper.instance();
+        instance.handleSubmit();
+        expect(instance.props.actions.leaveChannel).toHaveBeenCalledTimes(1);
+        process.nextTick(() => {
+            expect(wrapper.state('show')).toEqual(true);
+            expect(wrapper.state('channel')).not.toBeNull();
+            done();
+        });
+    });
+
+    test('should leave channel when pressing the enter key browse to default channel', (done) => {
+        const props = {
+            actions: {
+                leaveChannel: jest.fn().mockImplementation(() => {
+                    const data = true;
+
+                    return Promise.resolve({data});
+                }),
+            },
+        };
+        const wrapper = shallowWithIntl(
+            <LeavePrivateChannelModal
+                {...props}
+            />
+        ).dive({disableLifecycleMethods: true});
+
+        wrapper.setState({
+            show: true,
+            channel: channels['channel-1'],
+        });
+
+        const instance = wrapper.instance();
+        const enterKey = {
+            preventDefault: jest.fn(),
+            ctrlKey: false,
+            key: Constants.KeyCodes.ENTER[0],
+            keyCode: Constants.KeyCodes.ENTER[1],
+        };
+
+        instance.handleHide = jest.fn();
+        instance.handleKeyPress(enterKey);
+        expect(instance.props.actions.leaveChannel).toHaveBeenCalledTimes(1);
+        process.nextTick(() => {
+            expect(instance.handleHide).toHaveBeenCalledTimes(1);
+            done();
+        });
+    });
+});

--- a/tests/components/navbar/navbar.test.jsx
+++ b/tests/components/navbar/navbar.test.jsx
@@ -11,12 +11,16 @@ describe('components/navbar/Navbar', () => {
         teamDisplayName: 'team_display_name',
         isPinnedPosts: true,
         actions: {
-            toggleLhs: jest.fn(),
             closeLhs: jest.fn(),
             closeRhs: jest.fn(),
-            toggleRhsMenu: jest.fn(),
             closeRhsMenu: jest.fn(),
+            markFavorite: jest.fn(),
+            showPinnedPosts: jest.fn(),
+            toggleLhs: jest.fn(),
+            toggleRhsMenu: jest.fn(),
+            unmarkFavorite: jest.fn(),
             updateChannelNotifyProps: jest.fn(),
+            updateRhsState: jest.fn(),
             leaveChannel: jest.fn(),
         },
         isLicensed: true,
@@ -156,5 +160,22 @@ describe('components/navbar/Navbar', () => {
         expect(wrapper.state('isBusy')).toEqual(true);
         wrapper.instance().onBusy(false);
         expect(wrapper.state('isBusy')).toEqual(false);
+    });
+
+    test('should toggle favorite channel', () => {
+        const wrapper = shallow(
+            <Navbar {...baseProps}/>
+        );
+
+        const event = {
+            preventDefault: jest.fn(),
+        };
+
+        wrapper.instance().toggleFavorite(event);
+        expect(wrapper.instance().props.actions.markFavorite).toBeCalled();
+
+        wrapper.setProps({isFavoriteChannel: true});
+        wrapper.instance().toggleFavorite(event);
+        expect(wrapper.instance().props.actions.unmarkFavorite).toBeCalled();
     });
 });

--- a/tests/components/navbar/navbar.test.jsx
+++ b/tests/components/navbar/navbar.test.jsx
@@ -6,6 +6,16 @@ import {shallow} from 'enzyme';
 
 import Navbar from 'components/navbar/navbar.jsx';
 
+jest.mock('utils/browser_history', () => {
+    const original = require.requireActual('utils/browser_history');
+    return {
+        ...original,
+        browserHistory: {
+            push: jest.fn(),
+        },
+    };
+});
+
 describe('components/navbar/Navbar', () => {
     const baseProps = {
         teamDisplayName: 'team_display_name',
@@ -14,6 +24,7 @@ describe('components/navbar/Navbar', () => {
             closeLhs: jest.fn(),
             closeRhs: jest.fn(),
             closeRhsMenu: jest.fn(),
+            leaveChannel: jest.fn(),
             markFavorite: jest.fn(),
             showPinnedPosts: jest.fn(),
             toggleLhs: jest.fn(),
@@ -21,7 +32,6 @@ describe('components/navbar/Navbar', () => {
             unmarkFavorite: jest.fn(),
             updateChannelNotifyProps: jest.fn(),
             updateRhsState: jest.fn(),
-            leaveChannel: jest.fn(),
         },
         isLicensed: true,
         enableWebrtc: true,
@@ -178,5 +188,35 @@ describe('components/navbar/Navbar', () => {
         wrapper.setProps({isFavoriteChannel: true});
         wrapper.instance().toggleFavorite(event);
         expect(wrapper.instance().props.actions.unmarkFavorite).toBeCalled();
+    });
+
+    test('should leave public channel', () => {
+        const props = {
+            ...baseProps,
+            actions: {
+                ...baseProps.actions,
+                leaveChannel: jest.fn().mockImplementation(() => {
+                    const data = true;
+
+                    return Promise.resolve({data});
+                }),
+            },
+        };
+
+        const channel = {
+            id: 'channel-1',
+            name: 'test-channel-1',
+            display_name: 'Test Channel 1',
+            type: 'O',
+            team_id: 'team-1',
+        };
+
+        const wrapper = shallow(
+            <Navbar {...props}/>
+        );
+
+        wrapper.setState({channel});
+        wrapper.instance().handleLeave();
+        expect(wrapper.instance().props.actions.leaveChannel).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/components/navbar/navbar.test.jsx
+++ b/tests/components/navbar/navbar.test.jsx
@@ -171,6 +171,7 @@ describe('components/navbar/Navbar', () => {
             preventDefault: jest.fn(),
         };
 
+        wrapper.setState(validState);
         wrapper.instance().toggleFavorite(event);
         expect(wrapper.instance().props.actions.markFavorite).toBeCalled();
 


### PR DESCRIPTION
#### Summary
Migrates the channel actions joinChannel and leaveChannel to redux (this PR is on top of #1895) the relevant commit is [98e08ce](https://github.com/mattermost/mattermost-webapp/pull/1898/commits/98e08ce694d69c6484aeac9f6728299228251afa)

Affected areas:
* Leave public and private channels using the channel menu
* Join new channels from the more channels modal

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12693

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
