### PR TITLE
E2E: Quick fix for flaky tests

### DIFF
--- a/cypress/integration/account_settings/display/channel_display_mode_spec.js
+++ b/cypress/integration/account_settings/display/channel_display_mode_spec.js
@@ -25,8 +25,12 @@ describe('Account Settings > Display > Channel Display Mode', () => {
         cy.get('#displayButton').click();
 
         // * Check that it changed into the Display section
-        // * Check the min setting view if each element is present and contains expected text values
         cy.get('#displaySettingsTitle').should('be.visible').should('contain', 'Display Settings');
+
+        // 3. Scroll up to bring Channel Display setting in viewable area.
+        cy.get('#channel_display_modeTitle').scrollIntoView();
+
+        // * Check the min setting view if each element is present and contains expected text values
         cy.get('#channel_display_modeTitle').should('be.visible').should('contain', 'Channel Display');
         cy.get('#channel_display_modeDesc').should('be.visible').should('contain', 'Fixed width');
         cy.get('#channel_display_modeEdit').should('be.visible').should('contain', 'Edit');

--- a/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -118,7 +118,7 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // * Suggestion list should be visible
         cy.get('#suggestionList').should('be.visible');
 
-        // 5. Press down arrow and then enter
+        // 5. Press enter
         cy.get('#quickSwitchInput').type('{enter}');
 
         // * Verify that it redirected into "nesciunt" as selected channel

--- a/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -111,15 +111,15 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // * Channel switcher hint should be visible
         cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use ↑↓ to browse, ↵ to select, ESC to dismiss.');
 
-        // 4. Type "nt" on Channel switcher input
-        cy.get('#quickSwitchInput').type('nt');
+        // 4. Type "nesciunt" on Channel switcher input
+        cy.get('#quickSwitchInput').type('nesciunt');
         cy.wait(500);  // eslint-disable-line
 
         // * Suggestion list should be visible
         cy.get('#suggestionList').should('be.visible');
 
         // 5. Press down arrow and then enter
-        cy.get('#quickSwitchInput').type('{downarrow}{enter}');
+        cy.get('#quickSwitchInput').type('{enter}');
 
         // * Verify that it redirected into "nesciunt" as selected channel
         cy.url().should('include', '/ad-1/channels/sequi-7');

--- a/cypress/integration/channel/edit_message_spec.js
+++ b/cypress/integration/channel/edit_message_spec.js
@@ -28,6 +28,9 @@ describe('Edit Message', () => {
         // 5. Press the escape key
         cy.get('#edit_textbox').type('{esc}');
 
+        // * Check if the textbox contains expected text
+        cy.get('#edit_textbox').should('contain', 'Hello World! @');
+
         // * Assert user autocomplete is not visible
         cy.get('#suggestionList').should('not.exist');
 
@@ -39,6 +42,9 @@ describe('Edit Message', () => {
 
         // 6. Press the escape key
         cy.get('#edit_textbox').type('{esc}');
+
+        // * Check if the textbox contains expected text
+        cy.get('#edit_textbox').should('contain', 'Hello World! @ ~');
 
         // * Assert channel autocomplete is not visible
         cy.get('#suggestionList').should('not.exist');

--- a/cypress/integration/channel/message_draft_spec.js
+++ b/cypress/integration/channel/message_draft_spec.js
@@ -16,18 +16,21 @@ describe('Message Draft', () => {
 
     it('M13473 Message Draft - Pencil Icon', () => {
         // 1. Got to a test channel on the side bar
+        cy.get('#sidebarItem_town-square').scrollIntoView();
         cy.get('#sidebarItem_town-square').should('be.visible').click();
 
         // * Validate if the channel has been opened
         cy.url().should('include', '/ad-1/channels/town-square');
 
         // * Validate if the draft icon is not visible on the sidebar before making a draft
+        cy.get('#sidebarItem_town-square').scrollIntoView();
         cy.get('#sidebarItem_town-square #draftIcon').should('be.not.visible');
 
         //2. Type in some text into the text area of the opened channel
         cy.get('#post_textbox').type('comm');
 
         //3. Go to another test channel without submitting the draft in the previous channel
+        cy.get('#sidebarItem_ratione-1').scrollIntoView();
         cy.get('#sidebarItem_ratione-1').should('be.visible').click();
 
         //* Validate if the newly navigated channel is open

--- a/cypress/integration/login/login_spec.js
+++ b/cypress/integration/login/login_spec.js
@@ -9,6 +9,8 @@
 
 describe('Login page', () => {
     before(() => {
+        cy.logoutByAPI();
+
         // 1. Go to login page
         cy.visit('/login');
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,6 +25,15 @@ Cypress.Commands.add('logout', () => {
     cy.visit('/');
 });
 
+Cypress.Commands.add('logoutByAPI', ({otherURL} = {}) => {
+    const urlParam = otherURL ? `${otherURL}/api/v4/users/logout` : '/api/v4/users/logout';
+
+    cy.request({
+        url: urlParam,
+        method: 'POST',
+    });
+});
+
 Cypress.Commands.add('toMainChannelView', (username, {otherUsername, otherPassword, otherURL} = {}) => {
     cy.login('user-1', {otherUsername, otherPassword, otherURL});
     cy.visit('/');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11047,8 +11047,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#656b40147b82e5914aea9c0e7818ef9f042c298a",
-      "from": "github:mattermost/mattermost-redux#656b40147b82e5914aea9c0e7818ef9f042c298a",
+      "version": "github:mattermost/mattermost-redux#aa1b7f511493b5954bfdc17f7ec501abb0d5662a",
+      "from": "github:mattermost/mattermost-redux#aa1b7f511493b5954bfdc17f7ec501abb0d5662a",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "2.0.0",


### PR DESCRIPTION
#### Summary
Quick fix for flaky tests
- added scroll to view in case the target element is out of viewing window
- logout a user when needed since we're reusing cookies
- added more assertion before the main assertion, instead of adding unnecessary arbitrary wait time
- type exact text to match target item

#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Updated E2E tests
