### PR TITLE
MM-13415: Focus should move to search field when Direct Message tab is selected in the combined join modal

### DIFF
--- a/components/sidebar/more_public_direct_channels.jsx
+++ b/components/sidebar/more_public_direct_channels.jsx
@@ -59,6 +59,7 @@ export default class MorePublicDirectChannels extends React.PureComponent {
                         defaultActiveKey='channels'
                         activeKey={this.state.key}
                         onSelect={this.handleSelect}
+                        unmountOnExit={true}
                     >
                         <Tab
                             eventKey='channels'


### PR DESCRIPTION
#### Summary
In order to fix the issue of search input not gaining focus, this fix causes the tab content to unmount. When switching tabs, the content will mount to the DOM and `componentDidMount` will focus the input. `unmountOnExit` is defined in the react bootstrap tab component (https://react-bootstrap.github.io/components/tabs/)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13415

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed

![channels-dms-modal-focus-fix](https://user-images.githubusercontent.com/44858354/53071310-b2bd4d00-3496-11e9-98fa-0096974e816a.gif)

