### PR TITLE
MM-13583: Preventing delete/edit posts on edit post modal when you haven't the right permission

### DIFF
--- a/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
+++ b/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
@@ -1,5 +1,261 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/EditPostModal should disable the button on not canDeletePost and empty text in it 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="edit-modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onEntered={[Function]}
+  onExit={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Edit {title}"
+        id="edit_post.edit"
+        values={
+          Object {
+            "title": "test",
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <Connect(Textbox)
+      channelId="5"
+      characterLimit={4000}
+      createMessage="Edit the post..."
+      emojiEnabled={true}
+      handlePostError={[Function]}
+      id="edit_textbox"
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      suggestionListStyle="bottom"
+      supportsCommands={false}
+      value=""
+    />
+    <span
+      className="edit-post__actions"
+    >
+      <span
+        className="emoji-picker__container"
+      >
+        <EmojiPickerOverlay
+          container={[Function]}
+          enableGifPicker={false}
+          onEmojiClick={[Function]}
+          onGifClick={[Function]}
+          onHide={[Function]}
+          show={false}
+          spaceRequiredAbove={476}
+          spaceRequiredBelow={497}
+          target={[Function]}
+          topOffset={-20}
+        />
+        <EmojiIcon
+          className="icon icon--emoji"
+          onClick={[Function]}
+        />
+      </span>
+    </span>
+    <div
+      className="edit-post-footer"
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_post.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_post.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`components/EditPostModal should disable the button on not canEditPost and text in it 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="edit-modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onEntered={[Function]}
+  onExit={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Edit {title}"
+        id="edit_post.edit"
+        values={
+          Object {
+            "title": "test",
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <Connect(Textbox)
+      channelId="5"
+      characterLimit={4000}
+      createMessage="Edit the post..."
+      emojiEnabled={true}
+      handlePostError={[Function]}
+      id="edit_textbox"
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      suggestionListStyle="bottom"
+      supportsCommands={false}
+      value="new message"
+    />
+    <span
+      className="edit-post__actions"
+    >
+      <span
+        className="emoji-picker__container"
+      >
+        <EmojiPickerOverlay
+          container={[Function]}
+          enableGifPicker={false}
+          onEmojiClick={[Function]}
+          onGifClick={[Function]}
+          onHide={[Function]}
+          show={false}
+          spaceRequiredAbove={476}
+          spaceRequiredBelow={497}
+          target={[Function]}
+          topOffset={-20}
+        />
+        <EmojiIcon
+          className="icon icon--emoji"
+          onClick={[Function]}
+        />
+      </span>
+    </span>
+    <div
+      className="edit-post-footer"
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_post.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_post.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;
+
 exports[`components/EditPostModal should match with default config 1`] = `
 <Modal
   animation={true}
@@ -114,6 +370,7 @@ exports[`components/EditPostModal should match with default config 1`] = `
     </button>
     <button
       className="btn btn-primary"
+      disabled={false}
       onClick={[Function]}
       type="button"
     >
@@ -220,6 +477,391 @@ exports[`components/EditPostModal should match without emoji picker 1`] = `
     </button>
     <button
       className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_post.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`components/EditPostModal should not disable the button on not canDeletePost and text in it with canEditPost 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="edit-modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onEntered={[Function]}
+  onExit={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Edit {title}"
+        id="edit_post.edit"
+        values={
+          Object {
+            "title": "test",
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <Connect(Textbox)
+      channelId="5"
+      characterLimit={4000}
+      createMessage="Edit the post..."
+      emojiEnabled={true}
+      handlePostError={[Function]}
+      id="edit_textbox"
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      suggestionListStyle="bottom"
+      supportsCommands={false}
+      value="new message"
+    />
+    <span
+      className="edit-post__actions"
+    >
+      <span
+        className="emoji-picker__container"
+      >
+        <EmojiPickerOverlay
+          container={[Function]}
+          enableGifPicker={false}
+          onEmojiClick={[Function]}
+          onGifClick={[Function]}
+          onHide={[Function]}
+          show={false}
+          spaceRequiredAbove={476}
+          spaceRequiredBelow={497}
+          target={[Function]}
+          topOffset={-20}
+        />
+        <EmojiIcon
+          className="icon icon--emoji"
+          onClick={[Function]}
+        />
+      </span>
+    </span>
+    <div
+      className="edit-post-footer"
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_post.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_post.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`components/EditPostModal should not disable the button on not canEditPost and no text in it with canDeletePost 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="edit-modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onEntered={[Function]}
+  onExit={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Edit {title}"
+        id="edit_post.edit"
+        values={
+          Object {
+            "title": "test",
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <Connect(Textbox)
+      channelId="5"
+      characterLimit={4000}
+      createMessage="Edit the post..."
+      emojiEnabled={true}
+      handlePostError={[Function]}
+      id="edit_textbox"
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      suggestionListStyle="bottom"
+      supportsCommands={false}
+      value=""
+    />
+    <span
+      className="edit-post__actions"
+    >
+      <span
+        className="emoji-picker__container"
+      >
+        <EmojiPickerOverlay
+          container={[Function]}
+          enableGifPicker={false}
+          onEmojiClick={[Function]}
+          onGifClick={[Function]}
+          onHide={[Function]}
+          show={false}
+          spaceRequiredAbove={476}
+          spaceRequiredBelow={497}
+          target={[Function]}
+          topOffset={-20}
+        />
+        <EmojiIcon
+          className="icon icon--emoji"
+          onClick={[Function]}
+        />
+      </span>
+    </span>
+    <div
+      className="edit-post-footer"
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_post.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_post.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`components/EditPostModal should not disable the save button on not canDeletePost and no text when edited message has attachments 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="edit-modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onEntered={[Function]}
+  onExit={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      <FormattedMessage
+        defaultMessage="Edit {title}"
+        id="edit_post.edit"
+        values={
+          Object {
+            "title": "test",
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <Connect(Textbox)
+      channelId="5"
+      characterLimit={4000}
+      createMessage="Edit the post..."
+      emojiEnabled={true}
+      handlePostError={[Function]}
+      id="edit_textbox"
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      suggestionListStyle="bottom"
+      supportsCommands={false}
+      value=""
+    />
+    <span
+      className="edit-post__actions"
+    >
+      <span
+        className="emoji-picker__container"
+      >
+        <EmojiPickerOverlay
+          container={[Function]}
+          enableGifPicker={false}
+          onEmojiClick={[Function]}
+          onGifClick={[Function]}
+          onHide={[Function]}
+          show={false}
+          spaceRequiredAbove={476}
+          spaceRequiredBelow={497}
+          target={[Function]}
+          topOffset={-20}
+        />
+        <EmojiIcon
+          className="icon icon--emoji"
+          onClick={[Function]}
+        />
+      </span>
+    </span>
+    <div
+      className="edit-post-footer"
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_post.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary"
+      disabled={false}
       onClick={[Function]}
       type="button"
     >
@@ -347,6 +989,7 @@ exports[`components/EditPostModal should show emojis on emojis click 1`] = `
     </button>
     <button
       className="btn btn-primary"
+      disabled={false}
       onClick={[Function]}
       type="button"
     >
@@ -480,6 +1123,7 @@ exports[`components/EditPostModal should show errors when it is set in the state
     </button>
     <button
       className="btn btn-primary"
+      disabled={false}
       onClick={[Function]}
       type="button"
     >

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -18,55 +18,17 @@ const KeyCodes = Constants.KeyCodes;
 
 export default class EditPostModal extends React.PureComponent {
     static propTypes = {
-
-        /**
-         * Set to force form submission on CTRL/CMD + ENTER instead of ENTER
-         */
+        canEditPost: PropTypes.bool,
+        canDeletePost: PropTypes.bool,
         ctrlSend: PropTypes.bool,
-
-        /**
-         * Global config object
-         */
         config: PropTypes.object.isRequired,
-
-        /**
-         * The maximum length of a post
-         */
         maxPostSize: PropTypes.number.isRequired,
-
-        /**
-         * Editing post information
-         */
         editingPost: PropTypes.shape({
-
-            /**
-             * The post being edited
-             */
             post: PropTypes.object,
-
-            /**
-             * The ID of the post being edited
-             */
             postId: PropTypes.string,
-
-            /**
-             * The ID of a DOM node to focus with the keyboard when this modal closes
-             */
             refocusId: PropTypes.string,
-
-            /**
-             * Whether or not to show the modal
-             */
             show: PropTypes.bool.isRequired,
-
-            /**
-             * What to show in the title of the modal as "Edit {title}"
-             */
             title: PropTypes.string,
-
-            /**
-             * Whether or not the modal was open from RHS
-             */
             isRHS: PropTypes.bool,
         }).isRequired,
 
@@ -162,6 +124,10 @@ export default class EditPostModal extends React.PureComponent {
     }
 
     handleEdit = async () => {
+        if (this.isSaveDisabled()) {
+            return;
+        }
+
         const {actions, editingPost} = this.props;
         const updatedPost = {
             message: this.state.editText,
@@ -281,6 +247,20 @@ export default class EditPostModal extends React.PureComponent {
         }
     }
 
+    isSaveDisabled = () => {
+        const post = this.props.editingPost.post;
+        const hasAttachments = post && post.file_ids && post.file_ids.length > 0;
+        if (hasAttachments) {
+            return !this.props.canEditPost;
+        }
+
+        if (this.state.editText !== '') {
+            return !this.props.canEditPost;
+        }
+
+        return !this.props.canDeletePost;
+    }
+
     render() {
         const errorBoxClass = 'edit-post-footer' + (this.state.postError ? ' has-error' : '');
         let postError = null;
@@ -376,6 +356,7 @@ export default class EditPostModal extends React.PureComponent {
                     <button
                         type='button'
                         className='btn btn-primary'
+                        disabled={this.isSaveDisabled()}
                         onClick={this.handleEdit}
                     >
                         <FormattedMessage


### PR DESCRIPTION
#### Summary
During the post edition you can try to delete the posts. This mustn't be
allowed if you don't have the correct permissions.

I disabled the save button and "enter" press action if you don't have the right
permissions.

I added too the edit permissions control, because this permission can change
while you have the edit modal open. Now is updated through the websockets.

#### Ticket Link
[MM-13583](https://mattermost.atlassian.net/browse/MM-13583)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)