### PR TITLE
MM-14033 Fix scrolling on IE11 when changing notification settings

### DIFF
--- a/components/user_settings/notifications/user_settings_notifications.jsx
+++ b/components/user_settings/notifications/user_settings_notifications.jsx
@@ -741,7 +741,7 @@ export default class NotificationsTab extends React.Component {
                             />
                             <FormattedMessage
                                 id='user.settings.notifications.commentsAny'
-                                defaultMessage='Mention any comments in a thread you participated in (This will include both mentions to your root post and any comments after you commented on a post)'
+                                defaultMessage='Trigger notifications on messages in reply threads that I start or participate in'
                             />
                         </label>
                         <br/>
@@ -757,7 +757,7 @@ export default class NotificationsTab extends React.Component {
                             />
                             <FormattedMessage
                                 id='user.settings.notifications.commentsRoot'
-                                defaultMessage='Mention any comments on your post'
+                                defaultMessage='Trigger notifications on messages in threads that I start'
                             />
                         </label>
                         <br/>
@@ -773,7 +773,7 @@ export default class NotificationsTab extends React.Component {
                             />
                             <FormattedMessage
                                 id='user.settings.notifications.commentsNever'
-                                defaultMessage='No mentions for comments'
+                                defaultMessage="Do not trigger notifications on messages in reply threads unless I'm mentioned"
                             />
                         </label>
                     </div>

--- a/components/user_settings/notifications/user_settings_notifications.jsx
+++ b/components/user_settings/notifications/user_settings_notifications.jsx
@@ -220,22 +220,18 @@ export default class NotificationsTab extends React.Component {
 
     handleNotifyCommentsRadio(notifyCommentsLevel) {
         this.setState({notifyCommentsLevel});
-        this.refs.wrapper.focus();
     }
 
     handlePushRadio(pushActivity) {
         this.setState({pushActivity});
-        this.refs.wrapper.focus();
     }
 
     handlePushStatusRadio(pushStatus) {
         this.setState({pushStatus});
-        this.refs.wrapper.focus();
     }
 
     handleEmailRadio = (enableEmail) => {
         this.setState({enableEmail});
-        this.refs.wrapper.focus();
     }
 
     updateUsernameKey = (val) => {


### PR DESCRIPTION
#### Summary
First, I updated some default messages to match the english localization. Second, I removed unnecessary focuses on the notification settings. These were causing IE11 to scroll to the top of the modal and were unnecessary for other browsers (focus remains on the wrapper).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14033