### PR TITLE
MM-14187 Fix for Emojis are not appearing right away on posts

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -459,14 +459,12 @@ function handleNewPostEventWrapped(msg) {
     }
 }
 
-function handlePostEditEvent(msg) {
+export function handlePostEditEvent(msg) {
     // Store post
     const post = JSON.parse(msg.data.post);
     dispatch({
         type: PostTypes.RECEIVED_POST,
-        data: {
-            post,
-        },
+        data: post,
     });
 
     getProfilesAndStatusesForPosts([post], dispatch, getState);

--- a/actions/websocket_actions.test.jsx
+++ b/actions/websocket_actions.test.jsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import store from 'stores/redux_store.jsx';
+
+import {handlePostEditEvent} from './websocket_actions';
+
+jest.mock('stores/redux_store', () => {
+    return {
+        dispatch: jest.fn(),
+        getState: () => ({
+            entities: {
+                users: {
+                    profiles: {
+                        user: {
+                            id: 'user',
+                        },
+                    },
+                    statuses: {
+                        user: 'away',
+                    },
+                },
+                general: {
+                    config: {},
+                },
+                channels: {
+                    currentChannelId: 'otherChannel',
+                },
+            },
+        }),
+    };
+});
+
+test('handlePostEditEvent', async () => {
+    const post = '{"id":"test","create_at":123,"update_at":123,"user_id":"user","channel_id":"12345","root_id":"","message":"asd","pending_post_id":"2345","metadata":{}}';
+    const expectedAction = {type: 'RECEIVED_POST', data: JSON.parse(post)};
+    const msg = {
+        data: {
+            post,
+        },
+        broadcast: {
+            channel_id: '1234657',
+        },
+    };
+
+    handlePostEditEvent(msg);
+    expect(store.dispatch).toHaveBeenCalledWith(expectedAction);
+});


### PR DESCRIPTION
#### Summary
  * RECEIVED_POST event should take data as post object instead of nested post obj

#### Ticket Link
[MM-14187](https://mattermost.atlassian.net/browse/MM-14187)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
