### PR TITLE
MM-13801 Fix User Profile for root post in RHS

### DIFF
--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -258,6 +258,7 @@ export default class RhsRootPost extends React.Component {
             if (post.props.override_username && this.props.enablePostUsernameOverride) {
                 userProfile = (
                     <UserProfile
+                        key={post.user_id}
                         userId={post.user_id}
                         hideStatus={true}
                         overwriteName={post.props.override_username}
@@ -267,6 +268,7 @@ export default class RhsRootPost extends React.Component {
             } else {
                 userProfile = (
                     <UserProfile
+                        key={post.user_id}
                         userId={post.user_id}
                         hideStatus={true}
                         disablePopover={true}
@@ -278,6 +280,7 @@ export default class RhsRootPost extends React.Component {
         } else {
             userProfile = (
                 <UserProfile
+                    key={post.user_id}
                     userId={post.user_id}
                     isBusy={this.props.isBusy}
                     isRHS={true}


### PR DESCRIPTION
#### Summary
The User Profile component connector is using memoization to prevent the component to re-render when not necessary but it was not being updated when the prop for userId changed as the initialProps are also memoized.

With this PR we set a key to the `UserProfile` component to force it to re-render if the key changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13801

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
