### PR TITLE
MM-13271 Fix for Leave team making 403 calls

### DIFF
--- a/actions/team_actions.jsx
+++ b/actions/team_actions.jsx
@@ -9,7 +9,7 @@ import {getUser} from 'mattermost-redux/actions/users';
 
 import {browserHistory} from 'utils/browser_history';
 
-export function removeUserFromTeam(teamId, userId) {
+export function removeUserFromTeamAndGetStats(teamId, userId) {
     return async (dispatch, getState) => {
         const response = await dispatch(TeamActions.removeUserFromTeam(teamId, userId));
         dispatch(getUser(userId));

--- a/components/admin_console/manage_teams_modal/index.jsx
+++ b/components/admin_console/manage_teams_modal/index.jsx
@@ -5,8 +5,8 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {updateTeamMemberSchemeRoles, getTeamMembersForUser, getTeamsForUser} from 'mattermost-redux/actions/teams';
+import {removeUserFromTeam} from 'mattermost-redux/actions/teams';
 
-import {removeUserFromTeam} from 'actions/team_actions.jsx';
 import {getCurrentLocale} from 'selectors/i18n';
 
 import ManageTeamsModal from './manage_teams_modal';

--- a/components/admin_console/manage_teams_modal/index.jsx
+++ b/components/admin_console/manage_teams_modal/index.jsx
@@ -4,8 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {updateTeamMemberSchemeRoles, getTeamMembersForUser, getTeamsForUser} from 'mattermost-redux/actions/teams';
-import {removeUserFromTeam} from 'mattermost-redux/actions/teams';
+import {updateTeamMemberSchemeRoles, getTeamMembersForUser, getTeamsForUser, removeUserFromTeam} from 'mattermost-redux/actions/teams';
 
 import {getCurrentLocale} from 'selectors/i18n';
 

--- a/components/leave_team_modal/index.js
+++ b/components/leave_team_modal/index.js
@@ -5,9 +5,9 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {removeUserFromTeam as leaveTeam} from 'mattermost-redux/actions/teams';
 
 import {toggleSideBarRightMenuAction} from 'actions/global_actions.jsx';
-import {removeUserFromTeam} from 'actions/team_actions';
 import {ModalIdentifiers} from 'utils/constants';
 
 import {isModalOpen} from 'selectors/views/modals';
@@ -29,7 +29,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            removeUserFromTeam,
+            leaveTeam,
             toggleSideBarRightMenu: toggleSideBarRightMenuAction,
         }, dispatch),
     };

--- a/components/leave_team_modal/leave_team_modal.jsx
+++ b/components/leave_team_modal/leave_team_modal.jsx
@@ -42,7 +42,7 @@ class LeaveTeamModal extends React.PureComponent {
              * An action to remove user from team
              */
 
-            removeUserFromTeam: PropTypes.func.isRequired,
+            leaveTeam: PropTypes.func.isRequired,
 
             /**
              * An action to toggle the right menu
@@ -70,7 +70,7 @@ class LeaveTeamModal extends React.PureComponent {
 
     handleSubmit = () => {
         this.props.onHide();
-        this.props.actions.removeUserFromTeam(this.props.currentTeamId, this.props.currentUserId);
+        this.props.actions.leaveTeam(this.props.currentTeamId, this.props.currentUserId);
         this.props.actions.toggleSideBarRightMenu();
     };
 

--- a/components/leave_team_modal/leave_team_modal.test.jsx
+++ b/components/leave_team_modal/leave_team_modal.test.jsx
@@ -14,7 +14,7 @@ describe('components/LeaveTeamModal', () => {
         show: false,
         isBusy: false,
         actions: {
-            removeUserFromTeam: jest.fn(),
+            leaveTeam: jest.fn(),
             toggleSideBarRightMenu: jest.fn(),
         },
 
@@ -35,16 +35,16 @@ describe('components/LeaveTeamModal', () => {
         expect(requiredProps.onHide).toHaveBeenCalledTimes(1);
     });
 
-    it('should call removeUserFromTeam and toggleSideBarRightMenu when ok is clicked', () => {
+    it('should call leaveTeam and toggleSideBarRightMenu when ok is clicked', () => {
         const wrapper = shallowWithIntl(<LeaveTeamModal {...requiredProps}/>).
             dive({disableLifecycleMethods: true});
         const ok = wrapper.find('.btn-danger').first();
 
         ok.simulate('click');
-        expect(requiredProps.actions.removeUserFromTeam).toHaveBeenCalledTimes(1);
+        expect(requiredProps.actions.leaveTeam).toHaveBeenCalledTimes(1);
         expect(requiredProps.actions.toggleSideBarRightMenu).toHaveBeenCalledTimes(1);
         expect(requiredProps.onHide).toHaveBeenCalledTimes(1);
-        expect(requiredProps.actions.removeUserFromTeam).
+        expect(requiredProps.actions.leaveTeam).
             toHaveBeenCalledWith(requiredProps.currentTeamId, requiredProps.currentUserId);
     });
 

--- a/components/team_members_dropdown/index.js
+++ b/components/team_members_dropdown/index.js
@@ -11,7 +11,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 
-import {removeUserFromTeam} from 'actions/team_actions.jsx';
+import {removeUserFromTeamAndGetStats} from 'actions/team_actions.jsx';
 
 import TeamMembersDropdown from './team_members_dropdown.jsx';
 
@@ -30,7 +30,7 @@ function mapDispatchToProps(dispatch) {
             getTeamStats,
             getChannelStats,
             updateTeamMemberSchemeRoles,
-            removeUserFromTeam,
+            removeUserFromTeamAndGetStats,
         }, dispatch),
     };
 }

--- a/components/team_members_dropdown/team_members_dropdown.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.jsx
@@ -55,7 +55,7 @@ export default class TeamMembersDropdown extends React.Component {
     }
 
     handleRemoveFromTeam = async () => {
-        const {data, error} = await this.props.actions.removeUserFromTeam(this.props.teamMember.team_id, this.props.user.id);
+        const {error} = await this.props.actions.removeUserFromTeam(this.props.teamMember.team_id, this.props.user.id);
         if (error) {
             this.setState({serverError: error.message});
         }

--- a/components/team_members_dropdown/team_members_dropdown.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.jsx
@@ -56,9 +56,7 @@ export default class TeamMembersDropdown extends React.Component {
 
     handleRemoveFromTeam = async () => {
         const {data, error} = await this.props.actions.removeUserFromTeam(this.props.teamMember.team_id, this.props.user.id);
-        if (data) {
-            this.props.actions.getTeamStats(this.props.teamMember.team_id);
-        } else if (error) {
+        if (error) {
             this.setState({serverError: error.message});
         }
     }

--- a/tests/redux/actions/team_actions.test.js
+++ b/tests/redux/actions/team_actions.test.js
@@ -88,8 +88,8 @@ describe('Actions.Team', () => {
         expect(TeamActions.addUsersToTeam).toHaveBeenCalledWith('teamId', ['123', '1234']);
     });
 
-    test('removeUserFromTeam', async () => {
-        await testStore.dispatch(Actions.removeUserFromTeam('teamId', '123'));
+    test('removeUserFromTeamAndGetStats', async () => {
+        await testStore.dispatch(Actions.removeUserFromTeamAndGetStats('teamId', '123'));
         expect(userActions.getUser).toHaveBeenCalledWith('123');
         expect(TeamActions.getTeamStats).toHaveBeenCalledWith('teamId');
         expect(channelActions.getChannelStats).toHaveBeenCalledWith('currentChannelId');


### PR DESCRIPTION
#### Summary
Fixes leave team making 403 calls.
  Using redux actions instead of team_action in web for just removing a user or to leave a team

  manage_members in team uses team_action in web so team and channel stats can be updated
  manage_teams in admin console does not require channel and team stat calls so using redux action instead

#### Ticket Link
[MM-13271](https://mattermost.atlassian.net/browse/MM-13271)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
