### PR TITLE
MM-12921 Fix for redirection to last channel from team subpages

### DIFF
--- a/components/backstage/components/backstage_navbar.jsx
+++ b/components/backstage/components/backstage_navbar.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
-import {Constants} from 'utils/constants.jsx';
 import {localizeMessage} from 'utils/utils.jsx';
 
 export default class BackstageNavbar extends React.Component {
@@ -26,7 +25,7 @@ export default class BackstageNavbar extends React.Component {
             <div className='backstage-navbar'>
                 <Link
                     className='backstage-navbar__back'
-                    to={`/${this.props.team.name}/channels/${Constants.DEFAULT_CHANNEL}`}
+                    to={`/${this.props.team.name}`}
                 >
                     <i
                         className='fa fa-angle-left'


### PR DESCRIPTION
#### Summary
  * Fixes redirection from custom emoji and integration pages.

Solution is rather simple. Redirect users to root team url `/:teamName` and let `center_channel` take care of routing to last channel of the team.
https://github.com/mattermost/mattermost-webapp/blob/e5bd6115a732a53a35e4feb84e4151ccc94ef425/components/channel_layout/center_channel/center_channel.jsx#L68

#### Ticket Link
[MM-12921](https://mattermost.atlassian.net/browse/MM-12921)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
