### PR TITLE
[MM-14193] Render emojis in Message Attachment title

### DIFF
--- a/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
+++ b/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
@@ -247,6 +247,90 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
 </div>
 `;
 
+exports[`components/post_view/MessageAttachment should match snapshot when the attachment has an emoji in the title 1`] = `
+<div
+  className="attachment "
+>
+  <div
+    className="attachment__content"
+  >
+    <div
+      className="clearfix attachment__container attachment__container--undefined"
+    >
+      <h1
+        className="attachment__title"
+      >
+        <Connect(Markdown)
+          message="Do you like :pizza:?"
+          options={
+            Object {
+              "autolinkedUrlSchemes": Array [],
+              "markdown": false,
+              "mentionHighlight": false,
+            }
+          }
+        />
+      </h1>
+      <div>
+        <div
+          className="attachment__body attachment__body--no_thumb"
+          onClick={[Function]}
+        />
+        <div
+          style={
+            Object {
+              "clear": "both",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/post_view/MessageAttachment should match snapshot when the attachment hasn't any emojis in the title 1`] = `
+<div
+  className="attachment "
+>
+  <div
+    className="attachment__content"
+  >
+    <div
+      className="clearfix attachment__container attachment__container--undefined"
+    >
+      <h1
+        className="attachment__title"
+      >
+        <Connect(Markdown)
+          message="Don't you like emojis?"
+          options={
+            Object {
+              "autolinkedUrlSchemes": Array [],
+              "markdown": false,
+              "mentionHighlight": false,
+            }
+          }
+        />
+      </h1>
+      <div>
+        <div
+          className="attachment__body attachment__body--no_thumb"
+          onClick={[Function]}
+        />
+        <div
+          style={
+            Object {
+              "clear": "both",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`components/post_view/MessageAttachment should match value on getFieldsTable 1`] = `""`;
 
 exports[`components/post_view/MessageAttachment should match value on getFieldsTable 2`] = `

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -310,7 +310,14 @@ export default class MessageAttachment extends React.PureComponent {
             } else {
                 title = (
                     <h1 className='attachment__title'>
-                        {attachment.title}
+                        <Markdown
+                            message={attachment.title}
+                            options={{
+                                mentionHighlight: false,
+                                markdown: false,
+                                autolinkedUrlSchemes: [],
+                            }}
+                        />
                     </h1>
                 );
             }

--- a/components/post_view/message_attachments/message_attachment/message_attachment.test.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.test.jsx
@@ -138,4 +138,30 @@ describe('components/post_view/MessageAttachment', () => {
         expect(wrapper.find(SizeAwareImage).first().prop('src')).toMatch(`/api/v4/image?url=${encodeURIComponent(props.attachment.image_url)}`);
         expect(wrapper.find(SizeAwareImage).last().prop('src')).toMatch(`/api/v4/image?url=${encodeURIComponent(props.attachment.thumb_url)}`);
     });
+
+    test('should match snapshot when the attachment has an emoji in the title', () => {
+        const props = {
+            ...baseProps,
+            attachment: {
+                title: 'Do you like :pizza:?',
+            },
+        };
+
+        const wrapper = shallow(<MessageAttachment {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot when the attachment hasn\'t any emojis in the title', () => {
+        const props = {
+            ...baseProps,
+            attachment: {
+                title: 'Don\'t you like emojis?',
+            },
+        };
+
+        const wrapper = shallow(<MessageAttachment {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Summary
This PR makes it possible to render emojis in Message Attachment title.

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/MM-14193) | Fixes [GitHub issue #10291](https://github.com/mattermost/mattermost-server/issues/10291)

#### Screenshot
![image](https://user-images.githubusercontent.com/45372453/53305451-0ad2c580-3882-11e9-93ad-7b677bc82f55.png)


#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests
