### PR TITLE
MM-13857 Stop showing loading indicator when adding users from user list.

### DIFF
--- a/components/multiselect/multiselect.jsx
+++ b/components/multiselect/multiselect.jsx
@@ -120,7 +120,7 @@ export default class MultiSelect extends React.Component {
             return;
         }
 
-        if (this.state.input === '' && input === '') {
+        if (this.state.input === input) {
             return;
         }
 

--- a/components/multiselect/multiselect.jsx
+++ b/components/multiselect/multiselect.jsx
@@ -120,7 +120,7 @@ export default class MultiSelect extends React.Component {
             return;
         }
 
-        if(this.state.input === '' && input === '') {
+        if (this.state.input === '' && input === '') {
             return;
         }
 

--- a/components/multiselect/multiselect.jsx
+++ b/components/multiselect/multiselect.jsx
@@ -120,6 +120,10 @@ export default class MultiSelect extends React.Component {
             return;
         }
 
+        if(this.state.input === '' && input === '') {
+            return;
+        }
+
         this.setState({input});
 
         if (input === '') {


### PR DESCRIPTION
#### Summary
ReactSelect fires an InputChange event when adding names using the MultiSelectList. This causes the parent component to unnecessarily perform a search when names are added. This PR stops propagating the event up to the parent if the input value stored in the component state is blank and the new input value provided is also blank.

#### Ticket Link
[MM-13857](https://mattermost.atlassian.net/projects/MM/issues/MM-13857)

#### Checklist
- [X] Ran `make check-style` to check for style errors (required for all pull requests)
- [X] Ran `make test` to ensure unit and component tests passed