### PR TITLE
Remove flux store usages from utils

### DIFF
--- a/components/logged_in/index.js
+++ b/components/logged_in/index.js
@@ -5,8 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
-
-import {shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUser, shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
 
 import {checkIfMFARequired} from 'utils/route';
 
@@ -18,7 +17,7 @@ function mapStateToProps(state, ownProps) {
     const showTermsOfService = shouldShowTermsOfService(state);
 
     return {
-        mfaRequired: checkIfMFARequired(license, config, ownProps.match.url),
+        mfaRequired: checkIfMFARequired(getCurrentUser(state), license, config, ownProps.match.url),
         enableTimezone: config.ExperimentalTimezone === 'true',
         showTermsOfService,
     };

--- a/components/needs_team/index.js
+++ b/components/needs_team/index.js
@@ -22,11 +22,12 @@ import NeedsTeam from './needs_team.jsx';
 function mapStateToProps(state, ownProps) {
     const license = getLicense(state);
     const config = getConfig(state);
+    const currentUser = getCurrentUser(state);
 
     return {
         theme: getTheme(state),
-        mfaRequired: checkIfMFARequired(license, config, ownProps.match.url),
-        currentUser: getCurrentUser(state),
+        mfaRequired: checkIfMFARequired(currentUser, license, config, ownProps.match.url),
+        currentUser,
         currentTeamId: getCurrentTeamId(state),
         teamsList: getMyTeams(state),
         currentChannelId: getCurrentChannelId(state),

--- a/tests/utils/route.test.js
+++ b/tests/utils/route.test.js
@@ -1,0 +1,47 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import assert from 'assert';
+
+import {checkIfMFARequired} from 'utils/route';
+
+describe('Utils.Route', function() {
+    describe('checkIfMFARequired', () => {
+        test('mfa is enforced', () => {
+            const user = {mfa_active: false, auth_service: ''};
+            const config = {EnableMultifactorAuthentication: 'true', EnforceMultifactorAuthentication: 'true'};
+            const license = {MFA: 'true'};
+
+            assert.ok(checkIfMFARequired(user, license, config, ''));
+            assert.ok(!checkIfMFARequired(user, license, config, '/mfa/setup'));
+            assert.ok(!checkIfMFARequired(user, license, config, '/mfa/confirm'));
+
+            user.auth_service = 'email';
+            assert.ok(checkIfMFARequired(user, license, config, ''));
+
+            user.auth_service = 'ldap';
+            assert.ok(checkIfMFARequired(user, license, config, ''));
+
+            user.auth_service = 'saml';
+            assert.ok(!checkIfMFARequired(user, license, config, ''));
+
+            user.auth_service = '';
+            user.mfa_active = true;
+            assert.ok(!checkIfMFARequired(user, license, config, ''));
+        });
+
+        test('mfa is not enforced or enabled', () => {
+            const user = {mfa_active: false, auth_service: ''};
+            const config = {EnableMultifactorAuthentication: 'true', EnforceMultifactorAuthentication: 'false'};
+            const license = {MFA: 'true'};
+            assert.ok(!checkIfMFARequired(user, license, config, ''));
+
+            config.EnforceMultifactorAuthentication = 'true';
+            config.EnableMultifactorAuthentication = 'false';
+            assert.ok(!checkIfMFARequired(user, license, config, ''));
+
+            license.MFA = 'false';
+            config.EnableMultifactorAuthentication = 'true';
+            assert.ok(!checkIfMFARequired(user, license, config, ''));
+        });
+    });
+});

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -4,10 +4,10 @@
 import {Client4} from 'mattermost-redux/client';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {Permissions} from 'mattermost-redux/constants';
 
-import UserStore from 'stores/user_store.jsx';
 import store from 'stores/redux_store.jsx';
 
 import Constants from 'utils/constants.jsx';
@@ -29,7 +29,7 @@ export function isFromWebhook(post) {
 }
 
 export function isPostOwner(post) {
-    return UserStore.getCurrentId() === post.user_id;
+    return getCurrentUserId(store.getState()) === post.user_id;
 }
 
 export function isComment(post) {

--- a/utils/route.jsx
+++ b/utils/route.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import UserStore from 'stores/user_store.jsx';
 import {ErrorPageTypes} from 'utils/constants.jsx';
 
 export function importComponentSuccess(callback) {
@@ -27,12 +26,11 @@ const mfaAuthServices = [
     'ldap',
 ];
 
-export function checkIfMFARequired(license, config, path) {
+export function checkIfMFARequired(user, license, config, path) {
     if (license.MFA === 'true' &&
             config.EnableMultifactorAuthentication === 'true' &&
             config.EnforceMultifactorAuthentication === 'true' &&
             mfaPaths.indexOf(path) === -1) {
-        const user = UserStore.getCurrentUser();
         if (user && !user.mfa_active &&
                 mfaAuthServices.indexOf(user.auth_service) !== -1) {
             return true;


### PR DESCRIPTION
#### Summary
Remove flux store usages from utils. We should probably not have any references to the stores at all in the utils but that's a much larger task than what I'm trying to do here.

@lindy65 can you test to make sure MFA enforcement still works and that clicking on desktop notifications sends you to the right channel?

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/MM-12564

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)