### PR TITLE
[MM-14270] UI Automation: Write an automated test using cypress for Delete a par…

### DIFF
--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -223,6 +223,7 @@ export default class SearchBar extends React.Component {
             <div className='sidebar-right__table'>
                 <div className='sidebar-collapse__container'>
                     <div
+                        id='sidebarCollapse'
                         className='sidebar-collapse'
                         onClick={this.handleClose}
                     >

--- a/cypress/integration/channel/mobile_message_deletion_spec.js
+++ b/cypress/integration/channel/mobile_message_deletion_spec.js
@@ -1,0 +1,64 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getRandomInt} from '../../utils';
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/* eslint max-nested-callbacks: ["error", 4] */
+
+describe('Delete Parent Message', () => {
+    before(() => {
+        // 1. Go to Main Channel View with "user-1"
+        cy.viewport('iphone-6');
+        cy.toMainChannelView('user-1');
+    });
+
+    it('M14270 Deleting parent message should also delete replies from center and RHS', () => {
+        // 2. Close Hamburger menu, post a message, and add replies
+        cy.get('#post_textbox').click({force: true});
+        cy.postMessage('Parent Message');
+
+        cy.getLastPostId().then((postId) => {
+            cy.clickPostCommentIcon(postId);
+
+            // * Check that the RHS is open
+            cy.get('#rhsContainer').should('be.visible');
+
+            // * Add replies (randomly between 1 to 3)
+            const replyCount = getRandomInt(2) + 1;
+            for (var i = 0; i < replyCount; i++) {
+                cy.get('#reply_textbox').type('Reply').type('{enter}');
+
+                // add wait time to ensure that a post gets posted and not on pending state
+                cy.wait(500); // eslint-disable-line
+            }
+
+            cy.getLastPostId().then((replyPostId) => {
+                // * No delete modal should be visible yet
+                cy.get('#deletePostModal').should('not.be.visible');
+
+                // 3.Close RHS view, open delete confirmation modal for the parent message from the center screen
+                cy.get('#sidebarCollapse').click();
+                cy.clickPostDotMenu(postId);
+                cy.get(`#delete_post_${postId}`).click();
+
+                // * Modal should now be visible and warning message should match the number of replies
+                cy.get('#deletePostModal').should('be.visible');
+                cy.get('#deletePostModal').contains(`${replyCount}`).should('be.visible');
+
+                // 4. Delete the parent message
+                cy.get('#deletePostModalButton').click({force: true});
+
+                // * Post is deleted from both center and RHS is not visible to the user who deleted it
+                cy.get('#rhsContainer').should('not.be.visible');
+                cy.get(`#post_${postId}`).should('not.be.visible');
+                cy.get(`#post_${replyPostId}`).should('not.be.visible');
+            });
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
- Added E2E to check posts and replies deleted from both center and RHS
- Additionally checks that user can no longer see the post and if delete confirmation modal message is correct

#### Ticket Link
Github issue: https://github.com/mattermost/mattermost-server/issues/10323
Jira Ticket: https://mattermost.atlassian.net/browse/MM-14270

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [x] Added end-to-end tests (required for all new features)

No additions to components - only adds a cypress test file, so no unit test update or `make test` required.