### PR TITLE
Correctly load integration creators and convert integration actions

### DIFF
--- a/actions/integration_actions.jsx
+++ b/actions/integration_actions.jsx
@@ -3,195 +3,96 @@
 
 import request from 'superagent';
 import * as IntegrationActions from 'mattermost-redux/actions/integrations';
-import {getProfilesByIds, getUser} from 'mattermost-redux/actions/users';
-import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {getProfilesByIds} from 'mattermost-redux/actions/users';
+import {getUser} from 'mattermost-redux/selectors/entities/users';
 
-import store from 'stores/redux_store.jsx';
+import {Integrations} from 'utils/constants.jsx';
 
-const dispatch = store.dispatch;
-const getState = store.getState;
-
-export async function loadIncomingHooks(complete) {
-    const {data} = await IntegrationActions.getIncomingHooks('', 0, 10000)(dispatch, getState);
-    if (data) {
-        loadProfilesForIncomingHooks(data);
-    }
-
-    if (complete) {
-        complete(data);
-    }
-}
-
-export async function loadIncomingHooksForTeam(teamId, complete) {
-    const {data} = await IntegrationActions.getIncomingHooks(teamId, 0, 10000)(dispatch, getState);
-    if (data) {
-        loadProfilesForIncomingHooks(data);
-    }
-
-    if (complete) {
-        complete(data);
-    }
-}
-
-function loadProfilesForIncomingHooks(hooks) {
-    const state = getState();
-    const profilesToLoad = {};
-    for (let i = 0; i < hooks.length; i++) {
-        const hook = hooks[i];
-        if (!getUser(state, hook.user_id)) {
-            profilesToLoad[hook.user_id] = true;
+export function loadIncomingHooksAndProfilesForTeam(teamId, page = 0, perPage = Integrations.PAGE_SIZE) {
+    return async (dispatch) => {
+        const {data} = await dispatch(IntegrationActions.getIncomingHooks(teamId, page, perPage));
+        if (data) {
+            dispatch(loadProfilesForIncomingHooks(data));
         }
-    }
-
-    const list = Object.keys(profilesToLoad);
-    if (list.length === 0) {
-        return;
-    }
-
-    getProfilesByIds(list)(dispatch, getState);
+    };
 }
 
-export async function loadOutgoingHooks(complete) {
-    const {data} = await IntegrationActions.getOutgoingHooks('', '', 0, 10000)(dispatch, getState);
-    if (data) {
-        loadProfilesForOutgoingHooks(data);
-    }
-
-    if (complete) {
-        complete(data);
-    }
-}
-
-export async function loadOutgoingHooksForTeam(teamId, complete) {
-    const {data} = await IntegrationActions.getOutgoingHooks('', teamId, 0, 10000)(dispatch, getState);
-    if (data) {
-        loadProfilesForOutgoingHooks(data);
-    }
-
-    if (complete) {
-        complete(data);
-    }
-}
-
-function loadProfilesForOutgoingHooks(hooks) {
-    const state = getState();
-    const profilesToLoad = {};
-    for (let i = 0; i < hooks.length; i++) {
-        const hook = hooks[i];
-        if (!getUser(state, hook.creator_id)) {
-            profilesToLoad[hook.creator_id] = true;
+export function loadProfilesForIncomingHooks(hooks) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const profilesToLoad = {};
+        for (let i = 0; i < hooks.length; i++) {
+            const hook = hooks[i];
+            if (!getUser(state, hook.user_id)) {
+                profilesToLoad[hook.user_id] = true;
+            }
         }
-    }
 
-    const list = Object.keys(profilesToLoad);
-    if (list.length === 0) {
-        return;
-    }
-
-    getProfilesByIds(list)(dispatch, getState);
-}
-
-export async function loadTeamCommands(complete) {
-    const {data} = await dispatch(IntegrationActions.getCustomTeamCommands(getCurrentTeamId(getState())));
-    if (data) {
-        loadProfilesForCommands(data);
-    }
-
-    if (complete) {
-        complete(data);
-    }
-}
-
-function loadProfilesForCommands(commands) {
-    const state = getState();
-    const profilesToLoad = {};
-    for (let i = 0; i < commands.length; i++) {
-        const command = commands[i];
-        if (!getUser(state, command.creator_id)) {
-            profilesToLoad[command.creator_id] = true;
+        const list = Object.keys(profilesToLoad);
+        if (list.length === 0) {
+            return;
         }
-    }
 
-    const list = Object.keys(profilesToLoad);
-    if (list.length === 0) {
-        return;
-    }
-
-    getProfilesByIds(list)(dispatch, getState);
+        dispatch(getProfilesByIds(list));
+    };
 }
 
-export async function addIncomingHook(hook, success, error) {
-    const {data, error: err} = await IntegrationActions.createIncomingHook(hook)(dispatch, getState);
-    if (data && success) {
-        success(data);
-    } else if (err && error) {
-        error({id: err.server_error_id, ...err});
-    }
+export function loadOutgoingHooksAndProfilesForTeam(teamId, page = 0, perPage = Integrations.PAGE_SIZE) {
+    return async (dispatch) => {
+        const {data} = await dispatch(IntegrationActions.getOutgoingHooks('', teamId, page, perPage));
+        if (data) {
+            dispatch(loadProfilesForOutgoingHooks(data));
+        }
+    };
 }
 
-export async function updateIncomingHook(hook, success, error) {
-    const {data, error: err} = await IntegrationActions.updateIncomingHook(hook)(dispatch, getState);
-    if (data && success) {
-        success(data);
-    } else if (err && error) {
-        error({id: err.server_error_id, ...err});
-    }
+export function loadProfilesForOutgoingHooks(hooks) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const profilesToLoad = {};
+        for (let i = 0; i < hooks.length; i++) {
+            const hook = hooks[i];
+            if (!getUser(state, hook.creator_id)) {
+                profilesToLoad[hook.creator_id] = true;
+            }
+        }
+
+        const list = Object.keys(profilesToLoad);
+        if (list.length === 0) {
+            return;
+        }
+
+        dispatch(getProfilesByIds(list));
+    };
 }
 
-export async function addOutgoingHook(hook, success, error) {
-    const {data, error: err} = await IntegrationActions.createOutgoingHook(hook)(dispatch, getState);
-    if (data && success) {
-        success(data);
-    } else if (err && error) {
-        error({id: err.server_error_id, ...err});
-    }
+export function loadCommandsAndProfilesForTeam(teamId) {
+    return async (dispatch) => {
+        const {data} = await dispatch(IntegrationActions.getCustomTeamCommands(teamId));
+        if (data) {
+            dispatch(loadProfilesForCommands(data));
+        }
+    };
 }
 
-export async function updateOutgoingHook(hook, success, error) {
-    const {data, error: err} = await IntegrationActions.updateOutgoingHook(hook)(dispatch, getState);
-    if (data && success) {
-        success(data);
-    } else if (err && error) {
-        error({id: err.server_error_id, ...err});
-    }
-}
+export function loadProfilesForCommands(commands) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const profilesToLoad = {};
+        for (let i = 0; i < commands.length; i++) {
+            const command = commands[i];
+            if (!getUser(state, command.creator_id)) {
+                profilesToLoad[command.creator_id] = true;
+            }
+        }
 
-export function deleteIncomingHook(id) {
-    IntegrationActions.removeIncomingHook(id)(dispatch, getState);
-}
+        const list = Object.keys(profilesToLoad);
+        if (list.length === 0) {
+            return;
+        }
 
-export function deleteOutgoingHook(id) {
-    IntegrationActions.removeOutgoingHook(id)(dispatch, getState);
-}
-
-export function regenOutgoingHookToken(id) {
-    IntegrationActions.regenOutgoingHookToken(id)(dispatch, getState);
-}
-
-export async function addCommand(command, success, error) {
-    const {data, error: err} = await IntegrationActions.addCommand(command)(dispatch, getState);
-    if (data && success) {
-        success(data);
-    } else if (err && error) {
-        error({id: err.server_error_id, ...err});
-    }
-}
-
-export async function editCommand(command, success, error) {
-    const {data, error: err} = await IntegrationActions.editCommand(command)(dispatch, getState);
-    if (data && success) {
-        success(data);
-    } else if (err && error) {
-        error({id: err.server_error_id, ...err});
-    }
-}
-
-export function deleteCommand(id) {
-    IntegrationActions.deleteCommand(id)(dispatch, getState);
-}
-
-export function regenCommandToken(id) {
-    IntegrationActions.regenCommandToken(id)(dispatch, getState);
+        dispatch(getProfilesByIds(list));
+    };
 }
 
 export function getYoutubeVideoInfo(googleKey, videoId, success, error) {

--- a/components/integrations/commands_container/commands_container.jsx
+++ b/components/integrations/commands_container/commands_container.jsx
@@ -57,7 +57,7 @@ export default class CommandsContainer extends React.PureComponent {
             /**
             * The function to call to fetch team commands
             */
-            getCustomTeamCommands: PropTypes.func.isRequired,
+            loadCommandsAndProfilesForTeam: PropTypes.func.isRequired,
         }).isRequired,
 
         /**
@@ -75,7 +75,7 @@ export default class CommandsContainer extends React.PureComponent {
 
     componentDidMount() {
         if (this.props.enableCommands) {
-            this.props.actions.getCustomTeamCommands(this.props.team.id).then(
+            this.props.actions.loadCommandsAndProfilesForTeam(this.props.team.id).then(
                 () => this.setState({loading: false})
             );
         }

--- a/components/integrations/commands_container/index.js
+++ b/components/integrations/commands_container/index.js
@@ -3,10 +3,11 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {getCustomTeamCommands} from 'mattermost-redux/actions/integrations';
 import {getCommands} from 'mattermost-redux/selectors/entities/integrations';
 import {getUsers} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import {loadCommandsAndProfilesForTeam} from 'actions/integration_actions';
 
 import CommandsContainer from './commands_container.jsx';
 
@@ -24,7 +25,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            getCustomTeamCommands,
+            loadCommandsAndProfilesForTeam,
         }, dispatch),
     };
 }

--- a/components/integrations/installed_incoming_webhooks/index.js
+++ b/components/integrations/installed_incoming_webhooks/index.js
@@ -12,6 +12,8 @@ import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
+import {loadIncomingHooksAndProfilesForTeam} from 'actions/integration_actions';
+
 import InstalledIncomingWebhooks from './installed_incoming_webhooks.jsx';
 
 function mapStateToProps(state) {
@@ -37,7 +39,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            getIncomingHooks: Actions.getIncomingHooks,
+            loadIncomingHooksAndProfilesForTeam,
             removeIncomingHook: Actions.removeIncomingHook,
         }, dispatch),
     };

--- a/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.jsx
+++ b/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.jsx
@@ -58,7 +58,7 @@ export default class InstalledIncomingWebhooks extends React.PureComponent {
             /**
             * The function to call for incomingWebhook List and for the status of api
             */
-            getIncomingHooks: PropTypes.func,
+            loadIncomingHooksAndProfilesForTeam: PropTypes.func,
         }),
 
         /**
@@ -70,8 +70,6 @@ export default class InstalledIncomingWebhooks extends React.PureComponent {
     constructor(props) {
         super(props);
 
-        this.deleteIncomingWebhook = this.deleteIncomingWebhook.bind(this);
-        this.incomingWebhookCompare = this.incomingWebhookCompare.bind(this);
         this.state = {
             loading: true,
         };
@@ -79,7 +77,7 @@ export default class InstalledIncomingWebhooks extends React.PureComponent {
 
     componentDidMount() {
         if (this.props.enableIncomingWebhooks) {
-            this.props.actions.getIncomingHooks(
+            this.props.actions.loadIncomingHooksAndProfilesForTeam(
                 this.props.teamId,
                 Constants.Integrations.START_PAGE_NUM,
                 Constants.Integrations.PAGE_SIZE
@@ -93,7 +91,7 @@ export default class InstalledIncomingWebhooks extends React.PureComponent {
         this.props.actions.removeIncomingHook(incomingWebhook.id);
     }
 
-    incomingWebhookCompare(a, b) {
+    incomingWebhookCompare = (a, b) => {
         let displayNameA = a.display_name;
         if (!displayNameA) {
             const channelA = this.props.channels[a.channel_id];

--- a/components/integrations/installed_outgoing_webhooks/index.js
+++ b/components/integrations/installed_outgoing_webhooks/index.js
@@ -11,6 +11,8 @@ import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
+import {loadOutgoingHooksAndProfilesForTeam} from 'actions/integration_actions';
+
 import InstalledOutgoingWebhook from './installed_outgoing_webhooks.jsx';
 
 function mapStateToProps(state) {
@@ -36,7 +38,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            getOutgoingHooks: Actions.getOutgoingHooks,
+            loadOutgoingHooksAndProfilesForTeam,
             removeOutgoingHook: Actions.removeOutgoingHook,
             regenOutgoingHookToken: Actions.regenOutgoingHookToken,
         }, dispatch),

--- a/components/integrations/installed_outgoing_webhooks/installed_outgoing_webhooks.jsx
+++ b/components/integrations/installed_outgoing_webhooks/installed_outgoing_webhooks.jsx
@@ -58,7 +58,7 @@ export default class InstalledOutgoingWebhooks extends React.PureComponent {
             /**
             * The function to call for outgoingWebhook List and for the status of api
             */
-            getOutgoingHooks: PropTypes.func,
+            loadOutgoingHooksAndProfilesForTeam: PropTypes.func,
 
             /**
             * The function to call for regeneration of webhook token
@@ -84,8 +84,7 @@ export default class InstalledOutgoingWebhooks extends React.PureComponent {
 
     componentDidMount() {
         if (this.props.enableOutgoingWebhooks) {
-            this.props.actions.getOutgoingHooks(
-                '',
+            this.props.actions.loadOutgoingHooksAndProfilesForTeam(
                 this.props.teamId,
                 Constants.Integrations.START_PAGE_NUM,
                 Constants.Integrations.PAGE_SIZE

--- a/components/suggestion/command_provider.jsx
+++ b/components/suggestion/command_provider.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 
 import {Client4} from 'mattermost-redux/client';
-
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
 import store from 'stores/redux_store.jsx';

--- a/tests/components/integrations/installed_outgoing_webhooks.test.jsx
+++ b/tests/components/integrations/installed_outgoing_webhooks.test.jsx
@@ -9,7 +9,7 @@ import InstalledOutgoingWebhooks from 'components/integrations/installed_outgoin
 describe('components/integrations/InstalledOutgoingWebhooks', () => {
     let outgoingWebhooks = {};
     let mockFunc;
-    const getOutgoingHooks = () => new Promise((resolve) => resolve());
+    const loadOutgoingHooksAndProfilesForTeam = () => new Promise((resolve) => resolve());
     const teamId = 'testteamid';
     beforeEach(() => {
         mockFunc = jest.fn();
@@ -73,7 +73,7 @@ describe('components/integrations/InstalledOutgoingWebhooks', () => {
                 teamId={teamId}
                 actions={{
                     removeOutgoingHook: emptyFunction,
-                    getOutgoingHooks,
+                    loadOutgoingHooksAndProfilesForTeam,
                     regenOutgoingHookToken: emptyFunction,
                 }}
                 user={{
@@ -118,7 +118,7 @@ describe('components/integrations/InstalledOutgoingWebhooks', () => {
                 teamId={teamId}
                 actions={{
                     removeOutgoingHook: emptyFunction,
-                    getOutgoingHooks,
+                    loadOutgoingHooksAndProfilesForTeam,
                     regenOutgoingHookToken: mockFunc,
                 }}
                 user={{
@@ -165,7 +165,7 @@ describe('components/integrations/InstalledOutgoingWebhooks', () => {
                 teamId={teamId}
                 actions={{
                     removeOutgoingHook: mockFunc,
-                    getOutgoingHooks,
+                    loadOutgoingHooksAndProfilesForTeam,
                     regenOutgoingHookToken: emptyFunction,
                 }}
                 user={{

--- a/tests/redux/actions/integration_actions.test.js
+++ b/tests/redux/actions/integration_actions.test.js
@@ -1,0 +1,96 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import {getProfilesByIds} from 'mattermost-redux/actions/users';
+
+import * as Actions from 'actions/integration_actions.jsx';
+
+jest.mock('mattermost-redux/actions/users', () => ({
+    getProfilesByIds: jest.fn(() => {
+        return {type: ''};
+    }),
+}));
+
+const mockStore = configureStore([thunk]);
+
+describe('actions/integration_actions', () => {
+    const initialState = {
+        entities: {
+            teams: {
+                currentTeamId: 'team_id1',
+                teams: {
+                    team_id1: {
+                        id: 'team_id1',
+                        name: 'team1',
+                    },
+                },
+            },
+            users: {
+                currentUserId: 'current_user_id',
+                profiles: {current_user_id: {id: 'current_user_id', username: 'current_user'}, user_id3: {id: 'user_id3', username: 'user3'}, user_id4: {id: 'user_id4', username: 'user4'}},
+            },
+        },
+    };
+
+    describe('loadProfilesForIncomingHooks', () => {
+        test('load profiles for hooks including user we already have', () => {
+            const testStore = mockStore(initialState);
+            testStore.dispatch(Actions.loadProfilesForIncomingHooks([{user_id: 'current_user_id'}, {user_id: 'user_id2'}]));
+            expect(getProfilesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['user_id2']));
+        });
+
+        test('load profiles for hooks including only users we don\'t have', () => {
+            const testStore = mockStore(initialState);
+            testStore.dispatch(Actions.loadProfilesForIncomingHooks([{user_id: 'user_id1'}, {user_id: 'user_id2'}]));
+            expect(getProfilesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['user_id1', 'user_id2']));
+        });
+
+        test('load profiles for empty hooks', () => {
+            const testStore = mockStore(initialState);
+            testStore.dispatch(Actions.loadProfilesForIncomingHooks([]));
+            expect(getProfilesByIds).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('loadProfilesForOutgoingHooks', () => {
+        test('load profiles for hooks including user we already have', () => {
+            const testStore = mockStore(initialState);
+            testStore.dispatch(Actions.loadProfilesForOutgoingHooks([{creator_id: 'current_user_id'}, {creator_id: 'user_id2'}]));
+            expect(getProfilesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['user_id2']));
+        });
+
+        test('load profiles for hooks including only users we don\'t have', () => {
+            const testStore = mockStore(initialState);
+            testStore.dispatch(Actions.loadProfilesForOutgoingHooks([{creator_id: 'user_id1'}, {creator_id: 'user_id2'}]));
+            expect(getProfilesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['user_id1', 'user_id2']));
+        });
+
+        test('load profiles for empty hooks', () => {
+            const testStore = mockStore(initialState);
+            testStore.dispatch(Actions.loadProfilesForOutgoingHooks([]));
+            expect(getProfilesByIds).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('loadProfilesForCommands', () => {
+        test('load profiles for commands including user we already have', () => {
+            const testStore = mockStore(initialState);
+            testStore.dispatch(Actions.loadProfilesForCommands([{creator_id: 'current_user_id'}, {creator_id: 'user_id2'}]));
+            expect(getProfilesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['user_id2']));
+        });
+
+        test('load profiles for commands including only users we don\'t have', () => {
+            const testStore = mockStore(initialState);
+            testStore.dispatch(Actions.loadProfilesForCommands([{creator_id: 'user_id1'}, {creator_id: 'user_id2'}]));
+            expect(getProfilesByIds).toHaveBeenCalledWith(expect.arrayContainingExactly(['user_id1', 'user_id2']));
+        });
+
+        test('load profiles for empty commands', () => {
+            const testStore = mockStore(initialState);
+            testStore.dispatch(Actions.loadProfilesForCommands([]));
+            expect(getProfilesByIds).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
Correctly load integration creators and convert integration actions to follow the redux pattern. Removed a bunch of functions we weren't using.

@lindy65 can you check that MM-12777 is fixed and smoke test the integration pages for webhooks and slash commands?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12777
https://mattermost.atlassian.net/browse/MM-12586

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)