### PR TITLE
[MM-14296] Fix default email notification interval from never to immediate

### DIFF
--- a/components/user_settings/notifications/email_notification_setting/index.js
+++ b/components/user_settings/notifications/email_notification_setting/index.js
@@ -20,8 +20,8 @@ function mapStateToProps(state) {
         state,
         Preferences.CATEGORY_NOTIFICATIONS,
         Preferences.EMAIL_INTERVAL,
-        Preferences.INTERVAL_NEVER.toString(),
-    ), 10) || 0;
+        Preferences.INTERVAL_IMMEDIATE.toString(),
+    ), 10);
 
     return {
         currentUserId: getCurrentUserId(state),


### PR DESCRIPTION
#### Summary
Fix default email notification interval from never to immediate.

Main issue on ticket being out of sync between RN and desktop app was fixed by https://github.com/mattermost/mattermost-webapp/pull/2416.  This is just a follow up PR to correct the dafault value.

#### Ticket Link
Jira ticket: [MM-14296](https://mattermost.atlassian.net/browse/MM-14296)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
