### PR TITLE
[MM-13728] Fix pixelated Mattermost icon in Chrome bookmark rendering

### DIFF
--- a/root.html
+++ b/root.html
@@ -14,6 +14,10 @@
     <meta name='application-name' content='Mattermost'>
     <meta name='format-detection' content='telephone=no'>
 
+    <link rel="icon" type="image/png" href="/static/favicon-16x16.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="/static/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/static/favicon-96x96.png" sizes="96x96">
+
     <!-- CSS Should always go first -->
     <link rel='stylesheet' class='code_theme'>
     <style>

--- a/root.html
+++ b/root.html
@@ -14,9 +14,9 @@
     <meta name='application-name' content='Mattermost'>
     <meta name='format-detection' content='telephone=no'>
 
-    <link rel="icon" type="image/png" href="/static/favicon-16x16.png" sizes="16x16">
-    <link rel="icon" type="image/png" href="/static/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="/static/favicon-96x96.png" sizes="96x96">
+    <link rel="icon" type="image/png" href="/static/images/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="/static/images/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/static/images/favicon/favicon-96x96.png" sizes="96x96">
 
     <!-- CSS Should always go first -->
     <link rel='stylesheet' class='code_theme'>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -257,7 +257,6 @@ var config = {
             filename: 'root.html',
             inject: 'head',
             template: 'root.html',
-            favicon: 'images/favicon/favicon-16x16.png',
         }),
         new CopyWebpackPlugin([
             {from: 'images/emoji', to: 'emoji'},


### PR DESCRIPTION
#### Summary
Only one of the 3 available favicon sizes is getting included in the built root.html file (favicon-16x16.png) by the `HtmlWebpackPlugin` plugin. Chrome was using this as the only defined favicon for the bookmark rendering, which is too small for a crisp rendering.

This PR manually includes all 3 favicons in the root.html template file as the technologies currently used in the webpack config don't seem to support dynamically injecting more than one actual favicon. More effort into finding a different package or reconfiguring the webpack config file could be investigated, but may not be worth the mana.

Details:

- HtmlWebpackPlugin currently handles embedding the favicon into the page, but it only supports a single favicon size  (removed in this PR) ... unless we actually use a proper .ico format for the favicon (somewhat outdated) with multiple embedded sizes
- WebpackPwaManifest doesn’t handle favicons at all as they aren’t used by PWAs ... favicons passed to this plugin in the webpack config file are not being treated as favicons and are not getting injected into the built root.html file
- Favicons are automatically copied over during the build by CopyWebpackPlugin, so adding the favicons directly to the HTML template works fine.

#### Ticket Link
[MM-13728](https://mattermost.atlassian.net/projects/MM/issues/MM-13728)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed