### PR TITLE
[MM-12716] Remove doPostAction from post_actions and rename MessageAttachment and MessageAttachmentList components

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -250,10 +250,6 @@ export function unpinPost(postId) {
     };
 }
 
-export function doPostAction(postId, actionId) {
-    PostActions.doPostAction(postId, actionId)(dispatch, getState);
-}
-
 export function setEditingPost(postId = '', commentCount = 0, refocusId = '', title = '', isRHS = false) {
     return async (doDispatch, doGetState) => {
         const state = doGetState();

--- a/components/post_view/message_attachments/message_attachment/index.js
+++ b/components/post_view/message_attachments/message_attachment/index.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {doPostAction} from 'mattermost-redux/actions/posts';
+
+import MessageAttachment from './message_attachment';
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            doPostAction,
+        }, dispatch),
+    };
+}
+
+export default connect(null, mapDispatchToProps)(MessageAttachment);

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -4,18 +4,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import * as PostActions from 'actions/post_actions.jsx';
 import {postListScrollChange} from 'actions/global_actions';
 
 import {isUrlSafe} from 'utils/url.jsx';
-import * as Utils from 'utils/utils';
+import {handleFormattedTextClick} from 'utils/utils';
 
 import Markdown from 'components/markdown';
-
 import ShowMore from 'components/post_view/show_more';
 
-import ActionButton from './action_button.jsx';
-import ActionMenu from './action_menu';
+import ActionButton from '../action_button';
+import ActionMenu from '../action_menu';
 
 const MAX_ATTACHMENT_TEXT_HEIGHT = 200;
 
@@ -36,6 +34,10 @@ export default class MessageAttachment extends React.PureComponent {
          * Options specific to text formatting
          */
         options: PropTypes.object,
+
+        actions: PropTypes.shape({
+            doPostAction: PropTypes.func.isRequired,
+        }).isRequired,
     }
 
     constructor(props) {
@@ -111,7 +113,7 @@ export default class MessageAttachment extends React.PureComponent {
     handleAction = (e) => {
         e.preventDefault();
         const actionId = e.currentTarget.getAttribute('data-action-id');
-        PostActions.doPostAction(this.props.postId, actionId);
+        this.props.actions.doPostAction(this.props.postId, actionId);
     };
 
     getFieldsTable = () => {
@@ -339,7 +341,7 @@ export default class MessageAttachment extends React.PureComponent {
                         <div>
                             <div
                                 className={thumb ? 'attachment__body' : 'attachment__body attachment__body--no_thumb'}
-                                onClick={Utils.handleFormattedTextClick}
+                                onClick={handleFormattedTextClick}
                             >
                                 {attachmentText}
                                 {image}

--- a/components/post_view/message_attachments/message_attachment_list.jsx
+++ b/components/post_view/message_attachments/message_attachment_list.jsx
@@ -4,9 +4,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import PostAttachment from './message_attachment.jsx';
+import MessageAttachment from './message_attachment';
 
-export default class PostAttachmentList extends React.PureComponent {
+export default class MessageAttachmentList extends React.PureComponent {
     static propTypes = {
 
         /**
@@ -29,7 +29,7 @@ export default class PostAttachmentList extends React.PureComponent {
         const content = [];
         this.props.attachments.forEach((attachment, i) => {
             content.push(
-                <PostAttachment
+                <MessageAttachment
                     attachment={attachment}
                     postId={this.props.postId}
                     key={'att_' + i}

--- a/tests/components/post_view/__snapshots__/message_attachment.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/message_attachment.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/post_view/MessageAttachment should call PostActions.doPostAction on handleAction 1`] = `
+exports[`components/post_view/MessageAttachment should call actions.doPostAction on handleAction 1`] = `
 <div
   className="attachment attachment--pretext"
 >

--- a/tests/components/post_view/message_attachment.test.jsx
+++ b/tests/components/post_view/message_attachment.test.jsx
@@ -4,13 +4,8 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import MessageAttachment from 'components/post_view/message_attachments/message_attachment.jsx';
-import {doPostAction} from 'actions/post_actions.jsx';
+import MessageAttachment from 'components/post_view/message_attachments/message_attachment/message_attachment.jsx';
 import {postListScrollChange} from 'actions/global_actions';
-
-jest.mock('actions/post_actions.jsx', () => ({
-    doPostAction: jest.fn(),
-}));
 
 jest.mock('actions/global_actions.jsx', () => ({
     postListScrollChange: jest.fn(),
@@ -33,6 +28,7 @@ describe('components/post_view/MessageAttachment', () => {
     const baseProps = {
         postId: 'post_id',
         attachment,
+        actions: {doPostAction: jest.fn()},
     };
 
     test('should match snapshot', () => {
@@ -74,13 +70,14 @@ describe('components/post_view/MessageAttachment', () => {
         expect(wrapper.instance().getActionView()).toMatchSnapshot();
     });
 
-    test('should call PostActions.doPostAction on handleAction', () => {
+    test('should call actions.doPostAction on handleAction', () => {
+        const doPostAction = jest.fn();
         const actionId = 'action_id_1';
         const newAttachment = {
             ...attachment,
             actions: [{id: actionId, name: 'action_name_1'}],
         };
-        const props = {...baseProps, attachment: newAttachment};
+        const props = {...baseProps, actions: {doPostAction}, attachment: newAttachment};
         const wrapper = shallow(<MessageAttachment {...props}/>);
         expect(wrapper).toMatchSnapshot();
         wrapper.instance().handleAction({
@@ -90,6 +87,7 @@ describe('components/post_view/MessageAttachment', () => {
             }},
         });
 
+        expect(doPostAction).toHaveBeenCalledTimes(1);
         expect(doPostAction).toBeCalledWith(props.postId, actionId);
     });
 


### PR DESCRIPTION
#### Summary
Remove doPostAction from post_actions and rename MessageAttachment and MessageAttachmentList components

Affected area: 
- Message attachment with interactive button.

@DHaussermann Please help test on message attachment.  Interactive button can be tested by using the matterpoll plugin - https://github.com/matterpoll/matterpoll/releases.  Thanks!

#### Ticket Link
Jira ticket: [MM-12716](https://mattermost.atlassian.net/browse/MM-12716)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
