### PR TITLE
MM-13922 Fix wide image previews aspect ratio in posts

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/SizeAwareImage should render a placeholder and has loader when showLoader is true 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "position": "absolute",
+      }
+    }
+  >
+    <LoadingImagePreview
+      containerClass="file__image-loading"
+    />
+  </div>
+  <img
+    src="data:image/png;base64,abc123"
+  />
+</div>
+`;

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -66,6 +66,20 @@ export default class MessageAttachment extends React.PureComponent {
         this.mounted = false;
     }
 
+    handleHeightReceivedForThumbUrl = (height) => {
+        const {attachment} = this.props;
+        if (!this.props.imagesMetadata || (this.props.imagesMetadata && !this.props.imagesMetadata[attachment.thumb_url])) {
+            this.handleHeightReceived(height);
+        }
+    }
+
+    handleHeightReceivedForImageUrl = (height) => {
+        const {attachment} = this.props;
+        if (!this.props.imagesMetadata || (this.props.imagesMetadata && !this.props.imagesMetadata[attachment.image_url])) {
+            this.handleHeightReceived(height);
+        }
+    }
+
     handleHeightReceived = (height) => {
         if (!this.mounted) {
             return;
@@ -318,7 +332,7 @@ export default class MessageAttachment extends React.PureComponent {
                 <div className='attachment__image-container'>
                     <SizeAwareImage
                         className='attachment__image'
-                        onHeightReceived={this.handleHeightReceived}
+                        onHeightReceived={this.handleHeightReceivedForImageUrl}
                         src={attachment.image_url}
                         dimensions={this.props.imagesMetadata[attachment.image_url]}
                     />
@@ -333,7 +347,7 @@ export default class MessageAttachment extends React.PureComponent {
                     className='attachment__thumb-container'
                 >
                     <SizeAwareImage
-                        onHeightReceived={this.handleHeightReceived}
+                        onHeightReceived={this.handleHeightReceivedForThumbUrl}
                         src={attachment.thumb_url}
                         dimensions={this.props.imagesMetadata[attachment.thumb_url]}
                     />

--- a/components/post_view/post_image/post_image.jsx
+++ b/components/post_view/post_image/post_image.jsx
@@ -5,14 +5,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {postListScrollChange} from 'actions/global_actions';
-import LoadingImagePreview from 'components/loading_image_preview';
+import SizeAwareImage from 'components/size_aware_image';
 import * as PostUtils from 'utils/post_utils.jsx';
-import {getFileDimensionsForDisplay} from 'utils/file_utils';
-
-const MAX_IMAGE_DIMENSIONS = {
-    maxHeight: 500,
-    maxWidth: 450,
-};
 
 export default class PostImageEmbed extends React.PureComponent {
     static propTypes = {
@@ -51,67 +45,41 @@ export default class PostImageEmbed extends React.PureComponent {
     constructor(props) {
         super(props);
 
-        this.handleLoadComplete = this.handleLoadComplete.bind(this);
-        this.handleLoadError = this.handleLoadError.bind(this);
-
         this.state = {
-            loaded: false,
             errored: false,
         };
     }
 
     componentDidMount() {
         this.mounted = true;
-        this.loadImg(this.props.link);
-    }
-
-    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        if (nextProps.link !== this.props.link) {
-            this.setState({
-                loaded: false,
-                errored: false,
-            });
-        }
-    }
-
-    componentDidUpdate(prevProps) {
-        if (!this.state.loaded && prevProps.link !== this.props.link) {
-            this.loadImg(this.props.link);
-        }
     }
 
     componentWillUnmount() {
         this.mounted = false;
     }
 
-    loadImg(src) {
-        const img = new Image();
-        img.onload = this.handleLoadComplete;
-        img.onerror = this.handleLoadError;
-        img.src = PostUtils.getImageSrc(src, this.props.hasImageProxy);
-    }
-
-    handleLoadComplete() {
+    handleLoadComplete = () => {
         if (!this.mounted) {
             return;
         }
         this.setState({
-            loaded: true,
             errored: false,
         });
-        postListScrollChange();
+        if (!this.props.dimensions) {
+            postListScrollChange();
+        }
         if (this.props.onLinkLoaded) {
             this.props.onLinkLoaded();
         }
     }
 
-    handleLoadError() {
-        if (this.mouted) {
-            this.setState({
-                errored: true,
-                loaded: true,
-            });
+    handleLoadError = () => {
+        if (!this.mounted) {
+            return;
         }
+        this.setState({
+            errored: true,
+        });
 
         if (this.props.onLinkLoadError) {
             this.props.onLinkLoadError();
@@ -124,29 +92,22 @@ export default class PostImageEmbed extends React.PureComponent {
     };
 
     render() {
-        const imageDimensions = getFileDimensionsForDisplay(this.props.dimensions, MAX_IMAGE_DIMENSIONS);
-        if (this.state.errored || !this.state.loaded) {
-            if (!this.props.dimensions) {
-                return null;
-            }
-            return (
-                <div style={{...imageDimensions, marginBottom: '13px'}}>
-                    <LoadingImagePreview
-                        containerClass={'file__image-loading'}
-                    />
-                </div>
-            );
+        if (this.state.errored) {
+            return null;
         }
 
         return (
             <div
                 className='post__embed-container'
             >
-                <img
-                    onClick={this.onImageClick}
-                    className='img-div cursor--pointer'
+                <SizeAwareImage
+                    className='attachment__image cursor--pointer'
                     src={PostUtils.getImageSrc(this.props.link, this.props.hasImageProxy)}
-                    {...imageDimensions}
+                    dimensions={this.props.dimensions}
+                    showLoader={true}
+                    onHeightReceived={this.handleLoadComplete}
+                    onImageLoadFail={this.handleLoadError}
+                    onClick={this.onImageClick}
                 />
             </div>
         );

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -4,6 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import LoadingImagePreview from 'components/loading_image_preview';
 import {createPlaceholderImage, loadImage} from 'utils/image_utils';
 
 const WAIT_FOR_HEIGHT_TIMEOUT = 100;
@@ -14,9 +15,19 @@ export default class SizeAwareImage extends React.PureComponent {
     static propTypes = {
 
         /*
+         * The source URL of the image
+         */
+        src: PropTypes.string.isRequired,
+
+        /*
          * dimensions object to create empty space required to prevent scroll pop
          */
         dimensions: PropTypes.object,
+
+        /*
+         * Boolean value to pass for showing a loader when img is beign loaded
+         */
+        showLoader: PropTypes.bool,
 
         /*
          * A callback that is called as soon as the image component has a height value
@@ -24,9 +35,9 @@ export default class SizeAwareImage extends React.PureComponent {
         onHeightReceived: PropTypes.func.isRequired,
 
         /*
-         * The source URL of the image
+         * A callback that is called when image load fails
          */
-        src: PropTypes.string.isRequired,
+        onImageLoadFail: PropTypes.func,
     }
 
     constructor(props) {
@@ -84,9 +95,7 @@ export default class SizeAwareImage extends React.PureComponent {
     }
 
     handleLoad = (image) => {
-        const wasWaiting = this.stopWaitingForHeight();
-
-        if ((wasWaiting || !this.props.dimensions) && this.props.onHeightReceived) {
+        if (this.props.onHeightReceived && image.height) {
             this.props.onHeightReceived(image.height);
         }
 
@@ -97,6 +106,9 @@ export default class SizeAwareImage extends React.PureComponent {
 
     handleError = () => {
         this.stopWaitingForHeight();
+        if (this.props.onImageLoadFail) {
+            this.props.onImageLoadFail();
+        }
     };
 
     render() {
@@ -105,7 +117,9 @@ export default class SizeAwareImage extends React.PureComponent {
             ...props
         } = this.props;
 
+        Reflect.deleteProperty(props, 'showLoader');
         Reflect.deleteProperty(props, 'onHeightReceived');
+        Reflect.deleteProperty(props, 'onImageLoadFail');
 
         let src;
         if (!this.state.loaded && dimensions) {
@@ -117,10 +131,19 @@ export default class SizeAwareImage extends React.PureComponent {
         }
 
         return (
-            <img
-                {...props}
-                src={src}
-            />
+            <div>
+                {!this.state.loaded && this.props.showLoader &&
+                    <div style={{position: 'absolute'}}>
+                        <LoadingImagePreview
+                            containerClass={'file__image-loading'}
+                        />
+                    </div>
+                }
+                <img
+                    {...props}
+                    src={src}
+                />
+            </div>
         );
     }
 }

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -25,7 +25,7 @@ export default class SizeAwareImage extends React.PureComponent {
         dimensions: PropTypes.object,
 
         /*
-         * Boolean value to pass for showing a loader when img is beign loaded
+         * Boolean value to pass for showing a loader when image is being loaded
          */
         showLoader: PropTypes.bool,
 

--- a/utils/image_utils.jsx
+++ b/utils/image_utils.jsx
@@ -7,6 +7,7 @@ export function createPlaceholderImage(width, height) {
 
     placeholder.width = width;
     placeholder.height = height;
+    placeholder.style.backgroundColor = 'transparent';
 
     try {
         return placeholder.toDataURL();


### PR DESCRIPTION
#### Summary
  * Use SizeAwareImage component for PostImageEmbed component
  * Add new props onImageLoadFail and showLoader to SizeAwareImage
  * Change SizeAwareImage to call onHeightReceived when image is loaded and let parent component decide if any action is to be taken.
    Above change lets components such as PostImageEmbed show toggle/collapse based on imageLoad callback

#### Ticket Link
[MM-13922](https://mattermost.atlassian.net/browse/MM-13922)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)


![feb-01-2019 16-14-16](https://user-images.githubusercontent.com/4973621/52118519-7edfcc00-263c-11e9-9c4f-b645ad63aea9.gif)
