### PR TITLE
[MM-13590] Fix posts padding when 12H time format is used

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -711,7 +711,7 @@
 .post {
     @include legacy-pie-clearfix;
     max-width: 100%;
-    padding: 8px .5em 0 1em;
+    padding: 8px .5em 0 1.5em;
     position: relative;
     word-wrap: break-word;
 
@@ -1134,7 +1134,7 @@
 
     &.same--root {
         &.same--user {
-            padding: 0 .5em 0 1em;
+            padding: 0 .5em 0 1.5em;
 
             &:hover,
             &.post--hovered {

--- a/sass/responsive/_tablet.scss
+++ b/sass/responsive/_tablet.scss
@@ -474,7 +474,7 @@
 
                     .flag-icon__container {
                         .sidebar--right & {
-                            left: 26px;
+                            left: 30px;
                         }
                     }
 
@@ -490,7 +490,7 @@
                         width: 51px;
 
                         .sidebar--right & {
-                            left: -24px;
+                            left: -20px;
                         }
 
                         &:hover {


### PR DESCRIPTION
#### Summary
Fix posts padding when 12H time format is used to avoid cluttering of the left sidebar.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13590

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes