### PR TITLE
MM-13712 remove user is typing when the user post the message

### DIFF
--- a/actions/post_actions.test.js
+++ b/actions/post_actions.test.js
@@ -41,6 +41,10 @@ jest.mock('utils/user_agent', () => ({
 }));
 
 const POST_CREATED_TIME = Date.now();
+
+// This mocks the Date.now() function so it returns a constant value
+global.Date.now = jest.fn(() => POST_CREATED_TIME);
+
 const RECEIVED_POSTS = {
     channelId: 'current_channel_id',
     data: {order: [], posts: {new_post_id: {channel_id: 'current_channel_id', id: 'new_post_id', message: 'new message', type: '', user_id: 'some_user_id', create_at: POST_CREATED_TIME}}},

--- a/actions/post_utils.js
+++ b/actions/post_utils.js
@@ -68,7 +68,7 @@ export function lastPostActions(post, websocketMessageProps) {
             data: {
                 id: post.channel_id + post.root_id,
                 userId: post.user_id,
-                now: post.create_at,
+                now: Date.now(),
             },
         }];
 

--- a/actions/post_utils.test.js
+++ b/actions/post_utils.test.js
@@ -31,6 +31,10 @@ const MARK_CHANNEL_AS_VIEWED = {
     type: 'MOCK_MARK_CHANNEL_AS_VIEWED',
 };
 const POST_CREATED_TIME = Date.now();
+
+// This mocks the Date.now() function so it returns a constant value
+global.Date.now = jest.fn(() => POST_CREATED_TIME);
+
 const RECEIVED_POSTS = {
     channelId: 'current_channel_id',
     data: {order: [], posts: {new_post_id: {channel_id: 'current_channel_id', id: 'new_post_id', message: 'new message', type: '', user_id: 'some_user_id', create_at: POST_CREATED_TIME}}},


### PR DESCRIPTION
#### Summary
When a user starts writing a post we get the `user is typing...` showing in the UI and when the user posts the message the `user is typing...` should disappear as soon as the message is shown on screen.

Before we were using the timestamp when the post was created, but if the client has a few milliseconds off then the typing message was disappearing after the timeout and not as soon as the message got posted. This PR changes it so it uses the local client time instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13712

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
