### PR TITLE
fix for UnhandledPromiseRejectionWarning in test

### DIFF
--- a/components/user_settings/security/user_settings_security.test.js
+++ b/components/user_settings/security/user_settings_security.test.js
@@ -102,6 +102,7 @@ describe('components/user_settings/display/UserSettingsDisplay', () => {
         const event = {currentTarget: {getAttribute: jest.fn().mockReturnValue(appId)}, preventDefault: jest.fn()};
 
         const wrapper = shallow(<UserSettingsSecurity {...requiredProps}/>);
+        wrapper.setState({authorizedApps: []});
         wrapper.instance().deauthorizeApp(event);
 
         expect(requiredProps.actions.deauthorizeOAuthApp).toHaveBeenCalled();


### PR DESCRIPTION
#### Summary
In [PR-2387](https://github.com/mattermost/mattermost-webapp/pull/2387) I made a tiny mistake in a test file that [pollutes](https://build.mattermost.com/blue/organizations/jenkins/mw%2Fmattermost-webapp/detail/PR-2387/3/pipeline/31#step-32-log-73) test output while deploying. This is a quick fix.

For some reason `npm run test:watch` and `make test` do not show such warnings, this is why I didn't notice it 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed