### PR TITLE
Give precedence to metadata on attachments count

### DIFF
--- a/components/file_attachment_list/index.js
+++ b/components/file_attachment_list/index.js
@@ -19,7 +19,9 @@ function makeMapStateToProps() {
         const fileInfos = selectFilesForPost(state, postId);
 
         let fileCount = 0;
-        if (ownProps.post.file_ids) {
+        if (ownProps.post.metadata) {
+            fileCount = (ownProps.post.metadata.files || []).length;
+        } else if (ownProps.post.file_ids) {
             fileCount = ownProps.post.file_ids.length;
         } else if (ownProps.post.filenames) {
             fileCount = ownProps.post.filenames.length;


### PR DESCRIPTION
#### Summary
Give precedence to metadata on attachments count

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Needs to be implemented in mobile (https://mattermost.atlassian.net/browse/MM-13294)