### PR TITLE
[MM 14083] Support emoji like `:)` followed by additional non-word characters

### DIFF
--- a/utils/emoticons.jsx
+++ b/utils/emoticons.jsx
@@ -2,26 +2,26 @@
 // See LICENSE.txt for license information.
 
 export const emoticonPatterns = {
-    slightly_smiling_face: /(^|\s)(:-?\))(?=$|\s)/g, // :)
-    wink: /(^|\s)(;-?\))(?=$|\s)/g, // ;)
-    open_mouth: /(^|\s)(:o)(?=$|\s)/gi, // :o
-    scream: /(^|\s)(:-o)(?=$|\s)/gi, // :-o
-    smirk: /(^|\s)(:-?])(?=$|\s)/g, // :]
-    smile: /(^|\s)(:-?d)(?=$|\s)/gi, // :D
-    stuck_out_tongue_closed_eyes: /(^|\s)(x-d)(?=$|\s)/gi, // x-d
-    stuck_out_tongue: /(^|\s)(:-?p)(?=$|\s)/gi, // :p
-    rage: /(^|\s)(:-?[[@])(?=$|\s)/g, // :@
-    slightly_frowning_face: /(^|\s)(:-?\()(?=$|\s)/g, // :(
-    cry: /(^|\s)(:['’]-?\(|:&#x27;\(|:&#39;\()(?=$|\s)/g, // :`(
-    confused: /(^|\s)(:-?\/)(?=$|\s)/g, // :/
-    confounded: /(^|\s)(:-?s)(?=$|\s)/gi, // :s
-    neutral_face: /(^|\s)(:-?\|)(?=$|\s)/g, // :|
-    flushed: /(^|\s)(:-?\$)(?=$|\s)/g, // :$
-    mask: /(^|\s)(:-x)(?=$|\s)/gi, // :-x
-    heart: /(^|\s)(<3|&lt;3)(?=$|\s)/g, // <3
-    broken_heart: /(^|\s)(<\/3|&lt;&#x2F;3)(?=$|\s)/g, // </3
-    thumbsup: /(^|\s)(:\+1:)(?=$|\s)/g, // :+1:
-    thumbsdown: /(^|\s)(:-1:)(?=$|\s)/g, // :-1:
+    slightly_smiling_face: /(^|\B)(:-?\))(?=$|\B)/g, // :)
+    wink: /(^|\B)(;-?\))(?=$|\B)/g, // ;)
+    open_mouth: /(^|\B)(:o)(?=$|\b)/gi, // :o
+    scream: /(^|\B)(:-o)(?=$|\b)/gi, // :-o
+    smirk: /(^|\B)(:-?])(?=$|\B)/g, // :]
+    smile: /(^|\B)(:-?d)(?=$|\b)/gi, // :D
+    stuck_out_tongue_closed_eyes: /(^|\B)(x-d)(?=$|\b)/gi, // x-d
+    stuck_out_tongue: /(^|\B)(:-?p)(?=$|\b)/gi, // :p
+    rage: /(^|\B)(:-?[[@])(?=$|\B)/g, // :@
+    slightly_frowning_face: /(^|\B)(:-?\()(?=$|\B)/g, // :(
+    cry: /(^|\B)(:['’]-?\(|:&#x27;\(|:&#39;\()(?=$|\B)/g, // :`(
+    confused: /(^|\B)(:-?\/)(?=$|\B)/g, // :/
+    confounded: /(^|\B)(:-?s)(?=$|\b)/gi, // :s
+    neutral_face: /(^|\B)(:-?\|)(?=$|\B)/g, // :|
+    flushed: /(^|\B)(:-?\$)(?=$|\B)/g, // :$
+    mask: /(^|\B)(:-x)(?=$|\b)/gi, // :-x
+    heart: /(^|\B)(<3|&lt;3)(?=$|\b)/g, // <3
+    broken_heart: /(^|\B)(<\/3|&lt;&#x2F;3)(?=$|\b)/g, // </3
+    thumbsup: /(^|\B)(:\+1:)(?=$|\B)/g, // :+1:
+    thumbsdown: /(^|\B)(:-1:)(?=$|\B)/g, // :-1:
 };
 
 export const EMOJI_PATTERN = /(:([a-zA-Z0-9_-]+):)/g;
@@ -51,6 +51,7 @@ export function handleEmoticons(text, tokens) {
         // this might look a bit funny, but since the name isn't contained in the actual match
         // like with the named emoticons, we need to add it in manually
         output = output.replace(pattern, (fullMatch, prefix, matchText) => replaceEmoticonWithToken(fullMatch, prefix, matchText, name));
+        console.log(output);
     }
 
     return output;

--- a/utils/emoticons.jsx
+++ b/utils/emoticons.jsx
@@ -2,26 +2,26 @@
 // See LICENSE.txt for license information.
 
 export const emoticonPatterns = {
-    slightly_smiling_face: /(^|\B)(:-?\))(?=$|\B)/g, // :)
-    wink: /(^|\B)(;-?\))(?=$|\B)/g, // ;)
-    open_mouth: /(^|\B)(:o)(?=$|\b)/gi, // :o
-    scream: /(^|\B)(:-o)(?=$|\b)/gi, // :-o
-    smirk: /(^|\B)(:-?])(?=$|\B)/g, // :]
-    smile: /(^|\B)(:-?d)(?=$|\b)/gi, // :D
-    stuck_out_tongue_closed_eyes: /(^|\B)(x-d)(?=$|\b)/gi, // x-d
-    stuck_out_tongue: /(^|\B)(:-?p)(?=$|\b)/gi, // :p
-    rage: /(^|\B)(:-?[[@])(?=$|\B)/g, // :@
-    slightly_frowning_face: /(^|\B)(:-?\()(?=$|\B)/g, // :(
-    cry: /(^|\B)(:['’]-?\(|:&#x27;\(|:&#39;\()(?=$|\B)/g, // :`(
-    confused: /(^|\B)(:-?\/)(?=$|\B)/g, // :/
-    confounded: /(^|\B)(:-?s)(?=$|\b)/gi, // :s
-    neutral_face: /(^|\B)(:-?\|)(?=$|\B)/g, // :|
-    flushed: /(^|\B)(:-?\$)(?=$|\B)/g, // :$
-    mask: /(^|\B)(:-x)(?=$|\b)/gi, // :-x
-    heart: /(^|\B)(<3|&lt;3)(?=$|\b)/g, // <3
-    broken_heart: /(^|\B)(<\/3|&lt;&#x2F;3)(?=$|\b)/g, // </3
-    thumbsup: /(^|\B)(:\+1:)(?=$|\B)/g, // :+1:
-    thumbsdown: /(^|\B)(:-1:)(?=$|\B)/g, // :-1:
+    slightly_smiling_face: /(^|\B)(:-?\))($|\B)/g, // :)
+    wink: /(^|\B)(;-?\))($|\B)/g, // ;)
+    open_mouth: /(^|\B)(:o)($|\b)/gi, // :o
+    scream: /(^|\B)(:-o)($|\b)/gi, // :-o
+    smirk: /(^|\B)(:-?])($|\B)/g, // :]
+    smile: /(^|\B)(:-?d)($|\b)/gi, // :D
+    stuck_out_tongue_closed_eyes: /(^|\b)(x-d)($|\b)/gi, // x-d
+    stuck_out_tongue: /(^|\B)(:-?p)($|\b)/gi, // :p
+    rage: /(^|\B)(:-?[[@])($|\B)/g, // :@
+    slightly_frowning_face: /(^|\B)(:-?\()($|\B)/g, // :(
+    cry: /(^|\B)(:[`'’]-?\(|:&#x27;\(|:&#39;\()($|\B)/g, // :`(
+    confused: /(^|\B)(:-?\/)($|\B)/g, // :/
+    confounded: /(^|\B)(:-?s)($|\b)/gi, // :s
+    neutral_face: /(^|\B)(:-?\|)($|\B)/g, // :|
+    flushed: /(^|\B)(:-?\$)($|\B)/g, // :$
+    mask: /(^|\B)(:-x)($|\b)/gi, // :-x
+    heart: /(^|\B)(<3|&lt;3)($|\b)/g, // <3
+    broken_heart: /(^|\B)(<\/3|&lt;\/3)($|\b)/g, // </3
+    thumbsup: /(^|\B)(:\+1:)($|\B)/g, // :+1:
+    thumbsdown: /(^|\B)(:-1:)($|\B)/g, // :-1:
 };
 
 export const EMOJI_PATTERN = /(:([a-zA-Z0-9_-]+):)/g;

--- a/utils/emoticons.jsx
+++ b/utils/emoticons.jsx
@@ -51,7 +51,6 @@ export function handleEmoticons(text, tokens) {
         // this might look a bit funny, but since the name isn't contained in the actual match
         // like with the named emoticons, we need to add it in manually
         output = output.replace(pattern, (fullMatch, prefix, matchText) => replaceEmoticonWithToken(fullMatch, prefix, matchText, name));
-        console.log(output);
     }
 
     return output;

--- a/utils/emoticons.test.jsx
+++ b/utils/emoticons.test.jsx
@@ -29,5 +29,35 @@ describe('Emoticons', () => {
             expect(Emoticons.handleEmoticons(':goat : : dash:', new Map())).
                 toEqual(':goat : : dash:');
         });
+
+        test('should allow comma immediately following emoticon 1', () => {
+            expect(Emoticons.handleEmoticons(':),', new Map())).
+                toEqual('$MM_EMOTICON0$,');
+        });
+
+        test('should allow comma immediately following emoticon 2', () => {
+            expect(Emoticons.handleEmoticons(':P,', new Map())).
+                toEqual('$MM_EMOTICON0$,');
+        });
+
+        test('should allow punctuation immediately following emoticon 1', () => {
+            expect(Emoticons.handleEmoticons(':)!', new Map())).
+                toEqual('$MM_EMOTICON0$!');
+        });
+
+        test('should allow punctuation immediately following emoticon 2', () => {
+            expect(Emoticons.handleEmoticons(':P!', new Map())).
+                toEqual('$MM_EMOTICON0$!');
+        });
+
+        test('should allow punctuation immediately before and following emoticon 1', () => {
+            expect(Emoticons.handleEmoticons('":)"', new Map())).
+                toEqual('"$MM_EMOTICON0$"');
+        });
+
+        test('should allow punctuation immediately before and following emoticon 2', () => {
+            expect(Emoticons.handleEmoticons('":P"', new Map())).
+                toEqual('"$MM_EMOTICON0$"');
+        });
     });
 });

--- a/utils/emoticons.test.jsx
+++ b/utils/emoticons.test.jsx
@@ -5,6 +5,41 @@ import * as Emoticons from 'utils/emoticons.jsx';
 
 describe('Emoticons', () => {
     describe('handleEmoticons', () => {
+        // test emoticon patterns
+        const emoticonPatterns = {
+            slightly_smiling_face: [':)', ':-)'],
+            wink: [';)', ';-)'],
+            open_mouth: [':o'],
+            scream: [':-o'],
+            smirk: [':]', ':-]'],
+            smile: [':D', ':-D'],
+            stuck_out_tongue_closed_eyes: ['x-d'],
+            stuck_out_tongue: [':p', ':-p'],
+            rage: [':@', ':-@'],
+            slightly_frowning_face: [':(', ':-('],
+            cry: [':`(', ':\'(', ':’('],
+            confused: [':/', ':-/'],
+            confounded: [':s', ':-s'],
+            neutral_face: [':|', ':-|'],
+            flushed: [':$', ':-$'],
+            mask: [':-x'],
+            heart: ['<3', '&lt;3'],
+            broken_heart: ['</3', '&lt;/3'],
+            thumbsup: [':+1:'],
+            thumbsdown: [':-1:'],
+        };
+        for (const key in emoticonPatterns) {
+            if (emoticonPatterns.hasOwnProperty(key)) {
+                const emoticonVariations = emoticonPatterns[key];
+                emoticonVariations.forEach((emoticon) => {
+                    test(`text sequence '${emoticon}' should be recognized as an emoticon`, () => {
+                        expect(Emoticons.handleEmoticons(emoticon, new Map())).toEqual('$MM_EMOTICON0$');
+                    });
+                });
+            }
+        }
+
+        // test various uses of emoticons
         test('should replace emoticons with tokens', () => {
             expect(Emoticons.handleEmoticons(':goat: :dash:', new Map())).
                 toEqual('$MM_EMOTICON0$ $MM_EMOTICON1$');
@@ -30,32 +65,32 @@ describe('Emoticons', () => {
                 toEqual(':goat : : dash:');
         });
 
-        test('should allow comma immediately following emoticon 1', () => {
+        test('should allow comma immediately following emoticon :)', () => {
             expect(Emoticons.handleEmoticons(':),', new Map())).
                 toEqual('$MM_EMOTICON0$,');
         });
 
-        test('should allow comma immediately following emoticon 2', () => {
+        test('should allow comma immediately following emoticon :P', () => {
             expect(Emoticons.handleEmoticons(':P,', new Map())).
                 toEqual('$MM_EMOTICON0$,');
         });
 
-        test('should allow punctuation immediately following emoticon 1', () => {
+        test('should allow punctuation immediately following emoticon :)', () => {
             expect(Emoticons.handleEmoticons(':)!', new Map())).
                 toEqual('$MM_EMOTICON0$!');
         });
 
-        test('should allow punctuation immediately following emoticon 2', () => {
+        test('should allow punctuation immediately following emoticon :P', () => {
             expect(Emoticons.handleEmoticons(':P!', new Map())).
                 toEqual('$MM_EMOTICON0$!');
         });
 
-        test('should allow punctuation immediately before and following emoticon 1', () => {
+        test('should allow punctuation immediately before and following emoticon :)', () => {
             expect(Emoticons.handleEmoticons('":)"', new Map())).
                 toEqual('"$MM_EMOTICON0$"');
         });
 
-        test('should allow punctuation immediately before and following emoticon 2', () => {
+        test('should allow punctuation immediately before and following emoticon :P', () => {
             expect(Emoticons.handleEmoticons('":P"', new Map())).
                 toEqual('"$MM_EMOTICON0$"');
         });

--- a/utils/emoticons.test.jsx
+++ b/utils/emoticons.test.jsx
@@ -28,16 +28,11 @@ describe('Emoticons', () => {
             thumbsup: [':+1:'],
             thumbsdown: [':-1:'],
         };
-        for (const key in emoticonPatterns) {
-            if (emoticonPatterns.hasOwnProperty(key)) {
-                const emoticonVariations = emoticonPatterns[key];
-                emoticonVariations.forEach((emoticon) => {
-                    test(`text sequence '${emoticon}' should be recognized as an emoticon`, () => {
-                        expect(Emoticons.handleEmoticons(emoticon, new Map())).toEqual('$MM_EMOTICON0$');
-                    });
-                });
-            }
-        }
+        Array.prototype.concat(...Object.values(emoticonPatterns)).forEach((emoticon) => {
+            test(`text sequence '${emoticon}' should be recognized as an emoticon`, () => {
+                expect(Emoticons.handleEmoticons(emoticon, new Map())).toEqual('$MM_EMOTICON0$');
+            });
+        });
 
         // test various uses of emoticons
         test('should replace emoticons with tokens', () => {


### PR DESCRIPTION
#### Summary
Emoji characters like `:)` and `:+1:` currently need to be followed by a space in order to render, meaning that they can't be used immediately before punctuation like commas etc. This PR makes recognizing these emoji more flexible to support a wider range of non-word characters following an emoji.

#### Ticket Link
[MM-14083](https://mattermost.atlassian.net/projects/MM/issues/MM-14083)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, posting, etc.)
