### PR TITLE
[MM-14142] Saved recent emojis per user on local storage so it can be retrieved on user login

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -23,6 +23,7 @@ import {ChannelTypes} from 'mattermost-redux/action_types';
 import {browserHistory} from 'utils/browser_history';
 import {handleNewPost} from 'actions/post_actions.jsx';
 import {stopPeriodicStatusUpdates} from 'actions/status_actions.jsx';
+import {setPreviousRecentEmojis} from 'actions/local_storage';
 import {loadProfilesForSidebar} from 'actions/user_actions.jsx';
 import {closeRightHandSide, closeMenu as closeRhsMenu, updateRhsState} from 'actions/views/rhs';
 import {clearUserCookie} from 'actions/views/root';
@@ -238,6 +239,8 @@ export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = tr
     if (userAction) {
         LocalStorageStore.setWasLoggedIn(false);
     }
+
+    dispatch(setPreviousRecentEmojis());
 
     dispatch(logout()).then(() => {
         if (shouldSignalLogout) {

--- a/actions/local_storage.jsx
+++ b/actions/local_storage.jsx
@@ -5,6 +5,8 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import LocalStorageStore from 'stores/local_storage_store';
 
+import Constants from 'utils/constants.jsx';
+
 // setPreviousTeamId is a pseudo-action that writes not to the Redux store, but back to local
 // storage.
 //
@@ -14,6 +16,19 @@ export function setPreviousTeamId(teamId) {
         const userId = getCurrentUserId(getState());
 
         LocalStorageStore.setPreviousTeamId(userId, teamId);
+
+        return {data: true};
+    };
+}
+
+export function setPreviousRecentEmojis() {
+    return (dispatch, getState) => {
+        const currentUserId = getCurrentUserId(getState());
+
+        const recentEmojis = getState().storage.storage[Constants.RECENT_EMOJI_KEY];
+        if (recentEmojis && recentEmojis.value) {
+            LocalStorageStore.setPreviousRecentEmojis(currentUserId, recentEmojis.value);
+        }
 
         return {data: true};
     };

--- a/components/logged_in/logged_in.jsx
+++ b/components/logged_in/logged_in.jsx
@@ -8,11 +8,15 @@ import {Redirect} from 'react-router';
 import {viewChannel} from 'mattermost-redux/actions/channels';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
+import {setGlobalItem} from 'actions/storage';
 import * as WebSocketActions from 'actions/websocket_actions.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 import {getBrowserTimezone} from 'utils/timezone.jsx';
 import store from 'stores/redux_store.jsx';
+import LocalStorageStore from 'stores/local_storage_store';
+
+import Constants from 'utils/constants.jsx';
 
 const dispatch = store.dispatch;
 const getState = store.getState;
@@ -81,6 +85,13 @@ export default class LoggedIn extends React.PureComponent {
         if (!this.props.currentUser) {
             $('#root').attr('class', '');
             GlobalActions.emitUserLoggedOutEvent('/login?redirect_to=' + encodeURIComponent(this.props.location.pathname), true, false);
+        }
+
+        if (this.props.currentUser) {
+            const recentEmojis = LocalStorageStore.getPreviousRecentEmojis(this.props.currentUser.id);
+            if (recentEmojis) {
+                dispatch(setGlobalItem(Constants.RECENT_EMOJI_KEY, recentEmojis));
+            }
         }
 
         $('body').on('mouseenter mouseleave', '.post', function mouseOver(ev) {

--- a/stores/local_storage_store.jsx
+++ b/stores/local_storage_store.jsx
@@ -5,6 +5,7 @@ import {Constants} from 'utils/constants.jsx';
 const getPreviousTeamIdKey = (userId) => ['user_prev_team', userId].join(':');
 const getPreviousChannelNameKey = (userId, teamId) => ['user_team_prev_channel', userId, teamId].join(':');
 const getPenultimateChannelNameKey = (userId, teamId) => ['user_team_penultimate_channel', userId, teamId].join(':');
+const getPreviousRecentEmojisKey = (userId) => ['recent_emojis', userId].join(':');
 
 // LocalStorageStore exposes an interface for accessing entries in the localStorage.
 //
@@ -34,6 +35,14 @@ class LocalStorageStoreClass {
 
     setPreviousTeamId(userId, teamId) {
         localStorage.setItem(getPreviousTeamIdKey(userId), teamId);
+    }
+
+    getPreviousRecentEmojis(userId) {
+        return localStorage.getItem(getPreviousRecentEmojisKey(userId));
+    }
+
+    setPreviousRecentEmojis(userId, recentEmojis) {
+        localStorage.setItem(getPreviousRecentEmojisKey(userId), recentEmojis);
     }
 
     setWasLoggedIn(wasLoggedIn) {


### PR DESCRIPTION
#### Summary
Saved recent emojis per user to local storage on logout so it can be retrieved on user login.

#### Ticket Link
Jira ticket: [MM-14142](https://mattermost.atlassian.net/browse/MM-14142)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
