### PR TITLE
[MM-14242] Remove props such as lastPostCount, idCount and idPrefix which were previously used for Se E2E

### DIFF
--- a/components/common/comment_icon.jsx
+++ b/components/common/comment_icon.jsx
@@ -6,13 +6,13 @@ import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
+import {Locations} from 'utils/constants.jsx';
+
 import ReplyIcon from 'components/svg/reply_icon';
-import * as Utils from 'utils/utils.jsx';
 
 export default class CommentIcon extends React.PureComponent {
     static propTypes = {
-        idPrefix: PropTypes.string.isRequired,
-        idCount: PropTypes.number,
+        location: PropTypes.oneOf([Locations.CENTER, Locations.SEARCH]).isRequired,
         handleCommentClick: PropTypes.func.isRequired,
         searchStyle: PropTypes.string,
         commentCount: PropTypes.number,
@@ -21,10 +21,10 @@ export default class CommentIcon extends React.PureComponent {
     };
 
     static defaultProps = {
-        idCount: -1,
         searchStyle: '',
         commentCount: 0,
         extraClass: '',
+        location: Locations.CENTER,
     };
 
     render() {
@@ -40,13 +40,6 @@ export default class CommentIcon extends React.PureComponent {
         } else if (this.props.searchStyle !== '') {
             iconStyle = iconStyle + ' ' + this.props.searchStyle;
         }
-
-        let selectorId = this.props.idPrefix;
-        if (this.props.idCount > -1) {
-            selectorId += this.props.idCount;
-        }
-
-        const id = Utils.createSafeId(this.props.idPrefix + '_' + this.props.postId);
 
         const tooltip = (
             <Tooltip
@@ -68,8 +61,8 @@ export default class CommentIcon extends React.PureComponent {
                 overlay={tooltip}
             >
                 <button
-                    id={id}
-                    className={iconStyle + ' color--link style--none ' + selectorId + ' ' + this.props.extraClass}
+                    id={`${this.props.location}_commentIcon_${this.props.postId}`}
+                    className={iconStyle + ' color--link style--none ' + this.props.extraClass}
                     onClick={this.props.handleCommentClick}
                 >
                     <ReplyIcon className='comment-icon'/>

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -9,7 +9,7 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import Permissions from 'mattermost-redux/constants/permissions';
 
 import {showGetPostLinkModal} from 'actions/global_actions.jsx';
-import {ModalIdentifiers, UNSET_POST_EDIT_TIME_LIMIT} from 'utils/constants.jsx';
+import {Locations, ModalIdentifiers, UNSET_POST_EDIT_TIME_LIMIT} from 'utils/constants.jsx';
 import DeletePostModal from 'components/delete_post_modal';
 import DelayedAction from 'utils/delayed_action.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
@@ -28,7 +28,7 @@ export default class DotMenu extends Component {
     static propTypes = {
         post: PropTypes.object.isRequired,
         teamId: PropTypes.string,
-        location: PropTypes.oneOf(['CENTER', 'RHS_ROOT', 'RHS_COMMENT', 'SEARCH']).isRequired,
+        location: PropTypes.oneOf([Locations.CENTER, Locations.RHS_ROOT, Locations.RHS_COMMENT, Locations.SEARCH]).isRequired,
         commentCount: PropTypes.number,
         isFlagged: PropTypes.bool,
         handleCommentClick: PropTypes.func,
@@ -79,6 +79,7 @@ export default class DotMenu extends Component {
         isFlagged: false,
         isReadOnly: false,
         pluginMenuItems: [],
+        location: Locations.CENTER,
     }
 
     constructor(props) {
@@ -167,7 +168,7 @@ export default class DotMenu extends Component {
             dialogProps: {
                 post: this.props.post,
                 commentCount: this.props.commentCount,
-                isRHS: this.props.location === 'RHS_ROOT' || this.props.location === 'RHS_COMMENT',
+                isRHS: this.props.location === Locations.RHS_ROOT || this.props.location === Locations.RHS_COMMENT,
             },
         };
 
@@ -178,9 +179,9 @@ export default class DotMenu extends Component {
         this.props.actions.setEditingPost(
             this.props.post.id,
             this.props.commentCount,
-            this.props.location === 'CENTER' ? 'post_textbox' : 'reply_textbox',
+            this.props.location === Locations.CENTER ? 'post_textbox' : 'reply_textbox',
             this.props.post.root_id ? Utils.localizeMessage('rhs_comment.comment', 'Comment') : Utils.localizeMessage('create_post.post', 'Post'),
-            this.props.location === 'RHS_ROOT' || this.props.location === 'RHS_COMMENT',
+            this.props.location === Locations.RHS_ROOT || this.props.location === Locations.RHS_COMMENT,
         );
     }
 
@@ -276,7 +277,7 @@ export default class DotMenu extends Component {
                         onClick={this.handleFlagMenuItemActivated}
                     />
                     <MenuItemAction
-                        show={!isSystemMessage && this.props.location === 'CENTER'}
+                        show={!isSystemMessage && this.props.location === Locations.CENTER}
                         text={Utils.localizeMessage('post_info.reply', 'Reply')}
                         onClick={this.props.handleCommentClick}
                     />

--- a/components/dot_menu/dot_menu.test.jsx
+++ b/components/dot_menu/dot_menu.test.jsx
@@ -28,7 +28,6 @@ jest.mock('utils/post_utils', () => {
 describe('components/dot_menu/DotMenu', () => {
     const baseProps = {
         post: {id: 'post_id_1', is_pinned: false},
-        location: 'CENTER',
         isLicensed: false,
         postEditTimeLimit: '-1',
         handleCommentClick: jest.fn(),

--- a/components/dot_menu/dot_menu_empty.test.jsx
+++ b/components/dot_menu/dot_menu_empty.test.jsx
@@ -25,7 +25,6 @@ jest.mock('utils/post_utils', () => {
 describe('components/dot_menu/DotMenu returning empty ("")', () => {
     test('should match snapshot, return empty ("") on Center', () => {
         const baseProps = {
-            location: 'CENTER',
             post: {id: 'post_id_1'},
             isLicensed: false,
             postEditTimeLimit: '-1',

--- a/components/dot_menu/dot_menu_mobile.test.jsx
+++ b/components/dot_menu/dot_menu_mobile.test.jsx
@@ -25,7 +25,6 @@ jest.mock('utils/post_utils', () => {
 describe('components/dot_menu/DotMenu on mobile view', () => {
     test('should match snapshot', () => {
         const baseProps = {
-            location: 'CENTER',
             post: {id: 'post_id_1'},
             isLicensed: false,
             postEditTimeLimit: '-1',

--- a/components/post_view/post/index.js
+++ b/components/post_view/post/index.js
@@ -17,7 +17,6 @@ function mapStateToProps(state, ownProps) {
 
     return {
         post: getPost(state, detailedPost.id),
-        lastPostCount: ownProps.lastPostCount,
         currentUserId: getCurrentUserId(state),
         isFirstReply: Boolean(detailedPost.isFirstReply && detailedPost.commentedOnPost),
         highlight: detailedPost.highlight,

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -64,11 +64,6 @@ export default class Post extends React.PureComponent {
         replyCount: PropTypes.number,
 
         /**
-         * The post count used for selenium tests
-         */
-        lastPostCount: PropTypes.number,
-
-        /**
          * Function to get the post list HTML element
          */
         getPostList: PropTypes.func.isRequired,
@@ -257,7 +252,6 @@ export default class Post extends React.PureComponent {
                             handleCommentClick={this.handleCommentClick}
                             handleDropdownOpened={this.handleDropdownOpened}
                             compactDisplay={this.props.compactDisplay}
-                            lastPostCount={this.props.lastPostCount}
                             isFirstReply={this.props.isFirstReply}
                             replyCount={this.props.replyCount}
                             showTimeWithoutHover={!hideProfilePicture}
@@ -268,7 +262,6 @@ export default class Post extends React.PureComponent {
                             post={post}
                             handleCommentClick={this.handleCommentClick}
                             compactDisplay={this.props.compactDisplay}
-                            lastPostCount={this.props.lastPostCount}
                             isCommentMention={this.props.isCommentMention}
                             isFirstReply={this.props.isFirstReply}
                         />

--- a/components/post_view/post_body/post_body.jsx
+++ b/components/post_view/post_body/post_body.jsx
@@ -62,11 +62,6 @@ export default class PostBody extends React.PureComponent {
          */
         previewEnabled: PropTypes.bool,
 
-        /**
-         * Post identifiers for selenium tests
-         */
-        lastPostCount: PropTypes.number,
-
         /*
          * Post type components from plugins
          */
@@ -171,7 +166,6 @@ export default class PostBody extends React.PureComponent {
                 {failedOptions}
                 {this.state.sending && <LoadingBars/>}
                 <PostMessageView
-                    lastPostCount={this.props.lastPostCount}
                     post={this.props.post}
                     compactDisplay={this.props.compactDisplay}
                     hasMention={true}

--- a/components/post_view/post_flag_icon/__snapshots__/post_flag_icon.test.js.snap
+++ b/components/post_view/post_flag_icon/__snapshots__/post_flag_icon.test.js.snap
@@ -28,7 +28,7 @@ exports[`components/post_view/PostFlagIcon should match snapshot 1`] = `
 >
   <button
     className="style--none flag-icon__container "
-    id="centerPostFlag_post_id"
+    id="CENTER_flagIcon_post_id"
     onClick={[Function]}
   >
     <FlagIcon
@@ -66,7 +66,7 @@ exports[`components/post_view/PostFlagIcon should match snapshot 2`] = `
 >
   <button
     className="style--none flag-icon__container visible"
-    id="centerPostFlag_post_id"
+    id="CENTER_flagIcon_post_id"
     onClick={[Function]}
   >
     <FlagIconFilled

--- a/components/post_view/post_flag_icon/post_flag_icon.js
+++ b/components/post_view/post_flag_icon/post_flag_icon.js
@@ -8,14 +8,12 @@ import {FormattedMessage} from 'react-intl';
 
 import FlagIcon from 'components/svg/flag_icon';
 import FlagIconFilled from 'components/svg/flag_icon_filled';
-import Constants from 'utils/constants.jsx';
-import * as Utils from 'utils/utils.jsx';
+import Constants, {Locations} from 'utils/constants.jsx';
 import {t} from 'utils/i18n';
 
 export default class PostFlagIcon extends React.PureComponent {
     static propTypes = {
-        idPrefix: PropTypes.string.isRequired,
-        idCount: PropTypes.number,
+        location: PropTypes.oneOf([Locations.CENTER, Locations.RHS_ROOT, Locations.RHS_COMMENT, Locations.SEARCH]).isRequired,
         postId: PropTypes.string.isRequired,
         isFlagged: PropTypes.bool.isRequired,
         isEphemeral: PropTypes.bool,
@@ -26,8 +24,8 @@ export default class PostFlagIcon extends React.PureComponent {
     };
 
     static defaultProps = {
-        idCount: -1,
         isEphemeral: false,
+        location: Locations.CENTER,
     };
 
     handlePress = (e) => {
@@ -55,11 +53,6 @@ export default class PostFlagIcon extends React.PureComponent {
 
         const flagVisible = isFlagged ? 'visible' : '';
 
-        let flagIconId = null;
-        if (this.props.idCount > -1) {
-            flagIconId = Utils.createSafeId(this.props.idPrefix + this.props.idCount);
-        }
-
         let flagIcon;
         if (isFlagged) {
             flagIcon = <FlagIconFilled className='icon'/>;
@@ -83,7 +76,7 @@ export default class PostFlagIcon extends React.PureComponent {
                 }
             >
                 <button
-                    id={flagIconId || `${this.props.idPrefix}_${this.props.postId}`}
+                    id={`${this.props.location}_flagIcon_${this.props.postId}`}
                     className={'style--none flag-icon__container ' + flagVisible}
                     onClick={this.handlePress}
                 >

--- a/components/post_view/post_flag_icon/post_flag_icon.test.js
+++ b/components/post_view/post_flag_icon/post_flag_icon.test.js
@@ -8,7 +8,6 @@ import PostFlagIcon from 'components/post_view/post_flag_icon/post_flag_icon';
 
 describe('components/post_view/PostFlagIcon', () => {
     const baseProps = {
-        idPrefix: 'centerPostFlag',
         postId: 'post_id',
         isFlagged: false,
         isEphemeral: false,

--- a/components/post_view/post_header/post_header.jsx
+++ b/components/post_view/post_header/post_header.jsx
@@ -43,11 +43,6 @@ export default class PostHeader extends React.PureComponent {
          */
         isFirstReply: PropTypes.bool,
 
-        /*
-         * Post identifiers for selenium tests
-         */
-        lastPostCount: PropTypes.number,
-
         /**
          * Function to get the post list HTML element
          */
@@ -156,7 +151,6 @@ export default class PostHeader extends React.PureComponent {
                         handleCommentClick={this.props.handleCommentClick}
                         handleDropdownOpened={this.props.handleDropdownOpened}
                         compactDisplay={this.props.compactDisplay}
-                        lastPostCount={this.props.lastPostCount}
                         replyCount={this.props.replyCount}
                         isFirstReply={this.props.isFirstReply}
                         showTimeWithoutHover={this.props.showTimeWithoutHover}

--- a/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
+++ b/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
@@ -112,8 +112,6 @@ exports[`components/post_view/PostInfo should match snapshot, flagged post 1`] =
     className="col"
   >
     <Connect(PostFlagIcon)
-      idCount={-1}
-      idPrefix="centerPostFlag"
       isEphemeral={false}
       isFlagged={true}
       postId="e584uzbwwpny9kengqayx5ayzw"
@@ -138,8 +136,6 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
       postId="e584uzbwwpny9kengqayx5ayzw"
     />
     <Connect(PostFlagIcon)
-      idCount={-1}
-      idPrefix="centerPostFlag"
       isEphemeral={false}
       isFlagged={false}
       postId="e584uzbwwpny9kengqayx5ayzw"
@@ -155,7 +151,6 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
       handleCommentClick={[MockFunction]}
       handleDropdownOpened={[Function]}
       isFlagged={false}
-      location="CENTER"
       post={
         Object {
           "channel_id": "g6139tbospd18cmxroesdk3kkc",
@@ -181,8 +176,7 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
       commentCount={0}
       extraClass="pull-right"
       handleCommentClick={[MockFunction]}
-      idCount={-1}
-      idPrefix="commentIcon"
+      location="CENTER"
       postId="e584uzbwwpny9kengqayx5ayzw"
       searchStyle=""
     />
@@ -262,7 +256,6 @@ exports[`components/post_view/PostInfo toggleEmojiPicker, should have called pro
       handleCommentClick={[MockFunction]}
       handleDropdownOpened={[Function]}
       isFlagged={false}
-      location="CENTER"
       post={
         Object {
           "channel_id": "g6139tbospd18cmxroesdk3kkc",
@@ -295,8 +288,7 @@ exports[`components/post_view/PostInfo toggleEmojiPicker, should have called pro
       commentCount={0}
       extraClass="pull-right"
       handleCommentClick={[MockFunction]}
-      idCount={-1}
-      idPrefix="commentIcon"
+      location="CENTER"
       postId="e584uzbwwpny9kengqayx5ayzw"
       searchStyle=""
     />

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -8,7 +8,6 @@ import {FormattedMessage} from 'react-intl';
 import {Posts} from 'mattermost-redux/constants';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
 
-import Constants from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 import CommentIcon from 'components/common/comment_icon.jsx';
@@ -59,11 +58,6 @@ export default class PostInfo extends React.PureComponent {
          * Set to render in mobile view
          */
         isMobile: PropTypes.bool,
-
-        /*
-         * Post identifiers for selenium tests
-         */
-        lastPostCount: PropTypes.number,
 
         /**
          * Set to render in compact view
@@ -144,7 +138,7 @@ export default class PostInfo extends React.PureComponent {
         return this.refs.dotMenu;
     };
 
-    buildOptions = (post, isSystemMessage, fromAutoResponder, idCount) => {
+    buildOptions = (post, isSystemMessage, fromAutoResponder) => {
         if (!PostUtils.shouldShowDotMenu(post)) {
             return null;
         }
@@ -159,8 +153,6 @@ export default class PostInfo extends React.PureComponent {
         if (showCommentIcon) {
             commentIcon = (
                 <CommentIcon
-                    idPrefix='commentIcon'
-                    idCount={idCount}
                     handleCommentClick={this.props.handleCommentClick}
                     commentCount={this.props.replyCount}
                     postId={post.id}
@@ -190,7 +182,6 @@ export default class PostInfo extends React.PureComponent {
             dotMenu = (
                 <DotMenu
                     post={post}
-                    location={'CENTER'}
                     commentCount={this.props.replyCount}
                     isFlagged={this.props.isFlagged}
                     handleCommentClick={this.props.handleCommentClick}
@@ -217,11 +208,6 @@ export default class PostInfo extends React.PureComponent {
     render() {
         const post = this.props.post;
 
-        let idCount = -1;
-        if (this.props.lastPostCount >= 0 && this.props.lastPostCount < Constants.TEST_ID_COUNT) {
-            idCount = this.props.lastPostCount;
-        }
-
         const isEphemeral = Utils.isPostEphemeral(post);
         const isSystemMessage = PostUtils.isSystemMessage(post);
         const fromAutoResponder = PostUtils.fromAutoResponder(post);
@@ -231,8 +217,6 @@ export default class PostInfo extends React.PureComponent {
         if (showFlagIcon) {
             postFlagIcon = (
                 <PostFlagIcon
-                    idPrefix='centerPostFlag'
-                    idCount={idCount}
                     postId={post.id}
                     isFlagged={this.props.isFlagged}
                     isEphemeral={isEphemeral}
@@ -248,7 +232,7 @@ export default class PostInfo extends React.PureComponent {
                 </div>
             );
         } else if (!post.failed) {
-            options = this.buildOptions(post, isSystemMessage, fromAutoResponder, idCount);
+            options = this.buildOptions(post, isSystemMessage, fromAutoResponder);
         }
 
         let visibleMessage;

--- a/components/post_view/post_info/post_info.test.jsx
+++ b/components/post_view/post_info/post_info.test.jsx
@@ -33,7 +33,6 @@ describe('components/post_view/PostInfo', () => {
         handleCommentClick: jest.fn(),
         handleDropdownOpened: jest.fn(),
         compactDisplay: false,
-        lastPostCount: 0,
         replyCount: 0,
         getPostList: jest.fn(),
         useMilitaryTime: false,

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -565,7 +565,6 @@ export default class PostList extends React.PureComponent {
                     ref={post.id}
                     key={'post ' + (post.id || post.pending_post_id)}
                     post={post}
-                    lastPostCount={(i >= 0 && i < Constants.TEST_ID_COUNT) ? i : -1}
                     getPostList={this.getPostList}
                 />
             );

--- a/components/post_view/post_message_view/__snapshots__/post_message_view.test.jsx.snap
+++ b/components/post_view/post_message_view/__snapshots__/post_message_view.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
 >
   <div
     className="post-message__text"
-    id="lastPostMessageText1"
+    id="postMessageText_post_id"
     onClick={[Function]}
   >
     <Connect(PostMarkdown)
@@ -46,7 +46,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show Less
 >
   <div
     className="post-message__text"
-    id="lastPostMessageText1"
+    id="postMessageText_post_id"
     onClick={[Function]}
   >
     <Connect(PostMarkdown)
@@ -84,7 +84,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show More
 >
   <div
     className="post-message__text"
-    id="lastPostMessageText1"
+    id="postMessageText_post_id"
     onClick={[Function]}
   >
     <Connect(PostMarkdown)
@@ -142,7 +142,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on edited po
 >
   <div
     className="post-message__text"
-    id="lastPostMessageText1"
+    id="postMessageText_post_id"
     onClick={[Function]}
   >
     <Connect(PostMarkdown)
@@ -202,7 +202,7 @@ exports[`components/post_view/PostAttachment should match snapshot, on ephemeral
 >
   <div
     className="post-message__text"
-    id="lastPostMessageText1"
+    id="postMessageText_post_id"
     onClick={[Function]}
   >
     <Connect(PostMarkdown)

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -35,11 +35,6 @@ export default class PostMessageView extends React.PureComponent {
          */
         options: PropTypes.object,
 
-        /*
-         * Post identifiers for selenium tests
-         */
-        lastPostCount: PropTypes.number,
-
         /**
          * Set to render post body compactly
          */
@@ -139,7 +134,6 @@ export default class PostMessageView extends React.PureComponent {
             compactDisplay,
             isRHS,
             theme,
-            lastPostCount,
         } = this.props;
 
         if (post.state === Posts.POST_DELETED) {
@@ -163,11 +157,6 @@ export default class PostMessageView extends React.PureComponent {
             );
         }
 
-        let postId = null;
-        if (lastPostCount >= 0) {
-            postId = Utils.createSafeId('lastPostMessageText' + lastPostCount);
-        }
-
         let message = post.message;
         const isEphemeral = Utils.isPostEphemeral(post);
         if (compactDisplay && isEphemeral) {
@@ -182,7 +171,7 @@ export default class PostMessageView extends React.PureComponent {
                 text={message}
             >
                 <div
-                    id={postId}
+                    id={`postMessageText_${post.id}`}
                     className='post-message__text'
                     onClick={Utils.handleFormattedTextClick}
                 >

--- a/components/post_view/post_message_view/post_message_view.test.jsx
+++ b/components/post_view/post_message_view/post_message_view.test.jsx
@@ -26,7 +26,6 @@ describe('components/post_view/PostAttachment', () => {
         post,
         enableFormatting: true,
         options: {},
-        lastPostCount: 1,
         compactDisplay: false,
         isRHS: false,
         isRHSOpen: false,

--- a/components/post_view/post_reaction/post_reaction.jsx
+++ b/components/post_view/post_reaction/post_reaction.jsx
@@ -8,6 +8,8 @@ import {FormattedMessage} from 'react-intl';
 
 import Permissions from 'mattermost-redux/constants/permissions';
 
+import {Locations} from 'utils/constants.jsx';
+
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 import EmojiIcon from 'components/svg/emoji_icon';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
@@ -20,7 +22,7 @@ export default class PostReaction extends React.PureComponent {
         postId: PropTypes.string.isRequired,
         teamId: PropTypes.string.isRequired,
         getDotMenuRef: PropTypes.func.isRequired,
-        location: PropTypes.oneOf(['CENTER', 'RHS_ROOT', 'RHS_COMMENT']).isRequired,
+        location: PropTypes.oneOf([Locations.CENTER, Locations.RHS_ROOT, Locations.RHS_COMMENT]).isRequired,
         showEmojiPicker: PropTypes.bool.isRequired,
         toggleEmojiPicker: PropTypes.func.isRequired,
         actions: PropTypes.shape({
@@ -29,7 +31,7 @@ export default class PostReaction extends React.PureComponent {
     };
 
     static defaultProps = {
-        location: 'CENTER',
+        location: Locations.CENTER,
         showEmojiPicker: false,
     };
 
@@ -51,7 +53,7 @@ export default class PostReaction extends React.PureComponent {
 
         let spaceRequiredAbove;
         let spaceRequiredBelow;
-        if (location === 'RHS_ROOT' || location === 'RHS_COMMENT') {
+        if (location === Locations.RHS_ROOT || location === Locations.RHS_COMMENT) {
             spaceRequiredAbove = EmojiPickerOverlay.RHS_SPACE_REQUIRED_ABOVE;
             spaceRequiredBelow = EmojiPickerOverlay.RHS_SPACE_REQUIRED_BELOW;
         }

--- a/components/post_view/post_reaction/post_reaction.test.jsx
+++ b/components/post_view/post_reaction/post_reaction.test.jsx
@@ -13,7 +13,6 @@ describe('components/post_view/PostReaction', () => {
         teamId: 'current_team_id',
         getDotMenuRef: jest.fn(),
         showIcon: false,
-        location: 'CENTER',
         showEmojiPicker: false,
         toggleEmojiPicker: jest.fn(),
         actions: {

--- a/components/post_view/post_time/post_time.jsx
+++ b/components/post_view/post_time/post_time.jsx
@@ -7,6 +7,7 @@ import {Link} from 'react-router-dom';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {isMobile} from 'utils/user_agent.jsx';
+import {Locations} from 'utils/constants.jsx';
 import {isMobile as isMobileView} from 'utils/utils.jsx';
 import LocalDateTime from 'components/local_date_time';
 
@@ -23,7 +24,7 @@ export default class PostTime extends React.PureComponent {
          */
         eventTime: PropTypes.number.isRequired,
 
-        location: PropTypes.oneOf(['CENTER', 'RHS_ROOT', 'RHS_COMMENT', 'SEARCH']).isRequired,
+        location: PropTypes.oneOf([Locations.CENTER, Locations.RHS_ROOT, Locations.RHS_COMMENT, Locations.SEARCH]).isRequired,
 
         /*
          * The post id of posting being rendered
@@ -34,7 +35,7 @@ export default class PostTime extends React.PureComponent {
 
     static defaultProps = {
         eventTime: 0,
-        location: 'CENTER',
+        location: Locations.CENTER,
     };
 
     handleClick = () => {

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -10,7 +10,7 @@ import {
     isPostPendingOrFailed,
 } from 'mattermost-redux/utils/post_utils';
 
-import Constants from 'utils/constants.jsx';
+import Constants, {Locations} from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 import DotMenu from 'components/dot_menu';
@@ -29,7 +29,6 @@ export default class RhsComment extends React.Component {
     static propTypes = {
         post: PropTypes.object,
         teamId: PropTypes.string.isRequired,
-        lastPostCount: PropTypes.number,
         currentUserId: PropTypes.string.isRequired,
         compactDisplay: PropTypes.bool,
         isFlagged: PropTypes.bool,
@@ -73,10 +72,6 @@ export default class RhsComment extends React.Component {
         }
 
         if (this.state.showEmojiPicker !== nextState.showEmojiPicker) {
-            return true;
-        }
-
-        if (nextProps.lastPostCount !== this.props.lastPostCount) {
             return true;
         }
 
@@ -131,7 +126,7 @@ export default class RhsComment extends React.Component {
                 isPermalink={isPermalink}
                 eventTime={post.create_at}
                 postId={post.id}
-                location='RHS_COMMENT'
+                location={Locations.RHS_COMMENT}
             />
         );
     };
@@ -194,11 +189,6 @@ export default class RhsComment extends React.Component {
 
     render() {
         const {post, isConsecutivePost, isReadOnly, channelIsArchived} = this.props;
-
-        let idCount = -1;
-        if (this.props.lastPostCount >= 0 && this.props.lastPostCount < Constants.TEST_ID_COUNT) {
-            idCount = this.props.lastPostCount;
-        }
 
         const isEphemeral = isPostEphemeral(post);
         const isSystemMessage = PostUtils.isSystemMessage(post);
@@ -331,7 +321,7 @@ export default class RhsComment extends React.Component {
                     postId={post.id}
                     teamId={this.props.teamId}
                     getDotMenuRef={this.getDotMenuRef}
-                    location='RHS_COMMENT'
+                    location={Locations.RHS_COMMENT}
                     showEmojiPicker={this.state.showEmojiPicker}
                     toggleEmojiPicker={this.toggleEmojiPicker}
                 />
@@ -349,7 +339,7 @@ export default class RhsComment extends React.Component {
             const dotMenu = (
                 <DotMenu
                     post={this.props.post}
-                    location='RHS_COMMENT'
+                    location={Locations.RHS_COMMENT}
                     isFlagged={this.props.isFlagged}
                     handleDropdownOpened={this.handleDropdownOpened}
                     handleAddReactionClick={this.toggleEmojiPicker}
@@ -383,8 +373,7 @@ export default class RhsComment extends React.Component {
 
         const flagIcon = (
             <PostFlagIcon
-                idPrefix={'rhsCommentFlag'}
-                idCount={idCount}
+                location={Locations.RHS_COMMENT}
                 postId={post.id}
                 isFlagged={this.props.isFlagged}
                 isEphemeral={isEphemeral}

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 import {Posts} from 'mattermost-redux/constants';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
 
-import Constants from 'utils/constants.jsx';
+import Constants, {Locations} from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 import DotMenu from 'components/dot_menu';
@@ -116,7 +116,7 @@ export default class RhsRootPost extends React.Component {
                 isPermalink={isPermalink}
                 eventTime={post.create_at}
                 postId={post.id}
-                location={'RHS_ROOT'}
+                location={Locations.RHS_ROOT}
             />
         );
     };
@@ -190,7 +190,7 @@ export default class RhsRootPost extends React.Component {
                     postId={post.id}
                     teamId={teamId}
                     getDotMenuRef={this.getDotMenuRef}
-                    location='RHS_ROOT'
+                    location={Locations.RHS_ROOT}
                     showEmojiPicker={this.state.showEmojiPicker}
                     toggleEmojiPicker={this.toggleEmojiPicker}
                 />
@@ -277,7 +277,7 @@ export default class RhsRootPost extends React.Component {
         const dotMenu = (
             <DotMenu
                 post={this.props.post}
-                location={'RHS_ROOT'}
+                location={Locations.RHS_ROOT}
                 isFlagged={this.props.isFlagged}
                 handleDropdownOpened={this.handleDropdownOpened}
                 handleAddReactionClick={this.toggleEmojiPicker}
@@ -304,7 +304,7 @@ export default class RhsRootPost extends React.Component {
         if (this.props.post.type !== Constants.PostTypes.FAKE_PARENT_DELETED) {
             postFlagIcon = (
                 <PostFlagIcon
-                    idPrefix={'rhsRootPostFlag'}
+                    location={Locations.RHS_ROOT}
                     postId={post.id}
                     isFlagged={this.props.isFlagged}
                 />

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -260,7 +260,6 @@ export default class RhsThread extends React.Component {
             }
 
             const keyPrefix = comPost.id ? comPost.id : comPost.pending_post_id;
-            const reverseCount = postsLength - i - 1;
 
             commentsLists.push(
                 <RhsComment
@@ -269,7 +268,6 @@ export default class RhsThread extends React.Component {
                     post={comPost}
                     previousPostId={previousPostId}
                     teamId={this.props.channel.team_id}
-                    lastPostCount={(reverseCount >= 0 && reverseCount < Constants.TEST_ID_COUNT) ? reverseCount : -1}
                     currentUserId={currentUserId}
                     isBusy={this.state.isBusy}
                     removePost={this.props.actions.removePost}

--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -7,7 +7,6 @@ import Scrollbars from 'react-custom-scrollbars';
 
 import {debounce} from 'mattermost-redux/actions/helpers';
 
-import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import SearchResultsHeader from 'components/search_results_header';
@@ -182,16 +181,13 @@ export default class SearchResults extends React.PureComponent {
                 sortedResults = results;
             }
 
-            ctls = sortedResults.map((post, idx, arr) => {
-                const reverseCount = arr.length - idx - 1;
-
+            ctls = sortedResults.map((post) => {
                 return (
                     <SearchResultsItem
                         key={post.id}
                         compactDisplay={this.props.compactDisplay}
                         post={post}
                         matches={this.props.matches[post.id]}
-                        lastPostCount={(reverseCount >= 0 && reverseCount < Constants.TEST_ID_COUNT) ? reverseCount : -1}
                         term={(!this.props.isFlaggedPosts && !this.props.isPinnedPosts && !this.props.isMentionSearch) ? searchTerms : ''}
                         isMentionSearch={this.props.isMentionSearch}
                     />

--- a/components/search_results_item/__snapshots__/search_results_item.test.jsx.snap
+++ b/components/search_results_item/__snapshots__/search_results_item.test.jsx.snap
@@ -99,9 +99,8 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
               />
             </span>
             <Connect(PostFlagIcon)
-              idCount={-1}
-              idPrefix="searchPostFlag"
               isFlagged={true}
+              location="SEARCH"
               postId="id"
             />
           </div>
@@ -137,8 +136,7 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
               commentCount={0}
               extraClass=""
               handleCommentClick={[Function]}
-              idCount={-1}
-              idPrefix="searchCommentIcon"
+              location="SEARCH"
               postId="id"
               searchStyle="search-item__comment"
             />
@@ -305,9 +303,8 @@ exports[`components/SearchResultsItem should match snapshot for archived channel
               postId="id"
             />
             <Connect(PostFlagIcon)
-              idCount={-1}
-              idPrefix="searchPostFlag"
               isFlagged={true}
+              location="SEARCH"
               postId="id"
             />
           </div>
@@ -343,8 +340,7 @@ exports[`components/SearchResultsItem should match snapshot for archived channel
               commentCount={0}
               extraClass=""
               handleCommentClick={[Function]}
-              idCount={-1}
-              idPrefix="searchCommentIcon"
+              location="SEARCH"
               postId="id"
               searchStyle="search-item__comment"
             />
@@ -511,9 +507,8 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
               postId="id"
             />
             <Connect(PostFlagIcon)
-              idCount={-1}
-              idPrefix="searchPostFlag"
               isFlagged={true}
+              location="SEARCH"
               postId="id"
             />
           </div>
@@ -549,8 +544,7 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
               commentCount={0}
               extraClass=""
               handleCommentClick={[Function]}
-              idCount={-1}
-              idPrefix="searchCommentIcon"
+              location="SEARCH"
               postId="id"
               searchStyle="search-item__comment"
             />

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -20,7 +20,7 @@ import ArchiveIcon from 'components/svg/archive_icon';
 import PostTime from 'components/post_view/post_time';
 import {browserHistory} from 'utils/browser_history';
 
-import Constants from 'utils/constants.jsx';
+import Constants, {Locations} from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -36,11 +36,6 @@ export default class SearchResultsItem extends React.PureComponent {
         * An array of strings in this post that were matched by the search
         */
         matches: PropTypes.array,
-
-        /**
-        *  count used for passing down to PostFlagIcon, DotMenu and CommentIcon
-        */
-        lastPostCount: PropTypes.number,
 
         /**
         *  channel object for rendering channel name on top of result
@@ -131,7 +126,7 @@ export default class SearchResultsItem extends React.PureComponent {
                 isPermalink={isPermalink}
                 eventTime={post.create_at}
                 postId={post.id}
-                location='SEARCH'
+                location={Locations.SEARCH}
             />
         );
     };
@@ -233,8 +228,7 @@ export default class SearchResultsItem extends React.PureComponent {
         } else {
             flagContent = (
                 <PostFlagIcon
-                    idPrefix={'searchPostFlag'}
-                    idCount={this.props.lastPostCount}
+                    location={Locations.SEARCH}
                     postId={post.id}
                     isFlagged={this.props.isFlagged}
                 />
@@ -244,15 +238,14 @@ export default class SearchResultsItem extends React.PureComponent {
                 <div className='col__controls col__reply'>
                     <DotMenu
                         post={post}
-                        location={'SEARCH'}
+                        location={Locations.SEARCH}
                         isFlagged={this.props.isFlagged}
                         handleDropdownOpened={this.handleDropdownOpened}
                         commentCount={this.props.commentCountForPost}
                         isReadOnly={channelIsArchived || null}
                     />
                     <CommentIcon
-                        idPrefix={'searchCommentIcon'}
-                        idCount={this.props.lastPostCount}
+                        location={Locations.SEARCH}
                         handleCommentClick={this.handleFocusRHSClick}
                         postId={post.id}
                         searchStyle={'search-item__comment'}

--- a/components/search_results_item/search_results_item.test.jsx
+++ b/components/search_results_item/search_results_item.test.jsx
@@ -70,7 +70,6 @@ describe('components/SearchResultsItem', () => {
             channel,
             compactDisplay: true,
             post,
-            lastPostCount: -1,
             user,
             currentTeamName: 'test',
             term: 'test',

--- a/cypress/integration/post_header/post_header_spec.js
+++ b/cypress/integration/post_header/post_header_spec.js
@@ -65,19 +65,19 @@ describe('Post Header', () => {
 
         cy.getLastPostId().then((postId) => {
             // * Check that the center flag icon of a post is not visible
-            cy.get(`#centerPostFlag_${postId}`).should('not.be.visible');
+            cy.get(`#CENTER_flagIcon_${postId}`).should('not.be.visible');
 
             // 4. Click the center flag icon of a post
             cy.clickPostFlagIcon(postId);
 
             // * Check that the center flag icon of a post becomes visible
-            cy.get(`#centerPostFlag_${postId}`).should('be.visible').should('have.attr', 'class', 'style--none flag-icon__container visible');
+            cy.get(`#CENTER_flagIcon_${postId}`).should('be.visible').should('have.attr', 'class', 'style--none flag-icon__container visible');
 
             // 5. Click again the center flag icon of a post
             cy.clickPostFlagIcon(postId);
 
             // * Check that the center flag icon of a post is now hidden.
-            cy.get(`#centerPostFlag_${postId}`).should('not.be.visible');
+            cy.get(`#CENTER_flagIcon_${postId}`).should('not.be.visible');
         });
     });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -160,68 +160,88 @@ Cypress.Commands.add('getLastPostId', () => {
 // Post header
 // ***********************************************************
 
-// Click post time at center view
-Cypress.Commands.add('clickPostTime', (postId) => {
+/**
+ * Click post time
+ * @param {String} postId - Post ID
+ * @param {String} location - as 'CENTER', 'RHS_ROOT', 'RHS_COMMENT', 'SEARCH'
+ */
+Cypress.Commands.add('clickPostTime', (postId, location = 'CENTER') => {
     if (postId) {
         cy.get(`#post_${postId}`).trigger('mouseover');
-        cy.get(`#CENTER_time_${postId}`).click({force: true});
+        cy.get(`#${location}_time_${postId}`).click({force: true});
     } else {
         cy.getLastPostId().then((lastPostId) => {
             cy.get(`#post_${lastPostId}`).trigger('mouseover');
-            cy.get(`#CENTER_time_${lastPostId}`).click({force: true});
+            cy.get(`#${location}_time_${lastPostId}`).click({force: true});
         });
     }
 });
 
-// Click flag icon by post ID or to most recent post (if post ID is not provided)
-Cypress.Commands.add('clickPostFlagIcon', (postId) => {
+/**
+ * Click flag icon by post ID or to most recent post (if post ID is not provided)
+ * @param {String} postId - Post ID
+ * @param {String} location - as 'CENTER', 'RHS_ROOT', 'RHS_COMMENT', 'SEARCH'
+ */
+Cypress.Commands.add('clickPostFlagIcon', (postId, location = 'CENTER') => {
     if (postId) {
         cy.get(`#post_${postId}`).trigger('mouseover');
-        cy.get(`#centerPostFlag_${postId}`).click({force: true});
+        cy.get(`#${location}_flagIcon_${postId}`).click({force: true});
     } else {
         cy.getLastPostId().then((lastPostId) => {
             cy.get(`#post_${lastPostId}`).trigger('mouseover');
-            cy.get(`#centerPostFlag_${lastPostId}`).click({force: true});
+            cy.get(`#${location}_flagIcon_${lastPostId}`).click({force: true});
         });
     }
 });
 
-// Click dot menu by post ID or to most recent post (if post ID is not provided)
-Cypress.Commands.add('clickPostDotMenu', (postId) => {
+/**
+ * Click dot menu by post ID or to most recent post (if post ID is not provided)
+ * @param {String} postId - Post ID
+ * @param {String} location - as 'CENTER', 'RHS_ROOT', 'RHS_COMMENT', 'SEARCH'
+ */
+Cypress.Commands.add('clickPostDotMenu', (postId, location = 'CENTER') => {
     if (postId) {
         cy.get(`#post_${postId}`).trigger('mouseover');
-        cy.get(`#CENTER_button_${postId}`).click({force: true});
+        cy.get(`#${location}_button_${postId}`).click({force: true});
     } else {
         cy.getLastPostId().then((lastPostId) => {
             cy.get(`#post_${lastPostId}`).trigger('mouseover');
-            cy.get(`#CENTER_button_${lastPostId}`).click({force: true});
+            cy.get(`#${location}_button_${lastPostId}`).click({force: true});
         });
     }
 });
 
-// Click post reaction icon at center view
-Cypress.Commands.add('clickPostReactionIcon', (postId) => {
+/**
+ * Click post reaction icon
+ * @param {String} postId - Post ID
+ * @param {String} location - as 'CENTER', 'RHS_ROOT', 'RHS_COMMENT'
+ */
+Cypress.Commands.add('clickPostReactionIcon', (postId, location = 'CENTER') => {
     if (postId) {
         cy.get(`#post_${postId}`).trigger('mouseover');
-        cy.get(`#CENTER_reaction_${postId}`).click({force: true});
+        cy.get(`#${location}_reaction_${postId}`).click({force: true});
     } else {
         cy.getLastPostId().then((lastPostId) => {
             cy.get(`#post_${lastPostId}`).trigger('mouseover');
-            cy.get(`#CENTER_reaction_${lastPostId}`).click({force: true});
+            cy.get(`#${location}_reaction_${lastPostId}`).click({force: true});
         });
     }
 });
 
-// Click comment icon by post ID or to most recent post (if post ID is not provided)
-// This open up the RHS
-Cypress.Commands.add('clickPostCommentIcon', (postId) => {
+/**
+ * Click comment icon by post ID or to most recent post (if post ID is not provided)
+ * This open up the RHS
+ * @param {String} postId - Post ID
+ * @param {String} location - as 'CENTER', 'SEARCH'
+ */
+Cypress.Commands.add('clickPostCommentIcon', (postId, location = 'CENTER') => {
     if (postId) {
         cy.get(`#post_${postId}`).trigger('mouseover');
-        cy.get(`#commentIcon_${postId}`).click({force: true});
+        cy.get(`#${location}_commentIcon_${postId}`).click({force: true});
     } else {
         cy.getLastPostId().then((lastPostId) => {
             cy.get(`#post_${lastPostId}`).trigger('mouseover');
-            cy.get(`#commentIcon_${lastPostId}`).click({force: true});
+            cy.get(`#${location}_commentIcon_${lastPostId}`).click({force: true});
         });
     }
 });

--- a/plugins/test/__snapshots__/post_type.test.jsx.snap
+++ b/plugins/test/__snapshots__/post_type.test.jsx.snap
@@ -24,6 +24,7 @@ exports[`plugins/PostMessageView should match snapshot with extended post type 1
   }
   post={
     Object {
+      "id": "post_id",
       "message": "this is some text",
       "type": "testtype",
     }
@@ -43,6 +44,7 @@ exports[`plugins/PostMessageView should match snapshot with extended post type 1
     isRHS={false}
     post={
       Object {
+        "id": "post_id",
         "message": "this is some text",
         "type": "testtype",
       }
@@ -70,7 +72,7 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
 >
   <div
     className="post-message__text"
-    id={null}
+    id="postMessageText_post_id"
     onClick={[Function]}
   >
     <Connect(PostMarkdown)
@@ -84,6 +86,7 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
       options={Object {}}
       post={
         Object {
+          "id": "post_id",
           "message": "this is some text",
           "type": "testtype",
         }
@@ -93,6 +96,7 @@ exports[`plugins/PostMessageView should match snapshot with no extended post typ
   <Connect(Pluggable)
     onHeightChange={[Function]}
     pluggableName="PostMessageAttachment"
+    postId="post_id"
   />
 </Connect(ShowMore)>
 `;

--- a/plugins/test/post_type.test.jsx
+++ b/plugins/test/post_type.test.jsx
@@ -13,7 +13,7 @@ class PostTypePlugin extends React.PureComponent {
 }
 
 describe('plugins/PostMessageView', () => {
-    const post = {type: 'testtype', message: 'this is some text'};
+    const post = {type: 'testtype', message: 'this is some text', id: 'post_id'};
     const pluginPostTypes = {
         testtype: {component: PostTypePlugin},
     };

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -65,7 +65,7 @@ beforeEach(() => {
 
 afterEach(() => {
     if (logs.length > 0 || warns.length > 0 || errors.length > 0) {
-        throw new Error('Unexpected console logs' + logs + warns + errors);
+        // throw new Error('Unexpected console logs' + logs + warns + errors);
     }
 });
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -65,7 +65,7 @@ beforeEach(() => {
 
 afterEach(() => {
     if (logs.length > 0 || warns.length > 0 || errors.length > 0) {
-        // throw new Error('Unexpected console logs' + logs + warns + errors);
+        throw new Error('Unexpected console logs' + logs + warns + errors);
     }
 });
 

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -565,6 +565,13 @@ export const DefaultRolePermissions = {
     ],
 };
 
+export const Locations = {
+    CENTER: 'CENTER',
+    RHS_ROOT: 'RHS_ROOT',
+    RHS_COMMENT: 'RHS_COMMENT',
+    SEARCH: 'SEARCH',
+};
+
 export const Constants = {
     SettingsTypes,
     JobTypes,
@@ -579,6 +586,7 @@ export const Constants = {
     AnnouncementBarTypes,
     AnnouncementBarMessages,
     FileTypes,
+    Locations,
 
     MAX_POST_VISIBILITY: 1000000,
 
@@ -1212,10 +1220,6 @@ export const Constants = {
     ANIMATION_TIMEOUT: 1000,
     SEARCH_TIMEOUT_MILLISECONDS: 100,
     DIAGNOSTICS_SEGMENT_KEY: 'placeholder_segment_key',
-    TEST_ID_COUNT: 0,
-    CENTER: 'center',
-    RHS: 'rhs',
-    RHS_ROOT: 'rhsroot',
     TEAMMATE_NAME_DISPLAY: {
         SHOW_USERNAME: 'username',
         SHOW_NICKNAME_FULLNAME: 'nickname_full_name',


### PR DESCRIPTION
#### Summary
Due to some limitation of Se to identify post ID, dynamic IDs for Post component were introduced to make the last post/s be testable. Props were added for that purpose such as lastPostCount, idCount and idPrefix.  However, those dynamic IDs were eventually disabled due to unnecessary re-rendering of components on change of props (counts changed whenever new post/s arrived/submitted).  Related Se tests were eventually either disabled or put on manual tests.

With Cypress, we have now the ability to get post ID like `cy.getLastPostId()` or in the future we can add command like `cy.getPostId(xNumberFromRecent)`. 

This PR removed props such as lastPostCount, idCount and idPrefix.  This also aimed to organize how to assign ID into a component.  Naming convention is like `[location]_[name]_[post_id]` where location is either on CENTER, RHS_ROOT, RHS_COMMENT or SEARCH.

#### Ticket Link
Jira ticket: [MM-14242](https://mattermost.atlassian.net/browse/MM-14242)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Updated E2E
