### PR TITLE
Small fixes in the new menus

### DIFF
--- a/components/channel_header_dropdown/channel_header_dropdown_items.js
+++ b/components/channel_header_dropdown/channel_header_dropdown_items.js
@@ -170,6 +170,14 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
                 </MenuGroup>
 
                 <MenuGroup divider={divider}>
+                    <MenuItemToggleModalRedux
+                        id='channelEditHeader'
+                        show={(channel.type === Constants.DM_CHANNEL || channel.type === Constants.GM_CHANNEL) && !isArchived && !isReadonly}
+                        modalId={ModalIdentifiers.EDIT_CHANNEL_HEADER}
+                        dialogType={EditChannelHeaderModal}
+                        dialogProps={{channel}}
+                        text={localizeMessage('channel_header.setHeader', 'Edit Channel Header')}
+                    />
                     <ChannelPermissionGate
                         channelId={channel.id}
                         teamId={channel.team_id}

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -595,21 +595,6 @@ export default class FileUpload extends PureComponent {
                     </li>
                 );
             });
-            const FileDropdownComponent = () => {
-                return (
-                    <button
-                        type='button'
-                        className='style--none'
-                    >
-                        <div
-                            id='fileUploadButton'
-                            className='icon icon--attachment'
-                        >
-                            <AttachmentIcon/>
-                        </div>
-                    </button>
-                );
-            };
             bodyAction = (
                 <React.Fragment>
                     <input
@@ -623,7 +608,17 @@ export default class FileUpload extends PureComponent {
                         accept={accept}
                     />
                     <MenuWrapper>
-                        <FileDropdownComponent/>
+                        <button
+                            type='button'
+                            className='style--none'
+                        >
+                            <div
+                                id='fileUploadButton'
+                                className='icon icon--attachment'
+                            >
+                                <AttachmentIcon/>
+                            </div>
+                        </button>
                         <Menu
                             openLeft={true}
                             openUp={true}

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -167,6 +167,7 @@ export default class FileUpload extends PureComponent {
             requests: {},
             menuOpen: false,
         };
+        this.fileInput = React.createRef();
     }
 
     componentDidMount() {
@@ -491,7 +492,8 @@ export default class FileUpload extends PureComponent {
             const postTextbox = this.props.postType === 'post' && document.activeElement.id === 'post_textbox';
             const commentTextbox = this.props.postType === 'comment' && document.activeElement.id === 'reply_textbox';
             if (postTextbox || commentTextbox) {
-                $(this.refs.fileInput).focus().trigger('click');
+                this.fileInput.current.focus();
+                this.fileInput.current.click();
             }
         }
     }
@@ -535,6 +537,10 @@ export default class FileUpload extends PureComponent {
         this.setState({menuOpen: false});
     }
 
+    simulateInputClick = () => {
+        this.fileInput.current.click();
+    }
+
     render() {
         const {formatMessage} = this.context.intl;
         let multiple = true;
@@ -561,7 +567,7 @@ export default class FileUpload extends PureComponent {
                     <AttachmentIcon/>
                     <input
                         aria-label={formatMessage(holders.uploadFile)}
-                        ref='fileInput'
+                        ref={this.fileInput}
                         type='file'
                         onChange={this.handleChange}
                         onClick={this.handleLocalFileUploaded}
@@ -589,10 +595,10 @@ export default class FileUpload extends PureComponent {
                     </li>
                 );
             });
-            const FileDropdownComponent = (props) => {
+            const FileDropdownComponent = () => {
                 return (
                     <button
-                        onClick={props.onClick}
+                        type='button'
                         className='style--none'
                     >
                         <div
@@ -605,35 +611,37 @@ export default class FileUpload extends PureComponent {
                 );
             };
             bodyAction = (
-                <MenuWrapper>
-                    <FileDropdownComponent/>
-                    <Menu
-                        openLeft={true}
-                        openUp={true}
-                        ariaLabel={formatMessage({id: 'file_upload.menuAriaLabel', defaultMessage: 'Upload type selector'})}
-                    >
-                        <li>
-                            <a>
-                                <i className='fa fa-laptop'/>
-                                <FormattedMessage
-                                    id='yourcomputer'
-                                    defaultMessage='Your computer'
-                                />
-                                <input
-                                    aria-label={formatMessage(holders.uploadFile)}
-                                    ref='fileInput'
-                                    type='file'
-                                    className='file-attachment-menu-item-input'
-                                    onChange={this.handleChange}
-                                    onClick={this.handleLocalFileUploaded}
-                                    multiple={multiple}
-                                    accept={accept}
-                                />
-                            </a>
-                        </li>
-                        {pluginFileUploadMethods}
-                    </Menu>
-                </MenuWrapper>
+                <React.Fragment>
+                    <input
+                        aria-label={formatMessage(holders.uploadFile)}
+                        ref={this.fileInput}
+                        type='file'
+                        className='file-attachment-menu-item-input'
+                        onChange={this.handleChange}
+                        onClick={this.handleLocalFileUploaded}
+                        multiple={multiple}
+                        accept={accept}
+                    />
+                    <MenuWrapper>
+                        <FileDropdownComponent/>
+                        <Menu
+                            openLeft={true}
+                            openUp={true}
+                            ariaLabel={formatMessage({id: 'file_upload.menuAriaLabel', defaultMessage: 'Upload type selector'})}
+                        >
+                            <li>
+                                <a onClick={this.simulateInputClick}>
+                                    <i className='fa fa-laptop'/>
+                                    <FormattedMessage
+                                        id='yourcomputer'
+                                        defaultMessage='Your computer'
+                                    />
+                                </a>
+                            </li>
+                            {pluginFileUploadMethods}
+                        </Menu>
+                    </MenuWrapper>
+                </React.Fragment>
             );
         }
 

--- a/sass/widgets/menu/_menu_item.scss
+++ b/sass/widgets/menu/_menu_item.scss
@@ -7,6 +7,7 @@
         color: inherit;
         padding: 3px 20px;
         text-decoration: none;
+        width: 100%;
 
         &:focus,
         &:hover {

--- a/sass/widgets/menu/_menu_wrapper.scss
+++ b/sass/widgets/menu/_menu_wrapper.scss
@@ -4,6 +4,7 @@
         display: block;
     }
     *:first-child {
+        @include unselectable;
         cursor: pointer;
     }
 }


### PR DESCRIPTION
#### Summary
Fixing two small things in the new menu widgets.

One is to avoid any text inside the menu (including the clickable element that opens the menu) to be selected. The other one is to re-add the "Edit channel header" option to private messages and group messages.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed