### PR TITLE
MM-12682 FIx for expand/collapse not working after an image is posted

### DIFF
--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -88,7 +88,7 @@ export default class FileAttachmentList extends React.Component {
                         <SingleImageView
                             fileInfo={fileInfos[0]}
                             isEmbedVisible={this.props.isEmbedVisible}
-                            post={this.props.post}
+                            postId={this.props.post.id}
                         />
                     );
                 }

--- a/components/single_image_view/single_image_view.jsx
+++ b/components/single_image_view/single_image_view.jsx
@@ -23,6 +23,7 @@ const PREVIEW_IMAGE_MIN_DIMENSION = 50;
 
 export default class SingleImageView extends React.PureComponent {
     static propTypes = {
+        postId: PropTypes.string.isRequired,
         fileInfo: PropTypes.object.isRequired,
         isRhsOpen: PropTypes.bool.isRequired,
         isEmbedVisible: PropTypes.bool,
@@ -136,7 +137,7 @@ export default class SingleImageView extends React.PureComponent {
     }
 
     toggleEmbedVisibility = () => {
-        this.props.actions.toggleEmbedVisibility(this.props.fileInfo.post_id);
+        this.props.actions.toggleEmbedVisibility(this.props.postId);
     }
 
     render() {

--- a/tests/components/__snapshots__/file_attachment_list.test.jsx.snap
+++ b/tests/components/__snapshots__/file_attachment_list.test.jsx.snap
@@ -89,13 +89,6 @@ exports[`components/FileAttachmentList should match snapshot, single image view 
     }
   }
   isEmbedVisible={false}
-  post={
-    Object {
-      "file_ids": Array [
-        "file_id_1",
-      ],
-      "id": "post_id",
-    }
-  }
+  postId="post_id"
 />
 `;

--- a/tests/components/single_image_view.test.jsx
+++ b/tests/components/single_image_view.test.jsx
@@ -8,6 +8,7 @@ import SingleImageView from 'components/single_image_view/single_image_view.jsx'
 
 describe('components/SingleImageView', () => {
     const baseProps = {
+        postId: 'original_post_id',
         fileInfo: {
             id: 'file_info_id',
             post_id: 'post_id',
@@ -143,6 +144,6 @@ describe('components/SingleImageView', () => {
 
         wrapper.instance().toggleEmbedVisibility();
         expect(props.actions.toggleEmbedVisibility).toHaveBeenCalledTimes(1);
-        expect(props.actions.toggleEmbedVisibility).toBeCalledWith('post_id');
+        expect(props.actions.toggleEmbedVisibility).toBeCalledWith('original_post_id');
     });
 });


### PR DESCRIPTION
#### Summary
Fixes the issue of collapse/expand not working for images at times. 

The issue happens because of not having the key `post_id` in the `file_info` object at times
![image expand](https://user-images.githubusercontent.com/4973621/47551824-d5908800-d920-11e8-97de-3dd670995ccc.PNG)

I don't know the root cause of this but i spent fair mana and rather have this as a fix than spending more time on this for now. I might be addressing this with post meta data stuff changes anyway i am running into similar issue there 

#### Ticket Link
[MM-12682](https://mattermost.atlassian.net/browse/MM-12682)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

