### PR TITLE
[MM-14125] Fix endless spinner on image placeholder for invalid image URL

### DIFF
--- a/components/post_view/message_attachments/message_attachment/message_attachment.test.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.test.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import {mount, shallow} from 'enzyme';
 
+import SizeAwareImage from 'components/size_aware_image';
 import MessageAttachment from 'components/post_view/message_attachments/message_attachment/message_attachment.jsx';
 import {postListScrollChange} from 'actions/global_actions';
 
@@ -134,7 +135,7 @@ describe('components/post_view/MessageAttachment', () => {
         const wrapper = mount(<MessageAttachment {...props}/>);
 
         expect(wrapper.find('.attachment__author-icon').prop('src')).toMatch(`/api/v4/image?url=${encodeURIComponent(props.attachment.author_icon)}`);
-        expect(wrapper.find('.attachment__image-container img').prop('src')).toMatch(`/api/v4/image?url=${encodeURIComponent(props.attachment.image_url)}`);
-        expect(wrapper.find('.attachment__thumb-container img').prop('src')).toMatch(`/api/v4/image?url=${encodeURIComponent(props.attachment.thumb_url)}`);
+        expect(wrapper.find(SizeAwareImage).first().prop('src')).toMatch(`/api/v4/image?url=${encodeURIComponent(props.attachment.image_url)}`);
+        expect(wrapper.find(SizeAwareImage).last().prop('src')).toMatch(`/api/v4/image?url=${encodeURIComponent(props.attachment.thumb_url)}`);
     });
 });

--- a/components/post_view/post_image/post_image.jsx
+++ b/components/post_view/post_image/post_image.jsx
@@ -8,7 +8,7 @@ import {postListScrollChange} from 'actions/global_actions';
 import SizeAwareImage from 'components/size_aware_image';
 import * as PostUtils from 'utils/post_utils.jsx';
 
-export default class PostImageEmbed extends React.PureComponent {
+export default class PostImage extends React.PureComponent {
     static propTypes = {
 
         /**
@@ -42,14 +42,6 @@ export default class PostImageEmbed extends React.PureComponent {
         dimensions: PropTypes.object,
     }
 
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            errored: false,
-        };
-    }
-
     componentDidMount() {
         this.mounted = true;
     }
@@ -62,9 +54,7 @@ export default class PostImageEmbed extends React.PureComponent {
         if (!this.mounted) {
             return;
         }
-        this.setState({
-            errored: false,
-        });
+
         if (!this.props.dimensions) {
             postListScrollChange();
         }
@@ -77,9 +67,6 @@ export default class PostImageEmbed extends React.PureComponent {
         if (!this.mounted) {
             return;
         }
-        this.setState({
-            errored: true,
-        });
 
         if (this.props.onLinkLoadError) {
             this.props.onLinkLoadError();
@@ -92,10 +79,6 @@ export default class PostImageEmbed extends React.PureComponent {
     };
 
     render() {
-        if (this.state.errored) {
-            return null;
-        }
-
         return (
             <div
                 className='post__embed-container'

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -101,6 +101,7 @@ export default class SizeAwareImage extends React.PureComponent {
 
         this.setState({
             loaded: true,
+            error: false,
         });
     };
 
@@ -109,6 +110,7 @@ export default class SizeAwareImage extends React.PureComponent {
         if (this.props.onImageLoadFail) {
             this.props.onImageLoadFail();
         }
+        this.setState({error: true});
     };
 
     render() {
@@ -126,6 +128,8 @@ export default class SizeAwareImage extends React.PureComponent {
             // Generate a blank image as a placeholder because that will scale down to fit the available space
             // while maintaining the correct aspect ratio
             src = createPlaceholderImage(dimensions.width, dimensions.height);
+        } else if (this.state.error) {
+            return null;
         } else {
             src = this.props.src;
         }


### PR DESCRIPTION
#### Summary
For some reason, the usual flow is that the valid/invalid image URL fires an image.onerror at SizeAwareImage (children) before the componentDidMount of PostImage (parent) is called (to set this.mounted to true).  And so for invalid image URL, the state.errored at SizeAwareImage is never set and causes the UI to stuck with image placeholder with loading indicator. For valid image URL, there’s no issue since after the image.onerror, it gets resolved after the next image.onload.

The issue fixes by moving the error state from parent to children where the actual image.onerror is happening.  This also fixes the issue of trying to mount children after the parent component is unmounted.

Tested both on regular post and message attachment with post metadata enabled and disabled. 

#### Ticket Link
Jira ticket: [MM-14125](https://mattermost.atlassian.net/browse/MM-14125)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
