### PR TITLE
add build discader to avoid disk full issues in jenkins

### DIFF
--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -1,6 +1,9 @@
 #!/usr/bin/env groovy
 
 pipeline {
+
+    options { buildDiscarder(logRotator(numToKeepStr: '2')) }
+
     agent {
         docker {
             image 'mattermost/mattermost-build-webapp:oct-2-2018'


### PR DESCRIPTION
#### Summary
add a log rotator in the pipeline to avoid disk full issues 
