### PR TITLE
MM-14104 Update logic for Markdown emphasis from upstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11032,8 +11032,8 @@
       }
     },
     "marked": {
-      "version": "github:mattermost/marked#c1b6989f5cbacba6dceaabe8eabd7be8ec655cd6",
-      "from": "github:mattermost/marked#c1b6989f5cbacba6dceaabe8eabd7be8ec655cd6"
+      "version": "github:mattermost/marked#7ad73fe76f2264c533767f9105e7c7cff0fa34f1",
+      "from": "github:mattermost/marked#7ad73fe76f2264c533767f9105e7c7cff0fa34f1"
     },
     "material-colors": {
       "version": "1.2.6",
@@ -11310,6 +11310,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -11319,7 +11320,8 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11032,8 +11032,8 @@
       }
     },
     "marked": {
-      "version": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
-      "from": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d"
+      "version": "github:mattermost/marked#c1b6989f5cbacba6dceaabe8eabd7be8ec655cd6",
+      "from": "github:mattermost/marked#c1b6989f5cbacba6dceaabe8eabd7be8ec655cd6"
     },
     "material-colors": {
       "version": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "key-mirror": "1.0.1",
     "localforage": "1.7.3",
     "localforage-observable": "1.4.0",
-    "marked": "github:mattermost/marked#c1b6989f5cbacba6dceaabe8eabd7be8ec655cd6",
+    "marked": "github:mattermost/marked#7ad73fe76f2264c533767f9105e7c7cff0fa34f1",
     "mattermost-redux": "github:mattermost/mattermost-redux#aa1b7f511493b5954bfdc17f7ec501abb0d5662a",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "key-mirror": "1.0.1",
     "localforage": "1.7.3",
     "localforage-observable": "1.4.0",
-    "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
+    "marked": "github:mattermost/marked#c1b6989f5cbacba6dceaabe8eabd7be8ec655cd6",
     "mattermost-redux": "github:mattermost/mattermost-redux#aa1b7f511493b5954bfdc17f7ec501abb0d5662a",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",

--- a/utils/text_formatting_email.test.jsx
+++ b/utils/text_formatting_email.test.jsx
@@ -73,7 +73,7 @@ describe('TextFormatting.Emails', () => {
     it('Should be valid, but broken due to Markdown parsing happening before email autolinking', () => {
         assert.equal(
             TextFormatting.formatText('_______@domain.com').trim(),
-            '<p><strong><em>_</em></strong>@domain.com</p>',
+            '<p><strong>___</strong>@domain.com</p>',
         );
     });
 


### PR DESCRIPTION
For context, we don't have our marked fork up to date with upstream because we've made some extensive changes to it internally. Since the goal is still to switch to commonmark.js, there haven't been many efforts to get it up to date, but occasionally we need to manually copy changes like this to fix annoying bugs.

The actual changes for this PR are here: https://github.com/mattermost/marked/commit/c1b6989f5cbacba6dceaabe8eabd7be8ec655cd6

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14104
