### PR TITLE
MM-13446 Properly clear MMUSERID cookie when EnableCookiesForSubdomains is enabled

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -29,6 +29,7 @@ import {handleNewPost} from 'actions/post_actions.jsx';
 import {stopPeriodicStatusUpdates} from 'actions/status_actions.jsx';
 import {loadNewDMIfNeeded, loadNewGMIfNeeded, loadProfilesForSidebar} from 'actions/user_actions.jsx';
 import {closeRightHandSide, closeMenu as closeRhsMenu, updateRhsState} from 'actions/views/rhs';
+import {clearUserCookie} from 'actions/views/root';
 import {close as closeLhs} from 'actions/views/lhs';
 import * as WebsocketActions from 'actions/websocket_actions.jsx';
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
@@ -302,7 +303,9 @@ export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = tr
         BrowserStore.clear();
         stopPeriodicStatusUpdates();
         WebsocketActions.close();
-        document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/';
+
+        clearUserCookie();
+
         browserHistory.push(redirectTo);
     }).catch(() => {
         browserHistory.push(redirectTo);

--- a/actions/views/root.js
+++ b/actions/views/root.js
@@ -36,3 +36,10 @@ export function loadTranslations(locale, url) {
         }).catch(() => {}); // eslint-disable-line no-empty-function
     };
 }
+
+export function clearUserCookie() {
+    // We need to clear the cookie both with and without the domain set because we can't tell if the server set
+    // the cookie with it. At this time, the domain will be set if ServiceSettings.EnableCookiesForSubdomains is true.
+    document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/';
+    document.cookie = `MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;domain=${window.location.hostname};path=/`;
+}

--- a/store/index.js
+++ b/store/index.js
@@ -12,6 +12,7 @@ import configureServiceStore from 'mattermost-redux/store';
 import reduxInitialState from 'mattermost-redux/store/initial_state';
 
 import {storageRehydrate} from 'actions/storage';
+import {clearUserCookie} from 'actions/views/root';
 import appReducer from 'reducers';
 import {transformSet} from 'store/utils';
 import {detect} from 'utils/network.js';
@@ -148,7 +149,7 @@ export default function configureStore(initialState) {
                         purging = true;
 
                         persistor.purge().then(() => {
-                            document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+                            clearUserCookie();
 
                             // Preserve any query string parameters on logout, including parameters
                             // used by the application such as extra and redirect_to.


### PR DESCRIPTION
Ever since that setting was added, we haven't been clearing the MMUSERID cookie correctly which means that the client thinks it should still be logged in which means that the app tries to load some data about the current user when it's opened. Previously, this would just cause some harmless 401 errors, but then nothing else would happen because [no user would've been loaded](https://github.com/mattermost/mattermost-webapp/blob/release-5.5/components/root/root.jsx#L243). 

In an attempt to fix the bug where it redirects you to `/select_team` sometimes on slow connections, we changed how the redirect to the default team was done so that it would send the user to the default team [as long as loadMe returned successful](https://github.com/mattermost/mattermost-webapp/blob/release-5.6/components/root/root.jsx#L228). The problem with this is that [loadMe is always successful](https://github.com/mattermost/mattermost-redux/blob/master/src/actions/users.js#L258). Also note that loadMe is only called [if the MMUSERID cookie is set](https://github.com/mattermost/mattermost-webapp/blob/master/actions/views/root.js#L18).

Now, when the cookie isn't cleared after the user has been logged out and has been sent to `/`:
1. The Root component will call loadMe which will cause a 401 error but return successfully
2. Since loadMe was "successful", that same component will send you to `/select_team`
3. The SelectTeam component will [send some requests](https://github.com/mattermost/mattermost-webapp/blob/master/components/select_team/select_team.jsx#L54) which will fail with a 401 error.
4. mattermost-redux sees that 401 error and [triggers a logout](https://github.com/mattermost/mattermost-redux/blob/master/src/actions/helpers.js#L18) since it thinks your session has been revoked.
5. The webapp sees that you've been logged out, so it sends you back to `/` while once again [failing to clear the MMUSERID cookie](https://github.com/mattermost/mattermost-webapp/blob/master/store/index.js#L151).
6. Go to step 1 and get stuck in a redirect loop

I've tested this with the setting both enabled and disabled on Firefox/Chrome/Edge/Desktop App on Windows, Safari on Mac, and Safari on iOS. I was unable to test ~~IE11 due to [master being broken](https://mattermost.atlassian.net/browse/MM-13478)~~ or on the classic app due to [being unable to log back in on it](https://mattermost.atlassian.net/browse/MM-13477).

**Edit:** I tested IE11 by cherry picking the fix onto 5.6

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13446

#### Checklist
- Touches critical sections of the codebase (auth, posting, etc.)
