### PR TITLE
MM-14002 Do not open internal markdown links in a new tab if site URL is not set

### DIFF
--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -175,10 +175,8 @@ export default class Renderer extends marked.Renderer {
 
         // special case for team invite links, channel links, and permalinks that are inside the app
         let internalLink = false;
-        if (this.formattingOptions.siteURL) {
-            const pattern = new RegExp('^(' + TextFormatting.escapeRegex(this.formattingOptions.siteURL) + ')?\\/(?:signup_user_complete|admin_console|[^\\/]+\\/(?:pl|channels|messages))\\/');
-            internalLink = pattern.test(outHref);
-        }
+        const pattern = new RegExp('^(' + TextFormatting.escapeRegex(this.formattingOptions.siteURL) + ')?\\/(?:signup_user_complete|admin_console|[^\\/]+\\/(?:pl|channels|messages))\\/');
+        internalLink = pattern.test(outHref);
 
         if (internalLink) {
             output += ' data-link="' + outHref.replace(this.formattingOptions.siteURL, '') + '"';

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -251,6 +251,9 @@ function autolinkChannelMentions(text, tokens, channelNamesMap, team) {
 }
 
 export function escapeRegex(text) {
+    if (text == null) {
+        return '';
+    }
     return text.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 


### PR DESCRIPTION
#### Summary
Thanks to @hmhealey for helping me fix this. This fixes the case where site URL is not set and the announcement bar telling the system admin to add a site URL has a link to the system console.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14002