### PR TITLE
[MM-13147] Fix for file_upload crash when mimeTypesSuffix is not present

### DIFF
--- a/utils/file_utils.jsx
+++ b/utils/file_utils.jsx
@@ -64,20 +64,25 @@ export function getFileTypeFromMime(mimetype) {
     const mimeTypeSplitBySlash = mimetype.split('/');
     const mimeTypePrefix = mimeTypeSplitBySlash[0];
     const mimeTypeSuffix = mimeTypeSplitBySlash[1];
+
     if (mimeTypePrefix === 'video') {
         return 'video';
     } else if (mimeTypePrefix === 'audio') {
         return 'audio';
     } else if (mimeTypePrefix === 'image') {
         return 'image';
-    } else if (mimeTypeSuffix === 'pdf') {
-        return 'pdf';
-    } else if (mimeTypeSuffix.includes('vnd.ms-excel') || mimeTypeSuffix.includes('spreadsheetml') || mimeTypeSuffix.includes('vnd.sun.xml.calc') || mimeTypeSuffix.includes('opendocument.spreadsheet')) {
-        return 'spreadsheet';
-    } else if (mimeTypeSuffix.includes('vnd.ms-powerpoint') || mimeTypeSuffix.includes('presentationml') || mimeTypeSuffix.includes('vnd.sun.xml.impress') || mimeTypeSuffix.includes('opendocument.presentation')) {
-        return 'presentation';
-    } else if ((mimeTypeSuffix === 'msword') || mimeTypeSuffix.includes('vnd.ms-word') || mimeTypeSuffix.includes('officedocument.wordprocessingml') || mimeTypeSuffix.includes('application/x-mswrite')) {
-        return 'word';
+    }
+
+    if(mimeTypeSuffix) {
+        if (mimeTypeSuffix === 'pdf') {
+             return 'pdf';
+        } else if (mimeTypeSuffix.includes('vnd.ms-excel') || mimeTypeSuffix.includes('spreadsheetml') || mimeTypeSuffix.includes('vnd.sun.xml.calc') || mimeTypeSuffix.includes('opendocument.spreadsheet')) {
+             return 'spreadsheet';
+        } else if (mimeTypeSuffix.includes('vnd.ms-powerpoint') || mimeTypeSuffix.includes('presentationml') || mimeTypeSuffix.includes('vnd.sun.xml.impress') || mimeTypeSuffix.includes('opendocument.presentation')) {
+             return 'presentation';
+        } else if ((mimeTypeSuffix === 'msword') || mimeTypeSuffix.includes('vnd.ms-word') || mimeTypeSuffix.includes('officedocument.wordprocessingml') || mimeTypeSuffix.includes('application/x-mswrite')) {
+             return 'word';
+        }
     }
 
     return 'other';

--- a/utils/file_utils.jsx
+++ b/utils/file_utils.jsx
@@ -81,7 +81,7 @@ export function getFileTypeFromMime(mimetype) {
         } else if (mimeTypeSuffix.includes('vnd.ms-powerpoint') || mimeTypeSuffix.includes('presentationml') || mimeTypeSuffix.includes('vnd.sun.xml.impress') || mimeTypeSuffix.includes('opendocument.presentation')) {
             return 'presentation';
         } else if ((mimeTypeSuffix === 'msword') || mimeTypeSuffix.includes('vnd.ms-word') || mimeTypeSuffix.includes('officedocument.wordprocessingml') || mimeTypeSuffix.includes('application/x-mswrite')) {
-             return 'word';
+            return 'word';
         }
     }
 

--- a/utils/file_utils.jsx
+++ b/utils/file_utils.jsx
@@ -75,7 +75,7 @@ export function getFileTypeFromMime(mimetype) {
 
     if(mimeTypeSuffix) {
         if (mimeTypeSuffix === 'pdf') {
-             return 'pdf';
+            return 'pdf';
         } else if (mimeTypeSuffix.includes('vnd.ms-excel') || mimeTypeSuffix.includes('spreadsheetml') || mimeTypeSuffix.includes('vnd.sun.xml.calc') || mimeTypeSuffix.includes('opendocument.spreadsheet')) {
              return 'spreadsheet';
         } else if (mimeTypeSuffix.includes('vnd.ms-powerpoint') || mimeTypeSuffix.includes('presentationml') || mimeTypeSuffix.includes('vnd.sun.xml.impress') || mimeTypeSuffix.includes('opendocument.presentation')) {

--- a/utils/file_utils.jsx
+++ b/utils/file_utils.jsx
@@ -79,7 +79,7 @@ export function getFileTypeFromMime(mimetype) {
         } else if (mimeTypeSuffix.includes('vnd.ms-excel') || mimeTypeSuffix.includes('spreadsheetml') || mimeTypeSuffix.includes('vnd.sun.xml.calc') || mimeTypeSuffix.includes('opendocument.spreadsheet')) {
             return 'spreadsheet';
         } else if (mimeTypeSuffix.includes('vnd.ms-powerpoint') || mimeTypeSuffix.includes('presentationml') || mimeTypeSuffix.includes('vnd.sun.xml.impress') || mimeTypeSuffix.includes('opendocument.presentation')) {
-             return 'presentation';
+            return 'presentation';
         } else if ((mimeTypeSuffix === 'msword') || mimeTypeSuffix.includes('vnd.ms-word') || mimeTypeSuffix.includes('officedocument.wordprocessingml') || mimeTypeSuffix.includes('application/x-mswrite')) {
              return 'word';
         }

--- a/utils/file_utils.jsx
+++ b/utils/file_utils.jsx
@@ -77,7 +77,7 @@ export function getFileTypeFromMime(mimetype) {
         if (mimeTypeSuffix === 'pdf') {
             return 'pdf';
         } else if (mimeTypeSuffix.includes('vnd.ms-excel') || mimeTypeSuffix.includes('spreadsheetml') || mimeTypeSuffix.includes('vnd.sun.xml.calc') || mimeTypeSuffix.includes('opendocument.spreadsheet')) {
-             return 'spreadsheet';
+            return 'spreadsheet';
         } else if (mimeTypeSuffix.includes('vnd.ms-powerpoint') || mimeTypeSuffix.includes('presentationml') || mimeTypeSuffix.includes('vnd.sun.xml.impress') || mimeTypeSuffix.includes('opendocument.presentation')) {
              return 'presentation';
         } else if ((mimeTypeSuffix === 'msword') || mimeTypeSuffix.includes('vnd.ms-word') || mimeTypeSuffix.includes('officedocument.wordprocessingml') || mimeTypeSuffix.includes('application/x-mswrite')) {

--- a/utils/file_utils.jsx
+++ b/utils/file_utils.jsx
@@ -73,7 +73,7 @@ export function getFileTypeFromMime(mimetype) {
         return 'image';
     }
 
-    if(mimeTypeSuffix) {
+    if (mimeTypeSuffix) {
         if (mimeTypeSuffix === 'pdf') {
             return 'pdf';
         } else if (mimeTypeSuffix.includes('vnd.ms-excel') || mimeTypeSuffix.includes('spreadsheetml') || mimeTypeSuffix.includes('vnd.sun.xml.calc') || mimeTypeSuffix.includes('opendocument.spreadsheet')) {

--- a/utils/file_utils.test.jsx
+++ b/utils/file_utils.test.jsx
@@ -104,6 +104,10 @@ describe('FileUtils.canUploadFiles', () => {
         it('mime type for unknown file format', () => {
             assert.equal(getFileTypeFromMime('application/unknownFormat'), 'other');
         });
+
+        it('mime type for no suffix', () => {
+            assert.equal(getFileTypeFromMime('asdasd'), 'other');
+        });
     });
 });
 


### PR DESCRIPTION
#### Summary
Fix for file_upload crash for certain mimeTypes

#### Ticket Link
[MM-13147](https://mattermost.atlassian.net/browse/MM-13147)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
