### PR TITLE
Fix JS warnings on props.restrictTeamInvite

### DIFF
--- a/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
@@ -24,7 +24,7 @@ export default class TutorialIntroScreens extends React.Component {
         townSquareDisplayName: PropTypes.string.isRequired,
         appDownloadLink: PropTypes.string,
         isLicensed: PropTypes.bool.isRequired,
-        restrictTeamInvite: PropTypes.string.isRequired,
+        restrictTeamInvite: PropTypes.bool.isRequired,
         supportEmail: PropTypes.string.isRequired,
     };
 
@@ -205,7 +205,7 @@ export default class TutorialIntroScreens extends React.Component {
         let inviteText;
         const {teamType} = this.props;
 
-        if (!this.props.isLicensed || this.props.restrictTeamInvite === Constants.PERMISSIONS_ALL) {
+        if (!this.props.isLicensed || !this.props.restrictTeamInvite) {
             if (teamType === Constants.INVITE_TEAM) {
                 inviteModalLink = (
                     <ModalToggleButtonRedux

--- a/components/tutorial/tutorial_view.jsx
+++ b/components/tutorial/tutorial_view.jsx
@@ -43,7 +43,7 @@ TutorialView.propTypes = {
     townSquareDisplayName: PropTypes.string.isRequired,
     appDownloadLink: PropTypes.string,
     isLicensed: PropTypes.bool.isRequired,
-    restrictTeamInvite: PropTypes.string.isRequired,
+    restrictTeamInvite: PropTypes.bool.isRequired,
     supportEmail: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
#### Summary
Fix JS warnings on props.restrictTeamInvite.

Can be seen on browser console after creating a user where it goes through the tutorial screens.

![screen shot 2019-02-01 at 3 35 41 pm](https://user-images.githubusercontent.com/5334504/52116443-1567b980-264c-11e9-9bcb-36ddfe76b832.png)
![screen shot 2019-02-01 at 5 52 47 pm](https://user-images.githubusercontent.com/5334504/52116452-1ac50400-264c-11e9-8d71-1ceecb217a98.png)


#### Ticket Link
none - quick fix

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
