### PR TITLE
[MM-12713] Deleted emitEmojiPosted and added addReaction into post_actions

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -122,7 +122,7 @@ export async function createPost(post, files, success) {
     if (emojis) {
         for (const emoji of emojis) {
             const trimmed = emoji.substring(1, emoji.length - 1);
-            emitEmojiPosted(trimmed);
+            dispatch(addRecentEmoji(trimmed));
         }
     }
 
@@ -155,8 +155,11 @@ export function storeCommentDraft(rootPostId, draft) {
     };
 }
 
-export function emitEmojiPosted(emoji) {
-    dispatch(addRecentEmoji(emoji));
+export function addReaction(postId, emojiName) {
+    return (doDispatch) => {
+        doDispatch(PostActions.addReaction(postId, emojiName));
+        doDispatch(addRecentEmoji(emojiName));
+    };
 }
 
 const POST_INCREASE_AMOUNT = Constants.POST_CHUNK_SIZE / 2;

--- a/actions/views/create_comment.jsx
+++ b/actions/views/create_comment.jsx
@@ -7,7 +7,6 @@ import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {makeGetMessageInHistoryItem, makeGetCommentCountForPost, getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 import {
-    addReaction,
     removeReaction,
     addMessageIntoHistory,
     moveHistoryIndexBack,
@@ -88,8 +87,7 @@ export function submitPost(channelId, rootId, draft) {
 export function submitReaction(postId, action, emojiName) {
     return (dispatch) => {
         if (action === '+') {
-            dispatch(addReaction(postId, emojiName));
-            PostActions.emitEmojiPosted(emojiName);
+            dispatch(PostActions.addReaction(postId, emojiName));
         } else if (action === '-') {
             dispatch(removeReaction(postId, emojiName));
         }

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -9,7 +9,6 @@ import {Posts} from 'mattermost-redux/constants';
 import {sortFileInfos} from 'mattermost-redux/utils/file_utils';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
-import {emitEmojiPosted} from 'actions/post_actions.jsx';
 import Constants, {StoragePrefixes, ModalIdentifiers} from 'utils/constants.jsx';
 import {containsAtChannel, postMessageOnKeyPress, shouldFocusMainTextbox} from 'utils/post_utils.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
@@ -478,7 +477,6 @@ export default class CreatePost extends React.Component {
 
         if (postId && action === '+') {
             this.props.actions.addReaction(postId, emojiName);
-            emitEmojiPosted(emojiName);
         } else if (postId && action === '-') {
             this.props.actions.removeReaction(postId, emojiName);
         }

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -21,7 +21,6 @@ import {
     addMessageIntoHistory,
     moveHistoryIndexBack,
     moveHistoryIndexForward,
-    addReaction,
     removeReaction,
 } from 'mattermost-redux/actions/posts';
 import {Posts, Preferences as PreferencesRedux} from 'mattermost-redux/constants';
@@ -29,7 +28,7 @@ import {Posts, Preferences as PreferencesRedux} from 'mattermost-redux/constants
 import {connectionErrorCount} from 'selectors/views/system';
 
 import {emitUserPostedEvent, postListScrollChangeToBottom} from 'actions/global_actions.jsx';
-import {createPost, setEditingPost} from 'actions/post_actions.jsx';
+import {addReaction, createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
 import {executeCommand} from 'actions/command';
 import {getPostDraft, getIsRhsExpanded} from 'selectors/rhs';

--- a/components/post_view/post_info/index.js
+++ b/components/post_view/post_info/index.js
@@ -3,11 +3,13 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {addReaction, removePost} from 'mattermost-redux/actions/posts';
+import {removePost} from 'mattermost-redux/actions/posts';
 import {isCurrentChannelReadOnly} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import {addReaction} from 'actions/post_actions.jsx';
 
 import {Preferences} from 'utils/constants.jsx';
 

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -10,7 +10,6 @@ import {Posts} from 'mattermost-redux/constants';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
 import Permissions from 'mattermost-redux/constants/permissions';
 
-import {emitEmojiPosted} from 'actions/post_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -156,7 +155,6 @@ export default class PostInfo extends React.PureComponent {
         this.setState({showEmojiPicker: false, reactionPickerOffset: pickerOffset});
         const emojiName = emoji.name || emoji.aliases[0];
         this.props.actions.addReaction(this.props.post.id, emojiName);
-        emitEmojiPosted(emojiName);
         this.props.handleDropdownOpened(false);
     };
 

--- a/components/post_view/reaction/index.js
+++ b/components/post_view/reaction/index.js
@@ -3,7 +3,7 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {addReaction, removeReaction} from 'mattermost-redux/actions/posts';
+import {removeReaction} from 'mattermost-redux/actions/posts';
 import {getMissingProfilesByIds} from 'mattermost-redux/actions/users';
 import {getCurrentUserId, makeGetProfilesForReactions, getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
@@ -12,6 +12,8 @@ import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles'
 import Permissions from 'mattermost-redux/constants/permissions';
 import Constants from 'mattermost-redux/constants/general';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
+
+import {addReaction} from 'actions/post_actions.jsx';
 
 import * as Emoji from 'utils/emoji.jsx';
 

--- a/components/post_view/reaction/reaction.jsx
+++ b/components/post_view/reaction/reaction.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
-import {emitEmojiPosted} from 'actions/post_actions.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 export default class Reaction extends React.PureComponent {
@@ -85,7 +84,6 @@ export default class Reaction extends React.PureComponent {
         e.preventDefault();
         const {actions, post, emojiName} = this.props;
         actions.addReaction(post.id, emojiName);
-        emitEmojiPosted(emojiName);
     }
 
     handleRemoveReaction = (e) => {

--- a/components/post_view/reaction_list/index.js
+++ b/components/post_view/reaction_list/index.js
@@ -9,6 +9,8 @@ import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
+import {addReaction} from 'actions/post_actions.jsx';
+
 import ReactionList from './reaction_list.jsx';
 
 function makeMapStateToProps() {
@@ -34,7 +36,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             getReactionsForPost: Actions.getReactionsForPost,
-            addReaction: Actions.addReaction,
+            addReaction,
         }, dispatch),
     };
 }

--- a/components/post_view/reaction_list/reaction_list.jsx
+++ b/components/post_view/reaction_list/reaction_list.jsx
@@ -8,7 +8,6 @@ import {FormattedMessage} from 'react-intl';
 import Permissions from 'mattermost-redux/constants/permissions';
 
 import {postListScrollChange} from 'actions/global_actions.jsx';
-import {emitEmojiPosted} from 'actions/post_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import Reaction from 'components/post_view/reaction';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
@@ -87,7 +86,6 @@ export default class ReactionListView extends React.PureComponent {
         this.setState({showEmojiPicker: false});
         const emojiName = emoji.name || emoji.aliases[0];
         this.props.actions.addReaction(this.props.post.id, emojiName);
-        emitEmojiPosted(emojiName);
     }
 
     hideEmojiPicker = () => {

--- a/components/rhs_comment/index.js
+++ b/components/rhs_comment/index.js
@@ -4,7 +4,6 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {Posts} from 'mattermost-redux/constants';
-import {addReaction} from 'mattermost-redux/actions/posts';
 import {isChannelReadOnlyById} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getUser, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
@@ -12,6 +11,8 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
+
+import {addReaction} from 'actions/post_actions.jsx';
 
 import {Preferences, UserStatuses} from 'utils/constants.jsx';
 import {isEmbedVisible} from 'selectors/posts';

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -11,7 +11,6 @@ import {
 } from 'mattermost-redux/utils/post_utils';
 import Permissions from 'mattermost-redux/constants/permissions';
 
-import {emitEmojiPosted} from 'actions/post_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -172,7 +171,6 @@ export default class RhsComment extends React.Component {
         });
         const emojiName = emoji.name || emoji.aliases[0];
         this.props.actions.addReaction(this.props.post.id, emojiName);
-        emitEmojiPosted(emojiName);
     };
 
     getClassName = (post, isSystemMessage) => {

--- a/components/rhs_root_post/index.js
+++ b/components/rhs_root_post/index.js
@@ -8,8 +8,9 @@ import {isChannelReadOnlyById, getChannel} from 'mattermost-redux/selectors/enti
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getUser, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {addReaction} from 'mattermost-redux/actions/posts';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
+
+import {addReaction} from 'actions/post_actions.jsx';
 
 import {Preferences, UserStatuses} from 'utils/constants.jsx';
 import {isEmbedVisible} from 'selectors/posts';

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -8,7 +8,6 @@ import {Posts} from 'mattermost-redux/constants';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
 import Permissions from 'mattermost-redux/constants/permissions';
 
-import {emitEmojiPosted} from 'actions/post_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -157,7 +156,6 @@ export default class RhsRootPost extends React.Component {
         });
         const emojiName = emoji.name || emoji.aliases[0];
         this.props.actions.addReaction(this.props.post.id, emojiName);
-        emitEmojiPosted(emojiName);
     };
 
     getClassName = (post, isSystemMessage) => {

--- a/tests/components/create_post/create_post.test.jsx
+++ b/tests/components/create_post/create_post.test.jsx
@@ -29,7 +29,6 @@ jest.mock('react-dom', () => ({
 }));
 
 jest.mock('actions/post_actions.jsx', () => ({
-    emitEmojiPosted: jest.fn(),
     createPost: jest.fn(() => {
         return new Promise((resolve) => {
             process.nextTick(() => resolve());

--- a/tests/components/post_view/reaction.test.jsx
+++ b/tests/components/post_view/reaction.test.jsx
@@ -4,12 +4,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import {emitEmojiPosted} from 'actions/post_actions.jsx';
 import Reaction from 'components/post_view/reaction/reaction.jsx';
-
-jest.mock('actions/post_actions.jsx', () => ({
-    emitEmojiPosted: jest.fn(),
-}));
 
 describe('components/post_view/Reaction', () => {
     const post = {id: 'post_id_1'};
@@ -72,7 +67,7 @@ describe('components/post_view/Reaction', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should have called actions.addReaction and emitEmojiPosted when handleAddReaction is called', () => {
+    test('should have called actions.addReaction when handleAddReaction is called', () => {
         const newActions = {...actions, addReaction: jest.fn()};
         const props = {...baseProps, actions: newActions};
 
@@ -81,9 +76,6 @@ describe('components/post_view/Reaction', () => {
 
         expect(newActions.addReaction).toHaveBeenCalledTimes(1);
         expect(newActions.addReaction).toHaveBeenCalledWith(post.id, emojiName);
-
-        expect(emitEmojiPosted).toHaveBeenCalledTimes(1);
-        expect(emitEmojiPosted).toHaveBeenCalledWith(emojiName);
     });
 
     test('should have called actions.removeReaction when handleRemoveReaction is called', () => {

--- a/tests/redux/actions/post_actions.test.js
+++ b/tests/redux/actions/post_actions.test.js
@@ -12,8 +12,13 @@ import {Constants, ActionTypes} from 'utils/constants';
 const mockStore = configureStore([thunk]);
 
 jest.mock('mattermost-redux/actions/posts', () => ({
+    addReaction: (...args) => ({type: 'MOCK_ADD_REACTION', args}),
     getPosts: (...args) => ({type: 'MOCK_GET_POSTS', args}),
     getPostsBefore: (...args) => ({type: 'MOCK_GET_POSTS_BEFORE', args}),
+}));
+
+jest.mock('actions/emoji_actions', () => ({
+    addRecentEmoji: (...args) => ({type: 'MOCK_ADD_RECENT_EMOJI', args}),
 }));
 
 const RECEIVED_POSTS = {
@@ -124,6 +129,7 @@ describe('Actions.Posts', () => {
                     },
                 },
             },
+            emojis: {customEmoji: {}},
         },
         views: {
             posts: {
@@ -245,6 +251,16 @@ describe('Actions.Posts', () => {
             {state: 'search', type: 'UPDATE_RHS_STATE'},
             {terms: '', type: 'UPDATE_RHS_SEARCH_RESULTS_TERMS'},
             {isGettingMore: false, type: 'SEARCH_POSTS_REQUEST'},
+        ]);
+    });
+
+    test('addReaction', async () => {
+        const testStore = await mockStore(initialState);
+
+        await testStore.dispatch(Actions.addReaction('post_id_1', 'emoji_name_1'));
+        expect(testStore.getActions()).toEqual([
+            {args: ['post_id_1', 'emoji_name_1'], type: 'MOCK_ADD_REACTION'},
+            {args: ['emoji_name_1'], type: 'MOCK_ADD_RECENT_EMOJI'},
         ]);
     });
 });

--- a/tests/redux/actions/views/create_comment.test.jsx
+++ b/tests/redux/actions/views/create_comment.test.jsx
@@ -4,7 +4,6 @@
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import {
-    addReaction,
     removeReaction,
     addMessageIntoHistory,
     moveHistoryIndexBack,
@@ -30,7 +29,6 @@ import {StoragePrefixes} from 'utils/constants';
 const mockStore = configureStore([thunk]);
 
 jest.mock('mattermost-redux/actions/posts', () => ({
-    addReaction: (...args) => ({type: 'MOCK_ADD_REACTION', args}),
     removeReaction: (...args) => ({type: 'MOCK_REMOVE_REACTION', args}),
     addMessageIntoHistory: (...args) => ({type: 'MOCK_ADD_MESSAGE_INTO_HISTORY', args}),
     moveHistoryIndexBack: (...args) => ({type: 'MOCK_MOVE_MESSAGE_HISTORY_BACK', args}),
@@ -51,9 +49,9 @@ jest.mock('actions/global_actions.jsx', () => ({
 }));
 
 jest.mock('actions/post_actions.jsx', () => ({
+    addReaction: (...args) => ({type: 'MOCK_ADD_REACTION', args}),
     createPost: jest.fn(),
     setEditingPost: (...args) => ({type: 'MOCK_SET_EDITING_POST', args}),
-    emitEmojiPosted: jest.fn(),
 }));
 
 jest.mock('actions/storage', () => ({
@@ -228,21 +226,18 @@ describe('rhs view actions', () => {
 
     describe('submitReaction', () => {
         test('it adds a reaction when action is +', () => {
-            store.dispatch(submitReaction('', '+', ''));
+            store.dispatch(submitReaction('post_id_1', '+', 'emoji_name_1'));
 
             const testStore = mockStore(initialState);
-            testStore.dispatch(addReaction('', ''));
-            expect(PostActions.emitEmojiPosted).toHaveBeenCalled();
-
+            testStore.dispatch(PostActions.addReaction('post_id_1', 'emoji_name_1'));
             expect(store.getActions()).toEqual(testStore.getActions());
         });
 
         test('it removes a reaction when action is -', () => {
-            store.dispatch(submitReaction('', '-', ''));
+            store.dispatch(submitReaction('post_id_1', '-', 'emoji_name_1'));
 
             const testStore = mockStore(initialState);
-            testStore.dispatch(removeReaction('', ''));
-            expect(PostActions.emitEmojiPosted).not.toHaveBeenCalled();
+            testStore.dispatch(removeReaction('post_id_1', 'emoji_name_1'));
 
             expect(store.getActions()).toEqual(testStore.getActions());
         });


### PR DESCRIPTION
#### Summary
Deleted emitEmojiPosted and added addReaction into post_actions.

Affected areas:
- add reaction into a post and add that reaction into the recently used emojis (in the emoji picker)

Test steps:
- add reaction into a post (at center, RHS root post, RHS comment) or post a reaction by using emoji picker or by typing in the text box, and verify that the reaction is added into the post and that reaction is added into the recently used emojis visible at the emoji picker.

@DHaussermann I've tested this PR with above coverage and it looks good (functionality same, no bug introduced).

#### Ticket Link
Jira ticket: [MM-12713](https://mattermost.atlassian.net/browse/MM-12713)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
