### PR TITLE
MM-13243: Display the text version of an emoji if it's custom and cus…

### DIFF
--- a/components/post_emoji/index.jsx
+++ b/components/post_emoji/index.jsx
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
+import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 
 import {getEmojiMap} from 'selectors/emojis';
 
@@ -15,14 +16,16 @@ function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
     const emojiMap = getEmojiMap(state);
     const emoji = emojiMap.get(ownProps.name);
+    const isCustom = getCustomEmojisByName(state).has(ownProps.name);
+    const customEmojisAreEnabled = config.EnableCustomEmoji === 'true';
 
     let imageUrl = '';
     let displayTextOnly = false;
-    if (emoji) {
+    if (emoji && (!isCustom || (isCustom && customEmojisAreEnabled))) {
         imageUrl = getEmojiImageUrl(emoji);
     } else {
         displayTextOnly = state.entities.emojis.nonExistentEmoji.has(ownProps.name) ||
-            config.EnableCustomEmoji !== 'true' ||
+            !customEmojisAreEnabled ||
             config.ExperimentalEnablePostMetadata === 'true' ||
             getCurrentUserId(state) === '';
     }


### PR DESCRIPTION
#### Summary
Display the text version of an emoji if it's custom and the MM instance is configured to disable custom emoji.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13243

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)