### PR TITLE
MM-13804 Do not revert other team themes to default theme

### DIFF
--- a/actions/user_actions.test.js
+++ b/actions/user_actions.test.js
@@ -4,6 +4,8 @@
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 
+import {Preferences} from 'mattermost-redux/constants';
+
 import * as UserActions from 'actions/user_actions';
 
 const mockStore = configureStore([thunk]);
@@ -33,6 +35,15 @@ jest.mock('mattermost-redux/actions/channels', () => {
     };
 });
 
+jest.mock('mattermost-redux/actions/preferences', () => {
+    const original = require.requireActual('mattermost-redux/actions/preferences');
+    return {
+        ...original,
+        deletePreferences: (...args) => ({type: 'MOCK_DELETE_PREFERENCES', args}),
+        savePreferences: (...args) => ({type: 'MOCK_SAVE_PREFERENCES', args}),
+    };
+});
+
 describe('Actions.User', () => {
     const initialState = {
         entities: {
@@ -50,11 +61,11 @@ describe('Actions.User', () => {
                 channels: {
                     current_channel_id: {
                         total_msg_count: 10,
-                        team_id: 'team_id',
+                        team_id: 'team_1',
                     },
                 },
                 channelsInTeam: {
-                    team_id: ['current_channel_id'],
+                    team_1: ['current_channel_id'],
                 },
                 membersInChannel: {
                     current_channel_id: {
@@ -62,32 +73,54 @@ describe('Actions.User', () => {
                     },
                 },
             },
+            preferences: {
+                myPreferences: {
+                    'theme--team_1': {
+                        category: 'theme',
+                        name: 'team_1',
+                        user_id: 'current_user_id',
+                        value: JSON.stringify(Preferences.THEMES.mattermostDark),
+                    },
+                },
+            },
             teams: {
-                currentTeamId: 'team_id',
+                currentTeamId: 'team_1',
                 teams: {
-                    team_id: {
-                        id: 'team_id',
+                    team_1: {
+                        id: 'team_1',
                         name: 'team-1',
                         displayName: 'Team 1',
                     },
+                    team_2: {
+                        id: 'team_2',
+                        name: 'team-2',
+                        displayName: 'Team 2',
+                    },
                 },
                 myMembers: {
-                    team_id: {roles: 'team_role'},
+                    team_1: {roles: 'team_role'},
+                    team_2: {roles: 'team_role'},
                 },
                 membersInTeam: {
-                    team_id: {
+                    team_1: {
+                        current_user_id: {id: 'current_user_id'},
+                    },
+                    team_2: {
                         current_user_id: {id: 'current_user_id'},
                     },
                 },
+            },
+            users: {
+                currentUserId: 'current_user_id',
             },
         },
     };
 
     test('loadProfilesAndTeamMembers', async () => {
-        const expectedActions = [{type: 'MOCK_GET_PROFILES_IN_TEAM', args: ['team_id', 0, 60]}];
+        const expectedActions = [{type: 'MOCK_GET_PROFILES_IN_TEAM', args: ['team_1', 0, 60]}];
 
         let testStore = await mockStore({});
-        await testStore.dispatch(UserActions.loadProfilesAndTeamMembers(0, 60, 'team_id'));
+        await testStore.dispatch(UserActions.loadProfilesAndTeamMembers(0, 60, 'team_1'));
         let actualActions = testStore.getActions();
         expect(actualActions[0].args).toEqual(expectedActions[0].args);
         expect(actualActions[0].type).toEqual(expectedActions[0].type);
@@ -103,7 +136,7 @@ describe('Actions.User', () => {
         const expectedActions = [{type: 'MOCK_GET_PROFILES_IN_CHANNEL', args: ['current_channel_id', 0, 60]}];
 
         let testStore = await mockStore({});
-        await testStore.dispatch(UserActions.loadProfilesAndTeamMembersAndChannelMembers(0, 60, 'team_id', 'current_channel_id'));
+        await testStore.dispatch(UserActions.loadProfilesAndTeamMembersAndChannelMembers(0, 60, 'team_1', 'current_channel_id'));
         let actualActions = testStore.getActions();
         expect(actualActions[0].args).toEqual(expectedActions[0].args);
         expect(actualActions[0].type).toEqual(expectedActions[0].type);
@@ -116,43 +149,43 @@ describe('Actions.User', () => {
     });
 
     test('loadTeamMembersForProfilesList', async () => {
-        const expectedActions = [{args: ['team_id', ['other_user_id']], type: 'MOCK_GET_TEAM_MEMBERS_BY_IDS'}];
+        const expectedActions = [{args: ['team_1', ['other_user_id']], type: 'MOCK_GET_TEAM_MEMBERS_BY_IDS'}];
 
         // should call getTeamMembersByIds since 'other_user_id' is not loaded yet
         let testStore = await mockStore(initialState);
-        await testStore.dispatch(UserActions.loadTeamMembersForProfilesList([{id: 'other_user_id'}], 'team_id'));
+        await testStore.dispatch(UserActions.loadTeamMembersForProfilesList([{id: 'other_user_id'}], 'team_1'));
         expect(testStore.getActions()).toEqual(expectedActions);
 
         // should not call getTeamMembersByIds since 'current_user_id' is already loaded
         testStore = await mockStore(initialState);
-        await testStore.dispatch(UserActions.loadTeamMembersForProfilesList([{id: 'current_user_id'}], 'team_id'));
+        await testStore.dispatch(UserActions.loadTeamMembersForProfilesList([{id: 'current_user_id'}], 'team_1'));
         expect(testStore.getActions()).toEqual([]);
 
         // should not call getTeamMembersByIds since no or empty profile is passed
         testStore = await mockStore(initialState);
-        await testStore.dispatch(UserActions.loadTeamMembersForProfilesList([], 'team_id'));
+        await testStore.dispatch(UserActions.loadTeamMembersForProfilesList([], 'team_1'));
         expect(testStore.getActions()).toEqual([]);
     });
 
     test('loadTeamMembersAndChannelMembersForProfilesList', async () => {
         const expectedActions = [
-            {args: ['team_id', ['other_user_id']], type: 'MOCK_GET_TEAM_MEMBERS_BY_IDS'},
+            {args: ['team_1', ['other_user_id']], type: 'MOCK_GET_TEAM_MEMBERS_BY_IDS'},
             {args: ['current_channel_id', ['other_user_id']], type: 'MOCK_GET_CHANNEL_MEMBERS_BY_IDS'},
         ];
 
         // should call getTeamMembersByIds and getChannelMembersByIds since 'other_user_id' is not loaded yet
         let testStore = await mockStore(initialState);
-        await testStore.dispatch(UserActions.loadTeamMembersAndChannelMembersForProfilesList([{id: 'other_user_id'}], 'team_id', 'current_channel_id'));
+        await testStore.dispatch(UserActions.loadTeamMembersAndChannelMembersForProfilesList([{id: 'other_user_id'}], 'team_1', 'current_channel_id'));
         expect(testStore.getActions()).toEqual(expectedActions);
 
         // should not call getTeamMembersByIds/getChannelMembersByIds since 'current_user_id' is already loaded
         testStore = await mockStore(initialState);
-        await testStore.dispatch(UserActions.loadTeamMembersForProfilesList([{id: 'current_user_id'}], 'team_id', 'current_channel_id'));
+        await testStore.dispatch(UserActions.loadTeamMembersForProfilesList([{id: 'current_user_id'}], 'team_1', 'current_channel_id'));
         expect(testStore.getActions()).toEqual([]);
 
         // should not call getTeamMembersByIds/getChannelMembersByIds since no or empty profile is passed
         testStore = await mockStore(initialState);
-        await testStore.dispatch(UserActions.loadTeamMembersForProfilesList([], 'team_id', 'current_channel_id'));
+        await testStore.dispatch(UserActions.loadTeamMembersForProfilesList([], 'team_1', 'current_channel_id'));
         expect(testStore.getActions()).toEqual([]);
     });
 
@@ -173,5 +206,57 @@ describe('Actions.User', () => {
         testStore = await mockStore(initialState);
         await testStore.dispatch(UserActions.loadChannelMembersForProfilesList([], 'current_channel_id'));
         expect(testStore.getActions()).toEqual([]);
+    });
+
+    test('saveTheme for a specific team', async () => {
+        const {currentUserId} = initialState.entities.users;
+        const {currentTeamId} = initialState.entities.teams;
+        const expectedActions = [{
+            args: [
+                currentUserId,
+                [{
+                    category: 'theme',
+                    name: currentTeamId,
+                    user_id: currentUserId,
+                    value: JSON.stringify(Preferences.THEMES.mattermostDark),
+                }],
+            ],
+            type: 'MOCK_SAVE_PREFERENCES',
+        }];
+        const testStore = await mockStore(initialState);
+
+        await testStore.dispatch(UserActions.saveTheme(currentTeamId, Preferences.THEMES.mattermostDark));
+        expect(testStore.getActions()).toEqual(expectedActions);
+    });
+
+    test('saveTheme for a all teams', async () => {
+        const {currentUserId} = initialState.entities.users;
+        const {currentTeamId} = initialState.entities.teams;
+        const expectedActions = [{
+            args: [
+                currentUserId,
+                [{
+                    category: 'theme',
+                    name: '',
+                    user_id: currentUserId,
+                    value: JSON.stringify(Preferences.THEMES.mattermostDark),
+                }],
+            ],
+            type: 'MOCK_SAVE_PREFERENCES',
+        }, {
+            args: [
+                currentUserId,
+                [{
+                    category: 'theme',
+                    name: currentTeamId,
+                    user_id: currentUserId,
+                }],
+            ],
+            type: 'MOCK_DELETE_PREFERENCES',
+        }];
+        const testStore = await mockStore(initialState);
+
+        await testStore.dispatch(UserActions.saveTheme('', Preferences.THEMES.mattermostDark));
+        expect(testStore.getActions()).toEqual(expectedActions);
     });
 });

--- a/components/user_settings/display/user_settings_theme/index.js
+++ b/components/user_settings/display/user_settings_theme/index.js
@@ -2,9 +2,12 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 
 import {getTheme, makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentTeamId, getMyTeamsCount} from 'mattermost-redux/selectors/entities/teams';
+
+import {saveTheme} from 'actions/user_actions';
 
 import {Preferences} from 'utils/constants.jsx';
 
@@ -23,4 +26,12 @@ function makeMapStateToProps() {
     };
 }
 
-export default connect(makeMapStateToProps)(UserSettingsTheme);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            saveTheme,
+        }, dispatch),
+    };
+}
+
+export default connect(makeMapStateToProps, mapDispatchToProps)(UserSettingsTheme);

--- a/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
+++ b/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
-import * as UserActions from 'actions/user_actions.jsx';
 import {ActionTypes, Constants} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
@@ -19,6 +18,9 @@ import PremadeThemeChooser from './premade_theme_chooser';
 
 export default class ThemeSetting extends React.Component {
     static propTypes = {
+        actions: PropTypes.shape({
+            saveTheme: PropTypes.func.isRequired,
+        }).isRequired,
         currentTeamId: PropTypes.string.isRequired,
         theme: PropTypes.object,
         selected: PropTypes.bool.isRequired,
@@ -89,17 +91,16 @@ export default class ThemeSetting extends React.Component {
 
         this.setState({isSaving: true});
 
-        UserActions.saveTheme(
+        this.props.actions.saveTheme(
             teamId,
-            this.state.theme,
-            () => {
-                this.props.setRequireConfirm(false);
-                this.originalTheme = Object.assign({}, this.state.theme);
-                this.scrollToTop();
-                this.props.updateSection('');
-                this.setState({isSaving: false});
-            }
-        );
+            this.state.theme
+        ).then(() => {
+            this.props.setRequireConfirm(false);
+            this.originalTheme = Object.assign({}, this.state.theme);
+            this.scrollToTop();
+            this.props.updateSection('');
+            this.setState({isSaving: false});
+        });
     };
 
     updateTheme = (theme) => {


### PR DESCRIPTION
#### Summary
The value for `themePreferences` was treated as a Map instead of an Array so by checking the *size* property instead of the *length* it always continued the execution and deleting the previous theme preferences for the user.

In this PR we check the right property to avoid deleting the themes in other teams when the action does not require it. Also converted the action to be a redux action instead, and finally added some tests to cover both cases.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13804

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
