### PR TITLE
Add a default timezone 'Etc/UTC' for tests

### DIFF
--- a/tests/components/__snapshots__/shortcuts_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/shortcuts_modal.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`components/ShortcutsModal should match snapshot modal for Mac 1`] = `
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   isMac={true}
@@ -56,7 +56,7 @@ exports[`components/ShortcutsModal should match snapshot modal for Mac 1`] = `
         "now": [Function],
         "onError": [Function],
         "textComponent": "span",
-        "timeZone": "America/Los_Angeles",
+        "timeZone": "Etc/UTC",
       }
     }
     isMac={true}
@@ -147,7 +147,7 @@ exports[`components/ShortcutsModal should match snapshot modal for non-Mac like 
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   isMac={false}
@@ -177,7 +177,7 @@ exports[`components/ShortcutsModal should match snapshot modal for non-Mac like 
         "now": [Function],
         "onError": [Function],
         "textComponent": "span",
-        "timeZone": "America/Los_Angeles",
+        "timeZone": "Etc/UTC",
       }
     }
     isMac={false}

--- a/tests/components/__snapshots__/shortcuts_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/shortcuts_modal.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`components/ShortcutsModal should match snapshot modal for Mac 1`] = `
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   isMac={true}
@@ -56,7 +56,7 @@ exports[`components/ShortcutsModal should match snapshot modal for Mac 1`] = `
         "now": [Function],
         "onError": [Function],
         "textComponent": "span",
-        "timeZone": null,
+        "timeZone": "America/Los_Angeles",
       }
     }
     isMac={true}
@@ -147,7 +147,7 @@ exports[`components/ShortcutsModal should match snapshot modal for non-Mac like 
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   isMac={false}
@@ -177,7 +177,7 @@ exports[`components/ShortcutsModal should match snapshot modal for non-Mac like 
         "now": [Function],
         "onError": [Function],
         "textComponent": "span",
-        "timeZone": null,
+        "timeZone": "America/Los_Angeles",
       }
     }
     isMac={false}

--- a/tests/components/__snapshots__/toggle_modal_button_redux.test.jsx.snap
+++ b/tests/components/__snapshots__/toggle_modal_button_redux.test.jsx.snap
@@ -35,7 +35,7 @@ exports[`components/ToggleModalButtonRedux component should match snapshot 1`] =
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   modalId="delete_channel"
@@ -73,7 +73,7 @@ exports[`components/ToggleModalButtonRedux component should match snapshot 1`] =
         "now": [Function],
         "onError": [Function],
         "textComponent": "span",
-        "timeZone": null,
+        "timeZone": "America/Los_Angeles",
       }
     }
     onClick={[Function]}

--- a/tests/components/__snapshots__/toggle_modal_button_redux.test.jsx.snap
+++ b/tests/components/__snapshots__/toggle_modal_button_redux.test.jsx.snap
@@ -35,7 +35,7 @@ exports[`components/ToggleModalButtonRedux component should match snapshot 1`] =
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   modalId="delete_channel"
@@ -73,7 +73,7 @@ exports[`components/ToggleModalButtonRedux component should match snapshot 1`] =
         "now": [Function],
         "onError": [Function],
         "textComponent": "span",
-        "timeZone": "America/Los_Angeles",
+        "timeZone": "Etc/UTC",
       }
     }
     onClick={[Function]}

--- a/tests/components/admin_console/request_button/__snapshots__/request_button.test.jsx.snap
+++ b/tests/components/admin_console/request_button/__snapshots__/request_button.test.jsx.snap
@@ -81,7 +81,7 @@ exports[`components/admin_console/request_button/request_button.jsx should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   requestAction={
@@ -221,7 +221,7 @@ exports[`components/admin_console/request_button/request_button.jsx should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   requestAction={
@@ -369,7 +369,7 @@ exports[`components/admin_console/request_button/request_button.jsx should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   requestAction={
@@ -505,7 +505,7 @@ exports[`components/admin_console/request_button/request_button.jsx should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   requestAction={

--- a/tests/components/admin_console/request_button/__snapshots__/request_button.test.jsx.snap
+++ b/tests/components/admin_console/request_button/__snapshots__/request_button.test.jsx.snap
@@ -81,7 +81,7 @@ exports[`components/admin_console/request_button/request_button.jsx should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   requestAction={
@@ -221,7 +221,7 @@ exports[`components/admin_console/request_button/request_button.jsx should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   requestAction={
@@ -369,7 +369,7 @@ exports[`components/admin_console/request_button/request_button.jsx should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   requestAction={
@@ -505,7 +505,7 @@ exports[`components/admin_console/request_button/request_button.jsx should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   requestAction={

--- a/tests/components/navbar/__snapshots__/navbar_info_button.test.jsx.snap
+++ b/tests/components/navbar/__snapshots__/navbar_info_button.test.jsx.snap
@@ -37,7 +37,7 @@ exports[`components/navbar/NavbarInfoButton should match snapshot, with channel 
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
 >
@@ -160,7 +160,7 @@ exports[`components/navbar/NavbarInfoButton should match snapshot, without chann
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
 >

--- a/tests/components/navbar/__snapshots__/navbar_info_button.test.jsx.snap
+++ b/tests/components/navbar/__snapshots__/navbar_info_button.test.jsx.snap
@@ -37,7 +37,7 @@ exports[`components/navbar/NavbarInfoButton should match snapshot, with channel 
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
 >
@@ -160,7 +160,7 @@ exports[`components/navbar/NavbarInfoButton should match snapshot, without chann
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
 >

--- a/tests/components/post_view/__snapshots__/date_separator.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/date_separator.test.jsx.snap
@@ -27,7 +27,7 @@ exports[`components/post_view/DateSeparator should match snapshot 1`] = `
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
 >

--- a/tests/components/post_view/__snapshots__/date_separator.test.jsx.snap
+++ b/tests/components/post_view/__snapshots__/date_separator.test.jsx.snap
@@ -27,7 +27,7 @@ exports[`components/post_view/DateSeparator should match snapshot 1`] = `
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
 >

--- a/tests/components/user_settings/__snapshots__/email_notification_setting.test.jsx.snap
+++ b/tests/components/user_settings/__snapshots__/email_notification_setting.test.jsx.snap
@@ -30,7 +30,7 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   onCancel={[MockFunction]}
@@ -343,7 +343,7 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   onCancel={[MockFunction]}

--- a/tests/components/user_settings/__snapshots__/email_notification_setting.test.jsx.snap
+++ b/tests/components/user_settings/__snapshots__/email_notification_setting.test.jsx.snap
@@ -30,7 +30,7 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   onCancel={[MockFunction]}
@@ -343,7 +343,7 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   onCancel={[MockFunction]}

--- a/tests/components/user_settings/__snapshots__/manage_auto_responder.test.jsx.snap
+++ b/tests/components/user_settings/__snapshots__/manage_auto_responder.test.jsx.snap
@@ -29,7 +29,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   saving={false}
@@ -226,7 +226,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   saving={false}

--- a/tests/components/user_settings/__snapshots__/manage_auto_responder.test.jsx.snap
+++ b/tests/components/user_settings/__snapshots__/manage_auto_responder.test.jsx.snap
@@ -29,7 +29,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   saving={false}
@@ -226,7 +226,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   saving={false}

--- a/tests/helpers/intl-test-helper.jsx
+++ b/tests/helpers/intl-test-helper.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {IntlProvider, intlShape} from 'react-intl';
 import {mount, shallow} from 'enzyme';
 
-const intlProvider = new IntlProvider({locale: 'en'}, {});
+const intlProvider = new IntlProvider({locale: 'en', timeZone: 'America/Los_Angeles'}, {});
 const {intl} = intlProvider.getChildContext();
 
 export function shallowWithIntl(node, {context} = {}) {

--- a/tests/helpers/intl-test-helper.jsx
+++ b/tests/helpers/intl-test-helper.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {IntlProvider, intlShape} from 'react-intl';
 import {mount, shallow} from 'enzyme';
 
-const intlProvider = new IntlProvider({locale: 'en', timeZone: 'America/Los_Angeles'}, {});
+const intlProvider = new IntlProvider({locale: 'en', timeZone: 'Etc/UTC'}, {});
 const {intl} = intlProvider.getChildContext();
 
 export function shallowWithIntl(node, {context} = {}) {

--- a/tests/plugins/__snapshots__/pluggable.test.jsx.snap
+++ b/tests/plugins/__snapshots__/pluggable.test.jsx.snap
@@ -83,7 +83,7 @@ exports[`plugins/Pluggable should match snapshot with extended component with pl
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   pluggableName="PopoverSection1"
@@ -118,7 +118,7 @@ exports[`plugins/Pluggable should match snapshot with extended component with pl
         "now": [Function],
         "onError": [Function],
         "textComponent": "span",
-        "timeZone": "America/Los_Angeles",
+        "timeZone": "Etc/UTC",
       }
     }
     key="PopoverSection1undefined"
@@ -163,7 +163,7 @@ exports[`plugins/Pluggable should match snapshot with no extended component 1`] 
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   store={
@@ -210,7 +210,7 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": "America/Los_Angeles",
+      "timeZone": "Etc/UTC",
     }
   }
   store={

--- a/tests/plugins/__snapshots__/pluggable.test.jsx.snap
+++ b/tests/plugins/__snapshots__/pluggable.test.jsx.snap
@@ -83,7 +83,7 @@ exports[`plugins/Pluggable should match snapshot with extended component with pl
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   pluggableName="PopoverSection1"
@@ -118,7 +118,7 @@ exports[`plugins/Pluggable should match snapshot with extended component with pl
         "now": [Function],
         "onError": [Function],
         "textComponent": "span",
-        "timeZone": null,
+        "timeZone": "America/Los_Angeles",
       }
     }
     key="PopoverSection1undefined"
@@ -163,7 +163,7 @@ exports[`plugins/Pluggable should match snapshot with no extended component 1`] 
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   store={
@@ -210,7 +210,7 @@ exports[`plugins/Pluggable should match snapshot with no overridden component 1`
       "now": [Function],
       "onError": [Function],
       "textComponent": "span",
-      "timeZone": null,
+      "timeZone": "America/Los_Angeles",
     }
   }
   store={


### PR DESCRIPTION
#### Summary
Add a default timezone for intlProvider for consistent tests times across platforms

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
