### PR TITLE
MM-13612: Always shows 'view members' for default channel.

### DIFF
--- a/components/channel_header_dropdown/menu_items/__snapshots__/view_and_manage_members.test.js.snap
+++ b/components/channel_header_dropdown/menu_items/__snapshots__/view_and_manage_members.test.js.snap
@@ -65,20 +65,11 @@ exports[`components/ChannelHeaderDropdown/MenuItem.ViewAndManageMembers should m
     modalId="channel_members"
     role="menuitem"
   >
-    <Connect(ChannelPermissionGate)
-      invert={false}
-      permissions={
-        Array [
-          "manage_public_channel_members",
-        ]
-      }
-    >
-      <FormattedMessage
-        defaultMessage="View Members"
-        id="channel_header.viewMembers"
-        values={Object {}}
-      />
-    </Connect(ChannelPermissionGate)>
+    <FormattedMessage
+      defaultMessage="View Members"
+      id="channel_header.viewMembers"
+      values={Object {}}
+    />
   </Connect(ModalToggleButtonRedux)>
 </li>
 `;

--- a/components/channel_header_dropdown/menu_items/view_and_manage_members.js
+++ b/components/channel_header_dropdown/menu_items/view_and_manage_members.js
@@ -23,6 +23,12 @@ const ViewAndManageMembers = ({channel, isDefault}) => {
 
     const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
     const permission = isPrivate ? Permissions.MANAGE_PRIVATE_CHANNEL_MEMBERS : Permissions.MANAGE_PUBLIC_CHANNEL_MEMBERS;
+    const viewMembersMessage = (
+        <FormattedMessage
+            id='channel_header.viewMembers'
+            defaultMessage='View Members'
+        />
+    );
 
     return (
         <li role='presentation'>
@@ -34,28 +40,27 @@ const ViewAndManageMembers = ({channel, isDefault}) => {
                 dialogProps={{channel}}
             >
                 {!isDefault &&
-                    <ChannelPermissionGate
-                        channelId={channel.id}
-                        teamId={channel.team_id}
-                        permissions={[permission]}
-                    >
-                        <FormattedMessage
-                            id='channel_header.manageMembers'
-                            defaultMessage='Manage Members'
-                        />
-                    </ChannelPermissionGate>
-                }
-                <ChannelPermissionGate
-                    channelId={channel.id}
-                    teamId={channel.team_id}
-                    permissions={[permission]}
-                    invert={!isDefault}
-                >
-                    <FormattedMessage
-                        id='channel_header.viewMembers'
-                        defaultMessage='View Members'
-                    />
-                </ChannelPermissionGate>
+                    <>
+                        <ChannelPermissionGate
+                            channelId={channel.id}
+                            teamId={channel.team_id}
+                            permissions={[permission]}
+                        >
+                            <FormattedMessage
+                                id='channel_header.manageMembers'
+                                defaultMessage='Manage Members'
+                            />
+                        </ChannelPermissionGate>
+                        <ChannelPermissionGate
+                            channelId={channel.id}
+                            teamId={channel.team_id}
+                            permissions={[permission]}
+                            invert={!isDefault}
+                        >
+                            {viewMembersMessage}
+                        </ChannelPermissionGate>
+                    </>}
+                {isDefault && viewMembersMessage}
             </ToggleModalButtonRedux>
         </li>
     );

--- a/components/channel_header_dropdown/menu_items/view_and_manage_members.js
+++ b/components/channel_header_dropdown/menu_items/view_and_manage_members.js
@@ -55,7 +55,7 @@ const ViewAndManageMembers = ({channel, isDefault}) => {
                             channelId={channel.id}
                             teamId={channel.team_id}
                             permissions={[permission]}
-                            invert={!isDefault}
+                            invert={true}
                         >
                             {viewMembersMessage}
                         </ChannelPermissionGate>


### PR DESCRIPTION
#### Summary
Always displays "view members" for the default channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13612

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)