### PR TITLE
[MM-13847] Fix highlighting of at-channel, at-all, at-here when immediately followed by a period

### DIFF
--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -184,7 +184,7 @@ export function autolinkAtMentions(text, tokens) {
     // handle @channel, @all, @here mentions first (purposely excludes trailing punctuation)
     output = output.replace(/@(channel|all|here)/gi, replaceAtMentionWithToken);
 
-    // handle all other mentions (supports training punctuation)
+    // handle all other mentions (supports trailing punctuation)
     let match = output.match(AT_MENTION_PATTERN);
     while (match && match.length > 0) {
         output = output.replace(AT_MENTION_PATTERN, replaceAtMentionWithToken);

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -181,6 +181,10 @@ export function autolinkAtMentions(text, tokens) {
 
     let output = text;
 
+    // handle @channel, @all, @here mentions first (purposely excludes trailing punctuation)
+    output = output.replace(/@(channel|all|here)/gi, replaceAtMentionWithToken);
+
+    // handle all other mentions (supports training punctuation)
     let match = output.match(AT_MENTION_PATTERN);
     while (match && match.length > 0) {
         output = output.replace(AT_MENTION_PATTERN, replaceAtMentionWithToken);

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -182,7 +182,7 @@ export function autolinkAtMentions(text, tokens) {
     let output = text;
 
     // handle @channel, @all, @here mentions first (purposely excludes trailing punctuation)
-    output = output.replace(/@(channel|all|here)/gi, replaceAtMentionWithToken);
+    output = output.replace(/\B@(channel|all|here)/gi, replaceAtMentionWithToken);
 
     // handle all other mentions (supports trailing punctuation)
     let match = output.match(AT_MENTION_PATTERN);

--- a/utils/text_formatting.test.jsx
+++ b/utils/text_formatting.test.jsx
@@ -12,28 +12,28 @@ describe('autolinkAtMentions', () => {
     const mentionTestCases = [
         'channel',
         'all',
-        'here'
+        'here',
     ];
     function runSuccessfulAtMentionTests(leadingText = '', trailingText = '') {
-        mentionTestCases.forEach(testCase => {
+        mentionTestCases.forEach((testCase) => {
             const mention = `@${testCase}`;
             const text = `${leadingText}${mention}${trailingText}`;
             const tokens = new Map();
 
             const output = autolinkAtMentions(text, tokens);
             expect(output).toBe(`${leadingText}$MM_ATMENTION0$${trailingText}`);
-            expect(tokens.get(`$MM_ATMENTION0$`).value).toBe(`<span data-mention="${testCase}">${mention}</span>`);
+            expect(tokens.get('$MM_ATMENTION0$').value).toBe(`<span data-mention="${testCase}">${mention}</span>`);
         });
     }
     function runUnsuccessfulAtMentionTests(leadingText = '', trailingText = '') {
-        mentionTestCases.forEach(testCase => {
+        mentionTestCases.forEach((testCase) => {
             const mention = `@${testCase}`;
             const text = `${leadingText}${mention}${trailingText}`;
             const tokens = new Map();
 
             const output = autolinkAtMentions(text, tokens);
             expect(output).toBe(text);
-            expect(tokens.get(`$MM_ATMENTION0$`)).toBeUndefined();
+            expect(tokens.get('$MM_ATMENTION0$')).toBeUndefined();
         });
     }
 

--- a/utils/text_formatting.test.jsx
+++ b/utils/text_formatting.test.jsx
@@ -3,9 +3,83 @@
 
 import emojiRegex from 'emoji-regex';
 
-import {highlightSearchTerms, handleUnicodeEmoji} from 'utils/text_formatting.jsx';
+import {autolinkAtMentions, highlightSearchTerms, handleUnicodeEmoji} from 'utils/text_formatting.jsx';
 import {getEmojiMap} from 'selectors/emojis';
 import store from 'stores/redux_store.jsx';
+
+describe('autolinkAtMentions', () => {
+    // testing to make sure @channel, @all & @here are setup properly to get highlighted correctly
+    const mentionTestCases = [
+        'channel',
+        'all',
+        'here'
+    ];
+    function runSuccessfulAtMentionTests(leadingText = '', trailingText = '') {
+        mentionTestCases.forEach(testCase => {
+            const mention = `@${testCase}`;
+            const text = `${leadingText}${mention}${trailingText}`;
+            const tokens = new Map();
+
+            const output = autolinkAtMentions(text, tokens);
+            expect(output).toBe(`${leadingText}$MM_ATMENTION0$${trailingText}`);
+            expect(tokens.get(`$MM_ATMENTION0$`).value).toBe(`<span data-mention="${testCase}">${mention}</span>`);
+        });
+    }
+    function runUnsuccessfulAtMentionTests(leadingText = '', trailingText = '') {
+        mentionTestCases.forEach(testCase => {
+            const mention = `@${testCase}`;
+            const text = `${leadingText}${mention}${trailingText}`;
+            const tokens = new Map();
+
+            const output = autolinkAtMentions(text, tokens);
+            expect(output).toBe(text);
+            expect(tokens.get(`$MM_ATMENTION0$`)).toBeUndefined();
+        });
+    }
+
+    // cases where highlights should be successful
+    test('@channel, @all, @here should highlight properly with no leading or trailing content', () => {
+        runSuccessfulAtMentionTests();
+    });
+    test('@channel, @all, @here should highlight properly with a leading space', () => {
+        runSuccessfulAtMentionTests(' ', '');
+    });
+    test('@channel, @all, @here should highlight properly with a trailing space', () => {
+        runSuccessfulAtMentionTests('', ' ');
+    });
+    test('@channel, @all, @here should highlight properly with a leading period', () => {
+        runSuccessfulAtMentionTests('.', '');
+    });
+    test('@channel, @all, @here should highlight properly with a trailing period', () => {
+        runSuccessfulAtMentionTests('', '.');
+    });
+    test('@channel, @all, @here should highlight properly with a leading dash', () => {
+        runSuccessfulAtMentionTests('-', '');
+    });
+    test('@channel, @all, @here should highlight properly with a trailing dash', () => {
+        runSuccessfulAtMentionTests('', '-');
+    });
+    test('@channel, @all, @here should highlight properly with a trailing underscore', () => {
+        runSuccessfulAtMentionTests('', '_');
+    });
+    test('@channel, @all, @here should highlight when the first part of a word', () => {
+        runSuccessfulAtMentionTests('', 'testing');
+    });
+    test('@channel, @all, @here should highlight properly within a typical sentance', () => {
+        runSuccessfulAtMentionTests('This is a typical sentance, ', ' check out this sentance!');
+    });
+
+    // cases where highlights should be unseccessful
+    test('@channel, @all, @here should not highlight with a leading underscore', () => {
+        runUnsuccessfulAtMentionTests('_');
+    });
+    test('@channel, @all, @here should not highlight when the last part of a word', () => {
+        runUnsuccessfulAtMentionTests('testing');
+    });
+    test('@channel, @all, @here should not highlight when in the middle of a word', () => {
+        runUnsuccessfulAtMentionTests('test', 'ing');
+    });
+});
 
 describe('highlightSearchTerms', () => {
     test('hashtags should highlight case-insensitively', () => {


### PR DESCRIPTION
#### Summary
PR fixes highlighting of `@channel`, `@all` and `@here` when immediately followed by a period:
* general @mentions currently need to support periods as the last character, messing up highlighting if `@channel`, `@here` or `@all` are directly followed by a period (i.e. end of sentence)
* handling `@channel`, `@here` and `@all` before other `@mentions` allows for ignoring any punctuation immediately following and fixes highlighting

#### Ticket Link
[MM-13847](https://mattermost.atlassian.net/browse/MM-13847)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, posting, etc.)
