### PR TITLE
[MM-12808] Replace <string> tag with string template literal

### DIFF
--- a/components/suggestion/command_provider.jsx
+++ b/components/suggestion/command_provider.jsx
@@ -23,10 +23,10 @@ class CommandSuggestion extends Suggestion {
                 {...Suggestion.baseProps}
             >
                 <div className='command__title'>
-                    {`${item.suggestion} ${item.hint}`}
+                    <span>{item.suggestion} {item.hint}</span>
                 </div>
                 <div className='command__desc'>
-                    {item.description}
+                    <span>{item.description}</span>
                 </div>
             </div>
         );

--- a/components/suggestion/command_provider.jsx
+++ b/components/suggestion/command_provider.jsx
@@ -23,7 +23,7 @@ class CommandSuggestion extends Suggestion {
                 {...Suggestion.baseProps}
             >
                 <div className='command__title'>
-                    <string>{item.suggestion} {item.hint}</string>
+                    {`${item.suggestion} ${item.hint}`}
                 </div>
                 <div className='command__desc'>
                     {item.description}


### PR DESCRIPTION
#### Summary
Replace <string> tag with string template literal.
Looks like the <string> tag is not recognized by the browser (atleast with my Chrome installation) and React complained about it since it's not starting in uppercase letter.

Not sure what has changed recently as it's been there for 2 years already without such warning.

#### Ticket Link
Jira ticket: [MM-12808](https://mattermost.atlassian.net/browse/MM-12808)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
