### PR TITLE
[MM-12712] Remove updatePost from post_actions

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -155,19 +155,6 @@ export function storeCommentDraft(rootPostId, draft) {
     };
 }
 
-export async function updatePost(post, success) {
-    const {data, error: err} = await PostActions.editPost(post)(dispatch, getState);
-    if (data && success) {
-        success();
-    } else if (err) {
-        AppDispatcher.handleServerAction({
-            type: ActionTypes.RECEIVED_ERROR,
-            err: {id: err.server_error_id, ...err},
-            method: 'editPost',
-        });
-    }
-}
-
 export function emitEmojiPosted(emoji) {
     dispatch(addRecentEmoji(emoji));
 }

--- a/components/post_view/post_attachment_opengraph/index.js
+++ b/components/post_view/post_attachment_opengraph/index.js
@@ -3,9 +3,12 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+
 import {getOpenGraphMetadata} from 'mattermost-redux/actions/posts';
 import {getOpenGraphMetadataForUrl} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
+import {editPost} from 'actions/views/posts';
 
 import PostAttachmentOpenGraph from './post_attachment_opengraph.jsx';
 
@@ -19,6 +22,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            editPost,
             getOpenGraphMetadata,
         }, dispatch),
     };

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {postListScrollChange} from 'actions/global_actions.jsx';
-import {updatePost} from 'actions/post_actions.jsx';
 import * as CommonUtils from 'utils/commons.jsx';
 import {PostTypes} from 'utils/constants.jsx';
 import {useSafeUrl} from 'utils/url';
@@ -40,6 +39,8 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
 
         actions: PropTypes.shape({
 
+            editPost: PropTypes.func.isRequired,
+
             /**
              * The function to get open graph data for a link
              */
@@ -69,11 +70,6 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
             YES: 'yes',
             ERROR: 'error',
         };
-
-        this.fetchData = this.fetchData.bind(this);
-        this.onImageLoad = this.onImageLoad.bind(this);
-        this.onImageError = this.onImageError.bind(this);
-        this.handleRemovePreview = this.handleRemovePreview.bind(this);
     }
 
     UNSAFE_componentWillMount() { // eslint-disable-line camelcase
@@ -103,7 +99,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
         setTimeout(postListScrollChange, 0);
     }
 
-    fetchData(url) {
+    fetchData = (url) => {
         if (!this.props.openGraphData) {
             this.props.actions.getOpenGraphMetadata(url);
         }
@@ -118,7 +114,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
         return bestImage.secure_url || bestImage.url;
     }
 
-    onImageLoad(image) {
+    onImageLoad = (image) => {
         this.imageRatio = image.target.naturalWidth / image.target.naturalHeight;
         if (
             image.target.naturalWidth >= this.largeImageMinWidth &&
@@ -134,7 +130,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
         });
     }
 
-    onImageError() {
+    onImageError = () => {
         this.setState({imageLoaded: this.IMAGE_LOADED.ERROR});
     }
 
@@ -223,7 +219,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
         return text;
     }
 
-    handleRemovePreview() {
+    handleRemovePreview = async () => {
         const props = Object.assign({}, this.props.post.props);
         props[PostTypes.REMOVE_LINK_PREVIEW] = 'true';
 
@@ -232,9 +228,10 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
             props,
         });
 
-        updatePost(patchedPost, () => {
+        const {data} = await this.props.actions.editPost(patchedPost);
+        if (data) {
             this.setState({removePreview: true});
-        });
+        }
     }
 
     isRemovePreview(post) {


### PR DESCRIPTION
#### Summary
Remove updatePost from post_actions

Affected area:
Only on post attachment opengraph.  Could be tested by:
1. Ensure "Enable Link Preview" is set to true at System Console > Customization > Posts
2. Post a link that generates an open graph like "https://github.com/mattermost/mattermost-webapp"
3. Hit "x" at the left side of link preview and observe that link preview is removed.

@DHaussermann I'll not request for QA test since I've tested it and it's working fine.  I've listed the steps above in case you'd want to try it out.

#### Ticket Link
Jira ticket: [MM-12712](https://mattermost.atlassian.net/browse/MM-12712)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
