### PR TITLE
MM-12493: work around Desktop/Chromium rendering issue

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -330,7 +330,6 @@
                     @include alpha-property(background-color, $black, .1);
                     border-radius: 0;
                     font-weight: 400;
-                    position: relative;
 
                     &.unread-title {
                         font-weight: 600;
@@ -442,9 +441,4 @@
     span {
         outline: none;
     }
-}
-
-/* Fix for https://mattermost.atlassian.net/browse/MM-12493 */
-.react-contextmenu:not(.react-contextmenu--visible) {
-    z-index: -1 !important;
 }


### PR DESCRIPTION
#### Summary
Commit 0d02b1607352dc15dbd03d36f31f485764b1ccb7 (https://github.com/mattermost/mattermost-webapp/pull/1738) changed `.sidebar-item` to have `display: flex`, resulting in a Desktop/Electron/Chromium-specific bug that would sometimes result in an unread channel name being rendered as both bolded and not bolded.

An initial attempt at fixing this improved the behaviour some of the time, but didn't resolve the problem entirely. We've seen been able to reproduce the problem locally 100% of the time, and narrowed it down to what seems like a rendering "race" between in the CSS. It's likely this could be fixed with a larger refactor to avoid duplicate rules, but simply removing `position: relative` in this case appears to avoid the problem without any visual side effects.

I've tested this on Firefox, Chrome and Safari (OSX) (as well as the desktop app, of course!)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12493

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
