### PR TITLE
MM-12989: explicitly pass err.message to error callback

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -536,7 +536,7 @@ export async function createUserWithInvite(user, token, inviteId, success, error
     if (resp && success) {
         success(resp);
     } else if (err && error) {
-        error({id: err.server_error_id, ...err});
+        error({id: err.server_error_id, message: err.message, ...err});
     }
 }
 


### PR DESCRIPTION
#### Summary
See https://community-daily.mattermost.com/core/pl/xp46hxi3o7ntzdwxje1tpiu5se for a more detailed breakdown, but the gist is that the spread operator only copies enumerable objects, but `message` is part of the prototype chain of `ClientError` and is excluded here.

This is a release-5.5-only change, since the code in master was refactored to make this a non-issue. I'm also not bothering with tests given that this is literally going away in the next release. This is also the only place `createUserWithInvite` is used.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12989

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)