### PR TITLE
[MM-12971] Fix autocomplete selection for classic app

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -12,7 +12,6 @@ import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 const KeyCodes = Constants.KeyCodes;
-const MIN_TIME_BEFORE_CLICK = 200;
 
 export default class SuggestionBox extends React.Component {
     static propTypes = {
@@ -202,17 +201,13 @@ export default class SuggestionBox extends React.Component {
             return;
         }
 
-        this.setState({focused: false});
-
         if (UserAgent.isIos() && !e.relatedTarget) {
-            // iOS doesn't support e.relatedTarget, so we need to use the old method of just delaying the
-            // blur so that click handlers on the list items still register
-            if (this.presentationType !== 'date' || this.props.value.length === 0) {
-                this.handleEmitClearSuggestions(MIN_TIME_BEFORE_CLICK);
-            }
-        } else {
-            this.handleEmitClearSuggestions();
+            return;
         }
+
+        this.handleEmitClearSuggestions();
+
+        this.setState({focused: false});
 
         if (this.props.onBlur) {
             this.props.onBlur();

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -202,6 +202,8 @@ export default class SuggestionBox extends React.Component {
         }
 
         if (UserAgent.isIos() && !e.relatedTarget) {
+            // On Safari and iOS classic app, the autocomplete stays open
+            // when you tap outside of the post textbox or search box.
             return;
         }
 


### PR DESCRIPTION
#### Summary
Issue happened on classic app.  This fixes issue when selecting an item from autocomplete where the selected item does not appear on the text box.  This also fixes date filter selection on search bar. (e.g. "after:[date]").

Looks like this was introduced by the migration of SuggestionStore.

#### Ticket Link
Jira ticket: [MM-12971](https://mattermost.atlassian.net/browse/MM-12971)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
