### PR TITLE
NOTICE.txt updates for December 2018

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -212,56 +212,6 @@ THE SOFTWARE.
 
 ---
 
-## cypress
-
-This product contains 'cypress' by Cypress.
-
-Fast, easy and reliable testing for anything that runs in a browser.
-
-* HOMEPAGE:
-  * https://github.com/cypress-io/cypress
-
-* LICENSE: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Cypress.io, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
----
-
-## eslint-plugin-cypress
-
-This product contains 'eslint-plugin-cypress' by Cypress.
-
-An ESLint plugin for projects that use Cypress
-
-* HOMEPAGE:
-  * https://github.com/cypress-io/eslint-plugin-cypress
-
-* LICENSE: MIT
-
-(No license text is stated in the homepage.)
-
----
-
 ## exif2css
 
 This product contains 'exif2css' by Anton.
@@ -1984,16 +1934,16 @@ SOFTWARE.
 
 ---
 
-## rebound-js
+## rebound
 
-This product contains 'rebound-js' by Facebook.
+This product contains 'rebound' by Facebook.
 
-Rebound is a simple library that models Spring dynamics for the purpose of driving physical animations.
+A simple library for modeling spring dynamics
 
 * HOMEPAGE:
   * https://github.com/facebook/rebound-js
 
-* LICENSE: BSD
+* LICENSE: BSD-3-Clause
 
 BSD License
 


### PR DESCRIPTION
(This is the automated NOTICE.txt update for December 2018)

- Removed dependency `cypress`, which shifted from "dependencies" to "devDependencies"
- Follow dependency that was renamed from `rebound-js` to `rebound`