### PR TITLE
[MM-13979] Add commands, test specs for post header, and upgrade Cypress to 3.1 due to Chrome 72 issue

### DIFF
--- a/components/common/comment_icon.jsx
+++ b/components/common/comment_icon.jsx
@@ -16,7 +16,7 @@ export default class CommentIcon extends React.PureComponent {
         handleCommentClick: PropTypes.func.isRequired,
         searchStyle: PropTypes.string,
         commentCount: PropTypes.number,
-        id: PropTypes.string,
+        postId: PropTypes.string,
         extraClass: PropTypes.string,
     };
 
@@ -24,7 +24,6 @@ export default class CommentIcon extends React.PureComponent {
         idCount: -1,
         searchStyle: '',
         commentCount: 0,
-        id: '',
         extraClass: '',
     };
 
@@ -47,7 +46,7 @@ export default class CommentIcon extends React.PureComponent {
             selectorId += this.props.idCount;
         }
 
-        const id = Utils.createSafeId(this.props.idPrefix + '_' + this.props.id);
+        const id = Utils.createSafeId(this.props.idPrefix + '_' + this.props.postId);
 
         const tooltip = (
             <Tooltip

--- a/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
+++ b/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
@@ -38,6 +38,7 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
         aria-expanded="false"
         className="dropdown-toggle post__dropdown color--link style--none"
         data-toggle="dropdown"
+        id="CENTER_button_post_id_1"
         type="button"
       />
     </OverlayTrigger>
@@ -129,6 +130,7 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
         aria-expanded="false"
         className="dropdown-toggle post__dropdown color--link style--none"
         data-toggle="dropdown"
+        id="CENTER_button_post_id_1"
         type="button"
       />
     </OverlayTrigger>

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -377,6 +377,7 @@ class DotMenu extends Component {
                         rootClose={true}
                     >
                         <button
+                            id={`${this.props.location}_button_${this.props.post.id}`}
                             ref='dropdownToggle'
                             className='dropdown-toggle post__dropdown color--link style--none'
                             type='button'

--- a/components/post_view/post_flag_icon/__snapshots__/post_flag_icon.test.js.snap
+++ b/components/post_view/post_flag_icon/__snapshots__/post_flag_icon.test.js.snap
@@ -28,7 +28,7 @@ exports[`components/post_view/PostFlagIcon should match snapshot 1`] = `
 >
   <button
     className="style--none flag-icon__container "
-    id={null}
+    id="centerPostFlag_post_id"
     onClick={[Function]}
   >
     <FlagIcon
@@ -66,7 +66,7 @@ exports[`components/post_view/PostFlagIcon should match snapshot 2`] = `
 >
   <button
     className="style--none flag-icon__container visible"
-    id={null}
+    id="centerPostFlag_post_id"
     onClick={[Function]}
   >
     <FlagIconFilled

--- a/components/post_view/post_flag_icon/post_flag_icon.js
+++ b/components/post_view/post_flag_icon/post_flag_icon.js
@@ -83,7 +83,7 @@ export default class PostFlagIcon extends React.PureComponent {
                 }
             >
                 <button
-                    id={flagIconId}
+                    id={flagIconId || `${this.props.idPrefix}_${this.props.postId}`}
                     className={'style--none flag-icon__container ' + flagVisible}
                     onClick={this.handlePress}
                 >

--- a/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
+++ b/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
@@ -181,9 +181,9 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
       commentCount={0}
       extraClass="pull-right"
       handleCommentClick={[MockFunction]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
       idCount={-1}
       idPrefix="commentIcon"
+      postId="e584uzbwwpny9kengqayx5ayzw"
       searchStyle=""
     />
   </div>
@@ -295,9 +295,9 @@ exports[`components/post_view/PostInfo toggleEmojiPicker, should have called pro
       commentCount={0}
       extraClass="pull-right"
       handleCommentClick={[MockFunction]}
-      id="g6139tbospd18cmxroesdk3kkc_e584uzbwwpny9kengqayx5ayzw"
       idCount={-1}
       idPrefix="commentIcon"
+      postId="e584uzbwwpny9kengqayx5ayzw"
       searchStyle=""
     />
   </div>

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -163,7 +163,7 @@ export default class PostInfo extends React.PureComponent {
                     idCount={idCount}
                     handleCommentClick={this.props.handleCommentClick}
                     commentCount={this.props.replyCount}
-                    id={post.channel_id + '_' + post.id}
+                    postId={post.id}
                     extraClass={commentIconExtraClass}
                 />
             );

--- a/components/post_view/post_time/post_time.jsx
+++ b/components/post_view/post_time/post_time.jsx
@@ -23,6 +23,8 @@ export default class PostTime extends React.PureComponent {
          */
         eventTime: PropTypes.number.isRequired,
 
+        location: PropTypes.oneOf(['CENTER', 'RHS_ROOT', 'RHS_COMMENT', 'SEARCH']).isRequired,
+
         /*
          * The post id of posting being rendered
          */
@@ -32,6 +34,7 @@ export default class PostTime extends React.PureComponent {
 
     static defaultProps = {
         eventTime: 0,
+        location: 'CENTER',
     };
 
     handleClick = () => {
@@ -50,9 +53,16 @@ export default class PostTime extends React.PureComponent {
             return localDateTime;
         }
 
+        const {
+            location,
+            postId,
+            teamUrl,
+        } = this.props;
+
         return (
             <Link
-                to={`${this.props.teamUrl}/pl/${this.props.postId}`}
+                id={`${location}_time_${postId}`}
+                to={`${teamUrl}/pl/${postId}`}
                 className='post__permalink'
                 onClick={this.handleClick}
             >

--- a/components/rhs_header_post/rhs_header_post.jsx
+++ b/components/rhs_header_post/rhs_header_post.jsx
@@ -192,6 +192,7 @@ export default class RhsHeaderPost extends React.Component {
                         </OverlayTrigger>
                     </button>
                     <button
+                        id='rhsCloseButton'
                         type='button'
                         className='sidebar--right__close'
                         aria-label='Close'

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -325,6 +325,7 @@ export default class RhsThread extends React.Component {
 
         return (
             <div
+                id='rhsContainer'
                 className='sidebar-right__body'
                 ref='sidebarbody'
             >

--- a/components/search_results_item/__snapshots__/search_results_item.test.jsx.snap
+++ b/components/search_results_item/__snapshots__/search_results_item.test.jsx.snap
@@ -86,6 +86,7 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
             <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
+              location="SEARCH"
               postId="id"
             />
             <span
@@ -136,9 +137,9 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
               commentCount={0}
               extraClass=""
               handleCommentClick={[Function]}
-              id=""
               idCount={-1}
               idPrefix="searchCommentIcon"
+              postId="id"
               searchStyle="search-item__comment"
             />
             <a
@@ -300,6 +301,7 @@ exports[`components/SearchResultsItem should match snapshot for archived channel
             <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
+              location="SEARCH"
               postId="id"
             />
             <Connect(PostFlagIcon)
@@ -341,9 +343,9 @@ exports[`components/SearchResultsItem should match snapshot for archived channel
               commentCount={0}
               extraClass=""
               handleCommentClick={[Function]}
-              id=""
               idCount={-1}
               idPrefix="searchCommentIcon"
+              postId="id"
               searchStyle="search-item__comment"
             />
             <a
@@ -505,6 +507,7 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
             <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
+              location="SEARCH"
               postId="id"
             />
             <Connect(PostFlagIcon)
@@ -546,9 +549,9 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
               commentCount={0}
               extraClass=""
               handleCommentClick={[Function]}
-              id=""
               idCount={-1}
               idPrefix="searchCommentIcon"
+              postId="id"
               searchStyle="search-item__comment"
             />
             <a
@@ -728,6 +731,7 @@ exports[`components/SearchResultsItem should match snapshot for deleted message 
             <Connect(PostTime)
               eventTime={1502715365009}
               isPermalink={true}
+              location="SEARCH"
               postId="id"
             />
           </div>

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -131,6 +131,7 @@ export default class SearchResultsItem extends React.PureComponent {
                 isPermalink={isPermalink}
                 eventTime={post.create_at}
                 postId={post.id}
+                location='SEARCH'
             />
         );
     };
@@ -253,6 +254,7 @@ export default class SearchResultsItem extends React.PureComponent {
                         idPrefix={'searchCommentIcon'}
                         idCount={this.props.lastPostCount}
                         handleCommentClick={this.handleFocusRHSClick}
+                        postId={post.id}
                         searchStyle={'search-item__comment'}
                     />
                     <a

--- a/cypress/integration/post_header/post_header_spec.js
+++ b/cypress/integration/post_header/post_header_spec.js
@@ -1,0 +1,161 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/* eslint max-nested-callbacks: ["error", 3] */
+
+describe('Post Header', () => {
+    before(() => {
+        // 1. Go to Main Channel View with "user-1"
+        cy.toMainChannelView('user-1');
+    });
+
+    it('should render permalink view on click of post timestamp at center view', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post a message
+        cy.postMessage('test for permalink{enter}');
+
+        // * Check initial state that "the jump to recent messages" is not visible
+        cy.get('#archive-link-home').should('not.be.visible');
+
+        cy.getLastPostId().then((postId) => {
+            const divPostId = `#post_${postId}`;
+
+            // * Check initial state that the first message posted is not highlighted
+            cy.get(divPostId).should('be.visible').should('have.attr', 'class', 'post same--user same--root  current--user');
+
+            // 4. Click timestamp of a post
+            cy.clickPostTime(postId);
+
+            // * Check that it redirected to permalink URL
+            cy.url().should('include', `/ad-1/pl/${postId}`);
+
+            // * Check that the post is highlighted on permalink view
+            cy.get(divPostId).should('be.visible').should('have.attr', 'class', 'post post--highlight same--user same--root  current--user');
+
+            // * Check that the "jump to recent messages" is visible
+            cy.get('#archive-link-home').
+                should('be.visible').
+                should('contain', 'Click here to jump to recent messages.');
+
+            // 5. Click "jump to recent messages" link
+            cy.get('#archive-link-home').click();
+
+            // * Check that it redirects to channel URL
+            cy.url().should('include', '/ad-1/channels/town-square');
+
+            // * Check the said post not highlighted
+            cy.get(divPostId).should('be.visible').should('have.attr', 'class', 'post same--user same--root  current--user');
+        });
+    });
+
+    it('should flag a post on click to flag icon at center view', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post a message
+        cy.postMessage('test for flagged post{enter}');
+
+        cy.getLastPostId().then((postId) => {
+            // * Check that the center flag icon of a post is not visible
+            cy.get(`#centerPostFlag_${postId}`).should('not.be.visible');
+
+            // 4. Click the center flag icon of a post
+            cy.clickPostFlagIcon(postId);
+
+            // * Check that the center flag icon of a post becomes visible
+            cy.get(`#centerPostFlag_${postId}`).should('be.visible').should('have.attr', 'class', 'style--none flag-icon__container visible');
+
+            // 5. Click again the center flag icon of a post
+            cy.clickPostFlagIcon(postId);
+
+            // * Check that the center flag icon of a post is now hidden.
+            cy.get(`#centerPostFlag_${postId}`).should('not.be.visible');
+        });
+    });
+
+    it('should open dropdown menu on click of dot menu icon', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post a message
+        cy.postMessage('test for dropdown menu{enter}');
+
+        cy.getLastPostId().then((postId) => {
+            // * Check that the center dot menu' button and dropdown are hidden
+            cy.get(`#CENTER_button_${postId}`).should('not.be.visible');
+            cy.get(`#CENTER_dropdown_${postId}`).should('not.be.visible');
+
+            // 4. Click dot menu of a post
+            cy.clickPostDotMenu();
+
+            // * Check that the center dot menu button and dropdown are visible
+            cy.get(`#CENTER_button_${postId}`).should('be.visible');
+            cy.get(`#CENTER_dropdown_${postId}`).should('be.visible');
+
+            // 5. Click to other location like post textbox
+            cy.get('#post_textbox').click();
+
+            // * Chack that the center dot menu and dropdown are hidden
+            cy.get(`#CENTER_button_${postId}`).should('not.be.visible');
+            cy.get(`#CENTER_dropdown_${postId}`).should('not.be.visible');
+        });
+    });
+
+    it('should open and close Emoji Picker on click of reaction icon', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post a message
+        cy.postMessage('test for reaction and emoji picker{enter}');
+
+        cy.getLastPostId().then((postId) => {
+            // * Check that the center post reaction icon and emoji picker are not visible
+            cy.get(`#CENTER_reaction_${postId}`).should('not.be.visible');
+            cy.get('#emojiPicker').should('not.be.visible');
+
+            // 4. Click the center post reaction icon of the post
+            cy.clickPostReactionIcon(postId);
+
+            // * Check that the center post reaction icon of the post becomes visible
+            cy.get(`#CENTER_reaction_${postId}`).should('be.visible').should('have.attr', 'class', 'reacticon__container color--link style--none');
+
+            // * Check that the emoji picker becomes visible as well
+            cy.get('#emojiPicker').should('be.visible');
+
+            // 5. Click again the center post reaction icon of the post
+            cy.clickPostReactionIcon(postId);
+
+            // * Check that the center post reaction icon and emoji picker are not visible
+            cy.get(`#CENTER_reaction_${postId}`).should('not.be.visible');
+            cy.get('#emojiPicker').should('not.be.visible');
+        });
+    });
+
+    it('should open RHS on click of comment icon and close on RHS\' close button', () => {
+        // 2. Go to a known team and channel
+        cy.visit('/ad-1/channels/town-square');
+
+        // 3. Post a message
+        cy.postMessage('test for opening and closing RHS{enter}');
+
+        // 4. Open RHS on hover to a post and click to its comment icon
+        cy.clickPostCommentIcon();
+
+        // * Check that the RHS is open
+        cy.get('#rhsContainer').should('be.visible');
+
+        // 5. Close RHS on click of close button
+        cy.closeRHS();
+
+        // * Check that the RHS is close
+        cy.get('#rhsContainer').should('not.be.visible');
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -20,6 +20,13 @@ Cypress.Commands.add('login', (username, {otherUsername, otherPassword, otherURL
     });
 });
 
+Cypress.Commands.add('toMainChannelView', (username, {otherUsername, otherPassword, otherURL} = {}) => {
+    cy.login('user-1', {otherUsername, otherPassword, otherURL});
+    cy.visit('/');
+
+    cy.get('#post_textbox').should('be.visible');
+});
+
 // ***********************************************************
 // Account Settings Modal
 // ***********************************************************
@@ -89,10 +96,88 @@ function isMac() {
 
 Cypress.Commands.add('postMessage', (message) => {
     cy.get('#post_textbox').type(message).type('{enter}');
+
+    // add wait time to ensure that a post gets posted and not on pending state
+    cy.wait(500); // eslint-disable-line
 });
 
 Cypress.Commands.add('getLastPostId', () => {
     return cy.get('#postListContent').children().last().invoke('attr', 'id').then((divPostId) => {
         return divPostId.replace('post_', '');
     });
+});
+
+// ***********************************************************
+// Post header
+// ***********************************************************
+
+// Click post time at center view
+Cypress.Commands.add('clickPostTime', (postId) => {
+    if (postId) {
+        cy.get(`#post_${postId}`).trigger('mouseover');
+        cy.get(`#CENTER_time_${postId}`).click({force: true});
+    } else {
+        cy.getLastPostId().then((lastPostId) => {
+            cy.get(`#post_${lastPostId}`).trigger('mouseover');
+            cy.get(`#CENTER_time_${lastPostId}`).click({force: true});
+        });
+    }
+});
+
+// Click flag icon by post ID or to most recent post (if post ID is not provided)
+Cypress.Commands.add('clickPostFlagIcon', (postId) => {
+    if (postId) {
+        cy.get(`#post_${postId}`).trigger('mouseover');
+        cy.get(`#centerPostFlag_${postId}`).click({force: true});
+    } else {
+        cy.getLastPostId().then((lastPostId) => {
+            cy.get(`#post_${lastPostId}`).trigger('mouseover');
+            cy.get(`#centerPostFlag_${lastPostId}`).click({force: true});
+        });
+    }
+});
+
+// Click dot menu by post ID or to most recent post (if post ID is not provided)
+Cypress.Commands.add('clickPostDotMenu', (postId) => {
+    if (postId) {
+        cy.get(`#post_${postId}`).trigger('mouseover');
+        cy.get(`#CENTER_button_${postId}`).click({force: true});
+    } else {
+        cy.getLastPostId().then((lastPostId) => {
+            cy.get(`#post_${lastPostId}`).trigger('mouseover');
+            cy.get(`#CENTER_button_${lastPostId}`).click({force: true});
+        });
+    }
+});
+
+// Click post reaction icon at center view
+Cypress.Commands.add('clickPostReactionIcon', (postId) => {
+    if (postId) {
+        cy.get(`#post_${postId}`).trigger('mouseover');
+        cy.get(`#CENTER_reaction_${postId}`).click({force: true});
+    } else {
+        cy.getLastPostId().then((lastPostId) => {
+            cy.get(`#post_${lastPostId}`).trigger('mouseover');
+            cy.get(`#CENTER_reaction_${lastPostId}`).click({force: true});
+        });
+    }
+});
+
+// Click comment icon by post ID or to most recent post (if post ID is not provided)
+// This open up the RHS
+Cypress.Commands.add('clickPostCommentIcon', (postId) => {
+    if (postId) {
+        cy.get(`#post_${postId}`).trigger('mouseover');
+        cy.get(`#commentIcon_${postId}`).click({force: true});
+    } else {
+        cy.getLastPostId().then((lastPostId) => {
+            cy.get(`#post_${lastPostId}`).trigger('mouseover');
+            cy.get(`#commentIcon_${lastPostId}`).click({force: true});
+        });
+    }
+});
+
+// Close RHS by clicking close button
+Cypress.Commands.add('closeRHS', () => {
+    cy.get('#rhsCloseButton').should('be.visible').click();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1393,9 +1393,9 @@
       "dev": true
     },
     "@types/sinon-chai": {
-      "version": "2.7.29",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.29.tgz",
-      "integrity": "sha512-EkI/ZvJT4hglWo7Ipf9SX+J+R9htNOMjW8xiOhce7+0csqvgoF5IXqY5Ae1GqRgNtWCuaywR5HjVa1snkTqpOw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.2.tgz",
+      "integrity": "sha512-5zSs2AslzyPZdOsbm2NRtuSNAI2aTWzNKOHa/GRecKo7a5efYD7qGcPxMZXQDayVXT2Vnd5waXxBvV31eCZqiA==",
       "dev": true,
       "requires": {
         "@types/chai": "*",
@@ -4399,9 +4399,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.4.tgz",
-      "integrity": "sha512-8VJYtCAFqHXMnRDo4vdomR2CqfmhtReoplmbkXVspeKhKxU8WsZl0Nh5yeil8txxhq+YQwDrInItUqIm35Vw+g==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.5.tgz",
+      "integrity": "sha512-jzYGKJqU1CHoNocPndinf/vbG28SeU+hg+4qhousT/HDBMJxYgjecXOmSgBX/ga9/TakhqSrIrSP2r6gW/OLtg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -4415,7 +4415,7 @@
         "@types/minimatch": "3.0.3",
         "@types/mocha": "2.2.44",
         "@types/sinon": "7.0.0",
-        "@types/sinon-chai": "2.7.29",
+        "@types/sinon-chai": "3.2.2",
         "bluebird": "3.5.0",
         "cachedir": "1.3.0",
         "chalk": "2.4.1",
@@ -4540,7 +4540,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
@@ -4556,7 +4556,7 @@
         },
         "is-ci": {
           "version": "1.0.10",
-          "resolved": "http://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
           "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
           "dev": true,
           "requires": {
@@ -4571,7 +4571,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -6216,7 +6216,7 @@
         },
         "mkdirp": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
@@ -10889,7 +10889,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
           "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
           "dev": true
         }
@@ -11152,7 +11152,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -12213,7 +12213,7 @@
     },
     "ora": {
       "version": "0.2.3",
-      "resolved": "http://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
@@ -13154,7 +13154,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true,
           "optional": true

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "copy-webpack-plugin": "4.6.0",
     "cross-env": "5.2.0",
     "css-loader": "2.1.0",
-    "cypress": "3.1.4",
+    "cypress": "3.1.5",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.7.1",
     "enzyme-to-json": "3.3.5",


### PR DESCRIPTION
#### Summary
Add commands, test specs for post header, and upgrade Cypress to 3.1 due to Chrome 72 issue.

This PR is submitted on top of https://github.com/mattermost/mattermost-webapp/pull/2377.  Will rebase after it's merged.  You may review particular change in this commit - https://github.com/mattermost/mattermost-webapp/commit/6134ba8d4e16810d5d6aeba274079d983567fa83

Thanks to [courtneypattison](https://github.com/courtneypattison) for unlocking the way to test the post header section! 🎉 

#### Ticket Link
Jira ticket: [MM-13979](https://mattermost.atlassian.net/browse/MM-13979)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
