### PR TITLE
requireInteraction for notifications

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -131,7 +131,7 @@ export function getTeamRelativeUrl(team) {
 export function notifyMe(title, body, channel, teamId, silent) {
     showNotification({title,
         body,
-        requireInteraction: false,
+        requireInteraction: true,
         silent,
         onClick: () => {
             const state = store.getState();


### PR DESCRIPTION
#### Summary
Sets `requireInteraction` option for desktop notifications to `true`.

When user enables desktop notifications, he probably wants to really get notified about a new messages.

Currently notification is shown, but only for 5 seconds and then is deleted (and only web page title shows something happened). So when the user is doing something else or is AFK in that 5 seconds, then he gets no notification at all.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
