### PR TITLE
[GH-9961] Fix boolean setting not updating properly for plugins

### DIFF
--- a/components/admin_console/custom_plugin_settings/custom_plugin_settings.jsx
+++ b/components/admin_console/custom_plugin_settings/custom_plugin_settings.jsx
@@ -37,9 +37,11 @@ export default class CustomPluginSettings extends SchemaAdminSettings {
             const settings = schema.settings || [];
             settings.forEach((setting) => {
                 const lowerKey = setting.key.toLowerCase();
-                const value = this.state[lowerKey] || setting.default;
-                if (value == null) {
+                const value = this.state[lowerKey];
+                if (value == null && setting.default == null) {
                     Reflect.deleteProperty(configSettings, lowerKey);
+                } else if (value == null) {
+                    configSettings[lowerKey] = setting.default;
                 } else {
                     configSettings[lowerKey] = value;
                 }


### PR DESCRIPTION
#### Summary
In Admin Console page for plugin settings, boolean setting in plugins cannot be updated if their default value is true.
This PR fixes the above bug.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9961

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
