### PR TITLE
MM-12429 Add LDAP/AD create account label when redirected from sign-up to login

### DIFF
--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -64,13 +64,6 @@ class LoginController extends React.Component {
     constructor(props) {
         super(props);
 
-        this.preSubmit = this.preSubmit.bind(this);
-        this.submit = this.submit.bind(this);
-        this.finishSignin = this.finishSignin.bind(this);
-
-        this.handleLoginIdChange = this.handleLoginIdChange.bind(this);
-        this.handlePasswordChange = this.handlePasswordChange.bind(this);
-
         let loginId = '';
         if ((new URLSearchParams(this.props.location.search)).get('extra') === Constants.SIGNIN_VERIFIED && (new URLSearchParams(this.props.location.search)).get('email')) {
             loginId = (new URLSearchParams(this.props.location.search)).get('email');
@@ -131,7 +124,7 @@ class LoginController extends React.Component {
         }
     }
 
-    configureTitle() {
+    configureTitle = () => {
         if (this.state.sessionExpired) {
             document.title = this.props.intl.formatMessage({
                 id: 'login.session_expired.title',
@@ -172,7 +165,7 @@ class LoginController extends React.Component {
         }
     }
 
-    preSubmit(e) {
+    preSubmit = (e) => {
         e.preventDefault();
 
         const {location} = this.props;
@@ -257,7 +250,7 @@ class LoginController extends React.Component {
         );
     }
 
-    submit(loginId, password, token) {
+    submit = (loginId, password, token) => {
         this.setState({serverError: null, loading: true});
 
         webLogin(
@@ -321,7 +314,7 @@ class LoginController extends React.Component {
         );
     }
 
-    finishSignin(team) {
+    finishSignin = (team) => {
         const experimentalPrimaryTeam = this.props.experimentalPrimaryTeam;
         const primaryTeam = TeamStore.getByName(experimentalPrimaryTeam);
         const query = new URLSearchParams(this.props.location.search);
@@ -341,19 +334,19 @@ class LoginController extends React.Component {
         }
     }
 
-    handleLoginIdChange(e) {
+    handleLoginIdChange = (e) => {
         this.setState({
             loginId: e.target.value,
         });
     }
 
-    handlePasswordChange(e) {
+    handlePasswordChange = (e) => {
         this.setState({
             password: e.target.value,
         });
     }
 
-    createCustomLogin() {
+    createCustomLogin = () => {
         if (this.props.enableCustomBrand) {
             const text = this.props.customBrandText || '';
             const formattedText = TextFormatting.formatText(text);
@@ -373,7 +366,7 @@ class LoginController extends React.Component {
         return null;
     }
 
-    createLoginPlaceholder() {
+    createLoginPlaceholder = () => {
         const ldapEnabled = this.state.ldapEnabled;
         const usernameSigninEnabled = this.state.usernameSigninEnabled;
         const emailSigninEnabled = this.state.emailSigninEnabled;
@@ -406,7 +399,7 @@ class LoginController extends React.Component {
         return '';
     }
 
-    checkSignUpEnabled() {
+    checkSignUpEnabled = () => {
         return this.props.enableSignUpWithEmail ||
             this.props.enableSignUpWithGitLab ||
             this.props.enableSignUpWithOffice365 ||
@@ -420,11 +413,10 @@ class LoginController extends React.Component {
         this.setState({sessionExpired: false});
     }
 
-    createLoginOptions() {
+    createExtraText = () => {
         const extraParam = (new URLSearchParams(this.props.location.search)).get('extra');
-        let extraBox = '';
         if (this.state.sessionExpired) {
-            extraBox = (
+            return (
                 <div className='alert alert-warning'>
                     <i
                         className='fa fa-exclamation-triangle'
@@ -447,8 +439,10 @@ class LoginController extends React.Component {
                     </Link>
                 </div>
             );
-        } else if (extraParam === Constants.GET_TERMS_ERROR) {
-            extraBox = (
+        }
+
+        if (extraParam === Constants.GET_TERMS_ERROR) {
+            return (
                 <div className='alert has-error no-padding'>
                     <label className='control-label'>
                         <FormattedMessage
@@ -459,7 +453,7 @@ class LoginController extends React.Component {
                 </div>
             );
         } else if (extraParam === Constants.TERMS_REJECTED) {
-            extraBox = (
+            return (
                 <div className='alert alert-warning'>
                     <i
                         className='fa fa-exclamation-triangle'
@@ -475,7 +469,7 @@ class LoginController extends React.Component {
                 </div>
             );
         } else if (extraParam === Constants.SIGNIN_CHANGE) {
-            extraBox = (
+            return (
                 <div className='alert alert-success'>
                     <i
                         className='fa fa-check'
@@ -488,7 +482,7 @@ class LoginController extends React.Component {
                 </div>
             );
         } else if (extraParam === Constants.SIGNIN_VERIFIED) {
-            extraBox = (
+            return (
                 <div className='alert alert-success'>
                     <i
                         className='fa fa-check'
@@ -501,7 +495,7 @@ class LoginController extends React.Component {
                 </div>
             );
         } else if (extraParam === Constants.PASSWORD_CHANGE) {
-            extraBox = (
+            return (
                 <div className='alert alert-success'>
                     <i
                         className='fa fa-check'
@@ -513,8 +507,25 @@ class LoginController extends React.Component {
                     />
                 </div>
             );
+        } else if (extraParam === Constants.CREATE_LDAP) {
+            return (
+                <div className='alert alert-warning'>
+                    <i
+                        className='fa fa-exclamation-triangle'
+                        title={Utils.localizeMessage('generic_icons.warning', 'Warning Icon')}
+                    />
+                    <FormattedMessage
+                        id='login.ldapCreate'
+                        defaultMessage=' Enter your AD/LDAP username and password to create an account.'
+                    />
+                </div>
+            );
         }
 
+        return null;
+    }
+
+    createLoginOptions = () => {
         const loginControls = [];
 
         const ldapEnabled = this.state.ldapEnabled;
@@ -765,7 +776,7 @@ class LoginController extends React.Component {
 
         return (
             <div>
-                {extraBox}
+                {this.createExtraText()}
                 {loginControls}
             </div>
         );

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -509,11 +509,7 @@ class LoginController extends React.Component {
             );
         } else if (extraParam === Constants.CREATE_LDAP) {
             return (
-                <div className='alert alert-warning'>
-                    <i
-                        className='fa fa-exclamation-triangle'
-                        title={Utils.localizeMessage('generic_icons.warning', 'Warning Icon')}
-                    />
+                <div className='alert alert-grey'>
                     <FormattedMessage
                         id='login.ldapCreate'
                         defaultMessage=' Enter your AD/LDAP username and password to create an account.'

--- a/components/signup/signup_controller/signup_controller.jsx
+++ b/components/signup/signup_controller/signup_controller.jsx
@@ -236,6 +236,13 @@ export default class SignupController extends React.Component {
         }
 
         if (this.props.isLicensed && this.props.enableLDAP) {
+            let query = '';
+            if (this.props.location.search) {
+                query = '&extra=create_ldap';
+            } else {
+                query = '?extra=create_ldap';
+            }
+
             let LDAPText = (
                 <FormattedMessage
                     id='signup.ldap'
@@ -249,7 +256,7 @@ export default class SignupController extends React.Component {
                 <Link
                     className='btn btn-custom-login btn--full ldap'
                     key='ldap'
-                    to={'/login' + this.props.location.search}
+                    to={'/login' + this.props.location.search + query}
                 >
                     <span>
                         <span

--- a/components/signup/signup_controller/signup_controller.jsx
+++ b/components/signup/signup_controller/signup_controller.jsx
@@ -236,12 +236,9 @@ export default class SignupController extends React.Component {
         }
 
         if (this.props.isLicensed && this.props.enableLDAP) {
-            let query = '';
-            if (this.props.location.search) {
-                query = '&extra=create_ldap';
-            } else {
-                query = '?extra=create_ldap';
-            }
+            const params = new URLSearchParams(this.props.location.search);
+            params.append('extra', 'create_ldap');
+            const query = '?' + params.toString();
 
             let LDAPText = (
                 <FormattedMessage
@@ -256,7 +253,7 @@ export default class SignupController extends React.Component {
                 <Link
                     className='btn btn-custom-login btn--full ldap'
                     key='ldap'
-                    to={'/login' + this.props.location.search + query}
+                    to={'/login' + query}
                 >
                     <span>
                         <span

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2155,6 +2155,7 @@
   "login.username": "Username",
   "login.userNotFound": "We couldn't find an account matching your login credentials.",
   "login.verified": " Email Verified",
+  "login.ldapCreate": " Enter your AD/LDAP username and password to create an account.",
   "members_popover.manageMembers": "Manage Members",
   "members_popover.title": "Channel Members",
   "members_popover.viewMembers": "View Members",

--- a/sass/components/_alerts.scss
+++ b/sass/components/_alerts.scss
@@ -5,6 +5,11 @@
     padding: 8px 12px;
 }
 
+.alert-grey {
+    background: #f2f2f2;
+    color: #999999;
+}
+
 .alert--confirm {
     display: inline-block;
     float: left;

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -734,6 +734,7 @@ export const Constants = {
     GET_TERMS_ERROR: 'get_terms_error',
     TERMS_REJECTED: 'terms_rejected',
     SIGNIN_VERIFIED: 'verified',
+    CREATE_LDAP: 'create_ldap',
     SESSION_EXPIRED: 'expired',
     POST_CHUNK_SIZE: 60,
     PROFILE_CHUNK_SIZE: 100,


### PR DESCRIPTION
#### Summary
Add LDAP/AD create account label when redirected from sign-up to login so users are not confused as to why they're sent back to the login page.

UI looks like this:
![screen shot 2018-10-30 at 08 58 14](https://user-images.githubusercontent.com/2672098/47720246-cdd42a80-dc23-11e8-8d91-cf0ec0d0f30b.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12429

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
