### PR TITLE
MM-13437 Deleting a reply from center channel should not show "This post has ... comments" in confirmation modal

### DIFF
--- a/components/delete_post_modal/__snapshots__/delete_post_modal.test.jsx.snap
+++ b/components/delete_post_modal/__snapshots__/delete_post_modal.test.jsx.snap
@@ -214,3 +214,106 @@ exports[`components/delete_post_modal should match snapshot for delete_post_moda
   </ModalFooter>
 </Modal>
 `;
+
+exports[`components/delete_post_modal should match snapshot for post with 1 commentCount and is not rootPost 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={false}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onEntered={[Function]}
+  onExited={[MockFunction]}
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Confirm {term} Delete"
+        id="delete_post.confirm"
+        values={
+          Object {
+            "term": <FormattedMessage
+              defaultMessage="Comment"
+              id="delete_post.comment"
+              values={Object {}}
+            />,
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <FormattedMessage
+      defaultMessage="Are you sure you want to delete this {term}?"
+      id="delete_post.question"
+      values={
+        Object {
+          "term": <FormattedMessage
+            defaultMessage="Comment"
+            id="delete_post.comment"
+            values={Object {}}
+          />,
+        }
+      }
+    />
+    <br />
+    <br />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-default"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="delete_post.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      autoFocus={true}
+      className="btn btn-danger"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Delete"
+        id="delete_post.del"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;

--- a/components/delete_post_modal/delete_post_modal.jsx
+++ b/components/delete_post_modal/delete_post_modal.jsx
@@ -75,7 +75,7 @@ export default class DeletePostModal extends React.PureComponent {
 
     render() {
         var commentWarning = '';
-        if (this.props.commentCount > 0) {
+        if (this.props.commentCount > 0 && this.props.post.root_id === '') {
             commentWarning = (
                 <FormattedMessage
                     id='delete_post.warning'

--- a/components/delete_post_modal/delete_post_modal.test.jsx
+++ b/components/delete_post_modal/delete_post_modal.test.jsx
@@ -15,6 +15,7 @@ describe('components/delete_post_modal', () => {
         message: 'test',
         channel_id: '5',
         type: '',
+        root_id: '',
     };
 
     const baseProps = {
@@ -37,6 +38,25 @@ describe('components/delete_post_modal', () => {
     test('should match snapshot for delete_post_modal with 1 comment', () => {
         const commentCount = 1;
         const props = {...baseProps, commentCount};
+        const wrapper = shallow(
+            <DeletePostModal {...props}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot for post with 1 commentCount and is not rootPost', () => {
+        const commentCount = 1;
+        const postObj = {
+            ...post,
+            root_id: '1234',
+        };
+
+        const props = {
+            ...baseProps,
+            commentCount,
+            post: postObj,
+        };
+
         const wrapper = shallow(
             <DeletePostModal {...props}/>
         );


### PR DESCRIPTION
#### Summary
 * Check if the post is rootPost to decide if we need to show 'This post has ...comments'. commentCount is not enough to decide if we need to show the message. 
  Incase of RHS we have `rhs_comment` and `rhs_root_post` and we avoid sending the commentCount for for rootPost so it works.


#### Ticket Link
[MM-13437](https://mattermost.atlassian.net/browse/MM-13437)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
