### PR TITLE
Fix menu action selection not being shared between center and RHS

### DIFF
--- a/components/post_view/message_attachments/action_menu/index.js
+++ b/components/post_view/message_attachments/action_menu/index.js
@@ -10,7 +10,7 @@ import ActionMenu from './action_menu.jsx';
 
 function mapStateToProps(state, ownProps) {
     const actions = state.views.posts.menuActions[ownProps.postId];
-    const selected = actions && actions[ownProps.id];
+    const selected = actions && actions[ownProps.action && ownProps.action.id];
 
     return {
         selected,


### PR DESCRIPTION
#### Summary
Follow-up to something I broke with the fix for MM-12982. After that fix, choosing an option in the center channel would not reflect the option if that post was open in the RHS or vice versa. This fixes it.