### PR TITLE
Remove last flux store usage from actions

### DIFF
--- a/actions/diagnostics_actions.jsx
+++ b/actions/diagnostics_actions.jsx
@@ -2,9 +2,9 @@
 // See LICENSE.txt for license information.
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import store from 'stores/redux_store.jsx';
-import UserStore from 'stores/user_store.jsx';
 
 const SUPPORTS_CLEAR_MARKS = isSupported([performance.clearMarks]);
 const SUPPORTS_MARK = isSupported([performance.mark]);
@@ -17,7 +17,7 @@ const SUPPORTS_MEASURE_METHODS = isSupported([
 
 export function trackEvent(category, event, props) {
     if (global.window && global.window.analytics) {
-        const properties = Object.assign({category, type: event, user_actual_id: UserStore.getCurrentId()}, props);
+        const properties = Object.assign({category, type: event, user_actual_id: getCurrentUserId(store.getState())}, props);
         const options = {
             context: {
                 ip: '0.0.0.0',

--- a/actions/status_actions.jsx
+++ b/actions/status_actions.jsx
@@ -11,18 +11,19 @@ import {Constants} from 'utils/constants.jsx';
 
 export function loadStatusesForChannelAndSidebar() {
     return (dispatch, getState) => {
+        const state = getState();
         const statusesToLoad = {};
 
-        const channelId = getCurrentChannelId(getState());
-        const postsInChannel = getPostsInCurrentChannel(getState());
-        const posts = postsInChannel.slice(0, getState().views.channel.postVisibility[channelId] || 0);
+        const channelId = getCurrentChannelId(state);
+        const postsInChannel = getPostsInCurrentChannel(state);
+        const posts = postsInChannel.slice(0, state.views.channel.postVisibility[channelId] || 0);
         for (const post of posts) {
             if (post.user_id) {
                 statusesToLoad[post.user_id] = true;
             }
         }
 
-        const dmPrefs = getDirectShowPreferences(getState());
+        const dmPrefs = getDirectShowPreferences(state);
 
         for (const pref of dmPrefs) {
             if (pref.value === 'true') {
@@ -30,7 +31,7 @@ export function loadStatusesForChannelAndSidebar() {
             }
         }
 
-        const {currentUserId} = getState().entities.users;
+        const {currentUserId} = state.entities.users;
         statusesToLoad[currentUserId] = true;
 
         dispatch(loadStatusesByIds(Object.keys(statusesToLoad)));

--- a/actions/status_actions.jsx
+++ b/actions/status_actions.jsx
@@ -5,6 +5,7 @@ import {getStatusesByIds} from 'mattermost-redux/actions/users';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getPostsInCurrentChannel} from 'mattermost-redux/selectors/entities/posts';
 import {getDirectShowPreferences} from 'mattermost-redux/selectors/entities/preferences';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import store from 'stores/redux_store.jsx';
 import {Constants} from 'utils/constants.jsx';
@@ -31,7 +32,7 @@ export function loadStatusesForChannelAndSidebar() {
             }
         }
 
-        const {currentUserId} = state.entities.users;
+        const currentUserId = getCurrentUserId(state);
         statusesToLoad[currentUserId] = true;
 
         dispatch(loadStatusesByIds(Object.keys(statusesToLoad)));

--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -44,7 +44,7 @@ export async function switchFromLdapToEmail(email, password, token, ldapPassword
 export async function loadProfilesAndTeamMembers(page, perPage, teamId = getCurrentTeamId(getState()), success) {
     const {data} = await UserActions.getProfilesInTeam(teamId, page, perPage)(dispatch, getState);
     loadTeamMembersForProfilesList(data, teamId, success);
-    loadStatusesForProfilesList(data);
+    dispatch(loadStatusesForProfilesList(data));
 }
 
 export async function loadProfilesAndTeamMembersAndChannelMembers(page, perPage, teamId = getCurrentTeamId(getState()), channelId = getCurrentChannelId(getState()), success, error) {
@@ -55,7 +55,7 @@ export async function loadProfilesAndTeamMembersAndChannelMembers(page, perPage,
         teamId,
         () => {
             loadChannelMembersForProfilesList(data, channelId, success, error);
-            loadStatusesForProfilesList(data);
+            dispatch(loadStatusesForProfilesList(data));
         }
     );
 }
@@ -84,7 +84,7 @@ export function loadTeamMembersForProfilesList(profiles, teamId = getCurrentTeam
 
 export async function loadProfilesWithoutTeam(page, perPage, success) {
     const {data} = await UserActions.getProfilesWithoutTeam(page, perPage)(dispatch, getState);
-    loadStatusesForProfilesMap(data);
+    dispatch(loadStatusesForProfilesMap(data));
 
     if (success) {
         success(data);
@@ -342,7 +342,7 @@ function onThemeSaved(teamId, onSuccess) {
 
 export async function searchUsers(term, teamId = getCurrentTeamId(getState()), options = {}, success) {
     const {data} = await UserActions.searchProfiles(term, {team_id: teamId, ...options})(dispatch, getState);
-    loadStatusesForProfilesList(data);
+    dispatch(loadStatusesForProfilesList(data));
 
     if (success) {
         success(data);

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -130,7 +130,7 @@ export function reconnect(includeWebSocket = true) {
     if (currentTeamId) {
         loadChannelsForCurrentUser();
         getPosts(ChannelStore.getCurrentId())(dispatch, getState);
-        StatusActions.loadStatusesForChannelAndSidebar();
+        dispatch(StatusActions.loadStatusesForChannelAndSidebar());
         TeamActions.getMyTeamUnreads()(dispatch, getState);
     }
 

--- a/components/add_users_to_team/add_users_to_team.jsx
+++ b/components/add_users_to_team/add_users_to_team.jsx
@@ -7,7 +7,6 @@ import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import {Client4} from 'mattermost-redux/client';
 
-import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import {displayEntireNameForUser, localizeMessage} from 'utils/utils.jsx';
 
@@ -29,6 +28,7 @@ export default class AddUsersToTeam extends React.Component {
             setModalSearchTerm: PropTypes.func.isRequired,
             searchProfiles: PropTypes.func.isRequired,
             addUsersToTeam: PropTypes.func.isRequired,
+            loadStatusesForProfilesList: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -67,7 +67,7 @@ export default class AddUsersToTeam extends React.Component {
                     this.setUsersLoadingState(true);
                     const {data} = await this.props.actions.searchProfiles(searchTerm, {not_in_team_id: this.props.currentTeamId});
                     if (data) {
-                        loadStatusesForProfilesList(data);
+                        this.props.actions.loadStatusesForProfilesList(data);
                     }
                     this.setUsersLoadingState(false);
                 },

--- a/components/add_users_to_team/index.js
+++ b/components/add_users_to_team/index.js
@@ -7,6 +7,7 @@ import {getProfilesNotInTeam, searchProfiles} from 'mattermost-redux/actions/use
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {searchProfilesNotInCurrentTeam, getProfilesNotInCurrentTeam} from 'mattermost-redux/selectors/entities/users';
 
+import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 import {addUsersToTeam} from 'actions/team_actions.jsx';
 import {setModalSearchTerm} from 'actions/views/search';
 
@@ -39,6 +40,7 @@ function mapDispatchToProps(dispatch) {
             setModalSearchTerm,
             searchProfiles,
             addUsersToTeam,
+            loadStatusesForProfilesList,
         }, dispatch),
     };
 }

--- a/components/member_list_channel/index.js
+++ b/components/member_list_channel/index.js
@@ -11,6 +11,7 @@ import {getChannelStats} from 'mattermost-redux/actions/channels';
 import {searchProfiles} from 'mattermost-redux/actions/users';
 import {sortByUsername} from 'mattermost-redux/utils/user_utils';
 
+import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 import {setModalSearchTerm} from 'actions/views/search';
 
 import MemberListChannel from './member_list_channel.jsx';
@@ -72,6 +73,7 @@ function mapDispatchToProps(dispatch) {
             searchProfiles,
             getChannelStats,
             setModalSearchTerm,
+            loadStatusesForProfilesList,
         }, dispatch),
     };
 }

--- a/components/member_list_channel/member_list_channel.jsx
+++ b/components/member_list_channel/member_list_channel.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {loadProfilesAndTeamMembersAndChannelMembers, loadTeamMembersAndChannelMembersForProfilesList} from 'actions/user_actions.jsx';
-import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
@@ -28,6 +27,7 @@ export default class MemberListChannel extends React.PureComponent {
             searchProfiles: PropTypes.func.isRequired,
             getChannelStats: PropTypes.func.isRequired,
             setModalSearchTerm: PropTypes.func.isRequired,
+            loadStatusesForProfilesList: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -71,7 +71,7 @@ export default class MemberListChannel extends React.PureComponent {
 
                     this.setState({loading: true});
 
-                    loadStatusesForProfilesList(data);
+                    this.props.actions.loadStatusesForProfilesList(data);
                     loadTeamMembersAndChannelMembersForProfilesList(data, nextProps.currentTeamId, nextProps.currentChannelId, this.loadComplete);
                 },
                 Constants.SEARCH_TIMEOUT_MILLISECONDS

--- a/components/member_list_team/index.js
+++ b/components/member_list_team/index.js
@@ -10,6 +10,7 @@ import {getProfilesInCurrentTeam, searchProfilesInCurrentTeam} from 'mattermost-
 import {Permissions} from 'mattermost-redux/constants';
 import {searchProfiles} from 'mattermost-redux/actions/users';
 
+import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 import {setModalSearchTerm} from 'actions/views/search';
 
 import MemberListTeam from './member_list_team.jsx';
@@ -35,6 +36,7 @@ function mapStateToProps(state, ownProps) {
         currentTeamId: state.entities.teams.currentTeamId,
         totalTeamMembers: stats.active_member_count,
         canManageTeamMembers,
+        loadStatusesForProfilesList,
     };
 }
 

--- a/components/member_list_team/member_list_team.jsx
+++ b/components/member_list_team/member_list_team.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {loadProfilesAndTeamMembers, loadTeamMembersForProfilesList} from 'actions/user_actions.jsx';
-import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 
@@ -26,6 +25,7 @@ export default class MemberListTeam extends React.Component {
             searchProfiles: PropTypes.func.isRequired,
             getTeamStats: PropTypes.func.isRequired,
             setModalSearchTerm: PropTypes.func.isRequired,
+            loadStatusesForProfilesList: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -69,7 +69,7 @@ export default class MemberListTeam extends React.Component {
 
                     this.setState({loading: true});
 
-                    loadStatusesForProfilesList(data);
+                    this.props.actions.loadStatusesForProfilesList(data);
                     loadTeamMembersForProfilesList(data, nextProps.currentTeamId, this.loadComplete);
                 },
                 Constants.SEARCH_TIMEOUT_MILLISECONDS

--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -22,6 +22,7 @@ import {
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
+import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 import {setModalSearchTerm} from 'actions/views/search';
 
 import MoreDirectChannels from './more_direct_channels.jsx';
@@ -75,6 +76,7 @@ function mapDispatchToProps(dispatch) {
             searchProfiles,
             setModalSearchTerm,
             getTotalUsersStats,
+            loadStatusesForProfilesList,
         }, dispatch),
     };
 }

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -9,7 +9,6 @@ import {Client4} from 'mattermost-redux/client';
 
 import {browserHistory} from 'utils/browser_history';
 import {openDirectChannelToUser, openGroupChannelToUsers} from 'actions/channel_actions.jsx';
-import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import {displayEntireNameForUser, localizeMessage} from 'utils/utils.jsx';
 import MultiSelect from 'components/multiselect/multiselect.jsx';
@@ -53,6 +52,7 @@ export default class MoreDirectChannels extends React.Component {
             searchProfiles: PropTypes.func.isRequired,
             setModalSearchTerm: PropTypes.func.isRequired,
             getTotalUsersStats: PropTypes.func.isRequired,
+            loadStatusesForProfilesList: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -105,7 +105,7 @@ export default class MoreDirectChannels extends React.Component {
                         this.setUsersLoadingState(true);
                         const {data} = await this.props.actions.searchProfiles(searchTerm, {team_id: teamId});
                         if (data) {
-                            loadStatusesForProfilesList(data);
+                            this.props.actions.loadStatusesForProfilesList(data);
                             this.resetPaging();
                         }
                         this.setUsersLoadingState(false);

--- a/components/needs_team/index.js
+++ b/components/needs_team/index.js
@@ -13,6 +13,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
+import {loadStatusesForChannelAndSidebar} from 'actions/status_actions';
 import {setPreviousTeamId} from 'actions/local_storage';
 import {checkIfMFARequired} from 'utils/route';
 
@@ -43,6 +44,7 @@ function mapDispatchToProps(dispatch) {
             joinTeam,
             setPreviousTeamId,
             selectTeam,
+            loadStatusesForChannelAndSidebar,
         }, dispatch),
     };
 }

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {Route, Switch} from 'react-router-dom';
 import iNoBounce from 'inobounce';
 
-import {loadStatusesForChannelAndSidebar, startPeriodicStatusUpdates, stopPeriodicStatusUpdates} from 'actions/status_actions.jsx';
+import {startPeriodicStatusUpdates, stopPeriodicStatusUpdates} from 'actions/status_actions.jsx';
 import {startPeriodicSync, stopPeriodicSync, reconnect} from 'actions/websocket_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import Constants from 'utils/constants.jsx';
@@ -42,6 +42,7 @@ export default class NeedsTeam extends React.Component {
             joinTeam: PropTypes.func.isRequired,
             selectTeam: PropTypes.func.isRequired,
             setPreviousTeamId: PropTypes.func.isRequired,
+            loadStatusesForChannelAndSidebar: PropTypes.func.isRequired,
         }).isRequired,
         theme: PropTypes.object.isRequired,
         mfaRequired: PropTypes.bool.isRequired,
@@ -189,7 +190,7 @@ export default class NeedsTeam extends React.Component {
             }
         );
 
-        loadStatusesForChannelAndSidebar();
+        this.props.actions.loadStatusesForChannelAndSidebar();
         loadProfilesForSidebar();
 
         return team;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3303,9 +3303,9 @@
       }
     },
     "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
     "clone-deep": {
@@ -7009,6 +7009,14 @@
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+              "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+              "dev": true
+            }
           }
         }
       }
@@ -16764,6 +16772,12 @@
         "replace-ext": "0.0.1"
       },
       "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+          "dev": true
+        },
         "replace-ext": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "babel-jest": "23.6.0",
     "babel-loader": "8.0.4",
     "bundle-loader": "0.5.6",
-    "clone": "^2.1.2",
+    "clone": "2.1.2",
     "copy-webpack-plugin": "4.5.2",
     "cross-env": "5.2.0",
     "css-loader": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "babel-jest": "23.6.0",
     "babel-loader": "8.0.4",
     "bundle-loader": "0.5.6",
+    "clone": "^2.1.2",
     "copy-webpack-plugin": "4.5.2",
     "cross-env": "5.2.0",
     "css-loader": "1.0.0",

--- a/tests/components/add_users_to_team.test.jsx
+++ b/tests/components/add_users_to_team.test.jsx
@@ -9,10 +9,6 @@ import AddUsersToTeam from 'components/add_users_to_team/add_users_to_team.jsx';
 
 jest.useFakeTimers();
 
-jest.mock('actions/status_actions.jsx', () => ({
-    loadStatusesForProfilesList: jest.fn(),
-}));
-
 describe('components/AddUsersToTeam', () => {
     const baseProps = {
         currentTeamId: 'current_team_id',
@@ -37,6 +33,11 @@ describe('components/AddUsersToTeam', () => {
                 });
             }),
             addUsersToTeam: jest.fn(() => {
+                return new Promise((resolve) => {
+                    process.nextTick(() => resolve());
+                });
+            }),
+            loadStatusesForProfilesList: jest.fn(() => {
                 return new Promise((resolve) => {
                     process.nextTick(() => resolve());
                 });

--- a/tests/components/more_direct_channels.test.jsx
+++ b/tests/components/more_direct_channels.test.jsx
@@ -33,6 +33,7 @@ describe('components/MoreDirectChannels', () => {
             getStatusesByIds: emptyFunction,
             searchProfiles: emptyFunction,
             setModalSearchTerm: emptyFunction,
+            loadStatusesForProfilesList: emptyFunction,
             getTotalUsersStats: jest.fn(() => {
                 return new Promise((resolve) => {
                     process.nextTick(() => resolve());

--- a/tests/components/needs_team.test.jsx
+++ b/tests/components/needs_team.test.jsx
@@ -43,6 +43,7 @@ const actionsProp = {
     joinTeam: emptyFunction,
     selectTeam: emptyFunction,
     setPreviousTeamId: emptyFunction,
+    loadStatusesForChannelAndSidebar: emptyFunction,
 };
 
 const teamsList = [{

--- a/tests/redux/actions/status_actions.test.js
+++ b/tests/redux/actions/status_actions.test.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import clone from 'clone';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import {Preferences} from 'mattermost-redux/constants';
+import {getStatusesByIds} from 'mattermost-redux/actions/users';
+
+import * as Actions from 'actions/status_actions.jsx';
+
+jest.mock('mattermost-redux/actions/users', () => ({
+    getStatusesByIds: jest.fn(() => {
+        return {type: ''};
+    }),
+}));
+
+const mockStore = configureStore([thunk]);
+
+describe('actions/status_actions', () => {
+    const initialState = {
+        views: {
+            channel: {
+                postVisibility: {channel_id1: 100, channel_id2: 100},
+            },
+        },
+        entities: {
+            channels: {
+                currentChannelId: 'channel_id1',
+                channels: {channel_id1: {id: 'channel_id1', name: 'channel1', team_id: 'team_id1'}, channel_id2: {id: 'channel_id2', name: 'channel2', team_id: 'team_id1'}},
+                myMembers: {channel_id1: {channel_id: 'channel_id1', user_id: 'current_user_id'}},
+                channelsInTeam: {team_id1: ['channel_id1']},
+            },
+            teams: {
+                currentTeamId: 'team_id1',
+                teams: {
+                    team_id1: {
+                        id: 'team_id1',
+                        name: 'team1',
+                    },
+                },
+            },
+            users: {
+                currentUserId: 'current_user_id',
+                profiles: {user_id2: {id: 'user_id2', username: 'user2'}, user_id3: {id: 'user_id3', username: 'user3'}, user_id4: {id: 'user_id4', username: 'user4'}},
+            },
+            posts: {
+                posts: {post_id1: {id: 'post_id1', user_id: 'current_user_id'}, post_id2: {id: 'post_id2', user_id: 'user_id2'}},
+                postsInChannel: {channel_id1: ['post_id1', 'post_id2'], channel_id2: []},
+            },
+            preferences: {
+                myPreferences: {
+                    [Preferences.CATEGORY_DIRECT_CHANNEL_SHOW + '--user_id3']: {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: 'user_id3', value: 'true', user_id: 'current_user_id'},
+                    [Preferences.CATEGORY_DIRECT_CHANNEL_SHOW + '--user_id1']: {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: 'user_id1', value: 'false', user_id: 'current_user_id'},
+                },
+            },
+        },
+    };
+
+    describe('loadStatusesForChannelAndSidebar', () => {
+        test('load statuses with posts in channel and user in sidebar', () => {
+            const state = clone(initialState);
+            const testStore = mockStore(state);
+            testStore.dispatch(Actions.loadStatusesForChannelAndSidebar());
+            expect(getStatusesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['current_user_id', 'user_id2', 'user_id3']));
+        });
+
+        test('load statuses with empty channel and user in sidebar', () => {
+            const state = clone(initialState);
+            state.entities.channels.currentChannelId = 'channel_id2';
+            const testStore = mockStore(state);
+            testStore.dispatch(Actions.loadStatusesForChannelAndSidebar());
+            expect(getStatusesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['current_user_id', 'user_id3']));
+        });
+
+        test('load statuses with empty channel and no users in sidebar', () => {
+            const state = clone(initialState);
+            state.entities.channels.currentChannelId = 'channel_id2';
+            state.entities.preferences.myPreferences = {};
+            const testStore = mockStore(state);
+            testStore.dispatch(Actions.loadStatusesForChannelAndSidebar());
+            expect(getStatusesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['current_user_id']));
+        });
+    });
+
+    describe('loadStatusesForProfilesList', () => {
+        test('load statuses for users array', () => {
+            const state = clone(initialState);
+            const testStore = mockStore(state);
+            testStore.dispatch(Actions.loadStatusesForProfilesList([{id: 'user_id2', username: 'user2'}, {id: 'user_id4', username: 'user4'}]));
+            expect(getStatusesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['user_id2', 'user_id4']));
+        });
+
+        test('load statuses for empty users array', () => {
+            const state = clone(initialState);
+            const testStore = mockStore(state);
+            testStore.dispatch(Actions.loadStatusesForProfilesList([]));
+            expect(getStatusesByIds).not.toHaveBeenCalled();
+        });
+
+        test('load statuses for null users array', () => {
+            const state = clone(initialState);
+            const testStore = mockStore(state);
+            testStore.dispatch(Actions.loadStatusesForProfilesList(null));
+            expect(getStatusesByIds).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('loadStatusesForProfilesMap', () => {
+        test('load statuses for users map', () => {
+            const state = clone(initialState);
+            const testStore = mockStore(state);
+            testStore.dispatch(Actions.loadStatusesForProfilesMap({user_id2: {id: 'user_id2', username: 'user2'}, user_id3: {id: 'user_id3', username: 'user3'}, user_id4: {id: 'user_id4', username: 'user4'}}));
+            expect(getStatusesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['user_id2', 'user_id3', 'user_id4']));
+        });
+
+        test('load statuses for empty users map', () => {
+            const state = clone(initialState);
+            const testStore = mockStore(state);
+            testStore.dispatch(Actions.loadStatusesForProfilesMap({}));
+            expect(getStatusesByIds).not.toHaveBeenCalled();
+        });
+
+        test('load statuses for null users map', () => {
+            const state = clone(initialState);
+            const testStore = mockStore(state);
+            testStore.dispatch(Actions.loadStatusesForProfilesMap(null));
+            expect(getStatusesByIds).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -65,3 +65,21 @@ afterEach(() => {
         throw new Error('Unexpected console logs' + logs + warns + errors);
     }
 });
+
+expect.extend({
+    arrayContainingExactly(received, actual) {
+        const pass = received.sort().join(',') === actual.sort().join(',');
+        if (pass) {
+            return {
+                message: () =>
+                    `expected ${received} to not contain the exact same values as ${actual}`,
+                pass: true,
+            };
+        }
+        return {
+            message: () =>
+                `expected ${received} to not contain the exact same values as ${actual}`,
+            pass: false,
+        };
+    },
+});


### PR DESCRIPTION
#### Summary
Remove last flux store usage from actions. I took the liberty of converting the status actions to redux actions since that was the only good way to unit test them and my changes.

@lindy65, could you test to make sure statuses load correctly in channels/sidebar/user lists inside modals?

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/MM-12564
Also completes https://mattermost.atlassian.net/browse/MM-12589

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)