### PR TITLE
[GH-10035] Added the cypress spec for cancel out leave a team modal

### DIFF
--- a/components/leave_team_modal/__snapshots__/leave_team_modal.test.jsx.snap
+++ b/components/leave_team_modal/__snapshots__/leave_team_modal.test.jsx.snap
@@ -9,6 +9,7 @@ exports[`components/LeaveTeamModal should render the leave team model 1`] = `
   className="modal-confirm"
   dialogComponentClass={[Function]}
   enforceFocus={true}
+  id="leaveTeamModal"
   keyboard={true}
   manager={
     ModalManager {
@@ -59,6 +60,7 @@ exports[`components/LeaveTeamModal should render the leave team model 1`] = `
   >
     <button
       className="btn btn-default"
+      id="leaveTeamNo"
       onClick={[MockFunction]}
       type="button"
     >

--- a/components/leave_team_modal/leave_team_modal.jsx
+++ b/components/leave_team_modal/leave_team_modal.jsx
@@ -80,6 +80,7 @@ class LeaveTeamModal extends React.PureComponent {
                 className='modal-confirm'
                 show={this.props.show}
                 onHide={this.props.onHide}
+                id='leaveTeamModal'
             >
                 <Modal.Header closeButton={false}>
                     <Modal.Title>
@@ -100,6 +101,7 @@ class LeaveTeamModal extends React.PureComponent {
                         type='button'
                         className='btn btn-default'
                         onClick={this.props.onHide}
+                        id='leaveTeamNo'
                     >
                         <FormattedMessage
                             id='leave_team_modal.no'

--- a/cypress/integration/team/teams_spec.js
+++ b/cypress/integration/team/teams_spec.js
@@ -18,18 +18,28 @@ describe('Teams Suite', () => {
         // * check the team name
         cy.get('#headerTeamName').should('contain', 'eligendi');
 
+        // * check the initialUrl
+        cy.url().should('include', '/ad-1/channels/town-square');
+
         // 2. open the drop down menu
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
 
         // 3. click the leave team
         cy.get('#sidebarDropdownMenu #leaveTeam').should('be.visible').click();
 
+        // * Check that the "leave team modal" opened up
+        cy.get('#leaveTeamModal').should('be.visible');
+
         // 4. click on no
-        cy.get('.modal-content .modal-footer .btn-default').should('be.visible');
-        cy.get('.modal-content .modal-footer .btn-default').should('contain', 'No');
-        cy.get('.modal-content .modal-footer .btn-default').click();
+        cy.get('#leaveTeamNo').click();
+
+        // * Check that the "leave team modal" closed
+        cy.get('#leaveTeamModal').should('not.be.visible');
 
         // * check the team name
         cy.get('#headerTeamName').should('contain', 'eligendi');
+
+        // * check the finalUrl
+        cy.url().should('include', '/ad-1/channels/town-square');
     });
 });

--- a/cypress/integration/team/teams_spec.js
+++ b/cypress/integration/team/teams_spec.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+describe('Teams Suite', () => {
+    before(() => {
+        // 1. Login and go to /
+        cy.login('user-1');
+        cy.visit('/');
+    });
+
+    it('Cancel out of leaving a team', () => {
+        // * check the team name
+        cy.get('#headerTeamName').should('contain', 'eligendi');
+
+        // 2. open the drop down menu
+        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
+
+        // 3. click the leave team
+        cy.get('#sidebarDropdownMenu #leaveTeam').should('be.visible').click();
+
+        // 4. click on no
+        cy.get('.modal-content .modal-footer .btn-default').should('be.visible');
+        cy.get('.modal-content .modal-footer .btn-default').should('contain', 'No');
+        cy.get('.modal-content .modal-footer .btn-default').click();
+
+        // * check the team name
+        cy.get('#headerTeamName').should('contain', 'eligendi');
+    });
+});


### PR DESCRIPTION
#### Summary
Added the cypress test for the case "cancel out leave a team modal"

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10035

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed