### PR TITLE
Replacing allow_open_invites with is_public

### DIFF
--- a/actions/team_actions.jsx
+++ b/actions/team_actions.jsx
@@ -19,9 +19,31 @@ export function removeUserFromTeamAndGetStats(teamId, userId) {
     };
 }
 
-export function addUserToTeamFromInvite(token, inviteId) {
+export function addUserToTeamFromInvite(token, inviteId, teamId) {
     return async (dispatch) => {
-        const {data: member, error} = await dispatch(TeamActions.addUserToTeamFromInvite(token, inviteId));
+        const {data: member, error} = await dispatch(TeamActions.addUserToTeamFromInvite(token, inviteId, teamId));
+        if (member) {
+            const {data} = await dispatch(TeamActions.getTeam(member.team_id));
+
+            dispatch({
+                type: TeamTypes.RECEIVED_MY_TEAM_MEMBER,
+                data: {
+                    ...member,
+                    delete_at: 0,
+                    msg_count: 0,
+                    mention_count: 0,
+                },
+            });
+
+            return {data};
+        }
+        return {error};
+    };
+}
+
+export function joinTeamById(teamId) {
+    return async (dispatch) => {
+        const {data: member, error} = await dispatch(TeamActions.joinTeamById(teamId));
         if (member) {
             const {data} = await dispatch(TeamActions.getTeam(member.team_id));
 

--- a/components/admin_console/group_settings/group_details/group_teams_and_channels.jsx
+++ b/components/admin_console/group_settings/group_details/group_teams_and_channels.jsx
@@ -49,7 +49,7 @@ export default class GroupTeamsAndChannels extends React.PureComponent {
         teams.forEach((team) => {
             existingTeams.add(team.team_id);
             teamEntries.push({
-                type: team.team_type === 'O' ? 'public-team' : 'private-team',
+                type: team.is_public ? 'public-team' : 'private-team',
                 hasChildren: channels.some((channel) => channel.team_id === team.team_id),
                 name: team.team_display_name,
                 collapsed: this.state.collapsed[team.team_id],
@@ -70,7 +70,7 @@ export default class GroupTeamsAndChannels extends React.PureComponent {
             if (!existingTeams.has(channel.team_id)) {
                 existingTeams.add(channel.team_id);
                 teamEntries.push({
-                    type: channel.team_type === 'O' ? 'public-team' : 'private-team',
+                    type: channel.team_is_public ? 'public-team' : 'private-team',
                     hasChildren: true,
                     name: channel.team_display_name,
                     collapsed: this.state.collapsed[channel.team_id],

--- a/components/admin_console/group_settings/group_details/group_teams_and_channels.test.jsx
+++ b/components/admin_console/group_settings/group_details/group_teams_and_channels.test.jsx
@@ -12,24 +12,24 @@ describe('components/admin_console/group_settings/group_details/GroupTeamsAndCha
         teams: [
             {
                 team_id: '11111111111111111111111111',
-                team_type: 'O',
+                is_public: true,
                 team_display_name: 'Team 1',
             },
             {
                 team_id: '22222222222222222222222222',
-                team_type: 'P',
+                is_public: false,
                 team_display_name: 'Team 2',
             },
             {
                 team_id: '33333333333333333333333333',
-                team_type: 'P',
+                is_public: false,
                 team_display_name: 'Team 3',
             },
         ],
         channels: [
             {
                 team_id: '11111111111111111111111111',
-                team_type: 'O',
+                team_is_public: true,
                 team_display_name: 'Team 1',
                 channel_id: '44444444444444444444444444',
                 channel_type: 'O',
@@ -37,7 +37,7 @@ describe('components/admin_console/group_settings/group_details/GroupTeamsAndCha
             },
             {
                 team_id: '99999999999999999999999999',
-                team_type: 'O',
+                team_is_public: true,
                 team_display_name: 'Team 9',
                 channel_id: '55555555555555555555555555',
                 channel_type: 'P',
@@ -45,7 +45,7 @@ describe('components/admin_console/group_settings/group_details/GroupTeamsAndCha
             },
             {
                 team_id: '99999999999999999999999999',
-                team_type: 'O',
+                team_is_public: true,
                 team_display_name: 'Team 9',
                 channel_id: '55555555555555555555555555',
                 channel_type: 'P',

--- a/components/channel_layout/channel_controller.jsx
+++ b/components/channel_layout/channel_controller.jsx
@@ -29,11 +29,11 @@ import CenterChannel from 'components/channel_layout/center_channel';
 export default class ChannelController extends React.Component {
     static propTypes = {
         pathName: PropTypes.string.isRequired,
-        teamType: PropTypes.string.isRequired,
+        inviteId: PropTypes.string.isRequired,
     };
 
     shouldComponentUpdate(nextProps) {
-        return this.props.teamType !== nextProps.teamType || this.props.pathName !== nextProps.pathName;
+        return this.props.inviteId !== nextProps.inviteId || this.props.pathName !== nextProps.pathName;
     }
 
     render() {
@@ -47,7 +47,7 @@ export default class ChannelController extends React.Component {
 
                 <div className='container-fluid'>
                     <SidebarRight/>
-                    <SidebarRightMenu teamType={this.props.teamType}/>
+                    <SidebarRightMenu inviteId={this.props.inviteId}/>
                     <Route component={TeamSidebar}/>
                     <Route component={Sidebar}/>
                     <Route component={CenterChannel}/>

--- a/components/create_team/components/team_url/team_url.jsx
+++ b/components/create_team/components/team_url/team_url.jsx
@@ -120,7 +120,6 @@ export default class TeamUrl extends React.PureComponent {
 
         this.setState({isLoading: true});
         var teamSignup = JSON.parse(JSON.stringify(this.props.state));
-        teamSignup.team.type = 'O';
         teamSignup.team.name = name;
 
         const {exists} = await checkIfTeamExists(name);

--- a/components/create_team/components/team_url/team_url.test.jsx
+++ b/components/create_team/components/team_url/team_url.test.jsx
@@ -74,7 +74,7 @@ describe('/components/create_team/components/display_name', () => {
         await wrapper.instance().submitNext({preventDefault: jest.fn()});
         expect(actions.checkIfTeamExists).toHaveBeenCalledTimes(2);
         expect(actions.createTeam).toHaveBeenCalledTimes(1);
-        expect(actions.createTeam).toBeCalledWith({display_name: 'test-team', name: 'test-team', type: 'O'});
+        expect(actions.createTeam).toBeCalledWith({display_name: 'test-team', name: 'test-team'});
         expect(props.history.push).toHaveBeenCalledTimes(1);
         expect(props.history.push).toBeCalledWith('/test-team/channels/town-square');
     });

--- a/components/invite_member_modal/index.js
+++ b/components/invite_member_modal/index.js
@@ -28,7 +28,7 @@ function mapStateToProps(state) {
         enableUserCreation,
         currentUser: getCurrentUser(state),
         defaultChannelName: defaultChannel ? defaultChannel.display_name : '',
-        teamType: team ? team.type : '',
+        inviteId: team ? team.invite_id : '',
         teamId: team ? team.id : '',
     };
 }

--- a/components/invite_member_modal/invite_member_modal.jsx
+++ b/components/invite_member_modal/invite_member_modal.jsx
@@ -53,7 +53,7 @@ class InviteMemberModal extends React.PureComponent {
         enableUserCreation: PropTypes.bool.isRequired,
         currentUser: PropTypes.object.isRequired,
         defaultChannelName: PropTypes.string.isRequired,
-        teamType: PropTypes.string.isRequired,
+        inviteId: PropTypes.string.isRequired,
         teamId: PropTypes.string.isRequired,
         onHide: PropTypes.func.isRequired,
         actions: PropTypes.shape({
@@ -223,7 +223,7 @@ class InviteMemberModal extends React.PureComponent {
         const {currentUser} = this.props;
         const {formatMessage} = this.props.intl;
 
-        if (currentUser != null && this.props.teamType != null) {
+        if (currentUser != null && this.props.inviteId != null) {
             var inviteSections = [];
             var inviteIds = this.state.inviteIds;
             for (var i = 0; i < inviteIds.length; i++) {
@@ -399,7 +399,7 @@ class InviteMemberModal extends React.PureComponent {
                 );
             } else if (this.props.enableUserCreation) {
                 var teamInviteLink = null;
-                if (currentUser && this.props.teamType === 'O') {
+                if (currentUser && this.props.inviteId !== '') {
                     var link = (
                         <button
                             className='color--link style--none'

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -230,7 +230,7 @@ export default class NeedsTeam extends React.Component {
         if (this.state.team === null || this.state.finishedFetchingChannels === false) {
             return <div/>;
         }
-        const teamType = this.state.team ? this.state.team.type : '';
+        const inviteId = this.state.team ? this.state.team.invite_id : '';
 
         return (
             <Switch>
@@ -246,7 +246,7 @@ export default class NeedsTeam extends React.Component {
                     render={(renderProps) => (
                         <ChannelController
                             pathName={renderProps.location.pathname}
-                            teamType={teamType}
+                            inviteId={inviteId}
                         />
                     )}
                 />

--- a/components/select_team/index.js
+++ b/components/select_team/index.js
@@ -13,7 +13,7 @@ import {haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getSortedJoinableTeams, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
-import {addUserToTeamFromInvite} from 'actions/team_actions';
+import {joinTeamById} from 'actions/team_actions';
 
 import SelectTeam from './select_team.jsx';
 
@@ -38,7 +38,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             getTeams,
             loadRolesIfNeeded,
-            addUserToTeamFromInvite,
+            joinTeamById,
         }, dispatch),
     };
 }

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -38,7 +38,7 @@ export default class SelectTeam extends React.Component {
         actions: PropTypes.shape({
             getTeams: PropTypes.func.isRequired,
             loadRolesIfNeeded: PropTypes.func.isRequired,
-            addUserToTeamFromInvite: PropTypes.func.isRequired,
+            joinTeamById: PropTypes.func.isRequired,
         }).isRequired,
     };
 
@@ -67,7 +67,7 @@ export default class SelectTeam extends React.Component {
     handleTeamClick = async (team) => {
         this.setState({loadingTeamId: team.id});
 
-        const {data, error} = await this.props.actions.addUserToTeamFromInvite('', team.invite_id);
+        const {data, error} = await this.props.actions.joinTeamById(team.id);
         if (data) {
             this.props.history.push(`/${team.name}/channels/town-square`);
         } else if (error) {

--- a/components/sidebar/__snapshots__/sidebar.test.jsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.jsx.snap
@@ -19,11 +19,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         "id": "my-user-id",
       }
     }
+    inviteId="invite-id"
     teamDescription="Test team description"
     teamDisplayName="Test team display name"
     teamId="team_id"
     teamName="test-team"
-    teamType="team-type"
   />
   <div
     className="sidebar--left__icons"
@@ -272,11 +272,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         "id": "my-user-id",
       }
     }
+    inviteId="invite-id"
     teamDescription="Test team description"
     teamDisplayName="Test team display name"
     teamId="team_id"
     teamName="test-team"
-    teamType="team-type"
   />
   <div
     className="sidebar--left__icons"
@@ -525,11 +525,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         "id": "my-user-id",
       }
     }
+    inviteId="invite-id"
     teamDescription="Test team description"
     teamDisplayName="Test team display name"
     teamId="team_id"
     teamName="test-team"
-    teamType="team-type"
   />
   <div
     className="sidebar--left__icons"
@@ -778,11 +778,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
         "id": "my-user-id",
       }
     }
+    inviteId="invite-id"
     teamDescription="Test team description"
     teamDisplayName="Test team display name"
     teamId="team_id"
     teamName="test-team"
-    teamType="team-type"
   />
   <div
     className="sidebar--left__icons"
@@ -1039,11 +1039,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         "id": "my-user-id",
       }
     }
+    inviteId="invite-id"
     teamDescription="Test team description"
     teamDisplayName="Test team display name"
     teamId="team_id"
     teamName="test-team"
-    teamType="team-type"
   />
   <div
     className="sidebar--left__icons"
@@ -1292,11 +1292,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         "id": "my-user-id",
       }
     }
+    inviteId="invite-id"
     teamDescription="Test team description"
     teamDisplayName="Test team display name"
     teamId="team_id"
     teamName="test-team"
-    teamType="team-type"
   />
   <div
     className="sidebar--left__icons"
@@ -1549,11 +1549,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         "id": "my-user-id",
       }
     }
+    inviteId="invite-id"
     teamDescription="Test team description"
     teamDisplayName="Test team display name"
     teamId="team_id"
     teamName="test-team"
-    teamType="team-type"
   />
   <div
     className="sidebar--left__icons"
@@ -1802,11 +1802,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         "id": "my-user-id",
       }
     }
+    inviteId="invite-id"
     teamDescription="Test team description"
     teamDisplayName="Test team display name"
     teamId="team_id"
     teamName="test-team"
-    teamType="team-type"
   />
   <div
     className="sidebar--left__icons"
@@ -2055,11 +2055,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         "id": "my-user-id",
       }
     }
+    inviteId="invite-id"
     teamDescription="Test team description"
     teamDisplayName="Test team display name"
     teamId="team_id"
     teamName="test-team"
-    teamType="team-type"
   />
   <div
     className="sidebar--left__icons"
@@ -2308,11 +2308,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
         "id": "my-user-id",
       }
     }
+    inviteId="invite-id"
     teamDescription="Test team description"
     teamDisplayName="Test team display name"
     teamId="team_id"
     teamName="test-team"
-    teamType="team-type"
   />
   <div
     className="sidebar--left__icons"

--- a/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
+++ b/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
@@ -31,7 +31,7 @@ import ToggleModalButtonRedux from 'components/toggle_modal_button_redux';
 export default class SidebarHeaderDropdown extends React.PureComponent {
     static propTypes = {
         teamId: PropTypes.string,
-        teamType: PropTypes.string,
+        inviteId: PropTypes.string,
         teamName: PropTypes.string,
         currentUser: PropTypes.object,
         appDownloadLink: PropTypes.string,
@@ -56,7 +56,7 @@ export default class SidebarHeaderDropdown extends React.PureComponent {
     };
 
     static defaultProps = {
-        teamType: '',
+        inviteId: '',
         pluginMenuItems: [],
     };
 
@@ -271,7 +271,7 @@ export default class SidebarHeaderDropdown extends React.PureComponent {
                 </TeamPermissionGate>
             );
 
-            if (this.props.teamType === Constants.OPEN_TEAM && this.props.enableUserCreation) {
+            if (this.props.inviteId !== '' && this.props.enableUserCreation) {
                 teamLink = (
                     <TeamPermissionGate
                         teamId={this.props.teamId}

--- a/components/sidebar/header/sidebar_header.jsx
+++ b/components/sidebar/header/sidebar_header.jsx
@@ -18,7 +18,7 @@ export default class SidebarHeader extends React.PureComponent {
         teamDisplayName: PropTypes.string.isRequired,
         teamDescription: PropTypes.string.isRequired,
         teamName: PropTypes.string.isRequired,
-        teamType: PropTypes.string.isRequired,
+        inviteId: PropTypes.string.isRequired,
         currentUser: PropTypes.object.isRequired,
         showTutorialTip: PropTypes.bool.isRequired,
     };
@@ -132,7 +132,7 @@ export default class SidebarHeader extends React.PureComponent {
                 <div id='sidebarDropdownMenuContainer'>
                     <SidebarHeaderDropdown
                         teamId={this.props.teamId}
-                        teamType={this.props.teamType}
+                        inviteId={this.props.inviteId}
                         teamDisplayName={this.props.teamDisplayName}
                         teamName={this.props.teamName}
                         currentUser={this.props.currentUser}

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -741,7 +741,7 @@ export default class Sidebar extends React.PureComponent {
                     teamDisplayName={this.props.currentTeam.display_name}
                     teamDescription={this.props.currentTeam.description}
                     teamName={this.props.currentTeam.name}
-                    teamType={this.props.currentTeam.type}
+                    inviteId={this.props.currentTeam.invite_id}
                     currentUser={this.props.currentUser}
                 />
 

--- a/components/sidebar/sidebar.test.jsx
+++ b/components/sidebar/sidebar.test.jsx
@@ -102,7 +102,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             name: 'test-team',
             display_name: 'Test team display name',
             description: 'Test team description',
-            type: 'team-type',
+            invite_id: 'invite-id',
         },
         currentUser: {
             id: 'my-user-id',

--- a/components/sidebar_right_menu/sidebar_right_menu.jsx
+++ b/components/sidebar_right_menu/sidebar_right_menu.jsx
@@ -32,7 +32,7 @@ export default class SidebarRightMenu extends React.PureComponent {
         teamId: PropTypes.string,
         currentUserId: PropTypes.string.isRequired,
         isOpen: PropTypes.bool.isRequired,
-        teamType: PropTypes.string,
+        inviteId: PropTypes.string,
         teamDisplayName: PropTypes.string,
         isMentionSearch: PropTypes.bool,
         showTutorialTip: PropTypes.bool.isRequired,
@@ -183,7 +183,7 @@ export default class SidebarRightMenu extends React.PureComponent {
                 </TeamPermissionGate>
             );
 
-            if (this.props.teamType === Constants.OPEN_TEAM && this.props.enableUserCreation) {
+            if (this.props.inviteId !== '' && this.props.enableUserCreation) {
                 teamLink = (
                     <TeamPermissionGate
                         teamId={this.props.teamId}

--- a/components/team_general_tab/team_general_tab.jsx
+++ b/components/team_general_tab/team_general_tab.jsx
@@ -125,6 +125,7 @@ export default class GeneralTab extends React.Component {
 
         var data = {...this.props.team};
         data.is_public = this.state.is_public;
+        data.allow_open_invite = this.state.is_public;
 
         const {error} = await this.props.actions.patchTeam(data);
 

--- a/components/team_general_tab/team_general_tab.jsx
+++ b/components/team_general_tab/team_general_tab.jsx
@@ -38,7 +38,7 @@ export default class GeneralTab extends React.Component {
         this.handleNameSubmit = this.handleNameSubmit.bind(this);
         this.handleAllowedDomainsSubmit = this.handleAllowedDomainsSubmit.bind(this);
         this.handleInviteIdSubmit = this.handleInviteIdSubmit.bind(this);
-        this.handleOpenInviteSubmit = this.handleOpenInviteSubmit.bind(this);
+        this.handleIsPublicSubmit = this.handleIsPublicSubmit.bind(this);
         this.handleDescriptionSubmit = this.handleDescriptionSubmit.bind(this);
         this.handleTeamIconSubmit = this.handleTeamIconSubmit.bind(this);
         this.handleClose = this.handleClose.bind(this);
@@ -48,7 +48,7 @@ export default class GeneralTab extends React.Component {
         this.updateTeamIcon = this.updateTeamIcon.bind(this);
         this.updateAllowedDomains = this.updateAllowedDomains.bind(this);
         this.updateInviteId = this.updateInviteId.bind(this);
-        this.handleOpenInviteRadio = this.handleOpenInviteRadio.bind(this);
+        this.handleIsPublicRadio = this.handleIsPublicRadio.bind(this);
         this.handleGenerateInviteId = this.handleGenerateInviteId.bind(this);
 
         this.state = this.setupInitialState(props);
@@ -68,7 +68,7 @@ export default class GeneralTab extends React.Component {
         return {
             name: team.display_name,
             invite_id: team.invite_id,
-            allow_open_invite: team.allow_open_invite,
+            is_public: team.is_public,
             description: team.description,
             allowed_domains: team.allowed_domains,
             serverError: '',
@@ -85,7 +85,7 @@ export default class GeneralTab extends React.Component {
             description: nextProps.team.description,
             allowed_domains: nextProps.team.allowed_domains,
             invite_id: nextProps.team.invite_id,
-            allow_open_invite: nextProps.team.allow_open_invite,
+            is_public: nextProps.team.is_public,
         });
     }
 
@@ -100,8 +100,8 @@ export default class GeneralTab extends React.Component {
         this.setState({invite_id: newId});
     }
 
-    handleOpenInviteRadio(openInvite) {
-        this.setState({allow_open_invite: openInvite});
+    handleIsPublicRadio(isPublic) {
+        this.setState({is_public: isPublic});
     }
 
     handleAllowedDomainsSubmit = async () => {
@@ -120,11 +120,11 @@ export default class GeneralTab extends React.Component {
         }
     }
 
-    handleOpenInviteSubmit = async () => {
+    handleIsPublicSubmit = async () => {
         var state = {serverError: '', clientError: ''};
 
         var data = {...this.props.team};
-        data.allow_open_invite = this.state.allow_open_invite;
+        data.is_public = this.state.is_public;
 
         const {error} = await this.props.actions.patchTeam(data);
 
@@ -183,24 +183,10 @@ export default class GeneralTab extends React.Component {
 
     handleInviteIdSubmit = async () => {
         var state = {serverError: '', clientError: ''};
-        let valid = true;
-
-        const inviteId = this.state.invite_id.trim();
-        if (inviteId) {
-            state.clientError = '';
-        } else {
-            state.clientError = Utils.localizeMessage('general_tab.required', 'This field is required');
-            valid = false;
-        }
-
         this.setState(state);
 
-        if (!valid) {
-            return;
-        }
-
         var data = {...this.props.team};
-        data.invite_id = this.state.invite_id;
+        data.invite_id = this.state.invite_id.trim();
 
         const {error} = await this.props.actions.patchTeam(data);
 
@@ -379,8 +365,8 @@ export default class GeneralTab extends React.Component {
                                 id='teamOpenInvite'
                                 name='userOpenInviteOptions'
                                 type='radio'
-                                defaultChecked={this.state.allow_open_invite}
-                                onChange={this.handleOpenInviteRadio.bind(this, true)}
+                                defaultChecked={this.state.is_public}
+                                onChange={this.handleIsPublicRadio.bind(this, true)}
                             />
                             <FormattedMessage
                                 id='general_tab.yes'
@@ -395,8 +381,8 @@ export default class GeneralTab extends React.Component {
                                 id='teamOpenInviteNo'
                                 name='userOpenInviteOptions'
                                 type='radio'
-                                defaultChecked={!this.state.allow_open_invite}
-                                onChange={this.handleOpenInviteRadio.bind(this, false)}
+                                defaultChecked={!this.state.is_public}
+                                onChange={this.handleIsPublicRadio.bind(this, false)}
                             />
                             <FormattedMessage
                                 id='general_tab.no'
@@ -409,7 +395,7 @@ export default class GeneralTab extends React.Component {
                         <br/>
                         <FormattedMessage
                             id='general_tab.openInviteDesc'
-                            defaultMessage='When allowed, a link to this team will be included on the landing page allowing anyone with an account to join this team.'
+                            defaultMessage='When public, a link to this team will be included on the landing page allowing anyone with an account to join this team.'
                         />
                     </div>
                 </div>,
@@ -419,14 +405,14 @@ export default class GeneralTab extends React.Component {
                 <SettingItemMax
                     title={Utils.localizeMessage('general_tab.openInviteTitle', 'Allow any user with an account on this server to join this team')}
                     inputs={inputs}
-                    submit={this.handleOpenInviteSubmit}
+                    submit={this.handleIsPublicSubmit}
                     serverError={serverError}
                     updateSection={this.handleUpdateSection}
                 />
             );
         } else {
             let describe = '';
-            if (this.state.allow_open_invite === true) {
+            if (this.state.is_public === true) {
                 describe = Utils.localizeMessage('general_tab.yes', 'Yes');
             } else {
                 describe = Utils.localizeMessage('general_tab.no', 'No');

--- a/components/team_general_tab/team_general_tab.test.jsx
+++ b/components/team_general_tab/team_general_tab.test.jsx
@@ -116,12 +116,12 @@ describe('components/TeamSettings', () => {
         expect(actions.patchTeam).toHaveBeenCalledWith(props.team);
     });
 
-    test('should call actions.patchTeam on handleOpenInviteSubmit', () => {
+    test('should call actions.patchTeam on handleIsPublicSubmit', () => {
         const actions = {...baseActions};
         const props = {...defaultProps, actions};
         const wrapper = shallow(<GeneralTab {...props}/>);
 
-        wrapper.instance().handleOpenInviteSubmit({preventDefault: jest.fn()});
+        wrapper.instance().handleIsPublicSubmit({preventDefault: jest.fn()});
 
         expect(actions.patchTeam).toHaveBeenCalledTimes(1);
         expect(actions.patchTeam).toHaveBeenCalledWith(props.team);

--- a/components/tutorial/tutorial_intro_screens/index.jsx
+++ b/components/tutorial/tutorial_intro_screens/index.jsx
@@ -16,7 +16,7 @@ function mapStateToProps(state) {
     const team = getCurrentTeam(state) || {};
     return {
         currentUserId,
-        teamType: team.type,
+        inviteId: team.invite_id,
         step: getInt(state, Preferences.TUTORIAL_STEP, currentUserId, 0),
     };
 }

--- a/components/tutorial/tutorial_intro_screens/tutorial_intro_screen.test.jsx
+++ b/components/tutorial/tutorial_intro_screens/tutorial_intro_screen.test.jsx
@@ -16,7 +16,7 @@ describe('components/tutorial/tutorial_intro_screens/TutorialIntroScreens', () =
 
     const requiredProps = {
         currentUserId,
-        teamType: 'teamType',
+        inviteId: 'inviteId',
         step: 1,
         townSquareDisplayName: 'townSquareDisplayName',
         appDownloadLink: 'https://host/static/image.png',

--- a/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
@@ -18,7 +18,7 @@ const NUM_SCREENS = 3;
 export default class TutorialIntroScreens extends React.Component {
     static propTypes = {
         currentUserId: PropTypes.string.isRequired,
-        teamType: PropTypes.string,
+        inviteId: PropTypes.string,
         step: PropTypes.number,
         townSquareDisplayName: PropTypes.string.isRequired,
         appDownloadLink: PropTypes.string,
@@ -213,10 +213,10 @@ export default class TutorialIntroScreens extends React.Component {
     createScreenThree() {
         let inviteModalLink;
         let inviteText;
-        const {teamType} = this.props;
+        const {inviteId} = this.props;
 
         if (!this.props.isLicensed || !this.props.restrictTeamInvite) {
-            if (teamType === Constants.INVITE_TEAM) {
+            if (inviteId === '') {
                 inviteModalLink = (
                     <ModalToggleButtonRedux
                         id='tutorialIntroInvite'

--- a/plugins/test/main_menu_action.test.jsx
+++ b/plugins/test/main_menu_action.test.jsx
@@ -13,7 +13,7 @@ describe('plugins/MainMenuActions', () => {
 
         const requiredProps = {
             teamId: 'someteamid',
-            teamType: '',
+            inviteId: '',
             teamDisplayName: 'some name',
             teamName: 'somename',
             currentUser: {id: 'someuserid', roles: 'system_user'},
@@ -51,7 +51,7 @@ describe('plugins/MainMenuActions', () => {
         const requiredProps = {
             teamId: 'someteamid',
             isOpen: true,
-            teamType: '',
+            inviteId: '',
             teamDisplayName: 'some name',
             showTutorialTip: false,
             enableUserCreation: true,

--- a/tests/helpers/client-test-helper.jsx
+++ b/tests/helpers/client-test-helper.jsx
@@ -84,7 +84,7 @@ class TestHelperClass {
         var team = {};
         team.name = this.generateId();
         team.display_name = `Unit Test ${team.name}`;
-        team.type = 'O';
+        team.is_public = true;
         team.email = this.fakeEmail();
         team.allowed_domains = '';
         return team;


### PR DESCRIPTION
#### Summary
Replacing `allow_open_invites` and `type` from `Team` struct with `is_public` and define or not `invite_id`.

#### Ticket Link
[MM-13931](https://mattermost.atlassian.net/browse/MM-13931)

#### Checklist
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has server changes (please link)
- [x] Has redux changes (please link)