### PR TITLE
MM-13552: use .size, not .length, for Set returned from getUserIdsInChannels

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -207,8 +207,8 @@ export async function loadProfilesForGM() {
             continue;
         }
 
-        const userIds = userIdsInChannels[channel.id] || [];
-        if (userIds.length >= Constants.MIN_USERS_IN_GM) {
+        const userIds = userIdsInChannels[channel.id] || new Set([]);
+        if (userIds.size >= Constants.MIN_USERS_IN_GM) {
             continue;
         }
 

--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -207,7 +207,7 @@ export async function loadProfilesForGM() {
             continue;
         }
 
-        const userIds = userIdsInChannels[channel.id] || new Set([]);
+        const userIds = userIdsInChannels[channel.id] || new Set();
         if (userIds.size >= Constants.MIN_USERS_IN_GM) {
             continue;
         }


### PR DESCRIPTION
#### Summary
See `getUserIdsInChannels`:
https://github.com/mattermost/mattermost-redux/blob/632cda350e295aa0d7af07905c879b5014ca9456/src/selectors/entities/users.js#L25-L27

the reducer:
https://github.com/mattermost/mattermost-redux/blob/632cda350e295aa0d7af07905c879b5014ca9456/src/reducers/entities/users.js#L249-L258

and the `profilesListToSet` helper function that returns a `Set`:
https://github.com/mattermost/mattermost-redux/blob/5687cacdd95db4303aa7b4460776816770df038a/src/reducers/entities/users.js#L21-L36

But as per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set,
> Set.length
The value of the length property is 0.
To count how many elements are in a Set, use Set.prototype.size.

There is at least one other case in the code where we're using `length` on a `Set`, and likely others, but this is the most visible issue at present. We should do a holistic pass to verify the semantics on using `Set.size`. Testing this is easy in practice, but much harder to write a unit test given the need to mock the store and unwind the selector tree hierarchy, so I skipped that for expediency.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13552

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)