### PR TITLE
Fix OOO refresh logic that does not always display confirmation modal.

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -24,7 +24,7 @@ import {getChannelMembersForUserIds} from 'actions/channel_actions.jsx';
 import {loadStatusesForProfilesList, loadStatusesForProfilesMap} from 'actions/status_actions.jsx';
 import store from 'stores/redux_store.jsx';
 import * as Utils from 'utils/utils.jsx';
-import {Constants, Preferences} from 'utils/constants.jsx';
+import {Constants, Preferences, UserStatuses} from 'utils/constants.jsx';
 
 const dispatch = store.dispatch;
 const getState = store.getState;
@@ -660,7 +660,7 @@ export function autoResetStatus() {
         const {currentUserId} = getState().entities.users;
         const {data: userStatus} = await UserActions.getStatus(currentUserId)(doDispatch, doGetState);
 
-        if (!userStatus.manual) {
+        if (userStatus.status === UserStatuses.OUT_OF_OFFICE || !userStatus.manual) {
             return userStatus;
         }
 

--- a/components/reset_status_modal/reset_status_modal.jsx
+++ b/components/reset_status_modal/reset_status_modal.jsx
@@ -70,7 +70,7 @@ export default class ResetStatusModal extends React.PureComponent {
 
                 this.setState({
                     currentUserStatus: status, // Set in state until status refactor where we store 'manual' field in redux
-                    show: Boolean(statusIsManual && autoResetPrefNotSet),
+                    show: Boolean(status.status === UserStatuses.OUT_OF_OFFICE || (statusIsManual && autoResetPrefNotSet)),
                 });
             }
         );

--- a/components/reset_status_modal/reset_status_modal.jsx
+++ b/components/reset_status_modal/reset_status_modal.jsx
@@ -169,6 +169,8 @@ export default class ResetStatusModal extends React.PureComponent {
             />
         );
 
+        const showCheckbox = this.props.currentUserStatus !== UserStatuses.OUT_OF_OFFICE;
+
         return (
             <ConfirmModal
                 show={this.state.show}
@@ -179,7 +181,7 @@ export default class ResetStatusModal extends React.PureComponent {
                 cancelButtonText={manualStatusCancel}
                 onCancel={this.onCancel}
                 onExited={this.props.onHide}
-                showCheckbox={true}
+                showCheckbox={showCheckbox}
                 checkboxText={manualStatusCheckbox}
             />
         );

--- a/tests/components/__snapshots__/reset_status_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/reset_status_modal.test.jsx.snap
@@ -109,7 +109,7 @@ exports[`components/ResetStatusModal should match snapshot, render modal for OOF
   onCancel={[Function]}
   onConfirm={[Function]}
   show={false}
-  showCheckbox={true}
+  showCheckbox={false}
   title={
     <FormattedMessage
       defaultMessage="Your status is set to \\"{status}\\""


### PR DESCRIPTION
#### Summary
The issue is that the preference for "Do not ask me again" for OOO is not separate from other statuses, so if you've selected the checkbox and gone online from DND (for example), then you'll never see the pop up screen in OOO. 

Here's the discussion:
https://pre-release.mattermost.com/core/pl/c7siyro4oj85igad1hdjp34cue

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed