### PR TITLE
MM-12946: hide .post__header for .same--user in compact view

### DIFF
--- a/sass/layout/_post-right.scss
+++ b/sass/layout/_post-right.scss
@@ -65,7 +65,7 @@
             &.same--user {
                 .post__header {
                     .col__name {
-                        display: inline-block;
+                        display: none;
                     }
                 }
             }


### PR DESCRIPTION
#### Summary
This regressed in https://mattermost.atlassian.net/browse/MM-12776.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12946

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)