### PR TITLE
[MM-13181] Fix JS error after editing a post

### DIFF
--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -272,7 +272,10 @@ export default class EditPostModal extends React.PureComponent {
     }
 
     setEditboxRef = (ref) => {
-        this.editbox = ref.getWrappedInstance();
+        if (ref && ref.getWrappedInstance) {
+            this.editbox = ref.getWrappedInstance();
+        }
+
         if (this.editbox) {
             this.editbox.focus();
         }

--- a/components/edit_post_modal/edit_post_modal.test.jsx
+++ b/components/edit_post_modal/edit_post_modal.test.jsx
@@ -437,4 +437,18 @@ describe('components/EditPostModal', () => {
         instance.handleKeyDown({key: Constants.KeyCodes.ESCAPE[0], keyCode: Constants.KeyCodes.ESCAPE[1]});
         expect(instance.handleHide).not.toBeCalled();
     });
+
+    it('should set instance.editbox on setEditboxRef', () => {
+        const wrapper = shallow(createEditPost());
+
+        wrapper.instance().setEditboxRef();
+        expect(wrapper.instance().editbox).toEqual(undefined);
+
+        const focus = jest.fn();
+        const ref = {getWrappedInstance: () => ({focus})};
+        wrapper.instance().setEditboxRef(ref);
+        wrapper.update();
+        expect(wrapper.instance().editbox).toEqual({focus});
+        expect(wrapper.instance().editbox.focus).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION
#### Summary
Fix JS error after editing a post by adding extra check to ref being passed into setEditboxRef.

![screen shot 2018-11-26 at 6 03 27 pm](https://user-images.githubusercontent.com/5334504/49010002-f876bc00-f1ac-11e8-8739-0157754f2509.png)

#### Ticket Link
Jira ticket: [MM-13181](https://mattermost.atlassian.net/browse/MM-13181)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
