### PR TITLE
MM-12810 Fix for redirection if path is not root

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -229,7 +229,7 @@ export default class Root extends React.Component {
 
     componentDidMount() {
         this.props.actions.loadMeAndConfig().then((response) => {
-            if (response[2] && response[2].data) {
+            if (this.props.location.pathname === '/' && response[2] && response[2].data) {
                 GlobalActions.redirectUserToDefaultTeam();
             }
             this.onConfigLoaded();

--- a/tests/components/root/root.test.jsx
+++ b/tests/components/root/root.test.jsx
@@ -28,6 +28,9 @@ describe('components/Root', () => {
         actions: {
             loadMeAndConfig: async () => [{}, {}, {data: true}], // eslint-disable-line no-empty-function
         },
+        location: {
+            pathname: '/',
+        },
     };
 
     test('should load user, config, and license on mount and redirect to defaultTeam on success', (done) => {
@@ -51,5 +54,25 @@ describe('components/Root', () => {
         shallow(<MockedRoot {...props}/>);
 
         expect(props.actions.loadMeAndConfig).toHaveBeenCalledTimes(1);
+    });
+
+    test('should load user, config, and license on mount and should not redirect to defaultTeam id pathname is not root', (done) => {
+        const props = {
+            ...baseProps,
+            location: {
+                pathname: '/admin_console',
+            },
+        };
+
+        // Mock the method by extending the class because we don't have a chance to do it before shallow mounts the component
+        class MockedRoot extends Root {
+            onConfigLoaded = jest.fn(() => {
+                expect(this.onConfigLoaded).toHaveBeenCalledTimes(1);
+                expect(GlobalActions.redirectUserToDefaultTeam).not.toHaveBeenCalled();
+                done();
+            });
+        }
+
+        shallow(<MockedRoot {...props}/>);
     });
 });


### PR DESCRIPTION
#### Summary
If location is not root don't redirect to default team let it be matched through url

#### Ticket Link
[MM-12810](https://mattermost.atlassian.net/browse/MM-12810)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
