### PR TITLE
 Adds a flag to autocomplete users and channels using elasticsearch in the config

### DIFF
--- a/components/admin_console/elasticsearch_settings.jsx
+++ b/components/admin_console/elasticsearch_settings.jsx
@@ -36,6 +36,7 @@ export default class ElasticsearchSettings extends AdminSettings {
         config.ElasticsearchSettings.Sniff = this.state.sniff;
         config.ElasticsearchSettings.EnableIndexing = this.state.enableIndexing;
         config.ElasticsearchSettings.EnableSearching = this.state.enableSearching;
+        config.ElasticsearchSettings.EnableAutocomplete = this.state.enableAutocomplete;
 
         return config;
     }
@@ -48,6 +49,7 @@ export default class ElasticsearchSettings extends AdminSettings {
             sniff: config.ElasticsearchSettings.Sniff,
             enableIndexing: config.ElasticsearchSettings.EnableIndexing,
             enableSearching: config.ElasticsearchSettings.EnableSearching,
+            enableAutocomplete: config.ElasticsearchSettings.EnableAutocomplete,
             configTested: true,
             canSave: true,
             canPurgeAndIndex: config.ElasticsearchSettings.EnableIndexing,
@@ -59,6 +61,7 @@ export default class ElasticsearchSettings extends AdminSettings {
             if (value === false) {
                 this.setState({
                     enableSearching: false,
+                    enableAutocomplete: false,
                 });
             } else {
                 this.setState({
@@ -75,7 +78,7 @@ export default class ElasticsearchSettings extends AdminSettings {
             });
         }
 
-        if (id !== 'enableSearching') {
+        if (id !== 'enableSearching' && id !== 'enableAutocomplete') {
             this.setState({
                 canPurgeAndIndex: false,
             });
@@ -368,6 +371,25 @@ export default class ElasticsearchSettings extends AdminSettings {
                     disabled={!this.state.enableIndexing || !this.state.configTested}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.EnableSearching')}
+                />
+                <BooleanSetting
+                    id='enableAutocomplete'
+                    label={
+                        <FormattedMessage
+                            id='admin.elasticsearch.enableAutocompleteTitle'
+                            defaultMessage='Enable Elasticsearch for autocomplete queries:'
+                        />
+                    }
+                    helpText={
+                        <FormattedMessage
+                            id='admin.elasticsearch.enableAutocompleteDescription'
+                            defaultMessage='Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all autocompletion queries on users and channels using the latest index. Autocompletion results may be incomplete until a bulk index of the existing post database is finished. When false, database search is used.'
+                        />
+                    }
+                    value={this.state.enableAutocomplete}
+                    disabled={!this.state.enableIndexing || !this.state.configTested}
+                    onChange={this.handleSettingChanged}
+                    setByEnv={this.isSetByEnv('ElasticsearchSettings.EnableAutocomplete')}
                 />
             </SettingsGroup>
         );

--- a/components/admin_console/elasticsearch_settings.jsx
+++ b/components/admin_console/elasticsearch_settings.jsx
@@ -383,7 +383,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                     helpText={
                         <FormattedMessage
                             id='admin.elasticsearch.enableAutocompleteDescription'
-                            defaultMessage='Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all autocompletion queries on users and channels using the latest index. Autocompletion results may be incomplete until a bulk index of the existing post database is finished. When false, database search is used.'
+                            defaultMessage='Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all autocompletion queries on users and channels using the latest index. Autocompletion results may be incomplete until a bulk index of the existing users and channels database is finished. When false, database autocomplete is used.'
                         />
                     }
                     value={this.state.enableAutocomplete}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -361,6 +361,8 @@
   "admin.elasticsearch.enableIndexingTitle": "Enable Elasticsearch Indexing:",
   "admin.elasticsearch.enableSearchingDescription": "Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all search queries using the latest index. Search results may be incomplete until a bulk index of the existing post database is finished. When false, database search is used.",
   "admin.elasticsearch.enableSearchingTitle": "Enable Elasticsearch for search queries:",
+  "admin.elasticsearch.enableAutocompleteDescription": "Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all autocompletion queries on users and channels using the latest index. Autocompletion results may be incomplete until a bulk index of the existing post database is finished. When false, database search is used.",
+  "admin.elasticsearch.enableAutocompleteTitle": "Enable Elasticsearch for autocomplete queries:",
   "admin.elasticsearch.password": "E.g.: \"yourpassword\"",
   "admin.elasticsearch.passwordDescription": "(Optional) The password to authenticate to the Elasticsearch server.",
   "admin.elasticsearch.passwordTitle": "Server Password:",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -361,7 +361,7 @@
   "admin.elasticsearch.enableIndexingTitle": "Enable Elasticsearch Indexing:",
   "admin.elasticsearch.enableSearchingDescription": "Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all search queries using the latest index. Search results may be incomplete until a bulk index of the existing post database is finished. When false, database search is used.",
   "admin.elasticsearch.enableSearchingTitle": "Enable Elasticsearch for search queries:",
-  "admin.elasticsearch.enableAutocompleteDescription": "Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all autocompletion queries on users and channels using the latest index. Autocompletion results may be incomplete until a bulk index of the existing post database is finished. When false, database search is used.",
+  "admin.elasticsearch.enableAutocompleteDescription": "Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all autocompletion queries on users and channels using the latest index. Autocompletion results may be incomplete until a bulk index of the existing users and channels database is finished. When false, database autocomplete is used.",
   "admin.elasticsearch.enableAutocompleteTitle": "Enable Elasticsearch for autocomplete queries:",
   "admin.elasticsearch.password": "E.g.: \"yourpassword\"",
   "admin.elasticsearch.passwordDescription": "(Optional) The password to authenticate to the Elasticsearch server.",


### PR DESCRIPTION
#### Summary
This PR creates a config parameter in the elasticsearch config page to enable autocompletion in the users and channels queries.

#### Ticket Link
[MM-13629](https://mattermost.atlassian.net/browse/MM-13629)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] [Has server changes](https://github.com/mattermost/mattermost-server/pull/10354)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates