### PR TITLE
MM-13085: fix React warning passing unexpected prop to DOM

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -580,6 +580,7 @@ export default class SuggestionBox extends React.Component {
         Reflect.deleteProperty(props, 'containerClass');
         Reflect.deleteProperty(props, 'replaceAllInputOnSelect');
         Reflect.deleteProperty(props, 'renderDividers');
+        Reflect.deleteProperty(props, 'contextId');
 
         // This needs to be upper case so React doesn't think it's an html tag
         const SuggestionListComponent = listComponent;


### PR DESCRIPTION
#### Summary
A minor follow up to https://github.com/mattermost/mattermost-webapp/pull/2155 after observing a warning from React.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13085

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
