### PR TITLE
Fix getMyChannelMember selector usage

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -96,7 +96,7 @@ export function emitChannelClickEvent(channel) {
             type: ActionTypes.SELECT_CHANNEL_WITH_MEMBER,
             data: chan.id,
             channel: chan,
-            member,
+            member: member || {},
         }]));
     }
 

--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -49,7 +49,7 @@ export function sendDesktopNotification(post, msgProps) {
         const userStatus = getStatusForUserId(state, user.id);
         const member = getMyChannelMember(state, post.channel_id);
 
-        if (isChannelMuted(member) || userStatus === UserStatuses.DND || userStatus === UserStatuses.OUT_OF_OFFICE) {
+        if (!member || isChannelMuted(member) || userStatus === UserStatuses.DND || userStatus === UserStatuses.OUT_OF_OFFICE) {
             return;
         }
 


### PR DESCRIPTION
#### Summary
As part of the migration to flow the getMyChannelMember will return null
instead of {}. This PR handle that properly.

The mattermost-redux change was made here: mattermost/mattermost-redux#749

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Needs to be implemented in mobile (mattermost/mattermost-mobile#2493)
- [x] Has redux changes (mattermost/mattermost-redux#749)