### PR TITLE
Remove flux store usages from websocket_actions.jsx

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -17,7 +17,7 @@ import {getPostThread} from 'mattermost-redux/actions/posts';
 import {logout} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getCurrentTeamId, getTeam, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentTeamId, getTeam, getMyTeams, getMyTeamMember} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentChannelStats, getCurrentChannelId, getChannelByName} from 'mattermost-redux/selectors/entities/channels';
 
@@ -430,8 +430,10 @@ export async function redirectUserToDefaultTeam() {
     const teamId = LocalStorageStore.getPreviousTeamId(userId);
 
     let team = getTeam(state, teamId);
+    const myMember = getMyTeamMember(state, teamId);
 
-    if (!team) {
+    if (!team || !myMember || !myMember.team_id) {
+        team = null;
         let myTeams = getMyTeams(state);
 
         if (myTeams.length > 0) {

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -26,16 +26,14 @@ import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {handleNewPost} from 'actions/post_actions.jsx';
 import * as StatusActions from 'actions/status_actions.jsx';
-import {loadProfilesForSidebar} from 'actions/user_actions.jsx';
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import ErrorStore from 'stores/error_store.jsx';
-import PreferenceStore from 'stores/preference_store.jsx';
 import store from 'stores/redux_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import WebSocketClient from 'client/web_websocket_client.jsx';
 import {loadPlugin, loadPluginsIfNecessary, removePlugin} from 'plugins';
-import {ActionTypes, Constants, AnnouncementBarMessages, Preferences, SocketEvents, UserStatuses} from 'utils/constants.jsx';
+import {ActionTypes, Constants, AnnouncementBarMessages, SocketEvents, UserStatuses} from 'utils/constants.jsx';
 import {fromAutoResponder} from 'utils/post_utils';
 import {getSiteURL} from 'utils/url.jsx';
 import {ModalIdentifiers} from '../utils/constants';
@@ -529,9 +527,7 @@ function handleUpdateMemberRoleEvent(msg) {
 }
 
 function handleDirectAddedEvent(msg) {
-    getChannelAndMyMember(msg.broadcast.channel_id)(dispatch, getState);
-    PreferenceStore.setPreference(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, msg.data.teammate_id, 'true');
-    loadProfilesForSidebar();
+    dispatch(getChannelAndMyMember(msg.broadcast.channel_id));
 }
 
 function handleUserAddedEvent(msg) {
@@ -744,7 +740,6 @@ function handleChannelViewedEvent(msg) {
     // Useful for when multiple devices have the app open to different channels
     if ((!window.isActive || getCurrentChannelId(getState()) !== msg.data.channel_id) &&
         UserStore.getCurrentId() === msg.broadcast.user_id) {
-        console.log('yo');
         dispatch(markChannelAsRead(msg.data.channel_id, '', false));
     }
 }

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -31,10 +31,9 @@ import ErrorStore from 'stores/error_store.jsx';
 import store from 'stores/redux_store.jsx';
 import WebSocketClient from 'client/web_websocket_client.jsx';
 import {loadPlugin, loadPluginsIfNecessary, removePlugin} from 'plugins';
-import {ActionTypes, Constants, AnnouncementBarMessages, SocketEvents, UserStatuses} from 'utils/constants.jsx';
+import {ActionTypes, Constants, AnnouncementBarMessages, SocketEvents, UserStatuses, ModalIdentifiers} from 'utils/constants.jsx';
 import {fromAutoResponder} from 'utils/post_utils';
 import {getSiteURL} from 'utils/url.jsx';
-import {ModalIdentifiers} from '../utils/constants';
 import RemovedFromChannelModal from 'components/removed_from_channel_modal';
 
 const dispatch = store.dispatch;

--- a/components/channel_info_modal/channel_info_modal.jsx
+++ b/components/channel_info_modal/channel_info_modal.jsx
@@ -40,8 +40,6 @@ export default class ChannelInfoModal extends React.PureComponent {
     constructor(props) {
         super(props);
 
-        this.onHide = this.onHide.bind(this);
-
         this.state = {show: true};
 
         this.getHeaderMarkdownOptions = memoizeResult((channelNamesMap) => (
@@ -49,7 +47,7 @@ export default class ChannelInfoModal extends React.PureComponent {
         ));
     }
 
-    onHide() {
+    onHide = () => {
         this.setState({show: false});
     }
 

--- a/components/removed_from_channel_modal/index.js
+++ b/components/removed_from_channel_modal/index.js
@@ -5,7 +5,7 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import {closeModal} from 'actions/views/modals';
+import {goToLastViewedChannel} from 'actions/views/channel';
 
 import RemovedFromChannelModal from './removed_from_channel_modal';
 
@@ -18,7 +18,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            closeModal,
+            goToLastViewedChannel,
         }, dispatch),
     };
 }

--- a/components/removed_from_channel_modal/index.js
+++ b/components/removed_from_channel_modal/index.js
@@ -3,7 +3,7 @@
 
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
-import {getCurrentUser} from 'mattermost-redux/selectors/entities/common';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {closeModal} from 'actions/views/modals';
 
@@ -11,7 +11,7 @@ import RemovedFromChannelModal from './removed_from_channel_modal';
 
 function mapStateToProps(state) {
     return {
-        currentUser: getCurrentUser(state),
+        currentUserId: getCurrentUserId(state),
     };
 }
 

--- a/components/removed_from_channel_modal/removed_from_channel_modal.jsx
+++ b/components/removed_from_channel_modal/removed_from_channel_modal.jsx
@@ -10,8 +10,8 @@ export default class RemovedFromChannelModal extends React.PureComponent {
     static propTypes = {
         currentUserId: PropTypes.string.isRequired,
         onHide: PropTypes.func.isRequired,
-        channelName: PropTypes.string.isRequired,
-        remover: PropTypes.string.isRequired,
+        channelName: PropTypes.string,
+        remover: PropTypes.string,
         actions: PropTypes.shape({
             goToLastViewedChannel: PropTypes.func.isRequired,
         }),

--- a/components/removed_from_channel_modal/removed_from_channel_modal.jsx
+++ b/components/removed_from_channel_modal/removed_from_channel_modal.jsx
@@ -3,91 +3,64 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FormattedMessage} from 'react-intl';
 import {Modal} from 'react-bootstrap';
-
-import {ModalIdentifiers} from 'utils/constants.jsx';
+import {FormattedMessage} from 'react-intl';
 
 export default class RemovedFromChannelModal extends React.PureComponent {
     static propTypes = {
-
-        /**
-         * Object with info about townsquare
-         */
-        currentUser: PropTypes.object.isRequired,
-
-        /**
-         * String with name of currently selected channel
-         */
-        channelName: PropTypes.string,
-
-        /**
-         * String with name of admin who removed currentUser from channel
-         */
-        remover: PropTypes.string,
-
-        /*
-         * Object with redux action creators
-         */
+        currentUserId: PropTypes.string.isRequired,
+        onHide: PropTypes.func.isRequired,
+        channelName: PropTypes.string.isRequired,
+        remover: PropTypes.string.isRequired,
         actions: PropTypes.shape({
-
-            /*
-             * Action creator to close modal
-             */
-            closeModal: PropTypes.func.isRequired,
-        }).isRequired,
-    }
+            goToLastViewedChannel: PropTypes.func.isRequired,
+        }),
+    };
 
     constructor(props) {
         super(props);
-        this.state = {
-            show: true,
-        };
+
+        this.state = {show: true};
     }
 
-    handleClose = () => {
+    componentDidMount() {
+        this.props.actions.goToLastViewedChannel();
+    }
+
+    onHide = () => {
         this.setState({show: false});
     }
 
-    handleExited = () => {
-        this.props.actions.closeModal(ModalIdentifiers.REMOVED_FROM_CHANNEL);
-    }
-
     render() {
-        const {currentUser} = this.props;
-
-        var channelName = (
+        let channelName = (
             <FormattedMessage
                 id='removed_channel.channelName'
                 defaultMessage='the channel'
             />
         );
-
         if (this.props.channelName) {
             channelName = this.props.channelName;
         }
 
-        var remover = (
+        let remover = (
             <FormattedMessage
                 id='removed_channel.someone'
                 defaultMessage='Someone'
             />
         );
-
         if (this.props.remover) {
             remover = this.props.remover;
         }
 
-        if (!currentUser) {
+        if (this.props.currentUserId === '') {
             return null;
         }
 
         return (
             <Modal
                 show={this.state.show}
-                onHide={this.handleClose}
-                onExited={this.handleExited}
-                id={ModalIdentifiers.REMOVED_FROM_CHANNEL}
+                onHide={this.onHide}
+                onExited={this.props.onHide}
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>
@@ -95,10 +68,12 @@ export default class RemovedFromChannelModal extends React.PureComponent {
                             id='removed_channel.from'
                             defaultMessage='Removed from '
                         />
-                        <span className='name'>{channelName}</span>
+                        <span className='name'>
+                            {channelName}
+                        </span>
                     </Modal.Title>
                 </Modal.Header>
-                <Modal.Body>
+                <Modal.Body ref='modalBody'>
                     <p>
                         <FormattedMessage
                             id='removed_channel.remover'
@@ -114,8 +89,7 @@ export default class RemovedFromChannelModal extends React.PureComponent {
                     <button
                         type='button'
                         className='btn btn-primary'
-                        data-dismiss='modal'
-                        onClick={this.handleClose}
+                        onClick={this.onHide}
                     >
                         <FormattedMessage
                             id='removed_channel.okay'

--- a/tests/components/removed_from_channel_modal/__snapshots__/removed_from_channel_modal.test.jsx.snap
+++ b/tests/components/removed_from_channel_modal/__snapshots__/removed_from_channel_modal.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/AddUsersToTeam should match snapshot 1`] = `
+exports[`components/RemoveFromChannelModal should match snapshot 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
@@ -8,7 +8,6 @@ exports[`components/AddUsersToTeam should match snapshot 1`] = `
   bsClass="modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
-  id="removed_from_channel"
   keyboard={true}
   manager={
     ModalManager {
@@ -22,7 +21,7 @@ exports[`components/AddUsersToTeam should match snapshot 1`] = `
       "remove": [Function],
     }
   }
-  onExited={[Function]}
+  onExited={[MockFunction]}
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
@@ -72,7 +71,6 @@ exports[`components/AddUsersToTeam should match snapshot 1`] = `
   >
     <button
       className="btn btn-primary"
-      data-dismiss="modal"
       onClick={[Function]}
       type="button"
     >

--- a/tests/components/removed_from_channel_modal/removed_from_channel_modal.test.jsx
+++ b/tests/components/removed_from_channel_modal/removed_from_channel_modal.test.jsx
@@ -10,18 +10,14 @@ import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 
 import RemovedFromChannelModal from 'components/removed_from_channel_modal/removed_from_channel_modal';
 
-describe('components/AddUsersToTeam', () => {
+describe('components/RemoveFromChannelModal', () => {
     const baseProps = {
-        defaultChannel: {
-            name: 'town-square',
-        },
-        currentUser: {
-            id: 'current_user_id',
-        },
+        currentUserId: 'current_user_id',
         channelName: 'test-channel',
         remover: 'Administrator',
+        onHide: jest.fn(),
         actions: {
-            closeModal: jest.fn(),
+            goToLastViewedChannel: jest.fn(),
         },
     };
 
@@ -39,14 +35,6 @@ describe('components/AddUsersToTeam', () => {
         );
 
         expect(wrapper.state('show')).toBe(true);
-    });
-
-    test('should run handleClose on exit', () => {
-        const wrapper = shallow(
-            <RemovedFromChannelModal {...baseProps}/>
-        );
-        wrapper.find('#removed_from_channel button.btn-primary').simulate('click');
-        expect(wrapper.state('show')).toBe(false);
     });
 
     test('should display correct props on Modal.Title and Modal.Body', () => {
@@ -70,12 +58,12 @@ describe('components/AddUsersToTeam', () => {
         expect(wrapper.find('.modal-body').text()).toBe('Someone removed you from the channel');
     });
 
-    test('should run closeModal after modal exited', () => {
+    test('should run goToLastViewedChannel after modal exited', () => {
         const wrapper = shallow(
             <RemovedFromChannelModal {...baseProps}/>
         );
 
-        wrapper.find(Modal).first().props().onExited();
-        expect(baseProps.actions.closeModal).toHaveBeenCalledTimes(1);
+        wrapper.find(Modal).first().props().onHide();
+        expect(baseProps.actions.goToLastViewedChannel).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
#### Summary
Remove flux store usages from websocket_actions.jsx.

@lindy65, could you regression test the following logged in on multiple browsers: leaving a team, view an unread channel on the same team, updating a user, deleting a team, getting removed from a channel you're viewing.

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/MM-12564

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed