### PR TITLE
[MM-13302] Created the LocalizedInput component to remove usage of th…

### DIFF
--- a/components/__snapshots__/searchable_channel_list.test.jsx.snap
+++ b/components/__snapshots__/searchable_channel_list.test.jsx.snap
@@ -14,8 +14,14 @@ exports[`components/SearchableChannelList should match init snapshot 1`] = `
         className="form-control filter-textbox"
         delayInputUpdate={false}
         id="searchChannelsTextbox"
+        inputComponent={[Function]}
         onInput={[Function]}
-        placeholder="Search channels"
+        placeholder={
+          Object {
+            "defaultMessage": "Search channels",
+            "id": "filtered_channels_list.search",
+          }
+        }
         value=""
       />
     </div>

--- a/components/admin_console/__snapshots__/custom_url_schemes_setting.test.jsx.snap
+++ b/components/admin_console/__snapshots__/custom_url_schemes_setting.test.jsx.snap
@@ -7,12 +7,17 @@ exports[`components/AdminConsole/CustomUrlSchemeSetting initial state with multi
   label="Custom URL Schemes:"
   setByEnv={false}
 >
-  <input
+  <LocalizedInput
     className="form-control"
     disabled={false}
     id="MySetting"
     onChange={[Function]}
-    placeholder="E.g.: \\"git,smtp\\""
+    placeholder={
+      Object {
+        "defaultMessage": "E.g.: \\"git,smtp\\"",
+        "id": "admin.customization.customUrlSchemesPlaceholder",
+      }
+    }
     type="text"
     value="git,smtp,steam"
   />
@@ -26,12 +31,17 @@ exports[`components/AdminConsole/CustomUrlSchemeSetting initial state with no it
   label="Custom URL Schemes:"
   setByEnv={false}
 >
-  <input
+  <LocalizedInput
     className="form-control"
     disabled={false}
     id="MySetting"
     onChange={[Function]}
-    placeholder="E.g.: \\"git,smtp\\""
+    placeholder={
+      Object {
+        "defaultMessage": "E.g.: \\"git,smtp\\"",
+        "id": "admin.customization.customUrlSchemesPlaceholder",
+      }
+    }
     type="text"
     value=""
   />
@@ -45,12 +55,17 @@ exports[`components/AdminConsole/CustomUrlSchemeSetting initial state with one i
   label="Custom URL Schemes:"
   setByEnv={false}
 >
-  <input
+  <LocalizedInput
     className="form-control"
     disabled={false}
     id="MySetting"
     onChange={[Function]}
-    placeholder="E.g.: \\"git,smtp\\""
+    placeholder={
+      Object {
+        "defaultMessage": "E.g.: \\"git,smtp\\"",
+        "id": "admin.customization.customUrlSchemesPlaceholder",
+      }
+    }
     type="text"
     value="git"
   />
@@ -64,12 +79,17 @@ exports[`components/AdminConsole/CustomUrlSchemeSetting renders properly when di
   label="Custom URL Schemes:"
   setByEnv={false}
 >
-  <input
+  <LocalizedInput
     className="form-control"
     disabled={true}
     id="MySetting"
     onChange={[Function]}
-    placeholder="E.g.: \\"git,smtp\\""
+    placeholder={
+      Object {
+        "defaultMessage": "E.g.: \\"git,smtp\\"",
+        "id": "admin.customization.customUrlSchemesPlaceholder",
+      }
+    }
     type="text"
     value="git,smtp"
   />
@@ -83,12 +103,17 @@ exports[`components/AdminConsole/CustomUrlSchemeSetting renders properly when se
   label="Custom URL Schemes:"
   setByEnv={true}
 >
-  <input
+  <LocalizedInput
     className="form-control"
     disabled={true}
     id="MySetting"
     onChange={[Function]}
-    placeholder="E.g.: \\"git,smtp\\""
+    placeholder={
+      Object {
+        "defaultMessage": "E.g.: \\"git,smtp\\"",
+        "id": "admin.customization.customUrlSchemesPlaceholder",
+      }
+    }
     type="text"
     value="git,smtp"
   />

--- a/components/admin_console/compliance_reports/compliance_reports.jsx
+++ b/components/admin_console/compliance_reports/compliance_reports.jsx
@@ -6,9 +6,9 @@ import React from 'react';
 import {FormattedDate, FormattedMessage, FormattedTime} from 'react-intl';
 import {Client4} from 'mattermost-redux/client';
 
-import * as Utils from 'utils/utils.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 import ReloadIcon from 'components/icon/reload_icon';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 export default class ComplianceReports extends React.PureComponent {
     static propTypes = {
@@ -287,12 +287,12 @@ export default class ComplianceReports extends React.PureComponent {
                                 defaultMessage='Job Name:'
                             />
                         </label>
-                        <input
+                        <LocalizedInput
                             type='text'
                             className='form-control'
                             id='desc'
                             ref='desc'
-                            placeholder={Utils.localizeMessage('admin.compliance_reports.desc_placeholder', 'E.g. "Audit 445 for HR"')}
+                            placeholder={{id: 'admin.compliance_reports.desc_placeholder', defaultMessage: 'E.g. "Audit 445 for HR"'}}
                         />
                     </div>
                     <div className='col-sm-3 col-md-2 form-group'>
@@ -302,12 +302,12 @@ export default class ComplianceReports extends React.PureComponent {
                                 defaultMessage='From:'
                             />
                         </label>
-                        <input
+                        <LocalizedInput
                             type='text'
                             className='form-control'
                             id='from'
                             ref='from'
-                            placeholder={Utils.localizeMessage('admin.compliance_reports.from_placeholder', 'E.g. "2016-03-11"')}
+                            placeholder={{id: 'admin.compliance_reports.from_placeholder', defaultMessage: 'E.g. "2016-03-11"'}}
                         />
                     </div>
                     <div className='col-sm-3 col-md-2 form-group'>
@@ -317,12 +317,12 @@ export default class ComplianceReports extends React.PureComponent {
                                 defaultMessage='To:'
                             />
                         </label>
-                        <input
+                        <LocalizedInput
                             type='text'
                             className='form-control'
                             id='to'
                             ref='to'
-                            placeholder={Utils.localizeMessage('admin.compliance_reports.to_placeholder', 'E.g. "2016-03-15"')}
+                            placeholder={{id: 'admin.compliance_reports.to_placeholder', defaultMessage: 'E.g. "2016-03-15"'}}
                         />
                     </div>
                 </div>
@@ -334,12 +334,12 @@ export default class ComplianceReports extends React.PureComponent {
                                 defaultMessage='Emails:'
                             />
                         </label>
-                        <input
+                        <LocalizedInput
                             type='text'
                             className='form-control'
                             id='emails'
                             ref='emails'
-                            placeholder={Utils.localizeMessage('admin.compliance_reports.emails_placeholder', 'E.g. "bill@example.com, bob@example.com"')}
+                            placeholder={{id: 'admin.compliance_reports.emails_placeholder', defaultMessage: 'E.g. "bill@example.com, bob@example.com"'}}
                         />
                     </div>
                     <div className='col-sm-6 col-md-4 form-group'>
@@ -349,12 +349,12 @@ export default class ComplianceReports extends React.PureComponent {
                                 defaultMessage='Keywords:'
                             />
                         </label>
-                        <input
+                        <LocalizedInput
                             type='text'
                             className='form-control'
                             id='keywords'
                             ref='keywords'
-                            placeholder={Utils.localizeMessage('admin.compliance_reports.keywords_placeholder', 'E.g. "shorting stock"')}
+                            placeholder={{id: 'admin.compliance_reports.keywords_placeholder', defaultMessage: 'E.g. "shorting stock"'}}
                         />
                     </div>
                 </div>

--- a/components/admin_console/custom_url_schemes_setting.jsx
+++ b/components/admin_console/custom_url_schemes_setting.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 
 import * as Utils from 'utils/utils';
 
+import LocalizedInput from 'components/localized_input/localized_input';
+
 import Setting from './setting';
 
 export default class CustomUrlSchemesSetting extends React.Component {
@@ -51,7 +53,6 @@ export default class CustomUrlSchemesSetting extends React.Component {
             'admin.customization.customUrlSchemesDesc',
             'Allows message text to link if it begins with any of the comma-separated URL schemes listed. By default, the following schemes will create links: "http", "https", "ftp", "tel", and "mailto".'
         );
-        const placeholder = Utils.localizeMessage('admin.customization.customUrlSchemesPlaceholder', 'E.g.: "git,smtp"');
 
         return (
             <Setting
@@ -60,11 +61,11 @@ export default class CustomUrlSchemesSetting extends React.Component {
                 inputId={this.props.id}
                 setByEnv={this.props.setByEnv}
             >
-                <input
+                <LocalizedInput
                     id={this.props.id}
                     className='form-control'
                     type='text'
-                    placeholder={placeholder}
+                    placeholder={{id: 'admin.customization.customUrlSchemesPlaceholder', defaultMessage: 'E.g.: "git,smtp"'}}
                     value={this.state.value}
                     onChange={this.handleChange}
                     disabled={this.props.disabled || this.props.setByEnv}

--- a/components/admin_console/custom_url_schemes_setting.test.jsx
+++ b/components/admin_console/custom_url_schemes_setting.test.jsx
@@ -70,7 +70,7 @@ describe('components/AdminConsole/CustomUrlSchemeSetting', () => {
                 <CustomUrlSchemesSetting {...props}/>
             );
 
-            wrapper.find('input').simulate('change', {target: {value: ''}});
+            wrapper.find('LocalizedInput').simulate('change', {target: {value: ''}});
 
             expect(props.onChange).toBeCalledWith(baseProps.id, []);
         });
@@ -85,7 +85,7 @@ describe('components/AdminConsole/CustomUrlSchemeSetting', () => {
                 <CustomUrlSchemesSetting {...props}/>
             );
 
-            wrapper.find('input').simulate('change', {target: {value: '  steam  '}});
+            wrapper.find('LocalizedInput').simulate('change', {target: {value: '  steam  '}});
 
             expect(props.onChange).toBeCalledWith(baseProps.id, ['steam']);
         });
@@ -100,7 +100,7 @@ describe('components/AdminConsole/CustomUrlSchemeSetting', () => {
                 <CustomUrlSchemesSetting {...props}/>
             );
 
-            wrapper.find('input').simulate('change', {target: {value: 'steam, git'}});
+            wrapper.find('LocalizedInput').simulate('change', {target: {value: 'steam, git'}});
 
             expect(props.onChange).toBeCalledWith(baseProps.id, ['steam', 'git']);
         });
@@ -115,7 +115,7 @@ describe('components/AdminConsole/CustomUrlSchemeSetting', () => {
                 <CustomUrlSchemesSetting {...props}/>
             );
 
-            wrapper.find('input').simulate('change', {target: {value: 'ts3server, smtp, ms-excel'}});
+            wrapper.find('LocalizedInput').simulate('change', {target: {value: 'ts3server, smtp, ms-excel'}});
 
             expect(props.onChange).toBeCalledWith(baseProps.id, ['ts3server', 'smtp', 'ms-excel']);
         });
@@ -130,7 +130,7 @@ describe('components/AdminConsole/CustomUrlSchemeSetting', () => {
                 <CustomUrlSchemesSetting {...props}/>
             );
 
-            wrapper.find('input').simulate('change', {target: {value: ',,,,,chrome,,,,ms-excel,,'}});
+            wrapper.find('LocalizedInput').simulate('change', {target: {value: ',,,,,chrome,,,,ms-excel,,'}});
 
             expect(props.onChange).toBeCalledWith(baseProps.id, ['chrome', 'ms-excel']);
         });

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/__snapshots__/permission_team_scheme_settings.test.jsx.snap
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/__snapshots__/permission_team_scheme_settings.test.jsx.snap
@@ -70,11 +70,16 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
             values={Object {}}
           />
         </label>
-        <input
+        <LocalizedInput
           className="form-control"
           id="scheme-name"
           onChange={[Function]}
-          placeholder="Scheme Name"
+          placeholder={
+            Object {
+              "defaultMessage": "Scheme Name",
+              "id": "admin.permissions.teamScheme.schemeNamePlaceholder",
+            }
+          }
           type="text"
           value="Test scheme"
         />
@@ -432,11 +437,16 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
             values={Object {}}
           />
         </label>
-        <input
+        <LocalizedInput
           className="form-control"
           id="scheme-name"
           onChange={[Function]}
-          placeholder="Scheme Name"
+          placeholder={
+            Object {
+              "defaultMessage": "Scheme Name",
+              "id": "admin.permissions.teamScheme.schemeNamePlaceholder",
+            }
+          }
           type="text"
           value="Test scheme"
         />
@@ -774,11 +784,16 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
             values={Object {}}
           />
         </label>
-        <input
+        <LocalizedInput
           className="form-control"
           id="scheme-name"
           onChange={[Function]}
-          placeholder="Scheme Name"
+          placeholder={
+            Object {
+              "defaultMessage": "Scheme Name",
+              "id": "admin.permissions.teamScheme.schemeNamePlaceholder",
+            }
+          }
           type="text"
           value=""
         />
@@ -1146,11 +1161,16 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
             values={Object {}}
           />
         </label>
-        <input
+        <LocalizedInput
           className="form-control"
           id="scheme-name"
           onChange={[Function]}
-          placeholder="Scheme Name"
+          placeholder={
+            Object {
+              "defaultMessage": "Scheme Name",
+              "id": "admin.permissions.teamScheme.schemeNamePlaceholder",
+            }
+          }
           type="text"
           value=""
         />

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.jsx
@@ -19,6 +19,8 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 import PermissionsTree from '../permissions_tree';
 
+import LocalizedInput from 'components/localized_input/localized_input';
+
 import TeamInList from './team_in_list';
 
 export default class PermissionTeamSchemeSettings extends React.Component {
@@ -411,12 +413,12 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                                     defaultMessage='Scheme Name:'
                                 />
                             </label>
-                            <input
+                            <LocalizedInput
                                 id='scheme-name'
                                 className='form-control'
                                 type='text'
                                 value={schemeName}
-                                placeholder={localizeMessage('admin.permissions.teamScheme.schemeNamePlaceholder', 'Scheme Name')}
+                                placeholder={{id: 'admin.permissions.teamScheme.schemeNamePlaceholder', defaultMessage: 'Scheme Name'}}
                                 onChange={this.handleNameChange}
                             />
                         </div>

--- a/components/admin_console/system_users/system_users.jsx
+++ b/components/admin_console/system_users/system_users.jsx
@@ -11,6 +11,7 @@ import {loadProfiles, loadProfilesWithoutTeam, searchUsers} from 'actions/user_a
 import {Constants, UserSearchOptions, SearchUserTeamFilter, SearchUserOptionsFilter} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
+import LocalizedInput from 'components/localized_input/localized_input';
 import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header.jsx';
 
 import SystemUsersList from './list';
@@ -266,11 +267,11 @@ export default class SystemUsers extends React.Component {
         return (
             <div className='system-users__filter-row'>
                 <div className='system-users__filter'>
-                    <input
+                    <LocalizedInput
                         id='searchUsers'
                         ref='filter'
                         className='form-control filter-textbox'
-                        placeholder={Utils.localizeMessage('filtered_user_list.search', 'Search users')}
+                        placeholder={{id: 'filtered_user_list.search', defaultMessage: 'Search users'}}
                         onInput={doSearch}
                     />
                 </div>

--- a/components/claim/components/email_to_ldap.jsx
+++ b/components/claim/components/email_to_ldap.jsx
@@ -8,6 +8,7 @@ import {FormattedMessage} from 'react-intl';
 import {emailToLdap} from 'actions/admin_actions.jsx';
 import * as Utils from 'utils/utils.jsx';
 import LoginMfa from 'components/login/login_mfa.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 export default class EmailToLDAP extends React.Component {
     static propTypes = {
@@ -153,8 +154,6 @@ export default class EmailToLDAP extends React.Component {
             loginPlaceholder = Utils.localizeMessage('claim.email_to_ldap.ldapId', 'AD/LDAP ID');
         }
 
-        const passwordPlaceholder = Utils.localizeMessage('claim.email_to_ldap.ldapPwd', 'AD/LDAP Password');
-
         let content;
         if (this.state.showMfa) {
             content = (
@@ -197,13 +196,13 @@ export default class EmailToLDAP extends React.Component {
                         name='fakeusernameremembered'
                     />
                     <div className={passwordClass}>
-                        <input
+                        <LocalizedInput
                             type='password'
                             className='form-control'
                             name='emailPassword'
                             ref='emailpassword'
                             autoComplete='off'
-                            placeholder={Utils.localizeMessage('claim.email_to_ldap.pwd', 'Password')}
+                            placeholder={{id: 'claim.email_to_ldap.pwd', defaulMessage: 'Password'}}
                             spellCheck='false'
                         />
                     </div>
@@ -227,13 +226,13 @@ export default class EmailToLDAP extends React.Component {
                     </div>
                     {ldapError}
                     <div className={ldapPasswordClass}>
-                        <input
+                        <LocalizedInput
                             type='password'
                             className='form-control'
                             name='ldapPassword'
                             ref='ldappassword'
                             autoComplete='off'
-                            placeholder={passwordPlaceholder}
+                            placeholder={{id: 'claim.email_to_ldap.ldapPwd', defaultMessage: 'AD/LDAP Password'}}
                             spellCheck='false'
                         />
                     </div>

--- a/components/claim/components/email_to_oauth.jsx
+++ b/components/claim/components/email_to_oauth.jsx
@@ -10,6 +10,7 @@ import {emailToOAuth} from 'actions/admin_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import LoginMfa from 'components/login/login_mfa.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 export default class EmailToOAuth extends React.PureComponent {
     static propTypes = {
@@ -132,12 +133,12 @@ export default class EmailToOAuth extends React.PureComponent {
                         />
                     </p>
                     <div className={formClass}>
-                        <input
+                        <LocalizedInput
                             type='password'
                             className='form-control'
                             name='password'
                             ref='password'
-                            placeholder={Utils.localizeMessage('claim.email_to_oauth.pwd', 'Password')}
+                            placeholder={{id: 'claim.email_to_oauth.pwd', defaultMessage: 'Password'}}
                             spellCheck='false'
                         />
                     </div>

--- a/components/claim/components/ldap_to_email.jsx
+++ b/components/claim/components/ldap_to_email.jsx
@@ -8,6 +8,7 @@ import {FormattedMessage} from 'react-intl';
 import {switchFromLdapToEmail} from 'actions/user_actions.jsx';
 import * as Utils from 'utils/utils.jsx';
 import LoginMfa from 'components/login/login_mfa.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 export default class LDAPToEmail extends React.Component {
     static propTypes = {
@@ -201,23 +202,23 @@ export default class LDAPToEmail extends React.Component {
                         />
                     </p>
                     <div className={passwordClass}>
-                        <input
+                        <LocalizedInput
                             type='password'
                             className='form-control'
                             name='password'
                             ref='password'
-                            placeholder={Utils.localizeMessage('claim.ldap_to_email.pwd', 'Password')}
+                            placeholder={{id: 'claim.ldap_to_email.pwd', defaultMessage: 'Password'}}
                             spellCheck='false'
                         />
                     </div>
                     {passwordError}
                     <div className={confimClass}>
-                        <input
+                        <LocalizedInput
                             type='password'
                             className='form-control'
                             name='passwordconfirm'
                             ref='passwordconfirm'
-                            placeholder={Utils.localizeMessage('claim.ldap_to_email.confirm', 'Confirm Password')}
+                            placeholder={{id: 'claim.ldap_to_email.confirm', defaultMessage: 'Confirm Password'}}
                             spellCheck='false'
                         />
                     </div>

--- a/components/claim/components/oauth_to_email.jsx
+++ b/components/claim/components/oauth_to_email.jsx
@@ -9,6 +9,7 @@ import {FormattedMessage} from 'react-intl';
 import {oauthToEmail} from 'actions/admin_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 export default class OAuthToEmail extends React.PureComponent {
     static propTypes = {
@@ -108,22 +109,22 @@ export default class OAuthToEmail extends React.PureComponent {
                         />
                     </p>
                     <div className={formClass}>
-                        <input
+                        <LocalizedInput
                             type='password'
                             className='form-control'
                             name='password'
                             ref='password'
-                            placeholder={Utils.localizeMessage('claim.oauth_to_email.newPwd', 'New Password')}
+                            placeholder={{id: 'claim.oauth_to_email.newPwd', defaultMessage: 'New Password'}}
                             spellCheck='false'
                         />
                     </div>
                     <div className={formClass}>
-                        <input
+                        <LocalizedInput
                             type='password'
                             className='form-control'
                             name='passwordconfirm'
                             ref='passwordconfirm'
-                            placeholder={Utils.localizeMessage('claim.oauth_to_email.confirm', 'Confirm Password')}
+                            placeholder={{id: 'claim.oauth_to_email.confirm', defaultMessage: 'Confirm Password'}}
                             spellCheck='false'
                         />
                     </div>

--- a/components/emoji/emoji_list/emoji_list.jsx
+++ b/components/emoji/emoji_list/emoji_list.jsx
@@ -7,14 +7,13 @@ import {FormattedMessage} from 'react-intl';
 
 import {Emoji} from 'mattermost-redux/constants';
 
-import {localizeMessage} from 'utils/utils.jsx';
-
 import LoadingScreen from 'components/loading_screen.jsx';
 import SaveButton from 'components/save_button.jsx';
 import EmojiListItem from 'components/emoji/emoji_list_item';
 import NextIcon from 'components/icon/next_icon';
 import PreviousIcon from 'components/icon/previous_icon';
 import SearchIcon from 'components/icon/search_icon';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 const EMOJI_PER_PAGE = 50;
 const EMOJI_SEARCH_DELAY_MILLISECONDS = 200;
@@ -238,10 +237,10 @@ export default class EmojiList extends React.Component {
                 <div className='backstage-filters'>
                     <div className='backstage-filter__search'>
                         <SearchIcon/>
-                        <input
+                        <LocalizedInput
                             type='search'
                             className='form-control'
-                            placeholder={localizeMessage('emoji_list.search', 'Search Custom Emoji')}
+                            placeholder={{id: 'emoji_list.search', defaultMessage: 'Search Custom Emoji'}}
                             onChange={this.onSearchChange}
                             style={style.search}
                         />

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -11,6 +11,8 @@ import {compareEmojis} from 'utils/emoji_utils.jsx';
 import {t} from 'utils/i18n';
 import imgTrans from 'images/img_trans.gif';
 
+import LocalizedInput from 'components/localized_input/localized_input';
+
 import EmojiPickerHeader from './components/emoji_picker_header';
 import EmojiPickerCategory from './components/emoji_picker_category';
 import EmojiPickerItem from './components/emoji_picker_item';
@@ -524,22 +526,15 @@ export default class EmojiPicker extends React.PureComponent {
                     defaultMessage='Search for an emoji'
                 >
                     {(ariaLabel) => (
-                        <FormattedMessage
-                            id='emoji_picker.search'
-                            defaultMessage='Search Emoji'
-                        >
-                            {(placeholder) => (
-                                <input
-                                    aria-label={ariaLabel}
-                                    ref={this.emojiSearchInput}
-                                    className='emoji-picker__search'
-                                    type='text'
-                                    onChange={this.handleFilterChange}
-                                    onKeyDown={this.handleKeyDown}
-                                    placeholder={placeholder}
-                                />
-                            )}
-                        </FormattedMessage>
+                        <LocalizedInput
+                            aria-label={ariaLabel}
+                            ref={this.emojiSearchInput}
+                            className='emoji-picker__search'
+                            type='text'
+                            onChange={this.handleFilterChange}
+                            onKeyDown={this.handleKeyDown}
+                            placeholder={{id: 'emoji_picker.search', defaultMessage: 'Search Emoji'}}
+                        />
                     )}
                 </FormattedMessage>
             </div>

--- a/components/gif_picker/components/SearchBar/index.jsx
+++ b/components/gif_picker/components/SearchBar/index.jsx
@@ -11,8 +11,7 @@ import {changeOpacity, makeStyleFromTheme} from 'mattermost-redux/utils/theme_ut
 
 import GifSearchIcon from 'components/svg/gif_search_icon';
 import GifSearchClearIcon from 'components/svg/gif_search_clear_icon';
-
-import {localizeMessage} from 'utils/utils.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 import './SearchBar.scss';
 
@@ -203,11 +202,11 @@ export class SearchBar extends Component {
                         className='search-input-bg'
                         style={style.inputBackground}
                     />
-                    <input
+                    <LocalizedInput
                         className='search-input'
                         name='searchText'
                         autoFocus={true}
-                        placeholder={localizeMessage('gif_picker.gfycat', 'Search Gfycat')}
+                        placeholder={{id: 'gif_picker.gfycat', defaultMessage: 'Search Gfycat'}}
                         onChange={this.handleChange}
                         autoComplete='off'
                         autoCapitalize='off'

--- a/components/integrations/__snapshots__/abstract_command.test.jsx.snap
+++ b/components/integrations/__snapshots__/abstract_command.test.jsx.snap
@@ -114,12 +114,17 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="trigger"
             maxLength={128}
             onChange={[Function]}
-            placeholder="Command trigger e.g. \\"hello\\" not including the slash"
+            placeholder={
+              Object {
+                "defaultMessage": "Command trigger e.g. \\"hello\\" not including the slash",
+                "id": "add_command.trigger.placeholder",
+              }
+            }
             type="text"
             value="trigger"
           />
@@ -182,12 +187,17 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="url"
             maxLength="1024"
             onChange={[Function]}
-            placeholder="Must start with http:// or https://"
+            placeholder={
+              Object {
+                "defaultMessage": "Must start with http:// or https://",
+                "id": "add_command.url.placeholder",
+              }
+            }
             type="text"
             value="https://google.com/command"
           />
@@ -262,12 +272,17 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="username"
             maxLength="64"
             onChange={[Function]}
-            placeholder="Username"
+            placeholder={
+              Object {
+                "defaultMessage": "Username",
+                "id": "add_command.username.placeholder",
+              }
+            }
             type="text"
             value="username"
           />
@@ -298,12 +313,17 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="iconUrl"
             maxLength="1024"
             onChange={[Function]}
-            placeholder="https://www.example.com/myicon.png"
+            placeholder={
+              Object {
+                "defaultMessage": "https://www.example.com/myicon.png",
+                "id": "add_command.iconUrl.placeholder",
+              }
+            }
             type="text"
             value="https://google.com/icon"
           />
@@ -367,12 +387,17 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="autocompleteHint"
             maxLength="1024"
             onChange={[Function]}
-            placeholder="Example: [Patient Name]"
+            placeholder={
+              Object {
+                "defaultMessage": "Example: [Patient Name]",
+                "id": "add_command.autocompleteHint.placeholder",
+              }
+            }
             type="text"
             value="auto_complete_hint"
           />
@@ -403,12 +428,17 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="description"
             maxLength="128"
             onChange={[Function]}
-            placeholder="Example: \\"Returns search results for patient records\\""
+            placeholder={
+              Object {
+                "defaultMessage": "Example: \\"Returns search results for patient records\\"",
+                "id": "add_command.autocompleteDescription.placeholder",
+              }
+            }
             type="text"
             value="auto_complete_desc"
           />
@@ -581,12 +611,17 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="trigger"
             maxLength={128}
             onChange={[Function]}
-            placeholder="Command trigger e.g. \\"hello\\" not including the slash"
+            placeholder={
+              Object {
+                "defaultMessage": "Command trigger e.g. \\"hello\\" not including the slash",
+                "id": "add_command.trigger.placeholder",
+              }
+            }
             type="text"
             value=""
           />
@@ -649,12 +684,17 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="url"
             maxLength="1024"
             onChange={[Function]}
-            placeholder="Must start with http:// or https://"
+            placeholder={
+              Object {
+                "defaultMessage": "Must start with http:// or https://",
+                "id": "add_command.url.placeholder",
+              }
+            }
             type="text"
             value="https://google.com/command"
           />
@@ -729,12 +769,17 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="username"
             maxLength="64"
             onChange={[Function]}
-            placeholder="Username"
+            placeholder={
+              Object {
+                "defaultMessage": "Username",
+                "id": "add_command.username.placeholder",
+              }
+            }
             type="text"
             value="username"
           />
@@ -765,12 +810,17 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="iconUrl"
             maxLength="1024"
             onChange={[Function]}
-            placeholder="https://www.example.com/myicon.png"
+            placeholder={
+              Object {
+                "defaultMessage": "https://www.example.com/myicon.png",
+                "id": "add_command.iconUrl.placeholder",
+              }
+            }
             type="text"
             value="https://google.com/icon"
           />
@@ -834,12 +884,17 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="autocompleteHint"
             maxLength="1024"
             onChange={[Function]}
-            placeholder="Example: [Patient Name]"
+            placeholder={
+              Object {
+                "defaultMessage": "Example: [Patient Name]",
+                "id": "add_command.autocompleteHint.placeholder",
+              }
+            }
             type="text"
             value="auto_complete_hint"
           />
@@ -870,12 +925,17 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <input
+          <LocalizedInput
             className="form-control"
             id="description"
             maxLength="128"
             onChange={[Function]}
-            placeholder="Example: \\"Returns search results for patient records\\""
+            placeholder={
+              Object {
+                "defaultMessage": "Example: \\"Returns search results for patient records\\"",
+                "id": "add_command.autocompleteDescription.placeholder",
+              }
+            }
             type="text"
             value="auto_complete_desc"
           />

--- a/components/integrations/abstract_command.jsx
+++ b/components/integrations/abstract_command.jsx
@@ -11,6 +11,7 @@ import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import FormError from 'components/form_error.jsx';
 import SpinnerButton from 'components/spinner_button.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 const REQUEST_POST = 'P';
 const REQUEST_GET = 'G';
@@ -270,14 +271,14 @@ export default class AbstractCommand extends React.PureComponent {
                         />
                     </label>
                     <div className='col-md-5 col-sm-8'>
-                        <input
+                        <LocalizedInput
                             id='autocompleteHint'
                             type='text'
                             maxLength='1024'
                             className='form-control'
                             value={this.state.autocompleteHint}
                             onChange={this.updateAutocompleteHint}
-                            placeholder={Utils.localizeMessage('add_command.autocompleteHint.placeholder', 'Example: [Patient Name]')}
+                            placeholder={{id: 'add_command.autocompleteHint.placeholder', defaultMessage: 'Example: [Patient Name]'}}
                         />
                         <div className='form__help'>
                             <FormattedMessage
@@ -301,14 +302,14 @@ export default class AbstractCommand extends React.PureComponent {
                         />
                     </label>
                     <div className='col-md-5 col-sm-8'>
-                        <input
+                        <LocalizedInput
                             id='description'
                             type='text'
                             maxLength='128'
                             className='form-control'
                             value={this.state.autocompleteDescription}
                             onChange={this.updateAutocompleteDescription}
-                            placeholder={Utils.localizeMessage('add_command.autocompleteDescription.placeholder', 'Example: "Returns search results for patient records"')}
+                            placeholder={{id: 'add_command.autocompleteDescription.placeholder', defaultMessage: 'Example: "Returns search results for patient records"'}}
                         />
                         <div className='form__help'>
                             <FormattedMessage
@@ -405,14 +406,14 @@ export default class AbstractCommand extends React.PureComponent {
                                 />
                             </label>
                             <div className='col-md-5 col-sm-8'>
-                                <input
+                                <LocalizedInput
                                     id='trigger'
                                     type='text'
                                     maxLength={Constants.MAX_TRIGGER_LENGTH}
                                     className='form-control'
                                     value={this.state.trigger}
                                     onChange={this.updateTrigger}
-                                    placeholder={Utils.localizeMessage('add_command.trigger.placeholder', 'Command trigger e.g. "hello" not including the slash')}
+                                    placeholder={{id: 'add_command.trigger.placeholder', defaultMessage: 'Command trigger e.g. "hello" not including the slash'}}
                                 />
                                 <div className='form__help'>
                                     <FormattedMessage
@@ -459,14 +460,14 @@ export default class AbstractCommand extends React.PureComponent {
                                 />
                             </label>
                             <div className='col-md-5 col-sm-8'>
-                                <input
+                                <LocalizedInput
                                     id='url'
                                     type='text'
                                     maxLength='1024'
                                     className='form-control'
                                     value={this.state.url}
                                     onChange={this.updateUrl}
-                                    placeholder={Utils.localizeMessage('add_command.url.placeholder', 'Must start with http:// or https://')}
+                                    placeholder={{id: 'add_command.url.placeholder', defaultMessage: 'Must start with http:// or https://'}}
                                 />
                                 <div className='form__help'>
                                     <FormattedMessage
@@ -519,14 +520,14 @@ export default class AbstractCommand extends React.PureComponent {
                                 />
                             </label>
                             <div className='col-md-5 col-sm-8'>
-                                <input
+                                <LocalizedInput
                                     id='username'
                                     type='text'
                                     maxLength='64'
                                     className='form-control'
                                     value={this.state.username}
                                     onChange={this.updateUsername}
-                                    placeholder={Utils.localizeMessage('add_command.username.placeholder', 'Username')}
+                                    placeholder={{id: 'add_command.username.placeholder', defaultMessage: 'Username'}}
                                 />
                                 <div className='form__help'>
                                     <FormattedMessage
@@ -547,14 +548,14 @@ export default class AbstractCommand extends React.PureComponent {
                                 />
                             </label>
                             <div className='col-md-5 col-sm-8'>
-                                <input
+                                <LocalizedInput
                                     id='iconUrl'
                                     type='text'
                                     maxLength='1024'
                                     className='form-control'
                                     value={this.state.iconUrl}
                                     onChange={this.updateIconUrl}
-                                    placeholder={Utils.localizeMessage('add_command.iconUrl.placeholder', 'https://www.example.com/myicon.png')}
+                                    placeholder={{id: 'add_command.iconUrl.placeholder', defaultMessage: 'https://www.example.com/myicon.png'}}
                                 />
                                 <div className='form__help'>
                                     <FormattedMessage

--- a/components/invite_member_modal/invite_member_modal.jsx
+++ b/components/invite_member_modal/invite_member_modal.jsx
@@ -18,6 +18,7 @@ import ConfirmModal from 'components/confirm_modal.jsx';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper.jsx';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 const holders = defineMessages({
     emailError: {
@@ -277,12 +278,12 @@ class InviteMemberModal extends React.PureComponent {
                     <div className='row row--invite'>
                         <div className='col-sm-6'>
                             <div className={firstNameClass}>
-                                <input
+                                <LocalizedInput
                                     onKeyDown={this.handleKeyDown}
                                     type='text'
                                     className='form-control'
                                     ref={'first_name' + index}
-                                    placeholder={formatMessage(holders.firstname)}
+                                    placeholder={holders.firstname}
                                     maxLength='64'
                                     disabled={!this.props.sendEmailNotifications || !this.props.enableUserCreation}
                                     spellCheck='false'
@@ -292,12 +293,12 @@ class InviteMemberModal extends React.PureComponent {
                         </div>
                         <div className='col-sm-6'>
                             <div className={lastNameClass}>
-                                <input
+                                <LocalizedInput
                                     onKeyDown={this.handleKeyDown}
                                     type='text'
                                     className='form-control'
                                     ref={'last_name' + index}
-                                    placeholder={formatMessage(holders.lastname)}
+                                    placeholder={holders.lastname}
                                     maxLength='64'
                                     disabled={!this.props.sendEmailNotifications || !this.props.enableUserCreation}
                                     spellCheck='false'

--- a/components/localized_input/__snapshots__/localized_input.test.jsx.snap
+++ b/components/localized_input/__snapshots__/localized_input.test.jsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/localized_input/localized_input should match snapshot 1`] = `
+<input
+  className="test-class"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": "Etc/UTC",
+    }
+  }
+  placeholder="placeholder to test"
+  value="test value"
+/>
+`;

--- a/components/localized_input/localized_input.jsx
+++ b/components/localized_input/localized_input.jsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {intlShape} from 'react-intl';
+
+export default class LocalizedInput extends React.Component {
+    static propTypes = {
+
+        placeholder: PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            defaultMessage: PropTypes.string.isRequired,
+        }).isRequired,
+    };
+
+    static contextTypes = {
+        intl: intlShape.isRequired,
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.input = React.createRef();
+    }
+
+    get value() {
+        return this.input.current.value;
+    }
+
+    set value(value) {
+        this.input.current.value = value;
+    }
+
+    focus = () => {
+        this.input.current.focus();
+    };
+
+    shouldComponentUpdate(nextProps) {
+        return nextProps.placeholder.id !== this.props.placeholder.id ||
+            nextProps.placeholder.defaultMessage !== this.props.placeholder.defaultMessage;
+    }
+
+    render() {
+        const {formatMessage} = this.context.intl;
+        const {placeholder, ...otherProps} = this.props;
+        const placeholderString = formatMessage(placeholder);
+
+        return (
+            <input
+                ref={this.input}
+                {...otherProps}
+                placeholder={placeholderString}
+            />
+        );
+    }
+}

--- a/components/localized_input/localized_input.test.jsx
+++ b/components/localized_input/localized_input.test.jsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+
+import LocalizedInput from 'components/localized_input/localized_input';
+
+describe('components/localized_input/localized_input', () => {
+    const baseProps = {
+        className: 'test-class',
+        value: 'test value',
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallowWithIntl(
+            <LocalizedInput
+                {...baseProps}
+                placeholder={{id: 'test.placeholder', defaultMessage: 'placeholder to test'}}
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('input').length).toBe(1);
+        expect(wrapper.find('input').get(0).props.value).toBe('test value');
+        expect(wrapper.find('input').get(0).props.className).toBe('test-class');
+        expect(wrapper.find('input').get(0).props.placeholder).toBe('placeholder to test');
+    });
+});

--- a/components/login/__snapshots__/login_mfa.test.jsx.snap
+++ b/components/login/__snapshots__/login_mfa.test.jsx.snap
@@ -20,13 +20,18 @@ exports[`components/login/LoginMfa should match snapshot 1`] = `
     <div
       className="form-group"
     >
-      <input
+      <LocalizedInput
         autoComplete="off"
         autoFocus={true}
         className="form-control"
         name="token"
         onChange={[Function]}
-        placeholder="MFA Token"
+        placeholder={
+          Object {
+            "defaultMessage": "MFA Token",
+            "id": "login_mfa.token",
+          }
+        }
         spellCheck="false"
         type="text"
       />

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -30,6 +30,7 @@ import LoadingScreen from 'components/loading_screen.jsx';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper.jsx';
 import SuccessIcon from 'components/icon/success_icon';
 import WarningIcon from 'components/icon/warning_icon';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 import LoginMfa from '../login_mfa.jsx';
 
@@ -563,7 +564,7 @@ class LoginController extends React.Component {
                             />
                         </div>
                         <div className={'form-group' + errorClass}>
-                            <input
+                            <LocalizedInput
                                 id='loginPassword'
                                 type='password'
                                 className='form-control'
@@ -571,7 +572,7 @@ class LoginController extends React.Component {
                                 name='password'
                                 value={this.state.password}
                                 onChange={this.handlePasswordChange}
-                                placeholder={Utils.localizeMessage('login.password', 'Password')}
+                                placeholder={{id: 'login.password', defaultMessage: 'Password'}}
                                 spellCheck='false'
                             />
                         </div>

--- a/components/login/login_mfa.jsx
+++ b/components/login/login_mfa.jsx
@@ -7,6 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {localizeMessage} from 'utils/utils.jsx';
 import SaveButton from 'components/save_button.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 export default class LoginMfa extends React.PureComponent {
     static propTypes = {
@@ -84,11 +85,11 @@ export default class LoginMfa extends React.PureComponent {
                         {serverError}
                     </div>
                     <div className={'form-group' + errorClass}>
-                        <input
+                        <LocalizedInput
                             type='text'
                             className='form-control'
                             name='token'
-                            placeholder={localizeMessage('login_mfa.token', 'MFA Token')}
+                            placeholder={{id: 'login_mfa.token', defaultMessage: 'MFA Token'}}
                             spellCheck='false'
                             autoComplete='off'
                             autoFocus={true}

--- a/components/mfa/setup/setup.jsx
+++ b/components/mfa/setup/setup.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import * as Utils from 'utils/utils.jsx';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 export default class Setup extends React.Component {
     static propTypes = {
@@ -146,10 +147,10 @@ export default class Setup extends React.Component {
                         />
                     </p>
                     <p>
-                        <input
+                        <LocalizedInput
                             ref='code'
                             className='form-control'
-                            placeholder={Utils.localizeMessage('mfa.setup.code', 'MFA Code')}
+                            placeholder={{id: 'mfa.setup.code', defaultMessage: 'MFA Code'}}
                             autoFocus={true}
                         />
                     </p>

--- a/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
+++ b/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
@@ -127,14 +127,19 @@ exports[`components/NewChannelModal should match snapshot, display only private 
           <div
             className="col-sm-9"
           >
-            <input
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newPublicChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
-              placeholder="E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\""
+              placeholder={
+                Object {
+                  "defaultMessage": "E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\"",
+                  "id": "channel_modal.nameEx",
+                }
+              }
               tabIndex="1"
               type="text"
               value="testchannel"
@@ -419,14 +424,19 @@ exports[`components/NewChannelModal should match snapshot, display only public c
           <div
             className="col-sm-9"
           >
-            <input
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newPublicChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
-              placeholder="E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\""
+              placeholder={
+                Object {
+                  "defaultMessage": "E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\"",
+                  "id": "channel_modal.nameEx",
+                }
+              }
               tabIndex="1"
               type="text"
               value="testchannel"
@@ -751,14 +761,19 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
           <div
             className="col-sm-9"
           >
-            <input
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newPublicChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
-              placeholder="E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\""
+              placeholder={
+                Object {
+                  "defaultMessage": "E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\"",
+                  "id": "channel_modal.nameEx",
+                }
+              }
               tabIndex="1"
               type="text"
               value="testchannel"
@@ -1083,14 +1098,19 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
           <div
             className="col-sm-9"
           >
-            <input
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newPublicChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
-              placeholder="E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\""
+              placeholder={
+                Object {
+                  "defaultMessage": "E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\"",
+                  "id": "channel_modal.nameEx",
+                }
+              }
               tabIndex="1"
               type="text"
               value="testchannel"
@@ -1415,14 +1435,19 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
           <div
             className="col-sm-9"
           >
-            <input
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newPublicChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
-              placeholder="E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\""
+              placeholder={
+                Object {
+                  "defaultMessage": "E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\"",
+                  "id": "channel_modal.nameEx",
+                }
+              }
               tabIndex="1"
               type="text"
               value="testchannel"
@@ -1757,14 +1782,19 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
           <div
             className="col-sm-9"
           >
-            <input
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newPublicChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
-              placeholder="E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\""
+              placeholder={
+                Object {
+                  "defaultMessage": "E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\"",
+                  "id": "channel_modal.nameEx",
+                }
+              }
               tabIndex="1"
               type="text"
               value="testchannel"
@@ -2102,14 +2132,19 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
           <div
             className="col-sm-9"
           >
-            <input
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newPrivateChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
-              placeholder="E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\""
+              placeholder={
+                Object {
+                  "defaultMessage": "E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\"",
+                  "id": "channel_modal.nameEx",
+                }
+              }
               tabIndex="1"
               type="text"
               value="testchannel"

--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -10,6 +10,7 @@ import {FormattedMessage} from 'react-intl';
 
 import GlobeIcon from 'components/svg/globe_icon';
 import LockIcon from 'components/svg/lock_icon';
+import LocalizedInput from 'components/localized_input/localized_input';
 import Constants from 'utils/constants.jsx';
 import {getShortenedURL} from 'utils/url.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
@@ -321,13 +322,13 @@ export default class NewChannelModal extends React.PureComponent {
                                     />
                                 </label>
                                 <div className='col-sm-9'>
-                                    <input
+                                    <LocalizedInput
                                         id={inputPrefixId + 'Name'}
                                         onChange={this.handleChange}
                                         type='text'
                                         ref='display_name'
                                         className='form-control'
-                                        placeholder={Utils.localizeMessage('channel_modal.nameEx', 'E.g.: "Bugs", "Marketing", "客户支持"')}
+                                        placeholder={{id: 'channel_modal.nameEx', defaultMessage: 'E.g.: "Bugs", "Marketing", "客户支持"'}}
                                         maxLength={Constants.MAX_CHANNELNAME_LENGTH}
                                         value={this.props.channelData.displayName}
                                         autoFocus={true}

--- a/components/password_reset_form/password_reset_form.jsx
+++ b/components/password_reset_form/password_reset_form.jsx
@@ -8,7 +8,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {resetPassword} from 'actions/user_actions.jsx';
 import Constants from 'utils/constants.jsx';
-import * as Utils from 'utils/utils.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 class PasswordResetForm extends React.Component {
     constructor(props) {
@@ -89,15 +89,12 @@ class PasswordResetForm extends React.Component {
                             />
                         </p>
                         <div className={formClass}>
-                            <input
+                            <LocalizedInput
                                 type='password'
                                 className='form-control'
                                 name='password'
                                 ref='password'
-                                placeholder={Utils.localizeMessage(
-                                    'password_form.pwd',
-                                    'Password'
-                                )}
+                                placeholder={{id: 'password_form.pwd', defaultMessage: 'Password'}}
                                 spellCheck='false'
                             />
                         </div>

--- a/components/password_reset_send_link.jsx
+++ b/components/password_reset_send_link.jsx
@@ -10,8 +10,8 @@ import {FormattedMessage} from 'react-intl';
 import {isEmail} from 'mattermost-redux/utils/helpers';
 
 import {sendPasswordResetEmail} from 'actions/user_actions.jsx';
-import * as Utils from 'utils/utils.jsx';
 import BackButton from 'components/common/back_button.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 class PasswordResetSendLink extends React.Component {
     constructor(props) {
@@ -111,15 +111,12 @@ class PasswordResetSendLink extends React.Component {
                                 />
                             </p>
                             <div className={formClass}>
-                                <input
+                                <LocalizedInput
                                     type='email'
                                     className='form-control'
                                     name='email'
                                     ref='email'
-                                    placeholder={Utils.localizeMessage(
-                                        'password_send.email',
-                                        'Email'
-                                    )}
+                                    placeholder={{id: 'password_send.email', defaultMessage: 'Email'}}
                                     spellCheck='false'
                                 />
                             </div>

--- a/components/rename_channel_modal/__snapshots__/rename_channel_modal.test.jsx.snap
+++ b/components/rename_channel_modal/__snapshots__/rename_channel_modal.test.jsx.snap
@@ -63,12 +63,17 @@ exports[`components/RenameChannelModal should match snapshot 1`] = `
             values={Object {}}
           />
         </label>
-        <input
+        <LocalizedInput
           className="form-control"
           id="display_name"
           maxLength={22}
           onChange={[Function]}
-          placeholder="Enter display name"
+          placeholder={
+            Object {
+              "defaultMessage": "Enter display name",
+              "id": "rename_channel.displayNameHolder",
+            }
+          }
           type="text"
           value="Fake Channel"
         />
@@ -110,12 +115,17 @@ exports[`components/RenameChannelModal should match snapshot 1`] = `
               fake-channel/channels/
             </span>
           </OverlayTrigger>
-          <input
+          <LocalizedInput
             className="form-control"
             id="channel_name"
             maxLength={22}
             onChange={[Function]}
-            placeholder="lowercase alphanumeric characters"
+            placeholder={
+              Object {
+                "defaultMessage": "lowercase alphanumeric characters",
+                "id": "rename_channel.handleHolder",
+              }
+            }
             readOnly={false}
             type="text"
             value="fake-channel"

--- a/components/rename_channel_modal/rename_channel_modal.jsx
+++ b/components/rename_channel_modal/rename_channel_modal.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {Modal, OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
 
+import LocalizedInput from 'components/localized_input/localized_input';
 import {browserHistory} from 'utils/browser_history';
 import Constants from 'utils/constants.jsx';
 import {cleanUpUrlable, getShortenedURL} from 'utils/url.jsx';
@@ -289,13 +290,13 @@ export class RenameChannelModal extends React.PureComponent {
                                     defaultMessage='Display Name'
                                 />
                             </label>
-                            <input
+                            <LocalizedInput
                                 onChange={this.onDisplayNameChange}
                                 type='text'
                                 ref={this.getTextbox}
                                 id='display_name'
                                 className='form-control'
-                                placeholder={formatMessage(holders.displayNameHolder)}
+                                placeholder={holders.displayNameHolder}
                                 value={this.state.displayName}
                                 maxLength={Constants.MAX_CHANNELNAME_LENGTH}
                             />
@@ -313,12 +314,12 @@ export class RenameChannelModal extends React.PureComponent {
                                 >
                                     <span className='input-group-addon'>{shortUrl}</span>
                                 </OverlayTrigger>
-                                <input
+                                <LocalizedInput
                                     onChange={this.onNameChange}
                                     type='text'
                                     className={handleInputClass}
                                     id='channel_name'
-                                    placeholder={formatMessage(holders.handleHolder)}
+                                    placeholder={holders.handleHolder}
                                     value={this.state.channelName}
                                     maxLength={Constants.MAX_CHANNELNAME_LENGTH}
                                     readOnly={readOnlyHandleInput}

--- a/components/searchable_channel_list.jsx
+++ b/components/searchable_channel_list.jsx
@@ -12,6 +12,9 @@ import LoadingWrapper from 'components/widgets/loading/loading_wrapper.jsx';
 import QuickInput from 'components/quick_input';
 import * as UserAgent from 'utils/user_agent.jsx';
 import {localizeMessage} from 'utils/utils.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
+
+import {t} from 'utils/i18n';
 
 const NEXT_BUTTON_TIMEOUT_MILLISECONDS = 500;
 
@@ -178,7 +181,8 @@ export default class SearchableChannelList extends React.Component {
                         id='searchChannelsTextbox'
                         ref='filter'
                         className='form-control filter-textbox'
-                        placeholder={localizeMessage('filtered_channels_list.search', 'Search channels')}
+                        placeholder={{id: t('filtered_channels_list.search'), defaultMessage: 'Search channels'}}
+                        inputComponent={LocalizedInput}
                         onInput={this.doSearch}
                     />
                 </div>
@@ -193,7 +197,8 @@ export default class SearchableChannelList extends React.Component {
                             id='searchChannelsTextbox'
                             ref='filter'
                             className='form-control filter-textbox'
-                            placeholder={localizeMessage('filtered_channels_list.search', 'Search channels')}
+                            placeholder={{id: t('filtered_channels_list.search'), defaultMessage: 'Search channels'}}
+                            inputComponent={LocalizedInput}
                             onInput={this.doSearch}
                         />
                     </div>

--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -9,7 +9,9 @@ import {FormattedMessage} from 'react-intl';
 
 import QuickInput from 'components/quick_input';
 import UserList from 'components/user_list.jsx';
-import * as Utils from 'utils/utils.jsx';
+import LocalizedInput from 'components/localized_input/localized_input';
+
+import {t} from 'utils/i18n';
 
 const NEXT_BUTTON_TIMEOUT = 500;
 
@@ -216,7 +218,8 @@ export default class SearchableUserList extends React.Component {
                         id='searchUsersInput'
                         ref='filter'
                         className='form-control filter-textbox'
-                        placeholder={Utils.localizeMessage('filtered_user_list.search', 'Search users')}
+                        placeholder={{id: t('filtered_user_list.search'), defaultMessage: 'Search users'}}
+                        inputComponent={LocalizedInput}
                         value={this.props.term}
                         onInput={this.handleInput}
                     />

--- a/components/team_general_tab/team_general_tab.jsx
+++ b/components/team_general_tab/team_general_tab.jsx
@@ -12,6 +12,7 @@ import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min.jsx';
 import SettingPicture from 'components/setting_picture.jsx';
 import BackIcon from 'components/icon/back_icon';
+import LocalizedInput from 'components/localized_input/localized_input';
 
 const ACCEPTED_TEAM_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/bmp'];
 
@@ -717,7 +718,7 @@ export default class GeneralTab extends React.Component {
                     className='form-group'
                 >
                     <div className='col-sm-12'>
-                        <input
+                        <LocalizedInput
                             id='allowedDomains'
                             autoFocus={true}
                             className='form-control'
@@ -725,7 +726,7 @@ export default class GeneralTab extends React.Component {
                             onChange={this.updateAllowedDomains}
                             value={this.state.allowed_domains}
                             onFocus={Utils.moveCursorToEnd}
-                            placeholder={Utils.localizeMessage('general_tab.AllowedDomainsExample', 'corp.mattermost.com, mattermost.org')}
+                            placeholder={{id: 'general_tab.AllowedDomainsExample', defaultMessage: 'corp.mattermost.com, mattermost.org'}}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
…e localizeMessage method in input placeholders

#### Summary
Created the reusable `LocalizedInput` component and removed usages of the method `localizeMessage` to get translated text for input placeholders.

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/MM-13302) | Fixes [GitHub issue #9945](https://github.com/mattermost/mattermost-server/issues/9945)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
