### PR TITLE
[MM-13216] Add E2E for CTRL/CMD+K functionality

### DIFF
--- a/components/quick_switch_modal/__snapshots__/quick_switch_modal.test.jsx.snap
+++ b/components/quick_switch_modal/__snapshots__/quick_switch_modal.test.jsx.snap
@@ -38,6 +38,7 @@ exports[`components/QuickSwitchModal should match snapshot 1`] = `
   >
     <div
       className="modal__hint"
+      id="quickSwitchHint"
     >
       <FormattedMessage
         defaultMessage="Type to find a channel. Use ↑↓ to browse, ↵ to select, ESC to dismiss."
@@ -50,6 +51,7 @@ exports[`components/QuickSwitchModal should match snapshot 1`] = `
       completeOnTab={false}
       containerClass=""
       delayInputUpdate={true}
+      id="quickSwitchInput"
       isRHS={false}
       listComponent={[Function]}
       listStyle="bottom"

--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -264,10 +264,14 @@ export default class QuickSwitchModal extends React.PureComponent {
                 <Modal.Header closeButton={true}/>
                 <Modal.Body>
                     {header}
-                    <div className='modal__hint'>
+                    <div
+                        id='quickSwitchHint'
+                        className='modal__hint'
+                    >
                         {help}
                     </div>
                     <SuggestionBox
+                        id='quickSwitchInput'
                         ref={this.setSwitchBoxRef}
                         className='form-control focused'
                         onChange={this.onChange}

--- a/components/suggestion/suggestion_list.jsx
+++ b/components/suggestion/suggestion_list.jsx
@@ -179,6 +179,7 @@ export default class SuggestionList extends React.PureComponent {
         return (
             <div className={mainClass}>
                 <div
+                    id='suggestionList'
                     ref='content'
                     className={contentClass}
                 >

--- a/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -7,6 +7,8 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+/* eslint max-nested-callbacks: ["error", 3] */
+
 describe('Account Settings > Sidebar > Channel Switcher', () => {
     before(() => {
         // 1. Go to Account Settings with "user-1"
@@ -47,7 +49,7 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         cy.get('#accountSettingsHeader > .close').should('be.visible');
     });
 
-    it('change channel setting to Off', () => {
+    it('change channel switcher setting to Off', () => {
         // 4. Click the radio button for "Off"
         cy.get('#channelSwitcherSectionOff').click();
 
@@ -65,7 +67,7 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         cy.get('#sidebarSwitcherButton').should('be.not.visible');
     });
 
-    it('change channel setting to On', () => {
+    it('change channel switcher setting to On', () => {
         // 1. Return to Account Settings modal
         cy.toAccountSettingsModal('user-1', true);
 
@@ -93,5 +95,74 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
 
         // * Channel Switcher button should appear at the bottom of the left-hand-side bar
         cy.get('#sidebarSwitcherButton').should('be.visible');
+    });
+
+    it('set channel switcher setting to On and test on click of sidebar switcher button', () => {
+        // 1. Go to Account Settings modal > Sidebar > Channel Switcher and set setting to On
+        cy.toAccountSettingsModalChannelSwitcher('user-1');
+
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+
+        // 3. Click the sidebar switcher button
+        cy.get('#sidebarSwitcherButton').click();
+
+        // * Channel switcher hint should be visible
+        cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use ↑↓ to browse, ↵ to select, ESC to dismiss.');
+
+        // 4. Type "nt" on Channel switcher input
+        cy.get('#quickSwitchInput').type('nt');
+        cy.wait(500);  // eslint-disable-line
+
+        // * Suggestion list should be visible
+        cy.get('#suggestionList').should('be.visible');
+
+        // 5. Press down arrow and then enter
+        cy.get('#quickSwitchInput').type('{downarrow}{enter}');
+
+        // * Verify that it redirected into "nesciunt" as selected channel
+        cy.url().should('include', '/ad-1/channels/sequi-7');
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'nesciunt');
+    });
+
+    it('set channel switcher setting to On and test on press of Ctrl/Cmd+K', () => {
+        // 1. Go to Account Settings modal > Sidebar > Channel Switcher and set setting to On
+        cy.toAccountSettingsModalChannelSwitcher('user-1');
+
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+
+        // 3. Type CTRL/CMD+K
+        cy.typeCmdOrCtrl().type('K', {release: true});
+
+        // * Channel switcher hint should be visible
+        cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use ↑↓ to browse, ↵ to select, ESC to dismiss.');
+
+        // 4. Type "comm" on Channel switcher input
+        cy.get('#quickSwitchInput').type('comm');
+        cy.wait(500);  // eslint-disable-line
+
+        // * Suggestion list should be visible
+        cy.get('#suggestionList').should('be.visible');
+
+        // 5. Press enter
+        cy.get('#quickSwitchInput').type('{enter}');
+
+        // * Verify that it redirected into "commodi" as selected channel
+        cy.url().should('include', '/ad-1/channels/autem-2');
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'commodi');
+    });
+
+    it('set channel switcher setting to Off and test on press of Ctrl/Cmd+K', () => {
+        // 1. Go to Account Settings modal > Sidebar > Channel Switcher and set setting to Off
+        cy.toAccountSettingsModalChannelSwitcher('user-1', false);
+
+        // 2. Type CTRL/CMD+K
+        cy.typeCmdOrCtrl().type('K', {release: true});
+
+        // * Channel switcher should still be accessible
+        cy.get('#quickSwitchHint').should('be.visible');
     });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -20,6 +20,11 @@ Cypress.Commands.add('login', (username, {otherUsername, otherPassword, otherURL
     });
 });
 
+// ***********************************************************
+// Account Settings Modal
+// ***********************************************************
+
+// Go to Account Settings modal
 Cypress.Commands.add('toAccountSettingsModal', (username, isLoggedInAlready = false, {otherUsername, otherPassword, otherURL} = {}) => {
     if (!isLoggedInAlready) {
         cy.login('user-1', {otherUsername, otherPassword, otherURL});
@@ -31,3 +36,49 @@ Cypress.Commands.add('toAccountSettingsModal', (username, isLoggedInAlready = fa
     cy.get('#accountSettings').should('be.visible').click();
     cy.get('#accountSettingsModal').should('be.visible');
 });
+
+// Go to Account Settings modal > Sidebar > Channel Switcher
+Cypress.Commands.add('toAccountSettingsModalChannelSwitcher', (username, setToOn = true) => {
+    cy.toAccountSettingsModal(username);
+
+    cy.get('#sidebarButton').should('be.visible');
+    cy.get('#sidebarButton').click();
+
+    let isOn;
+    cy.get('#channelSwitcherDesc').should((desc) => {
+        if (desc.length > 0) {
+            isOn = Cypress.$(desc[0]).text() === 'On';
+        }
+    });
+
+    cy.get('#channelSwitcherEdit').click();
+
+    if (isOn && !setToOn) {
+        cy.get('#channelSwitcherSectionOff').click();
+    } else if (!isOn && setToOn) {
+        cy.get('#channelSwitcherSectionEnabled').click();
+    }
+
+    cy.get('#saveSetting').click();
+    cy.get('#accountSettingsHeader > .close').click();
+});
+
+// ***********************************************************
+// Key Press
+// ***********************************************************
+
+// Type Cmd or Ctrl depending on OS
+Cypress.Commands.add('typeCmdOrCtrl', () => {
+    let cmdOrCtrl;
+    if (isMac()) {
+        cmdOrCtrl = '{cmd}';
+    } else {
+        cmdOrCtrl = '{ctrl}';
+    }
+
+    cy.get('#post_textbox').type(cmdOrCtrl, {release: false});
+});
+
+function isMac() {
+    return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+}


### PR DESCRIPTION
#### Summary
- added E2E for CTRL/CMD+K functionality - on click of button and on key press
- added elements IDs to QuickSwitchModal such as `quickSwitchHint` and `quickSwitchInput`
- added commands such as `toAccountSettingsModalChannelSwitcher` and `typeCmdOrCtrl`

#### Ticket Link
Jira ticket: [MM-13216](https://mattermost.atlassian.net/browse/MM-13216)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
