### PR TITLE
[MM-13118] Add and remove duplicated divider at Sidebar user account setting

### DIFF
--- a/components/user_settings/sidebar/__snapshots__/user_settings_sidebar.test.jsx.snap
+++ b/components/user_settings/sidebar/__snapshots__/user_settings_sidebar.test.jsx.snap
@@ -92,9 +92,6 @@ exports[`components/user_settings/sidebar/UserSettingsSidebar should match snaps
     <div
       className="divider-light"
     />
-    <div
-      className="divider-light"
-    />
     <SettingItemMin
       describe={
         <FormattedMessage
@@ -113,6 +110,9 @@ exports[`components/user_settings/sidebar/UserSettingsSidebar should match snaps
         />
       }
       updateSection={[Function]}
+    />
+    <div
+      className="divider-dark"
     />
   </div>
 </div>

--- a/components/user_settings/sidebar/user_settings_sidebar.jsx
+++ b/components/user_settings/sidebar/user_settings_sidebar.jsx
@@ -733,9 +733,8 @@ export default class UserSettingsSidebar extends React.Component {
                     </h3>
                     <div className='divider-dark first'/>
                     {channelOrganizationSection}
-                    {showChannelOrganization && <div className='divider-light'/>}
                     {channelSwitcherSection}
-                    {showUnusedOption && <div className='divider-light'/>}
+                    {showUnusedOption ? <div className='divider-light'/> : <div className='divider-dark'/>}
                     {autoCloseDMSection}
                 </div>
             </div>


### PR DESCRIPTION
#### Summary
- Added divider below `channelSwitcherSection` when `autoCloseDMSection` is not present, and
- Removed duplicated divider of `channelOrganizationSection`

#### Ticket Link
Jira ticket: [MM-13118](https://mattermost.atlassian.net/browse/MM-13118)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [c] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
