### PR TITLE
[MM-13222] Add E2E to permalink view on timestamp click

### DIFF
--- a/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
+++ b/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
@@ -6,7 +6,30 @@ exports[`components/post_view/PostInfo hideEmojiPicker, should have called props
 >
   <div
     className="col"
-  />
+  >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+    <Connect(PostFlagIcon)
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+  </div>
   <div
     className="col col__reply"
   />
@@ -19,7 +42,30 @@ exports[`components/post_view/PostInfo reactEmojiClick, should have called props
 >
   <div
     className="col"
-  />
+  >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+    <Connect(PostFlagIcon)
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+  </div>
   <div
     className="col col__reply"
   />
@@ -32,7 +78,30 @@ exports[`components/post_view/PostInfo removePost, should have called props.acti
 >
   <div
     className="col"
-  />
+  >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+    <Connect(PostFlagIcon)
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+  </div>
   <div
     className="col col__reply"
   />
@@ -45,7 +114,30 @@ exports[`components/post_view/PostInfo should match snapshot 1`] = `
 >
   <div
     className="col"
-  />
+  >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+    <Connect(PostFlagIcon)
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+  </div>
   <div
     className="col col__reply"
   />
@@ -58,7 +150,30 @@ exports[`components/post_view/PostInfo should match snapshot, compact display 1`
 >
   <div
     className="col"
-  />
+  >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+    <Connect(PostFlagIcon)
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+  </div>
   <div
     className="col col__reply"
   />
@@ -71,7 +186,30 @@ exports[`components/post_view/PostInfo should match snapshot, enable emoji picke
 >
   <div
     className="col"
-  />
+  >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+    <Connect(PostFlagIcon)
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+  </div>
   <div
     className="col col__reply"
   />
@@ -84,7 +222,18 @@ exports[`components/post_view/PostInfo should match snapshot, ephemeral deleted 
 >
   <div
     className="col"
-  />
+  >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+  </div>
   <div
     className="col col__remove"
   >
@@ -106,6 +255,16 @@ exports[`components/post_view/PostInfo should match snapshot, ephemeral post 1`]
   <div
     className="col"
   >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
     <span
       className="post__visibility"
     >
@@ -137,12 +296,27 @@ exports[`components/post_view/PostInfo should match snapshot, flagged post 1`] =
   <div
     className="col"
   >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
     <Connect(PostFlagIcon)
       idCount={-1}
       idPrefix="centerPostFlag"
       isEphemeral={false}
       isFlagged={true}
       postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "hidden",
+        }
+      }
     />
   </div>
   <div
@@ -162,6 +336,11 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
       eventTime={1502715365009}
       isPermalink={true}
       postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "hidden",
+        }
+      }
     />
     <Connect(PostFlagIcon)
       idCount={-1}
@@ -169,6 +348,11 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
       isEphemeral={false}
       isFlagged={false}
       postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "hidden",
+        }
+      }
     />
   </div>
   <div
@@ -222,7 +406,30 @@ exports[`components/post_view/PostInfo should match snapshot, military time 1`] 
 >
   <div
     className="col"
-  />
+  >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+    <Connect(PostFlagIcon)
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+  </div>
   <div
     className="col col__reply"
   />
@@ -236,6 +443,16 @@ exports[`components/post_view/PostInfo should match snapshot, pinned post 1`] = 
   <div
     className="col"
   >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
     <span
       className="post__pinned-badge"
     >
@@ -245,6 +462,18 @@ exports[`components/post_view/PostInfo should match snapshot, pinned post 1`] = 
         values={Object {}}
       />
     </span>
+    <Connect(PostFlagIcon)
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
   </div>
   <div
     className="col col__reply"
@@ -263,6 +492,23 @@ exports[`components/post_view/PostInfo should match snapshot, showTimeWithoutHov
       eventTime={1502715365009}
       isPermalink={true}
       postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "hidden",
+        }
+      }
+    />
+    <Connect(PostFlagIcon)
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
     />
   </div>
   <div
@@ -277,7 +523,30 @@ exports[`components/post_view/PostInfo toggleEmojiPicker, should have called pro
 >
   <div
     className="col"
-  />
+  >
+    <Connect(PostTime)
+      eventTime={1502715365009}
+      isPermalink={true}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+    <Connect(PostFlagIcon)
+      idCount={-1}
+      idPrefix="centerPostFlag"
+      isEphemeral={false}
+      isFlagged={false}
+      postId="e584uzbwwpny9kengqayx5ayzw"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+    />
+  </div>
   <div
     className="col col__reply"
   >

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -298,7 +298,7 @@ export default class PostInfo extends React.PureComponent {
         const fromAutoResponder = PostUtils.fromAutoResponder(post);
 
         let flagIcon;
-        if (!isEphemeral && !post.failed && !isSystemMessage && (this.props.hover || this.props.isFlagged)) {
+        if (!isEphemeral && !post.failed && !isSystemMessage) {
             flagIcon = (
                 <PostFlagIcon
                     idPrefix='centerPostFlag'
@@ -306,6 +306,7 @@ export default class PostInfo extends React.PureComponent {
                     postId={post.id}
                     isFlagged={this.props.isFlagged}
                     isEphemeral={isEphemeral}
+                    style={{visibility: this.props.hover || this.props.isFlagged ? 'hidden' : 'visible'}}
                 />
             );
         }
@@ -345,21 +346,19 @@ export default class PostInfo extends React.PureComponent {
             );
         }
 
-        let postTime;
-        if (this.props.hover || this.props.showTimeWithoutHover) {
-            // timestamp should not be a permalink if the post has been deleted, is ephemeral message, or is pending
-            const isPermalink = !(isEphemeral ||
-                Posts.POST_DELETED === post.state ||
-                ReduxPostUtils.isPostPendingOrFailed(post));
+        // timestamp should not be a permalink if the post has been deleted, is ephemeral message, or is pending
+        const isPermalink = !(isEphemeral ||
+            Posts.POST_DELETED === post.state ||
+            ReduxPostUtils.isPostPendingOrFailed(post));
 
-            postTime = (
-                <PostTime
-                    isPermalink={isPermalink}
-                    eventTime={post.create_at}
-                    postId={post.id}
-                />
-            );
-        }
+        const postTime = (
+            <PostTime
+                isPermalink={isPermalink}
+                eventTime={post.create_at}
+                postId={post.id}
+                style={{visibility: this.props.hover || this.props.showTimeWithoutHover ? 'hidden' : 'visible'}}
+            />
+        );
 
         return (
             <div className='post__header--info'>

--- a/components/post_view/post_time/post_time.jsx
+++ b/components/post_view/post_time/post_time.jsx
@@ -52,6 +52,7 @@ export default class PostTime extends React.PureComponent {
 
         return (
             <Link
+                id={`permalink_${this.props.postId}`}
                 to={`${this.props.teamUrl}/pl/${this.props.postId}`}
                 className='post__permalink'
                 onClick={this.handleClick}

--- a/cypress/integration/post_message/permalink_view_spec.js
+++ b/cypress/integration/post_message/permalink_view_spec.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/* eslint max-nested-callbacks: ["error", 3] */
+
+describe('Permalink View', () => {
+    before(() => {
+        // 1. Go to Main Channel View with "user-1"
+        cy.toMainChannelView('user-1');
+    });
+
+    it('should render permalink view on click of timestamp', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post a message as "first message"
+        cy.get('#post_textbox').type('first message{enter}');
+
+        // 4. Post another message as "second message"
+        cy.get('#post_textbox').type('second message{enter}');
+
+        let lastPostId;
+
+        // * Check post list content
+        cy.get('#postListContent').each((postList) => {
+            const lastDivPost = postList[0].children[postList[0].children.length - 1];
+            if (lastDivPost && !lastPostId) {
+                lastPostId = lastDivPost.id.replace('post_', '');
+
+                // * Check that the last message posted is "second message"
+                cy.get(`#${lastPostId}_message`).should('contain', 'second message');
+
+                // * Check initial state that the last message posted is not highlighted
+                cy.get(`#${lastDivPost.id}`).should('be.visible').should('have.attr', 'class', 'post same--user same--root  current--user');
+
+                // * Check initial state that "the jump to recent messages" is not visible
+                cy.get('#archive-link-home').should('not.be.visible');
+
+                // * Check that the permalink ID for that last message is not visible
+                cy.get(`#permalink_${lastPostId}`).should('not.be.visible');
+
+                // 5. Click the permalink ID of that last post
+                cy.get(`#permalink_${lastPostId}`).click({force: true});
+
+                // * Check that the permalink ID for that last message is still not visible after clicking
+                cy.get(`#permalink_${lastPostId}`).should('not.be.visible');
+
+                // * Check that it redirected to the permalink
+                cy.url().should('include', `/ad-1/pl/${lastPostId}`);
+
+                // * Check that the post is highlighted on permalink view
+                cy.get(`#${lastDivPost.id}`).should('be.visible').should('have.attr', 'class', 'post post--highlight same--user same--root  current--user');
+
+                cy.get('#archive-link-home').
+                    should('be.visible').
+                    should('contain', 'Click here to jump to recent messages.');
+            }
+        });
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -20,6 +20,13 @@ Cypress.Commands.add('login', (username, {otherUsername, otherPassword, otherURL
     });
 });
 
+Cypress.Commands.add('toMainChannelView', (username, {otherUsername, otherPassword, otherURL} = {}) => {
+    cy.login('user-1', {otherUsername, otherPassword, otherURL});
+    cy.visit('/');
+
+    cy.get('#post_textbox').should('be.visible');
+});
+
 // ***********************************************************
 // Account Settings Modal
 // ***********************************************************


### PR DESCRIPTION
#### Summary
Add E2E to permalink view on timestamp click.

Note that it's impossible to test behaviour of `mouseover` without changing our logic of doing so.  Such limitation is not limited to Cypress but also to Selenium-based test framework.

To make it testable, I've changed the way we are rendering `PostTime` and `PostFlagIcon`.  Instead of mounting and unmounting on `mouseover` and `mouseleave` respectively, I keep it mounted and just set its style visibility to either hidden or visible.

#### Ticket Link
Jira ticket: [MM-13222](https://mattermost.atlassian.net/browse/MM-13222)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Added end-to-end test (Cypress)
