### PR TITLE
MM-12422 Post textbox sometimes covers posts at the bottom of the channel

### DIFF
--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -16,6 +16,7 @@ import EmoticonProvider from 'components/suggestion/emoticon_provider.jsx';
 import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
 import SuggestionList from 'components/suggestion/suggestion_list.jsx';
 import Constants from 'utils/constants.jsx';
+import {postListScrollChange} from 'actions/global_actions';
 import * as Utils from 'utils/utils.jsx';
 
 const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
@@ -125,7 +126,7 @@ export default class Textbox extends React.Component {
 
     handleHeightChange = (height, maxHeight) => {
         const wrapper = $(this.refs.wrapper);
-
+        postListScrollChange();
         // Move over attachment icon to compensate for the scrollbar
         if (height > maxHeight) {
             wrapper.closest('.post-create').addClass('scroll');


### PR DESCRIPTION
#### Summary
When textbox height is changed postList height gets effected triggering an onScroll event but this event does not work reliably so explicitly calling the correct scroll event.

https://github.com/mattermost/mattermost-webapp/blob/3bab7b658da4d50a8c1361ef463e872da2549df8/components/post_view/post_list.jsx#L685-L688

#### Ticket Link
[MM-12422](https://mattermost.atlassian.net/browse/MM-12422)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
