### PR TITLE
[MM-12749] Remove loadMyTeamMembers from user_actions.jsx

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -3,7 +3,7 @@
 
 import {getChannelAndMyMember, getChannelMembersByIds} from 'mattermost-redux/actions/channels';
 import {deletePreferences as deletePreferencesRedux, savePreferences as savePreferencesRedux} from 'mattermost-redux/actions/preferences';
-import {getMyTeamMembers, getMyTeamUnreads, getTeamMembersByIds} from 'mattermost-redux/actions/teams';
+import {getTeamMembersByIds} from 'mattermost-redux/actions/teams';
 import * as UserActions from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {Preferences as PreferencesRedux} from 'mattermost-redux/constants';
@@ -488,11 +488,6 @@ export async function loadProfiles(page, perPage, options = {}, success) {
     if (success) {
         success(data);
     }
-}
-
-export async function loadMyTeamMembers() {
-    await getMyTeamMembers()(dispatch, getState);
-    getMyTeamUnreads()(dispatch, getState);
 }
 
 export function autoResetStatus() {

--- a/components/team_members_dropdown/index.js
+++ b/components/team_members_dropdown/index.js
@@ -5,7 +5,12 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getChannelStats} from 'mattermost-redux/actions/channels';
-import {getTeamStats, updateTeamMemberSchemeRoles} from 'mattermost-redux/actions/teams';
+import {
+    getMyTeamMembers,
+    getMyTeamUnreads,
+    getTeamStats,
+    updateTeamMemberSchemeRoles,
+} from 'mattermost-redux/actions/teams';
 import {getUser} from 'mattermost-redux/actions/users';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
@@ -26,6 +31,8 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            getMyTeamMembers,
+            getMyTeamUnreads,
             getUser,
             getTeamStats,
             getChannelStats,

--- a/components/team_members_dropdown/team_members_dropdown.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {browserHistory} from 'utils/browser_history';
-import {loadMyTeamMembers, updateActive} from 'actions/user_actions.jsx';
+import {updateActive} from 'actions/user_actions.jsx';
 import * as Utils from 'utils/utils.jsx';
 import ConfirmModal from 'components/confirm_modal.jsx';
 import DropdownIcon from 'components/icon/dropdown_icon';
@@ -19,6 +19,8 @@ export default class TeamMembersDropdown extends React.Component {
         teamMember: PropTypes.object.isRequired,
         teamUrl: PropTypes.string.isRequired,
         actions: PropTypes.shape({
+            getMyTeamMembers: PropTypes.func.isRequired,
+            getMyTeamUnreads: PropTypes.func.isRequired,
             getUser: PropTypes.func.isRequired,
             getTeamStats: PropTypes.func.isRequired,
             getChannelStats: PropTypes.func.isRequired,
@@ -49,7 +51,8 @@ export default class TeamMembersDropdown extends React.Component {
             } else {
                 this.props.actions.getUser(this.props.user.id);
                 if (this.props.user.id === me.id) {
-                    loadMyTeamMembers();
+                    await this.props.actions.getMyTeamMembers();
+                    this.props.actions.getMyTeamUnreads();
                 }
             }
         }


### PR DESCRIPTION
#### Summary
Removed usage of `loadMyTeamMembers` from `user_actions.jsx`. The code of that function now resides within the only component that uses it.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10152
Part of https://mattermost.atlassian.net/browse/MM-12581

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed