### PR TITLE
Fix joining channels from the quick switcher

### DIFF
--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -1,10 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {leaveChannel as leaveChannelRedux, unfavoriteChannel} from 'mattermost-redux/actions/channels';
+import {leaveChannel as leaveChannelRedux, joinChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import {getChannel, getChannelByName, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentRelativeTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import {getUserByUsername} from 'mattermost-redux/selectors/entities/users';
+import {getCurrentUserId, getUserByUsername} from 'mattermost-redux/selectors/entities/users';
 import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
 import {isFavoriteChannel} from 'mattermost-redux/utils/channel_utils';
 import {autocompleteUsers} from 'mattermost-redux/actions/users';
@@ -66,6 +66,16 @@ export function switchToChannel(channel) {
         }
 
         return {data: true};
+    };
+}
+
+export function joinChannelById(channelId) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const currentUserId = getCurrentUserId(state);
+        const currentTeamId = getCurrentTeamId(state);
+
+        return dispatch(joinChannel(currentUserId, currentTeamId, channelId));
     };
 }
 

--- a/components/quick_switch_modal/index.js
+++ b/components/quick_switch_modal/index.js
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {switchToChannel} from 'actions/views/channel';
+import {joinChannelById, switchToChannel} from 'actions/views/channel';
 
 import QuickSwitchModal from './quick_switch_modal.jsx';
 
@@ -17,6 +17,7 @@ function mapStateToProps() {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            joinChannelById,
             switchToChannel,
         }, dispatch),
     };

--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -114,7 +114,7 @@ export default class QuickSwitchModal extends React.PureComponent {
             const {joinChannelById, switchToChannel} = this.props.actions;
             const selectedChannel = selected.channel;
 
-            if (selected.type === Constants.MENTION_MORE_CHANNELS && selectedChannel.type !== Constants.DM_CHANNEL) {
+            if (selected.type === Constants.MENTION_MORE_CHANNELS && selectedChannel.type === Constants.OPEN_CHANNEL) {
                 await joinChannelById(selectedChannel.id);
             }
             switchToChannel(selectedChannel).then((result) => {

--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -33,9 +33,10 @@ export default class QuickSwitchModal extends React.PureComponent {
         showTeamSwitcher: PropTypes.bool,
 
         actions: PropTypes.shape({
+            joinChannelById: PropTypes.func.isRequired,
             switchToChannel: PropTypes.func.isRequired,
         }).isRequired,
-    }
+    };
 
     constructor(props) {
         super(props);
@@ -66,7 +67,7 @@ export default class QuickSwitchModal extends React.PureComponent {
     setSwitchBoxRef = (input) => {
         this.switchBox = input;
         this.focusTextbox();
-    }
+    };
 
     onShow = () => {
         this.setState({
@@ -91,7 +92,7 @@ export default class QuickSwitchModal extends React.PureComponent {
                 }
             });
         }
-    }
+    };
 
     onChange = (e) => {
         this.setState({text: e.target.value});
@@ -104,14 +105,19 @@ export default class QuickSwitchModal extends React.PureComponent {
         }
     };
 
-    handleSubmit = (selected) => {
+    handleSubmit = async (selected) => {
         if (!selected) {
             return;
         }
 
         if (this.state.mode === CHANNEL_MODE) {
+            const {joinChannelById, switchToChannel} = this.props.actions;
             const selectedChannel = selected.channel;
-            this.props.actions.switchToChannel(selectedChannel).then((result) => {
+
+            if (selected.type === Constants.MENTION_MORE_CHANNELS && selectedChannel.type !== Constants.DM_CHANNEL) {
+                await joinChannelById(selectedChannel.id);
+            }
+            switchToChannel(selectedChannel).then((result) => {
                 if (result.data) {
                     this.onHide();
                 }

--- a/components/quick_switch_modal/quick_switch_modal.test.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.test.jsx
@@ -13,6 +13,7 @@ describe('components/QuickSwitchModal', () => {
         onHide: jest.fn(),
         showTeamSwitcher: false,
         actions: {
+            joinChannelById: jest.fn().mockResolvedValue({data: true}),
             switchToChannel: jest.fn().mockImplementation(() => {
                 const error = {
                     message: 'Failed',
@@ -61,6 +62,7 @@ describe('components/QuickSwitchModal', () => {
             const props = {
                 ...baseProps,
                 actions: {
+                    ...baseProps.actions,
                     switchToChannel: jest.fn().mockImplementation(() => {
                         const data = true;
                         return Promise.resolve({data});
@@ -74,6 +76,65 @@ describe('components/QuickSwitchModal', () => {
 
             const channel = {id: 'channel_id', userId: 'user_id', type: Constants.DM_CHANNEL};
             wrapper.instance().handleSubmit({channel});
+            expect(props.actions.switchToChannel).toBeCalledWith(channel);
+            process.nextTick(() => {
+                expect(baseProps.onHide).toBeCalled();
+                done();
+            });
+        });
+
+        it('should join the channel before switching', (done) => {
+            const props = {
+                ...baseProps,
+                actions: {
+                    ...baseProps.actions,
+                    switchToChannel: jest.fn().mockImplementation(() => {
+                        const data = true;
+                        return Promise.resolve({data});
+                    }),
+                },
+            };
+
+            const wrapper = shallow(
+                <QuickSwitchModal {...props}/>
+            );
+
+            const channel = {id: 'channel_id', name: 'test', type: Constants.OPEN_CHANNEL};
+            const selected = {
+                type: Constants.MENTION_MORE_CHANNELS,
+                channel,
+            };
+            wrapper.instance().handleSubmit(selected);
+            expect(props.actions.joinChannelById).toBeCalledWith(channel.id);
+            process.nextTick(() => {
+                expect(props.actions.switchToChannel).toBeCalledWith(channel);
+                done();
+            });
+        });
+
+        it('should not join the channel before switching if channel is DM', (done) => {
+            const props = {
+                ...baseProps,
+                actions: {
+                    ...baseProps.actions,
+                    switchToChannel: jest.fn().mockImplementation(() => {
+                        const data = true;
+                        return Promise.resolve({data});
+                    }),
+                },
+            };
+
+            const wrapper = shallow(
+                <QuickSwitchModal {...props}/>
+            );
+
+            const channel = {id: 'channel_id', name: 'test', type: Constants.DM_CHANNEL};
+            const selected = {
+                type: Constants.MENTION_MORE_CHANNELS,
+                channel,
+            };
+            wrapper.instance().handleSubmit(selected);
+            expect(props.actions.joinChannelById).not.toHaveBeenCalled();
             expect(props.actions.switchToChannel).toBeCalledWith(channel);
             process.nextTick(() => {
                 expect(baseProps.onHide).toBeCalled();


### PR DESCRIPTION
#### Summary
The functionality to join other channels from the quick channel switcher was not present, this PR adds it back

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12940

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
