### PR TITLE
[MM-13086] Add space between suggestion and hint

### DIFF
--- a/components/suggestion/__snapshots__/command_provider.test.js.snap
+++ b/components/suggestion/__snapshots__/command_provider.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CommandSuggestion should match snapshot 1`] = `
+<div
+  className="command suggestion--selected"
+  onClick={[Function]}
+  role="button"
+  tabIndex={0}
+>
+  <div
+    className="command__title"
+  >
+    /invite @[username] ~[channel]
+  </div>
+  <div
+    className="command__desc"
+  >
+    Invite a user to a channel
+  </div>
+</div>
+`;

--- a/components/suggestion/command_provider.jsx
+++ b/components/suggestion/command_provider.jsx
@@ -12,7 +12,7 @@ import * as UserAgent from 'utils/user_agent.jsx';
 
 import Suggestion from './suggestion.jsx';
 
-class CommandSuggestion extends Suggestion {
+export class CommandSuggestion extends Suggestion {
     render() {
         const {item, isSelection} = this.props;
 
@@ -28,7 +28,7 @@ class CommandSuggestion extends Suggestion {
                 {...Suggestion.baseProps}
             >
                 <div className='command__title'>
-                    {item.suggestion + item.hint}
+                    {item.suggestion + ' ' + item.hint}
                 </div>
                 <div className='command__desc'>
                     {item.description}

--- a/components/suggestion/command_provider.test.js
+++ b/components/suggestion/command_provider.test.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {CommandSuggestion} from './command_provider';
+
+describe('CommandSuggestion', () => {
+    const baseProps = {
+        item: {
+            suggestion: '/invite',
+            hint: '@[username] ~[channel]',
+            description: 'Invite a user to a channel',
+        },
+        isSelection: true,
+        term: '/',
+        matchedPretext: '',
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <CommandSuggestion {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('.command__title').first().text()).toEqual('/invite @[username] ~[channel]');
+        expect(wrapper.find('.command__desc').first().text()).toEqual('Invite a user to a channel');
+    });
+});


### PR DESCRIPTION
#### Summary
Add space between autocomplete's suggestion and hint

#### Ticket Link
Jira ticket: [MM-13086](https://mattermost.atlassian.net/browse/MM-13086)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
