### PR TITLE
[WIP][MM-10682] Emoji picker for mobile web view

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -736,9 +736,12 @@ export default class CreateComment extends React.PureComponent {
                 >
                     <EmojiPickerOverlay
                         show={this.state.showEmojiPicker}
-                        container={this.props.getSidebarBody}
+                        // - allows picker to be added on top of everything
+                        //   for mobile fullscreensupport
+                        // container={this.props.getSidebarBody}
                         target={this.getCreateCommentControls}
                         onHide={this.hideEmojiPicker}
+                        onEmojiClose={this.hideEmojiPicker}
                         onEmojiClick={this.handleEmojiClick}
                         onGifClick={this.handleGifClick}
                         enableGifPicker={this.props.enableGifPicker}

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -736,8 +736,9 @@ export default class CreateComment extends React.PureComponent {
                 >
                     <EmojiPickerOverlay
                         show={this.state.showEmojiPicker}
-                        // - allows picker to be added on top of everything
-                        //   for mobile fullscreensupport
+
+                        // - removing allows picker to be added on top
+                        //   of everything for mobile fullscreen support
                         // container={this.props.getSidebarBody}
                         target={this.getCreateCommentControls}
                         onHide={this.hideEmojiPicker}

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -969,7 +969,7 @@ export default class CreatePost extends React.Component {
                         onEmojiClick={this.handleEmojiClick}
                         onGifClick={this.handleGifClick}
                         enableGifPicker={this.props.enableGifPicker}
-                        rightOffset={15}
+                        rightOffset={12}
                         topOffset={-7}
                     />
                     <EmojiIcon

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -961,7 +961,9 @@ export default class CreatePost extends React.Component {
                 >
                     <EmojiPickerOverlay
                         show={this.state.showEmojiPicker}
-                        container={getChannelView}
+                        // - removed defined container to position picker
+                        // - above everything for fullscreen on web mobile
+                        // container={getChannelView}
                         target={this.getCreatePostControls}
                         onHide={this.hideEmojiPicker}
                         onEmojiClick={this.handleEmojiClick}

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -858,7 +858,6 @@ export default class CreatePost extends React.Component {
             currentChannelMembersCount,
             draft,
             fullWidthTextBox,
-            getChannelView,
             showTutorialTip,
             readOnlyChannel,
         } = this.props;
@@ -966,8 +965,9 @@ export default class CreatePost extends React.Component {
                 >
                     <EmojiPickerOverlay
                         show={this.state.showEmojiPicker}
-                        // - allows picker to be added on top of everything
-                        //   for mobile fullscreensupport
+
+                        // - removing allows picker to be added on top
+                        //   of everything for mobile fullscreen support
                         // container={getChannelView}
                         target={this.getCreatePostControls}
                         onHide={this.hideEmojiPicker}

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -773,6 +773,11 @@ export default class CreatePost extends React.Component {
         });
     }
 
+    handleEmojiClose = () => {
+        this.setState({showEmojiPicker: false});
+        this.focusTextbox();
+    }
+
     handleEmojiClick = (emoji) => {
         const emojiAlias = emoji.name || emoji.aliases[0];
 
@@ -961,11 +966,12 @@ export default class CreatePost extends React.Component {
                 >
                     <EmojiPickerOverlay
                         show={this.state.showEmojiPicker}
-                        // - removed defined container to position picker
-                        // - above everything for fullscreen on web mobile
+                        // - allows picker to be added on top of everything
+                        //   for mobile fullscreensupport
                         // container={getChannelView}
                         target={this.getCreatePostControls}
                         onHide={this.hideEmojiPicker}
+                        onEmojiClose={this.handleEmojiClose}
                         onEmojiClick={this.handleEmojiClick}
                         onGifClick={this.handleGifClick}
                         enableGifPicker={this.props.enableGifPicker}

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -127,8 +127,9 @@ export default class DotMenu extends Component {
     // listen to clicks/taps on add reaction menu item and pass to parent handler
     handleAddReactionenuItemActivated = (e) => {
         e.preventDefault();
+
         // to be safe, make sure the handler function has been defined
-        if(typeof this.props.handleAddReactionClick === 'function') {
+        if (typeof this.props.handleAddReactionClick === 'function') {
             this.props.handleAddReactionClick();
         }
     }
@@ -179,12 +180,11 @@ export default class DotMenu extends Component {
         const canEdit = PostUtils.canEditPost(this.props.post, this.editDisableAction); // Fix this crazy
 
         const menuItems = [];
-
         if (isMobile && !isSystemMessage) {
             // add menu item to support adding reactions to posts
             // - only add if handler is defined as this menu is used in
             //   multiple locations, not all requiring reaction functionality
-            if(typeof this.props.handleAddReactionClick === 'function') {
+            if (typeof this.props.handleAddReactionClick === 'function') {
                 menuItems.push(
                     <DotMenuItem
                         key={'react'}

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -28,6 +28,7 @@ export default class DotMenu extends Component {
         isFlagged: PropTypes.bool,
         handleCommentClick: PropTypes.func,
         handleDropdownOpened: PropTypes.func,
+        handleAddReactionClick: PropTypes.func,
         isReadOnly: PropTypes.bool,
         pluginMenuItems: PropTypes.arrayOf(PropTypes.object),
 
@@ -123,6 +124,12 @@ export default class DotMenu extends Component {
         }
     }
 
+    // listen to clicks/taps on add reaction menu item and pass to parent handler
+    handleAddReactionenuItemActivated = (e) => {
+        e.preventDefault();
+        this.props.handleAddReactionClick();
+    }
+
     handlePermalinkMenuItemActivated = (e) => {
         e.preventDefault();
         showGetPostLinkModal(this.props.post);
@@ -171,6 +178,19 @@ export default class DotMenu extends Component {
         const menuItems = [];
 
         if (isMobile && !isSystemMessage) {
+            // add menu item to support adding reactions to posts
+            menuItems.push(
+                <DotMenuItem
+                    key={'react'}
+                    menuItemText={
+                        <FormattedMessage
+                            id={'rhs_root.mobile.react'}
+                            defaultMessage={'Add Reaction'}
+                        />
+                    }
+                    handleMenuItemActivated={this.handleAddReactionenuItemActivated}
+                />
+            );
             let text = (
                 <FormattedMessage
                     id={'rhs_root.mobile.flag'}

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -127,7 +127,10 @@ export default class DotMenu extends Component {
     // listen to clicks/taps on add reaction menu item and pass to parent handler
     handleAddReactionenuItemActivated = (e) => {
         e.preventDefault();
-        this.props.handleAddReactionClick();
+        // to be safe, make sure the handler function has been defined
+        if(typeof this.props.handleAddReactionClick === 'function') {
+            this.props.handleAddReactionClick();
+        }
     }
 
     handlePermalinkMenuItemActivated = (e) => {
@@ -179,18 +182,22 @@ export default class DotMenu extends Component {
 
         if (isMobile && !isSystemMessage) {
             // add menu item to support adding reactions to posts
-            menuItems.push(
-                <DotMenuItem
-                    key={'react'}
-                    menuItemText={
-                        <FormattedMessage
-                            id={'rhs_root.mobile.react'}
-                            defaultMessage={'Add Reaction'}
-                        />
-                    }
-                    handleMenuItemActivated={this.handleAddReactionenuItemActivated}
-                />
-            );
+            // - only add if handler is defined as this menu is used in
+            //   multiple locations, not all requiring reaction functionality
+            if(typeof this.props.handleAddReactionClick === 'function') {
+                menuItems.push(
+                    <DotMenuItem
+                        key={'react'}
+                        menuItemText={
+                            <FormattedMessage
+                                id={'rhs_root.mobile.react'}
+                                defaultMessage={'Add Reaction'}
+                            />
+                        }
+                        handleMenuItemActivated={this.handleAddReactionenuItemActivated}
+                    />
+                );
+            }
             let text = (
                 <FormattedMessage
                     id={'rhs_root.mobile.flag'}

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -115,6 +115,11 @@ export default class EditPostModal extends React.PureComponent {
         }
     }
 
+    handleEmojiClose = () => {
+        this.setState({showEmojiPicker: false});
+        this.editbox.focus();
+    }
+
     handleEmojiClick = (emoji) => {
         const emojiAlias = emoji && (emoji.name || (emoji.aliases && emoji.aliases[0]));
 
@@ -286,9 +291,12 @@ export default class EditPostModal extends React.PureComponent {
                 <span className='emoji-picker__container'>
                     <EmojiPickerOverlay
                         show={this.state.showEmojiPicker}
-                        container={this.getContainer}
+                        // - allows picker to be added on top of everything
+                        //   for mobile fullscreensupport
+                        // container={this.getContainer}
                         target={this.getEditPostControls}
                         onHide={this.hideEmojiPicker}
+                        onEmojiClose={this.handleEmojiClose}
                         onEmojiClick={this.handleEmojiClick}
                         onGifClick={this.handleGifClick}
                         enableGifPicker={this.props.config.EnableGifPicker === 'true'}

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -98,7 +98,7 @@ export default class EditPostModal extends React.PureComponent {
     }
 
     getContainer = () => {
-        return this.refs.editModalBody;
+        return this.refs.emojiPickerContainer;
     }
 
     toggleEmojiPicker = () => {
@@ -291,9 +291,7 @@ export default class EditPostModal extends React.PureComponent {
                 <span className='emoji-picker__container'>
                     <EmojiPickerOverlay
                         show={this.state.showEmojiPicker}
-                        // - allows picker to be added on top of everything
-                        //   for mobile fullscreensupport
-                        // container={this.getContainer}
+                        container={this.getContainer}
                         target={this.getEditPostControls}
                         onHide={this.hideEmojiPicker}
                         onEmojiClose={this.handleEmojiClose}
@@ -384,6 +382,16 @@ export default class EditPostModal extends React.PureComponent {
                         />
                     </button>
                 </Modal.Footer>
+                {/*
+                    Custom container for emoji picker to support fullscreen
+                    on mobile screens < 480 and positioning with the edit modal
+                    on screens > 480
+                */}
+                <div
+                    ref="emojiPickerContainer"
+                    className="modal-emoji-container"
+                    >
+                </div>
             </Modal>
         );
     }

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -388,10 +388,9 @@ export default class EditPostModal extends React.PureComponent {
                     on screens > 480
                 */}
                 <div
-                    ref="emojiPickerContainer"
-                    className="modal-emoji-container"
-                    >
-                </div>
+                    ref='emojiPickerContainer'
+                    className='modal-emoji-container'
+                />
             </Modal>
         );
     }

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -478,16 +478,16 @@ export default class EmojiPicker extends React.PureComponent {
     // create header markup for fullscreen picker on web mobile
     emojiHeader() {
         return (
-            <div className="emoji-picker__header modal-header">
+            <div className='emoji-picker__header modal-header'>
                 <button
-                    type="button"
-                    className="close emoji-picker__header-close-button"
+                    type='button'
+                    className='close emoji-picker__header-close-button'
                     onClick={this.handleEmojiPickerClose}
-                    >
-                    <span aria-hidden="true">×</span>
-                    <span className="sr-only">Close</span>
+                >
+                    <span aria-hidden='true'>{'×'}</span>
+                    <span className='sr-only'>{Utils.localizeMessage('emoji_picker.close', 'Close')}</span>
                 </button>
-                <h4 className="modal-title emoji-picker__header-title">
+                <h4 className='modal-title emoji-picker__header-title'>
                     <FormattedMessage
                         id={'emoji_picker.header'}
                         defaultMessage={'Emoji Picker'}

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -118,6 +118,7 @@ const LOAD_MORE_AT_PIXELS_FROM_BOTTOM = 500;
 export default class EmojiPicker extends React.PureComponent {
     static propTypes = {
         listHeight: PropTypes.number,
+        onEmojiClose: PropTypes.func.isRequired,
         onEmojiClick: PropTypes.func.isRequired,
         customEmojisEnabled: PropTypes.bool,
         emojiMap: PropTypes.object.isRequired,
@@ -139,7 +140,7 @@ export default class EmojiPicker extends React.PureComponent {
     constructor(props) {
         super(props);
 
-        this.handleEmojiPickerClick = this.handleEmojiPickerClick.bind(this);
+        this.handleEmojiPickerClose = this.handleEmojiPickerClose.bind(this);
         this.handleCategoryClick = this.handleCategoryClick.bind(this);
         this.handleFilterChange = this.handleFilterChange.bind(this);
         this.handleItemOver = this.handleItemOver.bind(this);
@@ -251,8 +252,8 @@ export default class EmojiPicker extends React.PureComponent {
         this.searchInput = input;
     };
 
-    handleEmojiPickerClick() {
-        console.log('works!!');
+    handleEmojiPickerClose() {
+        this.props.onEmojiClose();
     }
 
     handleCategoryClick(categoryName) {
@@ -481,8 +482,8 @@ export default class EmojiPicker extends React.PureComponent {
             <div className="emoji-picker__header modal-header">
                 <button
                     type="button"
-                    className="close emoji-picker__header-button"
-                    onClick={this.handleEmojiPickerClick}
+                    className="close emoji-picker__header-close-button"
+                    onClick={this.handleEmojiPickerClose}
                     >
                     <span aria-hidden="true">×</span>
                     <span className="sr-only">Close</span>

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -4,6 +4,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import throttle from 'lodash/throttle';
+import {Modal} from 'react-bootstrap';
+import {FormattedMessage} from 'react-intl';
 
 import EmojiStore from 'stores/emoji_store.jsx';
 import * as Emoji from 'utils/emoji.jsx';
@@ -137,6 +139,7 @@ export default class EmojiPicker extends React.PureComponent {
     constructor(props) {
         super(props);
 
+        this.handleEmojiPickerClick = this.handleEmojiPickerClick.bind(this);
         this.handleCategoryClick = this.handleCategoryClick.bind(this);
         this.handleFilterChange = this.handleFilterChange.bind(this);
         this.handleItemOver = this.handleItemOver.bind(this);
@@ -247,6 +250,10 @@ export default class EmojiPicker extends React.PureComponent {
     emojiSearchInput = (input) => {
         this.searchInput = input;
     };
+
+    handleEmojiPickerClick() {
+        console.log('works!!');
+    }
 
     handleCategoryClick(categoryName) {
         this.emojiPickerContainer.scrollTop = this.state.categories[categoryName].offset;
@@ -468,6 +475,23 @@ export default class EmojiPicker extends React.PureComponent {
         return <div className='emoji-picker__categories'>{emojiPickerCategories}</div>;
     }
 
+    // create header markup for fullscreen picker on web mobile
+    emojiHeader() {
+        return (
+            <div className="emoji-picker__header modal-header">
+                <button
+                    type="button"
+                    className="close emoji-picker__header-button"
+                    onClick={this.handleEmojiPickerClick}
+                    >
+                    <span aria-hidden="true">×</span>
+                    <span className="sr-only">Close</span>
+                </button>
+                <h4 className="modal-title emoji-picker__header-title"><span>Emoji Picker</span></h4>
+            </div>
+        );
+    }
+
     emojiSearch() {
         return (
             <div className='emoji-picker__search-container'>
@@ -582,6 +606,7 @@ export default class EmojiPicker extends React.PureComponent {
     render() {
         return (
             <div>
+                {this.emojiHeader()}
                 {this.emojiSearch()}
                 {this.emojiCategories()}
                 {this.emojiCurrentResults()}

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -605,7 +605,7 @@ export default class EmojiPicker extends React.PureComponent {
 
     render() {
         return (
-            <div>
+            <div className='emoji-picker__inner'>
                 {this.emojiHeader()}
                 {this.emojiSearch()}
                 {this.emojiCategories()}

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import throttle from 'lodash/throttle';
-import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import EmojiStore from 'stores/emoji_store.jsx';
@@ -488,7 +487,12 @@ export default class EmojiPicker extends React.PureComponent {
                     <span aria-hidden="true">×</span>
                     <span className="sr-only">Close</span>
                 </button>
-                <h4 className="modal-title emoji-picker__header-title"><span>Emoji Picker</span></h4>
+                <h4 className="modal-title emoji-picker__header-title">
+                    <FormattedMessage
+                        id={'emoji_picker.header'}
+                        defaultMessage={'Emoji Picker'}
+                    />
+                </h4>
             </div>
         );
     }

--- a/components/emoji_picker/emoji_picker_overlay.jsx
+++ b/components/emoji_picker/emoji_picker_overlay.jsx
@@ -22,6 +22,7 @@ export default class EmojiPickerOverlay extends React.PureComponent {
         show: PropTypes.bool.isRequired,
         container: PropTypes.func,
         target: PropTypes.func.isRequired,
+        onEmojiClose: PropTypes.func.isRequired,
         onEmojiClick: PropTypes.func.isRequired,
         onGifClick: PropTypes.func,
         onHide: PropTypes.func.isRequired,
@@ -77,6 +78,7 @@ export default class EmojiPickerOverlay extends React.PureComponent {
             >
                 <EmojiPickerTabs
                     enableGifPicker={this.props.enableGifPicker}
+                    onEmojiClose={this.props.onEmojiClose}
                     onEmojiClick={this.props.onEmojiClick}
                     onGifClick={this.props.onGifClick}
                     rightOffset={this.props.rightOffset}

--- a/components/emoji_picker/emoji_picker_tabs.jsx
+++ b/components/emoji_picker/emoji_picker_tabs.jsx
@@ -18,6 +18,7 @@ export default class EmojiPickerTabs extends PureComponent {
         topOffset: PropTypes.number,
         placement: PropTypes.oneOf(['top', 'bottom', 'left']),
         customEmojis: PropTypes.object,
+        onEmojiClose: PropTypes.func.isRequired,
         onEmojiClick: PropTypes.func.isRequired,
         onGifClick: PropTypes.func,
         enableGifPicker: PropTypes.bool,
@@ -89,6 +90,7 @@ export default class EmojiPickerTabs extends PureComponent {
                     >
                         <EmojiPicker
                             style={this.props.style}
+                            onEmojiClose={this.props.onEmojiClose}
                             onEmojiClick={this.props.onEmojiClick}
                             customEmojis={this.props.customEmojis}
                             visible={this.state.emojiTabVisible}
@@ -114,6 +116,7 @@ export default class EmojiPickerTabs extends PureComponent {
             >
                 <EmojiPicker
                     style={this.props.style}
+                    onEmojiClose={this.props.onEmojiClose}
                     onEmojiClick={this.props.onEmojiClick}
                     customEmojis={this.props.customEmojis}
                 />

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -233,8 +233,9 @@ export default class PostInfo extends React.PureComponent {
                         <div>
                             <EmojiPickerOverlay
                                 show={this.state.showEmojiPicker}
-                                // - allows picker to be added on top of everything
-                                //   for mobile fullscreensupport
+
+                                // - removing allows picker to be added on top
+                                //   of everything for mobile fullscreen support
                                 // container={this.props.getPostList}
                                 target={this.getDotMenu}
                                 onHide={this.hideEmojiPicker}

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -229,7 +229,9 @@ export default class PostInfo extends React.PureComponent {
                         <div>
                             <EmojiPickerOverlay
                                 show={this.state.showEmojiPicker}
-                                container={this.props.getPostList}
+                                // - removed defined container to position picker
+                                // - above everything for fullscreen on web mobile
+                                // container={this.props.getPostList}
                                 target={this.getDotMenu}
                                 onHide={this.hideEmojiPicker}
                                 onEmojiClick={this.reactEmojiClick}

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -151,6 +151,10 @@ export default class PostInfo extends React.PureComponent {
         );
     };
 
+    reactEmojiClose = () => {
+        this.setState({showEmojiPicker: false});
+    }
+
     reactEmojiClick = (emoji) => {
         const pickerOffset = 21;
         this.setState({showEmojiPicker: false, reactionPickerOffset: pickerOffset});
@@ -229,11 +233,12 @@ export default class PostInfo extends React.PureComponent {
                         <div>
                             <EmojiPickerOverlay
                                 show={this.state.showEmojiPicker}
-                                // - removed defined container to position picker
-                                // - above everything for fullscreen on web mobile
+                                // - allows picker to be added on top of everything
+                                //   for mobile fullscreensupport
                                 // container={this.props.getPostList}
                                 target={this.getDotMenu}
                                 onHide={this.hideEmojiPicker}
+                                onEmojiClose={this.reactEmojiClose}
                                 onEmojiClick={this.reactEmojiClick}
                                 rightOffset={12}
                                 topOffset={-7}

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -264,6 +264,7 @@ export default class PostInfo extends React.PureComponent {
                     isFlagged={this.props.isFlagged}
                     handleCommentClick={this.props.handleCommentClick}
                     handleDropdownOpened={this.handleDotMenuOpened}
+                    handleAddReactionClick={this.toggleEmojiPicker}
                     isReadOnly={isReadOnly}
                 />
             );

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -235,7 +235,8 @@ export default class PostInfo extends React.PureComponent {
                                 target={this.getDotMenu}
                                 onHide={this.hideEmojiPicker}
                                 onEmojiClick={this.reactEmojiClick}
-                                rightOffset={7}
+                                rightOffset={12}
+                                topOffset={-7}
                             />
                             <OverlayTrigger
                                 className='hidden-xs'

--- a/components/post_view/reaction_list/reaction_list.jsx
+++ b/components/post_view/reaction_list/reaction_list.jsx
@@ -83,6 +83,10 @@ export default class ReactionListView extends React.PureComponent {
         return this.refs.addReactionButton;
     }
 
+    handleEmojiClose = () => {
+        this.setState({showEmojiPicker: false});
+    }
+
     handleEmojiClick = (emoji) => {
         this.setState({showEmojiPicker: false});
         const emojiName = emoji.name || emoji.aliases[0];
@@ -158,6 +162,7 @@ export default class ReactionListView extends React.PureComponent {
                         show={this.state.showEmojiPicker}
                         target={this.getTarget}
                         onHide={this.hideEmojiPicker}
+                        onEmojiClose={this.handleEmojiClose}
                         onEmojiClick={this.handleEmojiClick}
                         rightOffset={rightOffset}
                         topOffset={-5}

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -376,6 +376,7 @@ export default class RhsComment extends React.Component {
                             show={this.state.showEmojiPicker}
                             onHide={this.toggleEmojiPicker}
                             target={this.getDotMenuRef}
+                            onEmojiClose={this.toggleEmojiPicker}
                             onEmojiClick={this.reactEmojiClick}
                             rightOffset={15}
                             spaceRequiredAbove={EmojiPickerOverlay.RHS_SPACE_REQUIRED_ABOVE}

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -408,6 +408,7 @@ export default class RhsComment extends React.Component {
                     location={'RHS_COMMENT'}
                     isFlagged={this.props.isFlagged}
                     handleDropdownOpened={this.handleDropdownOpened}
+                    handleAddReactionClick={this.toggleEmojiPicker}
                     isReadOnly={isReadOnly || channelIsArchived}
                 />
             );

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -232,6 +232,7 @@ export default class RhsRootPost extends React.Component {
                             show={this.state.showEmojiPicker}
                             onHide={this.toggleEmojiPicker}
                             target={this.getDotMenuRef}
+                            onEmojiClose={this.toggleEmojiPicker}
                             onEmojiClick={this.reactEmojiClick}
                             rightOffset={15}
                             spaceRequiredAbove={EmojiPickerOverlay.RHS_SPACE_REQUIRED_ABOVE}

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -330,6 +330,7 @@ export default class RhsRootPost extends React.Component {
                 location={'RHS_ROOT'}
                 isFlagged={this.props.isFlagged}
                 handleDropdownOpened={this.handleDropdownOpened}
+                handleAddReactionClick={this.toggleEmojiPicker}
                 commentCount={this.props.commentCount}
                 isReadOnly={isReadOnly || channelIsArchived}
             />

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1772,6 +1772,7 @@
   "emoji_list.name": "Name",
   "emoji_list.search": "Search Custom Emoji",
   "emoji_picker.activity": "Activity",
+  "emoji_picker.close": "Close",
   "emoji_picker.custom": "Custom",
   "emoji_picker.emojiPicker": "Emoji Picker",
   "emoji_picker.flags": "Flags",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2398,6 +2398,7 @@
   "rhs_root.direct": "Direct Message",
   "rhs_root.mobile.flag": "Flag",
   "rhs_root.mobile.unflag": "Unflag",
+  "rhs_root.mobile.react": "Add Reaction",
   "rhs_thread.rootPostDeletedMessage.body": "Part of this thread has been deleted due to a data retention policy. You can no longer reply to this thread.",
   "save_button.save": "Save",
   "save_button.saving": "Saving",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1776,6 +1776,7 @@
   "emoji_picker.emojiPicker": "Emoji Picker",
   "emoji_picker.flags": "Flags",
   "emoji_picker.foods": "Foods",
+  "emoji_picker.header": "Emoji Picker",
   "emoji_picker.nature": "Nature",
   "emoji_picker.objects": "Objects",
   "emoji_picker.people": "People",

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -59,6 +59,12 @@
     position: absolute;
     width: 315px;
     z-index: 999;
+    top: 0 !important;
+    right: auto !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    z-index: 10000 !important;
 
     .browser--ie & {
         width: 325px;
@@ -132,6 +138,25 @@
 
         &.disable {
             pointer-events: none;
+        }
+    }
+}
+
+.emoji-picker__header {
+    // display: none; // only visible < 480px width screen
+    background: darken($primary-color, 10%);
+    border: 1px solid $light-gray;
+    color: $white;
+
+    .emoji-picker__header-button {
+        width: 30px;
+        height: 30px;
+        opacity: 1;
+        color: $white;
+        background: transparent;
+
+        &:hover {
+            background: rgba($black, 0.1);
         }
     }
 }

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -47,6 +47,22 @@
     vertical-align: middle;
 }
 
+// Custom container for emoji picker to support fullscreen
+// on mobile screens < 480 and positioning with the edit modal
+// on screens > 480
+.modal-emoji-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+
+    > * {
+        pointer-events: all;
+    }
+}
+
 .emoji-picker {
     @include border-radius($border-rad);
     @include clearfix;

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -59,12 +59,6 @@
     position: absolute;
     width: 315px;
     z-index: 999;
-    top: 0 !important;
-    right: auto !important;
-    left: 0 !important;
-    width: 100% !important;
-    height: 100% !important;
-    z-index: 10000 !important;
 
     .browser--ie & {
         width: 325px;
@@ -143,7 +137,7 @@
 }
 
 .emoji-picker__header {
-    // display: none; // only visible < 480px width screen
+    display: none; // only visible < 480px width screen
     background: darken($primary-color, 10%);
     border: 1px solid $light-gray;
     color: $white;
@@ -197,6 +191,7 @@
     padding: 0 8px 8px;
     position: relative;
     width: 100%;
+    background: $bg--gray;
 
     .emoji-picker__container {
         min-height: 100%;

--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -138,11 +138,17 @@
 
 .emoji-picker__header {
     display: none; // only visible < 480px width screen
-    background: darken($primary-color, 10%);
+    padding: 13px 10px 13px 15px;
+    background: $primary-color;
     border: 1px solid $light-gray;
     color: $white;
 
-    .emoji-picker__header-button {
+    .emoji-picker__header-title {
+        margin-top: 2px;
+        font-size: 17px;
+    }
+
+    .emoji-picker__header-close-button {
         width: 30px;
         height: 30px;
         opacity: 1;

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1637,7 +1637,8 @@
         margin: 0;
         text-rendering: auto;
         position: relative;
-        z-index: 5;
+        // previous value of 5 interferred with search help popup
+        z-index: 4;
 
         &.pull-left {
             margin: 4px 5px 0 0;

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -430,7 +430,7 @@
         }
 
         &.custom-textarea--emoji-picker {
-            padding-right: 80px;
+            padding-right: 130px;
         }
 
         &.textbox-preview-area {
@@ -463,7 +463,7 @@
             }
 
             &.custom-textarea--emoji-picker {
-                padding-right: 90px;
+                padding-right: 140px;
             }
         }
     }

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -1259,7 +1259,8 @@
             }
 
             .emoji-rhs {
-                display: none;
+                // bring back the emoji picker for mobile
+                // display: none;
                 position: relative;
                 right: -1px;
                 top: 1px;

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -1827,7 +1827,11 @@
         width: 100%;
         height: 100%;
         border-radius: 0;
-        z-index: 10000;
+        z-index: 1070;
+
+        &.bottom {
+            margin-top: 0;
+        }
     }
 
     .emoji-picker__inner {

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -1816,6 +1816,68 @@
     .integration__icon {
         display: none;
     }
+
+    .emoji-picker {
+        // !important is used to overide inline styles
+        // used on larger screens
+        top: 0 !important;
+        left: 0 !important;
+        right: auto !important;
+        bottom: auto !important;
+        width: 100%;
+        height: 100%;
+        border-radius: 0;
+        z-index: 10000;
+    }
+
+    .emoji-picker__inner {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+
+        > * {
+            flex-grow: 0;
+        }
+    }
+
+    .emoji-picker__header {
+        display: block;
+    }
+
+    .emoji-picker__categories {
+        .emoji-picker__category {
+            width: 30px;
+            height: 30px;
+            padding-top: 4px;
+        }
+    }
+
+    .emoji-picker__items {
+        // !important is used to overide inline styles
+        // used on larger screens
+        height: auto !important;
+        flex-grow: 1;
+
+        .emoji-picker-items__container {
+
+            .emoji-picker__category-header {
+                font-size: 14px;
+                padding-top: 8px;
+            }
+            .emoji-picker__item {
+                margin: 0 4px 7px;
+                padding: 5px 4px;
+                width: 30px;
+                height: 30px;
+            }
+        }
+    }
+
+    .emoji-picker__preview {
+        width: 100%;
+        height: 60px;
+        padding: 10px 10px 0;
+    }
 }
 
 @media screen and (max-height: 640px) {

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -1309,7 +1309,7 @@
             font-weight: 700;
             line-height: 0;
             position: relative;
-            top: 9px;
+            top: 3px;
         }
 
         .sidebar--right__close {

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -89,10 +89,6 @@
         .msg-typing {
             display: none;
         }
-
-        .emoji-picker__container {
-            display: none;
-        }
     }
 
     .suggestion-list__content {

--- a/tests/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
+++ b/tests/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
@@ -176,6 +176,7 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
   >
     <Connect(DotMenu)
       commentCount={0}
+      handleAddReactionClick={[Function]}
       handleCommentClick={[MockFunction]}
       handleDropdownOpened={[Function]}
       isFlagged={false}
@@ -281,6 +282,7 @@ exports[`components/post_view/PostInfo toggleEmojiPicker, should have called pro
   >
     <Connect(DotMenu)
       commentCount={0}
+      handleAddReactionClick={[Function]}
       handleCommentClick={[MockFunction]}
       handleDropdownOpened={[Function]}
       isFlagged={false}

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -539,6 +539,7 @@ export function applyTheme(theme) {
         changeCss('.app__body .multi-teams .team-sidebar, .app__body #navbar .navbar-default', 'background:' + theme.sidebarHeaderBg);
         changeCss('@media(max-width: 768px){.app__body .search-bar__container', 'background:' + theme.sidebarHeaderBg);
         changeCss('.app__body .attachment .attachment__container', 'border-left-color:' + theme.sidebarHeaderBg);
+        changeCss('.emoji-picker .emoji-picker__header', 'background:' + theme.sidebarHeaderBg);
     }
 
     if (theme.sidebarHeaderTextColor) {
@@ -557,6 +558,7 @@ export function applyTheme(theme) {
         changeCss('.app__body .navbar-right__icon svg', 'fill:' + theme.sidebarHeaderTextColor);
         changeCss('.app__body .navbar-right__icon svg', 'stroke:' + theme.sidebarHeaderTextColor);
         changeCss('.team-sidebar .fa', 'color:' + theme.sidebarHeaderTextColor);
+        changeCss('.emoji-picker .emoji-picker__header, .emoji-picker .emoji-picker__header .emoji-picker__header-close-button', 'color:' + theme.sidebarHeaderTextColor);
     }
 
     if (theme.onlineIndicator) {
@@ -697,6 +699,7 @@ export function applyTheme(theme) {
         changeCss('.app__body .channel-header .pinned-posts-button svg', 'fill:' + changeOpacity(theme.centerChannelColor, 0.6));
         changeCss('.app__body .channel-header .channel-header_plugin-dropdown svg', 'fill:' + changeOpacity(theme.centerChannelColor, 0.6));
         changeCss('.app__body .custom-textarea, .app__body .custom-textarea:focus, .app__body .file-preview, .app__body .post-image__details, .app__body .sidebar--right .sidebar-right__body, .app__body .markdown__table th, .app__body .markdown__table td, .app__body .suggestion-list__content, .app__body .modal .modal-content, .app__body .modal .settings-modal .settings-table .settings-content .divider-light, .app__body .webhooks__container, .app__body .dropdown-menu, .app__body .modal .modal-header', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
+        changeCss('.emoji-picker .emoji-picker__header', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .popover.bottom>.arrow', 'border-bottom-color:' + changeOpacity(theme.centerChannelColor, 0.25));
         changeCss('.app__body .btn.btn-transparent, .app__body .search-help-popover .search-autocomplete__divider span, .app__body .suggestion-list__divider > span', 'color:' + changeOpacity(theme.centerChannelColor, 0.7));
         changeCss('.app__body .popover.right>.arrow', 'border-right-color:' + changeOpacity(theme.centerChannelColor, 0.25));


### PR DESCRIPTION
#### Summary
This pull request (re)enables emoji/add reaction functionality to mobile web views ... currently using the exact same emoji popup as desktop web views ... UI updates of emoji popup for mobile are still pending. This pull request is a WIP for discussion purposes as I have a few questions (pending) to properly complete the original ticket.

#### Ticket Link
[GH-9045](https://github.com/mattermost/mattermost-server/issues/9045), [MM-10682](https://mattermost.atlassian.net/browse/MM-10682)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, posting, etc.)
