### PR TITLE
Fix Jest warning of "Cannot read property '_location' of null"

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -11,6 +11,16 @@ global.performance = {};
 
 configure({adapter: new Adapter()});
 
+global.window = Object.create(window);
+Object.defineProperty(window, 'location', {
+    value: {
+        href: 'http://localhost:8065',
+        origin: 'http://localhost:8065',
+        port: '8065',
+        protocol: 'http:',
+    },
+});
+
 const supportedCommands = ['copy'];
 
 Object.defineProperty(document, 'queryCommandSupported', {


### PR DESCRIPTION
#### Summary
This fixes the warnings when running unit test,
```
(node:9618) UnhandledPromiseRejectionWarning: TypeError: Cannot read property '_location' of null
    at Window.get location [as location] (/Users/nnn/go/src/github.com/mattermost/mattermost-webapp/node_modules/jsdom/lib/jsdom/browser/Window.js:223:79)
    at getBasePath (/Users/nnn/go/src/github.com/mattermost/mattermost-webapp/selectors/general.js:33:36)
```

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Updated unit test setup
