### PR TITLE
MM-13727 Broken image displays on login page if custom branding is enabled but no image has been uploaded

### DIFF
--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -364,11 +364,13 @@ class LoginController extends React.Component {
         if (this.props.enableCustomBrand) {
             const text = this.props.customBrandText || '';
             const formattedText = TextFormatting.formatText(text);
+            const brandImageUrl = Client4.getBrandImageUrl(0);
 
             return (
                 <div>
-                    <img
-                        src={Client4.getBrandImageUrl(0)}
+                    <object
+                        data={brandImageUrl}
+                        type='image/jpg'
                     />
                     <div>
                         {messageHtmlToComponent(formattedText, false, {mentions: false, imagesMetadata: null})}

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -82,6 +82,7 @@ class LoginController extends React.Component {
             showMfa: false,
             loading: false,
             sessionExpired: false,
+            brandImageError: false,
         };
     }
 
@@ -360,17 +361,23 @@ class LoginController extends React.Component {
         });
     }
 
+    handleBrandImageError = () => {
+        this.setState({brandImageError: true});
+    }
+
     createCustomLogin = () => {
         if (this.props.enableCustomBrand) {
             const text = this.props.customBrandText || '';
             const formattedText = TextFormatting.formatText(text);
             const brandImageUrl = Client4.getBrandImageUrl(0);
+            const brandImageStyle = this.state.brandImageError ? {display: 'none'} : {};
 
             return (
                 <div>
-                    <object
-                        data={brandImageUrl}
-                        type='image/jpg'
+                    <img
+                        src={brandImageUrl}
+                        onError={this.handleBrandImageError}
+                        style={brandImageStyle}
                     />
                     <div>
                         {messageHtmlToComponent(formattedText, false, {mentions: false, imagesMetadata: null})}


### PR DESCRIPTION
#### Summary
The API returns the same URL wether a custom brand image has been uploaded or not (`http://example.com/api/v4/brand/image?t=0`). This uses an object tag to suppress the broken image link, however, a 404 will be shown in the browser console.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13727

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
