### PR TITLE
MM-13674 Do not show announcement banner when text is empty

### DIFF
--- a/components/announcement_bar/announcement_bar_controller.jsx
+++ b/components/announcement_bar/announcement_bar_controller.jsx
@@ -27,7 +27,7 @@ export default class AnnouncementBarController extends React.PureComponent {
 
     render() {
         let adminConfiguredAnnouncementBar = null;
-        if (this.props.config.EnableBanner === 'true') {
+        if (this.props.config.EnableBanner === 'true' && this.props.config.BannerText.trim()) {
             adminConfiguredAnnouncementBar = (
                 <TextDismissableBar
                     color={this.props.config.BannerColor}


### PR DESCRIPTION
#### Summary
The announcement banner was being displayed when enabled and with a blank text, This PR ensures that the Announcement Banner is only displayed when the text is set.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13674

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
