### PR TITLE
Fix for inline markdown images key in metadata

### DIFF
--- a/components/markdown_image.jsx
+++ b/components/markdown_image.jsx
@@ -34,6 +34,7 @@ export default class MarkdownImage extends React.PureComponent {
 
         return (
             <img
+                ref='image'
                 {...props}
                 onLoad={this.handleLoad}
                 style={{

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -151,7 +151,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
         let element = null;
 
         if (!this.props.post.metadata) {
-          return element;
+            return element;
         }
 
         if (

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -149,6 +149,11 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
 
     imageTag(imageUrl, renderingForLargeImage = false) {
         let element = null;
+
+        if (!this.props.post.metadata) {
+          return element;
+        }
+
         if (
             imageUrl && renderingForLargeImage === this.state.hasLargeImage &&
             (!renderingForLargeImage || (renderingForLargeImage && this.props.isEmbedVisible))

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -81,7 +81,7 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
                 const callMarkdownImage = (
                     <MarkdownImage
                         className={className}
-                        dimensions={options.images[attribs.src]}
+                        dimensions={options.imagesMetadata[attribs.src]}
                         {...attribs}
                         {...options.imageProps}
                     />


### PR DESCRIPTION
* Look for imagesMetadata instead of images key for inline markdown images
 * Add a missing ref for mardown_image

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
