### PR TITLE
[MM-12328] Scroll to bottom the RHS thread whenever the state.draft.message is not empty on component update

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -233,6 +233,10 @@ export default class CreateComment extends React.PureComponent {
             this.scrollToBottom();
         }
 
+        if (this.state.draft.message !== '') {
+            this.scrollToBottom();
+        }
+
         if (prevProps.rootId !== this.props.rootId) {
             this.focusTextbox();
         }

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -197,6 +197,7 @@ export default class CreateComment extends React.PureComponent {
 
         this.lastBlurAt = 0;
         this.draftsForPost = {};
+        this.doInitialScrollToBottom = false;
     }
 
     UNSAFE_componentWillMount() { // eslint-disable-line camelcase
@@ -208,6 +209,13 @@ export default class CreateComment extends React.PureComponent {
     componentDidMount() {
         this.focusTextbox();
         document.addEventListener('keydown', this.focusTextboxIfNecessary);
+
+        // When draft.message is not empty, set doInitialScrollToBottom to true so that
+        // on next component update, the actual this.scrollToBottom() will be called.
+        // This is made so that the this.scrollToBottom() will be called only once.
+        if (this.props.draft.message !== '') {
+            this.doInitialScrollToBottom = true;
+        }
     }
 
     componentWillUnmount() {
@@ -233,12 +241,13 @@ export default class CreateComment extends React.PureComponent {
             this.scrollToBottom();
         }
 
-        if (this.state.draft.message !== '') {
-            this.scrollToBottom();
-        }
-
         if (prevProps.rootId !== this.props.rootId) {
             this.focusTextbox();
+        }
+
+        if (this.doInitialScrollToBottom) {
+            this.scrollToBottom();
+            this.doInitialScrollToBottom = false;
         }
     }
 

--- a/components/create_comment/create_comment.test.jsx
+++ b/components/create_comment/create_comment.test.jsx
@@ -736,4 +736,55 @@ describe('components/CreateComment', () => {
         expect(instance.focusTextbox).toHaveBeenCalledTimes(1);
         expect(instance.focusTextbox).toHaveBeenCalledWith(true);
     });
+
+    test('should the RHS thread scroll to bottom when state.draft.message is not empty', () => {
+        const draft = {
+            message: '',
+            uploadsInProgress: [],
+            fileInfos: [],
+        };
+
+        const wrapper = shallow(
+            <CreateComment
+                {...baseProps}
+                draft={draft}
+            />
+        );
+
+        wrapper.instance().scrollToBottom = jest.fn();
+        expect(wrapper.instance().scrollToBottom).toBeCalledTimes(0);
+
+        wrapper.setState({draft: {...draft, message: 'new message'}});
+        expect(wrapper.instance().scrollToBottom).toBeCalledTimes(1);
+
+        wrapper.setState({draft: {...draft, message: ''}});
+        expect(wrapper.instance().scrollToBottom).toBeCalledTimes(1);
+    });
+
+    test('should the RHS thread scroll to bottom when state.draft.uploadsInProgress increases but not when it decreases', () => {
+        const draft = {
+            message: '',
+            uploadsInProgress: [],
+            fileInfos: [],
+        };
+
+        const wrapper = shallow(
+            <CreateComment
+                {...baseProps}
+                draft={draft}
+            />
+        );
+
+        wrapper.instance().scrollToBottom = jest.fn();
+        expect(wrapper.instance().scrollToBottom).toBeCalledTimes(0);
+
+        wrapper.setState({draft: {...draft, uploadsInProgress: [1]}});
+        expect(wrapper.instance().scrollToBottom).toBeCalledTimes(1);
+
+        wrapper.setState({draft: {...draft, uploadsInProgress: [1, 2]}});
+        expect(wrapper.instance().scrollToBottom).toBeCalledTimes(2);
+
+        wrapper.setState({draft: {...draft, uploadsInProgress: [2]}});
+        expect(wrapper.instance().scrollToBottom).toBeCalledTimes(2);
+    });
 });

--- a/components/create_comment/create_comment.test.jsx
+++ b/components/create_comment/create_comment.test.jsx
@@ -737,7 +737,7 @@ describe('components/CreateComment', () => {
         expect(instance.focusTextbox).toHaveBeenCalledWith(true);
     });
 
-    test('should the RHS thread scroll to bottom when state.draft.message is not empty', () => {
+    test('should the RHS thread scroll to bottom one time after mount when props.draft.message is not empty', () => {
         const draft = {
             message: '',
             uploadsInProgress: [],
@@ -745,20 +745,22 @@ describe('components/CreateComment', () => {
         };
 
         const wrapper = shallow(
-            <CreateComment
-                {...baseProps}
-                draft={draft}
-            />
+            <CreateComment {...baseProps}/>
         );
 
         wrapper.instance().scrollToBottom = jest.fn();
         expect(wrapper.instance().scrollToBottom).toBeCalledTimes(0);
+        expect(wrapper.instance().doInitialScrollToBottom).toEqual(true);
 
+        // should scroll to bottom on first component update
         wrapper.setState({draft: {...draft, message: 'new message'}});
         expect(wrapper.instance().scrollToBottom).toBeCalledTimes(1);
+        expect(wrapper.instance().doInitialScrollToBottom).toEqual(false);
 
-        wrapper.setState({draft: {...draft, message: ''}});
+        // but not after the first update
+        wrapper.setState({draft: {...draft, message: 'another message'}});
         expect(wrapper.instance().scrollToBottom).toBeCalledTimes(1);
+        expect(wrapper.instance().doInitialScrollToBottom).toEqual(false);
     });
 
     test('should the RHS thread scroll to bottom when state.draft.uploadsInProgress increases but not when it decreases', () => {


### PR DESCRIPTION
#### Summary
Scroll to bottom the RHS thread whenever the state.draft.message is not empty on component update

#### Ticket Link
Jira ticket: [MM-12328](https://mattermost.atlassian.net/browse/MM-12328)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
