### PR TITLE
Do not remove edit_others_posts from system admins

### DIFF
--- a/utils/policy_roles_adapter.js
+++ b/utils/policy_roles_adapter.js
@@ -16,7 +16,7 @@ const MAPPING = {
         ],
         false: [
             {roleName: 'team_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: false},
-            {roleName: 'system_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: false},
+            {roleName: 'system_admin', permission: Permissions.EDIT_OTHERS_POSTS, shouldHave: true},
         ],
     },
 


### PR DESCRIPTION
#### Summary
When disabling the permission for team admins, it got also disabled for system admins.
This fixes it and also ensures system admins have the privilege when changing the value (in case they lost it during a previous change while the bug was there).

#### Ticket Link
https://pre-release.mattermost.com/core/pl/fh8wzt9z5jbbzqg485derbtp5a

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed