### PR TITLE
MM-12890 - Fix markdown preview error

### DIFF
--- a/components/post_markdown/index.js
+++ b/components/post_markdown/index.js
@@ -8,7 +8,7 @@ import PostMarkdown from './post_markdown';
 
 function mapStateToProps(state, ownProps) {
     return {
-        channel: getChannel(state, ownProps.post.channel_id),
+        channel: getChannel(state, ownProps.channelId),
         pluginHooks: state.plugins.components.MessageWillFormat,
     };
 }

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -192,6 +192,7 @@ export default class PostMessageView extends React.PureComponent {
                         isRHS={isRHS}
                         options={options}
                         post={post}
+                        channelId={post.channel_id}
                     />
                 </div>
                 {this.renderEditedIndicator()}


### PR DESCRIPTION
#### Summary
Fix not to require post attribute, because preview markdown doen't give post attribute.

#### Ticket Link
[\[MM\-12890\] \[master\] Clicking on "preview" below message box results in blank screen and JS error \- Mattermost](https://mattermost.atlassian.net/browse/MM-12890)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
