### PR TITLE
MM-13430 Fix /purpose from the post textbox

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -16,6 +16,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import ConfirmModal from 'components/confirm_modal.jsx';
 import EditChannelHeaderModal from 'components/edit_channel_header_modal';
+import EditChannelPurposeModal from 'components/edit_channel_purpose_modal';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
 import FilePreview from 'components/file_preview/file_preview.jsx';
 import FileUpload from 'components/file_upload';
@@ -480,7 +481,14 @@ export default class CreatePost extends React.Component {
 
         const isDirectOrGroup = ((updateChannel.type === Constants.DM_CHANNEL) || (updateChannel.type === Constants.GM_CHANNEL));
         if (!isDirectOrGroup && trimRight(this.state.message) === '/purpose') {
-            GlobalActions.showChannelPurposeUpdateModal(updateChannel);
+            const editChannelPurposeModalData = {
+                modalId: ModalIdentifiers.EDIT_CHANNEL_PURPOSE,
+                dialogType: EditChannelPurposeModal,
+                dialogProps: {channel: updateChannel},
+            };
+
+            this.props.actions.openModal(editChannelPurposeModalData);
+
             this.setState({message: ''});
             return;
         }

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -17,7 +17,6 @@ import FileUpload from 'components/file_upload';
 jest.mock('actions/global_actions.jsx', () => ({
     emitLocalUserTypingEvent: jest.fn(),
     emitUserPostedEvent: jest.fn(),
-    showChannelPurposeUpdateModal: jest.fn(),
     showChannelNameUpdateModal: jest.fn(),
     toggleShortcutsModal: jest.fn(),
     postListScrollChange: jest.fn(),
@@ -339,10 +338,20 @@ describe('components/create_post', () => {
         form.simulate('Submit', {preventDefault: jest.fn()});
         expect(openModal).toHaveBeenCalledTimes(1);
         expect(openModal.mock.calls[0][0].modalId).toEqual(ModalIdentifiers.EDIT_CHANNEL_HEADER);
+        expect(openModal.mock.calls[0][0].dialogProps.channel).toEqual(currentChannelProp);
     });
 
     it('onSubmit test for "/purpose" message', () => {
-        const wrapper = shallow(createPost());
+        const openModal = jest.fn();
+
+        const wrapper = shallow(
+            createPost({
+                actions: {
+                    ...actionsProp,
+                    openModal,
+                },
+            })
+        );
 
         wrapper.setState({
             message: '/purpose',
@@ -350,7 +359,9 @@ describe('components/create_post', () => {
 
         const form = wrapper.find('#create_post');
         form.simulate('Submit', {preventDefault: jest.fn()});
-        expect(GlobalActions.showChannelPurposeUpdateModal).toHaveBeenCalledWith(currentChannelProp);
+        expect(openModal).toHaveBeenCalledTimes(1);
+        expect(openModal.mock.calls[0][0].modalId).toEqual(ModalIdentifiers.EDIT_CHANNEL_PURPOSE);
+        expect(openModal.mock.calls[0][0].dialogProps.channel).toEqual(currentChannelProp);
     });
 
     it('onSubmit test for "/rename" message', () => {
@@ -363,18 +374,6 @@ describe('components/create_post', () => {
         const form = wrapper.find('#create_post');
         form.simulate('Submit', {preventDefault: jest.fn()});
         expect(GlobalActions.showChannelNameUpdateModal).toHaveBeenCalledWith(currentChannelProp);
-    });
-
-    it('onSubmit test for "/purpose" message', () => {
-        const wrapper = shallow(createPost());
-
-        wrapper.setState({
-            message: '/purpose',
-        });
-
-        const form = wrapper.find('#create_post');
-        form.simulate('Submit', {preventDefault: jest.fn()});
-        expect(GlobalActions.showChannelPurposeUpdateModal).toHaveBeenCalledWith(currentChannelProp);
     });
 
     it('onSubmit test for "/unknown" message ', () => {


### PR DESCRIPTION
#### Summary
Accidentally broken when this modal was converted to use the controller as part of the channel header refactor.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13430