### PR TITLE
[MM-13397] Clean up UnhandledPromiseRejectionWarning when running unit tests

### DIFF
--- a/components/admin_console/custom_terms_of_service_settings/custom_terms_of_service_settings.test.jsx
+++ b/components/admin_console/custom_terms_of_service_settings/custom_terms_of_service_settings.test.jsx
@@ -10,7 +10,7 @@ describe('components/admin_console/CustomTermsOfServiceSettings', () => {
     const baseProps = {
         actions: {
             createTermsOfService: jest.fn(),
-            getTermsOfService: jest.fn(),
+            getTermsOfService: jest.fn().mockResolvedValue({data: {id: 'tos_id', text: 'tos_text'}}),
         },
         config: {
             SupportSettings: {

--- a/components/do_verify_email/do_verify_email.test.jsx
+++ b/components/do_verify_email/do_verify_email.test.jsx
@@ -16,8 +16,8 @@ describe('components/DoVerifyEmail', () => {
         },
         siteName: 'Mattermost',
         actions: {
-            verifyUserEmail: jest.fn(),
-            updateMe: jest.fn(),
+            verifyUserEmail: jest.fn().mockResolvedValue({data: true}),
+            updateMe: jest.fn().mockResolvedValue({data: true}),
             logError: jest.fn(),
             clearErrors: jest.fn(),
         },

--- a/components/emoji/add_emoji/add_emoji.test.js
+++ b/components/emoji/add_emoji/add_emoji.test.js
@@ -21,7 +21,7 @@ describe('components/emoji/components/AddEmoji', () => {
             id: 'current-user-id',
         },
         actions: {
-            createCustomEmoji: jest.fn(),
+            createCustomEmoji: jest.fn().mockReturnValue({}),
         },
     };
 

--- a/components/permalink_view/permalink_view.test.jsx
+++ b/components/permalink_view/permalink_view.test.jsx
@@ -85,14 +85,16 @@ describe('components/PermalinkView', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should call emitPostFocusEvent on doPermalinkEvent', () => {
+    test('should call baseProps.actions.focusPost on doPermalinkEvent', async () => {
         const wrapper = shallow(
             <PermalinkView {...baseProps}/>
         );
 
-        wrapper.setState({valid: false});
-        wrapper.instance().doPermalinkEvent();
         expect(baseProps.actions.focusPost).toHaveBeenCalledTimes(1);
+
+        wrapper.setState({valid: false});
+        await wrapper.instance().doPermalinkEvent(baseProps);
+        expect(baseProps.actions.focusPost).toHaveBeenCalledTimes(2);
         expect(baseProps.actions.focusPost).toBeCalledWith(baseProps.match.params.postid, baseProps.returnTo);
     });
 
@@ -106,6 +108,7 @@ describe('components/PermalinkView', () => {
         wrapper.setState({valid: true});
         expect(wrapper).toMatchSnapshot();
     });
+
     describe('actions', () => {
         const initialState = {
             entities: {

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -34,6 +34,7 @@ export default class SelectTeam extends React.Component {
         siteName: PropTypes.string,
         canCreateTeams: PropTypes.bool.isRequired,
         canManageSystem: PropTypes.bool.isRequired,
+        history: PropTypes.object,
         actions: PropTypes.shape({
             getTeams: PropTypes.func.isRequired,
             loadRolesIfNeeded: PropTypes.func.isRequired,

--- a/components/select_team/select_team.test.jsx
+++ b/components/select_team/select_team.test.jsx
@@ -17,7 +17,7 @@ jest.mock('utils/policy_roles_adapter', () => ({
 }));
 
 describe('components/select_team/SelectTeam', () => {
-    const addUserToTeamFromInvite = jest.fn();
+    const addUserToTeamFromInvite = jest.fn().mockResolvedValue({data: true});
     const baseProps = {
         currentUserRoles: 'system_admin',
         isMemberOfTeam: true,
@@ -28,6 +28,7 @@ describe('components/select_team/SelectTeam', () => {
         siteName: 'Mattermost',
         canCreateTeams: false,
         canManageSystem: true,
+        history: {push: jest.fn()},
         actions: {
             getTeams: jest.fn(),
             loadRolesIfNeeded: jest.fn(),
@@ -72,9 +73,9 @@ describe('components/select_team/SelectTeam', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should match state and call addUserToTeamFromInvite on handleTeamClick', () => {
+    test('should match state and call addUserToTeamFromInvite on handleTeamClick', async () => {
         const wrapper = shallow(<SelectTeam {...baseProps}/>);
-        wrapper.instance().handleTeamClick({id: 'team_id'});
+        await wrapper.instance().handleTeamClick({id: 'team_id'});
         expect(wrapper.state('loadingTeamId')).toEqual('team_id');
         expect(addUserToTeamFromInvite).toHaveBeenCalledTimes(1);
     });

--- a/components/suggestion/search_channel_with_permissions_provider.jsx
+++ b/components/suggestion/search_channel_with_permissions_provider.jsx
@@ -184,6 +184,9 @@ export default class SearchChannelWithPermissionsProvider extends Provider {
 
         for (const id of Object.keys(allChannels)) {
             const channel = allChannels[id];
+            if (!channel) {
+                continue;
+            }
 
             if (completedChannels[channel.id]) {
                 continue;

--- a/components/suggestion/search_channel_with_permissions_provider.test.jsx
+++ b/components/suggestion/search_channel_with_permissions_provider.test.jsx
@@ -8,6 +8,7 @@ import {getState} from 'stores/redux_store';
 import SearchChannelWithPermissionsProvider from 'components/suggestion/search_channel_with_permissions_provider.jsx';
 
 jest.mock('stores/redux_store', () => ({
+    dispatch: jest.fn(),
     getState: jest.fn(),
 }));
 

--- a/components/terms_of_service/terms_of_service.jsx
+++ b/components/terms_of_service/terms_of_service.jsx
@@ -20,6 +20,7 @@ import {Constants} from 'utils/constants.jsx';
 
 export default class TermsOfService extends React.PureComponent {
     static propTypes = {
+        location: PropTypes.object,
         termsEnabled: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             getTermsOfService: PropTypes.func.isRequired,

--- a/components/terms_of_service/terms_of_service.test.jsx
+++ b/components/terms_of_service/terms_of_service.test.jsx
@@ -10,17 +10,19 @@ import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 
 jest.mock('actions/global_actions.jsx', () => ({
     emitUserLoggedOutEvent: jest.fn(),
+    redirectUserToDefaultTeam: jest.fn(),
 }));
 
 describe('components/terms_of_service/TermsOfService', () => {
-    const getTermsOfService = jest.fn();
-    const updateMyTermsOfServiceStatus = jest.fn();
+    const getTermsOfService = jest.fn().mockResolvedValue({data: {id: 'tos_id', text: 'tos_text'}});
+    const updateMyTermsOfServiceStatus = jest.fn().mockResolvedValue({data: true});
 
     const baseProps = {
         actions: {
             getTermsOfService,
             updateMyTermsOfServiceStatus,
         },
+        location: {search: ''},
         termsEnabled: true,
     };
 
@@ -57,9 +59,9 @@ describe('components/terms_of_service/TermsOfService', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should call updateTermsOfServiceStatus on registerUserAction', () => {
+    test('should call updateTermsOfServiceStatus on registerUserAction', async () => {
         const wrapper = shallow(<TermsOfService {...baseProps}/>);
-        wrapper.instance().registerUserAction({accepted: 'true', success: jest.fn()});
+        await wrapper.instance().registerUserAction(true, jest.fn());
         expect(baseProps.actions.updateMyTermsOfServiceStatus).toHaveBeenCalledTimes(1);
     });
 

--- a/utils/notifications.test.jsx
+++ b/utils/notifications.test.jsx
@@ -106,7 +106,7 @@ describe('Notifications.showNotification', () => {
         };
 
         // Call one to deny and mark as already requested
-        Notifications.showNotification();
+        await expect(Notifications.showNotification()).rejects.toThrow('Notifications not granted');
 
         // Try again
         await expect(Notifications.showNotification()).rejects.toThrow('Notifications already requested but not granted');


### PR DESCRIPTION
#### Summary
Clean up UnhandledPromiseRejectionWarning when running unit tests

I spent lots of time to make the test fail whenever 'unhandledRejection' occurred but I couldn't make it right.  I'd appreciate for others to look into it.

#### Ticket Link
Jira ticket: [MM-13397](https://mattermost.atlassian.net/browse/MM-13397)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
