### PR TITLE
MM-13332: Infinite scroll in search results has no loading indicator

### DIFF
--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -225,6 +225,16 @@ export default class SearchResults extends React.PureComponent {
                         {ctls}
                     </div>
                 </Scrollbars>
+                <div
+                    className='loading-screen'
+                    style={this.props.isSearchGettingMore ? {} : {display: 'none'}}
+                >
+                    <div className='loading__content'>
+                        <div className='round round-1'/>
+                        <div className='round round-2'/>
+                        <div className='round round-3'/>
+                    </div>
+                </div>
             </div>
         );
     }

--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -199,6 +199,21 @@ export default class SearchResults extends React.PureComponent {
             }, this);
         }
 
+        let loadingScreen = null;
+        if (this.props.isSearchGettingMore) {
+            loadingScreen = (
+                <div className='loading-screen'>
+                    <div className='loading__content'>
+                        <div className='round round-1'/>
+                        <div className='round round-2'/>
+                        <div className='round round-3'/>
+                    </div>
+                </div>
+            )
+        }
+
+        
+
         return (
             <div className='sidebar-right__body'>
                 <SearchResultsHeader
@@ -225,16 +240,7 @@ export default class SearchResults extends React.PureComponent {
                         {ctls}
                     </div>
                 </Scrollbars>
-                <div
-                    className='loading-screen'
-                    style={this.props.isSearchGettingMore ? {} : {display: 'none'}}
-                >
-                    <div className='loading__content'>
-                        <div className='round round-1'/>
-                        <div className='round round-2'/>
-                        <div className='round round-3'/>
-                    </div>
-                </div>
+                {loadingScreen}
             </div>
         );
     }

--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -209,10 +209,8 @@ export default class SearchResults extends React.PureComponent {
                         <div className='round round-3'/>
                     </div>
                 </div>
-            )
+            );
         }
-
-        
 
         return (
             <div className='sidebar-right__body'>

--- a/sass/layout/_sidebar-right.scss
+++ b/sass/layout/_sidebar-right.scss
@@ -164,6 +164,15 @@
         @include flex-direction(column);
         border-left: $border-gray;
         height: calc(100% - 56px);
+
+        .loading-screen {
+            position: relative;
+            height: 40px;
+            padding: 0px;
+            .loading__content {
+                height: 40px;
+            }
+        }
     }
 
     .sidebar__overlay {


### PR DESCRIPTION
#### Summary
Displays a loading indicator (animated dots) when RHS search is fetching additional pages of results.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13332

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed

http://g.recordit.co/OctJoSyVGP.gif