### PR TITLE
Fix snapshot test of delete post modal

### DIFF
--- a/components/delete_post_modal/__snapshots__/delete_post_modal.test.jsx.snap
+++ b/components/delete_post_modal/__snapshots__/delete_post_modal.test.jsx.snap
@@ -292,7 +292,7 @@ exports[`components/delete_post_modal should match snapshot for post with 1 comm
     componentClass="div"
   >
     <button
-      className="btn btn-default"
+      className="btn btn-link"
       onClick={[Function]}
       type="button"
     >


### PR DESCRIPTION
#### Summary
WebApp builds are currently broken, because a Snapshot test is failing. This PR fixes the snapshot.