### PR TITLE
MM-12934: Extra time to click handling for channel header icons

### DIFF
--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -86,7 +86,7 @@ export default class SearchBar extends React.Component {
         // when focus is released from the search box.
         setTimeout(() => {
             this.setState({focused: false});
-        }, 100);
+        }, 200);
     }
 
     handleClear = () => {


### PR DESCRIPTION
#### Summary
This is a hack to be able to click the pin posts and members button when
you close the help tooltip for search. The hack was already there, but
wasn't working properly and consistenly. Adding some extra time, still
feels fast and smooth, but now the click events are handled properly
more times (all times that I tested it, but I guess it can still fail in
certain heavy load situations or so).

We can try to find a better solution, but for now is the simplest and
less disruptive one.

#### Ticket Link
[MM-12934](https://mattermost.atlassian.net/browse/MM-12934)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed