### PR TITLE
MM-13425: Fix set header option in DM/GM dropdown.

### DIFF
--- a/components/channel_header_dropdown/menu_items/set_channel_header.js
+++ b/components/channel_header_dropdown/menu_items/set_channel_header.js
@@ -20,31 +20,39 @@ const SetChannelHeader = ({channel, isArchived, isReadonly}) => {
         return null;
     }
 
+    let menuItem = (
+        <li role='presentation'>
+            <ToggleModalButtonRedux
+                id='channelEditHeader'
+                role='menuitem'
+                modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
+                dialogType={EditChannelHeaderModal}
+                dialogProps={{channel}}
+            >
+                <FormattedMessage
+                    id='channel_header.setHeader'
+                    defaultMessage='Edit Channel Header'
+                />
+            </ToggleModalButtonRedux>
+        </li>
+    );
+
     const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
     const permission = isPrivate ? Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES : Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES;
 
-    return (
-        <ChannelPermissionGate
-            channelId={channel.id}
-            teamId={channel.team_id}
-            permissions={[permission]}
-        >
-            <li role='presentation'>
-                <ToggleModalButtonRedux
-                    id='channelEditHeader'
-                    role='menuitem'
-                    modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
-                    dialogType={EditChannelHeaderModal}
-                    dialogProps={{channel}}
-                >
-                    <FormattedMessage
-                        id='channel_header.setHeader'
-                        defaultMessage='Edit Channel Header'
-                    />
-                </ToggleModalButtonRedux>
-            </li>
-        </ChannelPermissionGate>
-    );
+    if (channel.type !== Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL) {
+        menuItem = (
+            <ChannelPermissionGate
+                channelId={channel.id}
+                teamId={channel.team_id}
+                permissions={[permission]}
+            >
+                {menuItem}
+            </ChannelPermissionGate>
+        );
+    }
+
+    return menuItem;
 };
 
 SetChannelHeader.propTypes = {

--- a/components/channel_header_dropdown/menu_items/set_channel_header.test.js
+++ b/components/channel_header_dropdown/menu_items/set_channel_header.test.js
@@ -46,18 +46,100 @@ describe('components/ChannelHeaderDropdown/MenuItem.SetChannelHeader', () => {
         expect(wrapper.isEmptyRender()).toBeTruthy();
     });
 
-    it('should requires right permission level for channel type to manage header', () => {
+    it('should not be permissions gated for a DM channel', () => {
+        const props = {
+            ...baseProps,
+            channel: {
+                ...baseProps.channel,
+                type: Constants.DM_CHANNEL,
+            },
+        };
+        const wrapper = shallow(<SetChannelHeader {...props}/>);
+
+        expect(wrapper).toMatchInlineSnapshot(`
+<li
+  role="presentation"
+>
+  <Connect(ModalToggleButtonRedux)
+    dialogProps={
+      Object {
+        "channel": Object {
+          "id": "channel_id",
+          "team_id": "team_id",
+          "type": "D",
+        },
+      }
+    }
+    dialogType={[Function]}
+    id="channelEditHeader"
+    modalId="edit_channel_header"
+    role="menuitem"
+  >
+    <FormattedMessage
+      defaultMessage="Edit Channel Header"
+      id="channel_header.setHeader"
+      values={Object {}}
+    />
+  </Connect(ModalToggleButtonRedux)>
+</li>
+`);
+    });
+
+    it('should not be permissions gated for a GM channel', () => {
+        const props = {
+            ...baseProps,
+            channel: {
+                ...baseProps.channel,
+                type: Constants.GM_CHANNEL,
+            },
+        };
+        const wrapper = shallow(<SetChannelHeader {...props}/>);
+
+        expect(wrapper).toMatchInlineSnapshot(`
+<li
+  role="presentation"
+>
+  <Connect(ModalToggleButtonRedux)
+    dialogProps={
+      Object {
+        "channel": Object {
+          "id": "channel_id",
+          "team_id": "team_id",
+          "type": "G",
+        },
+      }
+    }
+    dialogType={[Function]}
+    id="channelEditHeader"
+    modalId="edit_channel_header"
+    role="menuitem"
+  >
+    <FormattedMessage
+      defaultMessage="Edit Channel Header"
+      id="channel_header.setHeader"
+      values={Object {}}
+    />
+  </Connect(ModalToggleButtonRedux)>
+</li>
+`);
+    });
+
+    it('should requires right permission level for channel type to manage header in Public and Private channels', () => {
         const props = {
             ...baseProps,
             channel: {...baseProps.channel},
         };
         const makeWrapper = () => shallow(<SetChannelHeader {...props}/>);
 
-        // Public, DM, GM (is this correct?)
+        // Public Channel
         props.channel.type = Constants.OPEN_CHANNEL;
-        expect(makeWrapper().prop('permissions')[0]).toBe(Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES);
+        expect(makeWrapper().prop('permissions')[0]).toBe(
+            Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES
+        );
 
         props.channel.type = Constants.PRIVATE_CHANNEL;
-        expect(makeWrapper().prop('permissions')[0]).toBe(Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES);
+        expect(makeWrapper().prop('permissions')[0]).toBe(
+            Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES
+        );
     });
 });


### PR DESCRIPTION
#### Summary
Fix set header option in DM/GM dropdown. Should not depend on permissions for these channel types.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13425

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)