### PR TITLE
MM-13140 Fix to leave team from MainMenu

### DIFF
--- a/components/leave_team_modal/index.js
+++ b/components/leave_team_modal/index.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 
@@ -22,11 +23,16 @@ function mapStateToProps(state) {
         currentUserId,
         currentTeamId,
         show,
-        actions: {
-            removeUserFromTeam,
-            toggleSideBarRightMenu: toggleSideBarRightMenuAction,
-        },
     };
 }
 
-export default connect(mapStateToProps)(LeaveTeamModal);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            removeUserFromTeam,
+            toggleSideBarRightMenu: toggleSideBarRightMenuAction,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(LeaveTeamModal);


### PR DESCRIPTION
#### Summary
Fixes to leave team from main menu

Actions were misplaced into selector. Moving them back to `mapDispatchToProps`. 

#### Ticket Link
[MM-13140](https://mattermost.atlassian.net/browse/MM-13140)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
