### PR TITLE
MM-12810 Webapp redirecting to select_team page when base url is hit

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -18,7 +18,6 @@ import {trackLoadTime} from 'actions/diagnostics_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import BrowserStore from 'stores/browser_store.jsx';
 import ErrorStore from 'stores/error_store.jsx';
-import UserStore from 'stores/user_store.jsx';
 import {loadRecentlyUsedCustomEmojis} from 'actions/emoji_actions.jsx';
 import * as I18n from 'i18n/i18n.jsx';
 import {initializePlugins} from 'plugins';

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -189,7 +189,6 @@ export default class Root extends React.Component {
         const afterIntl = () => {
             initializePlugins();
 
-            this.redirectIfNecessary(this.props);
             this.setState({configLoaded: true});
         };
         if (global.Intl) {
@@ -221,8 +220,6 @@ export default class Root extends React.Component {
                 this.props.history.push('/signup_user_complete');
             } else if (props.showTermsOfService) {
                 this.props.history.push('/terms_of_service');
-            } else if (UserStore.getCurrentUser()) {
-                GlobalActions.redirectUserToDefaultTeam();
             }
         }
     }
@@ -233,6 +230,7 @@ export default class Root extends React.Component {
 
     componentDidMount() {
         this.props.actions.loadMeAndConfig().then(() => {
+            GlobalActions.redirectUserToDefaultTeam();
             this.onConfigLoaded();
         });
 

--- a/tests/components/root/root.test.jsx
+++ b/tests/components/root/root.test.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import Root from 'components/root/root';
+import * as GlobalActions from 'actions/global_actions.jsx';
 
 jest.mock('fastclick', () => ({
     attach: () => {}, // eslint-disable-line no-empty-function
@@ -12,6 +13,10 @@ jest.mock('fastclick', () => ({
 
 jest.mock('actions/diagnostics_actions', () => ({
     trackLoadTime: () => {}, // eslint-disable-line no-empty-function
+}));
+
+jest.mock('actions/global_actions', () => ({
+    redirectUserToDefaultTeam: jest.fn(),
 }));
 
 describe('components/Root', () => {
@@ -25,7 +30,7 @@ describe('components/Root', () => {
         },
     };
 
-    test('should load user, config, and license on mount', (done) => {
+    test('should load user, config, and license on mount and redirect to defaultTeam on success', (done) => {
         const props = {
             ...baseProps,
             actions: {
@@ -38,6 +43,7 @@ describe('components/Root', () => {
         class MockedRoot extends Root {
             onConfigLoaded = jest.fn(() => {
                 expect(this.onConfigLoaded).toHaveBeenCalledTimes(1);
+                expect(GlobalActions.redirectUserToDefaultTeam).toHaveBeenCalledTimes(1);
                 done();
             });
         }


### PR DESCRIPTION
#### Summary
Props change is used for redirecting to default team which causes a race condition. User info is loaded into state triggering a props change so redirectUserToDefaultTeam take user to select_team page if there is a delay in state change for user teams.

#### Ticket Link
[MM-12810](https://mattermost.atlassian.net/browse/MM-12810)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [] Added or updated unit tests (required for all new features)
