### PR TITLE
MM-13494 Remove fixed class from body when announcement bar is unmounted

### DIFF
--- a/components/announcement_bar/announcement_bar.jsx
+++ b/components/announcement_bar/announcement_bar.jsx
@@ -28,6 +28,10 @@ export default class AnnouncementBar extends React.PureComponent {
         this.setBodyClass(!this.props.showCloseButton);
     }
 
+    componentWillUnmount() {
+        document.body.classList.remove('announcement-bar--fixed');
+    }
+
     componentDidUpdate(prevProps) {
         if (this.props.showCloseButton !== prevProps.showCloseButton) {
             this.setBodyClass(!this.props.showCloseButton);


### PR DESCRIPTION
#### Summary
Remove fixed class from body when announcement bar is unmounted.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13494