### PR TITLE
MM-12398/MM-13153 Fix typing quickly in autocomplete selecting wrong item and fix channel switcher

### DIFF
--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -15,6 +15,7 @@ import {getLastViewedChannelName} from 'selectors/local_storage';
 import {browserHistory} from 'utils/browser_history';
 import {ActionTypes} from 'utils/constants.jsx';
 import {isMobile} from 'utils/utils.jsx';
+import Constants from '../../utils/constants';
 
 export function checkAndSetMobileView() {
     return (dispatch) => {
@@ -58,6 +59,9 @@ export function switchToChannel(channel) {
                 return {error: true};
             }
             browserHistory.push(`${teamUrl}/messages/@${channel.name}`);
+        } else if (channel.type === Constants.GM_CHANNEL) {
+            const gmChannel = getChannel(state, channel.id);
+            browserHistory.push(`${teamUrl}/channels/${gmChannel.name}`);
         } else {
             browserHistory.push(`${teamUrl}/channels/${channel.name}`);
         }

--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -13,9 +13,8 @@ import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
 import {getLastViewedChannelName} from 'selectors/local_storage';
 
 import {browserHistory} from 'utils/browser_history';
-import {ActionTypes} from 'utils/constants.jsx';
+import {Constants, ActionTypes} from 'utils/constants.jsx';
 import {isMobile} from 'utils/utils.jsx';
-import Constants from '../../utils/constants';
 
 export function checkAndSetMobileView() {
     return (dispatch) => {

--- a/actions/views/channel.test.js
+++ b/actions/views/channel.test.js
@@ -1,0 +1,77 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import {browserHistory} from 'utils/browser_history';
+import * as Actions from 'actions/views/channel';
+import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
+
+const mockStore = configureStore([thunk]);
+
+jest.mock('utils/browser_history', () => ({
+    browserHistory: {
+        push: jest.fn(),
+    },
+}));
+
+jest.mock('actions/channel_actions.jsx', () => ({
+    openDirectChannelToUserId: jest.fn(() => {
+        return {type: ''};
+    }),
+}));
+
+describe('channel view actions', () => {
+    const channel1 = {id: 'channelid1', name: 'channel1', display_name: 'Channel 1', type: 'O'};
+    const gmChannel = {id: 'gmchannelid', name: 'gmchannel', display_name: 'GM Channel 1', type: 'G'};
+    const team1 = {id: 'teamid1', name: 'team1'};
+
+    const initialState = {
+        entities: {
+            users: {
+                currentUserId: 'userid1',
+                profiles: {userid1: {id: 'userid1', username: 'username1'}, userid2: {id: 'userid2', username: 'username2'}},
+                profilesInChannel: {},
+            },
+            teams: {
+                currentTeamId: 'teamid1',
+                teams: {teamid1: team1},
+            },
+            channels: {
+                channels: {channelid1: channel1, gmchannelid: gmChannel},
+                myMembers: {gmchannelid: {channel_id: 'gmchannelid', user_id: 'userid1'}},
+            },
+            general: {
+                config: {},
+            },
+            preferences: {
+                myPreferences: {},
+            },
+        },
+    };
+
+    let store;
+
+    beforeEach(() => {
+        store = mockStore(initialState);
+    });
+
+    describe('switchToChannel', () => {
+        test('switch to public channel', () => {
+            store.dispatch(Actions.switchToChannel(channel1));
+            expect(browserHistory.push).toHaveBeenCalledWith(`/${team1.name}/channels/${channel1.name}`);
+        });
+
+        test('switch to fake direct channel', async () => {
+            await store.dispatch(Actions.switchToChannel({fake: true, userId: 'userid2', name: 'username2'}));
+            expect(openDirectChannelToUserId).toHaveBeenCalledWith('userid2');
+            expect(browserHistory.push).toHaveBeenCalledWith(`/${team1.name}/messages/@username2`);
+        });
+
+        test('switch to gm channel', async () => {
+            await store.dispatch(Actions.switchToChannel(gmChannel));
+            expect(browserHistory.push).toHaveBeenCalledWith(`/${team1.name}/channels/${gmChannel.name}`);
+        });
+    });
+});

--- a/components/quick_switch_modal/index.js
+++ b/components/quick_switch_modal/index.js
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {switchToChannelById} from 'actions/views/channel';
+import {switchToChannel} from 'actions/views/channel';
 
 import QuickSwitchModal from './quick_switch_modal.jsx';
 
@@ -17,7 +17,7 @@ function mapStateToProps() {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            switchToChannelById,
+            switchToChannel,
         }, dispatch),
     };
 }

--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -33,7 +33,7 @@ export default class QuickSwitchModal extends React.PureComponent {
         showTeamSwitcher: PropTypes.bool,
 
         actions: PropTypes.shape({
-            switchToChannelById: PropTypes.func.isRequired,
+            switchToChannel: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -111,7 +111,7 @@ export default class QuickSwitchModal extends React.PureComponent {
 
         if (this.state.mode === CHANNEL_MODE) {
             const selectedChannel = selected.channel;
-            this.props.actions.switchToChannelById(selectedChannel.id).then((result) => {
+            this.props.actions.switchToChannel(selectedChannel).then((result) => {
                 if (result.data) {
                     this.onHide();
                 }

--- a/components/quick_switch_modal/quick_switch_modal.test.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.test.jsx
@@ -13,7 +13,7 @@ describe('components/QuickSwitchModal', () => {
         onHide: jest.fn(),
         showTeamSwitcher: false,
         actions: {
-            switchToChannelById: jest.fn().mockImplementation(() => {
+            switchToChannel: jest.fn().mockImplementation(() => {
                 const error = {
                     message: 'Failed',
                 };
@@ -40,7 +40,7 @@ describe('components/QuickSwitchModal', () => {
 
             wrapper.instance().handleSubmit();
             expect(baseProps.onHide).not.toBeCalled();
-            expect(props.actions.switchToChannelById).not.toBeCalled();
+            expect(props.actions.switchToChannel).not.toBeCalled();
         });
 
         it('should fail to switch to a channel', (done) => {
@@ -50,7 +50,7 @@ describe('components/QuickSwitchModal', () => {
 
             const channel = {id: 'channel_id', userId: 'user_id', type: Constants.DM_CHANNEL};
             wrapper.instance().handleSubmit({channel});
-            expect(baseProps.actions.switchToChannelById).toBeCalledWith(channel.id);
+            expect(baseProps.actions.switchToChannel).toBeCalledWith(channel);
             process.nextTick(() => {
                 expect(baseProps.onHide).not.toBeCalled();
                 done();
@@ -61,7 +61,7 @@ describe('components/QuickSwitchModal', () => {
             const props = {
                 ...baseProps,
                 actions: {
-                    switchToChannelById: jest.fn().mockImplementation(() => {
+                    switchToChannel: jest.fn().mockImplementation(() => {
                         const data = true;
                         return Promise.resolve({data});
                     }),
@@ -74,7 +74,7 @@ describe('components/QuickSwitchModal', () => {
 
             const channel = {id: 'channel_id', userId: 'user_id', type: Constants.DM_CHANNEL};
             wrapper.instance().handleSubmit({channel});
-            expect(props.actions.switchToChannelById).toBeCalledWith(channel.id);
+            expect(props.actions.switchToChannel).toBeCalledWith(channel);
             process.nextTick(() => {
                 expect(baseProps.onHide).toBeCalled();
                 done();


### PR DESCRIPTION
#### Summary
When typing really quickly in the channel switcher and pressing enter, you could be sent to a channel that does not match what you have typed. This fixes that for all autocomplete by checking if the selection matches what has been typed. If it doesn't, then we go fetch the latest results before completing.

Also fixed MM-13153 because that was blocking testing on this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12398
https://mattermost.atlassian.net/browse/MM-13153

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)