### PR TITLE
Fixed usage of the LocalizedInput component with a "value" prop provided

### DIFF
--- a/components/localized_input/localized_input.jsx
+++ b/components/localized_input/localized_input.jsx
@@ -12,6 +12,7 @@ export default class LocalizedInput extends React.Component {
             id: PropTypes.string.isRequired,
             defaultMessage: PropTypes.string.isRequired,
         }).isRequired,
+        value: PropTypes.string,
     };
 
     static contextTypes = {
@@ -37,7 +38,8 @@ export default class LocalizedInput extends React.Component {
     };
 
     shouldComponentUpdate(nextProps) {
-        return nextProps.placeholder.id !== this.props.placeholder.id ||
+        return nextProps.value !== this.props.value ||
+            nextProps.placeholder.id !== this.props.placeholder.id ||
             nextProps.placeholder.defaultMessage !== this.props.placeholder.defaultMessage;
     }
 


### PR DESCRIPTION
#### Summary
This PR fixes my previous merged commit https://github.com/mattermost/mattermost-webapp/pull/2362. The commit caused that it isn't possible to type any character into the LocalizedInput whenever a `value` prop was provided to the component, like in `login_controller.jsx`:
```jsx
<LocalizedInput
    id='loginPassword'
    type='password'
    className='form-control'
    ref='password'
    name='password'
    value={this.state.password}
    onChange={this.handlePasswordChange}
    placeholder={{id: 'login.password', defaultMessage: 'Password'}}
    spellCheck='false'
/>
``` 
This issue makes that isn't event possible to log to the app in using a password.
I resolved that by including the `value` prop in the `shouldComponentUpdate` function of the `LocalizedInput` and it now works correctly, but maybe there are better solutions.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed