### PR TITLE
MM-12966: consistently pass NotificationSections.NONE

### DIFF
--- a/components/channel_notifications_modal/channel_notifications_modal.jsx
+++ b/components/channel_notifications_modal/channel_notifications_modal.jsx
@@ -56,19 +56,19 @@ export default class ChannelNotificationsModal extends React.Component {
     }
 
     handleOnHide = () => {
-        this.updateSection('');
+        this.updateSection(NotificationSections.NONE);
 
         this.props.onHide();
     }
 
-    updateSection = (section) => {
+    updateSection = (section = NotificationSections.NONE) => {
         if ($('.section-max').length) {
             $('.settings-modal .modal-body').scrollTop(0).perfectScrollbar('update');
         }
 
         this.setState({activeSection: section});
 
-        if (section === '') {
+        if (section === NotificationSections.NONE) {
             this.resetStateFromNotifyProps(this.props.channelMember.notify_props);
         }
     }
@@ -84,7 +84,7 @@ export default class ChannelNotificationsModal extends React.Component {
         if (error) {
             this.setState({serverError: error.message});
         } else {
-            this.updateSection('');
+            this.updateSection(NotificationSections.NONE);
         }
     }
 
@@ -93,7 +93,7 @@ export default class ChannelNotificationsModal extends React.Component {
         const {desktopNotifyLevel} = this.state;
 
         if (channelMember.notify_props.desktop === desktopNotifyLevel) {
-            this.updateSection('');
+            this.updateSection(NotificationSections.NONE);
             return;
         }
 
@@ -110,7 +110,7 @@ export default class ChannelNotificationsModal extends React.Component {
         const {markUnreadNotifyLevel} = this.state;
 
         if (channelMember.notify_props.mark_unread === markUnreadNotifyLevel) {
-            this.updateSection('');
+            this.updateSection(NotificationSections.NONE);
             return;
         }
 
@@ -126,7 +126,7 @@ export default class ChannelNotificationsModal extends React.Component {
         const {pushNotifyLevel} = this.state;
 
         if (this.props.channelMember.notify_props.push === pushNotifyLevel) {
-            this.updateSection('');
+            this.updateSection(NotificationSections.NONE);
             return;
         }
 

--- a/components/channel_notifications_modal/components/notification_section.jsx
+++ b/components/channel_notifications_modal/components/notification_section.jsx
@@ -4,6 +4,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {NotificationSections} from 'utils/constants.jsx';
+
 import CollapseView from './collapse_view.jsx';
 import ExpandView from './expand_view.jsx';
 
@@ -60,7 +62,7 @@ export default class NotificationSection extends React.PureComponent {
     }
 
     handleCollapseSection = () => {
-        this.props.onUpdateSection();
+        this.props.onUpdateSection(NotificationSections.NONE);
     }
 
     render() {

--- a/components/channel_notifications_modal/components/notification_section.test.jsx
+++ b/components/channel_notifications_modal/components/notification_section.test.jsx
@@ -103,7 +103,7 @@ describe('components/channel_notifications_modal/NotificationSection', () => {
         );
         wrapper.instance().handleCollapseSection({preventDefault: jest.fn()});
         expect(onUpdateSection).toHaveBeenCalledTimes(1);
-        expect(onUpdateSection).toHaveBeenCalledWith();
+        expect(onUpdateSection).toHaveBeenCalledWith(NotificationSections.NONE);
     });
 
     test('should match snapshot on server error', () => {


### PR DESCRIPTION
#### Summary
The collapse action in the section passed `undefined`, which failed to trigger the reset logic in the modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12966

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)