### PR TITLE
MM-13569 Add a check for percent value on upload progress to prevent app from crashing

### DIFF
--- a/components/file_preview/__snapshots__/file_progress_preview.test.jsx.snap
+++ b/components/file_preview/__snapshots__/file_progress_preview.test.jsx.snap
@@ -74,3 +74,65 @@ exports[`component/file_preview/file_progress_preview should match snapshot 1`] 
   </div>
 </div>
 `;
+
+exports[`component/file_preview/file_progress_preview snapshot for percent value undefined 1`] = `
+<div
+  className="file-preview post-image__column"
+  data-client-id="clientId"
+  key="clientId"
+>
+  <div
+    className="post-image__thumbnail"
+  >
+    <div
+      className="file-icon image"
+    />
+  </div>
+  <div
+    className="post-image__details"
+  >
+    <div
+      className="post-image__detail_wrapper"
+    >
+      <div
+        className="post-image__detail"
+      >
+        <FilenameOverlay
+          canDownload={false}
+          compactDisplay={false}
+          fileInfo={
+            Object {
+              "name": "file",
+              "percent": undefined,
+              "type": "image/png",
+            }
+          }
+          handleImageClick={null}
+          index="clientId"
+        />
+        <span
+          className="post-image__uploadingTxt"
+        >
+          <FormattedMessage
+            defaultMessage="Uploading..."
+            id="admin.plugin.uploading"
+            values={Object {}}
+          />
+          <span />
+        </span>
+      </div>
+    </div>
+    <div>
+      <a
+        className="file-preview__remove"
+        onClick={[Function]}
+      >
+        <i
+          className="fa fa-remove"
+          title="Remove Icon"
+        />
+      </a>
+    </div>
+  </div>
+</div>
+`;

--- a/components/file_preview/file_progress_preview.jsx
+++ b/components/file_preview/file_progress_preview.jsx
@@ -28,7 +28,7 @@ export default class FileProgressPreview extends React.PureComponent {
         const {fileInfo, clientId} = this.props;
         if (fileInfo) {
             percent = fileInfo.percent;
-            const percentTxt = ` (${percent.toFixed(0)}%)`;
+            const percentTxt = percent && ` (${percent.toFixed(0)}%)`;
             const fileType = getFileTypeFromMime(fileInfo.type);
             previewImage = <div className={'file-icon ' + Utils.getIconClassName(fileType)}/>;
 
@@ -57,11 +57,13 @@ export default class FileProgressPreview extends React.PureComponent {
                             </React.Fragment>
                         )}
                     </span>
-                    <ProgressBar
-                        className='post-image__progressBar'
-                        now={percent}
-                        active={percent === 100}
-                    />
+                    {percent && (
+                        <ProgressBar
+                            className='post-image__progressBar'
+                            now={percent}
+                            active={percent === 100}
+                        />
+                    )}
                 </React.Fragment>
             );
         }

--- a/components/file_preview/file_progress_preview.test.jsx
+++ b/components/file_preview/file_progress_preview.test.jsx
@@ -27,4 +27,19 @@ describe('component/file_preview/file_progress_preview', () => {
         );
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('snapshot for percent value undefined', () => {
+        const props = {
+            ...baseProps,
+            fileInfo: {
+                ...fileInfo,
+                percent: undefined,
+            },
+        };
+
+        const wrapper = shallow(
+            <FileProgressPreview {...props}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Summary
  * Progress percent can be undefined if the file size is unknown
    so adding a check to not show progress bar and avoid toFixed conversion

If percent is unknown this PR hides progress bar and percent value from the UI.
![dec-19-2018 22-47-14](https://user-images.githubusercontent.com/4973621/50237346-a8bd9600-03e2-11e9-9e94-00118c6d652c.gif)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13569

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes

