### PR TITLE
MM-12815: Stop using permissions-deprecated config settings in web app

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -5,10 +5,11 @@ import {batchActions} from 'redux-batched-actions';
 
 import {PostTypes, SearchTypes} from 'mattermost-redux/action_types';
 import {getMyChannelMember} from 'mattermost-redux/actions/channels';
-import {getMyChannelMember as getMyChannelMemberSelector} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, getMyChannelMember as getMyChannelMemberSelector} from 'mattermost-redux/selectors/entities/channels';
 import * as PostActions from 'mattermost-redux/actions/posts';
 import * as PostSelectors from 'mattermost-redux/selectors/entities/posts';
-import {comparePosts} from 'mattermost-redux/utils/post_utils';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {canEditPost, comparePosts} from 'mattermost-redux/utils/post_utils';
 
 import {addRecentEmoji} from 'actions/emoji_actions';
 import * as StorageActions from 'actions/storage';
@@ -259,20 +260,15 @@ export function setEditingPost(postId = '', commentCount = 0, refocusId = '', ti
             return {data: false};
         }
 
-        let canEditNow = true;
+        const config = state.entities.general.config;
+        const license = state.entities.general.license;
+        const userId = getCurrentUserId(state);
+        const channel = getChannel(state, post.channel_id);
+        const teamId = channel.team_id || '';
+
+        const canEditNow = canEditPost(state, config, license, teamId, post.channel_id, userId, post);
 
         // Only show the modal if we can edit the post now, but allow it to be hidden at any time
-        if (postId && state.entities.general.license.IsLicensed === 'true') {
-            const config = state.entities.general.config;
-
-            if (config.AllowEditPost === Constants.ALLOW_EDIT_POST_NEVER) {
-                canEditNow = false;
-            } else if (config.AllowEditPost === Constants.ALLOW_EDIT_POST_TIME_LIMIT) {
-                if ((post.create_at + (config.PostEditTimeLimit * 1000)) < Date.now()) {
-                    canEditNow = false;
-                }
-            }
-        }
 
         if (canEditNow) {
             doDispatch({

--- a/components/integrations/index.js
+++ b/components/integrations/index.js
@@ -13,7 +13,6 @@ function mapStateToProps(state) {
     const enableOutgoingWebhooks = config.EnableOutgoingWebhooks === 'true';
     const enableCommands = config.EnableCommands === 'true';
     const enableOAuthServiceProvider = config.EnableOAuthServiceProvider === 'true';
-    const enableOnlyAdminIntegrations = config.EnableOnlyAdminIntegrations === 'true';
 
     return {
         siteName,
@@ -21,7 +20,6 @@ function mapStateToProps(state) {
         enableOutgoingWebhooks,
         enableCommands,
         enableOAuthServiceProvider,
-        enableOnlyAdminIntegrations,
     };
 }
 

--- a/components/integrations/installed_oauth_apps/index.js
+++ b/components/integrations/installed_oauth_apps/index.js
@@ -14,14 +14,12 @@ import InstalledOAuthApps from './installed_oauth_apps.jsx';
 function mapStateToProps(state) {
     const config = getConfig(state);
     const enableOAuthServiceProvider = config.EnableOAuthServiceProvider === 'true';
-    const enableOnlyAdminIntegrations = config.EnableOnlyAdminIntegrations === 'true';
 
     return {
         canManageOauth: haveISystemPermission(state, {permission: Permissions.MANAGE_OAUTH}),
         oauthApps: getOAuthApps(state),
         regenOAuthAppSecretRequest: state.requests.integrations.updateOAuthApp,
         enableOAuthServiceProvider,
-        enableOnlyAdminIntegrations,
     };
 }
 

--- a/components/integrations/installed_oauth_apps/installed_oauth_apps.jsx
+++ b/components/integrations/installed_oauth_apps/installed_oauth_apps.jsx
@@ -54,12 +54,7 @@ export default class InstalledOAuthApps extends React.PureComponent {
         * Whether or not OAuth applications are enabled.
         */
         enableOAuthServiceProvider: PropTypes.bool,
-
-        /**
-        * Whether or not integration configuration is restricted to admins.
-        */
-        enableOnlyAdminIntegrations: PropTypes.bool,
-    }
+    };
 
     constructor(props) {
         super(props);

--- a/components/integrations/integrations.jsx
+++ b/components/integrations/integrations.jsx
@@ -28,7 +28,6 @@ export default class Integrations extends React.Component {
             enableOutgoingWebhooks: PropTypes.bool,
             enableCommands: PropTypes.bool,
             enableOAuthServiceProvider: PropTypes.bool,
-            enableOnlyAdminIntegrations: PropTypes.bool,
         };
     }
 

--- a/components/select_team/index.js
+++ b/components/select_team/index.js
@@ -23,7 +23,6 @@ function mapStateToProps(state) {
         currentUserRoles: currentUser.roles || '',
         customDescriptionText: config.CustomDescriptionText,
         roles: getRoles(state),
-        enableTeamCreation: config.EnableTeamCreation === 'true',
         isMemberOfTeam: myTeamMemberships && myTeamMemberships.length > 0,
         joinableTeams: getSortedJoinableTeams(state, currentUser.locale),
         siteName: config.SiteName,

--- a/components/select_team/index.js
+++ b/components/select_team/index.js
@@ -8,7 +8,8 @@ import {withRouter} from 'react-router-dom';
 import {getTeams} from 'mattermost-redux/actions/teams';
 import {loadRolesIfNeeded} from 'mattermost-redux/actions/roles';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getRoles} from 'mattermost-redux/selectors/entities/roles';
+import {Permissions} from 'mattermost-redux/constants';
+import {haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getSortedJoinableTeams, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
@@ -22,10 +23,11 @@ function mapStateToProps(state) {
     return {
         currentUserRoles: currentUser.roles || '',
         customDescriptionText: config.CustomDescriptionText,
-        roles: getRoles(state),
         isMemberOfTeam: myTeamMemberships && myTeamMemberships.length > 0,
         joinableTeams: getSortedJoinableTeams(state, currentUser.locale),
         siteName: config.SiteName,
+        canCreateTeams: haveISystemPermission(state, {permission: Permissions.CREATE_TEAM}),
+        canManageSystem: haveISystemPermission(state, {permission: Permissions.MANAGE_SYSTEM}),
     };
 }
 

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -6,12 +6,11 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
-import {General, Permissions} from 'mattermost-redux/constants';
+import {Permissions} from 'mattermost-redux/constants';
 
 import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 import {addUserToTeamFromInvite} from 'actions/team_actions.jsx';
 
-import {mappingValueFromRoles} from 'utils/policy_roles_adapter';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -33,13 +32,14 @@ export default class SelectTeam extends React.Component {
         customDescriptionText: PropTypes.string,
         isMemberOfTeam: PropTypes.bool.isRequired,
         joinableTeams: PropTypes.array,
-        roles: PropTypes.object.isRequired,
         siteName: PropTypes.string,
+        canCreateTeams: PropTypes.bool.isRequired,
+        canManageSystem: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             getTeams: PropTypes.func.isRequired,
             loadRolesIfNeeded: PropTypes.func.isRequired,
         }).isRequired,
-    }
+    };
 
     constructor(props) {
         super(props);
@@ -57,36 +57,10 @@ export default class SelectTeam extends React.Component {
     UNSAFE_componentWillMount() { // eslint-disable-line camelcase
         const {
             actions,
-            roles,
+            currentUserRoles,
         } = this.props;
 
-        actions.loadRolesIfNeeded([General.SYSTEM_ADMIN_ROLE, General.SYSTEM_USER_ROLE]);
-
-        if (
-            roles.system_admin &&
-            roles.system_user
-        ) {
-            this.loadPoliciesIntoState(roles);
-        }
-    }
-
-    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        if (
-            !this.state.loaded &&
-            nextProps.roles.system_admin &&
-            nextProps.roles.system_user
-        ) {
-            this.loadPoliciesIntoState(nextProps.roles);
-        }
-    }
-
-    // Is there a reason we are doing this rather than just using `haveISystemPermission(me, CREATE_TEAM)`?
-    loadPoliciesIntoState = (roles) => {
-        // Purposely parsing boolean from string 'true' or 'false'
-        // because the string comes from the policy roles adapter mapping.
-        const enableTeamCreation = (mappingValueFromRoles('enableTeamCreation', roles) === 'true');
-
-        this.setState({enableTeamCreation, loaded: true});
+        actions.loadRolesIfNeeded(currentUserRoles.split(' '));
     }
 
     handleTeamClick = (team) => {
@@ -108,7 +82,7 @@ export default class SelectTeam extends React.Component {
     handleLogoutClick = (e) => {
         e.preventDefault();
         emitUserLoggedOutEvent('/login');
-    }
+    };
 
     clearError = (e) => {
         e.preventDefault();
@@ -120,15 +94,13 @@ export default class SelectTeam extends React.Component {
 
     render() {
         const {
-            currentUserRoles,
+            canManageSystem,
             customDescriptionText,
             isMemberOfTeam,
             joinableTeams,
             siteName,
+            canCreateTeams,
         } = this.props;
-        const {enableTeamCreation} = this.state;
-
-        const isSystemAdmin = Utils.isSystemAdmin(currentUserRoles);
 
         let openContent;
         if (this.state.loadingTeamId) {
@@ -154,7 +126,7 @@ export default class SelectTeam extends React.Component {
                 );
             });
 
-            if (openTeamContents.length === 0 && (enableTeamCreation || isSystemAdmin)) {
+            if (openTeamContents.length === 0 && (canCreateTeams || canManageSystem)) {
                 openTeamContents = (
                     <div className='signup-team-dir-err'>
                         <div>
@@ -205,7 +177,7 @@ export default class SelectTeam extends React.Component {
         }
 
         let teamHelp = null;
-        if (isSystemAdmin && !enableTeamCreation) {
+        if (canManageSystem && !canCreateTeams) {
             teamHelp = (
                 <div>
                     <FormattedMessage

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -80,6 +80,7 @@ export default class SelectTeam extends React.Component {
         }
     }
 
+    // Is there a reason we are doing this rather than just using `haveISystemPermission(me, CREATE_TEAM)`?
     loadPoliciesIntoState = (roles) => {
         // Purposely parsing boolean from string 'true' or 'false'
         // because the string comes from the policy roles adapter mapping.

--- a/components/sidebar/header/dropdown/index.js
+++ b/components/sidebar/header/dropdown/index.js
@@ -32,7 +32,6 @@ function mapStateToProps(state) {
     const experimentalPrimaryTeam = config.ExperimentalPrimaryTeam;
     const helpLink = config.HelpLink;
     const reportAProblemLink = config.ReportAProblemLink;
-    const restrictTeamInvite = config.RestrictTeamInvite;
 
     let canCreateCustomEmoji = haveISystemPermission(state, {permission: Permissions.MANAGE_EMOJIS});
     if (!canCreateCustomEmoji) {
@@ -62,7 +61,6 @@ function mapStateToProps(state) {
         experimentalPrimaryTeam,
         helpLink,
         reportAProblemLink,
-        restrictTeamInvite,
         pluginMenuItems: state.plugins.components.MainMenu,
         canCreateCustomEmoji,
         moreTeamsToJoin,

--- a/components/sidebar/header/dropdown/index.js
+++ b/components/sidebar/header/dropdown/index.js
@@ -25,7 +25,6 @@ function mapStateToProps(state) {
     const enableIncomingWebhooks = config.EnableIncomingWebhooks === 'true';
     const enableOAuthServiceProvider = config.EnableOAuthServiceProvider === 'true';
     const enableOutgoingWebhooks = config.EnableOutgoingWebhooks === 'true';
-    const enableTeamCreation = config.EnableTeamCreation === 'true';
     const enableUserCreation = config.EnableUserCreation === 'true';
     const enableEmailInvitations = config.EnableEmailInvitations === 'true';
     const experimentalPrimaryTeam = config.ExperimentalPrimaryTeam;
@@ -53,7 +52,6 @@ function mapStateToProps(state) {
         enableIncomingWebhooks,
         enableOAuthServiceProvider,
         enableOutgoingWebhooks,
-        enableTeamCreation,
         enableUserCreation,
         enableEmailInvitations,
         experimentalPrimaryTeam,

--- a/components/sidebar/header/dropdown/index.js
+++ b/components/sidebar/header/dropdown/index.js
@@ -24,7 +24,6 @@ function mapStateToProps(state) {
     const enableCustomEmoji = config.EnableCustomEmoji === 'true';
     const enableIncomingWebhooks = config.EnableIncomingWebhooks === 'true';
     const enableOAuthServiceProvider = config.EnableOAuthServiceProvider === 'true';
-    const enableOnlyAdminIntegrations = config.EnableOnlyAdminIntegrations === 'true';
     const enableOutgoingWebhooks = config.EnableOutgoingWebhooks === 'true';
     const enableTeamCreation = config.EnableTeamCreation === 'true';
     const enableUserCreation = config.EnableUserCreation === 'true';
@@ -53,7 +52,6 @@ function mapStateToProps(state) {
         enableCustomEmoji,
         enableIncomingWebhooks,
         enableOAuthServiceProvider,
-        enableOnlyAdminIntegrations,
         enableOutgoingWebhooks,
         enableTeamCreation,
         enableUserCreation,

--- a/components/sidebar_right_menu/index.js
+++ b/components/sidebar_right_menu/index.js
@@ -25,7 +25,6 @@ function mapStateToProps(state) {
 
     const isLicensed = license.IsLicensed === 'true';
     const appDownloadLink = config.AppDownloadLink;
-    const enableTeamCreation = config.EnableTeamCreation === 'true';
     const enableUserCreation = config.EnableUserCreation === 'true';
     const experimentalPrimaryTeam = config.ExperimentalPrimaryTeam;
     const helpLink = config.HelpLink;
@@ -43,7 +42,6 @@ function mapStateToProps(state) {
         showTutorialTip: enableTutorial && isMobile() && tutorialStep === TutorialSteps.MENU_POPOVER,
         isLicensed,
         appDownloadLink,
-        enableTeamCreation,
         enableUserCreation,
         experimentalPrimaryTeam,
         helpLink,

--- a/components/sidebar_right_menu/index.js
+++ b/components/sidebar_right_menu/index.js
@@ -30,7 +30,6 @@ function mapStateToProps(state) {
     const experimentalPrimaryTeam = config.ExperimentalPrimaryTeam;
     const helpLink = config.HelpLink;
     const reportAProblemLink = config.ReportAProblemLink;
-    const restrictTeamInvite = config.RestrictTeamInvite;
     const siteName = config.SiteName;
 
     const joinableTeams = getJoinableTeamIds(state);
@@ -49,7 +48,6 @@ function mapStateToProps(state) {
         experimentalPrimaryTeam,
         helpLink,
         reportAProblemLink,
-        restrictTeamInvite,
         siteName,
         moreTeamsToJoin,
         pluginMenuItems: state.plugins.components.MainMenu,

--- a/components/tutorial/index.jsx
+++ b/components/tutorial/index.jsx
@@ -1,8 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import {connect} from 'react-redux';
+
+import {Permissions} from 'mattermost-redux/constants';
 import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
+import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import Constants from 'utils/constants.jsx';
 
@@ -12,13 +16,15 @@ function mapStateToProps(state) {
     const license = getLicense(state);
     const config = getConfig(state);
 
+    const team = getCurrentTeam(state);
+
     const teamChannels = getChannelsNameMapInCurrentTeam(state);
     const townSquare = teamChannels[Constants.DEFAULT_CHANNEL];
     const townSquareDisplayName = townSquare ? townSquare.display_name : Constants.DEFAULT_CHANNEL_UI_NAME;
 
     const appDownloadLink = config.AppDownloadLink;
     const isLicensed = license.IsLicensed === 'true';
-    const restrictTeamInvite = config.RestrictTeamInvite;
+    const restrictTeamInvite = !haveITeamPermission(state, {team: team.id, permission: Permissions.INVITE_USER});
     const supportEmail = config.SupportEmail;
 
     return {

--- a/tests/components/edit_post_modal.test.jsx
+++ b/tests/components/edit_post_modal.test.jsx
@@ -18,7 +18,6 @@ jest.mock('actions/global_actions.jsx', () => ({
 function createEditPost({ctrlSend, config, license, editingPost, actions} = {}) {
     const ctrlSendProp = ctrlSend || false;
     const configProp = config || {
-        AllowEditPost: 'always',
         PostEditTimeLimit: 300,
         EnableEmojiPicker: 'true',
     };
@@ -63,7 +62,6 @@ describe('components/EditPostModal', () => {
 
     it('should match without emoji picker', () => {
         const config = {
-            AllowEditPost: 'always',
             PostEditTimeLimit: 300,
             EnableEmojiPicker: 'false',
         };

--- a/tests/components/integrations/installed_oauth_apps.test.jsx
+++ b/tests/components/integrations/installed_oauth_apps.test.jsx
@@ -51,7 +51,6 @@ describe('components/integrations/InstalledOAuthApps', () => {
             deleteOAuthApp: jest.fn(),
         },
         enableOAuthServiceProvider: true,
-        enableOnlyAdminIntegrations: true,
     };
 
     test('should match snapshot', () => {

--- a/tests/components/select_team/select_team.test.jsx
+++ b/tests/components/select_team/select_team.test.jsx
@@ -4,8 +4,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import {General} from 'mattermost-redux/constants';
-
 import SelectTeam from 'components/select_team/select_team.jsx';
 
 import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
@@ -31,8 +29,9 @@ describe('components/select_team/SelectTeam', () => {
             {id: 'team_id_1', delete_at: 0, name: 'team-a', display_name: 'Team A'},
             {id: 'team_id_2', delete_at: 0, name: 'b-team', display_name: 'B Team'},
         ],
-        roles: {system_admin: {name: 'system_admin'}, system_user: {name: 'system_user'}},
         siteName: 'Mattermost',
+        canCreateTeams: false,
+        canManageSystem: true,
         actions: {
             getTeams: jest.fn(),
             loadRolesIfNeeded: jest.fn(),
@@ -45,7 +44,7 @@ describe('components/select_team/SelectTeam', () => {
         expect(wrapper).toMatchSnapshot();
 
         // on componentWillMount
-        expect(props.actions.loadRolesIfNeeded).toHaveBeenCalledWith([General.SYSTEM_ADMIN_ROLE, General.SYSTEM_USER_ROLE]);
+        expect(props.actions.loadRolesIfNeeded).toHaveBeenCalledWith(baseProps.currentUserRoles.split(' '));
 
         // on componentDidMount
         expect(props.actions.getTeams).toHaveBeenCalledTimes(1);
@@ -71,7 +70,7 @@ describe('components/select_team/SelectTeam', () => {
     });
 
     test('should match snapshot, on no joinable team and is not system admin nor can create team', () => {
-        const props = {...baseProps, joinableTeams: [], currentUserRoles: ''};
+        const props = {...baseProps, joinableTeams: [], currentUserRoles: '', canManageSystem: false, canCreateTeams: false};
         const wrapper = shallow(<SelectTeam {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });

--- a/tests/components/select_team/select_team.test.jsx
+++ b/tests/components/select_team/select_team.test.jsx
@@ -26,7 +26,6 @@ jest.mock('utils/policy_roles_adapter', () => ({
 describe('components/select_team/SelectTeam', () => {
     const baseProps = {
         currentUserRoles: 'system_admin',
-        enableTeamCreation: true,
         isMemberOfTeam: true,
         joinableTeams: [
             {id: 'team_id_1', delete_at: 0, name: 'team-a', display_name: 'Team A'},
@@ -72,7 +71,7 @@ describe('components/select_team/SelectTeam', () => {
     });
 
     test('should match snapshot, on no joinable team and is not system admin nor can create team', () => {
-        const props = {...baseProps, joinableTeams: [], currentUserRoles: '', enableTeamCreation: false};
+        const props = {...baseProps, joinableTeams: [], currentUserRoles: ''};
         const wrapper = shallow(<SelectTeam {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });

--- a/tests/plugins/main_menu_action.test.jsx
+++ b/tests/plugins/main_menu_action.test.jsx
@@ -22,7 +22,6 @@ describe('plugins/MainMenuActions', () => {
             enableIncomingWebhooks: true,
             enableOutgoingWebhooks: true,
             enableOAuthServiceProvider: true,
-            enableTeamCreation: true,
             enableUserCreation: true,
             enableEmailInvitations: false,
             showDropdown: true,

--- a/tests/plugins/main_menu_action.test.jsx
+++ b/tests/plugins/main_menu_action.test.jsx
@@ -22,7 +22,6 @@ describe('plugins/MainMenuActions', () => {
             enableIncomingWebhooks: true,
             enableOutgoingWebhooks: true,
             enableOAuthServiceProvider: true,
-            enableOnlyAdminIntegrations: false,
             enableTeamCreation: true,
             enableUserCreation: true,
             enableEmailInvitations: false,

--- a/tests/redux/actions/post_actions.test.js
+++ b/tests/redux/actions/post_actions.test.js
@@ -33,6 +33,7 @@ describe('Actions.Posts', () => {
         user_id: 'current_user_id',
         message: 'test msg',
         channel_id: 'current_channel_id',
+        type: 'normal,',
     };
     const initialState = {
         entities: {
@@ -53,7 +54,26 @@ describe('Actions.Posts', () => {
             },
             channels: {
                 currentChannelId: 'current_channel_id',
-                myMembers: {[latestPost.channel_id]: {channel_id: 'current_channel_id', user_id: 'current_user_id'}},
+                myMembers: {
+                    [latestPost.channel_id]: {
+                        channel_id: 'current_channel_id',
+                        user_id: 'current_user_id',
+                        roles: 'channel_role',
+                    },
+                },
+                channels: {
+                    current_channel_id: {team_id: 'team_id'},
+                },
+            },
+            preferences: {
+                myPreferences: {
+                    'display_settings--name_format': {
+                        category: 'display_settings',
+                        name: 'name_format',
+                        user_id: 'current_user_id',
+                        value: 'username',
+                    },
+                },
             },
             teams: {
                 currentTeamId: 'team-1',
@@ -64,11 +84,34 @@ describe('Actions.Posts', () => {
                         displayName: 'Team 1',
                     },
                 },
+                myMembers: {
+                    'team-1': {roles: 'team_role'},
+                },
             },
             users: {
                 currentUserId: 'current_user_id',
+                profiles: {
+                    current_user_id: {roles: 'system_role'},
+                },
             },
-            general: {license: {IsLicensed: 'false'}},
+            general: {
+                license: {IsLicensed: 'false'},
+                serverVersion: '5.4.0',
+                config: {PostEditTimeLimit: -1},
+            },
+            roles: {
+                roles: {
+                    system_role: {
+                        permissions: ['edit_post'],
+                    },
+                    team_role: {
+                        permissions: [],
+                    },
+                    channel_role: {
+                        permissions: [],
+                    },
+                },
+            },
         },
         views: {
             posts: {
@@ -98,17 +141,19 @@ describe('Actions.Posts', () => {
 
         const general = {
             license: {IsLicensed: 'true'},
-            config: {AllowEditPost: Constants.ALLOW_EDIT_POST_NEVER},
+            serverVersion: '5.4.0',
+            config: {PostEditTimeLimit: -1},
         };
         const withLicenseState = {...initialState};
         withLicenseState.entities.general = general;
 
-        // const testStore = mockStore(newInitialState);
         testStore = mockStore(withLicenseState);
 
         const {data: withLicenseData} = await testStore.dispatch(Actions.setEditingPost('latest_post_id', 0, 'test', 'title'));
-        expect(withLicenseData).toEqual(false);
-        expect(testStore.getActions()).toEqual([]);
+        expect(withLicenseData).toEqual(true);
+        expect(testStore.getActions()).toEqual(
+            [{data: {commentCount: 0, isRHS: false, postId: 'latest_post_id', refocusId: 'test', title: 'title'}, type: ActionTypes.SHOW_EDIT_POST_MODAL}]
+        );
 
         // should not allow edit for pending post
         const newLatestPost = {...latestPost, pending_post_id: latestPost.id};


### PR DESCRIPTION
#### Summary
Remove any residual usage of deprecated config settings due to advanced permissions.

~~There is also potentially going to be a redux and RN PR, but this PR is independent of any changes there.~~
redux PR: https://github.com/mattermost/mattermost-redux/pull/692
No changes to RN are required.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12815

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has server changes https://github.com/mattermost/mattermost-server/pull/9751