### PR TITLE
Remove flux usages from email invite modal

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -233,13 +233,6 @@ export function showGetTeamInviteLinkModal() {
     });
 }
 
-export function showInviteMemberModal() {
-    AppDispatcher.handleViewAction({
-        type: ActionTypes.TOGGLE_INVITE_MEMBER_MODAL,
-        value: true,
-    });
-}
-
 export function showLeavePrivateChannelModal(channel) {
     AppDispatcher.handleViewAction({
         type: ActionTypes.TOGGLE_LEAVE_PRIVATE_CHANNEL_MODAL,

--- a/components/channel_layout/channel_controller.jsx
+++ b/components/channel_layout/channel_controller.jsx
@@ -13,7 +13,6 @@ import EditPostModal from 'components/edit_post_modal';
 import GetPostLinkModal from 'components/get_post_link_modal';
 import GetTeamInviteLinkModal from 'components/get_team_invite_link_modal';
 import GetPublicLinkModal from 'components/get_public_link_modal';
-import InviteMemberModal from 'components/invite_member_modal';
 import LeavePrivateChannelModal from 'components/leave_private_channel_modal';
 import ResetStatusModal from 'components/reset_status_modal';
 import ShortcutsModal from 'components/shortcuts_modal.jsx';
@@ -53,7 +52,6 @@ export default class ChannelController extends React.Component {
                     <GetPostLinkModal/>
                     <GetPublicLinkModal/>
                     <GetTeamInviteLinkModal/>
-                    <InviteMemberModal/>
                     <ImportThemeModal/>
                     <TeamSettingsModal/>
                     <EditPostModal/>

--- a/components/invite_member_modal/index.js
+++ b/components/invite_member_modal/index.js
@@ -3,6 +3,11 @@
 
 import {connect} from 'react-redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import Constants from 'utils/constants';
 
 import InviteMemberModal from './invite_member_modal.jsx';
 
@@ -12,9 +17,15 @@ function mapStateToProps(state) {
     const sendEmailNotifications = config.SendEmailNotifications === 'true';
     const enableUserCreation = config.EnableUserCreation === 'true';
 
+    const defaultChannel = getChannelsNameMapInCurrentTeam(state)[Constants.DEFAULT_CHANNEL];
+    const team = getCurrentTeam(state);
+
     return {
         sendEmailNotifications,
         enableUserCreation,
+        currentUser: getCurrentUser(state),
+        defaultChannelName: defaultChannel ? defaultChannel.display_name : '',
+        teamType: team ? team.type : '',
     };
 }
 

--- a/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
+++ b/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
@@ -17,6 +17,7 @@ import AboutBuildModal from 'components/about_build_modal';
 import AddUsersToTeam from 'components/add_users_to_team';
 import TeamMembersModal from 'components/team_members_modal';
 import TeamSettingsModal from 'components/team_settings_modal.jsx';
+import InviteMemberModal from 'components/invite_member_modal';
 
 import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
 import SystemPermissionGate from 'components/permissions_gates/system_permission_gate';
@@ -123,7 +124,7 @@ export default class SidebarHeaderDropdown extends React.PureComponent {
 
         this.props.onToggleDropdown(false);
 
-        GlobalActions.showInviteMemberModal();
+        this.props.actions.openModal({ModalId: ModalIdentifiers.EMAIL_INVITE, dialogType: InviteMemberModal});
     }
 
     showGetTeamInviteLinkModal = (e) => {

--- a/components/sidebar_right_menu/sidebar_right_menu.jsx
+++ b/components/sidebar_right_menu/sidebar_right_menu.jsx
@@ -25,6 +25,7 @@ import MenuTutorialTip from 'components/tutorial/menu_tutorial_tip';
 import ToggleModalButtonRedux from 'components/toggle_modal_button_redux';
 import LeaveTeamModal from 'components/leave_team_modal';
 import UserSettingsModal from 'components/user_settings/modal';
+import InviteMemberModal from 'components/invite_member_modal';
 
 export default class SidebarRightMenu extends React.PureComponent {
     static propTypes = {
@@ -143,16 +144,19 @@ export default class SidebarRightMenu extends React.PureComponent {
                         permissions={[Permissions.ADD_USER_TO_TEAM]}
                     >
                         <li>
-                            <a
-                                href='#'
-                                onClick={GlobalActions.showInviteMemberModal}
+                            <ToggleModalButtonRedux
+                                id='emailInviteMobile'
+                                role='menuitem'
+                                modalId={ModalIdentifiers.EMAIL_INVITE}
+                                dialogType={InviteMemberModal}
+                                dialogProps={{}}
                             >
                                 <i className='icon fa fa-user-plus'/>
                                 <FormattedMessage
                                     id='sidebar_right_menu.inviteNew'
                                     defaultMessage='Send Email Invite'
                                 />
-                            </a>
+                            </ToggleModalButtonRedux>
                         </li>
                     </TeamPermissionGate>
                 </TeamPermissionGate>

--- a/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
@@ -8,9 +8,11 @@ import {FormattedMessage} from 'react-intl';
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {savePreference} from 'actions/user_actions.jsx';
-import {Constants, Preferences} from 'utils/constants.jsx';
+import {Constants, Preferences, ModalIdentifiers} from 'utils/constants.jsx';
 import {useSafeUrl} from 'utils/url.jsx';
 import AppIcons from 'images/appIcons.png';
+import ModalToggleButtonRedux from 'components/toggle_modal_button_redux';
+import InviteMemberModal from 'components/invite_member_modal';
 
 const NUM_SCREENS = 3;
 
@@ -206,16 +208,18 @@ export default class TutorialIntroScreens extends React.Component {
         if (!this.props.isLicensed || this.props.restrictTeamInvite === Constants.PERMISSIONS_ALL) {
             if (teamType === Constants.INVITE_TEAM) {
                 inviteModalLink = (
-                    <button
+                    <ModalToggleButtonRedux
                         id='tutorialIntroInvite'
                         className='intro-links color--link style--none'
-                        onClick={GlobalActions.showInviteMemberModal}
+                        modalId={ModalIdentifiers.EMAIL_INVITE}
+                        dialogType={InviteMemberModal}
+                        dialogProps={{}}
                     >
                         <FormattedMessage
                             id='tutorial_intro.invite'
                             defaultMessage='Invite teammates'
                         />
-                    </button>
+                    </ModalToggleButtonRedux>
                 );
             } else {
                 inviteModalLink = (

--- a/stores/modal_store.jsx
+++ b/stores/modal_store.jsx
@@ -30,7 +30,6 @@ class ModalStoreClass extends EventEmitter {
         switch (type) {
         case ActionTypes.TOGGLE_SHORTCUTS_MODAL:
         case ActionTypes.TOGGLE_IMPORT_THEME_MODAL:
-        case ActionTypes.TOGGLE_INVITE_MEMBER_MODAL:
         case ActionTypes.TOGGLE_DELETE_POST_MODAL:
         case ActionTypes.TOGGLE_GET_POST_LINK_MODAL:
         case ActionTypes.TOGGLE_GET_TEAM_INVITE_LINK_MODAL:

--- a/tests/plugins/__snapshots__/main_menu_action.test.jsx.snap
+++ b/tests/plugins/__snapshots__/main_menu_action.test.jsx.snap
@@ -401,9 +401,12 @@ exports[`plugins/MainMenuActions should match snapshot and click plugin item for
           teamId="someteamid"
         >
           <li>
-            <a
-              href="#"
-              onClick={[Function]}
+            <Connect(ModalToggleButtonRedux)
+              dialogProps={Object {}}
+              dialogType={[Function]}
+              id="emailInviteMobile"
+              modalId="email_invite"
+              role="menuitem"
             >
               <i
                 className="icon fa fa-user-plus"
@@ -413,7 +416,7 @@ exports[`plugins/MainMenuActions should match snapshot and click plugin item for
                 id="sidebar_right_menu.inviteNew"
                 values={Object {}}
               />
-            </a>
+            </Connect(ModalToggleButtonRedux)>
           </li>
         </Connect(TeamPermissionGate)>
       </Connect(TeamPermissionGate)>

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -213,7 +213,6 @@ export const ActionTypes = keyMirror({
 
     TOGGLE_SHORTCUTS_MODAL: null,
     TOGGLE_IMPORT_THEME_MODAL: null,
-    TOGGLE_INVITE_MEMBER_MODAL: null,
     TOGGLE_DELETE_POST_MODAL: null,
     TOGGLE_GET_POST_LINK_MODAL: null,
     TOGGLE_GET_TEAM_INVITE_LINK_MODAL: null,
@@ -286,6 +285,7 @@ export const ModalIdentifiers = {
     LEAVE_TEAM: 'leave_team',
     USER_SETTINGS: 'user_settings',
     REMOVED_FROM_CHANNEL: 'removed_from_channel',
+    EMAIL_INVITE: 'email_invite',
 };
 
 export const UserStatuses = {


### PR DESCRIPTION
#### Summary
Remove flux usages from email invite modal and converted the modal to use the modal controller.

@lindy65 can you regression test the email invite modal?

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/MM-12564

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)