### PR TITLE
MM-13301 Remove usage of localizeMessage from Team Settings modal

### DIFF
--- a/components/team_settings_modal.jsx
+++ b/components/team_settings_modal.jsx
@@ -89,8 +89,8 @@ class TeamSettingsModal extends React.Component {
     render() {
         const {formatMessage} = this.props.intl;
         const tabs = [];
-        tabs.push({name: 'general', uiName: formatMessage(holders.generalTab), icon: 'icon fa fa-cog', iconTitle: Utils.localizeMessage('generic_icons.settings', 'Settings Icon')});
-        tabs.push({name: 'import', uiName: formatMessage(holders.importTab), icon: 'icon fa fa-upload', iconTitle: Utils.localizeMessage('generic_icons.upload', 'Upload Icon')});
+        tabs.push({name: 'general', uiName: formatMessage(holders.generalTab), icon: 'icon fa fa-cog', iconTitle: formatMessage({id: 'generic_icons.settings', defaultMessage: 'Settings Icon'})});
+        tabs.push({name: 'import', uiName: formatMessage(holders.importTab), icon: 'icon fa fa-upload', iconTitle: formatMessage({id: 'generic_icons.upload', defaultMessage: 'Upload Icon'})});
 
         return (
             <Modal


### PR DESCRIPTION
#### Summary
Remove usage of localizeMessage from Team Settings modal and use formatMessage of intl object instead.

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/MM-13301) | [GitHub issue #9946](https://github.com/mattermost/mattermost-server/issues/9946)

Fixes https://github.com/mattermost/mattermost-server/issues/9946

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
