### PR TITLE
MM-13574 Fix cut off of mention count on team sidebar

### DIFF
--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -74,7 +74,6 @@
         background-color: alpha-color($black, .2);
         height: 100%;
         overflow: hidden;
-        padding-top: 15px;
 
         .team-container {
             display: flex;
@@ -128,6 +127,10 @@
                 @include opacity(.5);
                 cursor: not-allowed;
             }
+        }
+
+        .scrollbar--view {
+            padding-top: 15px;
         }
 
         .team-container a:hover {


### PR DESCRIPTION
#### Summary
Fixes mention count getting cutoff from first team in teambar

#### Ticket Link
[MM-13574](https://mattermost.atlassian.net/browse/MM-13574)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes

<img width="253" alt="screenshot 2018-12-21 at 9 30 23 pm" src="https://user-images.githubusercontent.com/4973621/50351437-3b3b7200-0568-11e9-89ea-dcdd7b21d701.png">
