### PR TITLE
[MM-12449] Use separate database and default config.json when running end-to-end testing 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build test run clean stop check-style run-unit emojis help
 
 BUILD_SERVER_DIR = ../mattermost-server
+BUILD_WEBAPP_DIR = ../mattermost-webapp
 EMOJI_TOOLS_DIR = ./build/emoji
 
 check-style: node_modules ## Checks JS file for ESLint confirmity
@@ -63,6 +64,41 @@ clean: ## Clears cached; deletes node_modules and dist directories
 
 	rm -rf dist
 	rm -rf node_modules
+
+e2e: node_modules setup-e2e test-e2e clean-e2e
+
+setup-e2e:
+	@echo E2E: Running mattermost-mysql-e2e
+
+	@if [ $(shell docker ps -a | grep -ci mattermost-mysql-e2e) -eq 0 ]; then \
+		echo starting mattermost-mysql-e2e; \
+		docker run --name mattermost-mysql-e2e -p 35476:3306 -e MYSQL_ROOT_PASSWORD=mostest \
+		-e MYSQL_USER=mmuser -e MYSQL_PASSWORD=mostest -e MYSQL_DATABASE=mattermost_test -d mysql:5.7 > /dev/null; \
+	elif [ $(shell docker ps | grep -ci mattermost-mysql-e2e) -eq 0 ]; then \
+		echo restarting mattermost-mysql-e2e; \
+		docker start mattermost-mysql-e2e > /dev/null; \
+	fi
+
+	cd $(BUILD_SERVER_DIR) && \
+		[[ -f config/config.json ]] && \
+			cp config/config.json config/config-backup.json && cp config/default.json config/config.json || \
+			echo "config.json not found" && cp config/default.json config/config.json
+
+test-e2e:
+	@echo E2E: Running end-to-end testing
+
+	npm run test:e2e
+
+clean-e2e:
+	@if [ $(shell docker ps -a | grep -ci mattermost-mysql-e2e) -eq 1 ]; then \
+		echo stopping mattermost-mysql-e2e; \
+		docker stop mattermost-mysql-e2e > /dev/null; \
+	fi
+
+	cd $(BUILD_SERVER_DIR) && \
+		[[ -f config/config-backup.json ]] && \
+			cp config/config-backup.json config/config.json && echo "revert local config.json" || \
+			echo "config-backup.json not found"
 
 emojis: ## Creates emoji JSX file and extracts emoji images from the system font
 	gem install bundler

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ clean-e2e:
 	cd $(BUILD_SERVER_DIR) && \
 		[[ -f config/config-backup.json ]] && \
 			cp config/config-backup.json config/config.json && echo "revert local config.json" || \
-			echo "config-backup.json not found"
+			echo "config-backup.json not found" && sed -i'' -e 's|"DataSource": ".*"|"DataSource": "mmuser:mostest@tcp(dockerhost:3306)/mattermost_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"|g' config/config.json
 
 emojis: ## Creates emoji JSX file and extracts emoji images from the system font
 	gem install bundler

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ clean: ## Clears cached; deletes node_modules and dist directories
 	rm -rf dist
 	rm -rf node_modules
 
-e2e: node_modules setup-e2e test-e2e clean-e2e
+e2e: | node_modules setup-e2e test-e2e clean-e2e
 
 setup-e2e:
 	@echo E2E: Running mattermost-mysql-e2e

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run clean stop check-style run-unit emojis help
+.PHONY: build test run clean stop e2e clean-e2e test-e2e setup-e2e check-style run-unit emojis help
 
 BUILD_SERVER_DIR = ../mattermost-server
 BUILD_WEBAPP_DIR = ../mattermost-webapp

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run clean stop e2e clean-e2e test-e2e setup-e2e check-style run-unit emojis help
+.PHONY: build test run clean stop check-style run-unit emojis help
 
 BUILD_SERVER_DIR = ../mattermost-server
 BUILD_WEBAPP_DIR = ../mattermost-webapp
@@ -65,11 +65,8 @@ clean: ## Clears cached; deletes node_modules and dist directories
 	rm -rf dist
 	rm -rf node_modules
 
-e2e: | node_modules setup-e2e test-e2e clean-e2e
-
-setup-e2e:
+e2e: node_modules
 	@echo E2E: Running mattermost-mysql-e2e
-
 	@if [ $(shell docker ps -a | grep -ci mattermost-mysql-e2e) -eq 0 ]; then \
 		echo starting mattermost-mysql-e2e; \
 		docker run --name mattermost-mysql-e2e -p 35476:3306 -e MYSQL_ROOT_PASSWORD=mostest \
@@ -79,15 +76,19 @@ setup-e2e:
 		docker start mattermost-mysql-e2e > /dev/null; \
 	fi
 
-	cd $(BUILD_SERVER_DIR) && \
-		[[ -f config/config.json ]] && \
-			cp config/config.json config/config-backup.json && cp config/default.json config/config.json || \
-			echo "config.json not found" && cp config/default.json config/config.json
+	cd $(BUILD_SERVER_DIR) && [[ -f config/config.json ]] && \
+		cp config/config.json config/config-backup.json && cp config/default.json config/config.json || \
+		echo "config.json not found" && cp config/default.json config/config.json
 
-test-e2e:
 	@echo E2E: Running end-to-end testing
-
 	npm run test:e2e
+
+	@echo stopping mattermost-mysql-e2e
+	docker stop mattermost-mysql-e2e > /dev/null
+
+	cd $(BUILD_SERVER_DIR) && [[ -f config/config-backup.json ]] && \
+		cp config/config-backup.json config/config.json && echo "revert local config.json" || \
+		echo "config-backup.json not found" && sed -i'' -e 's|"DataSource": ".*"|"DataSource": "mmuser:mostest@tcp(dockerhost:3306)/mattermost_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"|g' config/config.json
 
 clean-e2e:
 	@if [ $(shell docker ps -a | grep -ci mattermost-mysql-e2e) -eq 1 ]; then \
@@ -95,10 +96,9 @@ clean-e2e:
 		docker stop mattermost-mysql-e2e > /dev/null; \
 	fi
 
-	cd $(BUILD_SERVER_DIR) && \
-		[[ -f config/config-backup.json ]] && \
-			cp config/config-backup.json config/config.json && echo "revert local config.json" || \
-			echo "config-backup.json not found" && sed -i'' -e 's|"DataSource": ".*"|"DataSource": "mmuser:mostest@tcp(dockerhost:3306)/mattermost_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"|g' config/config.json
+	cd $(BUILD_SERVER_DIR) && [[ -f config/config-backup.json ]] && \
+		cp config/config-backup.json config/config.json && echo "revert local config.json" || \
+		echo "config-backup.json not found" && sed -i'' -e 's|"DataSource": ".*"|"DataSource": "mmuser:mostest@tcp(dockerhost:3306)/mattermost_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"|g' config/config.json
 
 emojis: ## Creates emoji JSX file and extracts emoji images from the system font
 	gem install bundler

--- a/tests/e2e/test.sh
+++ b/tests/e2e/test.sh
@@ -45,18 +45,28 @@ function modify_config {
     sed -i'' -e 's|"PushNotificationServer": ".*"|"PushNotificationServer": "https://push.mattermost.com"|g' config/config.json
     sed -i'' -e 's|"PushNotificationContents": ".*"|"PushNotificationContents": "generic"|g' config/config.json
 
+    echo "config: set e2e database"
+    sed -i'' -e 's|"DataSource": ".*"|"DataSource": "mmuser:mostest@tcp(dockerhost:35476)/mattermost_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"|g' config/config.json
+
     cd ../mattermost-webapp
     sleep 5
 }
 
-function restart_server {
+function start_server {
+    cd ../mattermost-server
+
+    echo "start the server"
+    make run
+
+    cd ../mattermost-webapp
+    sleep 5
+}
+
+function stop_server {
     cd ../mattermost-server
 
     echo "stop the server"
     make stop
-    sleep 5
-    echo "start the server"
-    make run
 
     cd ../mattermost-webapp
     sleep 5
@@ -123,7 +133,8 @@ function local_tests {
     local_setup
 
     modify_config
-    restart_server
+    stop_server
+    start_server
 
     if [ -n "$1" ]; then
         message "Tag: ${1} local E2E starts..."
@@ -138,6 +149,8 @@ function local_tests {
         message "E2E full local firefox starts..."
         nightwatch -e firefox --skiptags tutorial --suiteRetries 1
     fi
+
+    stop_server
 }
 
 local_tests $@

--- a/tests/e2e/test.sh
+++ b/tests/e2e/test.sh
@@ -37,13 +37,9 @@ function modify_config {
     echo "config: enable email invitation"
     sed -i'' -e 's|"EnableEmailInvitations": false|"EnableEmailInvitations": true|g' config/config.json
 
-    echo "config: enable email notification"
-    sed -i'' -e 's|"SendEmailNotifications": false|"SendEmailNotifications": true|g' config/config.json
-
     echo "config: enable mobile push notification"
     sed -i'' -e 's|"SendPushNotifications": false|"SendPushNotifications": true|g' config/config.json
     sed -i'' -e 's|"PushNotificationServer": ".*"|"PushNotificationServer": "https://push.mattermost.com"|g' config/config.json
-    sed -i'' -e 's|"PushNotificationContents": ".*"|"PushNotificationContents": "generic"|g' config/config.json
 
     echo "config: set e2e database"
     sed -i'' -e 's|"DataSource": ".*"|"DataSource": "mmuser:mostest@tcp(dockerhost:35476)/mattermost_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"|g' config/config.json

--- a/tests/e2e/test.sh
+++ b/tests/e2e/test.sh
@@ -2,6 +2,8 @@
 set -e
 
 PLATFORM_FILES="./cmd/mattermost/main.go"
+BUILD_SERVER_DIR="../mattermost-server"
+BUILD_WEBAPP_DIR="../mattermost-webapp"
 
 function message {
     echo ""
@@ -32,7 +34,7 @@ function selenium_start {
 function modify_config {
     message "Modifying config..."
 
-    cd ../mattermost-server
+    cd $BUILD_SERVER_DIR
 
     echo "config: enable email invitation"
     sed -i'' -e 's|"EnableEmailInvitations": false|"EnableEmailInvitations": true|g' config/config.json
@@ -44,27 +46,27 @@ function modify_config {
     echo "config: set e2e database"
     sed -i'' -e 's|"DataSource": ".*"|"DataSource": "mmuser:mostest@tcp(dockerhost:35476)/mattermost_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"|g' config/config.json
 
-    cd ../mattermost-webapp
+    cd $BUILD_WEBAPP_DIR
     sleep 5
 }
 
 function start_server {
-    cd ../mattermost-server
+    cd $BUILD_SERVER_DIR
 
     echo "start the server"
     make run
 
-    cd ../mattermost-webapp
+    cd $BUILD_WEBAPP_DIR
     sleep 5
 }
 
 function stop_server {
-    cd ../mattermost-server
+    cd $BUILD_SERVER_DIR
 
     echo "stop the server"
     make stop
 
-    cd ../mattermost-webapp
+    cd $BUILD_WEBAPP_DIR
     sleep 5
 }
 
@@ -85,18 +87,18 @@ function local_setup {
 }
 
 function reset_db {
-    cd ../mattermost-server
+    cd $BUILD_SERVER_DIR
 
     echo "reset the database"
     go run $PLATFORM_FILES reset --confirm true
 
-    cd ../mattermost-webapp
+    cd $BUILD_WEBAPP_DIR
     sleep 5
 }
 
 function add_test_users {
     message "Adding test users..."
-    cd ../mattermost-server
+    cd $BUILD_SERVER_DIR
 
     echo "reset the database"
     go run $PLATFORM_FILES reset --confirm true
@@ -116,7 +118,7 @@ function add_test_users {
     echo "adding users to 'ui-automation' team"
     go run $PLATFORM_FILES team add ui-automation test@test.com
 
-    cd ../mattermost-webapp
+    cd $BUILD_WEBAPP_DIR
     sleep 5
 }
 


### PR DESCRIPTION
#### Summary
Thanks @enahum for giving the idea on how to approach the two issues in running end-to-end testing on dev's local machine
1. Database is being reset after end-to-end testing
2. Different failing tests encountered are due to `config.json` not set to default values.

Above issues were fixed by  separating database and using default `config.json` when running end-to-end testing on local machine.

Added make commands:
- `make e2e` - use this command to run end-to-end testing.
- `make clean-e2e` - use to stop `mattermost-mysql-e2e` docker instance and revert local config.  This can be used to manually restore changes caused by running `make e2e` in case of error (early exit from command)

Other helper make commands:
- `make test-e2e` - alias for `npm run test:e2e` from npm script
- `make setup-e2e` - use to create or restart `mattermost-mysql-e2e` docker instance, back up local `config.json` and copy `default.json` as `config.json`

Workflow:
1. Dev to run `make e2e`.  Script will:
- do `node_modules` (`npm install`)
- do `setup-e2e`
  - create or restart `mattermost-mysql-e2e` database
  - back up local `config.json` as `config-backup.json`
  - copy `default.json` as `config.json`
- do `test-e2e`
  - do `npm run test:e2e`
    - do local setup of selenium (unchange)
    - modify config - using the new database connection
    - stop and start the server (unchange)
    - reset database (unchange)
    - add test users (unchange)
    - run Nightwatch (unchange)
    - stop the server
- do `clean-e2e`
  - stop `mattermost-mysql-e2e` database
  - revert local `config.json` from `config-backup.json`

Note this is submitted on top of https://github.com/mattermost/mattermost-webapp/pull/1922.  Will rebase once merge (that's after GH/mattermod back to normal operation)

#### Ticket Link
Jira ticket: [MM-12449](https://mattermost.atlassian.net/browse/MM-12449)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
