### PR TITLE
[MM-14051] Hides user count when user status filter is applied

### DIFF
--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -27,6 +27,7 @@ export default class SearchableUserList extends React.Component {
         actionUserProps: PropTypes.object,
         focusOnMount: PropTypes.bool,
         renderCount: PropTypes.func,
+        filter: PropTypes.string,
         renderFilterRow: PropTypes.func,
 
         page: PropTypes.number.isRequired,
@@ -112,6 +113,10 @@ export default class SearchableUserList extends React.Component {
 
     renderCount(users) {
         if (!users) {
+            return null;
+        }
+
+        if (this.props.filter) {
             return null;
         }
 


### PR DESCRIPTION
#### Summary
This commit adds `filter` as an optional prop to the `SearchableUserList`
component and hides the user count when the filter is applied.

#### Ticket Link
[MM-14051](https://mattermost.atlassian.net/browse/MM-14051)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes