### PR TITLE
[MM-12748] Migrate system console user list actions from user_actions.jsx to redux

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -83,13 +83,14 @@ export function loadTeamMembersForProfilesList(profiles, teamId) {
     };
 }
 
-export async function loadProfilesWithoutTeam(page, perPage, success) {
-    const {data} = await UserActions.getProfilesWithoutTeam(page, perPage)(dispatch, getState);
-    dispatch(loadStatusesForProfilesMap(data));
+export function loadProfilesWithoutTeam(page, perPage) {
+    return async (doDispatch) => {
+        const {data} = await doDispatch(UserActions.getProfilesWithoutTeam(page, perPage));
 
-    if (success) {
-        success(data);
-    }
+        doDispatch(loadStatusesForProfilesMap(data));
+
+        return data;
+    };
 }
 
 export function loadTeamMembersAndChannelMembersForProfilesList(profiles, teamId, channelId) {
@@ -343,17 +344,15 @@ export async function autocompleteUsers(username, success) {
     }
 }
 
-export function revokeAllSessions(userId, success, error) {
-    UserActions.revokeAllSessionsForUser(userId)(dispatch, getState).then(
-        (data) => {
-            if (data && success) {
-                success(data);
-            } else if (data == null && error) {
-                const serverError = getState().requests.users.updateUser.error;
-                error({id: serverError.server_error_id, ...serverError});
-            }
+export function revokeAllSessions(userId) {
+    return async (doDispatch, doGetState) => {
+        const {data, error} = await doDispatch(UserActions.revokeAllSessionsForUser(userId));
+        if (error) {
+            const serverError = doGetState().requests.users.updateUser.error;
+            return {error: {id: serverError.server_error_id, ...serverError}};
         }
-    );
+        return {data};
+    };
 }
 
 export async function verifyEmail(token, success, error) {
@@ -403,13 +402,6 @@ export function deauthorizeOAuthApp(appId) {
         clientFunc: Client4.deauthorizeOAuthApp,
         params: [appId],
     });
-}
-
-export async function loadProfiles(page, perPage, options = {}, success) {
-    const {data} = await UserActions.getProfiles(page, perPage, options)(dispatch, getState);
-    if (success) {
-        success(data);
-    }
 }
 
 export function autoResetStatus() {

--- a/components/admin_console/system_users/index.js
+++ b/components/admin_console/system_users/index.js
@@ -5,13 +5,13 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getTeams, getTeamStats} from 'mattermost-redux/actions/teams';
-import {getUser, getUserAccessToken} from 'mattermost-redux/actions/users';
+import {getUser, getUserAccessToken, getProfiles} from 'mattermost-redux/actions/users';
 import {getTeamsList} from 'mattermost-redux/selectors/entities/teams';
 import {getUsers} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {Stats} from 'mattermost-redux/constants';
 
-import {loadProfilesAndTeamMembers} from 'actions/user_actions.jsx';
+import {loadProfilesAndTeamMembers, loadProfilesWithoutTeam} from 'actions/user_actions.jsx';
 
 import {setSystemUsersSearch} from 'actions/views/search';
 import {SearchUserTeamFilter} from 'utils/constants.jsx';
@@ -70,6 +70,8 @@ function mapDispatchToProps(dispatch) {
             getUserAccessToken,
             loadProfilesAndTeamMembers,
             setSystemUsersSearch,
+            loadProfilesWithoutTeam,
+            getProfiles,
         }, dispatch),
     };
 }

--- a/components/admin_console/system_users/system_users.test.jsx
+++ b/components/admin_console/system_users/system_users.test.jsx
@@ -5,8 +5,12 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import SystemUsers from 'components/admin_console/system_users/system_users.jsx';
+import {Constants, SearchUserTeamFilter} from 'utils/constants.jsx';
+
+jest.mock('actions/admin_actions.jsx');
 
 describe('components/admin_console/system_users', () => {
+    const USERS_PER_PAGE = 50;
     const defaultProps = {
         teams: [],
         siteName: 'Site name',
@@ -25,6 +29,8 @@ describe('components/admin_console/system_users', () => {
             getUserAccessToken: jest.fn().mockImplementation(() => Promise.resolve()),
             loadProfilesAndTeamMembers: jest.fn(),
             setSystemUsersSearch: jest.fn().mockImplementation(() => Promise.resolve()),
+            loadProfilesWithoutTeam: jest.fn().mockResolvedValue(),
+            getProfiles: jest.fn().mockResolvedValue(),
         },
     };
 
@@ -32,5 +38,69 @@ describe('components/admin_console/system_users', () => {
         const props = defaultProps;
         const wrapper = shallow(<SystemUsers {...props}/>);
         expect(wrapper).toMatchSnapshot();
+    });
+
+    test('loadDataForTeam() should have called getProfiles', async () => {
+        const getProfiles = jest.fn().mockResolvedValue();
+        const props = {...defaultProps, actions: {...defaultProps.actions, getProfiles}};
+        const wrapper = shallow(<SystemUsers {...props}/>);
+
+        wrapper.setState({loading: true});
+
+        await wrapper.instance().loadDataForTeam(SearchUserTeamFilter.ALL_USERS, '');
+
+        expect(getProfiles).toHaveBeenCalled();
+        expect(getProfiles).toHaveBeenCalledWith(0, Constants.PROFILE_CHUNK_SIZE, {});
+        expect(wrapper.state().loading).toEqual(false);
+    });
+
+    test('loadDataForTeam() should have called loadProfilesWithoutTeam', async () => {
+        const loadProfilesWithoutTeam = jest.fn().mockResolvedValue();
+        const props = {...defaultProps, actions: {...defaultProps.actions, loadProfilesWithoutTeam}};
+        const wrapper = shallow(<SystemUsers {...props}/>);
+
+        wrapper.setState({loading: true});
+
+        await wrapper.instance().loadDataForTeam(SearchUserTeamFilter.NO_TEAM, '');
+
+        expect(loadProfilesWithoutTeam).toHaveBeenCalled();
+        expect(loadProfilesWithoutTeam).toHaveBeenCalledWith(0, Constants.PROFILE_CHUNK_SIZE);
+        expect(wrapper.state().loading).toEqual(false);
+    });
+
+    test('nextPage() should have called getProfiles', async () => {
+        const getProfiles = jest.fn().mockResolvedValue();
+        const props = {
+            ...defaultProps,
+            teamId: SearchUserTeamFilter.ALL_USERS,
+            actions: {...defaultProps.actions, getProfiles},
+        };
+        const wrapper = shallow(<SystemUsers {...props}/>);
+
+        wrapper.setState({loading: true});
+
+        await wrapper.instance().nextPage(0);
+
+        expect(getProfiles).toHaveBeenCalled();
+        expect(getProfiles).toHaveBeenCalledWith(1, USERS_PER_PAGE, {});
+        expect(wrapper.state().loading).toEqual(false);
+    });
+
+    test('nextPage() should have called loadProfilesWithoutTeam', async () => {
+        const loadProfilesWithoutTeam = jest.fn().mockResolvedValue();
+        const props = {
+            ...defaultProps,
+            teamId: SearchUserTeamFilter.NO_TEAM,
+            actions: {...defaultProps.actions, loadProfilesWithoutTeam},
+        };
+        const wrapper = shallow(<SystemUsers {...props}/>);
+
+        wrapper.setState({loading: true});
+
+        await wrapper.instance().nextPage(0);
+
+        expect(loadProfilesWithoutTeam).toHaveBeenCalled();
+        expect(loadProfilesWithoutTeam).toHaveBeenCalledWith(1, USERS_PER_PAGE);
+        expect(wrapper.state().loading).toEqual(false);
     });
 });

--- a/components/admin_console/system_users/system_users_dropdown/index.js
+++ b/components/admin_console/system_users/system_users_dropdown/index.js
@@ -7,6 +7,8 @@ import {bindActionCreators} from 'redux';
 import {updateUserActive} from 'mattermost-redux/actions/users';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
+import {revokeAllSessions} from 'actions/user_actions.jsx';
+
 import SystemUsersDropdown from './system_users_dropdown.jsx';
 
 function mapStateToProps(state) {
@@ -17,7 +19,10 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        actions: bindActionCreators({updateUserActive}, dispatch),
+        actions: bindActionCreators({
+            updateUserActive,
+            revokeAllSessions,
+        }, dispatch),
     };
 }
 

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
@@ -8,7 +8,6 @@ import * as UserUtils from 'mattermost-redux/utils/user_utils';
 import {Permissions} from 'mattermost-redux/constants';
 
 import {adminResetMfa} from 'actions/admin_actions.jsx';
-import {revokeAllSessions} from 'actions/user_actions.jsx';
 import {Constants} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
@@ -75,6 +74,7 @@ export default class SystemUsersDropdown extends React.Component {
         currentUser: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             updateUserActive: PropTypes.func.isRequired,
+            revokeAllSessions: PropTypes.func.isRequired,
         }).isRequired,
     };
 
@@ -217,13 +217,14 @@ export default class SystemUsersDropdown extends React.Component {
 
     handleRevokeSessions = () => {
         const me = this.props.currentUser;
-        revokeAllSessions(this.props.user.id,
-            () => {
-                if (this.props.user.id === me.id) {
+        this.props.actions.revokeAllSessions(this.props.user.id).then(
+            ({data, error}) => {
+                if (data && this.props.user.id === me.id) {
                     emitUserLoggedOutEvent();
+                } else if (error) {
+                    this.props.onError(error);
                 }
-            },
-            this.props.onError
+            }
         );
 
         this.setState({showRevokeSessionsModal: false});

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.test.js
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.test.js
@@ -27,6 +27,7 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
         teamUrl: 'teamUrl',
         actions: {
             updateUserActive: jest.fn(() => Promise.resolve({})),
+            revokeAllSessions: jest.fn().mockResolvedValue({data: true}),
         },
     };
 
@@ -45,12 +46,8 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
         const updateUserActive = jest.fn(() => {
             return Promise.resolve(retVal);
         });
-        const wrapper = shallow(
-            <SystemUsersDropdown
-                {...requiredProps}
-                actions={{updateUserActive}}
-            />
-        );
+        const props = {...requiredProps, actions: {...requiredProps.actions, updateUserActive}};
+        const wrapper = shallow(<SystemUsersDropdown {...props}/>);
 
         const event = {preventDefault: jest.fn()};
         await wrapper.instance().handleMakeActive(event);
@@ -73,16 +70,32 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
         const updateUserActive = jest.fn(() => {
             return Promise.resolve(retVal);
         });
-        const wrapper = shallow(
-            <SystemUsersDropdown
-                {...requiredProps}
-                actions={{updateUserActive}}
-            />
-        );
+        const props = {...requiredProps, actions: {...requiredProps.actions, updateUserActive}};
+        const wrapper = shallow(<SystemUsersDropdown {...props}/>);
 
         await wrapper.instance().handleDeactivateMember();
 
         expect(requiredProps.onError).toHaveBeenCalledTimes(1);
         expect(requiredProps.onError).toHaveBeenCalledWith({id: retVal.error.server_error_id, ...retVal.error});
+    });
+
+    test('handleRevokeSessions() should have called revokeAllSessions', async () => {
+        const wrapper = shallow(<SystemUsersDropdown {...requiredProps}/>);
+
+        await wrapper.instance().handleRevokeSessions();
+
+        expect(requiredProps.actions.revokeAllSessions).toHaveBeenCalled();
+        expect(requiredProps.actions.revokeAllSessions).toHaveBeenCalledWith(requiredProps.user.id);
+    });
+
+    test('handleRevokeSessions() should have called onError', async () => {
+        const revokeAllSessions = jest.fn().mockResolvedValue({error: {}});
+        const onError = jest.fn();
+        const props = {...requiredProps, onError, actions: {...requiredProps.actions, revokeAllSessions}};
+        const wrapper = shallow(<SystemUsersDropdown {...props}/>);
+
+        await wrapper.instance().handleRevokeSessions();
+
+        expect(onError).toHaveBeenCalled();
     });
 });

--- a/components/user_settings/advanced/index.js
+++ b/components/user_settings/advanced/index.js
@@ -10,6 +10,7 @@ import {get, makeGetCategory} from 'mattermost-redux/selectors/entities/preferen
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {updateUserActive} from 'mattermost-redux/actions/users';
 
+import {revokeAllSessions} from 'actions/user_actions.jsx';
 import {Preferences} from 'utils/constants.jsx';
 
 import AdvancedSettingsDisplay from './user_settings_advanced.jsx';
@@ -40,6 +41,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             savePreferences,
             updateUserActive,
+            revokeAllSessions,
         }, dispatch),
     };
 }

--- a/components/user_settings/advanced/user_settings_advanced.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import {revokeAllSessions} from 'actions/user_actions.jsx';
 import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -36,6 +35,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
         actions: PropTypes.shape({
             savePreferences: PropTypes.func.isRequired,
             updateUserActive: PropTypes.func.isRequired,
+            revokeAllSessions: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -158,12 +158,13 @@ export default class AdvancedSettingsDisplay extends React.Component {
                 }
             });
 
-        revokeAllSessions(userId,
-            () => {
-                emitUserLoggedOutEvent();
-            },
-            (err) => {
-                this.setState({serverError: err.message});
+        this.props.actions.revokeAllSessions(userId).then(
+            ({data, error}) => {
+                if (data) {
+                    emitUserLoggedOutEvent();
+                } else if (error) {
+                    this.setState({serverError: error.message});
+                }
             }
         );
     }

--- a/components/user_settings/advanced/user_settings_advanced.test.jsx
+++ b/components/user_settings/advanced/user_settings_advanced.test.jsx
@@ -6,6 +6,8 @@ import {shallow} from 'enzyme';
 
 import AdvancedSettingsDisplay from 'components/user_settings/advanced/user_settings_advanced.jsx';
 
+jest.mock('actions/global_actions.jsx');
+
 describe('components/user_settings/display/UserSettingsDisplay', () => {
     const user = {
         id: 'user_id',
@@ -26,7 +28,8 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         collapseModal: jest.fn(),
         actions: {
             savePreferences: jest.fn(),
-            updateUserActive: jest.fn(),
+            updateUserActive: jest.fn().mockResolvedValue({data: true}),
+            revokeAllSessions: jest.fn().mockResolvedValue({data: true}),
         },
         advancedSettingsCategory: [],
         sendOnCtrlEnter: '',
@@ -64,5 +67,24 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         wrapper.instance().handleDeactivateAccountSubmit();
         expect(updateUserActive).toHaveBeenCalled();
         expect(updateUserActive).toHaveBeenCalledWith(requiredProps.currentUser.id, false);
+    });
+
+    test('handleDeactivateAccountSubmit() should have called revokeAllSessions', () => {
+        const wrapper = shallow(<AdvancedSettingsDisplay {...requiredProps}/>);
+
+        wrapper.instance().handleDeactivateAccountSubmit();
+        expect(requiredProps.actions.revokeAllSessions).toHaveBeenCalled();
+        expect(requiredProps.actions.revokeAllSessions).toHaveBeenCalledWith(requiredProps.currentUser.id);
+    });
+
+    test('handleDeactivateAccountSubmit() should have updated state.serverError', async () => {
+        const error = {message: 'error'};
+        const revokeAllSessions = () => Promise.resolve({error});
+        const props = {...requiredProps, actions: {...requiredProps.actions, revokeAllSessions}};
+        const wrapper = shallow(<AdvancedSettingsDisplay {...props}/>);
+
+        await wrapper.instance().handleDeactivateAccountSubmit();
+
+        expect(wrapper.state().serverError).toEqual(error.message);
     });
 });


### PR DESCRIPTION
#### Summary
Converted
- revokeAllSessions
- loadProfilesWithoutTeam

actions to redux actions. Removed `loadProfiles`, instead `getProfiles` action from mm-redux used directly

#### Ticket Link
[MM-12748](https://github.com/mattermost/mattermost-server/issues/10149)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (session revoking)
