### PR TITLE
MM-13258 Fix Show More not being clickable in message attachments

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1902,7 +1902,7 @@
         position: relative;
     }
 
-    .post-collapse__show-more {
+    .post-collapse__show-more, .post-attachment-collapse__show-more {
         pointer-events: auto;
     }
 }


### PR DESCRIPTION
I didn't realize that the different Show More buttons had different CSS classes on them, so this fixes that

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13258
