### PR TITLE
MM-13680 Modify return value of getLanguages

### DIFF
--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -161,8 +161,9 @@ export function getLanguages() {
     if (!config.AvailableLocales) {
         return getAllLanguages();
     }
-
-    return config.AvailableLocales.split(',').filter((l) => languages[l]).map((l) => languages[l]);
+    const availables = {};
+    config.AvailableLocales.split(',').filter((l) => languages[l]).map((l) => Object.assign(availables, {[l]: languages[l]}));
+    return availables;
 }
 
 export function getLanguageInfo(locale) {

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -161,9 +161,12 @@ export function getLanguages() {
     if (!config.AvailableLocales) {
         return getAllLanguages();
     }
-    const availables = {};
-    config.AvailableLocales.split(',').filter((l) => languages[l]).map((l) => Object.assign(availables, {[l]: languages[l]}));
-    return availables;
+    return config.AvailableLocales.split(',').reduce((result, l) => {
+        if (languages[l]) {
+            result[l] = languages[l];
+        }
+        return result;
+    }, {});
 }
 
 export function getLanguageInfo(locale) {


### PR DESCRIPTION
#### Summary
`isLanguageAvailable` expect that the return value of `getLanguages` is following format.

```
{
    "en": { value: 'en', name: 'English',...},
    "ja": { value: 'ja', name: '日本語',...}
}
```

However, actually `getLanguages` returns 

```
[
    { value: 'en', name: 'English',...},
    { value: 'ja', name: '日本語',...}
]
```

So `isLanguageAvailable` always returns false. 

#### Ticket Link
[Language not set is selected in "Account Settings"\. · Issue \#10051 · mattermost/mattermost\-server](https://github.com/mattermost/mattermost-server/issues/10051)[MM-13680](https://mattermost.atlassian.net/browse/MM-13680)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
