### PR TITLE
GH-10205 Escape should not close modal when an autocomplete drop down is in use

### DIFF
--- a/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
+++ b/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
@@ -71,6 +71,7 @@ exports[`components/EditPostModal should disable the button on not canDeletePost
     />
     <span
       className="edit-post__actions"
+      id="editPostEmoji"
     >
       <span
         className="emoji-picker__container"
@@ -199,6 +200,7 @@ exports[`components/EditPostModal should disable the button on not canEditPost a
     />
     <span
       className="edit-post__actions"
+      id="editPostEmoji"
     >
       <span
         className="emoji-picker__container"
@@ -327,6 +329,7 @@ exports[`components/EditPostModal should match with default config 1`] = `
     />
     <span
       className="edit-post__actions"
+      id="editPostEmoji"
     >
       <span
         className="emoji-picker__container"
@@ -455,6 +458,7 @@ exports[`components/EditPostModal should match without emoji picker 1`] = `
     />
     <span
       className="edit-post__actions"
+      id="editPostEmoji"
     />
     <div
       className="edit-post-footer"
@@ -562,6 +566,7 @@ exports[`components/EditPostModal should not disable the button on not canDelete
     />
     <span
       className="edit-post__actions"
+      id="editPostEmoji"
     >
       <span
         className="emoji-picker__container"
@@ -690,6 +695,7 @@ exports[`components/EditPostModal should not disable the button on not canEditPo
     />
     <span
       className="edit-post__actions"
+      id="editPostEmoji"
     >
       <span
         className="emoji-picker__container"
@@ -818,6 +824,7 @@ exports[`components/EditPostModal should not disable the save button on not canD
     />
     <span
       className="edit-post__actions"
+      id="editPostEmoji"
     >
       <span
         className="emoji-picker__container"
@@ -946,6 +953,7 @@ exports[`components/EditPostModal should show emojis on emojis click 1`] = `
     />
     <span
       className="edit-post__actions"
+      id="editPostEmoji"
     >
       <span
         className="emoji-picker__container"
@@ -1074,6 +1082,7 @@ exports[`components/EditPostModal should show errors when it is set in the state
     />
     <span
       className="edit-post__actions"
+      id="editPostEmoji"
     >
       <span
         className="emoji-picker__container"

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -333,6 +333,7 @@ export default class EditPostModal extends React.PureComponent {
                         characterLimit={this.props.maxPostSize}
                     />
                     <span
+                        id='editPostEmoji'
                         ref='editPostEmoji'
                         className='edit-post__actions'
                     >

--- a/components/emoji_picker/emoji_picker_tabs.jsx
+++ b/components/emoji_picker/emoji_picker_tabs.jsx
@@ -111,6 +111,7 @@ export default class EmojiPickerTabs extends PureComponent {
         }
         return (
             <div
+                id='emojiPicker'
                 style={pickerStyle}
                 className={pickerClass}
             >

--- a/cypress/integration/channel/edit_message_spec.js
+++ b/cypress/integration/channel/edit_message_spec.js
@@ -34,13 +34,13 @@ describe('Edit Message', () => {
         // 6. In the modal type ~
         cy.get('#edit_textbox').type(' ~');
 
-        // * Assert user autocomplete is visible
+        // * Assert channel autocomplete is visible
         cy.get('#suggestionList').should('be.visible');
 
         // 6. Press the escape key
         cy.get('#edit_textbox').type('{esc}');
 
-        // * Assert user autocomplete is not visible
+        // * Assert channel autocomplete is not visible
         cy.get('#suggestionList').should('not.exist');
 
         // 7. In the modal click the emoji picker icon

--- a/cypress/integration/channel/edit_message_spec.js
+++ b/cypress/integration/channel/edit_message_spec.js
@@ -44,15 +44,15 @@ describe('Edit Message', () => {
         cy.get('#suggestionList').should('not.exist');
 
         // 7. In the modal click the emoji picker icon
-        cy.get('.edit-post__actions').click();
+        cy.get('#editPostEmoji').click();
 
         // * Assert emoji picker is visible
-        cy.get('.emoji-picker').should('be.visible');
+        cy.get('#emojiPicker').should('be.visible');
 
         // 8. Press the escape key
         cy.get('#edit_textbox').type('{esc}');
 
         // * Assert emoji picker is not visible
-        cy.get('.emoji-picker').should('not.exist');
+        cy.get('#emojiPicker').should('not.exist');
     });
 });

--- a/cypress/integration/channel/edit_message_spec.js
+++ b/cypress/integration/channel/edit_message_spec.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+describe('Edit Message', () => {
+    it('Escape should not close modal when an autocomplete drop down is in use', () => {
+        // 1. Login as "user-1" and go to /
+        cy.login('user-1');
+        cy.visit('/');
+
+        // 2. Post message "Hello"
+        cy.get('#post_textbox').type('Hello World!').type('{enter}');
+
+        // 3. Hit the up arrow to open the "edit modal"
+        cy.get('#post_textbox').type('{uparrow}');
+
+        // 4. In the modal type @
+        cy.get('#edit_textbox').type(' @');
+
+        // * Assert user autocomplete is visible
+        cy.get('#suggestionList').should('be.visible');
+
+        // 5. Press the escape key
+        cy.get('#edit_textbox').type('{esc}');
+
+        // * Assert user autocomplete is not visible
+        cy.get('#suggestionList').should('not.exist');
+
+        // 6. In the modal type ~
+        cy.get('#edit_textbox').type(' ~');
+
+        // * Assert user autocomplete is visible
+        cy.get('#suggestionList').should('be.visible');
+
+        // 6. Press the escape key
+        cy.get('#edit_textbox').type('{esc}');
+
+        // * Assert user autocomplete is not visible
+        cy.get('#suggestionList').should('not.exist');
+
+        // 7. In the modal click the emoji picker icon
+        cy.get('.edit-post__actions').click();
+
+        // * Assert emoji picker is visible
+        cy.get('.emoji-picker').should('be.visible');
+
+        // 8. Press the escape key
+        cy.get('#edit_textbox').type('{esc}');
+
+        // * Assert emoji picker is not visible
+        cy.get('.emoji-picker').should('not.exist');
+    });
+});


### PR DESCRIPTION
#### Summary

UI Automation: Write an automated test using `cypress` for "Escape should not close modal when an autocomplete drop down is in use" 

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/10205

#### Checklist

- [X] Ran `make check-style` to check for style errors (required for all pull requests)
- [X] Ran `make test` to ensure unit and component tests passed
- [X] Added or updated unit tests (required for all new features)

#### Demo

![mattermost-e2e-edit-post](https://user-images.githubusercontent.com/1492516/52508516-42404180-2bf5-11e9-97e4-51bb03863bc5.gif)

