### PR TITLE
MM-12944: force "Delete" focus on showing delete post modal

### DIFF
--- a/components/delete_post_modal/delete_post_modal.jsx
+++ b/components/delete_post_modal/delete_post_modal.jsx
@@ -17,30 +17,15 @@ export default class DeletePostModal extends React.PureComponent {
         teamName: PropTypes.string,
         post: PropTypes.object.isRequired,
         commentCount: PropTypes.number.isRequired,
-
-        /**
-         * Does the post come from RHS mode
-         */
         isRHS: PropTypes.bool.isRequired,
-
-        /**
-        * Function called when modal is dismissed
-        */
         onHide: PropTypes.func.isRequired,
-
         actions: PropTypes.shape({
-
-            /**
-            * Function called for deleting post
-            */
             deleteAndRemovePost: PropTypes.func.isRequired,
         }),
     }
 
     constructor(props) {
         super(props);
-        this.handleDelete = this.handleDelete.bind(this);
-        this.onHide = this.onHide.bind(this);
         this.state = {
             show: true,
         };
@@ -66,7 +51,13 @@ export default class DeletePostModal extends React.PureComponent {
         }
     }
 
-    onHide() {
+    handleEntered = () => {
+        if (this.deletePostBtn) {
+            this.deletePostBtn.focus();
+        }
+    }
+
+    onHide = () => {
         this.setState({show: false});
 
         if (!UserAgent.isMobile()) {
@@ -111,6 +102,7 @@ export default class DeletePostModal extends React.PureComponent {
         return (
             <Modal
                 show={this.state.show}
+                onEntered={this.handleEntered}
                 onHide={this.onHide}
                 onExited={this.props.onHide}
                 enforceFocus={false}

--- a/tests/components/__snapshots__/delete_post_modal.test.jsx.snap
+++ b/tests/components/__snapshots__/delete_post_modal.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`components/delete_post_modal should match snapshot for delete_post_moda
       "remove": [Function],
     }
   }
+  onEntered={[Function]}
   onExited={[MockFunction]}
   onHide={[Function]}
   renderBackdrop={[Function]}
@@ -123,6 +124,7 @@ exports[`components/delete_post_modal should match snapshot for delete_post_moda
       "remove": [Function],
     }
   }
+  onEntered={[Function]}
   onExited={[MockFunction]}
   onHide={[Function]}
   renderBackdrop={[Function]}

--- a/tests/components/delete_post_modal.test.jsx
+++ b/tests/components/delete_post_modal.test.jsx
@@ -43,6 +43,18 @@ describe('components/delete_post_modal', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should focus delete button on enter', () => {
+        const wrapper = shallow(
+            <DeletePostModal {...baseProps}/>
+        );
+
+        const deletePostBtn = {focus: jest.fn()};
+        wrapper.instance().deletePostBtn = deletePostBtn;
+
+        wrapper.instance().handleEntered();
+        expect(deletePostBtn.focus).toHaveBeenCalled();
+    });
+
     test('should match state when onHide is called', () => {
         const wrapper = shallow(
             <DeletePostModal {...baseProps}/>


### PR DESCRIPTION
#### Summary
Focus handling is a mess. This doesn't really make it much better, other than making the behaviour explicit and constrained to within the modal dialog in question, fixing a regression introduced by MM-12688.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12944

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)