### PR TITLE
[MM-14278] Display same recent emoji only once

### DIFF
--- a/actions/emoji_actions.jsx
+++ b/actions/emoji_actions.jsx
@@ -65,9 +65,7 @@ export function addRecentEmoji(alias) {
         } else if (emoji.name) {
             name = emoji.name;
         } else {
-            // Use the alias the user input or the first alias
-            // This puts the user chosen alias in recent emojis
-            name = emoji.aliases.find((aliasOption) => alias === aliasOption) || emoji.aliases[0];
+            name = emoji.aliases[0];
         }
 
         const index = recentEmojis.indexOf(name);

--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -604,7 +604,7 @@ export default class EmojiPicker extends React.PureComponent {
             }
             return (
                 <EmojiPickerItem
-                    key={emoji.filename + ':' + emoji.id}
+                    key={emoji.filename + ':' + emojiIndex}
                     emoji={emoji}
                     onItemOver={this.handleItemOver}
                     onItemClick={this.handleItemClick}


### PR DESCRIPTION
#### Summary
* A recent change had recent emojis stored by alias, resulting in identical emoji such as `:thumbsup:` or `:+1:` to be displayed twice
* This reverts that change to store by the first alias only, de-duplicating the recent history
* Additionally, `emoji.id` was undefined, using `emojiIndex` instead. No real impact with the above fix applied, but this prevents the indices from showing `1f609:undefined` for example.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14278

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has UI changes
