### PR TITLE
MM-12662 Remove flux store usages from ChannelIdentifierRouter

### DIFF
--- a/components/channel_layout/channel_identifier_router/actions.js
+++ b/components/channel_layout/channel_identifier_router/actions.js
@@ -1,0 +1,243 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {joinChannel, getChannelByNameAndTeamName, markGroupChannelOpen} from 'mattermost-redux/actions/channels';
+import {getUser, getUserByUsername, getUserByEmail} from 'mattermost-redux/actions/users';
+import {getTeamByName} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentUserId, getUserByUsername as selectUserByUsername} from 'mattermost-redux/selectors/entities/users';
+import {getChannelByName, getOtherChannels, getChannel} from 'mattermost-redux/selectors/entities/channels';
+
+import {Constants} from 'utils/constants.jsx';
+import {openDirectChannelToUser} from 'actions/channel_actions.jsx';
+import * as GlobalActions from 'actions/global_actions.jsx';
+import * as Utils from 'utils/utils.jsx';
+
+const LENGTH_OF_ID = 26;
+const LENGTH_OF_GROUP_ID = 40;
+const LENGTH_OF_USER_ID_PAIR = 54;
+
+export function onChannelByIdentifierEnter({match, history}) {
+    return (dispatch, getState) => {
+        const state = getState();
+        const {path, identifier, team} = match.params;
+
+        if (!getTeamByName(state, team)) {
+            return;
+        }
+
+        if (path === 'channels') {
+            if (identifier.length === LENGTH_OF_ID) {
+            // It's hard to tell an ID apart from a channel name of the same length, so check first if
+            // the identifier matches a channel that we have
+                const channelsByName = getChannelByName(state, identifier);
+                const moreChannelsByName = getOtherChannels(state).find((chan) => chan.name === identifier);
+                if (channelsByName || moreChannelsByName) {
+                    dispatch(goToChannelByChannelName(match, history));
+                } else {
+                    dispatch(goToChannelByChannelId(match, history));
+                }
+            } else if (identifier.length === LENGTH_OF_GROUP_ID) {
+                dispatch(goToGroupChannelByGroupId(match, history));
+            } else if (identifier.length === LENGTH_OF_USER_ID_PAIR) {
+                dispatch(goToDirectChannelByUserIds(match, history));
+            } else {
+                dispatch(goToChannelByChannelName(match, history));
+            }
+        } else if (path === 'messages') {
+            if (identifier.indexOf('@') === 0) {
+                dispatch(goToDirectChannelByUsername(match, history));
+            } else if (identifier.indexOf('@') > 0) {
+                dispatch(goToDirectChannelByEmail(match, history));
+            } else if (identifier.length === LENGTH_OF_ID) {
+                dispatch(goToDirectChannelByUserId(match, history, identifier));
+            } else if (identifier.length === LENGTH_OF_GROUP_ID) {
+                dispatch(goToGroupChannelByGroupId(match, history));
+            } else {
+                handleError(match, history);
+            }
+        }
+    };
+}
+
+function goToChannelByChannelId(match, history) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const {team, identifier} = match.params;
+        const channelId = identifier.toLowerCase();
+
+        let channel = getChannel(state, channelId);
+        const teamObj = getTeamByName(state, team);
+        if (!channel) {
+            const {data, error} = await dispatch(joinChannel(getCurrentUserId(state), teamObj.id, channelId, null));
+            if (error) {
+                handleChannelJoinError(match, history);
+                return;
+            }
+            channel = data.channel;
+        }
+
+        if (channel.type === Constants.DM_CHANNEL) {
+            dispatch(goToDirectChannelByUserId(match, history, Utils.getUserIdFromChannelId(channel.name)));
+        } else if (channel.type === Constants.GM_CHANNEL) {
+            history.replace(`/${team}/messages/${channel.name}`);
+        } else {
+            history.replace(`/${team}/channels/${channel.name}`);
+        }
+    };
+}
+
+function goToChannelByChannelName(match, history) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const {team, identifier} = match.params;
+        const channelName = identifier.toLowerCase();
+
+        let channel = getChannelByName(state, channelName);
+        const teamObj = getTeamByName(state, team);
+        if (!channel) {
+            const {data, error: joinError} = await dispatch(joinChannel(getCurrentUserId(state), teamObj.id, null, channelName));
+            if (joinError) {
+                const {data: data2, error: getChannelError} = await dispatch(getChannelByNameAndTeamName(team, channelName, true));
+                if (getChannelError || data2.delete_at === 0) {
+                    handleChannelJoinError(match, history);
+                    return;
+                }
+                channel = data2;
+            } else {
+                channel = data.channel;
+            }
+        }
+
+        if (channel.type === Constants.DM_CHANNEL) {
+            dispatch(goToDirectChannelByUserIds(match, history));
+        } else if (channel.type === Constants.GM_CHANNEL) {
+            history.replace(`/${team}/messages/${channel.name}`);
+        } else {
+            doChannelChange(channel);
+        }
+    };
+}
+
+function goToDirectChannelByUsername(match, history) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const {identifier} = match.params;
+        const username = identifier.slice(1, identifier.length).toLowerCase();
+
+        let user = selectUserByUsername(state, username);
+        if (!user) {
+            const {data, error} = await dispatch(getUserByUsername(username));
+            if (error) {
+                handleError(match, history);
+                return;
+            }
+            user = data;
+        }
+
+        openDirectChannelToUser(
+            user.id,
+            (channel) => {
+                doChannelChange(channel);
+            },
+            () => handleError(match, history)
+        );
+    };
+}
+
+function goToDirectChannelByUserId(match, history, userId) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const {team} = match.params;
+
+        let user = getUser(state, userId);
+        if (!user) {
+            const {data, error} = await dispatch(getUser(userId));
+            if (error) {
+                handleError(match, history);
+                return;
+            }
+            user = data;
+        }
+
+        history.replace(`/${team}/messages/@${user.username}`);
+    };
+}
+
+function goToDirectChannelByUserIds(match, history) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const {team, identifier} = match.params;
+        const userId = Utils.getUserIdFromChannelId(identifier.toLowerCase());
+
+        let user = getUser(state, userId);
+        if (!user) {
+            const {data, error} = await dispatch(getUser(userId));
+            if (error) {
+                handleError(match, history);
+                return;
+            }
+            user = data;
+        }
+
+        history.replace(`/${team}/messages/@${user.username}`);
+    };
+}
+
+function goToDirectChannelByEmail(match, history) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const {team, identifier} = match.params;
+        const email = identifier.toLowerCase();
+
+        let user = getUserByEmail(state, email);
+        if (!user) {
+            const {data, error} = await dispatch(getUserByEmail(email));
+            if (error) {
+                handleError(match, history);
+                return;
+            }
+            user = data;
+        }
+
+        history.replace(`/${team}/messages/@${user.username}`);
+    };
+}
+
+function goToGroupChannelByGroupId(match, history) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const {identifier, team} = match.params;
+        const groupId = identifier.toLowerCase();
+
+        history.replace(match.url.replace('/channels/', '/messages/'));
+
+        let channel = getChannelByName(state, groupId);
+        const teamObj = getTeamByName(state, team);
+        if (!channel) {
+            const {data, error} = await dispatch(joinChannel(getCurrentUserId(state), teamObj.id, null, groupId));
+            if (error) {
+                handleError(match, history);
+                return;
+            }
+            channel = data.channel;
+        }
+
+        dispatch(markGroupChannelOpen(channel.id));
+
+        doChannelChange(channel);
+    };
+}
+
+function doChannelChange(channel) {
+    GlobalActions.emitChannelClickEvent(channel);
+}
+
+function handleError(match, history) {
+    const {team} = match.params;
+    history.push(team ? `/${team}/channels/${Constants.DEFAULT_CHANNEL}` : '/');
+}
+
+function handleChannelJoinError(match, history) {
+    const {team} = match.params;
+    history.push(team ? `/error?type=channel_not_found&returnTo=/${team}/channels/${Constants.DEFAULT_CHANNEL}` : '/');
+}

--- a/components/channel_layout/channel_identifier_router/channel_identifier_router.jsx
+++ b/components/channel_layout/channel_identifier_router/channel_identifier_router.jsx
@@ -4,226 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {joinChannel, getChannelByNameAndTeamName, markGroupChannelOpen} from 'mattermost-redux/actions/channels';
-import {getUser, getUserByUsername, getUserByEmail} from 'mattermost-redux/actions/users';
-
 import ChannelView from 'components/channel_view/index';
-import UserStore from 'stores/user_store.jsx';
-import ChannelStore from 'stores/channel_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
-import {Constants} from 'utils/constants.jsx';
-import {openDirectChannelToUser} from 'actions/channel_actions.jsx';
-import * as GlobalActions from 'actions/global_actions.jsx';
-import * as Utils from 'utils/utils.jsx';
-import store from 'stores/redux_store.jsx';
-const dispatch = store.dispatch;
-const getState = store.getState;
-
-const LENGTH_OF_ID = 26;
-const LENGTH_OF_GROUP_ID = 40;
-const LENGTH_OF_USER_ID_PAIR = 54;
-
-function onChannelByIdentifierEnter({match, history}) {
-    const {path, identifier, team} = match.params;
-
-    if (!TeamStore.getByName(team)) {
-        return;
-    }
-
-    if (path === 'channels') {
-        if (identifier.length === LENGTH_OF_ID) {
-            // It's hard to tell an ID apart from a channel name of the same length, so check first if
-            // the identifier matches a channel that we have
-            const channelsByName = ChannelStore.getByName(identifier);
-            const moreChannelsByName = ChannelStore.getMoreChannelsList().find((chan) => chan.name === identifier);
-            if (channelsByName || moreChannelsByName) {
-                goToChannelByChannelName(match, history);
-            } else {
-                goToChannelByChannelId(match, history);
-            }
-        } else if (identifier.length === LENGTH_OF_GROUP_ID) {
-            goToGroupChannelByGroupId(match, history);
-        } else if (identifier.length === LENGTH_OF_USER_ID_PAIR) {
-            goToDirectChannelByUserIds(match, history);
-        } else {
-            goToChannelByChannelName(match, history);
-        }
-    } else if (path === 'messages') {
-        if (identifier.indexOf('@') === 0) {
-            goToDirectChannelByUsername(match, history);
-        } else if (identifier.indexOf('@') > 0) {
-            goToDirectChannelByEmail(match, history);
-        } else if (identifier.length === LENGTH_OF_ID) {
-            goToDirectChannelByUserId(match, history, identifier);
-        } else if (identifier.length === LENGTH_OF_GROUP_ID) {
-            goToGroupChannelByGroupId(match, history);
-        } else {
-            handleError(match, history);
-        }
-    }
-}
-
-async function goToChannelByChannelId(match, history) {
-    const {team, identifier} = match.params;
-    const channelId = identifier.toLowerCase();
-
-    let channel = ChannelStore.get(channelId);
-    const teamObj = TeamStore.getByName(team);
-    if (!channel) {
-        const {data, error} = await dispatch(joinChannel(UserStore.getCurrentId(), teamObj.id, channelId, null));
-        if (error) {
-            handleChannelJoinError(match, history);
-            return;
-        }
-        channel = data.channel;
-    }
-
-    if (channel.type === Constants.DM_CHANNEL) {
-        goToDirectChannelByUserId(match, history, Utils.getUserIdFromChannelId(channel.name));
-    } else if (channel.type === Constants.GM_CHANNEL) {
-        history.replace(`/${team}/messages/${channel.name}`);
-    } else {
-        history.replace(`/${team}/channels/${channel.name}`);
-    }
-}
-
-async function goToChannelByChannelName(match, history) {
-    const {team, identifier} = match.params;
-    const channelName = identifier.toLowerCase();
-
-    let channel = ChannelStore.getByName(channelName);
-    const teamObj = TeamStore.getByName(team);
-    if (!channel) {
-        const {data, error: joinError} = await dispatch(joinChannel(UserStore.getCurrentId(), teamObj.id, null, channelName));
-        if (joinError) {
-            const {data: data2, error: getChannelError} = await dispatch(getChannelByNameAndTeamName(team, channelName, true));
-            if (getChannelError || data2.delete_at === 0) {
-                handleChannelJoinError(match, history);
-                return;
-            }
-            channel = data2;
-        } else {
-            channel = data.channel;
-        }
-    }
-
-    if (channel.type === Constants.DM_CHANNEL) {
-        goToDirectChannelByUserIds(match, history);
-    } else if (channel.type === Constants.GM_CHANNEL) {
-        history.replace(`/${team}/messages/${channel.name}`);
-    } else {
-        doChannelChange(channel);
-    }
-}
-
-async function goToDirectChannelByUsername(match, history) {
-    const {identifier} = match.params;
-    const username = identifier.slice(1, identifier.length).toLowerCase();
-
-    let user = UserStore.getProfileByUsername(username);
-    if (!user) {
-        const {data, error} = await getUserByUsername(username)(dispatch, getState);
-        if (error) {
-            handleError(match, history);
-            return;
-        }
-        user = data;
-    }
-
-    openDirectChannelToUser(
-        user.id,
-        (channel) => {
-            doChannelChange(channel);
-        },
-        () => handleError(match, history)
-    );
-}
-
-async function goToDirectChannelByUserId(match, history, userId) {
-    const {team} = match.params;
-
-    let user = UserStore.getProfile(userId);
-    if (!user) {
-        const {data, error} = await getUser(userId)(dispatch, getState);
-        if (error) {
-            handleError(match, history);
-            return;
-        }
-        user = data;
-    }
-
-    history.replace(`/${team}/messages/@${user.username}`);
-}
-
-async function goToDirectChannelByUserIds(match, history) {
-    const {team, identifier} = match.params;
-    const userId = Utils.getUserIdFromChannelId(identifier.toLowerCase());
-
-    let user = UserStore.getProfile(userId);
-    if (!user) {
-        const {data, error} = await getUser(userId)(dispatch, getState);
-        if (error) {
-            handleError(match, history);
-            return;
-        }
-        user = data;
-    }
-
-    history.replace(`/${team}/messages/@${user.username}`);
-}
-
-async function goToDirectChannelByEmail(match, history) {
-    const {team, identifier} = match.params;
-    const email = identifier.toLowerCase();
-
-    let user = UserStore.getProfileByEmail(email);
-    if (!user) {
-        const {data, error} = await getUserByEmail(email)(dispatch, getState);
-        if (error) {
-            handleError(match, history);
-            return;
-        }
-        user = data;
-    }
-
-    history.replace(`/${team}/messages/@${user.username}`);
-}
-
-async function goToGroupChannelByGroupId(match, history) {
-    const {identifier, team} = match.params;
-    const groupId = identifier.toLowerCase();
-
-    history.replace(match.url.replace('/channels/', '/messages/'));
-
-    let channel = ChannelStore.getByName(groupId);
-    const teamObj = TeamStore.getByName(team);
-    if (!channel) {
-        const {data, error} = await dispatch(joinChannel(UserStore.getCurrentId(), teamObj.id, null, groupId));
-        if (error) {
-            handleError(match, history);
-            return;
-        }
-        channel = data.channel;
-    }
-
-    dispatch(markGroupChannelOpen(channel.id));
-
-    doChannelChange(channel);
-}
-
-function doChannelChange(channel) {
-    GlobalActions.emitChannelClickEvent(channel);
-}
-
-function handleError(match, history) {
-    const {team} = match.params;
-    history.push(team ? `/${team}/channels/${Constants.DEFAULT_CHANNEL}` : '/');
-}
-
-function handleChannelJoinError(match, history) {
-    const {team} = match.params;
-    history.push(team ? `/error?type=channel_not_found&returnTo=/${team}/channels/${Constants.DEFAULT_CHANNEL}` : '/');
-}
 
 export default class ChannelIdentifierRouter extends React.PureComponent {
     static propTypes = {
@@ -237,18 +18,22 @@ export default class ChannelIdentifierRouter extends React.PureComponent {
                 team: PropTypes.string.isRequired,
             }).isRequired,
         }).isRequired,
+
+        actions: PropTypes.shape({
+            onChannelByIdentifierEnter: PropTypes.func.isRequired,
+        }).isRequired,
     }
 
     constructor(props) {
         super(props);
 
-        onChannelByIdentifierEnter(props);
+        this.props.actions.onChannelByIdentifierEnter(props);
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
         if (this.props.match.params.team !== nextProps.match.params.team ||
             this.props.match.params.identifier !== nextProps.match.params.identifier) {
-            onChannelByIdentifierEnter(nextProps);
+            this.props.actions.onChannelByIdentifierEnter(nextProps);
         }
     }
 

--- a/components/channel_layout/channel_identifier_router/index.js
+++ b/components/channel_layout/channel_identifier_router/index.js
@@ -2,12 +2,19 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {withRouter} from 'react-router-dom';
+
+import {onChannelByIdentifierEnter} from './actions';
 
 import ChannelIdentifierRouter from './channel_identifier_router.jsx';
 
-function mapStateToProps() {
-    return {};
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            onChannelByIdentifierEnter,
+        }, dispatch),
+    };
 }
 
-export default withRouter(connect(mapStateToProps)(ChannelIdentifierRouter));
+export default withRouter(connect(null, mapDispatchToProps)(ChannelIdentifierRouter));


### PR DESCRIPTION
#### Summary
This mainly entailed turning the functions that were acting similar to action creators into actual redux action creators. I split out the actions into their own file as well.

QA, can you regression test loading the app at different team and channel URLs? For example loading to a DM using the `/teamname/messages/@username` and other similar URLs. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12662

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed