### PR TITLE
MM-13014 Do not try to load posts if channel ID is undefined

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -385,6 +385,10 @@ export default class PostList extends React.PureComponent {
     }
 
     loadPosts = async (channelId, focusedPostId) => {
+        if (!channelId) {
+            return;
+        }
+
         let posts;
         if (focusedPostId) {
             const getPostThreadAsync = this.props.actions.getPostThread(focusedPostId, false);


### PR DESCRIPTION
#### Summary
Sometimes we don't have the channel on initial mount so we were trying to request the posts with an undefined channel ID.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13014