### PR TITLE
MM-13176 Fix error when previewing a message

### DIFF
--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -71,7 +71,7 @@ export default class PostMarkdown extends React.PureComponent {
                 proxyImages={proxyImages}
                 options={this.props.options}
                 channelNamesMap={channelNamesMap}
-                imagesMetadata={this.props.post.metadata && this.props.post.metadata.images}
+                imagesMetadata={this.props.post && this.props.post.metadata && this.props.post.metadata.images}
             />
         );
     }

--- a/components/post_markdown/post_markdown.test.jsx
+++ b/components/post_markdown/post_markdown.test.jsx
@@ -15,6 +15,13 @@ describe('components/PostMarkdown', () => {
         post: {},
     };
 
+    test('should not error when rendering without a post', () => {
+        const props = {...baseProps};
+        Reflect.deleteProperty(props, 'post');
+
+        shallow(<PostMarkdown {...props}/>);
+    });
+
     test('should render properly with an empty post', () => {
         const wrapper = shallow(
             <PostMarkdown {...baseProps}/>


### PR DESCRIPTION
Regardless of whether or not metadata is enabled, there's no `post` passed into that component for the preview, so this will error out either way

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13176

#### Checklist
- Added or updated unit tests (required for all new features)