### PR TITLE
Set method for File Upload to ensure CSRF Token will be added

### DIFF
--- a/actions/file_actions.jsx
+++ b/actions/file_actions.jsx
@@ -16,7 +16,7 @@ export function uploadFile(file, name, channelId, rootId, clientId) {
 
         return request.
             post(Client4.getFilesRoute()).
-            set(Client4.getOptions().headers).
+            set(Client4.getOptions({method: "post"}).headers).
             attach('files', file, name).
             field('channel_id', channelId).
             field('client_ids', clientId).

--- a/actions/file_actions.jsx
+++ b/actions/file_actions.jsx
@@ -16,7 +16,7 @@ export function uploadFile(file, name, channelId, rootId, clientId) {
 
         return request.
             post(Client4.getFilesRoute()).
-            set(Client4.getOptions({method: "post"}).headers).
+            set(Client4.getOptions({method: 'post'}).headers).
             attach('files', file, name).
             field('channel_id', channelId).
             field('client_ids', clientId).


### PR DESCRIPTION
#### Summary
Currently the file upload on mobile doesn't utilize the redux client, but builds the request itself. Since the request method isn't passed to the `Client4.getOptions` call no CSRF token will be attached. This PR adds the method manually to ensure a CSRF token is being generated, since the original request made is POST based.