### PR TITLE
[MM-12897] Fix redirect to default team and channel on team invite link

### DIFF
--- a/components/signup/signup_controller/signup_controller.jsx
+++ b/components/signup/signup_controller/signup_controller.jsx
@@ -113,14 +113,14 @@ export default class SignupController extends React.Component {
     }
 
     getInviteInfo = async (inviteId) => {
-        const {data} = await this.props.actions.getTeamInviteInfo(inviteId);
+        const {data, error} = await this.props.actions.getTeamInviteInfo(inviteId);
         if (data) {
             this.setState({
                 serverError: '',
                 loading: false,
             });
-        } else {
-            this.handleInvalidInvite();
+        } else if (error) {
+            this.handleInvalidInvite(error);
         }
     }
 


### PR DESCRIPTION
#### Summary
On team invite link, fix redirect to default team and channel.

This fixes the issue on this repro steps:
1. Create a new team
2. Get team invite link
3. Log out
4. Open team invite URL
5. Enter new account info and click to save
6. Observe team selection page
7. Open team invite URL again (in same browser), still team selection page
8. Open team invite URL a third time, then the team you joined displays

#### Ticket Link
Jira ticket: [MM-12897](https://mattermost.atlassian.net/browse/MM-12897)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
