### PR TITLE
MM-13085: update prefix if context changes

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -113,6 +113,12 @@ export default class SuggestionBox extends React.Component {
          * If true, replace all input in the suggestion box with the selected option after a select, defaults to false
          */
         replaceAllInputOnSelect: PropTypes.bool,
+
+        /**
+         * An optional, opaque identifier that distinguishes the context in which the suggestion
+         * box is rendered. This allows the reused component to otherwise respond to changes.
+         */
+        contextId: PropTypes.string,
     }
 
     static defaultProps = {
@@ -156,6 +162,15 @@ export default class SuggestionBox extends React.Component {
             allowDividers: true,
             presentationType: 'text',
         };
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.contextId !== this.props.contextId) {
+            const textbox = this.getTextbox();
+            const pretext = textbox.value.substring(0, textbox.selectionEnd).toLowerCase();
+
+            this.handlePretextChanged(pretext);
+        }
     }
 
     getTextbox = () => {

--- a/components/suggestion/suggestion_box.test.jsx
+++ b/components/suggestion/suggestion_box.test.jsx
@@ -73,4 +73,24 @@ describe('components/SuggestionBox', () => {
         expect(wrapper.state('focused')).toEqual(false);
         expect(onBlur).toBeCalledTimes(1);
     });
+
+    test('should force pretext change on context change', () => {
+        const wrapper = shallow(
+            <SuggestionBox
+                {...baseProps}
+            />
+        );
+        const instance = wrapper.instance();
+        instance.handlePretextChanged = jest.fn();
+        instance.getTextbox = jest.fn().mockReturnValue({value: 'value'});
+
+        wrapper.setProps({...baseProps});
+        expect(instance.handlePretextChanged).not.toBeCalled();
+
+        wrapper.setProps({...baseProps, contextId: 'new'});
+        expect(instance.handlePretextChanged).toBeCalledWith('value');
+
+        wrapper.setProps({...baseProps, contextId: 'new'});
+        expect(instance.handlePretextChanged.mock.calls.length).toBe(1);
+    });
 });

--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -336,6 +336,7 @@ export default class Textbox extends React.Component {
                     renderDividers={true}
                     isRHS={this.props.isRHS}
                     disabled={this.props.disabled}
+                    contextId={this.props.channelId}
                 />
                 {preview}
                 <div className={'help__text ' + helpTextClass}>


### PR DESCRIPTION
#### Summary
A rendered suggestion box can have its context changed out from underneath it without any other props changing, for example when switching between channels. Trigger a pretext match when such a context change is detected to ensure we aren't comparing "state" from a previous context.

Note that this requires opt-in from the parent component, and otherwise won't change anything if not employed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13085

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)