### PR TITLE
MM-13348: Fix TOS reappears on next page refresh

### DIFF
--- a/actions/views/root.js
+++ b/actions/views/root.js
@@ -9,20 +9,20 @@ import {ActionTypes} from 'utils/constants';
 
 export function loadMeAndConfig() {
     return async (dispatch) => {
-        // need to await for clientConfig first as it is required for loadMe
-        const clientConfig = await dispatch(getClientConfig());
+        // if any new promise needs to be added please be mindful of the order as it is used in root.jsx for redirection
         const promises = [
+            dispatch(getClientConfig()),
             dispatch(getLicenseConfig()),
         ];
 
-        if (document.cookie.indexOf('MMUSERID=') > -1) {
-            promises.push(dispatch(UserActions.loadMe()));
-        }
-
         const resolvedPromises = await Promise.all(promises);
 
-        // if any new promise needs to be added please be mindful of the order as it is used in root.jsx for redirection
-        return [clientConfig, ...resolvedPromises];
+        // need to await for clientConfig first as it is required for loadMe
+        if (document.cookie.indexOf('MMUSERID=') > -1) {
+            const loadMeResponse = await dispatch(UserActions.loadMe());
+        }
+
+        return [...resolvedPromises, loadMeResponse];
     };
 }
 

--- a/actions/views/root.js
+++ b/actions/views/root.js
@@ -8,10 +8,10 @@ import {Client4} from 'mattermost-redux/client';
 import {ActionTypes} from 'utils/constants';
 
 export function loadMeAndConfig() {
-    return (dispatch) => {
-        // if any new promise needs to be added please be mindful of the order as it is used in root.jsx for redirection
+    return async (dispatch) => {
+        // need to await for clientConfig first as it is required for loadMe
+        const clientConfig = await dispatch(getClientConfig());
         const promises = [
-            dispatch(getClientConfig()),
             dispatch(getLicenseConfig()),
         ];
 
@@ -19,7 +19,10 @@ export function loadMeAndConfig() {
             promises.push(dispatch(UserActions.loadMe()));
         }
 
-        return Promise.all(promises);
+        const resolvedPromises = await Promise.all(promises);
+
+        // if any new promise needs to be added please be mindful of the order as it is used in root.jsx for redirection
+        return [clientConfig, ...resolvedPromises];
     };
 }
 

--- a/actions/views/root.js
+++ b/actions/views/root.js
@@ -15,11 +15,12 @@ export function loadMeAndConfig() {
             dispatch(getLicenseConfig()),
         ];
 
+        // need to await for clientConfig first as it is required for loadMe
         const resolvedPromises = await Promise.all(promises);
 
-        // need to await for clientConfig first as it is required for loadMe
+        let loadMeResponse;
         if (document.cookie.indexOf('MMUSERID=') > -1) {
-            const loadMeResponse = await dispatch(UserActions.loadMe());
+            loadMeResponse = await dispatch(UserActions.loadMe());
         }
 
         return [...resolvedPromises, loadMeResponse];

--- a/actions/views/root.js
+++ b/actions/views/root.js
@@ -17,13 +17,11 @@ export function loadMeAndConfig() {
 
         // need to await for clientConfig first as it is required for loadMe
         const resolvedPromises = await Promise.all(promises);
-
-        let loadMeResponse;
         if (document.cookie.indexOf('MMUSERID=') > -1) {
-            loadMeResponse = await dispatch(UserActions.loadMe());
+            resolvedPromises.push(await dispatch(UserActions.loadMe()));
         }
 
-        return [...resolvedPromises, loadMeResponse];
+        return resolvedPromises;
     };
 }
 


### PR DESCRIPTION
#### Summary
`loadMe` method expects `clientConfig` to be loaded in advance. The value from `clientConfig` is used to load terms of service status and custom emoji conditionally.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13348

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Touches critical sections of the codebase (custom terms of service)
