### PR TITLE
MM-13580: disable red favicon

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -218,7 +218,10 @@ export default class Sidebar extends React.PureComponent {
         }
 
         this.updateTitle();
-        this.setBadgesActiveAndFavicon();
+
+        // Don't modify favicon for now: https://mattermost.atlassian.net/browse/MM-13643.
+        // this.setBadgesActiveAndFavicon();
+
         this.setFirstAndLastUnreadChannels();
         this.updateUnreadIndicators();
     }


### PR DESCRIPTION
#### Summary
A previous feature that showed a red favicon for mentions somehow got re-enabled recently, presumably by fixing something else upstream. Until UX has a chance to revisit this feature, we're disabling it properly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13580

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed