### PR TITLE
MM-12840 Remove the last usages of the flux stores

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -111,14 +111,7 @@ export function emitChannelClickEvent(channel) {
     }
 }
 
-export async function doFocusPost(channelId, postId, data) {
-    AppDispatcher.handleServerAction({
-        type: ActionTypes.RECEIVED_FOCUSED_POST,
-        postId,
-        channelId,
-        post_list: data,
-    });
-
+export async function doFocusPost(channelId, postId) {
     dispatch({
         type: ActionTypes.RECEIVED_FOCUSED_POST,
         data: postId,

--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -112,6 +112,7 @@ export function emitChannelClickEvent(channel) {
 }
 
 export async function doFocusPost(channelId, postId) {
+    dispatch(selectChannel(channelId));
     dispatch({
         type: ActionTypes.RECEIVED_FOCUSED_POST,
         data: postId,

--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -275,3 +275,7 @@ export function toggleRhsExpanded() {
         type: ActionTypes.TOGGLE_RHS_EXPANDED,
     };
 }
+
+export function selectPost(post) {
+    return {type: ActionTypes.SELECT_POST, postId: post.root_id || post.id, channelId: post.channel_id};
+}

--- a/components/analytics/system_analytics/index.js
+++ b/components/analytics/system_analytics/index.js
@@ -12,6 +12,7 @@ function mapStateToProps(state) {
 
     return {
         isLicensed,
+        stats: state.entities.admin.analytics,
     };
 }
 

--- a/components/analytics/system_analytics/system_analytics.jsx
+++ b/components/analytics/system_analytics/system_analytics.jsx
@@ -6,9 +6,7 @@ import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 
 import * as AdminActions from 'actions/admin_actions.jsx';
-import AnalyticsStore from 'stores/analytics_store.jsx';
 import Constants from 'utils/constants.jsx';
-import * as Utils from 'utils/utils.jsx';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
@@ -25,20 +23,13 @@ import {
 
 const StatTypes = Constants.StatTypes;
 
-export default class SystemAnalytics extends React.Component {
+export default class SystemAnalytics extends React.PureComponent {
     static propTypes = {
         isLicensed: PropTypes.bool.isRequired,
-    }
-
-    constructor(props) {
-        super(props);
-
-        this.state = {stats: AnalyticsStore.getAllSystem()};
+        stats: PropTypes.object,
     }
 
     componentDidMount() {
-        AnalyticsStore.addChangeListener(this.onChange);
-
         AdminActions.getStandardAnalytics();
         AdminActions.getPostsPerDayAnalytics();
         AdminActions.getUsersPerDayAnalytics();
@@ -48,24 +39,8 @@ export default class SystemAnalytics extends React.Component {
         }
     }
 
-    componentWillUnmount() {
-        AnalyticsStore.removeChangeListener(this.onChange);
-    }
-
-    shouldComponentUpdate(nextProps, nextState) {
-        if (!Utils.areObjectsEqual(nextState.stats, this.state.stats)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    onChange = () => {
-        this.setState({stats: AnalyticsStore.getAllSystem()});
-    }
-
     render() {
-        const stats = this.state.stats;
+        const stats = this.props.stats;
         const isLicensed = this.props.isLicensed;
         const skippedIntensiveQueries = stats[StatTypes.TOTAL_POSTS] === -1;
         const postCountsDay = formatPostsPerDayData(stats[StatTypes.POST_PER_DAY]);

--- a/components/analytics/team_analytics/index.js
+++ b/components/analytics/team_analytics/index.js
@@ -23,6 +23,7 @@ function mapStateToProps(state) {
         initialTeam,
         locale: getCurrentLocale(state),
         teams,
+        stats: state.entities.admin.teamAnalytics,
     };
 }
 

--- a/components/analytics/team_analytics/team_analytics.jsx
+++ b/components/analytics/team_analytics/team_analytics.jsx
@@ -9,7 +9,6 @@ import {General} from 'mattermost-redux/constants';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
 import * as AdminActions from 'actions/admin_actions.jsx';
-import AnalyticsStore from 'stores/analytics_store.jsx';
 import BrowserStore from 'stores/browser_store.jsx';
 import {StatTypes} from 'utils/constants.jsx';
 import Banner from 'components/admin_console/banner.jsx';
@@ -41,6 +40,7 @@ export default class TeamAnalytics extends React.Component {
          * The locale of the current user
           */
         locale: PropTypes.string.isRequired,
+        stats: PropTypes.object.isRequired,
 
         actions: PropTypes.shape({
 
@@ -59,19 +59,14 @@ export default class TeamAnalytics extends React.Component {
     constructor(props) {
         super(props);
 
-        const teamId = props.initialTeam ? props.initialTeam.id : '';
-
         this.state = {
             team: props.initialTeam,
-            stats: AnalyticsStore.getAllTeam(teamId),
             recentlyActiveUsers: [],
             newUsers: [],
         };
     }
 
     componentDidMount() {
-        AnalyticsStore.addChangeListener(this.onChange);
-
         if (this.state.team) {
             this.getData(this.state.team.id);
         }
@@ -98,17 +93,6 @@ export default class TeamAnalytics extends React.Component {
         });
     }
 
-    componentWillUnmount() {
-        AnalyticsStore.removeChangeListener(this.onChange);
-    }
-
-    onChange = () => {
-        const teamId = this.state.team ? this.state.team.id : '';
-        this.setState({
-            stats: AnalyticsStore.getAllTeam(teamId),
-        });
-    }
-
     handleTeamChange = (e) => {
         const teamId = e.target.value;
 
@@ -127,7 +111,7 @@ export default class TeamAnalytics extends React.Component {
     }
 
     render() {
-        if (this.props.teams.length === 0 || !this.state.team || !this.state.stats) {
+        if (this.props.teams.length === 0 || !this.state.team || !this.props.stats[this.state.team.id]) {
             return <LoadingScreen/>;
         }
 
@@ -144,7 +128,7 @@ export default class TeamAnalytics extends React.Component {
             );
         }
 
-        const stats = this.state.stats;
+        const stats = this.props.stats[this.state.team.id];
         const postCountsDay = formatPostsPerDayData(stats[StatTypes.POST_PER_DAY]);
         const userCountsWithPostsDay = formatUsersWithPostsPerDayData(stats[StatTypes.USERS_WITH_POSTS_PER_DAY]);
 

--- a/components/integrations/abstract_outgoing_webhook.jsx
+++ b/components/integrations/abstract_outgoing_webhook.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
-import TeamStore from 'stores/team_store.jsx';
 import {localizeMessage} from 'utils/utils.jsx';
 import BackstageHeader from 'components/backstage/components/backstage_header.jsx';
 import ChannelSelect from 'components/channel_select';
@@ -161,7 +160,7 @@ export default class AbstractOutgoingWebhook extends React.Component {
         }
 
         const hook = {
-            team_id: TeamStore.getCurrentId(),
+            team_id: this.props.team.id,
             channel_id: this.state.channelId,
             trigger_words: triggerWords,
             trigger_when: parseInt(this.state.triggerWhen, 10),

--- a/components/logged_in/index.js
+++ b/components/logged_in/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser, shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
 
@@ -17,6 +18,8 @@ function mapStateToProps(state, ownProps) {
     const showTermsOfService = shouldShowTermsOfService(state);
 
     return {
+        currentUser: getCurrentUser(state),
+        currentChannelId: getCurrentChannelId(state),
         mfaRequired: checkIfMFARequired(getCurrentUser(state), license, config, ownProps.match.url),
         enableTimezone: config.ExperimentalTimezone === 'true',
         showTermsOfService,

--- a/components/logged_in/logged_in.jsx
+++ b/components/logged_in/logged_in.jsx
@@ -9,10 +9,7 @@ import {viewChannel} from 'mattermost-redux/actions/channels';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import * as WebSocketActions from 'actions/websocket_actions.jsx';
-import UserStore from 'stores/user_store.jsx';
-import ChannelStore from 'stores/channel_store.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
-import * as Utils from 'utils/utils.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 import {getBrowserTimezone} from 'utils/timezone.jsx';
 import store from 'stores/redux_store.jsx';
@@ -22,15 +19,21 @@ const getState = store.getState;
 
 const BACKSPACE_CHAR = 8;
 
-export default class LoggedIn extends React.Component {
-    constructor(params) {
-        super(params);
+export default class LoggedIn extends React.PureComponent {
+    static propTypes = {
+        currentUser: PropTypes.object,
+        currentChannelId: PropTypes.string,
+        children: PropTypes.object,
+        mfaRequired: PropTypes.bool.isRequired,
+        enableTimezone: PropTypes.bool.isRequired,
+        actions: PropTypes.shape({
+            autoUpdateTimezone: PropTypes.func.isRequired,
+        }).isRequired,
+        showTermsOfService: PropTypes.bool.isRequired,
+    }
 
-        this.onUserChanged = this.onUserChanged.bind(this);
-
-        this.state = {
-            user: UserStore.getCurrentUser(),
-        };
+    constructor(props) {
+        super(props);
 
         const root = document.getElementById('root');
         if (root) {
@@ -39,18 +42,7 @@ export default class LoggedIn extends React.Component {
     }
 
     isValidState() {
-        return this.state.user != null;
-    }
-
-    onUserChanged() {
-        // Grab the current user
-        const user = UserStore.getCurrentUser();
-
-        if (!Utils.areObjectsEqual(this.state.user, user)) {
-            this.setState({
-                user,
-            });
-        }
+        return this.props.currentUser != null;
     }
 
     componentDidMount() {
@@ -67,14 +59,11 @@ export default class LoggedIn extends React.Component {
                 // Turn off to prevent getting stuck in a loop
                 $(window).off('beforeunload');
                 if (document.cookie.indexOf('MMUSERID=') > -1) {
-                    viewChannel('', ChannelStore.getCurrentId() || '')(dispatch, getState);
+                    viewChannel('', this.props.currentChannelId || '')(dispatch, getState);
                 }
                 WebSocketActions.close();
             }
         );
-
-        // Listen for user
-        UserStore.addChangeListener(this.onUserChanged);
 
         // Listen for focused tab/window state
         window.addEventListener('focus', this.onFocusListener);
@@ -89,7 +78,7 @@ export default class LoggedIn extends React.Component {
             $('body').addClass('android');
         }
 
-        if (!this.state.user) {
+        if (!this.props.currentUser) {
             $('#root').attr('class', '');
             GlobalActions.emitUserLoggedOutEvent('/login?redirect_to=' + encodeURIComponent(this.props.location.pathname), true, false);
         }
@@ -134,7 +123,6 @@ export default class LoggedIn extends React.Component {
 
     componentWillUnmount() {
         WebSocketActions.close();
-        UserStore.removeChangeListener(this.onUserChanged);
 
         $('body').off('click.userpopover');
         $('body').off('mouseenter mouseleave', '.post');
@@ -177,13 +165,3 @@ export default class LoggedIn extends React.Component {
         GlobalActions.emitBrowserFocus(false);
     }
 }
-
-LoggedIn.propTypes = {
-    children: PropTypes.object,
-    mfaRequired: PropTypes.bool.isRequired,
-    enableTimezone: PropTypes.bool.isRequired,
-    actions: PropTypes.shape({
-        autoUpdateTimezone: PropTypes.func.isRequired,
-    }).isRequired,
-    showTermsOfService: PropTypes.bool.isRequired,
-};

--- a/components/login/login_controller/index.js
+++ b/components/login/login_controller/index.js
@@ -3,11 +3,11 @@
 
 import {connect} from 'react-redux';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getTeamByName, getMyTeamMember} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {RequestStatus} from 'mattermost-redux/constants';
 
 import LoginController from './login_controller.jsx';
-import {getTeamByName, getMyTeamMember} from 'mattermost-redux/selectors/entities/teams';
 
 function mapStateToProps(state) {
     const config = getConfig(state);

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -11,8 +11,6 @@ import {Client4} from 'mattermost-redux/client';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {addUserToTeamFromInvite} from 'actions/team_actions.jsx';
 import {checkMfa, webLogin} from 'actions/user_actions.jsx';
-import UserStore from 'stores/user_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
 import LocalStorageStore from 'stores/local_storage_store';
 
 import {browserHistory} from 'utils/browser_history';
@@ -40,6 +38,8 @@ class LoginController extends React.Component {
 
             location: PropTypes.object.isRequired,
             isLicensed: PropTypes.bool.isRequired,
+
+            currentUser: PropTypes.object,
 
             customBrandText: PropTypes.string,
             customDescriptionText: PropTypes.string,
@@ -85,7 +85,7 @@ class LoginController extends React.Component {
     componentDidMount() {
         this.configureTitle();
 
-        if (UserStore.getCurrentUser()) {
+        if (this.props.currentUser) {
             GlobalActions.redirectUserToDefaultTeam();
             return;
         }
@@ -323,7 +323,6 @@ class LoginController extends React.Component {
 
     finishSignin = (team) => {
         const experimentalPrimaryTeam = this.props.experimentalPrimaryTeam;
-        const primaryTeam = TeamStore.getByName(experimentalPrimaryTeam);
         const query = new URLSearchParams(this.props.location.search);
         const redirectTo = query.get('redirect_to');
 
@@ -334,8 +333,8 @@ class LoginController extends React.Component {
             browserHistory.push(redirectTo);
         } else if (team) {
             browserHistory.push(`/${team.name}`);
-        } else if (primaryTeam) {
-            browserHistory.push(`/${primaryTeam.name}/channels/${Constants.DEFAULT_CHANNEL}`);
+        } else if (experimentalPrimaryTeam) {
+            browserHistory.push(`/${experimentalPrimaryTeam}/channels/${Constants.DEFAULT_CHANNEL}`);
         } else {
             GlobalActions.redirectUserToDefaultTeam();
         }

--- a/components/popover_list_members/index.js
+++ b/components/popover_list_members/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getProfilesInChannel} from 'mattermost-redux/actions/users';
 import {getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getUserStatuses, makeGetProfilesInChannel} from 'mattermost-redux/selectors/entities/users';
 
 import PopoverListMembers from './popover_list_members.jsx';
@@ -21,6 +22,7 @@ function makeMapStateToProps() {
             memberCount: stats.member_count,
             users,
             statuses: getUserStatuses(state),
+            teamUrl: getCurrentRelativeTeamUrl(state),
         };
     };
 }

--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -9,8 +9,6 @@ import {FormattedMessage} from 'react-intl';
 
 import {browserHistory} from 'utils/browser_history';
 import {openDirectChannelToUser} from 'actions/channel_actions.jsx';
-import ChannelStore from 'stores/channel_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
 import {canManageMembers} from 'utils/channel_utils.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -28,6 +26,7 @@ export default class PopoverListMembers extends React.Component {
         users: PropTypes.array.isRequired,
         memberCount: PropTypes.number,
         currentUserId: PropTypes.string.isRequired,
+        teamUrl: PropTypes.string,
         actions: PropTypes.shape({
             getProfilesInChannel: PropTypes.func.isRequired,
         }).isRequired,
@@ -68,7 +67,7 @@ export default class PopoverListMembers extends React.Component {
             openDirectChannelToUser(
                 teammateId,
                 (channel, channelAlreadyExisted) => {
-                    browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + channel.name);
+                    browserHistory.push(this.props.teamUrl + '/channels/' + channel.name);
                     if (channelAlreadyExisted) {
                         this.closePopover();
                     }
@@ -142,7 +141,7 @@ export default class PopoverListMembers extends React.Component {
             );
 
             const manageMembers = canManageMembers(this.props.channel);
-            const isDefaultChannel = ChannelStore.isDefault(this.props.channel);
+            const isDefaultChannel = this.props.channel.name === Constants.DEFAULT_CHANNEL;
 
             if (isDefaultChannel || !manageMembers) {
                 membersName = (

--- a/components/post_markdown/index.js
+++ b/components/post_markdown/index.js
@@ -2,11 +2,13 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import PostMarkdown from './post_markdown';
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
     return {
+        channel: getChannel(state, ownProps.post.channel_id),
         pluginHooks: state.plugins.components.MessageWillFormat,
     };
 }

--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -30,6 +30,7 @@ export default class PostMarkdown extends React.PureComponent {
          * The optional post for which this message is being rendered
          */
         post: PropTypes.object,
+        channel: PropTypes.object,
 
         options: PropTypes.object,
 
@@ -43,7 +44,7 @@ export default class PostMarkdown extends React.PureComponent {
 
     render() {
         if (this.props.post) {
-            const renderedSystemMessage = renderSystemMessage(this.props.post);
+            const renderedSystemMessage = renderSystemMessage(this.props.post, this.props.channel);
             if (renderedSystemMessage) {
                 return <div>{renderedSystemMessage}</div>;
             }

--- a/components/post_markdown/system_message_helpers.jsx
+++ b/components/post_markdown/system_message_helpers.jsx
@@ -6,8 +6,6 @@ import {FormattedMessage} from 'react-intl';
 
 import {General, Posts} from 'mattermost-redux/constants';
 
-import ChannelStore from 'stores/channel_store.jsx';
-
 import {canManageMembers} from 'utils/channel_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -319,9 +317,8 @@ const systemMessageRenderers = {
     [Posts.POST_TYPES.CHANNEL_DELETED]: renderChannelDeletedMessage,
 };
 
-export function renderSystemMessage(post) {
+export function renderSystemMessage(post, channel) {
     if (post.props && post.props.add_channel_member) {
-        const channel = ChannelStore.getCurrent();
         const isUserCanManageMembers = canManageMembers(channel);
         const isEphemeral = Utils.isPostEphemeral(post);
 

--- a/components/post_view/post/index.js
+++ b/components/post_view/post/index.js
@@ -2,10 +2,12 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser, getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 
+import {selectPost} from 'actions/views/rhs';
 import {Preferences} from 'utils/constants.jsx';
 
 import Post from './post.jsx';
@@ -30,4 +32,12 @@ function mapStateToProps(state, ownProps) {
     };
 }
 
-export default connect(mapStateToProps)(Post);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            selectPost,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Post);

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -5,10 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Posts} from 'mattermost-redux/constants';
 
-import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
-import {ActionTypes} from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
-import * as Utils from 'utils/utils.jsx';
 import PostProfilePicture from 'components/post_profile_picture';
 import PostBody from 'components/post_view/post_body';
 import PostHeader from 'components/post_view/post_header';
@@ -85,6 +82,10 @@ export default class Post extends React.PureComponent {
          * Function to get the post list HTML element
          */
         getPostList: PropTypes.func.isRequired,
+
+        actions: PropTypes.shape({
+            selectPost: PropTypes.func.isRequired,
+        }).isRequired,
     }
 
     static defaultProps = {
@@ -113,11 +114,7 @@ export default class Post extends React.PureComponent {
             return;
         }
 
-        AppDispatcher.handleServerAction({
-            type: ActionTypes.RECEIVED_POST_SELECTED,
-            postId: Utils.getRootId(post),
-            channelId: post.channel_id,
-        });
+        this.props.actions.selectPost(post);
     }
 
     handleDropdownOpened = (opened) => {

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -18,7 +18,7 @@ import CommentIcon from 'components/common/comment_icon.jsx';
 import DotMenu from 'components/dot_menu';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
 import PostFlagIcon from 'components/post_view/post_flag_icon';
-import PostTime from 'components/post_view/post_time.jsx';
+import PostTime from 'components/post_view/post_time';
 import EmojiIcon from 'components/svg/emoji_icon';
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 

--- a/components/post_view/post_time/index.js
+++ b/components/post_view/post_time/index.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
+
+import PostTime from './post_time.jsx';
+
+function mapStateToProps(state) {
+    return {
+        teamUrl: getCurrentRelativeTeamUrl(state),
+    };
+}
+
+export default connect(mapStateToProps)(PostTime);

--- a/components/post_view/post_time/post_time.jsx
+++ b/components/post_view/post_time/post_time.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
-import TeamStore from 'stores/team_store.jsx';
 import {isMobile} from 'utils/user_agent.jsx';
 import {isMobile as isMobileView} from 'utils/utils.jsx';
 import LocalDateTime from 'components/local_date_time';
@@ -28,19 +27,12 @@ export default class PostTime extends React.PureComponent {
          * The post id of posting being rendered
          */
         postId: PropTypes.string,
+        teamUrl: PropTypes.string,
     };
 
     static defaultProps = {
         eventTime: 0,
     };
-
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            currentTeamDisplayName: TeamStore.getCurrent().name,
-        };
-    }
 
     handleClick = () => {
         if (isMobileView()) {
@@ -60,7 +52,7 @@ export default class PostTime extends React.PureComponent {
 
         return (
             <Link
-                to={`/${this.state.currentTeamDisplayName}/pl/${this.props.postId}`}
+                to={`${this.props.teamUrl}/pl/${this.props.postId}`}
                 className='post__permalink'
                 onClick={this.handleClick}
             >

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -12,7 +12,6 @@ import {
 import Permissions from 'mattermost-redux/constants/permissions';
 
 import {emitEmojiPosted} from 'actions/post_actions.jsx';
-import TeamStore from 'stores/team_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -60,7 +59,6 @@ export default class RhsComment extends React.Component {
         super(props);
 
         this.state = {
-            currentTeamDisplayName: TeamStore.getCurrent().name,
             showEmojiPicker: false,
             dropdownOpened: false,
         };

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -21,7 +21,7 @@ import FileAttachmentListContainer from 'components/file_attachment_list';
 import PostProfilePicture from 'components/post_profile_picture';
 import FailedPostOptions from 'components/post_view/failed_post_options';
 import PostFlagIcon from 'components/post_view/post_flag_icon';
-import PostTime from 'components/post_view/post_time.jsx';
+import PostTime from 'components/post_view/post_time';
 import ReactionListContainer from 'components/post_view/reaction_list';
 import EmojiIcon from 'components/svg/emoji_icon';
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';

--- a/components/rhs_root_post/index.js
+++ b/components/rhs_root_post/index.js
@@ -4,7 +4,7 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
+import {isChannelReadOnlyById, getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {addReaction} from 'mattermost-redux/actions/posts';
@@ -18,7 +18,7 @@ function mapStateToProps(state, ownProps) {
     const enableEmojiPicker = config.EnableEmojiPicker === 'true';
     const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
     const teamId = ownProps.teamId || getCurrentTeamId(state);
-    const channel = state.entities.channels.channels[ownProps.post.channel_id];
+    const channel = getChannel(state, ownProps.post.channel_id) || {};
 
     return {
         enableEmojiPicker,
@@ -28,6 +28,8 @@ function mapStateToProps(state, ownProps) {
         teamId,
         pluginPostTypes: state.plugins.postTypes,
         channelIsArchived: channel.delete_at !== 0,
+        channelType: channel.type,
+        channelDisplayName: channel.display_name,
     };
 }
 

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -18,7 +18,7 @@ import FileAttachmentListContainer from 'components/file_attachment_list';
 import PostProfilePicture from 'components/post_profile_picture';
 import PostFlagIcon from 'components/post_view/post_flag_icon';
 import ReactionListContainer from 'components/post_view/reaction_list';
-import PostTime from 'components/post_view/post_time.jsx';
+import PostTime from 'components/post_view/post_time';
 import EmojiIcon from 'components/svg/emoji_icon';
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 import MessageWithAdditionalContent from 'components/message_with_additional_content';

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -9,9 +9,6 @@ import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
 import Permissions from 'mattermost-redux/constants/permissions';
 
 import {emitEmojiPosted} from 'actions/post_actions.jsx';
-import UserStore from 'stores/user_store.jsx';
-import ChannelStore from 'stores/channel_store.jsx';
-import TeamStore from 'stores/team_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -47,6 +44,8 @@ export default class RhsRootPost extends React.Component {
         isReadOnly: PropTypes.bool.isRequired,
         pluginPostTypes: PropTypes.object,
         channelIsArchived: PropTypes.bool.isRequired,
+        channelType: PropTypes.string,
+        channelDisplayName: PropTypes.string,
         actions: PropTypes.shape({
             addReaction: PropTypes.func.isRequired,
         }).isRequired,
@@ -60,7 +59,6 @@ export default class RhsRootPost extends React.Component {
         super(props);
 
         this.state = {
-            currentTeamDisplayName: TeamStore.getCurrent().name,
             showEmojiPicker: false,
             testStateObj: true,
             dropdownOpened: false,
@@ -164,7 +162,7 @@ export default class RhsRootPost extends React.Component {
 
     getClassName = (post, isSystemMessage) => {
         let className = 'post post--root post--thread';
-        if (UserStore.getCurrentId() === post.user_id) {
+        if (this.props.currentUser.id === post.user_id) {
             className += ' current--user';
         }
 
@@ -198,24 +196,21 @@ export default class RhsRootPost extends React.Component {
     };
 
     render() {
-        const {post, user, isReadOnly, teamId, channelIsArchived} = this.props;
-        var channel = ChannelStore.get(post.channel_id);
+        const {post, user, isReadOnly, teamId, channelIsArchived, channelType, channelDisplayName} = this.props;
 
         const isEphemeral = Utils.isPostEphemeral(post);
         const isSystemMessage = PostUtils.isSystemMessage(post);
 
-        var channelName;
-        if (channel) {
-            if (channel.type === 'D') {
-                channelName = (
-                    <FormattedMessage
-                        id='rhs_root.direct'
-                        defaultMessage='Direct Message'
-                    />
-                );
-            } else {
-                channelName = channel.display_name;
-            }
+        let channelName;
+        if (channelType === 'D') {
+            channelName = (
+                <FormattedMessage
+                    id='rhs_root.direct'
+                    defaultMessage='Direct Message'
+                />
+            );
+        } else {
+            channelName = channelDisplayName;
         }
 
         let react;

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -17,7 +17,7 @@ import DateSeparator from 'components/post_view/date_separator.jsx';
 import PostBodyAdditionalContent from 'components/post_view/post_body_additional_content';
 import PostFlagIcon from 'components/post_view/post_flag_icon';
 import ArchiveIcon from 'components/svg/archive_icon';
-import PostTime from 'components/post_view/post_time.jsx';
+import PostTime from 'components/post_view/post_time';
 import {browserHistory} from 'utils/browser_history';
 
 import Constants from 'utils/constants.jsx';

--- a/components/sidebar_right/index.js
+++ b/components/sidebar_right/index.js
@@ -7,7 +7,6 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
-import PostStore from 'stores/post_store';
 import {getPinnedPosts, setRhsExpanded, showPinnedPosts} from 'actions/views/rhs';
 import {
     getIsRhsExpanded,
@@ -31,8 +30,8 @@ function mapStateToProps(state) {
         channel = getChannel(state, channelId);
         if (channel == null) {
             // the permalink view is not really tied to a particular channel but still needs it
-            const postId = PostStore.getFocusedPostId();
-            const post = getPost(state, postId);
+            const {focusedPostId} = state.views.channel;
+            const post = getPost(state, focusedPostId);
 
             // the post take some time before being available on page load
             if (post != null) {

--- a/tests/components/__snapshots__/search_results_item.test.jsx.snap
+++ b/tests/components/__snapshots__/search_results_item.test.jsx.snap
@@ -100,7 +100,7 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
           <div
             className="col"
           >
-            <PostTime
+            <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
               postId="id"
@@ -331,7 +331,7 @@ exports[`components/SearchResultsItem should match snapshot for archived channel
           <div
             className="col"
           >
-            <PostTime
+            <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
               postId="id"
@@ -553,7 +553,7 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
           <div
             className="col"
           >
-            <PostTime
+            <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
               postId="id"
@@ -792,7 +792,7 @@ exports[`components/SearchResultsItem should match snapshot for deleted message 
           <div
             className="col"
           >
-            <PostTime
+            <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
               postId="id"

--- a/tests/components/logged_in/logged_in.test.jsx
+++ b/tests/components/logged_in/logged_in.test.jsx
@@ -13,6 +13,7 @@ jest.mock('actions/websocket_actions.jsx', () => ({
 describe('components/logged_in/LoggedIn', () => {
     const children = <span>{'Test'}</span>;
     const baseProps = {
+        currentUser: {},
         mfaRequired: false,
         enableTimezone: false,
         actions: {
@@ -27,6 +28,7 @@ describe('components/logged_in/LoggedIn', () => {
     it('should render loading state without user', () => {
         const props = {
             ...baseProps,
+            currentUser: null,
         };
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
@@ -47,9 +49,6 @@ describe('components/logged_in/LoggedIn', () => {
         };
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-        wrapper.setState({
-            user: {},
-        });
 
         expect(wrapper).toMatchInlineSnapshot(`
 <Redirect
@@ -70,9 +69,6 @@ describe('components/logged_in/LoggedIn', () => {
         };
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-        wrapper.setState({
-            user: {},
-        });
 
         expect(wrapper).toMatchInlineSnapshot(`
 <span>
@@ -92,9 +88,6 @@ describe('components/logged_in/LoggedIn', () => {
         };
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-        wrapper.setState({
-            user: {},
-        });
 
         expect(wrapper).toMatchInlineSnapshot(`
 <span>
@@ -112,9 +105,6 @@ describe('components/logged_in/LoggedIn', () => {
         };
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-        wrapper.setState({
-            user: {},
-        });
 
         expect(wrapper).toMatchInlineSnapshot(`
 <Redirect
@@ -136,9 +126,6 @@ describe('components/logged_in/LoggedIn', () => {
         };
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-        wrapper.setState({
-            user: {},
-        });
 
         expect(wrapper).toMatchInlineSnapshot(`
 <span>
@@ -156,9 +143,6 @@ describe('components/logged_in/LoggedIn', () => {
         };
 
         const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-        wrapper.setState({
-            user: {},
-        });
 
         expect(wrapper).toMatchInlineSnapshot(`
 <span>

--- a/tests/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
+++ b/tests/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
@@ -158,7 +158,7 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
   <div
     className="col"
   >
-    <PostTime
+    <Connect(PostTime)
       eventTime={1502715365009}
       isPermalink={true}
       postId="e584uzbwwpny9kengqayx5ayzw"
@@ -257,7 +257,7 @@ exports[`components/post_view/PostInfo should match snapshot, showTimeWithoutHov
   <div
     className="col"
   >
-    <PostTime
+    <Connect(PostTime)
       eventTime={1502715365009}
       isPermalink={true}
       postId="e584uzbwwpny9kengqayx5ayzw"


### PR DESCRIPTION
#### Summary
Remove the last usages of the flux stores with the exception of BrowserStore, which will be coming in another PR. Removing the flux stores themselves will be coming in another PR after all others are merged.

@lindy65 this one is a little all over the place, but a quick smoke test of the following should cover most of it:
* Logging in and being redirected to the correct team
* Opening the RHS to reply to a post
* Permalink view
* Analytics pages in the system console

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12840

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)