### PR TITLE
[MM-13249] Fix jumping down of channel with mention in Unread section

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -179,7 +179,7 @@ export default class Sidebar extends React.PureComponent {
             newOrderedChannelIds[0].items = prevState.unreadChannelIds;
 
             return {
-                unreadChannelIds: prevState.unreadChannelIds || [],
+                unreadChannelIds: prevState.unreadChannelIds,
                 orderedChannelIds: newOrderedChannelIds,
             };
         }

--- a/components/sidebar/sidebar.test.jsx
+++ b/components/sidebar/sidebar.test.jsx
@@ -335,7 +335,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
         expect(instance.updateScrollbarOnChannelChange).not.toBeCalled();
         expect(instance.props.actions.switchToChannelById).not.toBeCalled();
 
-        wrapper.setState({unreadChannelIds: ['c3', 'c6']});
+        wrapper.setProps({unreadChannelIds: ['c3', 'c6']});
         instance.navigateUnreadChannelShortcut(nextEvent);
         expect(instance.props.actions.switchToChannelById).lastCalledWith('c3');
         expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c3');

--- a/components/sidebar/sidebar.test.jsx
+++ b/components/sidebar/sidebar.test.jsx
@@ -335,7 +335,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
         expect(instance.updateScrollbarOnChannelChange).not.toBeCalled();
         expect(instance.props.actions.switchToChannelById).not.toBeCalled();
 
-        wrapper.setProps({unreadChannelIds: ['c3', 'c6']});
+        wrapper.setState({unreadChannelIds: ['c3', 'c6']});
         instance.navigateUnreadChannelShortcut(nextEvent);
         expect(instance.props.actions.switchToChannelById).lastCalledWith('c3');
         expect(instance.updateScrollbarOnChannelChange).lastCalledWith('c3');
@@ -471,8 +471,8 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             <Sidebar {...defaultProps}/>
         );
         const instance = wrapper.instance();
-        expect(instance.channelIdIsDisplayedForProps(instance.props, 'c1')).toBe(true);
-        expect(instance.channelIdIsDisplayedForProps(instance.props, 'c9')).toBe(false);
+        expect(instance.channelIdIsDisplayedForProps(instance.props.orderedChannelIds, 'c1')).toBe(true);
+        expect(instance.channelIdIsDisplayedForProps(instance.props.orderedChannelIds, 'c9')).toBe(false);
     });
 
     test('should handle correctly open more direct channels toggle', () => {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -437,6 +437,11 @@ export const GroupUnreadChannels = {
     DEFAULT_OFF: 'default_off',
 };
 
+export const SidebarChannelGroups = {
+    UNREADS: 'unreads',
+    FAVORITE: 'favorite',
+};
+
 export const PermissionsScope = {
     [Permissions.INVITE_USER]: 'team_scope',
     [Permissions.ADD_USER_TO_TEAM]: 'team_scope',


### PR DESCRIPTION
#### Summary
Fix jumping down of channel with mention in Unread section:
- by tracking the previous values of `unreadChannelIds` and `orderedChannelIds` and keeping its values or order whenever the (new) currentChannelId is included in the list of unread channels.

#### Ticket Link
Jira ticket: [MM-13249](https://mattermost.atlassian.net/browse/MM-13249)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
