### PR TITLE
Remove config setting check for create team button in sidebar

### DIFF
--- a/components/team_sidebar/index.js
+++ b/components/team_sidebar/index.js
@@ -18,7 +18,6 @@ function mapStateToProps(state) {
     const config = getConfig(state);
 
     const experimentalPrimaryTeam = config.ExperimentalPrimaryTeam;
-    const enableTeamCreation = config.EnableTeamCreation === 'true';
     const joinableTeams = getJoinableTeamIds(state);
     const moreTeamsToJoin = joinableTeams && joinableTeams.length > 0;
 
@@ -28,7 +27,6 @@ function mapStateToProps(state) {
         myTeamMembers: getTeamMemberships(state),
         isOpen: getIsLhsOpen(state),
         experimentalPrimaryTeam,
-        enableTeamCreation,
         locale: getCurrentLocale(state),
         moreTeamsToJoin,
     };

--- a/components/team_sidebar/team_sidebar_controller.jsx
+++ b/components/team_sidebar/team_sidebar_controller.jsx
@@ -24,7 +24,6 @@ export default class TeamSidebar extends React.PureComponent {
         myTeamMembers: PropTypes.object.isRequired,
         isOpen: PropTypes.bool.isRequired,
         experimentalPrimaryTeam: PropTypes.string,
-        enableTeamCreation: PropTypes.bool.isRequired,
         locale: PropTypes.string.isRequired,
         actions: PropTypes.shape({
             getTeams: PropTypes.func.isRequired,
@@ -75,7 +74,7 @@ export default class TeamSidebar extends React.PureComponent {
                     content={'+'}
                 />
             );
-        } else if (this.props.enableTeamCreation) {
+        } else {
             teams.push(
                 <SystemPermissionGate
                     permissions={[Permissions.CREATE_TEAM]}


### PR DESCRIPTION
#### Summary
We should completely rely on the permissions system here, like the sidebar dropdown does.