### PR TITLE
MM-12908: defer enter sending until 500ms after channel switch

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -242,6 +242,7 @@ export default class CreatePost extends React.Component {
         };
 
         this.lastBlurAt = 0;
+        this.lastChannelSwitchAt = 0;
         this.draftsForChannel = {};
     }
 
@@ -279,6 +280,7 @@ export default class CreatePost extends React.Component {
 
     componentDidUpdate(prevProps) {
         if (prevProps.currentChannel.id !== this.props.currentChannel.id) {
+            this.lastChannelSwitchAt = Date.now();
             this.focusTextbox();
         }
     }
@@ -518,7 +520,7 @@ export default class CreatePost extends React.Component {
     postMsgKeyPress = (e) => {
         const {ctrlSend, codeBlockOnCtrlEnter, currentChannel} = this.props;
 
-        const {allowSending, withClosedCodeBlock, message} = postMessageOnKeyPress(e, this.state.message, ctrlSend, codeBlockOnCtrlEnter);
+        const {allowSending, withClosedCodeBlock, message} = postMessageOnKeyPress(e, this.state.message, ctrlSend, codeBlockOnCtrlEnter, Date.now(), this.lastChannelSwitchAt);
 
         if (allowSending) {
             e.persist();

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -16,6 +16,8 @@ import MentionableRenderer from 'utils/markdown/mentionable_renderer';
 import * as Utils from 'utils/utils.jsx';
 import {isMobile} from 'utils/user_agent.jsx';
 
+const CHANNEL_SWITCH_IGNORE_ENTER_THRESHOLD_MS = 500;
+
 export function isSystemMessage(post) {
     return Boolean(post.type && (post.type.lastIndexOf(Constants.SYSTEM_MESSAGE_PREFIX) === 0));
 }
@@ -193,14 +195,23 @@ function sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, isSendMessageOnCtrlEnter
     return {allowSending: false};
 }
 
-export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, sendCodeBlockOnCtrlEnter) {
-    if (
-        !event ||
-        isMobile() ||
-        !Utils.isKeyPressed(event, Constants.KeyCodes.ENTER) ||
-        event.shiftKey ||
-        event.altKey
-    ) {
+export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, sendCodeBlockOnCtrlEnter, now = 0, lastChannelSwitchAt = 0) {
+    if (!event) {
+        return {allowSending: false};
+    }
+
+    // Typing enter on mobile never sends.
+    if (isMobile()) {
+        return {allowSending: false};
+    }
+
+    // Only ENTER sends, unless shift or alt key pressed.
+    if (!Utils.isKeyPressed(event, Constants.KeyCodes.ENTER) || event.shiftKey || event.altKey) {
+        return {allowSending: false};
+    }
+
+    // Don't send if we just switched channels within a threshold.
+    if (lastChannelSwitchAt > 0 && now > 0 && now - lastChannelSwitchAt <= CHANNEL_SWITCH_IGNORE_ENTER_THRESHOLD_MS) {
         return {allowSending: false};
     }
 

--- a/utils/post_utils.test.jsx
+++ b/utils/post_utils.test.jsx
@@ -477,4 +477,50 @@ describe('PostUtils.postMessageOnKeyPress', () => {
             expect(output).toEqual(testCase.expected);
         });
     }
+
+    // on sending within channel threshold
+    const channelThresholdCases = [{
+        name: 'now unspecified, last channel switch unspecified',
+        input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true, now: 0, lastChannelSwitch: 0},
+        expected: {allowSending: true},
+    }, {
+        name: 'now specified, last channel switch unspecified',
+        input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true, now: 1541658920334, lastChannelSwitch: 0},
+        expected: {allowSending: true},
+    }, {
+        name: 'now specified, last channel switch unspecified',
+        input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true, now: 0, lastChannelSwitch: 1541658920334},
+        expected: {allowSending: true},
+    }, {
+        name: 'last channel switch within threshold',
+        input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true, now: 1541658920334, lastChannelSwitch: 1541658920334 - 250},
+        expected: {allowSending: false},
+    }, {
+        name: 'last channel switch at threshold',
+        input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true, now: 1541658920334, lastChannelSwitch: 1541658920334 - 500},
+        expected: {allowSending: false},
+    }, {
+        name: 'last channel switch outside threshold',
+        input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true, now: 1541658920334, lastChannelSwitch: 1541658920334 - 501},
+        expected: {allowSending: true},
+    }, {
+        name: 'last channel switch well outside threshold',
+        input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true, now: 1541658920334, lastChannelSwitch: 1541658920334 - 1500},
+        expected: {allowSending: true},
+    }];
+
+    for (const testCase of channelThresholdCases) {
+        it(testCase.name, () => {
+            const output = PostUtils.postMessageOnKeyPress(
+                testCase.input.event,
+                testCase.input.message,
+                testCase.input.sendMessageOnCtrlEnter,
+                testCase.input.sendCodeBlockOnCtrlEnter,
+                testCase.input.now,
+                testCase.input.lastChannelSwitch
+            );
+
+            expect(output).toEqual(testCase.expected);
+        });
+    }
 });


### PR DESCRIPTION
#### Summary
It is unlikely that you want to send a draft within 500ms of switching channels. We could refine this by detecting additional typed characters as intent otherwise, but this keeps it simple.

I didn't touch creating a comment, since that never gets focussed on a channel switch.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12908

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)