### PR TITLE
MM-13580: explicitly configure a favicon

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -257,6 +257,7 @@ var config = {
             filename: 'root.html',
             inject: 'head',
             template: 'root.html',
+            favicon: 'images/favicon/favicon-16x16.png',
         }),
         new CopyWebpackPlugin([
             {from: 'images/emoji', to: 'emoji'},


### PR DESCRIPTION
#### Summary
My testing for MM-13580 must have run into some caching issues, since the code I commented out was actually responsible for initializing the favicon the first time (accidentally, I'd argue, given the test of `false !== 0` passing the first time). Anyway, to avoid this I've just configured Webpack to explicitly define a favicon. This change injects a `<link rel="shortcut icon" href="/static/favicon-16x16.png">` into the root.html.

It's worth noting that this approach ensures a favicon even before login occurs, as seen (currently) on https://ci-linux-mysql-prev.mattermost.com/login, for example.

One consideration is how this might affect custom branding, but I suspect the asset in question was just replaced manually before anyway.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13580
