### PR TITLE
MM-13257 Delete cookie properly on logout

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -302,7 +302,7 @@ export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = tr
         BrowserStore.clear();
         stopPeriodicStatusUpdates();
         WebsocketActions.close();
-        document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+        document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/';
         browserHistory.push(redirectTo);
     }).catch(() => {
         browserHistory.push(redirectTo);


### PR DESCRIPTION
#### Summary
We weren't actually deleting the cookie before, so we would still have it until after we made a number of requests that responded with 401 and cleared the cookie. By correctly clearing it manually on logout we don't make those requests as we know the user is not logged in.

I went to add a unit test but to do so would require more refactoring than I was comfortable with putting into the release.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13257

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed