### PR TITLE
MM-13979 Render those unmounted components when EnableTesting is set to true for E2E testability

### DIFF
--- a/components/common/comment_icon.jsx
+++ b/components/common/comment_icon.jsx
@@ -16,7 +16,7 @@ export default class CommentIcon extends React.PureComponent {
         handleCommentClick: PropTypes.func.isRequired,
         searchStyle: PropTypes.string,
         commentCount: PropTypes.number,
-        id: PropTypes.string,
+        postId: PropTypes.string,
         extraClass: PropTypes.string,
     };
 
@@ -24,7 +24,6 @@ export default class CommentIcon extends React.PureComponent {
         idCount: -1,
         searchStyle: '',
         commentCount: 0,
-        id: '',
         extraClass: '',
     };
 
@@ -47,7 +46,7 @@ export default class CommentIcon extends React.PureComponent {
             selectorId += this.props.idCount;
         }
 
-        const id = Utils.createSafeId(this.props.idPrefix + '_' + this.props.id);
+        const id = Utils.createSafeId(this.props.idPrefix + '_' + this.props.postId);
 
         const tooltip = (
             <Tooltip

--- a/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
+++ b/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
@@ -38,11 +38,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
         aria-expanded="false"
         className="dropdown-toggle post__dropdown color--link style--none"
         data-toggle="dropdown"
+        id="CENTER_button_post_id_1"
         type="button"
       />
     </OverlayTrigger>
     <div
       className="dropdown-menu__content"
+      id="CENTER_menu_post_id_1"
     >
       <ul
         className="dropdown-menu"
@@ -129,11 +131,13 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
         aria-expanded="false"
         className="dropdown-toggle post__dropdown color--link style--none"
         data-toggle="dropdown"
+        id="CENTER_button_post_id_1"
         type="button"
       />
     </OverlayTrigger>
     <div
       className="dropdown-menu__content"
+      id="CENTER_menu_post_id_1"
     >
       <ul
         className="dropdown-menu"

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -16,6 +16,7 @@ import DelayedAction from 'utils/delayed_action.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
+
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 
 import Pluggable from 'plugins/pluggable';
@@ -38,7 +39,6 @@ class DotMenu extends Component {
         postEditTimeLimit: PropTypes.string.isRequired,
         intl: intlShape.isRequired,
         enableEmojiPicker: PropTypes.bool.isRequired,
-
         actions: PropTypes.shape({
 
             /**
@@ -377,6 +377,7 @@ class DotMenu extends Component {
                         rootClose={true}
                     >
                         <button
+                            id={`${this.props.location}_button_${this.props.post.id}`}
                             ref='dropdownToggle'
                             className='dropdown-toggle post__dropdown color--link style--none'
                             type='button'
@@ -384,7 +385,10 @@ class DotMenu extends Component {
                             aria-expanded='false'
                         />
                     </OverlayTrigger>
-                    <div className='dropdown-menu__content'>
+                    <div
+                        id={`${this.props.location}_menu_${this.props.post.id}`}
+                        className='dropdown-menu__content'
+                    >
                         <ul
                             ref='dropdown'
                             className='dropdown-menu'

--- a/components/post_view/post_flag_icon/__snapshots__/post_flag_icon.test.js.snap
+++ b/components/post_view/post_flag_icon/__snapshots__/post_flag_icon.test.js.snap
@@ -28,7 +28,7 @@ exports[`components/post_view/PostFlagIcon should match snapshot 1`] = `
 >
   <button
     className="style--none flag-icon__container "
-    id={null}
+    id="centerPostFlag_post_id"
     onClick={[Function]}
   >
     <FlagIcon
@@ -66,7 +66,7 @@ exports[`components/post_view/PostFlagIcon should match snapshot 2`] = `
 >
   <button
     className="style--none flag-icon__container visible"
-    id={null}
+    id="centerPostFlag_post_id"
     onClick={[Function]}
   >
     <FlagIconFilled

--- a/components/post_view/post_flag_icon/post_flag_icon.js
+++ b/components/post_view/post_flag_icon/post_flag_icon.js
@@ -83,7 +83,7 @@ export default class PostFlagIcon extends React.PureComponent {
                 }
             >
                 <button
-                    id={flagIconId}
+                    id={flagIconId || `${this.props.idPrefix}_${this.props.postId}`}
                     className={'style--none flag-icon__container ' + flagVisible}
                     onClick={this.handlePress}
                 >

--- a/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
+++ b/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
@@ -181,9 +181,9 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
       commentCount={0}
       extraClass="pull-right"
       handleCommentClick={[MockFunction]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
       idCount={-1}
       idPrefix="commentIcon"
+      postId="e584uzbwwpny9kengqayx5ayzw"
       searchStyle=""
     />
   </div>
@@ -295,9 +295,9 @@ exports[`components/post_view/PostInfo toggleEmojiPicker, should have called pro
       commentCount={0}
       extraClass="pull-right"
       handleCommentClick={[MockFunction]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
       idCount={-1}
       idPrefix="commentIcon"
+      postId="e584uzbwwpny9kengqayx5ayzw"
       searchStyle=""
     />
   </div>

--- a/components/post_view/post_info/index.js
+++ b/components/post_view/post_info/index.js
@@ -26,6 +26,7 @@ function mapStateToProps(state, ownProps) {
         isMobile: state.views.channel.mobileView,
         enableEmojiPicker,
         isReadOnly: isCurrentChannelReadOnly(state) || channelIsArchived,
+        enableTesting: config.EnableTesting === 'true',
     };
 }
 

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -95,6 +95,8 @@ export default class PostInfo extends React.PureComponent {
          */
         isReadOnly: PropTypes.bool,
 
+        enableTesting: PropTypes.bool.isRequired,
+
         actions: PropTypes.shape({
 
             /*
@@ -156,49 +158,73 @@ export default class PostInfo extends React.PureComponent {
         (!isSystemMessage && (isMobile || hover || (!post.root_id && Boolean(this.props.replyCount)) || this.props.isFirstReply));
         const commentIconExtraClass = isMobile ? '' : 'pull-right';
         let commentIcon;
-        if (showCommentIcon) {
+        const commentIconProps = {
+            idPrefix: 'commentIcon',
+            idCount,
+            handleCommentClick: this.props.handleCommentClick,
+            commentCount: this.props.replyCount,
+            postId: post.id,
+            extraClass: commentIconExtraClass,
+        };
+        if (this.props.enableTesting) {
             commentIcon = (
                 <CommentIcon
-                    idPrefix='commentIcon'
-                    idCount={idCount}
-                    handleCommentClick={this.props.handleCommentClick}
-                    commentCount={this.props.replyCount}
-                    id={post.channel_id + '_' + post.id}
-                    extraClass={commentIconExtraClass}
+                    style={{visibility: showCommentIcon ? 'visible' : 'hidden'}}
+                    {...commentIconProps}
                 />
+            );
+        } else if (showCommentIcon) {
+            commentIcon = (
+                <CommentIcon {...commentIconProps}/>
             );
         }
 
         const showReactionIcon = !isSystemMessage && hover && !isReadOnly && this.props.enableEmojiPicker;
         let postReaction;
-        if (showReactionIcon) {
+        const postReactionProps = {
+            channelId: post.channel_id,
+            postId: post.id,
+            teamId: this.props.teamId,
+            getDotMenuRef: this.getDotMenu,
+            showEmojiPicker: this.state.showEmojiPicker,
+            toggleEmojiPicker: this.toggleEmojiPicker,
+        };
+        if (this.props.enableTesting) {
             postReaction = (
                 <PostReaction
-                    channelId={post.channel_id}
-                    postId={post.id}
-                    teamId={this.props.teamId}
-                    getDotMenuRef={this.getDotMenu}
-                    showEmojiPicker={this.state.showEmojiPicker}
-                    toggleEmojiPicker={this.toggleEmojiPicker}
+                    style={{visibility: showReactionIcon ? 'visible' : 'hidden'}}
+                    {...postReactionProps}
                 />
+            );
+        } else if (showReactionIcon) {
+            postReaction = (
+                <PostReaction {...postReactionProps}/>
             );
         }
 
         const showDotMenuIcon = isMobile || hover;
         let dotMenu;
-        if (showDotMenuIcon) {
+        const dotMenuProps = {
+            post,
+            location: 'CENTER',
+            commentCount: this.props.replyCount,
+            isFlagged: this.props.isFlagged,
+            handleCommentClick: this.props.handleCommentClick,
+            handleDropdownOpened: this.handleDotMenuOpened,
+            handleAddReactionClick: this.toggleEmojiPicker,
+            isReadOnly,
+            enableEmojiPicker: this.props.enableEmojiPicker,
+        };
+        if (this.props.enableTesting) {
             dotMenu = (
                 <DotMenu
-                    post={post}
-                    location={'CENTER'}
-                    commentCount={this.props.replyCount}
-                    isFlagged={this.props.isFlagged}
-                    handleCommentClick={this.props.handleCommentClick}
-                    handleDropdownOpened={this.handleDotMenuOpened}
-                    handleAddReactionClick={this.toggleEmojiPicker}
-                    isReadOnly={isReadOnly}
-                    enableEmojiPicker={this.props.enableEmojiPicker}
+                    style={{visibility: showDotMenuIcon ? 'visible' : 'hidden'}}
+                    {...dotMenuProps}
                 />
+            );
+        } else if (showDotMenuIcon) {
+            dotMenu = (
+                <DotMenu {...dotMenuProps}/>
             );
         }
 
@@ -228,15 +254,23 @@ export default class PostInfo extends React.PureComponent {
 
         const showFlagIcon = !isEphemeral && !post.failed && !isSystemMessage && (this.props.hover || this.props.isFlagged);
         let postFlagIcon;
-        if (showFlagIcon) {
+        const postFlagIconProps = {
+            idPrefix: 'centerPostFlag',
+            idCount,
+            postId: post.id,
+            isFlagged: this.props.isFlagged,
+            isEphemeral,
+        };
+        if (this.props.enableTesting) {
             postFlagIcon = (
                 <PostFlagIcon
-                    idPrefix='centerPostFlag'
-                    idCount={idCount}
-                    postId={post.id}
-                    isFlagged={this.props.isFlagged}
-                    isEphemeral={isEphemeral}
+                    style={{visibility: showFlagIcon ? 'visible' : 'hidden'}}
+                    {...postFlagIconProps}
                 />
+            );
+        } else if (showFlagIcon) {
+            postFlagIcon = (
+                <PostFlagIcon {...postFlagIconProps}/>
             );
         }
 
@@ -275,18 +309,25 @@ export default class PostInfo extends React.PureComponent {
             );
         }
 
+        // timestamp should not be a permalink if the post has been deleted, is ephemeral message, or is pending
+        const isPermalink = !(isEphemeral || Posts.POST_DELETED === post.state || ReduxPostUtils.isPostPendingOrFailed(post));
         const showPostTime = this.props.hover || this.props.showTimeWithoutHover;
         let postTime;
-        if (showPostTime) {
-            // timestamp should not be a permalink if the post has been deleted, is ephemeral message, or is pending
-            const isPermalink = !(isEphemeral || Posts.POST_DELETED === post.state || ReduxPostUtils.isPostPendingOrFailed(post));
-
+        const postTimeProps = {
+            isPermalink,
+            eventTime: post.create_at,
+            postId: post.id,
+        };
+        if (this.props.enableTesting) {
             postTime = (
                 <PostTime
-                    isPermalink={isPermalink}
-                    eventTime={post.create_at}
-                    postId={post.id}
+                    style={{visibility: showPostTime ? 'visible' : 'hidden'}}
+                    {...postTimeProps}
                 />
+            );
+        } else if (showPostTime) {
+            postTime = (
+                <PostTime {...postTimeProps}/>
             );
         }
 

--- a/components/post_view/post_info/post_info.test.jsx
+++ b/components/post_view/post_info/post_info.test.jsx
@@ -8,6 +8,12 @@ import {Posts} from 'mattermost-redux/constants';
 import Constants from 'utils/constants.jsx';
 import PostInfo from 'components/post_view/post_info/post_info.jsx';
 
+import CommentIcon from 'components/common/comment_icon.jsx';
+import DotMenu from 'components/dot_menu';
+import PostFlagIcon from 'components/post_view/post_flag_icon';
+import PostReaction from 'components/post_view/post_reaction';
+import PostTime from 'components/post_view/post_time';
+
 describe('components/post_view/PostInfo', () => {
     const post = {
         channel_id: 'g6139tbospd18cmxroesdk3kkc',
@@ -41,6 +47,7 @@ describe('components/post_view/PostInfo', () => {
         hover: false,
         showTimeWithoutHover: false,
         enableEmojiPicker: false,
+        enableTesting: false,
         actions: {
             removePost: jest.fn(),
         },
@@ -49,6 +56,23 @@ describe('components/post_view/PostInfo', () => {
     test('should match snapshot', () => {
         const wrapper = shallow(<PostInfo {...requiredProps}/>);
         expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(CommentIcon).exists()).toBeFalsy();
+        expect(wrapper.find(DotMenu).exists()).toBeFalsy();
+        expect(wrapper.find(PostFlagIcon).exists()).toBeFalsy();
+        expect(wrapper.find(PostReaction).exists()).toBeFalsy();
+        expect(wrapper.find(PostTime).exists()).toBeFalsy();
+
+        wrapper.setProps({enableTesting: true});
+        expect(wrapper.find(CommentIcon).exists()).toBeTruthy();
+        expect(wrapper.find(CommentIcon).props().style).toEqual({visibility: 'hidden'});
+        expect(wrapper.find(DotMenu).exists()).toBeTruthy();
+        expect(wrapper.find(DotMenu).props().style).toEqual({visibility: 'hidden'});
+        expect(wrapper.find(PostFlagIcon).exists()).toBeTruthy();
+        expect(wrapper.find(PostFlagIcon).props().style).toEqual({visibility: 'hidden'});
+        expect(wrapper.find(PostReaction).exists()).toBeTruthy();
+        expect(wrapper.find(PostReaction).props().style).toEqual({visibility: 'hidden'});
+        expect(wrapper.find(PostTime).exists()).toBeTruthy();
+        expect(wrapper.find(PostTime).props().style).toEqual({visibility: 'hidden'});
     });
 
     test('should match snapshot, compact display', () => {

--- a/components/post_view/post_time/post_time.jsx
+++ b/components/post_view/post_time/post_time.jsx
@@ -23,6 +23,8 @@ export default class PostTime extends React.PureComponent {
          */
         eventTime: PropTypes.number.isRequired,
 
+        location: PropTypes.oneOf(['CENTER', 'RHS_ROOT', 'RHS_COMMENT', 'SEARCH']).isRequired,
+
         /*
          * The post id of posting being rendered
          */
@@ -32,6 +34,7 @@ export default class PostTime extends React.PureComponent {
 
     static defaultProps = {
         eventTime: 0,
+        location: 'CENTER',
     };
 
     handleClick = () => {
@@ -41,18 +44,25 @@ export default class PostTime extends React.PureComponent {
     };
 
     render() {
+        const {
+            eventTime,
+            isPermalink,
+            location,
+            postId,
+            teamUrl,
+        } = this.props;
+
         const localDateTime = (
-            <LocalDateTime
-                eventTime={this.props.eventTime}
-            />
+            <LocalDateTime eventTime={eventTime}/>
         );
-        if (isMobile() || !this.props.isPermalink) {
+        if (isMobile() || !isPermalink) {
             return localDateTime;
         }
 
         return (
             <Link
-                to={`${this.props.teamUrl}/pl/${this.props.postId}`}
+                id={`${location}_time_${postId}`}
+                to={`${teamUrl}/pl/${postId}`}
                 className='post__permalink'
                 onClick={this.handleClick}
             >

--- a/components/rhs_header_post/rhs_header_post.jsx
+++ b/components/rhs_header_post/rhs_header_post.jsx
@@ -192,6 +192,7 @@ export default class RhsHeaderPost extends React.Component {
                         </OverlayTrigger>
                     </button>
                     <button
+                        id={'rhsCloseButton'}
                         type='button'
                         className='sidebar--right__close'
                         aria-label='Close'

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -325,6 +325,7 @@ export default class RhsThread extends React.Component {
 
         return (
             <div
+                id='rhsContainer'
                 className='sidebar-right__body'
                 ref='sidebarbody'
             >

--- a/components/search_results_item/__snapshots__/search_results_item.test.jsx.snap
+++ b/components/search_results_item/__snapshots__/search_results_item.test.jsx.snap
@@ -86,6 +86,7 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
             <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
+              location="SEARCH"
               postId="id"
             />
             <span
@@ -136,9 +137,9 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
               commentCount={0}
               extraClass=""
               handleCommentClick={[Function]}
-              id=""
               idCount={-1}
               idPrefix="searchCommentIcon"
+              postId="id"
               searchStyle="search-item__comment"
             />
             <a
@@ -300,6 +301,7 @@ exports[`components/SearchResultsItem should match snapshot for archived channel
             <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
+              location="SEARCH"
               postId="id"
             />
             <Connect(PostFlagIcon)
@@ -341,9 +343,9 @@ exports[`components/SearchResultsItem should match snapshot for archived channel
               commentCount={0}
               extraClass=""
               handleCommentClick={[Function]}
-              id=""
               idCount={-1}
               idPrefix="searchCommentIcon"
+              postId="id"
               searchStyle="search-item__comment"
             />
             <a
@@ -505,6 +507,7 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
             <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
+              location="SEARCH"
               postId="id"
             />
             <Connect(PostFlagIcon)
@@ -546,9 +549,9 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
               commentCount={0}
               extraClass=""
               handleCommentClick={[Function]}
-              id=""
               idCount={-1}
               idPrefix="searchCommentIcon"
+              postId="id"
               searchStyle="search-item__comment"
             />
             <a
@@ -728,6 +731,7 @@ exports[`components/SearchResultsItem should match snapshot for deleted message 
             <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
+              location="SEARCH"
               postId="id"
             />
           </div>

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -131,6 +131,7 @@ export default class SearchResultsItem extends React.PureComponent {
                 isPermalink={isPermalink}
                 eventTime={post.create_at}
                 postId={post.id}
+                location={'SEARCH'}
             />
         );
     };
@@ -253,6 +254,7 @@ export default class SearchResultsItem extends React.PureComponent {
                         idPrefix={'searchCommentIcon'}
                         idCount={this.props.lastPostCount}
                         handleCommentClick={this.handleFocusRHSClick}
+                        postId={post.id}
                         searchStyle={'search-item__comment'}
                     />
                     <a

--- a/cypress/integration/post_message/permalink_view_spec.js
+++ b/cypress/integration/post_message/permalink_view_spec.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/* eslint max-nested-callbacks: ["error", 3] */
+
+import assert from 'assert';
+
+describe('Permalink View', () => {
+    before(() => {
+        // 1. Go to Main Channel View with "user-1"
+        cy.toMainChannelView('user-1');
+    });
+
+    it('should render permalink view on click of post timestamp at center view', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post consecutive messages
+        const firstMessage = 'first message for permalink';
+        cy.get('#post_textbox').type(firstMessage + '{enter}');
+        cy.get('#post_textbox').type('second message for permalink{enter}');
+
+        // * Check post list content
+        cy.get('#postListContent').each((postList) => {
+            const firstDivPost = postList[0].children[postList[0].children.length - 2];
+            assert.ok(firstDivPost, 'should get the first posted message');
+
+            const firstPostId = firstDivPost.id.replace('post_', '');
+
+            // * Check that the first message is posted
+            cy.get(`#${firstPostId}_message`).should('contain', firstMessage);
+
+            // * Check initial state that the first message posted is not highlighted
+            cy.get(`#${firstDivPost.id}`).should('be.visible').should('have.attr', 'class', 'post same--user same--root  current--user');
+
+            // * Check initial state that "the jump to recent messages" is not visible
+            cy.get('#archive-link-home').should('not.be.visible');
+
+            // * Check that the timestamp of the first post is not visible
+            cy.get(`#CENTER_time_${firstPostId}`).should('not.be.visible');
+
+            // 4. Click the timestamp of the first post
+            cy.get(`#CENTER_time_${firstPostId}`).click({force: true});
+
+            // * Check that it redirected to permalink view
+            cy.url().should('include', `/ad-1/pl/${firstPostId}`);
+
+            // * Check that the post is highlighted on permalink view
+            cy.get(`#${firstDivPost.id}`).should('be.visible').should('have.attr', 'class', 'post post--highlight same--user same--root  current--user');
+
+            cy.get('#archive-link-home').
+                should('be.visible').
+                should('contain', 'Click here to jump to recent messages.');
+        });
+    });
+});

--- a/cypress/integration/post_message/post_comment_spec.js
+++ b/cypress/integration/post_message/post_comment_spec.js
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/* eslint max-nested-callbacks: ["error", 3] */
+
+import assert from 'assert';
+
+describe('Post Comment', () => {
+    before(() => {
+        // 1. Go to Main Channel View with "user-1"
+        cy.toMainChannelView('user-1');
+    });
+
+    it('should open and close RHS on click of comment icon', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post a message
+        const message = 'test for opening and closing RHS';
+        cy.get('#post_textbox').type(message + '{enter}');
+        cy.get('#post_textbox').type('post another message{enter}');
+
+        // * Check post list content
+        cy.get('#postListContent').each((postList) => {
+            const firstDivPost = postList[0].children[postList[0].children.length - 2];
+            assert.ok(firstDivPost, 'should get the posted message');
+
+            const firstPostId = firstDivPost.id.replace('post_', '');
+
+            // * Check that the message is posted
+            cy.get(`#${firstPostId}_message`).should('contain', message);
+
+            // * Check that the center post comment icon is not visible and RHS is closed
+            cy.get(`#commentIcon_${firstPostId}`).should('not.be.visible');
+            cy.get('#rhsContainer').should('not.be.visible');
+
+            // 4. Click the center post comment icon of the post
+            cy.get(`#commentIcon_${firstPostId}`).click({force: true});
+
+            // * Check that the RHS is open
+            cy.get('#rhsContainer').should('be.visible');
+
+            // 5. Click close button of RHS
+            cy.get('#rhsCloseButton').should('be.visible').click();
+
+            // * Check that the center post comment icon is not visible and RHS is closed
+            cy.get(`#commentIcon_${firstPostId}`).should('not.be.visible');
+            cy.get('#rhsContainer').should('not.be.visible');
+        });
+    });
+});

--- a/cypress/integration/post_message/post_dropdown_menu_spec.js
+++ b/cypress/integration/post_message/post_dropdown_menu_spec.js
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/* eslint max-nested-callbacks: ["error", 3] */
+
+import assert from 'assert';
+
+describe('Post Dropdown Menu', () => {
+    before(() => {
+        // 1. Go to Main Channel View with "user-1"
+        cy.toMainChannelView('user-1');
+    });
+
+    it('should open dropdown menu on click of dotmenu icon', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post a message
+        const message = 'test for dropdown menu';
+        cy.get('#post_textbox').type(message + '{enter}');
+
+        // * Check post list content
+        cy.get('#postListContent').each((postList) => {
+            const divPost = postList[0].children[postList[0].children.length - 1];
+            assert.ok(divPost, 'should get the posted message');
+
+            const postId = divPost.id.replace('post_', '');
+
+            // * Check that the message is posted
+            cy.get(`#${postId}_message`).should('contain', message);
+
+            // * Check that the center dotmenu button and menu are not visible
+            cy.get(`#CENTER_button_${postId}`).should('not.be.visible');
+            cy.get(`#CENTER_menu_${postId}`).should('not.be.visible');
+
+            // 4. Click the center dotmenu button of the post
+            cy.get(`#CENTER_button_${postId}`).click({force: true});
+
+            // * Check that the center dotmenu button of the post becomes visible
+            cy.get(`#CENTER_button_${postId}`).should('be.visible').should('have.attr', 'class', 'dropdown-toggle post__dropdown color--link style--none');
+
+            // * Check that the center post menu becomes visible as well
+            cy.get(`#CENTER_menu_${postId} > .dropdown-menu`).should('be.visible');
+
+            // 5. Click again the center dotmenu button of the post
+            cy.get(`#CENTER_button_${postId}`).click();
+
+            // * Check that the center dotmenu button and menu are not visible
+            cy.get(`#CENTER_button_${postId}`).should('not.be.visible');
+            cy.get(`#CENTER_menu_${postId}`).should('not.be.visible');
+        });
+    });
+});

--- a/cypress/integration/post_message/post_flag_spec.js
+++ b/cypress/integration/post_message/post_flag_spec.js
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/* eslint max-nested-callbacks: ["error", 3] */
+
+import assert from 'assert';
+
+describe('Flag Post', () => {
+    before(() => {
+        // 1. Go to Main Channel View with "user-1"
+        cy.toMainChannelView('user-1');
+    });
+
+    it('should flag a post on click to flag icon at center view', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post a message
+        cy.get('#post_textbox').type('first message for flagged post{enter}');
+        const secondMessage = 'second message for flagged post';
+        cy.get('#post_textbox').type(secondMessage + '{enter}');
+        cy.get('#post_textbox').type('third message for flagged post{enter}');
+
+        // * Check post list content
+        cy.get('#postListContent').each((postList) => {
+            const secondDivPost = postList[0].children[postList[0].children.length - 2];
+            assert.ok(secondDivPost, 'should get the second posted message');
+
+            const secondPostId = secondDivPost.id.replace('post_', '');
+
+            // * Check that the second message is posted
+            cy.get(`#${secondPostId}_message`).should('contain', secondMessage);
+
+            // * Check that the center flag icon of the second post is not visible
+            cy.get(`#centerPostFlag_${secondPostId}`).should('not.be.visible');
+
+            // 4. Click the center flag icon of the second post
+            cy.get(`#centerPostFlag_${secondPostId}`).click({force: true});
+
+            // * Check that the center flag icon of the second post becomes visible
+            cy.get(`#centerPostFlag_${secondPostId}`).should('be.visible').should('have.attr', 'class', 'style--none flag-icon__container visible');
+
+            // 5. Click again the center flag icon of the second post
+            cy.get(`#centerPostFlag_${secondPostId}`).click();
+
+            // * Check that the center flag icon of the second post is now hidden.
+            cy.get(`#centerPostFlag_${secondPostId}`).should('not.be.visible');
+        });
+    });
+});

--- a/cypress/integration/post_message/post_reaction_spec.js
+++ b/cypress/integration/post_message/post_reaction_spec.js
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/* eslint max-nested-callbacks: ["error", 3] */
+
+import assert from 'assert';
+
+describe('Post Reaction', () => {
+    before(() => {
+        // 1. Go to Main Channel View with "user-1"
+        cy.toMainChannelView('user-1');
+    });
+
+    it('should open and close Emoji Picker on click of reaction icon', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post a message
+        const message = 'test for reaction and emoji picker';
+        cy.get('#post_textbox').type(message + '{enter}');
+
+        // * Check post list content
+        cy.get('#postListContent').each((postList) => {
+            const divPost = postList[0].children[postList[0].children.length - 1];
+            assert.ok(divPost, 'should get the posted message');
+
+            const postId = divPost.id.replace('post_', '');
+
+            // * Check that the message is posted
+            cy.get(`#${postId}_message`).should('contain', message);
+
+            // * Check that the center post reaction icon and emoji picker are not visible
+            cy.get(`#CENTER_reaction_${postId}`).should('not.be.visible');
+            cy.get('#emojiPicker').should('not.be.visible');
+
+            // 4. Click the center post reaction icon of the post
+            cy.get(`#CENTER_reaction_${postId}`).click({force: true});
+
+            // * Check that the center post reaction icon of the post becomes visible
+            cy.get(`#CENTER_reaction_${postId}`).should('be.visible').should('have.attr', 'class', 'reacticon__container color--link style--none');
+
+            // * Check that the emoji picker becomes visible as well
+            cy.get('#emojiPicker').should('be.visible');
+
+            // 5. Click again the center post reaction icon of the post
+            cy.get(`#CENTER_reaction_${postId}`).click();
+
+            // * Check that the center post reaction icon and emoji picker are not visible
+            cy.get(`#CENTER_reaction_${postId}`).should('not.be.visible');
+            cy.get('#emojiPicker').should('not.be.visible');
+        });
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -20,6 +20,13 @@ Cypress.Commands.add('login', (username, {otherUsername, otherPassword, otherURL
     });
 });
 
+Cypress.Commands.add('toMainChannelView', (username, {otherUsername, otherPassword, otherURL} = {}) => {
+    cy.login('user-1', {otherUsername, otherPassword, otherURL});
+    cy.visit('/');
+
+    cy.get('#post_textbox').should('be.visible');
+});
+
 // ***********************************************************
 // Account Settings Modal
 // ***********************************************************


### PR DESCRIPTION
#### Summary
This PR is submitted due to limitation of Cypress to do E2E for cases like clicking the timestamp, flagging a post, opening the dropdown menu of a post, opening emoji picker and commenting on a post since those components are normally not mounted.  Said components are accessible via hover/mouseover which is not possible with [Cypress API](https://docs.cypress.io/api/commands/hover.html#Workarounds).  @jespino and I tried to do some workarounds like trigger (standard/custom) but it's not working as expected.
With that, such functionality we have can't be tested without doing some trade off to make those testable.  The solution provided here meets the requirement for E2E testing without sacrificing client performance on production.

Included in this PR:
1.  When `config.EnableTesting` is set to true, those normally unmounted components at center posts are rendered with style - `visibility: "hidden"`. On hover, visibility is set to `visible`.  When `config.EnableTesting` is set to false, the behaviour is unchanged (same as what we're doing now which is unmounted on first load and mounted only on hover). Affected components are those in the post header such as PostTime, PostFlagIcon, CommentIcon, DotMenu and PostReaction.
Note that I've used `config.EnableTesting` since it's already available in our config, though it's intended for other test purpose. If it's not desirable, we can add new config setting for E2E test purpose, or maybe use env variable instead.
2.  Added E2E for the following:
  - click on post time to check permalink view
  - open and close of RHS
  - open and close of Emoji Picker
  - flag and unflag of post
  - open and close of Dot Menu
3.  Added element IDs
4. Pull out reaction icon into its own component as PostReaction 

I did profile to compare performance and found that there's no difference between master and this PR with `EnableTesting: false`. The performance degrades when this PR is used with `EnableTesting: true`, which is expected.

Profile steps:
1. Clear cache, browser refresh
2. Start recording
3. Click each channel in the LHS
4. Stop recording

Each flame graph below represents each channel's first load metrics.  There are four channels observed.

a. MASTER:
<img width="1680" alt="master_all_first_load_2" src="https://user-images.githubusercontent.com/5334504/52477844-56c50f80-2bde-11e9-8bb8-8923c863c4fe.png">

b. THIS PR WITH `EnableTesting: false`:
<img width="1680" alt="new_testing_false_all_first_load_3" src="https://user-images.githubusercontent.com/5334504/52477861-63e1fe80-2bde-11e9-956d-e861ea849403.png">

c. THIS PR WITH `EnableTesting: true` (for E2E):
<img width="1679" alt="new_testing_true_all_first_load_2" src="https://user-images.githubusercontent.com/5334504/52477879-74927480-2bde-11e9-92c2-8f9195005db0.png">

#### Ticket Link
Jira ticket: [MM-13979](https://mattermost.atlassian.net/browse/MM-13979)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)

