### PR TITLE
MM-13924 Ensure OpenGraph and message attachment images go through the proxy

### DIFF
--- a/components/post_view/message_attachments/message_attachment/index.js
+++ b/components/post_view/message_attachments/message_attachment/index.js
@@ -5,8 +5,15 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {doPostAction} from 'mattermost-redux/actions/posts';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import MessageAttachment from './message_attachment';
+
+function mapStateToProps(state) {
+    return {
+        hasImageProxy: getConfig(state).HasImageProxy === 'true',
+    };
+}
 
 function mapDispatchToProps(dispatch) {
     return {
@@ -16,4 +23,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(null, mapDispatchToProps)(MessageAttachment);
+export default connect(mapStateToProps, mapDispatchToProps)(MessageAttachment);

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -6,7 +6,8 @@ import React from 'react';
 
 import {postListScrollChange} from 'actions/global_actions';
 
-import {isUrlSafe} from 'utils/url.jsx';
+import {getImageSrc} from 'utils/post_utils';
+import {isUrlSafe} from 'utils/url';
 import {handleFormattedTextClick} from 'utils/utils';
 
 import Markdown from 'components/markdown';
@@ -35,6 +36,11 @@ export default class MessageAttachment extends React.PureComponent {
          * Options specific to text formatting
          */
         options: PropTypes.object,
+
+        /**
+         * Whether or not the server has an image proxy enabled
+         */
+        hasImageProxy: PropTypes.bool.isRequired,
 
         /**
          * images object for dimensions
@@ -254,7 +260,7 @@ export default class MessageAttachment extends React.PureComponent {
                 author.push(
                     <img
                         className='attachment__author-icon'
-                        src={attachment.author_icon}
+                        src={getImageSrc(attachment.author_icon, this.props.hasImageProxy)}
                         key={'attachment__author-icon'}
                         height='14'
                         width='14'
@@ -333,7 +339,7 @@ export default class MessageAttachment extends React.PureComponent {
                     <SizeAwareImage
                         className='attachment__image'
                         onHeightReceived={this.handleHeightReceivedForImageUrl}
-                        src={attachment.image_url}
+                        src={getImageSrc(attachment.image_url, this.props.hasImageProxy)}
                         dimensions={this.props.imagesMetadata[attachment.image_url]}
                     />
                 </div>
@@ -343,12 +349,10 @@ export default class MessageAttachment extends React.PureComponent {
         let thumb;
         if (attachment.thumb_url) {
             thumb = (
-                <div
-                    className='attachment__thumb-container'
-                >
+                <div className='attachment__thumb-container'>
                     <SizeAwareImage
                         onHeightReceived={this.handleHeightReceivedForThumbUrl}
-                        src={attachment.thumb_url}
+                        src={getImageSrc(attachment.thumb_url, this.props.hasImageProxy)}
                         dimensions={this.props.imagesMetadata[attachment.thumb_url]}
                     />
                 </div>

--- a/components/post_view/message_attachments/message_attachment/message_attachment.test.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.test.jsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 
 import MessageAttachment from 'components/post_view/message_attachments/message_attachment/message_attachment.jsx';
 import {postListScrollChange} from 'actions/global_actions';
@@ -29,6 +29,7 @@ describe('components/post_view/MessageAttachment', () => {
         postId: 'post_id',
         attachment,
         actions: {doPostAction: jest.fn()},
+        hasImageProxy: false,
         imagesMetadata: {
             image_url: {
                 height: 200,
@@ -117,5 +118,23 @@ describe('components/post_view/MessageAttachment', () => {
 
         wrapper = shallow(<MessageAttachment {...props}/>);
         expect(wrapper.instance().getFieldsTable()).toMatchSnapshot();
+    });
+
+    test('should proxy external images if image proxy is enabled', () => {
+        const props = {
+            ...baseProps,
+            attachment: {
+                author_icon: 'http://example.com/author.png',
+                image_url: 'http://example.com/image.png',
+                thumb_url: 'http://example.com/thumb.png',
+            },
+            hasImageProxy: true,
+        };
+
+        const wrapper = mount(<MessageAttachment {...props}/>);
+
+        expect(wrapper.find('.attachment__author-icon').prop('src')).toMatch(`/api/v4/image\\?url=${encodeURIComponent(props.attachment.author_icon)}`);
+        expect(wrapper.find('.attachment__image-container img').prop('src')).toMatch(`/api/v4/image\\?url=${encodeURIComponent(props.attachment.image_url)}`);
+        expect(wrapper.find('.attachment__thumb-container img').prop('src')).toMatch(`/api/v4/image\\?url=${encodeURIComponent(props.attachment.thumb_url)}`);
     });
 });

--- a/components/post_view/post_attachment_opengraph/index.js
+++ b/components/post_view/post_attachment_opengraph/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getOpenGraphMetadata} from 'mattermost-redux/actions/posts';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getOpenGraphMetadataForUrl} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
@@ -14,6 +15,7 @@ import PostAttachmentOpenGraph from './post_attachment_opengraph.jsx';
 function mapStateToProps(state, ownProps) {
     return {
         currentUser: getCurrentUser(state),
+        hasImageProxy: getConfig(state).HasImageProxy === 'true',
         openGraphData: getOpenGraphMetadataForUrl(state, ownProps.link),
     };
 }

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.test.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.test.jsx
@@ -1,0 +1,72 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Client4} from 'mattermost-redux/client';
+
+import PostAttachmentOpenGraph from './post_attachment_opengraph';
+
+describe('PostAttachmentOpenGraph', () => {
+    describe('getBestImageUrl', () => {
+        test('should return nothing with no OpenGraph metadata', () => {
+            const data = null;
+
+            expect(PostAttachmentOpenGraph.getBestImageUrl(data, false)).toEqual(null);
+        });
+
+        test('should return nothing with missing OpenGraph images', () => {
+            const data = {};
+
+            expect(PostAttachmentOpenGraph.getBestImageUrl(data, false)).toEqual(null);
+        });
+
+        test('should return nothing with no OpenGraph images', () => {
+            const data = {
+                images: [],
+            };
+
+            expect(PostAttachmentOpenGraph.getBestImageUrl(data, false)).toEqual(null);
+        });
+
+        test('should return secure_url if specified', () => {
+            const data = {
+                images: [{
+                    secure_url: 'https://example.com/image.png',
+                    url: 'http://example.com/image.png',
+                }],
+            };
+
+            expect(PostAttachmentOpenGraph.getBestImageUrl(data, false)).toEqual(data.images[0].secure_url);
+        });
+
+        test('should return url if secure_url is not specified', () => {
+            const data = {
+                images: [{
+                    secure_url: '',
+                    url: 'http://example.com/image.png',
+                }],
+            };
+
+            expect(PostAttachmentOpenGraph.getBestImageUrl(data, false)).toEqual(data.images[0].url);
+        });
+
+        test('should return a proxied image URL if the image proxy is enabled', () => {
+            const data = {
+                images: [{
+                    url: 'http://example.com/image.png',
+                }],
+            };
+
+            expect(PostAttachmentOpenGraph.getBestImageUrl(data, true).endsWith(`/api/v4/image?url=${encodeURIComponent(data.images[0].url)}`)).toEqual(true);
+        });
+
+        test('should not mangle a URL that is already proxied if the image proxy is enabled', () => {
+            const data = {
+                images: [{
+                    url: `${Client4.getBaseRoute()}/image?url=${encodeURIComponent('http://example.com/image.png')}`,
+                }],
+            };
+
+            expect(PostAttachmentOpenGraph.getBestImageUrl(data, true)).toEqual(data.images[0].url);
+        });
+    });
+});

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -47,9 +47,16 @@ export function isEdited(post) {
 }
 
 export function getImageSrc(src, hasImageProxy) {
-    if (hasImageProxy) {
-        return Client4.getBaseRoute() + '/image?url=' + encodeURIComponent(src);
+    if (!src) {
+        return src;
     }
+
+    const imageAPI = Client4.getBaseRoute() + '/image?url=';
+
+    if (hasImageProxy && !src.startsWith(imageAPI)) {
+        return imageAPI + encodeURIComponent(src);
+    }
+
     return src;
 }
 


### PR DESCRIPTION
Doing this on the app instead of the server because it might otherwise cause problems when we're requesting image dimensions. I was looking at a more generic way of doing this, but this doesn't seem like the time to add it since we're just about to kick off RC testing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13924

#### Checklist
- Added or updated unit tests (required for all new features)