### PR TITLE
[MM-13174] Fix text rendering of non-existent emoji when post metadata is enabled

### DIFF
--- a/components/post_emoji/index.jsx
+++ b/components/post_emoji/index.jsx
@@ -12,6 +12,7 @@ import {getEmojiMap} from 'selectors/emojis';
 import PostEmoji from './post_emoji.jsx';
 
 function mapStateToProps(state, ownProps) {
+    const config = getConfig(state);
     const emojiMap = getEmojiMap(state);
     const emoji = emojiMap.get(ownProps.name);
 
@@ -21,7 +22,8 @@ function mapStateToProps(state, ownProps) {
         imageUrl = getEmojiImageUrl(emoji);
     } else {
         displayTextOnly = state.entities.emojis.nonExistentEmoji.has(ownProps.name) ||
-            getConfig(state).EnableCustomEmoji !== 'true' ||
+            config.EnableCustomEmoji !== 'true' ||
+            config.ExperimentalEnablePostMetadata === 'true' ||
             getCurrentUserId(state) === '';
     }
 


### PR DESCRIPTION
#### Summary
Fix text rendering of non-existent emoji when post metadata is enabled

#### Ticket Link
Jira ticket: [MM-13174](https://mattermost.atlassian.net/browse/MM-13174)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Server change (https://github.com/mattermost/mattermost-server/pull/9970)
