### PR TITLE
MM-13723: Guard against null imagesMetadata.

### DIFF
--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -366,7 +366,7 @@ class LoginController extends React.Component {
                         src={Client4.getBrandImageUrl(0)}
                     />
                     <div>
-                        {messageHtmlToComponent(formattedText, false, {mentions: false})}
+                        {messageHtmlToComponent(formattedText, false, {mentions: false, imagesMetadata: null})}
                     </div>
                 </div>
             );

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -17,6 +17,7 @@ import PostEmoji from 'components/post_emoji';
  * - images - If specified, markdown images are replaced with the image component. Defaults to true.
  * - imageProps - If specified, any extra props that should be passed into the image component.
  * - latex - If specified, latex is replaced with the LatexBlock component. Defaults to true.
+ * - imagesMetadata - the dimensions of the image as retrieved from post.metadata.images.
  */
 export function messageHtmlToComponent(html, isRHS, options = {}) {
     if (!html) {
@@ -81,7 +82,7 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
                 return (
                     <SizeAwareImage
                         className={className}
-                        dimensions={options.imagesMetadata[attribs.src]}
+                        dimensions={options.imagesMetadata && options.imagesMetadata[attribs.src]}
                         {...attribs}
                         {...options.imageProps}
                     />


### PR DESCRIPTION
#### Summary
Guard agains null image metadata because the feature can be disabled or the text being rendered may not be a post.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13723

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)