### PR TITLE
MM-13761 Properly request external image through proxy when viewed in preview modal

### DIFF
--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -268,7 +268,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
     }
 
     renderImagePreview() {
-        const link = this.state.link;
+        let link = this.state.link;
         if (!link || !this.isLinkImage(link)) {
             return null;
         }
@@ -279,6 +279,8 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         }
 
         const ext = captureExt.exec(link)[1];
+
+        link = PostUtils.getImageSrc(link, this.props.hasImageProxy);
 
         return (
             <ViewImageModal

--- a/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
@@ -70,7 +70,7 @@ describe('components/post_view/PostBodyAdditionalContent', () => {
         expect(props.actions.toggleEmbedVisibility).toBeCalledWith('post_id_1');
     });
 
-    test('image link should go image through proxy in preview modal', () => {
+    test('image link should go through image proxy in preview modal', () => {
         const link = 'http://example.com/image.png';
 
         const props = {

--- a/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
@@ -5,6 +5,9 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import PostBodyAdditionalContent from 'components/post_view/post_body_additional_content/post_body_additional_content.jsx';
+import ViewImageModal from 'components/view_image';
+
+import * as PostUtils from 'utils/post_utils';
 
 describe('components/post_view/PostBodyAdditionalContent', () => {
     const post = {
@@ -65,5 +68,28 @@ describe('components/post_view/PostBodyAdditionalContent', () => {
         wrapper.instance().toggleEmbedVisibility();
         expect(props.actions.toggleEmbedVisibility).toHaveBeenCalledTimes(1);
         expect(props.actions.toggleEmbedVisibility).toBeCalledWith('post_id_1');
+    });
+
+    test('image link should go image through proxy in preview modal', () => {
+        const link = 'http://example.com/image.png';
+
+        const props = {
+            ...baseProps,
+            hasImageProxy: true,
+            post: {
+                ...post,
+                message: link,
+            },
+        };
+
+        const wrapper = shallow(
+            <PostBodyAdditionalContent {...props}>
+                <div/>
+            </PostBodyAdditionalContent>
+        );
+
+        const fileInfos = wrapper.find(ViewImageModal).prop('fileInfos');
+        expect(fileInfos.length).toBe(1);
+        expect(fileInfos[0].link).toBe(PostUtils.getImageSrc(link, true));
     });
 });


### PR DESCRIPTION
This one use of an external image link wasn't being passed through the proxy by either the server or web app, so we'll now make sure to do that before passing it to the ViewImageModal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13761

#### Checklist
- Added or updated unit tests (required for all new features).)
