### PR TITLE
MM-13212 Fix redirect to error page when sysadmin clicks DM/GM permalink

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -5,16 +5,13 @@ import debounce from 'lodash/debounce';
 import {batchActions} from 'redux-batched-actions';
 
 import {
-    getChannel,
     createDirectChannel,
     getChannelByNameAndTeamName,
     getChannelStats,
     getMyChannelMember,
-    joinChannel,
     markChannelAsRead,
     selectChannel,
 } from 'mattermost-redux/actions/channels';
-import {getPostThread} from 'mattermost-redux/actions/posts';
 import {logout} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -24,10 +21,9 @@ import {getCurrentChannelStats, getCurrentChannelId, getChannelByName, getMyChan
 import {ChannelTypes} from 'mattermost-redux/action_types';
 
 import {browserHistory} from 'utils/browser_history';
-import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
 import {handleNewPost} from 'actions/post_actions.jsx';
 import {stopPeriodicStatusUpdates} from 'actions/status_actions.jsx';
-import {loadNewDMIfNeeded, loadNewGMIfNeeded, loadProfilesForSidebar} from 'actions/user_actions.jsx';
+import {loadProfilesForSidebar} from 'actions/user_actions.jsx';
 import {closeRightHandSide, closeMenu as closeRhsMenu, updateRhsState} from 'actions/views/rhs';
 import {close as closeLhs} from 'actions/views/lhs';
 import * as WebsocketActions from 'actions/websocket_actions.jsx';
@@ -39,7 +35,7 @@ import store from 'stores/redux_store.jsx';
 import LocalStorageStore from 'stores/local_storage_store';
 import WebSocketClient from 'client/web_websocket_client.jsx';
 
-import {ActionTypes, Constants, ErrorPageTypes, PostTypes, RHSStates} from 'utils/constants.jsx';
+import {ActionTypes, Constants, PostTypes, RHSStates} from 'utils/constants.jsx';
 import EventTypes from 'utils/event_types.jsx';
 import {filterAndSortTeamsByDisplayName} from 'utils/team_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -118,60 +114,8 @@ export function emitChannelClickEvent(channel) {
     }
 }
 
-export async function doFocusPost(channelId, postId) {
-    dispatch(selectChannel(channelId));
-    dispatch({
-        type: ActionTypes.RECEIVED_FOCUSED_POST,
-        data: postId,
-    });
-
-    const member = getState().entities.channels.myMembers[channelId];
-    if (member == null) {
-        await dispatch(joinChannel(getCurrentUserId(getState()), null, channelId));
-    }
-
-    dispatch(loadChannelsForCurrentUser());
-    dispatch(getChannelStats(channelId));
-}
-
 export function emitCloseRightHandSide() {
     dispatch(closeRightHandSide());
-}
-
-export async function emitPostFocusEvent(postId, returnTo = '') {
-    dispatch(loadChannelsForCurrentUser());
-    const {data} = await dispatch(getPostThread(postId));
-
-    if (!data) {
-        browserHistory.replace(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=${returnTo}`);
-        return;
-    }
-
-    const channelId = data.posts[data.order[0]].channel_id;
-    let channel = getState().entities.channels.channels[channelId];
-    const teamId = getCurrentTeamId(getState());
-
-    if (!channel) {
-        const {data: channelData} = await dispatch(getChannel(channelId));
-        if (!channelData) {
-            browserHistory.replace(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=${returnTo}`);
-            return;
-        }
-        channel = channelData;
-    }
-
-    if (channel.team_id && channel.team_id !== teamId) {
-        browserHistory.replace(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=${returnTo}`);
-        return;
-    }
-
-    if (channel && channel.type === Constants.DM_CHANNEL) {
-        loadNewDMIfNeeded(channel.id);
-    } else if (channel && channel.type === Constants.GM_CHANNEL) {
-        loadNewGMIfNeeded(channel.id);
-    }
-
-    await doFocusPost(channelId, postId, data);
 }
 
 export function toggleShortcutsModal() {

--- a/components/permalink_view/actions.js
+++ b/components/permalink_view/actions.js
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getChannel, selectChannel, joinChannel, getChannelStats} from 'mattermost-redux/actions/channels';
+import {getPostThread} from 'mattermost-redux/actions/posts';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
+import {loadNewDMIfNeeded, loadNewGMIfNeeded} from 'actions/user_actions.jsx';
+import {browserHistory} from 'utils/browser_history';
+import {ActionTypes, Constants, ErrorPageTypes} from 'utils/constants.jsx';
+
+export function focusPost(postId, returnTo = '') {
+    return async (dispatch, getState) => {
+        const {data} = await dispatch(getPostThread(postId));
+
+        if (!data) {
+            browserHistory.replace(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=${returnTo}`);
+            return;
+        }
+
+        const state = getState();
+        const channelId = data.posts[data.order[0]].channel_id;
+        let channel = state.entities.channels.channels[channelId];
+        const teamId = getCurrentTeamId(getState());
+
+        if (!channel) {
+            const {data: channelData} = await dispatch(getChannel(channelId));
+
+            if (!channelData) {
+                browserHistory.replace(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=${returnTo}`);
+                return;
+            }
+
+            channel = channelData;
+        }
+
+        const myMember = state.entities.channels.myMembers[channelId];
+
+        if (!myMember) {
+            // If it's a DM or GM channel and we don't have a channel member for it already, user is not a member
+            if (channel.type === Constants.DM_CHANNEL || channel.type === Constants.GM_CHANNEL) {
+                browserHistory.replace(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=${returnTo}`);
+                return;
+            }
+
+            await dispatch(joinChannel(getCurrentUserId(getState()), null, channelId));
+        }
+
+        if (channel.team_id && channel.team_id !== teamId) {
+            browserHistory.replace(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=${returnTo}`);
+            return;
+        }
+
+        if (channel && channel.type === Constants.DM_CHANNEL) {
+            loadNewDMIfNeeded(channel.id);
+        } else if (channel && channel.type === Constants.GM_CHANNEL) {
+            loadNewGMIfNeeded(channel.id);
+        }
+
+        dispatch(selectChannel(channelId));
+        dispatch({
+            type: ActionTypes.RECEIVED_FOCUSED_POST,
+            data: postId,
+        });
+
+        dispatch(loadChannelsForCurrentUser());
+        dispatch(getChannelStats(channelId));
+    };
+}

--- a/components/permalink_view/actions.js
+++ b/components/permalink_view/actions.js
@@ -23,7 +23,7 @@ export function focusPost(postId, returnTo = '') {
         const state = getState();
         const channelId = data.posts[data.order[0]].channel_id;
         let channel = state.entities.channels.channels[channelId];
-        const teamId = getCurrentTeamId(getState());
+        const teamId = getCurrentTeamId(state);
 
         if (!channel) {
             const {data: channelData} = await dispatch(getChannel(channelId));

--- a/components/permalink_view/index.js
+++ b/components/permalink_view/index.js
@@ -2,10 +2,12 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 
 import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
+import {focusPost} from './actions';
 import PermalinkView from './permalink_view.jsx';
 
 function mapStateToProps(state) {
@@ -33,4 +35,12 @@ function mapStateToProps(state) {
     };
 }
 
-export default connect(mapStateToProps)(PermalinkView);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            focusPost,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PermalinkView);

--- a/components/permalink_view/permalink_view.jsx
+++ b/components/permalink_view/permalink_view.jsx
@@ -9,7 +9,6 @@ import {Link} from 'react-router-dom';
 import ChannelHeader from 'components/channel_header';
 import {localizeMessage} from 'utils/utils.jsx';
 import PostView from 'components/post_view';
-import {emitPostFocusEvent} from 'actions/global_actions.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 export default class PermalinkView extends React.PureComponent {
@@ -28,6 +27,9 @@ export default class PermalinkView extends React.PureComponent {
         }).isRequired,
         returnTo: PropTypes.string.isRequired,
         teamName: PropTypes.string,
+        actions: PropTypes.shape({
+            focusPost: PropTypes.func.isRequired,
+        }).isRequired,
     };
 
     constructor(props) {
@@ -53,7 +55,7 @@ export default class PermalinkView extends React.PureComponent {
     doPermalinkEvent = async (props) => {
         this.setState({valid: false});
         const postId = props.match.params.postid;
-        await emitPostFocusEvent(postId, this.props.returnTo);
+        await this.props.actions.focusPost(postId, this.props.returnTo);
         this.setState({valid: true});
     }
 

--- a/components/permalink_view/permalink_view.test.jsx
+++ b/components/permalink_view/permalink_view.test.jsx
@@ -3,13 +3,65 @@
 
 import React from 'react';
 import {shallow} from 'enzyme';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
 
-import {emitPostFocusEvent} from 'actions/global_actions.jsx';
+import {getPostThread} from 'mattermost-redux/actions/posts';
 
+import {ErrorPageTypes} from 'utils/constants';
+import {browserHistory} from 'utils/browser_history';
+
+import {focusPost} from 'components/permalink_view/actions';
 import PermalinkView from 'components/permalink_view/permalink_view.jsx';
 
-jest.mock('actions/global_actions.jsx', () => ({
-    emitPostFocusEvent: jest.fn(),
+const mockStore = configureStore([thunk]);
+
+jest.mock('utils/browser_history', () => ({
+    browserHistory: {
+        replace: jest.fn(),
+    },
+}));
+
+jest.mock('actions/channel_actions.jsx', () => ({
+    loadChannelsForCurrentUser: jest.fn(() => {
+        return {type: 'MOCK_LOAD_CHANNELS_FOR_CURRENT_USER'};
+    }),
+}));
+
+jest.mock('mattermost-redux/actions/posts', () => ({
+    getPostThread: jest.fn((postId) => {
+        const post = {id: 'postid1', message: 'some message', channel_id: 'channelid1'};
+        const post2 = {id: 'postid2', message: 'some message', channel_id: 'channelid2'};
+        const dmPost = {id: 'dmpostid1', message: 'some message', channel_id: 'dmchannelid'};
+        const gmPost = {id: 'gmpostid1', message: 'some message', channel_id: 'gmchannelid'};
+
+        switch (postId) {
+        case 'postid1':
+            return {type: 'MOCK_GET_POST_THREAD', data: {posts: {postid1: post}, order: [post.id]}};
+        case 'postid2':
+            return {type: 'MOCK_GET_POST_THREAD', data: {posts: {postid2: post2}, order: [post2.id]}};
+        case 'dmpostid1':
+            return {type: 'MOCK_GET_POST_THREAD', data: {posts: {dmpostid1: dmPost}, order: [dmPost.id]}};
+        case 'gmpostid1':
+            return {type: 'MOCK_GET_POST_THREAD', data: {posts: {gmpostid1: gmPost}, order: [gmPost.id]}};
+        default:
+            return {type: 'MOCK_GET_POST_THREAD'};
+        }
+    }),
+}));
+
+jest.mock('mattermost-redux/actions/channels', () => ({
+    selectChannel: (...args) => ({type: 'MOCK_SELECT_CHANNEL', args}),
+    joinChannel: (...args) => ({type: 'MOCK_JOIN_CHANNEL', args}),
+    getChannelStats: (...args) => ({type: 'MOCK_GET_CHANNEL_STATS', args}),
+    getChannel: jest.fn((channelId) => {
+        switch (channelId) {
+        case 'channelid2':
+            return {type: 'MOCK_GET_CHANNEL', data: {id: 'channelid2', type: 'O', team_id: 'current_team_id'}};
+        default:
+            return {type: 'MOCK_GET_CHANNEL', args: [channelId]};
+        }
+    }),
 }));
 
 describe('components/PermalinkView', () => {
@@ -19,6 +71,9 @@ describe('components/PermalinkView', () => {
         match: {params: {postid: 'post_id'}},
         returnTo: 'return_to',
         teamName: 'team_name',
+        actions: {
+            focusPost: jest.fn(),
+        },
     };
 
     test('should match snapshot', () => {
@@ -37,8 +92,8 @@ describe('components/PermalinkView', () => {
 
         wrapper.setState({valid: false});
         wrapper.instance().doPermalinkEvent();
-        expect(emitPostFocusEvent).toHaveBeenCalledTimes(1);
-        expect(emitPostFocusEvent).toBeCalledWith(baseProps.match.params.postid, baseProps.returnTo);
+        expect(baseProps.actions.focusPost).toHaveBeenCalledTimes(1);
+        expect(baseProps.actions.focusPost).toBeCalledWith(baseProps.match.params.postid, baseProps.returnTo);
     });
 
     test('should match snapshot with archived channel', () => {
@@ -50,5 +105,79 @@ describe('components/PermalinkView', () => {
 
         wrapper.setState({valid: true});
         expect(wrapper).toMatchSnapshot();
+    });
+    describe('actions', () => {
+        const initialState = {
+            entities: {
+                users: {
+                    currentUserId: 'current_user_id',
+                },
+                channels: {
+                    channels: {
+                        channelid1: {id: 'channelid1', name: 'channel1', type: 'O', team_id: 'current_team_id'},
+                        dmchannelid: {id: 'dmchannelid', name: 'dmchannel', type: 'D'},
+                        gmchannelid: {id: 'gmchannelid', name: 'gmchannel', type: 'G'},
+                    },
+                    myMembers: {channelid1: {channel_id: 'channelid1', user_id: 'current_user_id'}},
+                },
+                teams: {
+                    currentTeamId: 'current_team_id',
+                },
+            },
+        };
+
+        describe('focusPost', async () => {
+            test('should focus post in already loaded channel', async () => {
+                const testStore = await mockStore(initialState);
+                await testStore.dispatch(focusPost('postid1'));
+
+                expect(getPostThread).toHaveBeenCalledWith('postid1');
+                expect(testStore.getActions()).toEqual([
+                    {type: 'MOCK_GET_POST_THREAD', data: {posts: {postid1: {id: 'postid1', message: 'some message', channel_id: 'channelid1'}}, order: ['postid1']}},
+                    {type: 'MOCK_SELECT_CHANNEL', args: ['channelid1']},
+                    {type: 'RECEIVED_FOCUSED_POST', data: 'postid1'},
+                    {type: 'MOCK_LOAD_CHANNELS_FOR_CURRENT_USER'},
+                    {type: 'MOCK_GET_CHANNEL_STATS', args: ['channelid1']},
+                ]);
+            });
+
+            test('should focus post in not loaded channel', async () => {
+                const testStore = await mockStore(initialState);
+                await testStore.dispatch(focusPost('postid2'));
+
+                expect(getPostThread).toHaveBeenCalledWith('postid2');
+                expect(testStore.getActions()).toEqual([
+                    {type: 'MOCK_GET_POST_THREAD', data: {posts: {postid2: {id: 'postid2', message: 'some message', channel_id: 'channelid2'}}, order: ['postid2']}},
+                    {type: 'MOCK_GET_CHANNEL', data: {id: 'channelid2', type: 'O', team_id: 'current_team_id'}},
+                    {type: 'MOCK_JOIN_CHANNEL', args: ['current_user_id', null, 'channelid2']},
+                    {type: 'MOCK_SELECT_CHANNEL', args: ['channelid2']},
+                    {type: 'RECEIVED_FOCUSED_POST', data: 'postid2'},
+                    {type: 'MOCK_LOAD_CHANNELS_FOR_CURRENT_USER'},
+                    {type: 'MOCK_GET_CHANNEL_STATS', args: ['channelid2']},
+                ]);
+            });
+
+            test('should redirect to error page for DM channel not a member of', async () => {
+                const testStore = await mockStore(initialState);
+                await testStore.dispatch(focusPost('dmpostid1'));
+
+                expect(getPostThread).toHaveBeenCalledWith('dmpostid1');
+                expect(testStore.getActions()).toEqual([
+                    {type: 'MOCK_GET_POST_THREAD', data: {posts: {dmpostid1: {id: 'dmpostid1', message: 'some message', channel_id: 'dmchannelid'}}, order: ['dmpostid1']}},
+                ]);
+                expect(browserHistory.replace).toHaveBeenCalledWith(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=`);
+            });
+
+            test('should redirect to error page for GM channel not a member of', async () => {
+                const testStore = await mockStore(initialState);
+                await testStore.dispatch(focusPost('gmpostid1'));
+
+                expect(getPostThread).toHaveBeenCalledWith('gmpostid1');
+                expect(testStore.getActions()).toEqual([
+                    {type: 'MOCK_GET_POST_THREAD', data: {posts: {gmpostid1: {id: 'gmpostid1', message: 'some message', channel_id: 'gmchannelid'}}, order: ['gmpostid1']}},
+                ]);
+                expect(browserHistory.replace).toHaveBeenCalledWith(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=`);
+            });
+        });
     });
 });


### PR DESCRIPTION
#### Summary
Turned the focus post action into a redux action, moved it to live in the permalink_view component's folder (wasn't being used anywhere else), and added some tests to cover some basic cases and the case fixed here.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13212

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)