### PR TITLE
MM-13178: ignore enter key within 500ms of switching channels

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -534,7 +534,13 @@ export default class CreatePost extends React.Component {
     postMsgKeyPress = (e) => {
         const {ctrlSend, codeBlockOnCtrlEnter, currentChannel} = this.props;
 
-        const {allowSending, withClosedCodeBlock, message} = postMessageOnKeyPress(e, this.state.message, ctrlSend, codeBlockOnCtrlEnter, Date.now(), this.lastChannelSwitchAt);
+        const {allowSending, withClosedCodeBlock, ignoreKeyPress, message} = postMessageOnKeyPress(e, this.state.message, ctrlSend, codeBlockOnCtrlEnter, Date.now(), this.lastChannelSwitchAt);
+
+        if (ignoreKeyPress) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+        }
 
         if (allowSending) {
             e.persist();

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -212,7 +212,7 @@ export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, se
 
     // Don't send if we just switched channels within a threshold.
     if (lastChannelSwitchAt > 0 && now > 0 && now - lastChannelSwitchAt <= CHANNEL_SWITCH_IGNORE_ENTER_THRESHOLD_MS) {
-        return {allowSending: false};
+        return {allowSending: false, ignoreKeyPress: true};
     }
 
     if (

--- a/utils/post_utils.test.jsx
+++ b/utils/post_utils.test.jsx
@@ -494,11 +494,11 @@ describe('PostUtils.postMessageOnKeyPress', () => {
     }, {
         name: 'last channel switch within threshold',
         input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true, now: 1541658920334, lastChannelSwitch: 1541658920334 - 250},
-        expected: {allowSending: false},
+        expected: {allowSending: false, ignoreKeyPress: true},
     }, {
         name: 'last channel switch at threshold',
         input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true, now: 1541658920334, lastChannelSwitch: 1541658920334 - 500},
-        expected: {allowSending: false},
+        expected: {allowSending: false, ignoreKeyPress: true},
     }, {
         name: 'last channel switch outside threshold',
         input: {event: {keyCode: 13}, message: 'message', sendMessageOnCtrlEnter: false, sendCodeBlockOnCtrlEnter: true, now: 1541658920334, lastChannelSwitch: 1541658920334 - 501},


### PR DESCRIPTION
#### Summary
In MM-12908, we changed the behaviour to disallow sending within 500ms of switching channels, but still funnelled the enter key into the textbox. With the theory as to the original cause now confirmed, we are updating this fix to suppress the enter key altogether in that window.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13178

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)