### PR TITLE
[MM 14024] Stop leading spaces from preventing jumbo emoji

### DIFF
--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -77,7 +77,7 @@ export function formatText(text, inputOptions) {
     }
 
     if (htmlEmojiPattern.test(output.trim())) {
-        output = '<span class="all-emoji">' + output + '</span>';
+        output = '<span class="all-emoji">' + output.trim() + '</span>';
     }
 
     return output;

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -19,7 +19,7 @@ const punctuation = XRegExp.cache('[^\\pL\\d]');
 
 const AT_MENTION_PATTERN = /\B@([a-z0-9.\-_]*)/gi;
 const UNICODE_EMOJI_REGEX = emojiRegex();
-const htmlEmojiPattern = /^<p> *(?:<img class="emoticon"[^>]*>|<span data-emoticon[^>]*>[^<]*<\/span>\s*|<span class="emoticon emoticon--unicode">[^<]*<\/span>\s*)+<\/p>$/;
+const htmlEmojiPattern = /^<p>\s*(?:<img class="emoticon"[^>]*>|<span data-emoticon[^>]*>[^<]*<\/span>\s*|<span class="emoticon emoticon--unicode">[^<]*<\/span>\s*)+<\/p>$/;
 
 // pattern to detect the existence of a Chinese, Japanese, or Korean character in a string
 // http://stackoverflow.com/questions/15033196/using-javascript-to-check-whether-a-string-contains-japanese-characters-includi

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -19,7 +19,7 @@ const punctuation = XRegExp.cache('[^\\pL\\d]');
 
 const AT_MENTION_PATTERN = /\B@([a-z0-9.\-_]*)/gi;
 const UNICODE_EMOJI_REGEX = emojiRegex();
-const htmlEmojiPattern = /^<p>(?:<img class="emoticon"[^>]*>|<span data-emoticon[^>]*>[^<]*<\/span>\s*|<span class="emoticon emoticon--unicode">[^<]*<\/span>\s*)+<\/p>$/;
+const htmlEmojiPattern = /^<p> *(?:<img class="emoticon"[^>]*>|<span data-emoticon[^>]*>[^<]*<\/span>\s*|<span class="emoticon emoticon--unicode">[^<]*<\/span>\s*)+<\/p>$/;
 
 // pattern to detect the existence of a Chinese, Japanese, or Korean character in a string
 // http://stackoverflow.com/questions/15033196/using-javascript-to-check-whether-a-string-contains-japanese-characters-includi

--- a/utils/text_formatting.test.jsx
+++ b/utils/text_formatting.test.jsx
@@ -3,9 +3,22 @@
 
 import emojiRegex from 'emoji-regex';
 
-import {autolinkAtMentions, highlightSearchTerms, handleUnicodeEmoji} from 'utils/text_formatting.jsx';
+import {formatText, autolinkAtMentions, highlightSearchTerms, handleUnicodeEmoji} from 'utils/text_formatting.jsx';
 import {getEmojiMap} from 'selectors/emojis';
 import store from 'stores/redux_store.jsx';
+
+describe('formatText', () => {
+    test('jumbo emoji should be able to handle up to 3 spaces before the emoji character', () => {
+        const emoji = ':)';
+        let spaces = '';
+
+        for(let i = 0; i < 3; i++) {
+            spaces += ' ';
+            const output = formatText(`${spaces}${emoji}`, {});
+            expect(output).toBe(`<span class="all-emoji"><p>${spaces}<span data-emoticon="slightly_smiling_face">${emoji}</span></p></span>`);
+        }
+    });
+});
 
 describe('autolinkAtMentions', () => {
     // testing to make sure @channel, @all & @here are setup properly to get highlighted correctly

--- a/utils/text_formatting.test.jsx
+++ b/utils/text_formatting.test.jsx
@@ -12,7 +12,7 @@ describe('formatText', () => {
         const emoji = ':)';
         let spaces = '';
 
-        for(let i = 0; i < 3; i++) {
+        for (let i = 0; i < 3; i++) {
             spaces += ' ';
             const output = formatText(`${spaces}${emoji}`, {});
             expect(output).toBe(`<span class="all-emoji"><p>${spaces}<span data-emoticon="slightly_smiling_face">${emoji}</span></p></span>`);


### PR DESCRIPTION
#### Summary
Currently, spaces preceding what should be jumbo emoji posts are preventing the emoji from becoming jumbo. This PR allows jumbo emoji to still be recognized with leading spaces.

#### Ticket Link
[MM-14024](https://mattermost.atlassian.net/projects/MM/issues/MM-14024)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, posting, etc.)
