### PR TITLE
MM-12135: Make sure archived channels are fetched for flags.

### DIFF
--- a/components/sidebar_right/index.js
+++ b/components/sidebar_right/index.js
@@ -8,7 +8,7 @@ import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
 import PostStore from 'stores/post_store';
-import {getPinnedPosts, getFlaggedPosts, setRhsExpanded, showPinnedPosts} from 'actions/views/rhs';
+import {getPinnedPosts, setRhsExpanded, showPinnedPosts} from 'actions/views/rhs';
 import {
     getIsRhsExpanded,
     getIsRhsOpen,
@@ -59,7 +59,6 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             getPinnedPosts,
-            getFlaggedPosts,
             setRhsExpanded,
             showPinnedPosts,
         }, dispatch),

--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -28,7 +28,6 @@ export default class SidebarRight extends React.PureComponent {
         previousRhsState: PropTypes.string,
         actions: PropTypes.shape({
             getPinnedPosts: PropTypes.func.isRequired,
-            getFlaggedPosts: PropTypes.func.isRequired,
             setRhsExpanded: PropTypes.func.isRequired,
             showPinnedPosts: PropTypes.func.isRequired,
         }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10532,8 +10532,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#4b1fadba2b4385293d188ca15893d9e716a27673",
-      "from": "github:mattermost/mattermost-redux#4b1fadba2b4385293d188ca15893d9e716a27673",
+      "version": "github:mattermost/mattermost-redux#dcfde2f962cafc77f9c24ed275de52511f365cdf",
+      "from": "github:mattermost/mattermost-redux#dcfde2f962cafc77f9c24ed275de52511f365cdf",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "localforage": "1.7.2",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-    "mattermost-redux": "github:mattermost/mattermost-redux#4b1fadba2b4385293d188ca15893d9e716a27673",
+    "mattermost-redux": "github:mattermost/mattermost-redux#dcfde2f962cafc77f9c24ed275de52511f365cdf",
     "moment-timezone": "0.5.21",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/tests/redux/actions/views/rhs.test.js
+++ b/tests/redux/actions/views/rhs.test.js
@@ -14,7 +14,6 @@ import {
     selectPostFromRightHandSideSearch,
     updateSearchTerms,
     performSearch,
-    getFlaggedPosts,
     getPinnedPosts,
     showSearchResults,
     showFlaggedPosts,
@@ -223,36 +222,6 @@ describe('rhs view actions', () => {
                 terms,
             });
             compareStore.dispatch(performSearch(terms));
-
-            expect(store.getActions()).toEqual(compareStore.getActions());
-        });
-    });
-
-    describe('getFlaggedPosts', () => {
-        test('it dispatches the right actions', async () => {
-            await store.dispatch(getFlaggedPosts());
-
-            const compareStore = mockStore(initialState);
-            const result = await Client4.getFlaggedPosts(currentUserId, '', currentTeamId);
-            await PostActions.getProfilesAndStatusesForPosts(result.posts, compareStore.dispatch, compareStore.getState);
-
-            compareStore.dispatch(batchActions([
-                {
-                    type: SearchTypes.RECEIVED_SEARCH_POSTS,
-                    data: result,
-                },
-                {
-                    type: SearchTypes.RECEIVED_SEARCH_TERM,
-                    data: {
-                        teamId: '321',
-                        terms: null,
-                        isOrSearch: false,
-                    },
-                },
-                {
-                    type: SearchTypes.SEARCH_POSTS_SUCCESS,
-                },
-            ]));
 
             expect(store.getActions()).toEqual(compareStore.getActions());
         });


### PR DESCRIPTION
#### Summary
Make sure archived channels are fetched for flagged posts.

This fixes both MM-12135 and MM-12137

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12135
https://mattermost.atlassian.net/browse/MM-12137

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)