### PR TITLE
Fix setStates on async callbacks

### DIFF
--- a/components/file_attachment/file_attachment.jsx
+++ b/components/file_attachment/file_attachment.jsx
@@ -55,8 +55,8 @@ export default class FileAttachment extends React.PureComponent {
     }
 
     componentDidMount() {
-        this.loadFiles();
         this.mounted = true;
+        this.loadFiles();
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase

--- a/components/file_attachment/file_attachment.jsx
+++ b/components/file_attachment/file_attachment.jsx
@@ -56,6 +56,7 @@ export default class FileAttachment extends React.PureComponent {
 
     componentDidMount() {
         this.loadFiles();
+        this.mounted = true;
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
@@ -74,6 +75,10 @@ export default class FileAttachment extends React.PureComponent {
         }
     }
 
+    componentWillUnmount() {
+        this.mounted = false;
+    }
+
     loadFiles = () => {
         const fileInfo = this.props.fileInfo;
         const fileType = getFileType(fileInfo.extension);
@@ -88,9 +93,11 @@ export default class FileAttachment extends React.PureComponent {
     }
 
     handleImageLoaded = () => {
-        this.setState({
-            loaded: true,
-        });
+        if (this.mounted) {
+            this.setState({
+                loaded: true,
+            });
+        }
     }
 
     onAttachmentClick = (e) => {

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -67,15 +67,17 @@ export default class MessageAttachment extends React.PureComponent {
     }
 
     handleHeightReceived = (height) => {
+        if (!this.mounted) {
+            return;
+        }
+
         if (height > 0) {
             // Increment checkOverflow to indicate change in height
             // and recompute textContainer height at ShowMore component
             // and see whether overflow text of show more/less is necessary or not.
-            if (this.mounted) {
-                this.setState((prevState) => {
-                    return {checkOverflow: prevState.checkOverflow + 1};
-                });
-            }
+            this.setState((prevState) => {
+                return {checkOverflow: prevState.checkOverflow + 1};
+            });
 
             postListScrollChange();
         }

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -58,14 +58,24 @@ export default class MessageAttachment extends React.PureComponent {
         };
     }
 
+    componentDidMount() {
+        this.mounted = true;
+    }
+
+    componentWillUnmount() {
+        this.mounted = false;
+    }
+
     handleHeightReceived = (height) => {
         if (height > 0) {
             // Increment checkOverflow to indicate change in height
             // and recompute textContainer height at ShowMore component
             // and see whether overflow text of show more/less is necessary or not.
-            this.setState((prevState) => {
-                return {checkOverflow: prevState.checkOverflow + 1};
-            });
+            if (this.mounted) {
+                this.setState((prevState) => {
+                    return {checkOverflow: prevState.checkOverflow + 1};
+                });
+            }
 
             postListScrollChange();
         }

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -86,6 +86,7 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
                 this.loadImage(this.state.imageUrl);
             }
         }
+        this.mounted = true;
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
@@ -116,6 +117,10 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
         if (!this.props.post.metadata && (this.state.imageUrl !== prevState.imageUrl)) {
             this.loadImage(this.state.imageUrl);
         }
+    }
+
+    componentWillUnmount() {
+        this.mounted = false;
     }
 
     fetchData = (url) => {
@@ -150,11 +155,12 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
 
     onImageLoad = (image) => {
         const hasLargeImage = this.hasLargeImage({width: image.target.naturalWidth, height: image.target.naturalHeight});
-
-        this.setState({
-            hasLargeImage,
-            imageLoaded: true,
-        });
+        if (this.mounted) {
+            this.setState({
+                hasLargeImage,
+                imageLoaded: true,
+            });
+        }
 
         postListScrollChange();
     }
@@ -250,7 +256,9 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
 
         const {data} = await this.props.actions.editPost(patchedPost);
         if (data) {
-            this.setState({removePreview: true});
+            if (this.mounted) {
+                this.setState({removePreview: true});
+            }
         }
     }
 

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -80,13 +80,13 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
     }
 
     componentDidMount() {
+        this.mounted = true;
         if (!this.props.post.metadata) {
             this.fetchData(this.props.link);
             if (this.state.imageUrl) {
                 this.loadImage(this.state.imageUrl);
             }
         }
-        this.mounted = true;
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
@@ -154,14 +154,16 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
     }
 
     onImageLoad = (image) => {
-        const hasLargeImage = this.hasLargeImage({width: image.target.naturalWidth, height: image.target.naturalHeight});
-        if (this.mounted) {
-            this.setState({
-                hasLargeImage,
-                imageLoaded: true,
-            });
+        if (!this.mounted) {
+            return;
         }
 
+        const hasLargeImage = this.hasLargeImage({width: image.target.naturalWidth, height: image.target.naturalHeight});
+
+        this.setState({
+            hasLargeImage,
+            imageLoaded: true,
+        });
         postListScrollChange();
     }
 

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -192,15 +192,19 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
     }
 
     handleLinkLoadError() {
-        this.setState({
-            linkLoadError: true,
-        });
+        if (this.mounted) {
+            this.setState({
+                linkLoadError: true,
+            });
+        }
     }
 
     handleLinkLoaded() {
-        this.setState({
-            linkLoaded: true,
-        });
+        if (this.mounted) {
+            this.setState({
+                linkLoaded: true,
+            });
+        }
     }
 
     handleImageClick = () => {

--- a/components/post_view/post_image/post_image.jsx
+++ b/components/post_view/post_image/post_image.jsx
@@ -61,8 +61,8 @@ export default class PostImageEmbed extends React.PureComponent {
     }
 
     componentDidMount() {
-        this.loadImg(this.props.link);
         this.mounted = true;
+        this.loadImg(this.props.link);
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
@@ -92,12 +92,13 @@ export default class PostImageEmbed extends React.PureComponent {
     }
 
     handleLoadComplete() {
-        if (this.mounted) {
-            this.setState({
-                loaded: true,
-                errored: false,
-            });
+        if (!this.mounted) {
+            return;
         }
+        this.setState({
+            loaded: true,
+            errored: false,
+        });
         postListScrollChange();
         if (this.props.onLinkLoaded) {
             this.props.onLinkLoaded();

--- a/components/post_view/post_image/post_image.jsx
+++ b/components/post_view/post_image/post_image.jsx
@@ -60,8 +60,9 @@ export default class PostImageEmbed extends React.PureComponent {
         };
     }
 
-    UNSAFE_componentWillMount() { // eslint-disable-line camelcase
+    componentDidMount() {
         this.loadImg(this.props.link);
+        this.mounted = true;
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
@@ -79,6 +80,10 @@ export default class PostImageEmbed extends React.PureComponent {
         }
     }
 
+    componentWillUnmount() {
+        this.mounted = false;
+    }
+
     loadImg(src) {
         const img = new Image();
         img.onload = this.handleLoadComplete;
@@ -87,11 +92,12 @@ export default class PostImageEmbed extends React.PureComponent {
     }
 
     handleLoadComplete() {
-        this.setState({
-            loaded: true,
-            errored: false,
-        });
-
+        if (this.mounted) {
+            this.setState({
+                loaded: true,
+                errored: false,
+            });
+        }
         postListScrollChange();
         if (this.props.onLinkLoaded) {
             this.props.onLinkLoaded();
@@ -99,10 +105,13 @@ export default class PostImageEmbed extends React.PureComponent {
     }
 
     handleLoadError() {
-        this.setState({
-            errored: true,
-            loaded: true,
-        });
+        if (this.mouted) {
+            this.setState({
+                errored: true,
+                loaded: true,
+            });
+        }
+
         if (this.props.onLinkLoadError) {
             this.props.onLinkLoadError();
         }

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -120,7 +120,6 @@ export default class PostList extends React.PureComponent {
         this.scrollAnimationFrame = null;
         this.resizeAnimationFrame = null;
         this.atBottom = false;
-        this.mounted = true;
 
         this.state = {
             atEnd: false,
@@ -133,6 +132,7 @@ export default class PostList extends React.PureComponent {
     }
 
     componentDidMount() {
+        this.mounted = true;
         this.loadPosts(this.props.channel.id, this.props.focusedPostId);
         this.props.actions.checkAndSetMobileView();
         GlobalEventEmitter.addListener(EventTypes.POST_LIST_SCROLL_CHANGE, this.handleResize);
@@ -143,9 +143,9 @@ export default class PostList extends React.PureComponent {
     }
 
     componentWillUnmount() {
+        this.mounted = false;
         GlobalEventEmitter.removeListener(EventTypes.POST_LIST_SCROLL_CHANGE, this.handleResize);
         window.removeEventListener('resize', this.handleWindowResize);
-        this.mounted = false;
     }
 
     getSnapshotBeforeUpdate() {

--- a/components/single_image_view/single_image_view.jsx
+++ b/components/single_image_view/single_image_view.jsx
@@ -51,6 +51,7 @@ export default class SingleImageView extends React.PureComponent {
         window.addEventListener('resize', this.handleResize);
         this.setViewPortWidth();
         this.loadImage(this.props.fileInfo);
+        this.mounted = true;
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
@@ -63,6 +64,7 @@ export default class SingleImageView extends React.PureComponent {
 
     componentWillUnmount() {
         window.removeEventListener('resize', this.handleResize);
+        this.mounted = false;
     }
 
     handleResize = () => {
@@ -92,8 +94,9 @@ export default class SingleImageView extends React.PureComponent {
             if (this.imageLoaded) {
                 this.imageLoaded.src = previewURL;
             }
-
-            this.setState({loaded: true});
+            if (this.mounted) {
+                this.setState({loaded: true});
+            }
         };
     }
 

--- a/components/single_image_view/single_image_view.jsx
+++ b/components/single_image_view/single_image_view.jsx
@@ -48,10 +48,10 @@ export default class SingleImageView extends React.PureComponent {
     }
 
     componentDidMount() {
+        this.mounted = true;
         window.addEventListener('resize', this.handleResize);
         this.setViewPortWidth();
         this.loadImage(this.props.fileInfo);
-        this.mounted = true;
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
@@ -63,8 +63,8 @@ export default class SingleImageView extends React.PureComponent {
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', this.handleResize);
         this.mounted = false;
+        window.removeEventListener('resize', this.handleResize);
     }
 
     handleResize = () => {


### PR DESCRIPTION
#### Summary
Fix async callbacks for setState to have a check for mounted component which cause memory leaks.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
