### PR TITLE
MM-12760: Proper fix for this and also the divider for date input.

### DIFF
--- a/components/suggestion/provider.jsx
+++ b/components/suggestion/provider.jsx
@@ -40,4 +40,12 @@ export default class Provider {
 
         return false;
     }
+
+    allowDividers() {
+        return true;
+    }
+
+    presentationType() {
+        return 'text';
+    }
 }

--- a/components/suggestion/search_date_provider.jsx
+++ b/components/suggestion/search_date_provider.jsx
@@ -52,4 +52,12 @@ export default class SearchDateProvider extends Provider {
 
         return Boolean(captured);
     }
+
+    allowDividers() {
+        return false;
+    }
+
+    presentationType() {
+        return 'date';
+    }
 }

--- a/components/suggestion/search_user_provider.jsx
+++ b/components/suggestion/search_user_provider.jsx
@@ -87,4 +87,8 @@ export default class SearchUserProvider extends Provider {
 
         return Boolean(captured);
     }
+
+    allowDividers() {
+        return false;
+    }
 }


### PR DESCRIPTION
#### Summary
Proper fix for this and also the divider for date input.

The old fix copied a hack used for the date, which only worked on
development builds (oops). This fixes both the header for "from:" and
for date-type inputs properly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12760

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed