### PR TITLE
[MM-7865] Option to send as message when an invalid slash command is entered in RHS chat

### DIFF
--- a/actions/views/create_comment.jsx
+++ b/actions/views/create_comment.jsx
@@ -119,7 +119,7 @@ export function submitCommand(channelId, rootId, draft) {
 }
 
 export function makeOnSubmit(channelId, rootId, latestPostId) {
-    return () => async (dispatch, getState) => {
+    return (options = {}) => async (dispatch, getState) => {
         const draft = getPostDraft(getState(), StoragePrefixes.COMMENT_DRAFT, rootId);
         const {message} = draft;
 
@@ -134,7 +134,7 @@ export function makeOnSubmit(channelId, rootId, latestPostId) {
 
         if (isReaction && emojiMap.has(isReaction[2])) {
             dispatch(submitReaction(latestPostId, isReaction[1], isReaction[2]));
-        } else if (message.indexOf('/') === 0) {
+        } else if (message.indexOf('/') === 0 && !options.ignoreSlash) {
             await dispatch(submitCommand(channelId, rootId, draft));
         } else {
             dispatch(submitPost(channelId, rootId, draft));


### PR DESCRIPTION
#### Summary

Follow up PR for https://github.com/mattermost/mattermost-webapp/pull/1969.

Currently when a user enters an invalid slash command in the RHS chat, they are asked to add a space at the beginning to allow for sending their message, if they wish to just send the text as a message.

This ticket's feature is to allow the user to click a link within the displayed error to "force send" the message, skipping the slash command processing. Pressing "enter" for a second time will send the message as well.

The linked PR fixed the issue in the main post chat, but not in the RHS chat.

#### Ticket Link
[Jira Ticket](https://mattermost.atlassian.net/browse/MM-7865)
[GitHub Ticket](https://github.com/mattermost/mattermost-server/issues/8338)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, posting, etc.)