### PR TITLE
MM-13180 Call load posts earlier for infinite scroll

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -441,6 +441,7 @@ export default class PostList extends React.PureComponent {
             // Only count as user scroll if we've already performed our first load scroll
             this.hasScrolled = this.hasScrolledToNewMessageSeparator || this.hasScrolledToFocusedPost;
             const postList = this.postListRef.current;
+            const postListScrollTop = postList.scrollTop;
 
             if (postList.scrollHeight === this.previousScrollHeight) {
                 this.atBottom = this.checkBottom();
@@ -462,7 +463,9 @@ export default class PostList extends React.PureComponent {
                 });
             }
 
-            if (postList.scrollTop <= 0.5 * postList.clientHeight && !this.state.loadingPosts && !this.state.atEnd && this.state.autoRetryEnable) {
+            const didScrollPastLoadingPoint = postListScrollTop < 0.3 * (postList.scrollHeight - postList.clientHeight);
+
+            if ((didScrollPastLoadingPoint || postListScrollTop < 300) && !this.state.loadingPosts && !this.state.atEnd && this.state.autoRetryEnable) {
                 this.setState({loadingPosts: true});
                 this.loadMorePosts();
             }

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -30,6 +30,10 @@ const POSTS_PER_PAGE = Constants.POST_CHUNK_SIZE / 2;
 const MAX_EXTRA_PAGES_LOADED = 10;
 const MAX_NUMBER_OF_AUTO_RETRIES = 3;
 
+const LOADPOSTS_MIN_HEIGHT = 300;
+const LOADPOSTS_MAX_HEIGHT = 4000;
+const LOADPOSTS_SCROLL_RATIO = 0.3;
+
 export default class PostList extends React.PureComponent {
     static propTypes = {
 
@@ -463,9 +467,16 @@ export default class PostList extends React.PureComponent {
                 });
             }
 
-            const didScrollPastLoadingPoint = postListScrollTop < 0.3 * (postList.scrollHeight - postList.clientHeight);
+            let shouldLoadPosts = false;
+            const scrollHeightAoveFoldForLoad = LOADPOSTS_SCROLL_RATIO * (postList.scrollHeight - postList.clientHeight);
 
-            if ((didScrollPastLoadingPoint || postListScrollTop < 300) && !this.state.loadingPosts && !this.state.atEnd && this.state.autoRetryEnable) {
+            if (postListScrollTop < LOADPOSTS_MIN_HEIGHT) {
+                shouldLoadPosts = true;
+            } else if ((scrollHeightAoveFoldForLoad < LOADPOSTS_MAX_HEIGHT) && (postListScrollTop < scrollHeightAoveFoldForLoad)) {
+                shouldLoadPosts = true;
+            }
+
+            if (shouldLoadPosts && !this.state.loadingPosts && !this.state.atEnd && this.state.autoRetryEnable) {
                 this.setState({loadingPosts: true});
                 this.loadMorePosts();
             }

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -472,7 +472,7 @@ export default class PostList extends React.PureComponent {
 
             if (postListScrollTop < LOADPOSTS_MIN_HEIGHT) {
                 shouldLoadPosts = true;
-            } else if ((scrollHeightAoveFoldForLoad < LOADPOSTS_MAX_HEIGHT) && (postListScrollTop < scrollHeightAoveFoldForLoad)) {
+            } else if ((postListScrollTop < LOADPOSTS_MAX_HEIGHT) && (postListScrollTop < scrollHeightAoveFoldForLoad)) {
                 shouldLoadPosts = true;
             }
 

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -31,7 +31,7 @@ const MAX_EXTRA_PAGES_LOADED = 10;
 const MAX_NUMBER_OF_AUTO_RETRIES = 3;
 
 const LOADPOSTS_MIN_HEIGHT = 300;
-const LOADPOSTS_MAX_HEIGHT = 4000;
+const LOADPOSTS_MAX_HEIGHT = 2500;
 const LOADPOSTS_SCROLL_RATIO = 0.3;
 
 export default class PostList extends React.PureComponent {


### PR DESCRIPTION
#### Summary
Loads posts earlier than existing trigger.

Existing trigger is at 40% of clientHeight(visible scroll area) so typically about `0.4 * 800(clientHeight)` i.e `200px `from the top of the postList. If there are `4000px` of posts in total at present we trigger to load posts when user reaches to `3800px` 

With this PR we change this to load when scroll position is at 30% from the top. i.e if `4000px` we trigger to load posts at `3040px`.  i.e by `0.3 * (4000 - 800)` i.e `960px` 


#### Ticket Link
[MM-13180](https://mattermost.atlassian.net/browse/MM-13180)
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
