### PR TITLE
custom URL scheme upper case letters not working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9517,13 +9517,8 @@
       "integrity": "sha1-GA8fnr74sOY45BZq1S24eb6y/8U="
     },
     "marked": {
-<<<<<<< HEAD
-      "version": "github:mattermost/marked#2c0c788631f703cad7cdc9fbbdc54ca4b6166b25",
-      "from": "github:mattermost/marked#2c0c788631f703cad7cdc9fbbdc54ca4b6166b25"
-=======
       "version": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
       "from": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705"
->>>>>>> updated mattermost/marked
     },
     "material-colors": {
       "version": "1.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9517,8 +9517,13 @@
       "integrity": "sha1-GA8fnr74sOY45BZq1S24eb6y/8U="
     },
     "marked": {
+<<<<<<< HEAD
       "version": "github:mattermost/marked#2c0c788631f703cad7cdc9fbbdc54ca4b6166b25",
       "from": "github:mattermost/marked#2c0c788631f703cad7cdc9fbbdc54ca4b6166b25"
+=======
+      "version": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
+      "from": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705"
+>>>>>>> updated mattermost/marked
     },
     "material-colors": {
       "version": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,7 @@
     "localforage": "1.7.3",
     "localforage-observable": "1.4.0",
     "mark.js": "8.11.1",
-<<<<<<< HEAD
-    "marked": "github:mattermost/marked#2c0c788631f703cad7cdc9fbbdc54ca4b6166b25",
-=======
     "marked": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
->>>>>>> updated mattermost/marked
     "mattermost-redux": "github:mattermost/mattermost-redux#c57649018344820122c00b485118415588f2778b",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
     "localforage": "1.7.3",
     "localforage-observable": "1.4.0",
     "mark.js": "8.11.1",
+<<<<<<< HEAD
     "marked": "github:mattermost/marked#2c0c788631f703cad7cdc9fbbdc54ca4b6166b25",
+=======
+    "marked": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
+>>>>>>> updated mattermost/marked
     "mattermost-redux": "github:mattermost/mattermost-redux#c57649018344820122c00b485118415588f2778b",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",

--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -144,24 +144,19 @@ export default class Renderer extends marked.Renderer {
         let outHref = href;
 
         if (!href.startsWith('/')) {
-			console.log("href before scheme: ", href);
             const scheme = getScheme(href);
-			console.log("scheme: ", scheme);
             if (!scheme) {
-				console.log("scheme: false");
-				outHref = `http://${outHref}`;
+                outHref = `http://${outHref}`;
             } else if (isUrl && this.formattingOptions.autolinkedUrlSchemes) {
-                const isValidUrl = this.formattingOptions.autolinkedUrlSchemes.indexOf(scheme) !== -1;
+                const isValidUrl = this.formattingOptions.autolinkedUrlSchemes.indexOf(scheme.toLowerCase()) !== -1;
 
                 if (!isValidUrl) {
-					console.log("isValidUrl: false");
-					return text;
+                    return text;
                 }
             }
         }
 
         if (!isUrlSafe(unescapeHtmlEntities(href))) {
-			console.log("isUrlSafe: false");
             return text;
         }
 

--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -144,19 +144,24 @@ export default class Renderer extends marked.Renderer {
         let outHref = href;
 
         if (!href.startsWith('/')) {
+			console.log("href before scheme: ", href);
             const scheme = getScheme(href);
+			console.log("scheme: ", scheme);
             if (!scheme) {
-                outHref = `http://${outHref}`;
+				console.log("scheme: false");
+				outHref = `http://${outHref}`;
             } else if (isUrl && this.formattingOptions.autolinkedUrlSchemes) {
                 const isValidUrl = this.formattingOptions.autolinkedUrlSchemes.indexOf(scheme) !== -1;
 
                 if (!isValidUrl) {
-                    return text;
+					console.log("isValidUrl: false");
+					return text;
                 }
             }
         }
 
         if (!isUrlSafe(unescapeHtmlEntities(href))) {
+			console.log("isUrlSafe: false");
             return text;
         }
 

--- a/utils/url.jsx
+++ b/utils/url.jsx
@@ -76,7 +76,7 @@ export function useSafeUrl(url, defaultUrl = '') {
 }
 
 export function getScheme(url) {
-    const match = (/([a-z0-9+.-]+):/i).exec(url);
+    const match = (/([A-Za-z0-9+.-]+):/i).exec(url);
 
     return match && match[1];
 }

--- a/utils/url.jsx
+++ b/utils/url.jsx
@@ -76,7 +76,7 @@ export function useSafeUrl(url, defaultUrl = '') {
 }
 
 export function getScheme(url) {
-    const match = (/([A-Za-z0-9+.-]+):/i).exec(url);
+    const match = (/([a-z0-9+.-]+):/i).exec(url);
 
     return match && match[1];
 }


### PR DESCRIPTION
#### Summary
1. System Console > Customization > Posts 
2. In `Custom URL Schemes` field enter a value like "file, DMS, dms"

I did so and the upper case one is not working. We have a software which is exporting links as
```
DMS:<GUID>
```
inserting this link into a message is not working. Manually replace _DMS_ to
```
dms:<GUID>
```
is working as a clickable link.
I don't know if this is the only place, but I didn't find any other... If this is only rendered on client side, the windows desktop is also affected (have not tested other apps).

Webapp -> uppercase not working
windows desktop app -> uppercase not working
Android App -> uppercase partially working (_DMS_ does, _HTTP_ does not)

![image](https://user-images.githubusercontent.com/6012744/52047468-575c0700-2549-11e9-9757-04aa6f6312d3.png)
![image](https://user-images.githubusercontent.com/6012744/52047589-9c803900-2549-11e9-94fb-dcb34ef8320d.png)


#### Ticket Link
none

#### Checklist
- [x] just a little regex
