### PR TITLE
[MM-13299] Remove usage of localizeMessage from the DotMenu component

### DIFF
--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -4,7 +4,7 @@
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage, injectIntl, intlShape} from 'react-intl';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 import {showGetPostLinkModal} from 'actions/global_actions.jsx';
@@ -20,7 +20,7 @@ import Pluggable from 'plugins/pluggable';
 
 import DotMenuItem from './dot_menu_item.jsx';
 
-export default class DotMenu extends Component {
+class DotMenu extends Component {
     static propTypes = {
         post: PropTypes.object.isRequired,
         location: PropTypes.oneOf(['CENTER', 'RHS_ROOT', 'RHS_COMMENT', 'SEARCH']).isRequired,
@@ -30,6 +30,7 @@ export default class DotMenu extends Component {
         handleDropdownOpened: PropTypes.func,
         isReadOnly: PropTypes.bool,
         pluginMenuItems: PropTypes.arrayOf(PropTypes.object),
+        intl: intlShape.isRequired,
 
         actions: PropTypes.shape({
 
@@ -153,11 +154,13 @@ export default class DotMenu extends Component {
     }
 
     handleEditMenuItemActivated = () => {
+        const {formatMessage} = this.props.intl;
+
         this.props.actions.setEditingPost(
             this.props.post.id,
             this.props.commentCount,
             this.props.location === 'CENTER' ? 'post_textbox' : 'reply_textbox',
-            this.props.post.root_id ? Utils.localizeMessage('rhs_comment.comment', 'Comment') : Utils.localizeMessage('create_post.post', 'Post'),
+            this.props.post.root_id ? formatMessage({id: 'rhs_comment.comment', defaultMessage: 'Comment'}) : formatMessage({id: 'create_post.post', defaultMessage: 'Post'}),
             this.props.location === 'RHS_ROOT' || this.props.location === 'RHS_COMMENT',
         );
     }
@@ -342,3 +345,5 @@ export default class DotMenu extends Component {
         );
     }
 }
+
+export default injectIntl(DotMenu);

--- a/components/dot_menu/dot_menu.test.jsx
+++ b/components/dot_menu/dot_menu.test.jsx
@@ -2,7 +2,8 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallow} from 'enzyme';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 
 import DotMenu from 'components/dot_menu/dot_menu.jsx';
 
@@ -39,9 +40,9 @@ describe('components/dot_menu/DotMenu', () => {
     };
 
     test('should match snapshot, on Center', () => {
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <DotMenu {...baseProps}/>
-        );
+        ).dive({disableLifecycleMethods: true});
 
         expect(wrapper).toMatchSnapshot();
 
@@ -51,9 +52,9 @@ describe('components/dot_menu/DotMenu', () => {
     });
 
     test('should match snapshot, canDelete', () => {
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <DotMenu {...baseProps}/>
-        );
+        ).dive({disableLifecycleMethods: true});
 
         wrapper.setState({canDelete: true});
         expect(wrapper).toMatchSnapshot();

--- a/components/dot_menu/dot_menu_empty.test.jsx
+++ b/components/dot_menu/dot_menu_empty.test.jsx
@@ -2,7 +2,8 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallow} from 'enzyme';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 
 import DotMenu from 'components/dot_menu/dot_menu.jsx';
 
@@ -36,9 +37,9 @@ describe('components/dot_menu/DotMenu returning empty ("")', () => {
             },
         };
 
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <DotMenu {...baseProps}/>
-        );
+        ).dive({disableLifecycleMethods: true});
 
         expect(wrapper).toMatchSnapshot();
     });

--- a/components/dot_menu/dot_menu_mobile.test.jsx
+++ b/components/dot_menu/dot_menu_mobile.test.jsx
@@ -2,7 +2,8 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallow} from 'enzyme';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 
 import DotMenu from 'components/dot_menu/dot_menu.jsx';
 
@@ -36,9 +37,9 @@ describe('components/dot_menu/DotMenu on mobile view', () => {
             },
         };
 
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <DotMenu {...baseProps}/>
-        );
+        ).dive({disableLifecycleMethods: true});
 
         expect(wrapper).toMatchSnapshot();
     });

--- a/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
+++ b/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
@@ -174,7 +174,7 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
   <div
     className="col col__reply"
   >
-    <Connect(DotMenu)
+    <Connect(InjectIntl(DotMenu))
       commentCount={0}
       handleCommentClick={[MockFunction]}
       handleDropdownOpened={[Function]}
@@ -279,7 +279,7 @@ exports[`components/post_view/PostInfo toggleEmojiPicker, should have called pro
   <div
     className="col col__reply"
   >
-    <Connect(DotMenu)
+    <Connect(InjectIntl(DotMenu))
       commentCount={0}
       handleCommentClick={[MockFunction]}
       handleDropdownOpened={[Function]}

--- a/components/search_results_item/__snapshots__/search_results_item.test.jsx.snap
+++ b/components/search_results_item/__snapshots__/search_results_item.test.jsx.snap
@@ -124,7 +124,7 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
           <div
             className="col__controls col__reply"
           >
-            <Connect(DotMenu)
+            <Connect(InjectIntl(DotMenu))
               handleDropdownOpened={[Function]}
               isFlagged={true}
               isReadOnly={true}
@@ -346,7 +346,7 @@ exports[`components/SearchResultsItem should match snapshot for archived channel
           <div
             className="col__controls col__reply"
           >
-            <Connect(DotMenu)
+            <Connect(InjectIntl(DotMenu))
               handleDropdownOpened={[Function]}
               isFlagged={true}
               isReadOnly={true}
@@ -568,7 +568,7 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
           <div
             className="col__controls col__reply"
           >
-            <Connect(DotMenu)
+            <Connect(InjectIntl(DotMenu))
               handleDropdownOpened={[Function]}
               isFlagged={true}
               isReadOnly={true}


### PR DESCRIPTION
#### Summary
Remove usage of localizeMessage when editing a post from the DotMenu component and use formatMessage of intl object instead.

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/MM-13299) | [GitHub issue #9950](https://github.com/mattermost/mattermost-server/issues/9950)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)