### PR TITLE
MM-13473 Added cypress tests for Message Draft - Pencil Icon

### DIFF
--- a/components/sidebar/sidebar_channel/__snapshots__/sidebar_channel.test.jsx.snap
+++ b/components/sidebar/sidebar_channel/__snapshots__/sidebar_channel.test.jsx.snap
@@ -9,6 +9,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="D"
     displayName="Channel display name"
@@ -35,6 +36,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="D"
     displayName="Channel display name"
@@ -59,6 +61,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test"
     channelIsArchived={false}
+    channelName="town-square"
     channelStatus="test"
     channelType="O"
     displayName="Town Square"
@@ -87,6 +90,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={true}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="D"
     displayName="Channel display name"
@@ -111,6 +115,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="D"
     displayName="Channel display name"
@@ -135,6 +140,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="D"
     displayName={
@@ -169,6 +175,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="town-square"
     channelStatus="test"
     channelType="P"
     displayName="Channel display name"
@@ -193,6 +200,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="town-square"
     channelStatus="test"
     channelType="O"
     displayName="Channel display name"
@@ -217,6 +225,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="D"
     displayName="Channel display name"
@@ -241,6 +250,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="P"
     displayName="Channel display name"
@@ -265,6 +275,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="P"
     displayName="Channel display name"
@@ -289,6 +300,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="D"
     displayName={
@@ -323,6 +335,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="P"
     displayName="Channel display name"
@@ -347,6 +360,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="P"
     displayName="Channel display name"
@@ -371,6 +385,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="O"
     displayName="Channel display name"
@@ -395,6 +410,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     badge={false}
     channelId="test-channel-id"
     channelIsArchived={false}
+    channelName="channel-name"
     channelStatus="test"
     channelType="O"
     displayName="Channel display name"

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -285,6 +285,7 @@ export default class SidebarChannel extends React.PureComponent {
                     link={link}
                     rowClass={rowClass}
                     channelId={this.props.channelId}
+                    channelName={this.props.channelName}
                     channelStatus={this.props.channelStatus}
                     channelType={this.props.channelType}
                     displayName={displayName}

--- a/components/sidebar/sidebar_channel_button_or_link/__snapshots__/sidebar_channel_button_or_link.test.jsx.snap
+++ b/components/sidebar/sidebar_channel_button_or_link/__snapshots__/sidebar_channel_button_or_link.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOrLink should match snapshot, on desktop with draft 1`] = `
 <Link
   className="test-class"
+  id="sidebarItem_test-channel-name"
   onClick={[Function]}
   replace={false}
   to="test-link"
@@ -36,6 +37,7 @@ exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOr
 exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOrLink should match snapshot, on desktop with mentions badge 1`] = `
 <Link
   className="test-class"
+  id="sidebarItem_test-channel-name"
   onClick={[Function]}
   replace={false}
   to="test-link"
@@ -74,6 +76,7 @@ exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOr
 exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOrLink should match snapshot, on desktop without badge 1`] = `
 <Link
   className="test-class"
+  id="sidebarItem_test-channel-name"
   onClick={[Function]}
   replace={false}
   to="test-link"
@@ -106,6 +109,7 @@ exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOr
 exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOrLink should match snapshot, on non-desktop with mentions badge 1`] = `
 <Link
   className="test-class"
+  id="sidebarItem_test-channel-name"
   onClick={[Function]}
   replace={false}
   to="test-link"
@@ -144,6 +148,7 @@ exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOr
 exports[`component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonOrLink should match snapshot, on non-desktop without badge 1`] = `
 <Link
   className="test-class"
+  id="sidebarItem_test-channel-name"
   onClick={[Function]}
   replace={false}
   to="test-link"

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
@@ -19,6 +19,7 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
         rowClass: PropTypes.string.isRequired,
         channelType: PropTypes.string.isRequired,
         channelId: PropTypes.string.isRequired,
+        channelName: PropTypes.string.isRequired,
         displayName: PropTypes.oneOfType([
             PropTypes.string,
             PropTypes.object,
@@ -93,6 +94,7 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
         } else {
             element = (
                 <Link
+                    id={`sidebarItem_${this.props.channelName}`}
                     to={this.props.link}
                     className={this.props.rowClass}
                     onClick={this.trackChannelSelectedEvent}

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.test.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.test.jsx
@@ -13,6 +13,7 @@ describe('component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonO
             <SidebarChannelButtonOrLink
                 channelType={Constants.DM_CHANNEL}
                 channelId={'test-channel-id'}
+                channelName={'test-channel-name'}
                 channelStatus={'test'}
                 link={'test-link'}
                 rowClass={'test-class'}
@@ -35,6 +36,7 @@ describe('component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonO
             <SidebarChannelButtonOrLink
                 channelType={Constants.DM_CHANNEL}
                 channelId={'test-channel-id'}
+                channelName={'test-channel-name'}
                 channelStatus={'test'}
                 link={'test-link'}
                 rowClass={'test-class'}
@@ -57,6 +59,7 @@ describe('component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonO
             <SidebarChannelButtonOrLink
                 channelType={Constants.DM_CHANNEL}
                 channelId={'test-channel-id'}
+                channelName={'test-channel-name'}
                 channelStatus={'test'}
                 link={'test-link'}
                 rowClass={'test-class'}
@@ -89,6 +92,7 @@ describe('component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonO
             <SidebarChannelButtonOrLink
                 channelType={Constants.DM_CHANNEL}
                 channelId={'test-channel-id'}
+                channelName={'test-channel-name'}
                 channelStatus={'test'}
                 link={'test-link'}
                 rowClass={'test-class'}
@@ -114,6 +118,7 @@ describe('component/sidebar/sidebar_channel_button_or_link/SidebarChannelButtonO
             <SidebarChannelButtonOrLink
                 channelType={Constants.DM_CHANNEL}
                 channelId={'test-channel-id'}
+                channelName={'test-channel-name'}
                 channelStatus={'test'}
                 link={'test-link'}
                 rowClass={'test-class'}

--- a/components/svg/draft_icon.jsx
+++ b/components/svg/draft_icon.jsx
@@ -8,7 +8,10 @@ import {localizeMessage} from 'utils/utils.jsx';
 export default class DraftIcon extends React.PureComponent {
     render() {
         return (
-            <span {...this.props}>
+            <span
+                {...this.props}
+                id='draftIcon'
+            >
                 <svg
                     width='14px'
                     height='14px'

--- a/cypress/integration/channel/message_draft_spec.js
+++ b/cypress/integration/channel/message_draft_spec.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+describe('Message Draft', () => {
+    before(() => {
+        // 1. Login and go to /
+        cy.login('user-1');
+        cy.visit('/');
+    });
+
+    it('should show the pencil draft icon on the channel with a draft on the sidebar', () => {
+        // 1. Got to a test channel on the side bar
+        cy.get('#sidebarItem_town-square').should('be.visible').click();
+
+        // * Validate if the channel has been opened
+        cy.url().should('include', '/ad-1/channels/town-square');
+
+        // * Validate if the draft icon is not visible on the sidebar before making a draft
+        cy.get('#sidebarItem_town-square #draftIcon').should('be.not.visible');
+
+        //2. Type in some text into the text area of the opened channel
+        cy.get('#post_textbox').type('comm');
+
+        //3. Go to another test channel without submitting the draft in the previous channel
+        cy.get('#sidebarItem_ratione-1').should('be.visible').click();
+
+        //* Validate if the newly navigated channel is open
+        cy.url().should('include', '/ad-1/channels/ratione-1');
+
+        //* Validate if the draft icon is visible on side bar on the previous channel with a draft
+        cy.get('#sidebarItem_town-square #draftIcon').should('be.visible');
+    });
+});


### PR DESCRIPTION
#### Summary
Added automated tests using cypress for the following scenario
"Message Draft - Pencil Icon"
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13473

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
