### PR TITLE
[MM-14281] Updated option value for multiselect to react-select 2.x

### DIFF
--- a/components/add_users_to_team/__snapshots__/add_users_to_team.test.jsx.snap
+++ b/components/add_users_to_team/__snapshots__/add_users_to_team.test.jsx.snap
@@ -79,7 +79,6 @@ exports[`components/AddUsersToTeam should match snapshot 1`] = `
       options={Array []}
       perPage={50}
       saving={false}
-      valueKey="id"
       valueRenderer={[Function]}
       values={Array []}
     />

--- a/components/add_users_to_team/add_users_to_team.jsx
+++ b/components/add_users_to_team/add_users_to_team.jsx
@@ -243,7 +243,6 @@ export default class AddUsersToTeam extends React.Component {
                         options={users}
                         optionRenderer={this.renderOption}
                         values={this.state.values}
-                        valueKey='id'
                         valueRenderer={this.renderValue}
                         perPage={USERS_PER_PAGE}
                         handlePageChange={this.handlePageChange}

--- a/components/channel_invite_modal/__snapshots__/channel_invite_modal.test.jsx.snap
+++ b/components/channel_invite_modal/__snapshots__/channel_invite_modal.test.jsx.snap
@@ -78,7 +78,6 @@ exports[`components/channel_invite_modal should match snapshot for channel_invit
       options={Array []}
       perPage={50}
       saving={false}
-      valueKey="id"
       valueRenderer={[Function]}
       values={Array []}
     />

--- a/components/channel_invite_modal/channel_invite_modal.jsx
+++ b/components/channel_invite_modal/channel_invite_modal.jsx
@@ -200,7 +200,6 @@ export default class ChannelInviteModal extends React.Component {
                 options={users}
                 optionRenderer={this.renderOption}
                 values={this.state.values}
-                valueKey='id'
                 valueRenderer={this.renderValue}
                 perPage={USERS_PER_PAGE}
                 handlePageChange={this.handlePageChange}

--- a/components/channel_selector_modal/__snapshots__/channel_selector_modal.test.jsx.snap
+++ b/components/channel_selector_modal/__snapshots__/channel_selector_modal.test.jsx.snap
@@ -84,7 +84,6 @@ exports[`components/ChannelSelectorModal should match snapshot 1`] = `
       }
       perPage={50}
       saving={false}
-      valueKey="id"
       valueRenderer={[Function]}
       values={Array []}
     />

--- a/components/channel_selector_modal/channel_selector_modal.jsx
+++ b/components/channel_selector_modal/channel_selector_modal.jsx
@@ -209,7 +209,6 @@ export default class ChannelSelectorModal extends React.Component {
                         options={channels}
                         optionRenderer={this.renderOption}
                         values={this.state.values}
-                        valueKey='id'
                         valueRenderer={this.renderValue}
                         perPage={CHANNELS_PER_PAGE}
                         handlePageChange={this.handlePageChange}

--- a/components/more_direct_channels/__snapshots__/more_direct_channels.test.jsx.snap
+++ b/components/more_direct_channels/__snapshots__/more_direct_channels.test.jsx.snap
@@ -143,7 +143,6 @@ exports[`components/MoreDirectChannels should match snapshot 1`] = `
           },
         ]
       }
-      valueKey="id"
       valueRenderer={[Function]}
       values={
         Array [

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -398,7 +398,6 @@ export default class MoreDirectChannels extends React.Component {
                 options={options}
                 optionRenderer={this.renderOption}
                 values={this.state.values}
-                valueKey='id'
                 valueRenderer={this.renderValue}
                 perPage={USERS_PER_PAGE}
                 handlePageChange={this.handlePageChange}

--- a/components/multiselect/__snapshots__/multiselect.test.jsx.snap
+++ b/components/multiselect/__snapshots__/multiselect.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`components/multiselect/multiselect should match snapshot 1`] = `
         defaultInputValue=""
         defaultMenuIsOpen={false}
         defaultValue={null}
+        getOptionValue={[Function]}
         id="selectItems"
         inputValue=""
         isClearable={false}
@@ -181,6 +182,7 @@ exports[`components/multiselect/multiselect should match snapshot for page 2 1`]
         defaultInputValue=""
         defaultMenuIsOpen={false}
         defaultValue={null}
+        getOptionValue={[Function]}
         id="selectItems"
         inputValue=""
         isClearable={false}

--- a/components/multiselect/multiselect.jsx
+++ b/components/multiselect/multiselect.jsx
@@ -320,6 +320,7 @@ export default class MultiSelect extends React.Component {
                             value={this.props.values}
                             placeholder={localizeMessage('multiselect.placeholder', 'Search and add members')}
                             inputValue={this.state.input}
+                            getOptionValue={(option) => option.id}
                         />
                         <SaveButton
                             id='saveItems'

--- a/components/team_selector_modal/__snapshots__/team_selector_modal.test.jsx.snap
+++ b/components/team_selector_modal/__snapshots__/team_selector_modal.test.jsx.snap
@@ -110,7 +110,6 @@ exports[`components/TeamSelectorModal should match snapshot 1`] = `
       }
       perPage={50}
       saving={false}
-      valueKey="id"
       valueRenderer={[Function]}
       values={Array []}
     />

--- a/components/team_selector_modal/team_selector_modal.jsx
+++ b/components/team_selector_modal/team_selector_modal.jsx
@@ -247,7 +247,6 @@ export default class TeamSelectorModal extends React.Component {
                         options={teams}
                         optionRenderer={this.renderOption}
                         values={this.state.values}
-                        valueKey='id'
                         valueRenderer={this.renderValue}
                         perPage={TEAMS_PER_PAGE}
                         handlePageChange={this.handlePageChange}


### PR DESCRIPTION
#### Summary
Changed `valueKey='id'` to `getOptionValue={(option) => option.id}` to [upgrade to react-select 2.x](https://react-select.com/upgrade-guide#concepts). I moved the option value setting to multiselect since it is always 'id'. I could move it back to the components that use it to future proof it or maybe set id as a default.

#### Ticket Link
Jira ticket: [MM-14281](https://mattermost.atlassian.net/browse/MM-14281)
Fixes: mattermost/mattermost-server#10317

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed