### PR TITLE
MM-13268 Fix dimensions of webhook images (5.7)

### DIFF
--- a/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
+++ b/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
@@ -73,12 +73,16 @@ exports[`components/post_view/MessageAttachment should call actions.doPostAction
               message="short text"
             />
           </Connect(ShowMore)>
-          <img
-            className="attachment__image"
-            height={200}
-            src="image_url"
-            width={200}
-          />
+          <div
+            className="attachment__image-container"
+          >
+            <img
+              className="attachment__image"
+              height={200}
+              src="image_url"
+              width={200}
+            />
+          </div>
           <div
             className="attachment-actions"
           >
@@ -189,12 +193,16 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
               message="short text"
             />
           </Connect(ShowMore)>
-          <img
-            className="attachment__image"
-            height={200}
-            src="image_url"
-            width={200}
-          />
+          <div
+            className="attachment__image-container"
+          >
+            <img
+              className="attachment__image"
+              height={200}
+              src="image_url"
+              width={200}
+            />
+          </div>
         </div>
         <div
           className="attachment__thumb-container"

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -313,11 +313,13 @@ export default class MessageAttachment extends React.PureComponent {
         if (attachment.image_url) {
             const imageDimensions = getFileDimensionsForDisplay(this.props.imagesMetadata[attachment.image_url], MAX_DIMENSIONS_IMAGE_URL);
             image = (
-                <img
-                    className='attachment__image'
-                    src={attachment.image_url}
-                    {...imageDimensions}
-                />
+                <div className='attachment__image-container'>
+                    <img
+                        className='attachment__image'
+                        src={attachment.image_url}
+                        {...imageDimensions}
+                    />
+                </div>
             );
         }
 

--- a/sass/layout/_webhooks.scss
+++ b/sass/layout/_webhooks.scss
@@ -206,10 +206,13 @@
             width: 95px;
         }
 
+        .attachment__image-container {
+            max-width: 500px;
+        }
+
         .attachment__image {
             margin-bottom: 1em;
             max-height: 300px;
-            max-width: 500px;
             border: 1px solid transparent;
 
             &.attachment__image--opengraph {


### PR DESCRIPTION
This is part of https://github.com/mattermost/mattermost-webapp/pull/2103 that will have to go directly into 5.7 since that one has already been merged into master.

Here are screenshots featuring a wide image:
![image](https://user-images.githubusercontent.com/3277310/49957500-01b69700-fed6-11e8-958c-94ee74f6ca71.png)
and a tall image:
![image](https://user-images.githubusercontent.com/3277310/49957508-0bd89580-fed6-11e8-9a64-c5cc820f1f23.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13268