### PR TITLE
MM-12810 Fix infinite logout loop

### DIFF
--- a/actions/views/root.js
+++ b/actions/views/root.js
@@ -9,6 +9,7 @@ import {ActionTypes} from 'utils/constants';
 
 export function loadMeAndConfig() {
     return (dispatch) => {
+        // if any new promise needs to be added please be mindful of the order as it is used in root.jsx for redirection
         const promises = [
             dispatch(getClientConfig()),
             dispatch(getLicenseConfig()),

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -228,11 +228,12 @@ export default class Root extends React.Component {
     }
 
     componentDidMount() {
-        this.props.actions.loadMeAndConfig().then(() => {
-            GlobalActions.redirectUserToDefaultTeam();
+        this.props.actions.loadMeAndConfig().then((response) => {
+            if (response[2] && response[2].data) {
+                GlobalActions.redirectUserToDefaultTeam();
+            }
             this.onConfigLoaded();
         });
-
         trackLoadTime();
     }
 

--- a/tests/components/root/root.test.jsx
+++ b/tests/components/root/root.test.jsx
@@ -26,7 +26,7 @@ describe('components/Root', () => {
         noAccounts: false,
         showTermsOfService: false,
         actions: {
-            loadMeAndConfig: async () => {}, // eslint-disable-line no-empty-function
+            loadMeAndConfig: async () => [{}, {}, {data: true}], // eslint-disable-line no-empty-function
         },
     };
 


### PR DESCRIPTION
#### Summary
Fixes infinite loop caused by the PR https://github.com/mattermost/mattermost-webapp/pull/1945
`loadMeAndConfig ` promise will always resolve even if user is not loggedIn or failed to login which causes an infinite loop as it tries to exec `redirectUserToDefaultTeam`

https://github.com/mattermost/mattermost-webapp/blob/96752fe2c617233e745e19a0118d846e0825d572/actions/views/root.js#L10-L23

So checking if third promise resolve exists for redirections.

#### Ticket Link
[MM-12810](https://mattermost.atlassian.net/browse/MM-12810)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
