### PR TITLE
MM-12885: Add UI widgets AdminHeader and FormattedAdminHeader.

### DIFF
--- a/components/admin_console/__snapshots__/message_export_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/message_export_settings.test.jsx.snap
@@ -4,15 +4,13 @@ exports[`components/MessageExportSettings should match snapshot, disabled, actia
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Compliance Export (Beta)"
       id="admin.complianceExport.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -185,15 +183,13 @@ exports[`components/MessageExportSettings should match snapshot, disabled, globa
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Compliance Export (Beta)"
       id="admin.complianceExport.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -476,15 +472,13 @@ exports[`components/MessageExportSettings should match snapshot, enabled, actian
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Compliance Export (Beta)"
       id="admin.complianceExport.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -657,15 +651,13 @@ exports[`components/MessageExportSettings should match snapshot, enabled, global
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Compliance Export (Beta)"
       id="admin.complianceExport.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -38,14 +38,11 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
-    <FormattedMessage
-      id="config"
-      values={Object {}}
-    />
-  </h3>
+  <FormattedAdminHeader
+    defaultMessage="Configuration"
+    id="config"
+    values={Object {}}
+  />
   <form
     className="form-horizontal"
     onSubmit={[Function]}

--- a/components/admin_console/admin_settings.jsx
+++ b/components/admin_console/admin_settings.jsx
@@ -11,6 +11,8 @@ import SaveButton from 'components/save_button.jsx';
 import FormError from 'components/form_error.jsx';
 import Constants from 'utils/constants.jsx';
 
+import AdminHeader from 'components/widgets/admin_console/admin_header.jsx';
+
 export default class AdminSettings extends React.Component {
     static propTypes = {
 
@@ -190,9 +192,9 @@ export default class AdminSettings extends React.Component {
     render() {
         return (
             <div className='wrapper--fixed'>
-                <h3 className='admin-console-header'>
+                <AdminHeader>
                     {this.renderTitle()}
-                </h3>
+                </AdminHeader>
                 <form
                     className='form-horizontal'
                     role='form'

--- a/components/admin_console/audits/audits.jsx
+++ b/components/admin_console/audits/audits.jsx
@@ -10,6 +10,8 @@ import {localizeMessage} from 'utils/utils.jsx';
 import AuditTable from 'components/audit_table';
 import LoadingScreen from 'components/loading_screen.jsx';
 
+import AdminHeader from 'components/widgets/admin_console/admin_header.jsx';
+
 export default class Audits extends React.PureComponent {
     static propTypes = {
         isLicensed: PropTypes.bool.isRequired,
@@ -76,7 +78,7 @@ export default class Audits extends React.PureComponent {
                 <ComplianceReports/>
 
                 <div className='panel audit-panel'>
-                    <h3 className='admin-console-header'>
+                    <AdminHeader>
                         <FormattedMessage
                             id='admin.audits.title'
                             defaultMessage='User Activity Logs'
@@ -95,7 +97,7 @@ export default class Audits extends React.PureComponent {
                                 defaultMessage='Reload User Activity Logs'
                             />
                         </button>
-                    </h3>
+                    </AdminHeader>
                     <div className='audit-panel__table'>
                         {content}
                     </div>

--- a/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.jsx.snap
+++ b/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.jsx.snap
@@ -4,11 +4,9 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     testplugin
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -223,11 +221,9 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     testplugin
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -280,11 +276,9 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     testplugin
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}

--- a/components/admin_console/license_settings.jsx
+++ b/components/admin_console/license_settings.jsx
@@ -13,6 +13,8 @@ import {t} from 'utils/i18n';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
+import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header.jsx';
+
 const holders = defineMessages({
     removing: {
         id: t('admin.license.removing'),
@@ -223,12 +225,10 @@ class LicenseSettings extends React.Component {
 
         return (
             <div className='wrapper--fixed'>
-                <h3 className='admin-console-header'>
-                    <FormattedMessage
-                        id='admin.license.title'
-                        defaultMessage='Edition and License'
-                    />
-                </h3>
+                <FormattedAdminHeader
+                    id='admin.license.title'
+                    defaultMessage='Edition and License'
+                />
                 <form
                     className='form-horizontal'
                     role='form'

--- a/components/admin_console/permission_schemes_settings/__snapshots__/permission_schemes_settings.test.jsx.snap
+++ b/components/admin_console/permission_schemes_settings/__snapshots__/permission_schemes_settings.test.jsx.snap
@@ -11,15 +11,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_schemes
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
-    <FormattedMessage
-      defaultMessage="Permission Schemes"
-      id="admin.permissions.permissionSchemes"
-      values={Object {}}
-    />
-  </h3>
+  <FormattedAdminHeader
+    defaultMessage="Permission Schemes"
+    id="admin.permissions.permissionSchemes"
+    values={Object {}}
+  />
   <div
     className="banner info"
   >
@@ -149,15 +145,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_schemes
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
-    <FormattedMessage
-      defaultMessage="Permission Schemes"
-      id="admin.permissions.permissionSchemes"
-      values={Object {}}
-    />
-  </h3>
+  <FormattedAdminHeader
+    defaultMessage="Permission Schemes"
+    id="admin.permissions.permissionSchemes"
+    values={Object {}}
+  />
   <div
     className="banner info"
   >
@@ -266,15 +258,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_schemes
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
-    <FormattedMessage
-      defaultMessage="Permission Schemes"
-      id="admin.permissions.permissionSchemes"
-      values={Object {}}
-    />
-  </h3>
+  <FormattedAdminHeader
+    defaultMessage="Permission Schemes"
+    id="admin.permissions.permissionSchemes"
+    values={Object {}}
+  />
   <div
     className="banner info"
   >
@@ -431,15 +419,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_schemes
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
-    <FormattedMessage
-      defaultMessage="Permission Schemes"
-      id="admin.permissions.permissionSchemes"
-      values={Object {}}
-    />
-  </h3>
+  <FormattedAdminHeader
+    defaultMessage="Permission Schemes"
+    id="admin.permissions.permissionSchemes"
+    values={Object {}}
+  />
   <div
     className="banner info"
   >
@@ -596,15 +580,11 @@ exports[`components/admin_console/permission_schemes_settings/permission_schemes
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
-    <FormattedMessage
-      defaultMessage="Permission Schemes"
-      id="admin.permissions.permissionSchemes"
-      values={Object {}}
-    />
-  </h3>
+  <FormattedAdminHeader
+    defaultMessage="Permission Schemes"
+    id="admin.permissions.permissionSchemes"
+    values={Object {}}
+  />
   <div
     className="banner info"
   >

--- a/components/admin_console/permission_schemes_settings/permission_schemes_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_schemes_settings.jsx
@@ -12,6 +12,8 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 import LoadingScreen from 'components/loading_screen.jsx';
 
+import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header.jsx';
+
 import PermissionsSchemeSummary from './permissions_scheme_summary';
 
 const PAGE_SIZE = 30;
@@ -140,13 +142,10 @@ export default class PermissionSchemesSettings extends React.PureComponent {
 
         return (
             <div className='wrapper--fixed'>
-                <h3 className='admin-console-header'>
-                    <FormattedMessage
-                        id='admin.permissions.permissionSchemes'
-                        defaultMessage='Permission Schemes'
-                    />
-                </h3>
-
+                <FormattedAdminHeader
+                    id='admin.permissions.permissionSchemes'
+                    defaultMessage='Permission Schemes'
+                />
                 <div className={'banner info'}>
                     <div className='banner__content'>
                         <span>

--- a/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
+++ b/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
@@ -4,15 +4,13 @@ exports[`components/PluginManagement should match snapshot 1`] = `
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Management"
       id="admin.plugin.management.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -191,15 +189,13 @@ exports[`components/PluginManagement should match snapshot, No installed plugins
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Management"
       id="admin.plugin.management.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -383,15 +379,13 @@ exports[`components/PluginManagement should match snapshot, disabled 1`] = `
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Management"
       id="admin.plugin.management.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -543,15 +537,13 @@ exports[`components/PluginManagement should match snapshot, upload disabled 1`] 
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Management"
       id="admin.plugin.management.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -730,15 +722,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Management"
       id="admin.plugin.management.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -980,15 +970,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Management"
       id="admin.plugin.management.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -1198,15 +1186,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Management"
       id="admin.plugin.management.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -1416,15 +1402,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Management"
       id="admin.plugin.management.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}
@@ -1634,15 +1618,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
+  <AdminHeader>
     <FormattedMessage
       defaultMessage="Management"
       id="admin.plugin.management.title"
       values={Object {}}
     />
-  </h3>
+  </AdminHeader>
   <form
     className="form-horizontal"
     onSubmit={[Function]}

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -32,6 +32,9 @@ import FormError from 'components/form_error.jsx';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
+import AdminHeader from 'components/widgets/admin_console/admin_header.jsx';
+import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header.jsx';
+
 export default class SchemaAdminSettings extends React.Component {
     static propTypes = {
         config: PropTypes.object,
@@ -230,10 +233,19 @@ export default class SchemaAdminSettings extends React.Component {
             return '';
         }
         if (this.props.schema.translate === false) {
-            return this.props.schema.name || this.props.schema.id;
+            return (
+                <AdminHeader>
+                    {this.props.schema.name || this.props.schema.id}
+                </AdminHeader>
+            );
         }
-        return <FormattedMessage id={this.props.schema.name || this.props.schema.id}/>;
-    }
+        return (
+            <FormattedAdminHeader
+                id={this.props.schema.name || this.props.schema.id}
+                defaultMessage={this.props.schema.name_default || this.props.schema.id}
+            />
+        );
+    };
 
     renderBanner = (setting) => {
         if (!this.props.schema) {
@@ -862,9 +874,7 @@ export default class SchemaAdminSettings extends React.Component {
         }
         return (
             <div className='wrapper--fixed'>
-                <h3 className='admin-console-header'>
-                    {this.renderTitle()}
-                </h3>
+                {this.renderTitle()}
                 <form
                     className='form-horizontal'
                     role='form'

--- a/components/admin_console/server_logs/logs.jsx
+++ b/components/admin_console/server_logs/logs.jsx
@@ -7,6 +7,8 @@ import {FormattedMessage} from 'react-intl';
 
 import LoadingScreen from 'components/loading_screen.jsx';
 
+import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header.jsx';
+
 import LogList from './log_list.jsx';
 
 export default class Logs extends React.Component {
@@ -84,12 +86,10 @@ export default class Logs extends React.Component {
 
         return (
             <div className='wrapper--admin'>
-                <h3 className='admin-console-header'>
-                    <FormattedMessage
-                        id='admin.logs.title'
-                        defaultMessage='Server Logs'
-                    />
-                </h3>
+                <FormattedAdminHeader
+                    id='admin.logs.title'
+                    defaultMessage='Server Logs'
+                />
                 <div className='banner'>
                     <div className='banner__content'>
                         <FormattedMessage

--- a/components/admin_console/system_users/__snapshots__/system_users.test.jsx.snap
+++ b/components/admin_console/system_users/__snapshots__/system_users.test.jsx.snap
@@ -4,19 +4,15 @@ exports[`components/admin_console/system_users should match default snapshot 1`]
 <div
   className="wrapper--fixed"
 >
-  <h3
-    className="admin-console-header"
-  >
-    <FormattedMessage
-      defaultMessage="{siteName} Users"
-      id="admin.system_users.title"
-      values={
-        Object {
-          "siteName": "Site name",
-        }
+  <FormattedAdminHeader
+    defaultMessage="{siteName} Users"
+    id="admin.system_users.title"
+    values={
+      Object {
+        "siteName": "Site name",
       }
-    />
-  </h3>
+    }
+  />
   <div
     className="more-modal__list member-list-holder"
   >

--- a/components/admin_console/system_users/system_users.jsx
+++ b/components/admin_console/system_users/system_users.jsx
@@ -11,6 +11,8 @@ import {loadProfiles, loadProfilesAndTeamMembers, loadProfilesWithoutTeam, searc
 import {Constants, UserSearchOptions, SearchUserTeamFilter} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
+import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header.jsx';
+
 import SystemUsersList from './list';
 
 const USER_ID_LENGTH = 26;
@@ -271,15 +273,13 @@ export default class SystemUsers extends React.Component {
     render() {
         return (
             <div className='wrapper--fixed'>
-                <h3 className='admin-console-header'>
-                    <FormattedMessage
-                        id='admin.system_users.title'
-                        defaultMessage='{siteName} Users'
-                        values={{
-                            siteName: this.props.siteName,
-                        }}
-                    />
-                </h3>
+                <FormattedAdminHeader
+                    id='admin.system_users.title'
+                    defaultMessage='{siteName} Users'
+                    values={{
+                        siteName: this.props.siteName,
+                    }}
+                />
                 <div className='more-modal__list member-list-holder'>
                     <SystemUsersList
                         loading={this.state.loading}

--- a/components/analytics/system_analytics/system_analytics.jsx
+++ b/components/analytics/system_analytics/system_analytics.jsx
@@ -10,6 +10,8 @@ import Constants from 'utils/constants.jsx';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
+import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header.jsx';
+
 import DoughnutChart from '../doughnut_chart.jsx';
 import LineChart from '../line_chart.jsx';
 import StatisticCount from '../statistic_count.jsx';
@@ -362,12 +364,10 @@ export default class SystemAnalytics extends React.PureComponent {
 
         return (
             <div className='wrapper--fixed team_statistics'>
-                <h3 className='admin-console-header'>
-                    <FormattedMessage
-                        id='analytics.system.title'
-                        defaultMessage='System Statistics'
-                    />
-                </h3>
+                <FormattedAdminHeader
+                    id='analytics.system.title'
+                    defaultMessage='System Statistics'
+                />
                 {banner}
                 <div className='row'>
                     {firstRow}

--- a/components/analytics/team_analytics/team_analytics.jsx
+++ b/components/analytics/team_analytics/team_analytics.jsx
@@ -17,6 +17,8 @@ import StatisticCount from 'components/analytics/statistic_count.jsx';
 import TableChart from 'components/analytics/table_chart.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
+import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header.jsx';
+
 import {getMonthLong} from 'utils/i18n';
 
 import {formatPostsPerDayData, formatUsersWithPostsPerDayData} from '../format.jsx';
@@ -234,15 +236,13 @@ export default class TeamAnalytics extends React.Component {
             <div className='wrapper--fixed team_statistics'>
                 <div className='admin-console-header team-statistics__header-row'>
                     <div className='team-statistics__header'>
-                        <h3 className='admin-console-header'>
-                            <FormattedMessage
-                                id='analytics.team.title'
-                                defaultMessage='Team Statistics for {team}'
-                                values={{
-                                    team: this.state.team.display_name,
-                                }}
-                            />
-                        </h3>
+                        <FormattedAdminHeader
+                            id='analytics.team.title'
+                            defaultMessage='Team Statistics for {team}'
+                            values={{
+                                team: this.state.team.display_name,
+                            }}
+                        />
                     </div>
                     <div className='team-statistics__team-filter'>
                         <select

--- a/components/widgets/admin_console/admin_header.jsx
+++ b/components/widgets/admin_console/admin_header.jsx
@@ -1,0 +1,17 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const AdminHeader = (props) => (
+    <h3 className='admin-console-header'>
+        {props.children}
+    </h3>
+);
+
+AdminHeader.propTypes = {
+    children: PropTypes.node.isRequired,
+};
+
+export default AdminHeader;

--- a/components/widgets/admin_console/admin_header.test.jsx
+++ b/components/widgets/admin_console/admin_header.test.jsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import AdminHeader from './admin_header.jsx';
+
+describe('components/widgets/admin_console/AdminHeader', () => {
+    test('render component with child', () => {
+        const wrapper = shallow(<AdminHeader>{'Test'}</AdminHeader>);
+        expect(wrapper).toMatchInlineSnapshot(`
+<h3
+  className="admin-console-header"
+>
+  Test
+</h3>
+`
+        );
+    });
+
+    test('children prop is mandatory', () => {
+        console.originalError = console.error;
+        console.error = jest.fn();
+
+        shallow(<AdminHeader/>);
+
+        expect(console.error).toBeCalledTimes(1);
+        expect(console.error).toBeCalledWith('Warning: Failed prop type: The prop `children` is marked as required in `AdminHeader`, but its value is `undefined`.\n    in AdminHeader');
+
+        console.error = console.originalError;
+    });
+});

--- a/components/widgets/admin_console/formatted_admin_header.jsx
+++ b/components/widgets/admin_console/formatted_admin_header.jsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import AdminHeader from 'components/widgets/admin_console/admin_header.jsx';
+import FormattedMarkdownMessage from 'components/formatted_markdown_message';
+
+const FormattedAdminHeader = (props) => (
+    <AdminHeader>
+        <FormattedMarkdownMessage
+            id={props.id}
+            defaultMessage={props.defaultMessage}
+            values={props.values}
+        />
+    </AdminHeader>
+);
+
+FormattedAdminHeader.propTypes = {
+    id: PropTypes.string.isRequired,
+    defaultMessage: PropTypes.string.isRequired,
+    values: PropTypes.object,
+};
+
+FormattedAdminHeader.defaultProps = {
+    values: {},
+};
+
+export default FormattedAdminHeader;

--- a/components/widgets/admin_console/formatted_admin_header.test.jsx
+++ b/components/widgets/admin_console/formatted_admin_header.test.jsx
@@ -1,0 +1,86 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import FormattedAdminHeader from './formatted_admin_header.jsx';
+
+describe('components/widgets/admin_console/FormattedAdminHeader', () => {
+    test('render component with required props', () => {
+        const wrapper = shallow(
+            <FormattedAdminHeader
+                id='string.id'
+                defaultMessage='default message'
+            />
+        );
+        expect(wrapper).toMatchInlineSnapshot(`
+<AdminHeader>
+  <InjectIntl(FormattedMarkdownMessage)
+    defaultMessage="default message"
+    id="string.id"
+    values={Object {}}
+  />
+</AdminHeader>
+`
+        );
+    });
+
+    test('render component with all props', () => {
+        const wrapper = shallow(
+            <FormattedAdminHeader
+                id='string.id'
+                defaultMessage='default message'
+                values={{
+                    a_key: 'a_value',
+                }}
+            />
+        );
+        expect(wrapper).toMatchInlineSnapshot(`
+<AdminHeader>
+  <InjectIntl(FormattedMarkdownMessage)
+    defaultMessage="default message"
+    id="string.id"
+    values={
+      Object {
+        "a_key": "a_value",
+      }
+    }
+  />
+</AdminHeader>
+`
+        );
+    });
+
+    test('id prop is mandatory', () => {
+        console.originalError = console.error;
+        console.error = jest.fn();
+
+        shallow(
+            <FormattedAdminHeader
+                defaultMessage='default message'
+            />
+        );
+
+        expect(console.error).toBeCalledTimes(1);
+        expect(console.error).toBeCalledWith('Warning: Failed prop type: The prop `id` is marked as required in `FormattedAdminHeader`, but its value is `undefined`.\n    in FormattedAdminHeader');
+
+        console.error = console.originalError;
+    });
+
+    test('defaultMessage prop is mandatory', () => {
+        console.originalError = console.error;
+        console.error = jest.fn();
+
+        shallow(
+            <FormattedAdminHeader
+                id='string.id'
+            />
+        );
+
+        expect(console.error).toBeCalledTimes(1);
+        expect(console.error).toBeCalledWith('Warning: Failed prop type: The prop `defaultMessage` is marked as required in `FormattedAdminHeader`, but its value is `undefined`.\n    in FormattedAdminHeader');
+
+        console.error = console.originalError;
+    });
+});


### PR DESCRIPTION
#### Summary

Add UI widgets AdminHeader and FormattedAdminHeader.

This adds 2 new widgets:
* AdminHeader, which is a widget that makes the Admin Console page header which can take any components or values as children.
* FormattedAdminHeader, which is a child widget that can be used where the AdminHeader component is to contain a single localised (markdown) string.

These are not the most complicated components in existence, but they are
distinctly UI widgets that can be separated from the code, and were
needed for the code I was writing at the present.

This also adds a dependency on `sinon` for testing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12885

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)