### PR TITLE
[MM-12945] Display alternate title text when mute is enabled

### DIFF
--- a/components/channel_notifications_modal/components/__snapshots__/collapse_view.test.jsx.snap
+++ b/components/channel_notifications_modal/components/__snapshots__/collapse_view.test.jsx.snap
@@ -5,9 +5,9 @@ exports[`components/channel_notifications_modal/CollapseView should match snapsh
   describe={
     <Describe
       globalNotifyLevel="default"
+      isCollapsed={true}
       memberNotifyLevel="all"
       section="desktop"
-      view="collapse"
     />
   }
   focused={false}
@@ -26,9 +26,9 @@ exports[`components/channel_notifications_modal/CollapseView should match snapsh
   describe={
     <Describe
       globalNotifyLevel={null}
+      isCollapsed={true}
       memberNotifyLevel="all"
       section="markUnread"
-      view="collapse"
     />
   }
   focused={false}
@@ -47,9 +47,9 @@ exports[`components/channel_notifications_modal/CollapseView should match snapsh
   describe={
     <Describe
       globalNotifyLevel="default"
+      isCollapsed={true}
       memberNotifyLevel="all"
       section="push"
-      view="collapse"
     />
   }
   focused={false}

--- a/components/channel_notifications_modal/components/__snapshots__/collapse_view.test.jsx.snap
+++ b/components/channel_notifications_modal/components/__snapshots__/collapse_view.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`components/channel_notifications_modal/CollapseView should match snapsh
       globalNotifyLevel="default"
       memberNotifyLevel="all"
       section="desktop"
+      view="collapse"
     />
   }
   focused={false}
@@ -27,6 +28,7 @@ exports[`components/channel_notifications_modal/CollapseView should match snapsh
       globalNotifyLevel={null}
       memberNotifyLevel="all"
       section="markUnread"
+      view="collapse"
     />
   }
   focused={false}
@@ -47,6 +49,7 @@ exports[`components/channel_notifications_modal/CollapseView should match snapsh
       globalNotifyLevel="default"
       memberNotifyLevel="all"
       section="push"
+      view="collapse"
     />
   }
   focused={false}

--- a/components/channel_notifications_modal/components/collapse_view.jsx
+++ b/components/channel_notifications_modal/components/collapse_view.jsx
@@ -19,6 +19,7 @@ export default function CollapseView({onExpandSection, globalNotifyLevel, member
                     ignoreChannelMentions={ignoreChannelMentions}
                     memberNotifyLevel={memberNotifyLevel}
                     globalNotifyLevel={globalNotifyLevel}
+                    view={'collapse'}
                 />
             }
             updateSection={onExpandSection}

--- a/components/channel_notifications_modal/components/collapse_view.jsx
+++ b/components/channel_notifications_modal/components/collapse_view.jsx
@@ -19,7 +19,7 @@ export default function CollapseView({onExpandSection, globalNotifyLevel, member
                     ignoreChannelMentions={ignoreChannelMentions}
                     memberNotifyLevel={memberNotifyLevel}
                     globalNotifyLevel={globalNotifyLevel}
-                    view={'collapse'}
+                    isCollapsed={true}
                 />
             }
             updateSection={onExpandSection}

--- a/components/channel_notifications_modal/components/describe.jsx
+++ b/components/channel_notifications_modal/components/describe.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {IgnoreChannelMentions, NotificationLevels, NotificationSections} from 'utils/constants.jsx';
 
-export default function Describe({section, view, memberNotifyLevel, globalNotifyLevel, ignoreChannelMentions}) {
+export default function Describe({section, isCollapsed, memberNotifyLevel, globalNotifyLevel, ignoreChannelMentions}) {
     if (memberNotifyLevel === NotificationLevels.DEFAULT && globalNotifyLevel) {
         return (
             <FormattedMessage
@@ -19,7 +19,7 @@ export default function Describe({section, view, memberNotifyLevel, globalNotify
             />
         );
     } else if (memberNotifyLevel === NotificationLevels.MENTION && section === NotificationSections.MARK_UNREAD) {
-        if (view === 'collapse') {
+        if (isCollapsed) {
             return (
                 <FormattedMessage
                     id='channel_notifications.muteChannel.on.title.collapse'
@@ -95,5 +95,5 @@ Describe.propTypes = {
     ignoreChannelMentions: PropTypes.string,
     memberNotifyLevel: PropTypes.string.isRequired,
     section: PropTypes.string.isRequired,
-    view: PropTypes.string,
+    isCollapsed: PropTypes.bool,
 };

--- a/components/channel_notifications_modal/components/describe.jsx
+++ b/components/channel_notifications_modal/components/describe.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {IgnoreChannelMentions, NotificationLevels, NotificationSections} from 'utils/constants.jsx';
 
-export default function Describe({section, memberNotifyLevel, globalNotifyLevel, ignoreChannelMentions}) {
+export default function Describe({section, view, memberNotifyLevel, globalNotifyLevel, ignoreChannelMentions}) {
     if (memberNotifyLevel === NotificationLevels.DEFAULT && globalNotifyLevel) {
         return (
             <FormattedMessage
@@ -19,6 +19,14 @@ export default function Describe({section, memberNotifyLevel, globalNotifyLevel,
             />
         );
     } else if (memberNotifyLevel === NotificationLevels.MENTION && section === NotificationSections.MARK_UNREAD) {
+        if (view === 'collapse') {
+            return (
+                <FormattedMessage
+                    id='channel_notifications.muteChannel.on.title.collapse'
+                    defaultMessage='Mute is enabled. Desktop, email and push notifications will not be sent for this channel.'
+                />
+            );
+        }
         return (
             <FormattedMessage
                 id='channel_notifications.muteChannel.on.title'
@@ -87,4 +95,5 @@ Describe.propTypes = {
     ignoreChannelMentions: PropTypes.string,
     memberNotifyLevel: PropTypes.string.isRequired,
     section: PropTypes.string.isRequired,
+    view: PropTypes.string,
 };

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1622,6 +1622,7 @@
   "channel_notifications.muteChannel.help": "Muting turns off desktop, email and push notifications for this channel. The channel will not be marked as unread unless you're mentioned.",
   "channel_notifications.muteChannel.off.title": "Off",
   "channel_notifications.muteChannel.on.title": "On",
+  "channel_notifications.muteChannel.on.title.collapse": "Mute is enabled. Desktop, email and push notifications will not be sent for this channel.",
   "channel_notifications.muteChannel.settings": "Mute channel",
   "channel_notifications.never": "Never",
   "channel_notifications.onlyMentions": "Only for mentions",


### PR DESCRIPTION
#### Summary
To clarify whey desktop and mobile notifications options are hidden when a channel is muted, the text now reads "Mute is enabled. Desktop, email and push notifications will not be sent for this channel." when the option section is collapsed:
![gif](http://g.recordit.co/9e9yoTWu6D.gif)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12945

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
