### PR TITLE
MM-13172 add switchTeam Props to all TeamButtons

### DIFF
--- a/components/team_sidebar/components/team_button.jsx
+++ b/components/team_sidebar/components/team_button.jsx
@@ -161,5 +161,5 @@ TeamButton.propTypes = {
     mentions: PropTypes.number,
     placement: PropTypes.oneOf(['left', 'right', 'top', 'bottom']),
     teamIconUrl: PropTypes.string,
-    switchTeam: PropTypes.func,
+    switchTeam: PropTypes.func.isRequired,
 };

--- a/components/team_sidebar/team_sidebar_controller.jsx
+++ b/components/team_sidebar/team_sidebar_controller.jsx
@@ -74,6 +74,7 @@ export default class TeamSidebar extends React.PureComponent {
                         />
                     }
                     content={'+'}
+                    switchTeam={this.props.actions.switchTeam}
                 />
             );
         } else {
@@ -92,6 +93,7 @@ export default class TeamSidebar extends React.PureComponent {
                             />
                         }
                         content={'+'}
+                        switchTeam={this.props.actions.switchTeam}
                     />
                 </SystemPermissionGate>
             );


### PR DESCRIPTION
#### Summary
Fixes the issue of routing to create_team/select_team pages.
switch_team is a required prop for all TeamButtons 

#### Ticket Link
[MM-13172](https://mattermost.atlassian.net/browse/MM-13172)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
