### PR TITLE
MM-13098 Fix for Minor scroll pop on firefox

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -702,6 +702,9 @@
         position: relative;
         height: 40px;
         padding: 0px;
+        .loading__content {
+            height: 40px;
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
Fixes minor scroll pop on Firefox when a channel is loaded
Loaded needs a min height or otherwise Firefox has a flicker offscreen because of loader causing a scroll pop

#### Ticket Link
[MM-13098](https://mattermost.atlassian.net/browse/MM-13098)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
