### PR TITLE
MM-13266: Doing the filter of GMs properly on "more direct channels" modal

### DIFF
--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -75,7 +75,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 const filterGroupChannels = memoizeResult((channels, term) => {
-    return channels.filter((channel) => filterProfilesMatchingTerm(channel.profiles, term));
+    return channels.filter((channel) => {
+        const matches = filterProfilesMatchingTerm(channel.profiles, term);
+        return matches.length > 0;
+    });
 });
 
 function mapDispatchToProps(dispatch) {


### PR DESCRIPTION
#### Summary
Doing the filter of GMs properly on "more direct channels" modal

This bug was introduced in the PR #1556

#### Ticket Link
[MM-13266](https://mattermost.atlassian.net/browse/MM-13266)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed