### PR TITLE
[MM-13939] Fix for unicode emoji rending on separate line from the rest of a sentence in a post

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/SizeAwareImage should render a placeholder and has loader when showLoader is true 1`] = `
-<div>
+<Fragment>
   <div
     style={
       Object {
@@ -16,5 +16,5 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
   <img
     src="data:image/png;base64,abc123"
   />
-</div>
+</Fragment>
 `;

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -131,7 +131,7 @@ export default class SizeAwareImage extends React.PureComponent {
         }
 
         return (
-            <div>
+            <React.Fragment>
                 {!this.state.loaded && this.props.showLoader &&
                     <div style={{position: 'absolute'}}>
                         <LoadingImagePreview
@@ -143,7 +143,7 @@ export default class SizeAwareImage extends React.PureComponent {
                     {...props}
                     src={src}
                 />
-            </div>
+            </React.Fragment>
         );
     }
 }


### PR DESCRIPTION
#### Summary
Corrects the rendering of an inline emoji that is initially added via unicode and is swapped for an emoji image at render time. The swapped emoji image renders on its own line instead of rending inline with the rest of the sentence. This PR ensures the emoji image renders inline as intended.

#### Ticket Link
[MM-13939](https://mattermost.atlassian.net/projects/MM/issues/MM-13939)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Touches critical sections of the codebase (auth, posting, etc.)
