### PR TITLE
[MM-12750] Remove getMissingProfiles from user_actions.jsx

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -490,17 +490,6 @@ export async function loadProfiles(page, perPage, options = {}, success) {
     }
 }
 
-export function getMissingProfiles(ids) {
-    const state = getState();
-    const missingIds = ids.filter((id) => !Selectors.getUser(state, id));
-
-    if (missingIds.length === 0) {
-        return;
-    }
-
-    UserActions.getProfilesByIds(missingIds)(dispatch, getState);
-}
-
 export async function loadMyTeamMembers() {
     await getMyTeamMembers()(dispatch, getState);
     getMyTeamUnreads()(dispatch, getState);


### PR DESCRIPTION
#### Summary
Upon investigation of the usage of `getMissingProfiles` defined under `actions/user_actions.jsx`, it seems like the function is not being used at all, and has already been replaced by the implementations defined in the redux repository. As a result, I've removed the function.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10151
Part of: https://mattermost.atlassian.net/browse/MM-12581

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed