### PR TITLE
fix typo that prevented accepting tos

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -471,7 +471,7 @@ export async function resendVerification(email, success, error) {
 }
 
 export async function updateTermsOfServiceStatus(termsOfServiceId, accepted, success, error) {
-    const {data, error: err} = await UserActions.updateTermsOfServiceStatus(termsOfServiceId, accepted)(dispatch, getState);
+    const {data, error: err} = await UserActions.updateMyTermsOfServiceStatus(termsOfServiceId, accepted)(dispatch, getState);
     if (data && success) {
         success(data);
     } else if (err && error) {


### PR DESCRIPTION
#### Summary
Found this broken in master whilst testing other changes: looks like the Redux API was just renamed.

#### Ticket Link
N/A

#### Checklist
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
