### PR TITLE
[MM-10569] Invite links won't work in mobile browser when the user is asked if they want to download the app

### DIFF
--- a/components/get_android_app/get_android_app.jsx
+++ b/components/get_android_app/get_android_app.jsx
@@ -3,14 +3,13 @@
 
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {Link} from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import {useSafeUrl} from 'utils/url';
 import MattermostIcon from 'images/favicon/android-chrome-192x192.png';
 import Nexus6Mockup from 'images/nexus-6p-mockup.png';
 
-export default function GetAndroidApp({androidAppDownloadLink}) {
+export default function GetAndroidApp({androidAppDownloadLink, history}) {
     return (
         <div className='get-app get-android-app'>
             <h1 className='get-app__header'>
@@ -41,7 +40,7 @@ export default function GetAndroidApp({androidAppDownloadLink}) {
                 </div>
             </div>
             <a
-                className='btn btn-primary get-android-app__continue'
+                className='btn btn-primary get-android-app__app-store-link'
                 href={useSafeUrl(androidAppDownloadLink)}
             >
                 <FormattedMessage
@@ -59,12 +58,16 @@ export default function GetAndroidApp({androidAppDownloadLink}) {
                     defaultMessage='Or {link}'
                     values={{
                         link: (
-                            <Link to='/'>
+                            <a
+                                onClick={history.goBack}
+                                className='get-android-app__continue'
+                            >
+
                                 <FormattedMessage
                                     id='get_app.continueWithBrowserLink'
                                     defaultMessage='continue with browser'
                                 />
-                            </Link>
+                            </a>
                         ),
                     }}
                 />

--- a/components/get_android_app/get_android_app.jsx
+++ b/components/get_android_app/get_android_app.jsx
@@ -9,7 +9,18 @@ import {useSafeUrl} from 'utils/url';
 import MattermostIcon from 'images/favicon/android-chrome-192x192.png';
 import Nexus6Mockup from 'images/nexus-6p-mockup.png';
 
-export default function GetAndroidApp({androidAppDownloadLink, history}) {
+export default function GetAndroidApp({androidAppDownloadLink, history, location}) {
+    const onContinue = (e) => {
+        e.preventDefault();
+
+        const redirectTo = (new URLSearchParams(location.search)).get('redirect_to');
+        if (redirectTo) {
+            history.push(redirectTo);
+        } else {
+            history.push('/');
+        }
+    };
+
     return (
         <div className='get-app get-android-app'>
             <h1 className='get-app__header'>
@@ -59,7 +70,7 @@ export default function GetAndroidApp({androidAppDownloadLink, history}) {
                     values={{
                         link: (
                             <a
-                                onClick={history.goBack}
+                                onClick={onContinue}
                                 className='get-android-app__continue'
                             >
 

--- a/components/get_ios_app/get_ios_app.jsx
+++ b/components/get_ios_app/get_ios_app.jsx
@@ -9,7 +9,18 @@ import {useSafeUrl} from 'utils/url';
 import AppStoreButton from 'images/app-store-button.png';
 import IPhone6Mockup from 'images/iphone-6-mockup.png';
 
-export default function GetIosApp({iosAppDownloadLink, history}) {
+export default function GetIosApp({iosAppDownloadLink, history, location}) {
+    const onContinue = (e) => {
+        e.preventDefault();
+
+        const redirectTo = (new URLSearchParams(location.search)).get('redirect_to');
+        if (redirectTo) {
+            history.push(redirectTo);
+        } else {
+            history.push('/');
+        }
+    };
+
     return (
         <div className='get-app get-ios-app'>
             <h1 className='get-app__header'>
@@ -52,7 +63,7 @@ export default function GetIosApp({iosAppDownloadLink, history}) {
                     values={{
                         link: (
                             <a
-                                onClick={history.goBack}
+                                onClick={onContinue}
                                 className='get-ios-app__continue'
                             >
 

--- a/components/get_ios_app/get_ios_app.jsx
+++ b/components/get_ios_app/get_ios_app.jsx
@@ -3,14 +3,13 @@
 
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {Link} from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import {useSafeUrl} from 'utils/url';
 import AppStoreButton from 'images/app-store-button.png';
 import IPhone6Mockup from 'images/iphone-6-mockup.png';
 
-export default function GetIosApp({iosAppDownloadLink}) {
+export default function GetIosApp({iosAppDownloadLink, history}) {
     return (
         <div className='get-app get-ios-app'>
             <h1 className='get-app__header'>
@@ -52,12 +51,16 @@ export default function GetIosApp({iosAppDownloadLink}) {
                     defaultMessage='Or {link}'
                     values={{
                         link: (
-                            <Link to='/'>
+                            <a
+                                onClick={history.goBack}
+                                className='get-ios-app__continue'
+                            >
+
                                 <FormattedMessage
                                     id='get_app.continueWithBrowserLink'
                                     defaultMessage='continue with browser'
                                 />
-                            </Link>
+                            </a>
                         ),
                     }}
                 />

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -201,10 +201,10 @@ export default class Root extends React.Component {
 
         // redirect to the mobile landing page if the user hasn't seen it before
         if (iosDownloadLink && UserAgent.isIosWeb() && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen) {
-            this.props.history.push('/get_ios_app');
+            this.props.history.push('/get_ios_app?redirect_to=' + encodeURIComponent(this.props.location.pathname) + encodeURIComponent(this.props.location.search));
             BrowserStore.setLandingPageSeen(true);
         } else if (androidDownloadLink && UserAgent.isAndroidWeb() && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen) {
-            this.props.history.push('/get_android_app');
+            this.props.history.push('/get_android_app?redirect_to=' + encodeURIComponent(this.props.location.pathname) + encodeURIComponent(this.props.location.search));
             BrowserStore.setLandingPageSeen(true);
         }
     }

--- a/tests/components/get_android_app/__snapshots__/get_android_app.test.jsx.snap
+++ b/tests/components/get_android_app/__snapshots__/get_android_app.test.jsx.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/GetAndroidApp should match snapshot 1`] = `
+<div
+  className="get-app get-android-app"
+>
+  <h1
+    className="get-app__header"
+  >
+    <FormattedMessage
+      defaultMessage="Mattermost works best if you switch to our Android app"
+      id="get_app.androidHeader"
+      values={Object {}}
+    />
+  </h1>
+  <hr />
+  <div>
+    <img
+      className="get-android-app__icon"
+      src="mockup.png"
+    />
+    <div
+      className="get-android-app__app-info"
+    >
+      <span
+        className="get-android-app__app-name"
+      >
+        <FormattedMessage
+          defaultMessage="Mattermost for Android"
+          id="get_app.androidAppName"
+          values={Object {}}
+        />
+      </span>
+      <span
+        className="get-android-app__app-creator"
+      >
+        <FormattedMessage
+          defaultMessage="Mattermost, Inc"
+          id="get_app.mattermostInc"
+          values={Object {}}
+        />
+      </span>
+    </div>
+  </div>
+  <a
+    className="btn btn-primary get-android-app__app-store-link"
+    href="https://about.mattermost.com/mattermost-android-app"
+  >
+    <FormattedMessage
+      defaultMessage="Continue"
+      id="get_app.continue"
+      values={Object {}}
+    />
+  </a>
+  <img
+    className="get-app__screenshot"
+    src="mockup.png"
+  />
+  <span
+    className="get-app__continue-with-browser"
+  >
+    <FormattedMessage
+      defaultMessage="Or {link}"
+      id="get_app.continueWithBrowser"
+      values={
+        Object {
+          "link": <a
+            className="get-android-app__continue"
+            onClick={[MockFunction]}
+          >
+            <FormattedMessage
+              defaultMessage="continue with browser"
+              id="get_app.continueWithBrowserLink"
+              values={Object {}}
+            />
+          </a>,
+        }
+      }
+    />
+  </span>
+</div>
+`;

--- a/tests/components/get_android_app/__snapshots__/get_android_app.test.jsx.snap
+++ b/tests/components/get_android_app/__snapshots__/get_android_app.test.jsx.snap
@@ -66,7 +66,7 @@ exports[`components/GetAndroidApp should match snapshot 1`] = `
         Object {
           "link": <a
             className="get-android-app__continue"
-            onClick={[MockFunction]}
+            onClick={[Function]}
           >
             <FormattedMessage
               defaultMessage="continue with browser"

--- a/tests/components/get_android_app/get_android_app.test.jsx
+++ b/tests/components/get_android_app/get_android_app.test.jsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+import GetAndroidApp from 'components/get_android_app/get_android_app.jsx';
+
+jest.mock('images/favicon/android-chrome-192x192.png', () => 'favicon.png');
+jest.mock('images/nexus-6p-mockup.png', () => 'mockup.png');
+
+describe('components/GetAndroidApp', () => {
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <GetAndroidApp
+                androidAppDownloadLink={'https://about.mattermost.com/mattermost-android-app'}
+                history={{goBack: jest.fn()}}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should contain the download link', () => {
+        const wrapper = shallow(
+            <GetAndroidApp
+                androidAppDownloadLink={'https://about.mattermost.com/mattermost-android-app'}
+                history={{goBack: jest.fn()}}
+            />
+        );
+
+        const link = wrapper.find('.get-android-app__app-store-link');
+        expect(link.prop('href')).toEqual('https://about.mattermost.com/mattermost-android-app');
+    });
+
+    test('should call go to previous page if user chooses to stay in the browser', () => {
+        const goBack = jest.fn();
+        const wrapper = mountWithIntl(
+            <GetAndroidApp
+                androidAppDownloadLink={'https://about.mattermost.com/mattermost-android-app'}
+                history={{goBack}}
+            />
+        );
+        expect(goBack).not.toHaveBeenCalled();
+
+        const link = wrapper.find('.get-android-app__continue');
+        link.simulate('click');
+        expect(goBack).toHaveBeenCalled();
+    });
+});

--- a/tests/components/get_android_app/get_android_app.test.jsx
+++ b/tests/components/get_android_app/get_android_app.test.jsx
@@ -15,7 +15,6 @@ describe('components/GetAndroidApp', () => {
         const wrapper = shallow(
             <GetAndroidApp
                 androidAppDownloadLink={'https://about.mattermost.com/mattermost-android-app'}
-                history={{goBack: jest.fn()}}
             />
         );
         expect(wrapper).toMatchSnapshot();
@@ -25,7 +24,6 @@ describe('components/GetAndroidApp', () => {
         const wrapper = shallow(
             <GetAndroidApp
                 androidAppDownloadLink={'https://about.mattermost.com/mattermost-android-app'}
-                history={{goBack: jest.fn()}}
             />
         );
 
@@ -33,18 +31,35 @@ describe('components/GetAndroidApp', () => {
         expect(link.prop('href')).toEqual('https://about.mattermost.com/mattermost-android-app');
     });
 
-    test('should call go to previous page if user chooses to stay in the browser', () => {
-        const goBack = jest.fn();
+    test('should redirect if the user chooses to stay in the browser. Redirect url param is present', () => {
+        const push = jest.fn();
         const wrapper = mountWithIntl(
             <GetAndroidApp
                 androidAppDownloadLink={'https://about.mattermost.com/mattermost-android-app'}
-                history={{goBack}}
+                history={{push}}
+                location={{search: '?redirect_to=last_page'}}
             />
         );
-        expect(goBack).not.toHaveBeenCalled();
+        expect(push).not.toHaveBeenCalled();
 
         const link = wrapper.find('.get-android-app__continue');
         link.simulate('click');
-        expect(goBack).toHaveBeenCalled();
+        expect(push).toHaveBeenCalledWith('last_page');
+    });
+
+    test('should redirect if the user chooses to stay in the browser. Redirect url param is not present', () => {
+        const push = jest.fn();
+        const wrapper = mountWithIntl(
+            <GetAndroidApp
+                androidAppDownloadLink={'https://about.mattermost.com/mattermost-android-app'}
+                history={{push}}
+                location={{search: ''}}
+            />
+        );
+        expect(push).not.toHaveBeenCalled();
+
+        const link = wrapper.find('.get-android-app__continue');
+        link.simulate('click');
+        expect(push).toHaveBeenCalledWith('/');
     });
 });

--- a/tests/components/get_ios_app/__snapshots__/get_ios_app.test.jsx.snap
+++ b/tests/components/get_ios_app/__snapshots__/get_ios_app.test.jsx.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/GetIosApp should match snapshot 1`] = `
+<div
+  className="get-app get-ios-app"
+>
+  <h1
+    className="get-app__header"
+  >
+    <FormattedMessage
+      defaultMessage="Mattermost works best if you switch to our iPhone app"
+      id="get_app.iosHeader"
+      values={Object {}}
+    />
+  </h1>
+  <hr />
+  <a
+    className="get-ios-app__app-store-link"
+    href="https://about.mattermost.com/mattermost-ios-app"
+    rel="noopener noreferrer"
+  >
+    <img
+      src="mockup.png"
+    />
+  </a>
+  <img
+    className="get-app__screenshot"
+    src="mockup.png"
+  />
+  <h2
+    className="get-ios-app__already-have-it"
+  >
+    <FormattedMessage
+      defaultMessage="Already have it?"
+      id="get_app.alreadyHaveIt"
+      values={Object {}}
+    />
+  </h2>
+  <a
+    className="btn btn-primary get-ios-app__open-mattermost"
+    href="mattermost://"
+  >
+    <FormattedMessage
+      defaultMessage="Open Mattermost"
+      id="get_app.openMattermost"
+      values={Object {}}
+    />
+  </a>
+  <span
+    className="get-app__continue-with-browser"
+  >
+    <FormattedMessage
+      defaultMessage="Or {link}"
+      id="get_app.continueWithBrowser"
+      values={
+        Object {
+          "link": <a
+            className="get-ios-app__continue"
+            onClick={[MockFunction]}
+          >
+            <FormattedMessage
+              defaultMessage="continue with browser"
+              id="get_app.continueWithBrowserLink"
+              values={Object {}}
+            />
+          </a>,
+        }
+      }
+    />
+  </span>
+</div>
+`;

--- a/tests/components/get_ios_app/__snapshots__/get_ios_app.test.jsx.snap
+++ b/tests/components/get_ios_app/__snapshots__/get_ios_app.test.jsx.snap
@@ -56,7 +56,7 @@ exports[`components/GetIosApp should match snapshot 1`] = `
         Object {
           "link": <a
             className="get-ios-app__continue"
-            onClick={[MockFunction]}
+            onClick={[Function]}
           >
             <FormattedMessage
               defaultMessage="continue with browser"

--- a/tests/components/get_ios_app/get_ios_app.test.jsx
+++ b/tests/components/get_ios_app/get_ios_app.test.jsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+import GetIosApp from 'components/get_ios_app/get_ios_app.jsx';
+
+jest.mock('images/app-store-button.png', () => 'store-button.png');
+jest.mock('images/iphone-6-mockup.png', () => 'mockup.png');
+
+describe('components/GetIosApp', () => {
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <GetIosApp
+                iosAppDownloadLink={'https://about.mattermost.com/mattermost-ios-app'}
+                history={{goBack: jest.fn()}}
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should contain the download link', () => {
+        const wrapper = shallow(
+            <GetIosApp
+                iosAppDownloadLink={'https://about.mattermost.com/mattermost-ios-app'}
+                history={{goBack: jest.fn()}}
+            />
+        );
+
+        const link = wrapper.find('.get-ios-app__app-store-link');
+        expect(link.prop('href')).toEqual('https://about.mattermost.com/mattermost-ios-app');
+    });
+
+    test('should return to previous page if user chooses to stay in the browser', () => {
+        const goBack = jest.fn();
+        const wrapper = mountWithIntl(
+            <GetIosApp
+                iosAppDownloadLink={'https://about.mattermost.com/mattermost-ios-app'}
+                history={{goBack}}
+            />
+        );
+        expect(goBack).not.toHaveBeenCalled();
+
+        const link = wrapper.find('.get-ios-app__continue');
+        link.simulate('click');
+        expect(goBack).toHaveBeenCalled();
+    });
+});

--- a/tests/components/get_ios_app/get_ios_app.test.jsx
+++ b/tests/components/get_ios_app/get_ios_app.test.jsx
@@ -15,7 +15,6 @@ describe('components/GetIosApp', () => {
         const wrapper = shallow(
             <GetIosApp
                 iosAppDownloadLink={'https://about.mattermost.com/mattermost-ios-app'}
-                history={{goBack: jest.fn()}}
             />
         );
 
@@ -26,7 +25,6 @@ describe('components/GetIosApp', () => {
         const wrapper = shallow(
             <GetIosApp
                 iosAppDownloadLink={'https://about.mattermost.com/mattermost-ios-app'}
-                history={{goBack: jest.fn()}}
             />
         );
 
@@ -34,18 +32,37 @@ describe('components/GetIosApp', () => {
         expect(link.prop('href')).toEqual('https://about.mattermost.com/mattermost-ios-app');
     });
 
-    test('should return to previous page if user chooses to stay in the browser', () => {
-        const goBack = jest.fn();
+    test('should redirect if the user chooses to stay in the browser. Redirect url param is present', () => {
+        const push = jest.fn();
         const wrapper = mountWithIntl(
             <GetIosApp
                 iosAppDownloadLink={'https://about.mattermost.com/mattermost-ios-app'}
-                history={{goBack}}
+                history={{push}}
+                location={{search: '?redirect_to=last_page'}}
             />
         );
-        expect(goBack).not.toHaveBeenCalled();
+
+        expect(push).not.toHaveBeenCalled();
 
         const link = wrapper.find('.get-ios-app__continue');
         link.simulate('click');
-        expect(goBack).toHaveBeenCalled();
+        expect(push).toHaveBeenCalledWith('last_page');
+    });
+
+    test('should redirect if the user chooses to stay in the browser. Redirect url param is not present', () => {
+        const push = jest.fn();
+        const wrapper = mountWithIntl(
+            <GetIosApp
+                iosAppDownloadLink={'https://about.mattermost.com/mattermost-ios-app'}
+                history={{push}}
+                location={{search: ''}}
+            />
+        );
+
+        expect(push).not.toHaveBeenCalled();
+
+        const link = wrapper.find('.get-ios-app__continue');
+        link.simulate('click');
+        expect(push).toHaveBeenCalledWith('/');
     });
 });


### PR DESCRIPTION
#### Summary
Fixes issue with first-time mobile viewers being indirected to sign up page incorrectly.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/8782
https://mattermost.atlassian.net/browse/MM-10569


#### Checklist

- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed

As @esethna pointed out in the github ticket, the query parameter for the invite link is dropped off when the user is redirected to the "Download App" page.
The `/` route is used for the "continue with browser" link, which in turn resolves to `/login`, so the user loses the team invite link's context.

For the solution, we are using a redirect url param to hook into the previous page.