### PR TITLE
[MM-12737] Migrate preference-related actions from user_actions.jsx t…

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -506,22 +506,6 @@ export async function loadMyTeamMembers() {
     getMyTeamUnreads()(dispatch, getState);
 }
 
-export async function savePreferences(prefs, callback) {
-    const currentUserId = Selectors.getCurrentUserId(getState());
-    await savePreferencesRedux(currentUserId, prefs)(dispatch, getState);
-    callback();
-}
-
-export async function savePreference(category, name, value) {
-    const currentUserId = Selectors.getCurrentUserId(getState());
-    return savePreferencesRedux(currentUserId, [{user_id: currentUserId, category, name, value}])(dispatch, getState);
-}
-
-export function deletePreferences(prefs) {
-    const currentUserId = Selectors.getCurrentUserId(getState());
-    return deletePreferencesRedux(currentUserId, prefs)(dispatch, getState);
-}
-
 export function autoResetStatus() {
     return async (doDispatch, doGetState) => {
         const {currentUserId} = getState().entities.users;

--- a/components/tutorial/tutorial_intro_screens/__snapshots__/tutorial_intro_screen.test.jsx.snap
+++ b/components/tutorial/tutorial_intro_screens/__snapshots__/tutorial_intro_screen.test.jsx.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/tutorial/tutorial_intro_screens/TutorialIntroScreens should match snapshot 1`] = `
+<div
+  className="tutorial-steps__container"
+>
+  <div
+    className="tutorial__content"
+    id="tutorialIntroContent"
+  >
+    <div
+      className="tutorial__steps"
+    >
+      <div
+        id="tutorialIntroOne"
+      >
+        <h3>
+          <FormattedMessage
+            defaultMessage="Welcome to:"
+            id="tutorial_intro.screenOne.title1"
+            values={Object {}}
+          />
+        </h3>
+        <h1>
+          <FormattedMessage
+            defaultMessage="Mattermost"
+            id="tutorial_intro.screenOne.title2"
+            values={Object {}}
+          />
+        </h1>
+        <p>
+          <FormattedMessage
+            defaultMessage="Your team communication all in one place, instantly searchable and available anywhere."
+            id="tutorial_intro.screenOne.body1"
+            values={Object {}}
+          />
+        </p>
+        <p>
+          <FormattedMessage
+            defaultMessage="Keep your team connected to help them achieve what matters most."
+            id="tutorial_intro.screenOne.body2"
+            values={Object {}}
+          />
+        </p>
+        <div
+          className="tutorial__circles"
+        >
+          <a
+            className="circle active"
+            data-screen={0}
+            href="#"
+            id="tutorialIntroCircle0"
+            key="circle0"
+            onClick={[Function]}
+          />
+          <a
+            className="circle"
+            data-screen={1}
+            href="#"
+            id="tutorialIntroCircle1"
+            key="circle1"
+            onClick={[Function]}
+          />
+          <a
+            className="circle"
+            data-screen={2}
+            href="#"
+            id="tutorialIntroCircle2"
+            key="circle2"
+            onClick={[Function]}
+          />
+        </div>
+      </div>
+      <div
+        className="tutorial__footer"
+      >
+        <button
+          className="btn btn-primary"
+          id="tutorialNextButton"
+          onClick={[Function]}
+          tabIndex="1"
+        >
+          <FormattedMessage
+            defaultMessage="Next"
+            id="tutorial_intro.next"
+            values={Object {}}
+          />
+        </button>
+        <a
+          className="tutorial-skip"
+          href="#"
+          id="tutorialSkipLink"
+          onClick={[Function]}
+        >
+          <FormattedMessage
+            defaultMessage="Skip tutorial"
+            id="tutorial_intro.skip"
+            values={Object {}}
+          />
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/tutorial/tutorial_intro_screens/index.jsx
+++ b/components/tutorial/tutorial_intro_screens/index.jsx
@@ -1,9 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getInt} from 'mattermost-redux/selectors/entities/preferences';
+import {savePreferences} from 'mattermost-redux/actions/preferences';
 
 import {Preferences} from 'utils/constants.jsx';
 
@@ -19,4 +21,10 @@ function mapStateToProps(state) {
     };
 }
 
-export default connect(mapStateToProps)(TutorialIntroScreens);
+function mapDispatchToProps(dispatch) {
+    return {actions: bindActionCreators({
+        savePreferences,
+    }, dispatch)};
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(TutorialIntroScreens);

--- a/components/tutorial/tutorial_intro_screens/tutorial_intro_screen.test.jsx
+++ b/components/tutorial/tutorial_intro_screens/tutorial_intro_screen.test.jsx
@@ -1,0 +1,97 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import TutorialIntroScreens from 'components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx';
+import {Constants, Preferences} from 'utils/constants.jsx';
+
+describe('components/tutorial/tutorial_intro_screens/TutorialIntroScreens', () => {
+    jest.mock('actions/diagnostics_actions.jsx');
+
+    jest.mock('actions/global_actions.jsx');
+
+    const currentUserId = 'currentUserId';
+
+    const requiredProps = {
+        currentUserId,
+        teamType: 'teamType',
+        step: 1,
+        townSquareDisplayName: 'townSquareDisplayName',
+        appDownloadLink: 'https://host/static/image.png',
+        isLicensed: true,
+        restrictTeamInvite: false,
+        supportEmail: 'supportEmail',
+        actions: {savePreferences: jest.fn()},
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(<TutorialIntroScreens {...requiredProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should not call savePreferences when handleNext', () => {
+        const savePreferences = jest.fn();
+
+        const props = {...requiredProps, actions: {savePreferences}};
+        const wrapper = shallow(<TutorialIntroScreens {...props}/>);
+
+        wrapper.instance().handleNext();
+        expect(savePreferences).toHaveBeenCalledTimes(0);
+
+        wrapper.instance().handleNext();
+        expect(savePreferences).toHaveBeenCalledTimes(0);
+    });
+
+    test('should have called savePreferences when handleNext', () => {
+        const savePreferences = jest.fn();
+
+        const props = {...requiredProps, actions: {savePreferences}};
+        const wrapper = shallow(<TutorialIntroScreens {...props}/>);
+
+        wrapper.instance().handleNext();
+        wrapper.instance().handleNext();
+        wrapper.instance().handleNext();
+
+        const expectedPref = [{
+            user_id: currentUserId,
+            category: Preferences.TUTORIAL_STEP,
+            name: currentUserId,
+            value: (requiredProps.step + 1).toString(),
+        }];
+
+        expect(savePreferences).toHaveBeenCalledTimes(1);
+        expect(savePreferences).toHaveBeenCalledWith(currentUserId, expectedPref);
+    });
+
+    test('should have called mockEvent.preventDefault when skipTutorial', () => {
+        const mockEvent = {preventDefault: jest.fn()};
+
+        const props = {...requiredProps};
+        const wrapper = shallow(<TutorialIntroScreens {...props}/>);
+
+        wrapper.instance().skipTutorial(mockEvent);
+        expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    test('should have called savePreferences when skipTutorial', () => {
+        const savePreferences = jest.fn();
+        const mockEvent = {preventDefault: jest.fn()};
+
+        const props = {...requiredProps, actions: {savePreferences}};
+        const wrapper = shallow(<TutorialIntroScreens {...props}/>);
+
+        wrapper.instance().skipTutorial(mockEvent);
+
+        const expectedPref = [{
+            user_id: currentUserId,
+            category: Preferences.TUTORIAL_STEP,
+            name: currentUserId,
+            value: Constants.TutorialSteps.FINISHED.toString(),
+        }];
+
+        expect(savePreferences).toHaveBeenCalledTimes(1);
+        expect(savePreferences).toHaveBeenCalledWith(currentUserId, expectedPref);
+    });
+});

--- a/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
@@ -7,7 +7,6 @@ import {FormattedMessage} from 'react-intl';
 
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
-import {savePreference} from 'actions/user_actions.jsx';
 import {Constants, Preferences, ModalIdentifiers} from 'utils/constants.jsx';
 import {useSafeUrl} from 'utils/url.jsx';
 import AppIcons from 'images/appIcons.png';
@@ -26,6 +25,9 @@ export default class TutorialIntroScreens extends React.Component {
         isLicensed: PropTypes.bool.isRequired,
         restrictTeamInvite: PropTypes.bool.isRequired,
         supportEmail: PropTypes.string.isRequired,
+        actions: PropTypes.shape({
+            savePreferences: PropTypes.func.isRequired,
+        }).isRequired,
     };
 
     constructor(props) {
@@ -52,11 +54,15 @@ export default class TutorialIntroScreens extends React.Component {
             return;
         }
 
-        savePreference(
-            Preferences.TUTORIAL_STEP,
-            this.props.currentUserId,
-            (this.props.step + 1).toString()
-        );
+        const {currentUserId} = this.props;
+        const preferences = [{
+            user_id: currentUserId,
+            category: Preferences.TUTORIAL_STEP,
+            name: currentUserId,
+            value: (this.props.step + 1).toString(),
+        }];
+
+        this.props.actions.savePreferences(currentUserId, preferences);
     }
 
     skipTutorial = (e) => {
@@ -74,11 +80,15 @@ export default class TutorialIntroScreens extends React.Component {
             break;
         }
 
-        savePreference(
-            Preferences.TUTORIAL_STEP,
-            this.props.currentUserId,
-            Constants.TutorialSteps.FINISHED.toString(),
-        );
+        const {currentUserId} = this.props;
+        const preferences = [{
+            user_id: currentUserId,
+            category: Preferences.TUTORIAL_STEP,
+            name: currentUserId,
+            value: Constants.TutorialSteps.FINISHED.toString(),
+        }];
+
+        this.props.actions.savePreferences(currentUserId, preferences);
     }
     createScreen = () => {
         switch (this.state.currentScreen) {

--- a/components/tutorial/tutorial_tip/__snapshots__/tutorial_tip.test.jsx.snap
+++ b/components/tutorial/tutorial_tip/__snapshots__/tutorial_tip.test.jsx.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/tutorial/tutorial_tip/tutorial_tip.jsx should match snapshot 1`] = `
+<div
+  className="tip-div "
+  id="tipButton"
+  onClick={[Function]}
+>
+  <img
+    className="tip-button"
+    onClick={[Function]}
+    src={null}
+    width="35"
+  />
+  <Overlay
+    animation={[Function]}
+    placement="right"
+    rootClose={false}
+    show={false}
+  >
+    <div
+      className="tip-backdrop"
+    />
+  </Overlay>
+  <Overlay
+    animation={[Function]}
+    onHide={[Function]}
+    placement="right"
+    rootClose={true}
+    show={false}
+    target={[Function]}
+  >
+    <div
+      className="tip-overlay "
+    >
+      <div
+        className="arrow"
+      />
+      1
+      <div
+        className="tutorial__footer"
+      >
+        <div
+          className="tutorial__circles"
+        >
+          <a
+            className="circle active"
+            data-screen={0}
+            href="#"
+            key="dotactive0"
+            onClick={[Function]}
+          />
+          <a
+            className="circle"
+            data-screen={1}
+            href="#"
+            key="dotactive1"
+            onClick={[Function]}
+          />
+          <a
+            className="circle"
+            data-screen={2}
+            href="#"
+            key="dotactive2"
+            onClick={[Function]}
+          />
+        </div>
+        <div
+          className="text-right"
+        >
+          <button
+            className="btn btn-primary"
+            id="tipNextButton"
+            onClick={[Function]}
+          >
+            <FormattedMessage
+              defaultMessage="Next"
+              id="tutorial_tip.next"
+              values={Object {}}
+            />
+          </button>
+          <div
+            className="tip-opt"
+          >
+            <FormattedMessage
+              defaultMessage="Seen this before? "
+              id="tutorial_tip.seen"
+              values={Object {}}
+            />
+            <a
+              href="#"
+              onClick={[Function]}
+            >
+              <FormattedMessage
+                defaultMessage="Opt out of these tips."
+                id="tutorial_tip.out"
+                values={Object {}}
+              />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Overlay>
+</div>
+`;

--- a/components/tutorial/tutorial_tip/index.js
+++ b/components/tutorial/tutorial_tip/index.js
@@ -5,6 +5,7 @@ import {bindActionCreators} from 'redux';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getInt} from 'mattermost-redux/selectors/entities/preferences';
+import {savePreferences} from 'mattermost-redux/actions/preferences';
 
 import {closeMenu as closeRhsMenu} from 'actions/views/rhs';
 import {Preferences} from 'utils/constants.jsx';
@@ -23,6 +24,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             closeRhsMenu,
+            savePreferences,
         }, dispatch),
     };
 }

--- a/components/tutorial/tutorial_tip/tutorial_tip.jsx
+++ b/components/tutorial/tutorial_tip/tutorial_tip.jsx
@@ -7,7 +7,6 @@ import {Overlay} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
-import {savePreference} from 'actions/user_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import tutorialGif from 'images/tutorialTip.gif';
 import tutorialGifWhite from 'images/tutorialTipWhite.gif';
@@ -25,6 +24,7 @@ export default class TutorialTip extends React.Component {
         diagnosticsTag: PropTypes.string,
         actions: PropTypes.shape({
             closeRhsMenu: PropTypes.func.isRequired,
+            savePreferences: PropTypes.func.isRequired,
         }),
     }
 
@@ -68,14 +68,20 @@ export default class TutorialTip extends React.Component {
             trackEvent('tutorial', tag);
         }
 
-        this.props.actions.closeRhsMenu();
+        const {currentUserId, actions} = this.props;
+        const {closeRhsMenu, savePreferences} = actions;
+
+        const preferences = [{
+            user_id: currentUserId,
+            category: Preferences.TUTORIAL_STEP,
+            name: currentUserId,
+            value: (this.props.step + 1).toString(),
+        }];
+
+        closeRhsMenu();
         this.hide();
 
-        savePreference(
-            Preferences.TUTORIAL_STEP,
-            this.props.currentUserId,
-            (this.props.step + 1).toString()
-        );
+        savePreferences(currentUserId, preferences);
     }
 
     skipTutorial = (e) => {
@@ -90,11 +96,15 @@ export default class TutorialTip extends React.Component {
             trackEvent('tutorial', tag);
         }
 
-        savePreference(
-            Preferences.TUTORIAL_STEP,
-            this.props.currentUserId,
-            TutorialSteps.FINISHED.toString()
-        );
+        const {currentUserId, actions} = this.props;
+        const preferences = [{
+            user_id: currentUserId,
+            category: Preferences.TUTORIAL_STEP,
+            name: currentUserId,
+            value: TutorialSteps.FINISHED.toString(),
+        }];
+
+        actions.savePreferences(currentUserId, preferences);
     }
 
     handleCircleClick = (e, screen) => {

--- a/components/tutorial/tutorial_tip/tutorial_tip.test.jsx
+++ b/components/tutorial/tutorial_tip/tutorial_tip.test.jsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import TutorialTip from 'components/tutorial/tutorial_tip/tutorial_tip.jsx';
+import {Constants, Preferences} from 'utils/constants.jsx';
+
+describe('components/tutorial/tutorial_tip/tutorial_tip.jsx', () => {
+    jest.mock('actions/diagnostics_actions.jsx');
+
+    const currentUserId = 'currentUserId';
+
+    const requiredProps = {
+        currentUserId,
+        step: 1,
+        actions: {
+            closeRhsMenu: jest.fn(),
+            savePreferences: jest.fn(),
+        },
+        screens: [1, 2, 3],
+        placement: 'right',
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(<TutorialTip {...requiredProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should not call both closeRhsMenu and savePreferences', () => {
+        const savePreferences = jest.fn();
+        const closeRhsMenu = jest.fn();
+
+        const props = {...requiredProps, actions: {closeRhsMenu, savePreferences}};
+        const wrapper = shallow(<TutorialTip {...props}/>);
+
+        wrapper.instance().handleNext();
+        expect(closeRhsMenu).toHaveBeenCalledTimes(0);
+        expect(savePreferences).toHaveBeenCalledTimes(0);
+
+        wrapper.instance().handleNext();
+        expect(closeRhsMenu).toHaveBeenCalledTimes(0);
+        expect(savePreferences).toHaveBeenCalledTimes(0);
+    });
+
+    test('should have called both closeRhsMenu and savePreferences', () => {
+        const savePreferences = jest.fn();
+        const closeRhsMenu = jest.fn();
+
+        const props = {...requiredProps, actions: {closeRhsMenu, savePreferences}};
+        const wrapper = shallow(<TutorialTip {...props}/>);
+
+        wrapper.instance().handleNext();
+        wrapper.instance().handleNext();
+        wrapper.instance().handleNext();
+
+        const expectedPref = [{
+            user_id: currentUserId,
+            category: Preferences.TUTORIAL_STEP,
+            name: currentUserId,
+            value: (requiredProps.step + 1).toString(),
+        }];
+
+        expect(closeRhsMenu).toHaveBeenCalledTimes(1);
+        expect(savePreferences).toHaveBeenCalledTimes(1);
+        expect(savePreferences).toHaveBeenCalledWith(currentUserId, expectedPref);
+    });
+
+    test('should have called mockEvent.preventDefault when skipTutorial', () => {
+        const mockEvent = {preventDefault: jest.fn()};
+
+        const props = {...requiredProps};
+        const wrapper = shallow(<TutorialTip {...props}/>);
+
+        wrapper.instance().skipTutorial(mockEvent);
+        expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    test('should have called both closeRhsMenu and savePreferences when skipTutorial', () => {
+        const savePreferences = jest.fn();
+        const closeRhsMenu = jest.fn();
+        const mockEvent = {preventDefault: jest.fn()};
+
+        const props = {...requiredProps, actions: {closeRhsMenu, savePreferences}};
+        const wrapper = shallow(<TutorialTip {...props}/>);
+
+        wrapper.instance().skipTutorial(mockEvent);
+
+        const expectedPref = [{
+            user_id: currentUserId,
+            category: Preferences.TUTORIAL_STEP,
+            name: currentUserId,
+            value: Constants.TutorialSteps.FINISHED.toString(),
+        }];
+
+        expect(savePreferences).toHaveBeenCalledTimes(1);
+        expect(savePreferences).toHaveBeenCalledWith(currentUserId, expectedPref);
+    });
+});

--- a/components/user_settings/advanced/index.js
+++ b/components/user_settings/advanced/index.js
@@ -2,10 +2,12 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {get, makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
+import {savePreferences} from 'mattermost-redux/actions/preferences';
 
 import {Preferences} from 'utils/constants.jsx';
 
@@ -32,4 +34,12 @@ function makeMapStateToProps() {
     };
 }
 
-export default connect(makeMapStateToProps)(AdvancedSettingsDisplay);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            savePreferences,
+        }, dispatch),
+    };
+}
+
+export default connect(makeMapStateToProps, mapDispatchToProps)(AdvancedSettingsDisplay);

--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import {savePreferences, updateActive, revokeAllSessions} from 'actions/user_actions.jsx';
+import {updateActive, revokeAllSessions} from 'actions/user_actions.jsx';
 import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -33,6 +33,9 @@ export default class AdvancedSettingsDisplay extends React.Component {
         collapseModal: PropTypes.func.isRequired,
         enablePreviewFeatures: PropTypes.bool,
         enableUserDeactivation: PropTypes.bool,
+        actions: PropTypes.shape({
+            savePreferences: PropTypes.func.isRequired,
+        }).isRequired,
     }
 
     constructor(props) {
@@ -120,9 +123,10 @@ export default class AdvancedSettingsDisplay extends React.Component {
         this.handleSubmit(features);
     }
 
-    handleSubmit = (settings) => {
+    handleSubmit = async (settings) => {
         const preferences = [];
-        const userId = this.props.currentUser.id;
+        const {actions, currentUser} = this.props;
+        const userId = currentUser.id;
 
         // this should be refactored so we can actually be certain about what type everything is
         (Array.isArray(settings) ? settings : [settings]).forEach((setting) => {
@@ -136,12 +140,9 @@ export default class AdvancedSettingsDisplay extends React.Component {
 
         this.setState({isSaving: true});
 
-        savePreferences(
-            preferences,
-            () => {
-                this.handleUpdateSection('');
-            }
-        );
+        await actions.savePreferences(userId, preferences);
+
+        this.handleUpdateSection('');
     }
 
     handleDeactivateAccountSubmit = () => {

--- a/components/user_settings/advanced/user_settings_advanced.test.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.test.jsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import AdvancedSettingsDisplay from 'components/user_settings/advanced/user_settings_advanced.jsx';
+
+describe('components/user_settings/display/UserSettingsDisplay', () => {
+    const user = {
+        id: 'user_id',
+        username: 'username',
+        locale: 'en',
+        timezone: {
+            useAutomaticTimezone: 'true',
+            automaticTimezone: 'America/New_York',
+            manualTimezone: '',
+        },
+    };
+
+    const requiredProps = {
+        currentUser: user,
+        updateSection: jest.fn(),
+        activeSection: '',
+        closeModal: jest.fn(),
+        collapseModal: jest.fn(),
+        actions: {
+            savePreferences: jest.fn(),
+        },
+        advancedSettingsCategory: [],
+        sendOnCtrlEnter: '',
+        formatting: '',
+        joinLeave: '',
+    };
+
+    test('should have called handleSubmit', async () => {
+        const updateSection = jest.fn();
+
+        const props = {...requiredProps, updateSection};
+        const wrapper = shallow(<AdvancedSettingsDisplay {...props}/>);
+
+        await wrapper.instance().handleSubmit();
+        expect(updateSection).toHaveBeenCalledWith('');
+    });
+
+    test('should have called updateSection', () => {
+        const updateSection = jest.fn();
+        const props = {...requiredProps, updateSection};
+        const wrapper = shallow(<AdvancedSettingsDisplay {...props}/>);
+
+        wrapper.instance().handleUpdateSection('');
+        expect(updateSection).toHaveBeenCalledWith('');
+
+        wrapper.instance().handleUpdateSection('linkpreview');
+        expect(updateSection).toHaveBeenCalledWith('linkpreview');
+    });
+});

--- a/components/user_settings/display/index.js
+++ b/components/user_settings/display/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
+import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getSupportedTimezones} from 'mattermost-redux/actions/general';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {getConfig, getSupportedTimezones as getTimezones} from 'mattermost-redux/selectors/entities/general';
@@ -56,6 +57,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             getSupportedTimezones,
             autoUpdateTimezone,
+            savePreferences,
         }, dispatch),
     };
 }

--- a/components/user_settings/display/user_settings_display.jsx
+++ b/components/user_settings/display/user_settings_display.jsx
@@ -6,8 +6,6 @@ import React from 'react';
 import {getTimezoneRegion} from 'mattermost-redux/utils/timezone_utils';
 import {FormattedMessage} from 'react-intl';
 
-import {savePreferences} from 'actions/user_actions.jsx';
-
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {getBrowserTimezone} from 'utils/timezone.jsx';
@@ -65,6 +63,7 @@ export default class UserSettingsDisplay extends React.Component {
         actions: PropTypes.shape({
             getSupportedTimezones: PropTypes.func.isRequired,
             autoUpdateTimezone: PropTypes.func.isRequired,
+            savePreferences: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -98,7 +97,7 @@ export default class UserSettingsDisplay extends React.Component {
         }
     }
 
-    handleSubmit = () => {
+    handleSubmit = async () => {
         const userId = this.props.user.id;
 
         const timePreference = {
@@ -149,9 +148,9 @@ export default class UserSettingsDisplay extends React.Component {
             teammateNameDisplayPreference,
         ];
 
-        savePreferences(preferences, () => {
-            this.updateSection('');
-        });
+        await this.props.actions.savePreferences(userId, preferences);
+
+        this.updateSection('');
     }
 
     handleClockRadio = (militaryTime) => {

--- a/components/user_settings/display/user_settings_display.test.jsx
+++ b/components/user_settings/display/user_settings_display.test.jsx
@@ -4,13 +4,8 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import {savePreferences} from 'actions/user_actions.jsx';
 import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 import UserSettingsDisplay from 'components/user_settings/display/user_settings_display.jsx';
-
-jest.mock('actions/user_actions.jsx', () => ({
-    savePreferences: jest.fn(),
-}));
 
 describe('components/user_settings/display/UserSettingsDisplay', () => {
     const user = {
@@ -50,6 +45,7 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         actions: {
             getSupportedTimezones: jest.fn(),
             autoUpdateTimezone: jest.fn(),
+            savePreferences: jest.fn(),
         },
     };
 
@@ -140,17 +136,13 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should have called handleSubmit', () => {
+    test('should have called handleSubmit', async () => {
         const updateSection = jest.fn();
 
         const props = {...requiredProps, updateSection};
         const wrapper = mountWithIntl(<UserSettingsDisplay {...props}/>);
 
-        savePreferences.mockImplementation((args, cb) => {
-            cb();
-        });
-
-        wrapper.instance().handleSubmit();
+        await wrapper.instance().handleSubmit();
         expect(updateSection).toHaveBeenCalledWith('');
     });
 

--- a/components/user_settings/display/user_settings_theme/__snapshots__/user_settings_theme.test.jsx.snap
+++ b/components/user_settings/display/user_settings_theme/__snapshots__/user_settings_theme.test.jsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/user_settings/display/user_settings_theme/user_settings_theme.jsx should match snapshot 1`] = `
+<SettingItemMin
+  describe={
+    <FormattedMessage
+      defaultMessage="Open to manage your theme"
+      id="user.settings.display.theme.describe"
+      values={Object {}}
+    />
+  }
+  focused={false}
+  section="theme"
+  title={
+    <FormattedMessage
+      defaultMessage="Theme"
+      id="user.settings.display.theme.title"
+      values={Object {}}
+    />
+  }
+  updateSection={[Function]}
+/>
+`;

--- a/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
+++ b/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
@@ -91,7 +91,7 @@ export default class ThemeSetting extends React.Component {
 
         this.setState({isSaving: true});
 
-        this.props.actions.saveTheme(
+        return this.props.actions.saveTheme(
             teamId,
             this.state.theme
         ).then(() => {

--- a/components/user_settings/display/user_settings_theme/user_settings_theme.test.jsx
+++ b/components/user_settings/display/user_settings_theme/user_settings_theme.test.jsx
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {Preferences} from 'mattermost-redux/constants';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+import UserSettingsTheme from 'components/user_settings/display/user_settings_theme/user_settings_theme.jsx';
+
+describe('components/user_settings/display/user_settings_theme/user_settings_theme.jsx', () => {
+    const requiredProps = {
+        theme: Preferences.THEMES.default,
+        updateTheme: jest.fn(),
+        currentTeamId: 'teamId',
+        selected: false,
+        updateSection: jest.fn(),
+        setRequireConfirm: jest.fn(),
+        setEnforceFocus: jest.fn(),
+        actions: {
+            saveTheme: jest.fn(() => Promise.resolve()),
+        },
+    };
+
+    it('should match snapshot', () => {
+        const wrapper = shallowWithIntl(
+            <UserSettingsTheme {...requiredProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should saveTheme', async () => {
+        const wrapper = shallowWithIntl(
+            <UserSettingsTheme {...requiredProps}/>
+        );
+
+        await wrapper.instance().submitTheme();
+
+        expect(requiredProps.setRequireConfirm).toHaveBeenCalledTimes(1);
+        expect(requiredProps.setRequireConfirm).toHaveBeenCalledWith(false);
+
+        expect(requiredProps.updateSection).toHaveBeenCalledTimes(1);
+        expect(requiredProps.updateSection).toHaveBeenCalledWith('');
+    });
+});

--- a/components/user_settings/notifications/email_notification_setting/__snapshots__/email_notification_setting.test.jsx.snap
+++ b/components/user_settings/notifications/email_notification_setting/__snapshots__/email_notification_setting.test.jsx.snap
@@ -2,7 +2,13 @@
 
 exports[`components/user_settings/notifications/EmailNotificationSetting should match snapshot 1`] = `
 <EmailNotificationSetting
+  actions={
+    Object {
+      "savePreferences": [MockFunction],
+    }
+  }
   activeSection="email"
+  currentUserId="current_user_id"
   emailInterval={0}
   enableEmail={false}
   enableEmailBatching={false}
@@ -321,7 +327,13 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
 
 exports[`components/user_settings/notifications/EmailNotificationSetting should match snapshot, enabled email batching 1`] = `
 <EmailNotificationSetting
+  actions={
+    Object {
+      "savePreferences": [MockFunction],
+    }
+  }
   activeSection="email"
+  currentUserId="current_user_id"
   emailInterval={0}
   enableEmail={false}
   enableEmailBatching={true}

--- a/components/user_settings/notifications/email_notification_setting/email_notification_setting.jsx
+++ b/components/user_settings/notifications/email_notification_setting/email_notification_setting.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import {savePreference} from 'actions/user_actions.jsx';
 import {Preferences} from 'utils/constants.jsx';
 import {localizeMessage} from 'utils/utils.jsx';
 import SettingItemMax from 'components/setting_item_max.jsx';
@@ -13,6 +12,7 @@ import SettingItemMin from 'components/setting_item_min.jsx';
 
 export default class EmailNotificationSetting extends React.Component {
     static propTypes = {
+        currentUserId: PropTypes.string.isRequired,
         activeSection: PropTypes.string.isRequired,
         updateSection: PropTypes.func.isRequired,
         enableEmail: PropTypes.bool.isRequired,
@@ -25,6 +25,9 @@ export default class EmailNotificationSetting extends React.Component {
         sendEmailNotifications: PropTypes.bool,
         enableEmailBatching: PropTypes.bool,
         siteName: PropTypes.string,
+        actions: PropTypes.shape({
+            savePreferences: PropTypes.func.isRequired,
+        }).isRequired,
     };
 
     constructor(props) {
@@ -54,11 +57,19 @@ export default class EmailNotificationSetting extends React.Component {
         });
     }
 
-    handleSubmit = () => {
+    handleSubmit = async () => {
         const {enableEmail, emailInterval} = this.state;
         if (this.props.enableEmail !== enableEmail || this.props.emailInterval !== emailInterval) {
             // until the rest of the notification settings are moved to preferences, we have to do this separately
-            savePreference(Preferences.CATEGORY_NOTIFICATIONS, Preferences.EMAIL_INTERVAL, emailInterval.toString());
+            const {currentUserId, actions} = this.props;
+            const preferences = [{
+                user_id: currentUserId,
+                category: Preferences.CATEGORY_NOTIFICATIONS,
+                name: Preferences.EMAIL_INTERVAL,
+                value: emailInterval.toString(),
+            }];
+
+            await actions.savePreferences(currentUserId, preferences);
 
             this.props.onSubmit(enableEmail);
         } else {

--- a/components/user_settings/notifications/email_notification_setting/index.js
+++ b/components/user_settings/notifications/email_notification_setting/index.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {savePreferences} from 'mattermost-redux/actions/preferences';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
+
+import EmailNotificationSetting from './email_notification_setting';
+
+function mapStateToProps() {
+    return (state) => ({
+        currentUserId: getCurrentUserId(state),
+    });
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            savePreferences,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(EmailNotificationSetting);

--- a/components/user_settings/notifications/user_settings_notifications.jsx
+++ b/components/user_settings/notifications/user_settings_notifications.jsx
@@ -12,7 +12,7 @@ import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min.jsx';
 
 import DesktopNotificationSettings from './desktop_notification_settings.jsx';
-import EmailNotificationSetting from './email_notification_setting.jsx';
+import EmailNotificationSetting from './email_notification_setting';
 import ManageAutoResponder from './manage_auto_responder.jsx';
 
 function getNotificationsStateFromProps(props) {


### PR DESCRIPTION
#### Summary
Migrated preference related old actions to redux actions. Updated corresponding components. 

#### Ticket Link
[MM-12737](https://github.com/mattermost/mattermost-server/issues/10147)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Added or updated unit tests (required for all new features)
