### PR TITLE
MM-12839: Remove archived channels posts from search results when needed

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -706,7 +706,7 @@ function handleChannelDeletedEvent(msg) {
         browserHistory.push(teamUrl + '/channels/' + Constants.DEFAULT_CHANNEL);
     }
 
-    dispatch({type: ChannelTypes.RECEIVED_CHANNEL_DELETED, data: {id: msg.data.channel_id, team_id: msg.broadcast.team_id, deleteAt: msg.data.delete_at}});
+    dispatch({type: ChannelTypes.RECEIVED_CHANNEL_DELETED, data: {id: msg.data.channel_id, team_id: msg.broadcast.team_id, deleteAt: msg.data.delete_at, viewArchivedChannels}});
 }
 
 function handlePreferenceChangedEvent(msg) {

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -241,7 +241,7 @@ export default class RhsThread extends React.Component {
         const {selected, currentUser} = this.props;
 
         let createAt = selected.create_at;
-        if (!createAt) {
+        if (!createAt && this.props.posts.length > 0) {
             createAt = this.props.posts[this.props.posts.length - 1].create_at;
         }
         const rootPostDay = Utils.getDateForUnixTicks(createAt);
@@ -362,7 +362,7 @@ export default class RhsThread extends React.Component {
                             previewEnabled={this.props.previewEnabled}
                             isBusy={this.state.isBusy}
                         />
-                        {isFakeDeletedPost && <DateSeparator date={rootPostDay}/>}
+                        {isFakeDeletedPost && rootPostDay && <DateSeparator date={rootPostDay}/>}
                         <div
                             ref='rhspostlist'
                             className='post-right-comments-container'


### PR DESCRIPTION
#### Summary
Remove archived channels posts from search results when view archived
channels options is configured to false.

#### Ticket Link
[MM-12839](https://mattermost.atlassian.net/browse/MM-12839)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has redux changes (mattermost/mattermost-redux#717)