### PR TITLE
MM-13099 Use size_aware_image component for when loading images in posts

### DIFF
--- a/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
+++ b/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`components/post_view/MessageAttachment should call actions.doPostAction
             <Connect(Markdown)
               imageProps={
                 Object {
-                  "onHeightReceived": [Function],
+                  "onImageLoaded": [Function],
                 }
               }
               message="short text"
@@ -84,7 +84,7 @@ exports[`components/post_view/MessageAttachment should call actions.doPostAction
                   "width": 200,
                 }
               }
-              onHeightReceived={[Function]}
+              onImageLoaded={[Function]}
               src="image_url"
             />
           </div>
@@ -114,7 +114,7 @@ exports[`components/post_view/MessageAttachment should call actions.doPostAction
                 "width": 200,
               }
             }
-            onHeightReceived={[Function]}
+            onImageLoaded={[Function]}
             src="thumb_url"
           />
         </div>
@@ -198,7 +198,7 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
             <Connect(Markdown)
               imageProps={
                 Object {
-                  "onHeightReceived": [Function],
+                  "onImageLoaded": [Function],
                 }
               }
               message="short text"
@@ -215,7 +215,7 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
                   "width": 200,
                 }
               }
-              onHeightReceived={[Function]}
+              onImageLoaded={[Function]}
               src="image_url"
             />
           </div>
@@ -230,7 +230,7 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
                 "width": 200,
               }
             }
-            onHeightReceived={[Function]}
+            onImageLoaded={[Function]}
             src="thumb_url"
           />
         </div>

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -60,7 +60,7 @@ export default class MessageAttachment extends React.PureComponent {
         };
 
         this.imageProps = {
-            onHeightReceived: this.handleHeightReceived,
+            onImageLoaded: this.handleHeightReceived,
         };
     }
 
@@ -72,14 +72,14 @@ export default class MessageAttachment extends React.PureComponent {
         this.mounted = false;
     }
 
-    handleHeightReceivedForThumbUrl = (height) => {
+    handleHeightReceivedForThumbUrl = ({height}) => {
         const {attachment} = this.props;
         if (!this.props.imagesMetadata || (this.props.imagesMetadata && !this.props.imagesMetadata[attachment.thumb_url])) {
             this.handleHeightReceived(height);
         }
     }
 
-    handleHeightReceivedForImageUrl = (height) => {
+    handleHeightReceivedForImageUrl = ({height}) => {
         const {attachment} = this.props;
         if (!this.props.imagesMetadata || (this.props.imagesMetadata && !this.props.imagesMetadata[attachment.image_url])) {
             this.handleHeightReceived(height);
@@ -347,7 +347,7 @@ export default class MessageAttachment extends React.PureComponent {
                 <div className='attachment__image-container'>
                     <SizeAwareImage
                         className='attachment__image'
-                        onHeightReceived={this.handleHeightReceivedForImageUrl}
+                        onImageLoaded={this.handleHeightReceivedForImageUrl}
                         src={getImageSrc(attachment.image_url, this.props.hasImageProxy)}
                         dimensions={this.props.imagesMetadata[attachment.image_url]}
                     />
@@ -360,7 +360,7 @@ export default class MessageAttachment extends React.PureComponent {
             thumb = (
                 <div className='attachment__thumb-container'>
                     <SizeAwareImage
-                        onHeightReceived={this.handleHeightReceivedForThumbUrl}
+                        onImageLoaded={this.handleHeightReceivedForThumbUrl}
                         src={getImageSrc(attachment.thumb_url, this.props.hasImageProxy)}
                         dimensions={this.props.imagesMetadata[attachment.thumb_url]}
                     />

--- a/components/post_view/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
+++ b/components/post_view/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
@@ -38,26 +38,19 @@ exports[`components/post_view/PostAttachmentOpenGraph Match snapshot for large i
             <div>
               description
                
-              <a
-                aria-label="Toggle Embed Visibility"
-                className="post__embed-visibility"
-                data-expanded={true}
-                onClick={[MockFunction]}
-              />
             </div>
-            <SizeAwareImage
-              className="attachment__image attachment__image--opengraph large_image"
-              dimensions={
-                Object {
-                  "height": 180,
-                  "width": 400,
-                }
-              }
-              onImageLoaded={[Function]}
-              src="http://mattermost.com/OpenGraphImage.jpg"
-            />
           </div>
         </div>
+      </div>
+      <div
+        className="attachment__image__container--opengraph"
+      >
+        <SizeAwareImage
+          className="attachment__image attachment__image--opengraph"
+          dimensions={null}
+          onImageLoaded={[Function]}
+          src="/api/v4/image?url=http%3A%2F%2Fmattermost.com%2FOpenGraphImage.jpg"
+        />
       </div>
     </div>
   </div>
@@ -113,14 +106,9 @@ exports[`components/post_view/PostAttachmentOpenGraph Match snapshot for small i
       >
         <SizeAwareImage
           className="attachment__image attachment__image--opengraph"
-          dimensions={
-            Object {
-              "height": 100,
-              "width": 100,
-            }
-          }
+          dimensions={null}
           onImageLoaded={[Function]}
-          src="http://mattermost.com/OpenGraphImage.jpg"
+          src="/api/v4/image?url=http%3A%2F%2Fmattermost.com%2FOpenGraphImage.jpg"
         />
       </div>
     </div>
@@ -188,14 +176,9 @@ exports[`components/post_view/PostAttachmentOpenGraph Match snapshot for with re
       >
         <SizeAwareImage
           className="attachment__image attachment__image--opengraph"
-          dimensions={
-            Object {
-              "height": 100,
-              "width": 100,
-            }
-          }
+          dimensions={null}
           onImageLoaded={[Function]}
-          src="http://mattermost.com/OpenGraphImage.jpg"
+          src="/api/v4/image?url=http%3A%2F%2Fmattermost.com%2FOpenGraphImage.jpg"
         />
       </div>
     </div>

--- a/components/post_view/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
+++ b/components/post_view/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
@@ -1,0 +1,204 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/post_view/PostAttachmentOpenGraph Match snapshot for large image openGraphData 1`] = `
+<div
+  className="attachment attachment--opengraph"
+>
+  <div
+    className="attachment__content"
+  >
+    <div
+      className="clearfix attachment__container attachment__container--opengraph"
+    >
+      <div
+        className="attachment__body__wrap attachment__body__wrap--opengraph"
+      >
+        <span
+          className="sitename"
+        >
+          Mattermost
+        </span>
+        <h1
+          className="attachment__title attachment__title--opengraph"
+        >
+          <a
+            className="attachment__title-link attachment__title-link--opengraph"
+            href="http://mattermost.com"
+            rel="noopener noreferrer"
+            target="_blank"
+            title="Mattermost Private Cloud Messaging"
+          >
+            Mattermost Private Cloud Messaging
+          </a>
+        </h1>
+        <div
+          className="attachment__body attachment__body--opengraph"
+        >
+          <div>
+            <div>
+              description
+               
+              <a
+                aria-label="Toggle Embed Visibility"
+                className="post__embed-visibility"
+                data-expanded={true}
+                onClick={[MockFunction]}
+              />
+            </div>
+            <SizeAwareImage
+              className="attachment__image attachment__image--opengraph large_image"
+              dimensions={
+                Object {
+                  "height": 180,
+                  "width": 400,
+                }
+              }
+              onImageLoaded={[Function]}
+              src="http://mattermost.com/OpenGraphImage.jpg"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/post_view/PostAttachmentOpenGraph Match snapshot for no openGraphData 1`] = `""`;
+
+exports[`components/post_view/PostAttachmentOpenGraph Match snapshot for small image openGraphData 1`] = `
+<div
+  className="attachment attachment--opengraph"
+>
+  <div
+    className="attachment__content"
+  >
+    <div
+      className="clearfix attachment__container attachment__container--opengraph"
+    >
+      <div
+        className="attachment__body__wrap attachment__body__wrap--opengraph"
+      >
+        <span
+          className="sitename"
+        >
+          Mattermost
+        </span>
+        <h1
+          className="attachment__title attachment__title--opengraph"
+        >
+          <a
+            className="attachment__title-link attachment__title-link--opengraph"
+            href="http://mattermost.com"
+            rel="noopener noreferrer"
+            target="_blank"
+            title="Mattermost Private Cloud Messaging"
+          >
+            Mattermost Private Cloud Messaging
+          </a>
+        </h1>
+        <div
+          className="attachment__body attachment__body--opengraph"
+        >
+          <div>
+            <div>
+              description
+               
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="attachment__image__container--opengraph"
+      >
+        <SizeAwareImage
+          className="attachment__image attachment__image--opengraph"
+          dimensions={
+            Object {
+              "height": 100,
+              "width": 100,
+            }
+          }
+          onImageLoaded={[Function]}
+          src="http://mattermost.com/OpenGraphImage.jpg"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/post_view/PostAttachmentOpenGraph Match snapshot for with remove preview 1`] = `
+<div
+  className="attachment attachment--opengraph"
+>
+  <div
+    className="attachment__content"
+  >
+    <div
+      className="clearfix attachment__container attachment__container--opengraph"
+    >
+      <div
+        className="attachment__body__wrap attachment__body__wrap--opengraph"
+      >
+        <span
+          className="sitename"
+        >
+          Mattermost
+        </span>
+        <button
+          aria-label="Close"
+          className="btn-close"
+          id="removePreviewButton"
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+          >
+            ×
+          </span>
+        </button>
+        <h1
+          className="attachment__title attachment__title--opengraph"
+        >
+          <a
+            className="attachment__title-link attachment__title-link--opengraph"
+            href="http://mattermost.com"
+            rel="noopener noreferrer"
+            target="_blank"
+            title="Mattermost Private Cloud Messaging"
+          >
+            Mattermost Private Cloud Messaging
+          </a>
+        </h1>
+        <div
+          className="attachment__body attachment__body--opengraph"
+        >
+          <div>
+            <div>
+              description
+               
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="attachment__image__container--opengraph"
+      >
+        <SizeAwareImage
+          className="attachment__image attachment__image--opengraph"
+          dimensions={
+            Object {
+              "height": 100,
+              "width": 100,
+            }
+          }
+          onImageLoaded={[Function]}
+          src="http://mattermost.com/OpenGraphImage.jpg"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.test.js
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.test.js
@@ -1,0 +1,123 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import PostAttachmentOpenGraph from './post_attachment_opengraph.jsx';
+
+describe('components/post_view/PostAttachmentOpenGraph', () => {
+    const post = {
+        id: 'post_id_1',
+        root_id: 'root_id',
+        channel_id: 'channel_id',
+        create_at: 1,
+        message: 'https://mattermost.com',
+        metadata: {
+            images: {
+                'http://mattermost.com/OpenGraphImage.jpg': {
+                    height: 100,
+                    width: 100,
+                },
+            },
+        },
+    };
+
+    const baseProps = {
+        post,
+        link: 'http://mattermost.com',
+        previewEnabled: true,
+        isEmbedVisible: true,
+        enableLinkPreviews: true,
+        hasImageProxy: true,
+        currentUser: {
+            id: '1234',
+        },
+        openGraphData: {
+            description: 'description',
+            images: [{
+                height: 100,
+                secure_url: '',
+                url: 'http://mattermost.com/OpenGraphImage.jpg',
+                width: 100,
+            }],
+            site_name: 'Mattermost',
+            title: 'Mattermost Private Cloud Messaging',
+        },
+        toggleEmbedVisibility: jest.fn(),
+        actions: {
+            editPost: jest.fn(),
+            getOpenGraphMetadata: jest.fn(),
+        },
+    };
+
+    test('Match snapshot for no openGraphData', () => {
+        const props = {
+            ...baseProps,
+            openGraphData: null,
+        };
+
+        const wrapper = shallow(
+            <PostAttachmentOpenGraph {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('Match snapshot for small image openGraphData', () => {
+        const wrapper = shallow(
+            <PostAttachmentOpenGraph {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('Match snapshot for large image openGraphData', () => {
+        const props = {
+            ...baseProps,
+            openGraphData: {
+                ...baseProps.openGraphData,
+                images: [{
+                    height: 180,
+                    secure_url: '',
+                    url: 'http://mattermost.com/OpenGraphImage.jpg',
+                    width: 400,
+                }],
+            },
+            post: {
+                ...post,
+                metadata: {
+                    ...post.metadata,
+                    images: {
+                        'http://mattermost.com/OpenGraphImage.jpg': {
+                            height: 180,
+                            width: 400,
+                        },
+                    },
+                },
+            },
+        };
+
+        const wrapper = shallow(
+            <PostAttachmentOpenGraph {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('Match snapshot for with remove preview', () => {
+        const props = {
+            ...baseProps,
+            post: {
+                ...post,
+                user_id: '1234',
+            },
+        };
+
+        const wrapper = shallow(
+            <PostAttachmentOpenGraph {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/post_view/post_image/post_image.jsx
+++ b/components/post_view/post_image/post_image.jsx
@@ -88,7 +88,7 @@ export default class PostImage extends React.PureComponent {
                     src={PostUtils.getImageSrc(this.props.link, this.props.hasImageProxy)}
                     dimensions={this.props.dimensions}
                     showLoader={true}
-                    onHeightReceived={this.handleLoadComplete}
+                    onImageLoaded={this.handleLoadComplete}
                     onImageLoadFail={this.handleLoadError}
                     onClick={this.onImageClick}
                 />

--- a/components/post_view/post_message_view/__snapshots__/post_message_view.test.jsx.snap
+++ b/components/post_view/post_message_view/__snapshots__/post_message_view.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
     <Connect(PostMarkdown)
       imageProps={
         Object {
-          "onHeightReceived": [Function],
+          "onImageLoaded": [Function],
         }
       }
       isRHS={false}
@@ -52,7 +52,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show Less
     <Connect(PostMarkdown)
       imageProps={
         Object {
-          "onHeightReceived": [Function],
+          "onImageLoaded": [Function],
         }
       }
       isRHS={false}
@@ -90,7 +90,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show More
     <Connect(PostMarkdown)
       imageProps={
         Object {
-          "onHeightReceived": [Function],
+          "onImageLoaded": [Function],
         }
       }
       isRHS={false}
@@ -148,7 +148,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on edited po
     <Connect(PostMarkdown)
       imageProps={
         Object {
-          "onHeightReceived": [Function],
+          "onImageLoaded": [Function],
         }
       }
       isRHS={false}
@@ -208,7 +208,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on ephemeral
     <Connect(PostMarkdown)
       imageProps={
         Object {
-          "onHeightReceived": [Function],
+          "onImageLoaded": [Function],
         }
       }
       isRHS={false}

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -82,7 +82,7 @@ export default class PostMessageView extends React.PureComponent {
         };
 
         this.imageProps = {
-            onHeightReceived: this.handleHeightReceived,
+            onImageLoaded: this.handleHeightReceived,
         };
     }
 

--- a/components/single_image_view/__snapshots__/single_image_view.test.jsx.snap
+++ b/components/single_image_view/__snapshots__/single_image_view.test.jsx.snap
@@ -28,16 +28,12 @@ exports[`components/SingleImageView should match snapshot 1`] = `
       style={Object {}}
     >
       <div
-        className="image-loaded "
+        className="image-loaded  "
         onClick={[Function]}
-        style={
-          Object {
-            "height": "initial",
-          }
-        }
+        style={Object {}}
       >
         <SizeAwareImage
-          className=" "
+          className=""
           dimensions={
             Object {
               "height": 200,
@@ -82,16 +78,12 @@ exports[`components/SingleImageView should match snapshot 2`] = `
       style={Object {}}
     >
       <div
-        className="image-loaded image-fade-in"
+        className="image-loaded image-fade-in "
         onClick={[Function]}
-        style={
-          Object {
-            "height": "initial",
-          }
-        }
+        style={Object {}}
       >
         <SizeAwareImage
-          className=" "
+          className=""
           dimensions={
             Object {
               "height": 200,
@@ -153,20 +145,17 @@ exports[`components/SingleImageView should match snapshot, SVG image 1`] = `
       style={
         Object {
           "height": 150,
+          "width": "auto",
         }
       }
     >
       <div
-        className="image-loaded "
+        className="image-loaded  svg"
         onClick={[Function]}
-        style={
-          Object {
-            "height": "100%",
-          }
-        }
+        style={Object {}}
       >
         <SizeAwareImage
-          className=" post-image normal"
+          className=""
           dimensions={
             Object {
               "height": undefined,
@@ -211,20 +200,17 @@ exports[`components/SingleImageView should match snapshot, SVG image 2`] = `
       style={
         Object {
           "height": 150,
+          "width": "auto",
         }
       }
     >
       <div
-        className="image-loaded image-fade-in"
+        className="image-loaded image-fade-in svg"
         onClick={[Function]}
-        style={
-          Object {
-            "height": "100%",
-          }
-        }
+        style={Object {}}
       >
         <SizeAwareImage
-          className=" post-image normal"
+          className=""
           dimensions={
             Object {
               "height": undefined,
@@ -283,16 +269,12 @@ exports[`components/SingleImageView should set loaded state on callback of onIma
       style={Object {}}
     >
       <div
-        className="image-loaded image-fade-in"
+        className="image-loaded image-fade-in "
         onClick={[Function]}
-        style={
-          Object {
-            "height": "initial",
-          }
-        }
+        style={Object {}}
       >
         <SizeAwareImage
-          className=" "
+          className=""
           dimensions={
             Object {
               "height": 200,

--- a/components/single_image_view/__snapshots__/single_image_view.test.jsx.snap
+++ b/components/single_image_view/__snapshots__/single_image_view.test.jsx.snap
@@ -30,6 +30,11 @@ exports[`components/SingleImageView should match snapshot 1`] = `
       <div
         className="image-loaded "
         onClick={[Function]}
+        style={
+          Object {
+            "height": "initial",
+          }
+        }
       >
         <SizeAwareImage
           className=" "
@@ -79,6 +84,11 @@ exports[`components/SingleImageView should match snapshot 2`] = `
       <div
         className="image-loaded image-fade-in"
         onClick={[Function]}
+        style={
+          Object {
+            "height": "initial",
+          }
+        }
       >
         <SizeAwareImage
           className=" "
@@ -149,6 +159,11 @@ exports[`components/SingleImageView should match snapshot, SVG image 1`] = `
       <div
         className="image-loaded "
         onClick={[Function]}
+        style={
+          Object {
+            "height": "100%",
+          }
+        }
       >
         <SizeAwareImage
           className=" post-image normal"
@@ -202,6 +217,11 @@ exports[`components/SingleImageView should match snapshot, SVG image 2`] = `
       <div
         className="image-loaded image-fade-in"
         onClick={[Function]}
+        style={
+          Object {
+            "height": "100%",
+          }
+        }
       >
         <SizeAwareImage
           className=" post-image normal"
@@ -265,6 +285,11 @@ exports[`components/SingleImageView should set loaded state on callback of onIma
       <div
         className="image-loaded image-fade-in"
         onClick={[Function]}
+        style={
+          Object {
+            "height": "initial",
+          }
+        }
       >
         <SizeAwareImage
           className=" "

--- a/components/single_image_view/__snapshots__/single_image_view.test.jsx.snap
+++ b/components/single_image_view/__snapshots__/single_image_view.test.jsx.snap
@@ -30,27 +30,18 @@ exports[`components/SingleImageView should match snapshot 1`] = `
       <div
         className="image-loaded "
         onClick={[Function]}
-        style={
-          Object {
-            "height": 200,
-          }
-        }
       >
-        <img
+        <SizeAwareImage
           className=" "
-          style={
+          dimensions={
             Object {
               "height": 200,
+              "width": 350,
             }
           }
-        />
-      </div>
-      <div
-        className="image-preload"
-      >
-        <LoadingImagePreview
-          containerClass="file__image-loading"
-          loading="Loading"
+          onImageLoaded={[Function]}
+          showLoader={true}
+          src="/api/v4/files/file_info_id/preview"
         />
       </div>
     </div>
@@ -88,20 +79,20 @@ exports[`components/SingleImageView should match snapshot 2`] = `
       <div
         className="image-loaded image-fade-in"
         onClick={[Function]}
-        style={Object {}}
       >
-        <img
+        <SizeAwareImage
           className=" "
-          style={
+          dimensions={
             Object {
-              "cursor": "pointer",
+              "height": 200,
+              "width": 350,
             }
           }
+          onImageLoaded={[Function]}
+          showLoader={true}
+          src="/api/v4/files/file_info_id/preview"
         />
       </div>
-      <div
-        className="image-preload"
-      />
     </div>
     <Connect(ViewImageModal)
       fileInfos={
@@ -151,27 +142,25 @@ exports[`components/SingleImageView should match snapshot, SVG image 1`] = `
       className="image-container"
       style={
         Object {
-          "height": 350,
-          "width": 300,
+          "height": 150,
         }
       }
     >
       <div
         className="image-loaded "
         onClick={[Function]}
-        style={Object {}}
       >
-        <img
+        <SizeAwareImage
           className=" post-image normal"
-          style={Object {}}
-        />
-      </div>
-      <div
-        className="image-preload"
-      >
-        <LoadingImagePreview
-          containerClass="file__image-loading"
-          loading="Loading"
+          dimensions={
+            Object {
+              "height": undefined,
+              "width": undefined,
+            }
+          }
+          onImageLoaded={[Function]}
+          showLoader={true}
+          src="/api/v4/files/svg_file_info_id"
         />
       </div>
     </div>
@@ -206,27 +195,27 @@ exports[`components/SingleImageView should match snapshot, SVG image 2`] = `
       className="image-container"
       style={
         Object {
-          "width": 300,
+          "height": 150,
         }
       }
     >
       <div
         className="image-loaded image-fade-in"
         onClick={[Function]}
-        style={Object {}}
       >
-        <img
+        <SizeAwareImage
           className=" post-image normal"
-          style={
+          dimensions={
             Object {
-              "cursor": "pointer",
+              "height": undefined,
+              "width": undefined,
             }
           }
+          onImageLoaded={[Function]}
+          showLoader={true}
+          src="/api/v4/files/svg_file_info_id"
         />
       </div>
-      <div
-        className="image-preload"
-      />
     </div>
     <Connect(ViewImageModal)
       fileInfos={
@@ -236,6 +225,72 @@ exports[`components/SingleImageView should match snapshot, SVG image 2`] = `
             "id": "svg_file_info_id",
             "name": "name_svg",
             "post_id": "post_id",
+          },
+        ]
+      }
+      onModalDismissed={[Function]}
+      show={false}
+    />
+  </div>
+</div>
+`;
+
+exports[`components/SingleImageView should set loaded state on callback of onImageLoaded on SizeAwareImage component 1`] = `
+<div
+  className="file-view--single"
+>
+  <div
+    className="file__image"
+  >
+    <div
+      className="image-name"
+    >
+      <a
+        aria-label="Toggle Embed Visibility"
+        className="post__embed-visibility"
+        data-expanded={true}
+        key="toggle"
+        onClick={[Function]}
+      />
+      <div
+        onClick={[Function]}
+      >
+        name
+      </div>
+    </div>
+    <div
+      className="image-container"
+      style={Object {}}
+    >
+      <div
+        className="image-loaded image-fade-in"
+        onClick={[Function]}
+      >
+        <SizeAwareImage
+          className=" "
+          dimensions={
+            Object {
+              "height": 200,
+              "width": 350,
+            }
+          }
+          onImageLoaded={[Function]}
+          showLoader={true}
+          src="/api/v4/files/file_info_id/preview"
+        />
+      </div>
+    </div>
+    <Connect(ViewImageModal)
+      fileInfos={
+        Array [
+          Object {
+            "extension": "jpg",
+            "has_preview_image": true,
+            "height": 200,
+            "id": "file_info_id",
+            "name": "name",
+            "post_id": "post_id",
+            "width": 350,
           },
         ]
       }

--- a/components/single_image_view/single_image_view.jsx
+++ b/components/single_image_view/single_image_view.jsx
@@ -63,10 +63,6 @@ export default class SingleImageView extends React.PureComponent {
         this.mounted = false;
     }
 
-    setViewPortRef = (node) => {
-        this.viewPort = node;
-    }
-
     imageLoaded = () => {
         if (this.mounted) {
             this.setState({loaded: true});
@@ -133,24 +129,22 @@ export default class SingleImageView extends React.PureComponent {
         let viewImageModal;
         let fadeInClass = '';
 
-        let height = previewHeight;
-        if (height < PREVIEW_IMAGE_MIN_DIMENSION) {
-            height = PREVIEW_IMAGE_MIN_DIMENSION;
-        }
-
-        let width = previewWidth;
-        if (width < PREVIEW_IMAGE_MIN_DIMENSION) {
-            width = PREVIEW_IMAGE_MIN_DIMENSION;
-        }
-
         const fileType = getFileType(fileInfo.extension);
-        let svgClass = '';
+        let styleIfSvgWithDimentions = {};
         let imageContainerStyle = {};
+        let svgClass = '';
         if (fileType === FileTypes.SVG) {
-            svgClass = 'post-image normal';
-            imageContainerStyle = {
-                height: 150,
-            };
+            svgClass = 'svg';
+            if (this.state.dimensions.height) {
+                styleIfSvgWithDimentions = {
+                    width: '100%',
+                };
+            } else {
+                imageContainerStyle = {
+                    height: 150,
+                    width: 'auto',
+                };
+            }
         }
 
         if (loaded) {
@@ -167,7 +161,6 @@ export default class SingleImageView extends React.PureComponent {
 
         return (
             <div
-                ref='singleImageView'
                 className={`${'file-view--single'}`}
             >
                 <div
@@ -180,12 +173,12 @@ export default class SingleImageView extends React.PureComponent {
                         style={imageContainerStyle}
                     >
                         <div
-                            className={`image-loaded ${fadeInClass}`}
-                            style={{height: fileType === FileTypes.SVG ? '100%' : 'initial'}}
+                            className={`image-loaded ${fadeInClass} ${svgClass}`}
+                            style={styleIfSvgWithDimentions}
                             onClick={this.handleImageClick}
                         >
                             <SizeAwareImage
-                                className={`${minPreviewClass} ${svgClass}`}
+                                className={minPreviewClass}
                                 src={previewURL}
                                 dimensions={this.state.dimensions}
                                 onImageLoaded={this.imageLoaded}

--- a/components/single_image_view/single_image_view.jsx
+++ b/components/single_image_view/single_image_view.jsx
@@ -33,7 +33,6 @@ export default class SingleImageView extends React.PureComponent {
 
     constructor(props) {
         super(props);
-
         this.state = {
             loaded: false,
             showPreviewModal: false,
@@ -182,12 +181,13 @@ export default class SingleImageView extends React.PureComponent {
                     >
                         <div
                             className={`image-loaded ${fadeInClass}`}
+                            style={{height: fileType === FileTypes.SVG ? '100%' : 'initial'}}
                             onClick={this.handleImageClick}
                         >
                             <SizeAwareImage
                                 className={`${minPreviewClass} ${svgClass}`}
                                 src={previewURL}
-                                dimensions={this.state.dimensions}
+                                dimensions={fileType !== FileTypes.SVG ? this.state.dimensions : null}
                                 onImageLoaded={this.imageLoaded}
                                 showLoader={this.props.isEmbedVisible}
                             />

--- a/components/single_image_view/single_image_view.jsx
+++ b/components/single_image_view/single_image_view.jsx
@@ -187,7 +187,7 @@ export default class SingleImageView extends React.PureComponent {
                             <SizeAwareImage
                                 className={`${minPreviewClass} ${svgClass}`}
                                 src={previewURL}
-                                dimensions={fileType !== FileTypes.SVG ? this.state.dimensions : null}
+                                dimensions={this.state.dimensions}
                                 onImageLoaded={this.imageLoaded}
                                 showLoader={this.props.isEmbedVisible}
                             />

--- a/components/single_image_view/single_image_view.test.jsx
+++ b/components/single_image_view/single_image_view.test.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import SingleImageView from 'components/single_image_view/single_image_view.jsx';
+import SizeAwareImage from 'components/size_aware_image';
 
 describe('components/SingleImageView', () => {
     const baseProps = {
@@ -55,31 +56,6 @@ describe('components/SingleImageView', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should call setViewPortWidth on handleResize', () => {
-        const wrapper = shallow(
-            <SingleImageView {...baseProps}/>
-        );
-
-        const instance = wrapper.instance();
-        instance.setViewPortWidth = jest.fn();
-
-        instance.handleResize();
-        expect(instance.setViewPortWidth).toHaveBeenCalledTimes(1);
-    });
-
-    test('should match state on setViewPortWidth', () => {
-        const wrapper = shallow(
-            <SingleImageView {...baseProps}/>
-        );
-
-        wrapper.setState({viewPortWidth: 300});
-        const instance = wrapper.instance();
-        instance.viewPort = {getBoundingClientRect: () => ({width: 500})};
-        instance.setViewPortWidth();
-
-        expect(wrapper.state('viewPortWidth')).toEqual(500);
-    });
-
     test('should match state on handleImageClick', () => {
         const wrapper = shallow(
             <SingleImageView {...baseProps}/>
@@ -116,5 +92,15 @@ describe('components/SingleImageView', () => {
         wrapper.instance().toggleEmbedVisibility();
         expect(props.actions.toggleEmbedVisibility).toHaveBeenCalledTimes(1);
         expect(props.actions.toggleEmbedVisibility).toBeCalledWith('original_post_id');
+    });
+
+    test('should set loaded state on callback of onImageLoaded on SizeAwareImage component', () => {
+        const wrapper = shallow(
+            <SingleImageView {...baseProps}/>
+        );
+        expect(wrapper.state('loaded')).toEqual(false);
+        wrapper.find(SizeAwareImage).prop('onImageLoaded')();
+        expect(wrapper.state('loaded')).toEqual(true);
+        expect(wrapper).toMatchSnapshot();
     });
 });

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -51,6 +51,7 @@ export default class SizeAwareImage extends React.PureComponent {
     }
 
     componentDidMount() {
+        this.mounted = true;
         this.loadImage();
     }
 
@@ -61,6 +62,7 @@ export default class SizeAwareImage extends React.PureComponent {
     }
 
     componentWillUnmount() {
+        this.mounted = false;
         this.stopWaitingForHeight();
     }
 
@@ -95,22 +97,25 @@ export default class SizeAwareImage extends React.PureComponent {
     }
 
     handleLoad = (image) => {
-        if (this.props.onImageLoaded && image.height) {
-            this.props.onImageLoaded({height: image.height, width: image.width});
+        if (this.mounted) {
+            if (this.props.onImageLoaded && image.height) {
+                this.props.onImageLoaded({height: image.height, width: image.width});
+            }
+            this.setState({
+                loaded: true,
+                error: false,
+            });
         }
-
-        this.setState({
-            loaded: true,
-            error: false,
-        });
     };
 
     handleError = () => {
-        this.stopWaitingForHeight();
-        if (this.props.onImageLoadFail) {
-            this.props.onImageLoadFail();
+        if (this.mounted) {
+            this.stopWaitingForHeight();
+            if (this.props.onImageLoadFail) {
+                this.props.onImageLoadFail();
+            }
+            this.setState({error: true});
         }
-        this.setState({error: true});
     };
 
     render() {

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -32,7 +32,7 @@ export default class SizeAwareImage extends React.PureComponent {
         /*
          * A callback that is called as soon as the image component has a height value
          */
-        onHeightReceived: PropTypes.func.isRequired,
+        onImageLoaded: PropTypes.func,
 
         /*
          * A callback that is called when image load fails
@@ -76,8 +76,8 @@ export default class SizeAwareImage extends React.PureComponent {
 
     waitForHeight = (image) => {
         if (image && image.height) {
-            if (this.props.onHeightReceived) {
-                this.props.onHeightReceived(image.height);
+            if (this.props.onImageLoaded) {
+                this.props.onImageLoaded({height: image.height, width: image.width});
             }
             this.heightTimeout = 0;
         } else {
@@ -95,8 +95,8 @@ export default class SizeAwareImage extends React.PureComponent {
     }
 
     handleLoad = (image) => {
-        if (this.props.onHeightReceived && image.height) {
-            this.props.onHeightReceived(image.height);
+        if (this.props.onImageLoaded && image.height) {
+            this.props.onImageLoaded({height: image.height, width: image.width});
         }
 
         this.setState({
@@ -120,7 +120,7 @@ export default class SizeAwareImage extends React.PureComponent {
         } = this.props;
 
         Reflect.deleteProperty(props, 'showLoader');
-        Reflect.deleteProperty(props, 'onHeightReceived');
+        Reflect.deleteProperty(props, 'onImageLoaded');
         Reflect.deleteProperty(props, 'onImageLoadFail');
 
         let src;

--- a/components/size_aware_image.test.jsx
+++ b/components/size_aware_image.test.jsx
@@ -17,7 +17,7 @@ describe('components/SizeAwareImage', () => {
             height: 200,
             width: 300,
         },
-        onHeightReceived: jest.fn(),
+        onImageLoaded: jest.fn(),
         src: 'https://example.com/image.png',
     };
 
@@ -79,10 +79,11 @@ describe('components/SizeAwareImage', () => {
         expect(loadImage.mock.calls[1][0]).toEqual(newSrc);
     });
 
-    test('should call onHeightReceived on image is loaded', () => {
+    test('should call onImageLoaded on image is loaded', () => {
         const height = 123;
+        const width = 1234;
         loadImage.mockImplementation((src, onLoad) => {
-            onLoad({height});
+            onLoad({height, width});
 
             return {};
         });
@@ -90,7 +91,7 @@ describe('components/SizeAwareImage', () => {
         const props = {...baseProps};
         shallow(<SizeAwareImage {...props}/>);
 
-        expect(baseProps.onHeightReceived).toHaveBeenCalledWith(height);
+        expect(baseProps.onImageLoaded).toHaveBeenCalledWith({height, width});
     });
 
     test('should call onImageLoadFail when image load fails and should render empty/null', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12941,7 +12941,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serialize-javascript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12941,7 +12941,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serialize-javascript": {

--- a/plugins/test/__snapshots__/post_type.test.jsx.snap
+++ b/plugins/test/__snapshots__/post_type.test.jsx.snap
@@ -78,7 +78,7 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
     <Connect(PostMarkdown)
       imageProps={
         Object {
-          "onHeightReceived": [Function],
+          "onImageLoaded": [Function],
         }
       }
       isRHS={false}

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -216,6 +216,13 @@
                     max-width: 50px;
                 }
             }
+            &.svg {
+                  width: 100%;
+                  height: inherit;
+                img {
+                    height: inherit;
+               }
+            }
         }
 
         .image-fade-in {

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -193,9 +193,6 @@
             min-width: 40px;
             max-height: 350px;
             max-width: 100%;
-            align-content: center;
-            justify-content: center;
-            opacity: 0;
             overflow: hidden;
             position: relative;
             z-index: 2;

--- a/utils/file_utils.jsx
+++ b/utils/file_utils.jsx
@@ -36,30 +36,6 @@ export function trimFilename(filename) {
     return trimmedFilename;
 }
 
-export function getFileDimensionsForDisplay(dimensions, {maxHeight, maxWidth}) {
-    if (!dimensions) {
-        return null;
-    }
-
-    const {width, height} = dimensions;
-    if (height <= maxHeight && width <= maxWidth) {
-        return dimensions;
-    }
-    const widthRatio = width / maxWidth;
-    const heightRatio = height / maxHeight;
-    if (heightRatio > widthRatio) {
-        return {
-            height: maxHeight,
-            width: width * (1 / heightRatio),
-        };
-    }
-
-    return {
-        height: height * (1 / widthRatio),
-        width: maxWidth,
-    };
-}
-
 export function getFileTypeFromMime(mimetype) {
     const mimeTypeSplitBySlash = mimetype.split('/');
     const mimeTypePrefix = mimeTypeSplitBySlash[0];

--- a/utils/file_utils.test.jsx
+++ b/utils/file_utils.test.jsx
@@ -6,7 +6,6 @@ import assert from 'assert';
 import {
     trimFilename,
     canUploadFiles,
-    getFileDimensionsForDisplay,
     getFileTypeFromMime,
 } from 'utils/file_utils.jsx';
 import * as UserAgent from 'utils/user_agent';
@@ -108,37 +107,5 @@ describe('FileUtils.canUploadFiles', () => {
         it('mime type for no suffix', () => {
             assert.equal(getFileTypeFromMime('asdasd'), 'other');
         });
-    });
-});
-
-describe('FileUtils.getFileDimensionsForDisplay', () => {
-    it('return image dimensions as they are smaller than max dimensions', () => {
-        const expectedDimensions = getFileDimensionsForDisplay({height: 200, width: 200}, {maxHeight: 300, maxWidth: 300});
-        expect(expectedDimensions).toEqual({height: 200, width: 200});
-    });
-
-    it('return image dimensions based on height dimetions as ratio of height > width', () => {
-        const expectedDimensions = getFileDimensionsForDisplay({height: 600, width: 400}, {maxHeight: 300, maxWidth: 300});
-        expect(expectedDimensions).toEqual({height: 300, width: 200});
-    });
-
-    it('return image dimensions based on width dimetions as ratio of width > height', () => {
-        const expectedDimensions = getFileDimensionsForDisplay({height: 400, width: 600}, {maxHeight: 300, maxWidth: 300});
-        expect(expectedDimensions).toEqual({height: 200, width: 300});
-    });
-
-    it('return image dimensions based on width ratio', () => {
-        const expectedDimensions = getFileDimensionsForDisplay({height: 200, width: 600}, {maxHeight: 300, maxWidth: 300});
-        expect(expectedDimensions).toEqual({height: 100, width: 300});
-    });
-
-    it('return image dimensions based on height ratio', () => {
-        const expectedDimensions = getFileDimensionsForDisplay({height: 600, width: 200}, {maxHeight: 300, maxWidth: 300});
-        expect(expectedDimensions).toEqual({height: 300, width: 100});
-    });
-
-    it('return null if dimensions does not exists', () => {
-        const expectedDimensions = getFileDimensionsForDisplay(null, {maxHeight: 300, maxWidth: 300});
-        expect(expectedDimensions).toEqual(null);
     });
 });


### PR DESCRIPTION
#### Summary
* Removing getFileDimensionsForDisplay in favour of  SizeAwareImage as it would be reliable in 
   preventing scroll pop
* Changes also includes standard dimensions for svg as we don't have dimensions for old svgs

#### Ticket Link
[MM-13099](https://mattermost.atlassian.net/browse/MM-13099)
[MM-13158](https://mattermost.atlassian.net/browse/MM-13158)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
