### PR TITLE
MM-13603 Manifest for mobile browser

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -274,6 +274,7 @@ var config = {
         new WebpackPwaManifest({
             name: 'Mattermost',
             short_name: 'Mattermost',
+            start_url: '..',
             description: 'Mattermost is an open source, self-hosted Slack-alternative',
             background_color: '#ffffff',
             inject: true,


### PR DESCRIPTION
#### Summary
The `start_url` for the manifest.json was not being set so the default value of `start_url: "."` was included in the manifest.json file that pointed to `<URL>/static` as that's where the manifest.json file is hosted, by changing that value now the URL is picked up correctly

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13603
