### PR TITLE
All routes and menus generated using admin definitions

### DIFF
--- a/components/admin_console/__snapshots__/admin_console.test.jsx.snap
+++ b/components/admin_console/__snapshots__/admin_console.test.jsx.snap
@@ -1,5 +1,121 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/AdminConsole should generate the routes 1`] = `
+<div
+  className="admin-console__wrapper"
+>
+  <Connect(AnnouncementBarController) />
+  <Connect(SystemNotice) />
+  <Connect(AdminSidebar) />
+  <div
+    className="admin-console"
+  >
+    <Switch>
+      <Route
+        key="system_analytics"
+        path="/system_analytics"
+        render={[Function]}
+      />
+      <Route
+        key="team_analytics"
+        path="/team_analytics"
+        render={[Function]}
+      />
+      <Route
+        key="users"
+        path="/users"
+        render={[Function]}
+      />
+      <Route
+        key="logs"
+        path="/logs"
+        render={[Function]}
+      />
+      <Route
+        key="license"
+        path="/license"
+        render={[Function]}
+      />
+      <Route
+        key="audits"
+        path="/audits"
+        render={[Function]}
+      />
+      <Route
+        key="general"
+        path="/general"
+        render={[Function]}
+      />
+      <Route
+        key="access-control"
+        path="/access-control"
+        render={[Function]}
+      />
+      <Route
+        key="permissions"
+        path="/permissions"
+        render={[Function]}
+      />
+      <Route
+        key="authentication"
+        path="/authentication"
+        render={[Function]}
+      />
+      <Route
+        key="security"
+        path="/security"
+        render={[Function]}
+      />
+      <Route
+        key="notifications"
+        path="/notifications"
+        render={[Function]}
+      />
+      <Route
+        key="integrations"
+        path="/integrations"
+        render={[Function]}
+      />
+      <Route
+        key="plugins"
+        path="/plugins"
+        render={[Function]}
+      />
+      <Route
+        key="files"
+        path="/files"
+        render={[Function]}
+      />
+      <Route
+        key="customization"
+        path="/customization"
+        render={[Function]}
+      />
+      <Route
+        key="compliance"
+        path="/compliance"
+        render={[Function]}
+      />
+      <Route
+        key="advanced"
+        path="/advanced"
+        render={[Function]}
+      />
+      <Redirect
+        push={false}
+        to="/system_analytics"
+      />
+    </Switch>
+  </div>
+  <DiscardChangesModal
+    onCancel={[MockFunction]}
+    onConfirm={[MockFunction]}
+    show={false}
+  />
+  <Connect(ModalController) />
+</div>
+`;
+
 exports[`components/AdminConsole should redirect to / when not system admin 1`] = `
 <Redirect
   push={false}

--- a/components/admin_console/admin_console.test.jsx
+++ b/components/admin_console/admin_console.test.jsx
@@ -8,12 +8,21 @@ import AdminConsole from 'components/admin_console/admin_console';
 
 describe('components/AdminConsole', () => {
     const baseProps = {
-        config: {},
+        config: {
+            TestField: true,
+        },
         license: {},
         match: {
             url: '',
         },
-        roles: {},
+        roles: {
+            channel_admin: 'test',
+            channel_user: 'test',
+            team_admin: 'test',
+            team_user: 'test',
+            system_admin: 'test',
+            system_user: 'test',
+        },
         showNavigationPrompt: false,
         isCurrentUserSystemAdmin: false,
         actions: {
@@ -30,7 +39,18 @@ describe('components/AdminConsole', () => {
     test('should redirect to / when not system admin', () => {
         const props = {
             ...baseProps,
-            isCurrentSystemAdmin: false,
+            isCurrentUserSystemAdmin: false,
+        };
+        const wrapper = shallow(
+            <AdminConsole {...props}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should generate the routes', () => {
+        const props = {
+            ...baseProps,
+            isCurrentUserSystemAdmin: true,
         };
         const wrapper = shallow(
             <AdminConsole {...props}/>

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -30,6 +30,17 @@ import SystemUsers from './system_users';
 import ServerLogs from './server_logs';
 import BrandImageSetting from './brand_image_setting/brand_image_setting.jsx';
 import GroupSettings from './group_settings/group_settings.jsx';
+import GroupDetails from './group_settings/group_details';
+
+import PasswordSettings from './password_settings.jsx';
+import EmailNotificationsSettings from './email_settings.jsx';
+import PushNotificationsSettings from './push_settings.jsx';
+import DataRetentionSettings from './data_retention_settings.jsx';
+import MessageExportSettings from './message_export_settings.jsx';
+import DatabaseSettings from './database_settings.jsx';
+import ElasticSearchSettings from './elasticsearch_settings.jsx';
+import ClusterSettings from './cluster_settings.jsx';
+import CustomTermsOfServiceSettings from './custom_terms_of_service_settings';
 
 import * as DefinitionConstants from './admin_definition_constants';
 
@@ -141,24 +152,36 @@ export const needsUtils = {
 export default {
     reporting: {
         system_analytics: {
+            url: 'system_analytics',
+            title: t('admin.sidebar.view_statistics'),
+            title_default: 'Site Statistics',
             schema: {
                 id: 'SystemAnalytics',
                 component: SystemAnalytics,
             },
         },
         team_analytics: {
+            url: 'team_analytics',
+            title: t('admin.sidebar.statistics'),
+            title_default: 'Team Statistics',
             schema: {
                 id: 'TeamAnalytics',
                 component: TeamAnalytics,
             },
         },
         system_users: {
+            url: 'users',
+            title: t('admin.sidebar.users'),
+            title_default: 'Users',
             schema: {
                 id: 'SystemUsers',
                 component: SystemUsers,
             },
         },
         server_logs: {
+            url: 'logs',
+            title: t('admin.sidebar.logs'),
+            title_default: 'Logs',
             schema: {
                 id: 'ServerLogs',
                 component: ServerLogs,
@@ -167,7 +190,13 @@ export default {
     },
     settings: {
         general: {
+            url: 'general',
+            title: t('admin.sidebar.general'),
+            title_default: 'General',
             configuration: {
+                url: 'configuration',
+                title: t('admin.sidebar.configuration'),
+                title_default: 'Configuration',
                 schema: {
                     id: 'ServiceSettings',
                     name: t('admin.general.configuration'),
@@ -356,6 +385,9 @@ export default {
                 },
             },
             localization: {
+                url: 'localization',
+                title: t('admin.sidebar.localization'),
+                title_default: 'Localization',
                 schema: {
                     id: 'LocalizationSettings',
                     name: t('admin.general.localization'),
@@ -395,6 +427,9 @@ export default {
                 },
             },
             users_and_teams: {
+                url: 'users_and_teams',
+                title: t('admin.sidebar.usersAndTeams'),
+                title_default: 'Users and Teams',
                 schema: {
                     id: 'UserAndTeamsSettings',
                     name: t('admin.general.usersAndTeams'),
@@ -533,6 +568,9 @@ export default {
                 },
             },
             privacy: {
+                url: 'privacy',
+                title: t('admin.sidebar.privacy'),
+                title_default: 'Privacy',
                 schema: {
                     id: 'PrivacySettings',
                     name: t('admin.general.privacy'),
@@ -558,6 +596,10 @@ export default {
                 },
             },
             compliance: {
+                url: 'compliance',
+                title: t('admin.sidebar.compliance'),
+                title_default: 'Compliance',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('Compliance')),
                 schema: {
                     id: 'ComplianceSettings',
                     name: t('admin.compliance.title'),
@@ -608,6 +650,9 @@ export default {
                 },
             },
             logging: {
+                url: 'logging',
+                title: t('admin.sidebar.logging'),
+                title_default: 'Logging',
                 schema: {
                     id: 'LogSettings',
                     name: t('admin.general.log'),
@@ -716,27 +761,75 @@ export default {
             },
         },
         accessControl: {
+            url: 'access-control',
+            title: t('admin.sidebar.access-control'),
+            title_default: 'Access Control',
             groups: {
+                url: 'groups',
+                title: t('admin.sidebar.groups'),
+                title_default: 'Groups',
+                isHidden: needsUtils.or(
+                    needsUtils.not(needsUtils.hasLicenseFeature('LDAPGroups')),
+                    (config) => !config.ServiceSettings.ExperimentalLdapGroupSync,
+                ),
                 schema: {
                     id: 'Groups',
                     component: GroupSettings,
                 },
             },
+            group_detail: {
+                url: 'groups/:group_id',
+                isHidden: needsUtils.or(
+                    needsUtils.not(needsUtils.hasLicenseFeature('LDAPGroups')),
+                    (config) => !config.ServiceSettings.ExperimentalLdapGroupSync,
+                ),
+                schema: {
+                    id: 'GroupDetail',
+                    component: GroupDetails,
+                },
+            },
         },
         permissions: {
+            url: 'permissions',
+            title: t('admin.sidebar.permissions'),
+            title_default: 'Advanced Permissions',
             schemes: {
+                url: 'schemes',
+                title: t('admin.sidebar.schemes'),
+                title_default: 'Permission Schemes',
+                isHidden: needsUtils.or(
+                    needsUtils.not(needsUtils.hasLicense),
+                    needsUtils.not(needsUtils.hasLicenseFeature('CustomPermissionsSchemes'))
+                ),
                 schema: {
                     id: 'PermissionSchemes',
                     component: PermissionSchemesSettings,
                 },
             },
             systemScheme: {
+                url: 'system-scheme',
+                title: t('admin.sidebar.system-scheme'),
+                title_default: 'System scheme',
+                isHidden: needsUtils.or(
+                    needsUtils.not(needsUtils.hasLicense),
+                    needsUtils.hasLicenseFeature('CustomPermissionsSchemes')
+                ),
                 schema: {
                     id: 'PermissionSystemScheme',
                     component: PermissionSystemSchemeSettings,
                 },
             },
+            teamSchemeDetail: {
+                url: 'team-override-scheme/:scheme_id',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('CustomPermissionsSchemes')),
+                schema: {
+                    id: 'PermissionSystemScheme',
+                    component: PermissionTeamSchemeSettings,
+                },
+            },
             teamScheme: {
+                url: 'team-override-scheme',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('CustomPermissionsSchemes')),
                 schema: {
                     id: 'PermissionSystemScheme',
                     component: PermissionTeamSchemeSettings,
@@ -744,7 +837,50 @@ export default {
             },
         },
         authentication: {
+            url: 'authentication',
+            title: t('admin.sidebar.authentication'),
+            title_default: 'Authentication',
+            email: {
+                url: 'authentication_email',
+                title: t('admin.sidebar.email'),
+                title_default: 'Email',
+                schema: {
+                    id: 'EmailSettings',
+                    name: t('admin.authentication.email'),
+                    name_default: 'Email Authentication',
+                    settings: [
+                        {
+                            type: Constants.SettingsTypes.TYPE_BOOL,
+                            key: 'EmailSettings.EnableSignUpWithEmail',
+                            label: t('admin.email.allowSignupTitle'),
+                            label_default: 'Enable account creation with email:',
+                            help_text: t('admin.email.allowSignupDescription'),
+                            help_text_default: 'When true, Mattermost allows account creation using email and password. This value should be false only when you want to limit sign up to a single sign-on service like AD/LDAP, SAML or GitLab.',
+                        },
+                        {
+                            type: Constants.SettingsTypes.TYPE_BOOL,
+                            key: 'EmailSettings.EnableSignInWithEmail',
+                            label: t('admin.email.allowEmailSignInTitle'),
+                            label_default: 'Enable sign-in with email:',
+                            help_text: t('admin.email.allowEmailSignInDescription'),
+                            help_text_default: 'When true, Mattermost allows users to sign in using their email and password.',
+                        },
+                        {
+                            type: Constants.SettingsTypes.TYPE_BOOL,
+                            key: 'EmailSettings.EnableSignInWithUsername',
+                            label: t('admin.email.allowUsernameSignInTitle'),
+                            label_default: 'Enable sign-in with username:',
+                            help_text: t('admin.email.allowUsernameSignInDescription'),
+                            help_text_default: 'When true, users with email login can sign in using their username and password. This setting does not affect AD/LDAP login.',
+                        },
+                    ],
+                },
+            },
             gitlab: {
+                url: 'gitlab',
+                title: t('admin.sidebar.gitlab'),
+                title_default: 'GitLab',
+                isHidden: needsUtils.hasLicense,
                 schema: {
                     id: 'GitLabSettings',
                     name: t('admin.authentication.gitlab'),
@@ -845,6 +981,10 @@ export default {
                 },
             },
             oauth: {
+                url: 'oauth',
+                title: t('admin.sidebar.oauth'),
+                title_default: 'OAuth 2.0',
+                isHidden: needsUtils.not(needsUtils.hasLicense),
                 schema: {
                     id: 'OAuthSettings',
                     name: t('admin.authentication.oauth'),
@@ -1104,40 +1244,11 @@ export default {
                     ],
                 },
             },
-            email: {
-                schema: {
-                    id: 'EmailSettings',
-                    name: t('admin.authentication.email'),
-                    name_default: 'Email Authentication',
-                    settings: [
-                        {
-                            type: Constants.SettingsTypes.TYPE_BOOL,
-                            key: 'EmailSettings.EnableSignUpWithEmail',
-                            label: t('admin.email.allowSignupTitle'),
-                            label_default: 'Enable account creation with email:',
-                            help_text: t('admin.email.allowSignupDescription'),
-                            help_text_default: 'When true, Mattermost allows account creation using email and password. This value should be false only when you want to limit sign up to a single sign-on service like AD/LDAP, SAML or GitLab.',
-                        },
-                        {
-                            type: Constants.SettingsTypes.TYPE_BOOL,
-                            key: 'EmailSettings.EnableSignInWithEmail',
-                            label: t('admin.email.allowEmailSignInTitle'),
-                            label_default: 'Enable sign-in with email:',
-                            help_text: t('admin.email.allowEmailSignInDescription'),
-                            help_text_default: 'When true, Mattermost allows users to sign in using their email and password.',
-                        },
-                        {
-                            type: Constants.SettingsTypes.TYPE_BOOL,
-                            key: 'EmailSettings.EnableSignInWithUsername',
-                            label: t('admin.email.allowUsernameSignInTitle'),
-                            label_default: 'Enable sign-in with username:',
-                            help_text: t('admin.email.allowUsernameSignInDescription'),
-                            help_text_default: 'When true, users with email login can sign in using their username and password. This setting does not affect AD/LDAP login.',
-                        },
-                    ],
-                },
-            },
             ldap: {
+                url: 'ldap',
+                title: t('admin.sidebar.ldap'),
+                title_default: 'AD/LDAP',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('LDAP')),
                 schema: {
                     id: 'LdapSettings',
                     name: t('admin.authentication.ldap'),
@@ -1622,6 +1733,10 @@ export default {
                 },
             },
             saml: {
+                url: 'saml',
+                title: t('admin.sidebar.saml'),
+                title_default: 'SAML 2.0',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('SAML')),
                 schema: {
                     id: 'SamlSettings',
                     name: t('admin.authentication.saml'),
@@ -1890,6 +2005,9 @@ export default {
                 },
             },
             mfa: {
+                url: 'mfa',
+                title: t('admin.sidebar.mfa'),
+                title_default: 'MFA',
                 schema: {
                     id: 'ServiceSettings',
                     name: t('admin.mfa.title'),
@@ -1926,7 +2044,13 @@ export default {
             },
         },
         security: {
+            url: 'security',
+            title: t('admin.sidebar.security'),
+            title_default: 'Security',
             signup: {
+                url: 'signup',
+                title: t('admin.sidebar.signUp'),
+                title_default: 'Sign Up',
                 schema: {
                     id: 'SignupSettings',
                     name: t('admin.security.signup'),
@@ -1973,7 +2097,19 @@ export default {
                     ],
                 },
             },
+            password: {
+                url: 'password',
+                title: t('admin.sidebar.password'),
+                title_default: 'Password',
+                schema: {
+                    id: 'PasswordSettings',
+                    component: PasswordSettings,
+                },
+            },
             public_links: {
+                url: 'public_links',
+                title: t('admin.sidebar.publicLinks'),
+                title_default: 'Public Links',
                 schema: {
                     id: 'PublicLinkSettings',
                     name: t('admin.security.public_links'),
@@ -1999,6 +2135,9 @@ export default {
                 },
             },
             sessions: {
+                url: 'sessions',
+                title: t('admin.sidebar.sessions'),
+                title_default: 'Sessions',
                 schema: {
                     id: 'SessionsSettings',
                     name: t('admin.security.session'),
@@ -2066,6 +2205,9 @@ export default {
                 },
             },
             connections: {
+                url: 'connections',
+                title: t('admin.sidebar.connections'),
+                title_default: 'Connections',
                 schema: {
                     id: 'ConnectionSettings',
                     name: t('admin.security.connection'),
@@ -2119,6 +2261,7 @@ export default {
                 },
             },
             clientVersions: {
+                url: 'client_versions',
                 schema: {
                     id: 'ClientVersionsSettings',
                     name: t('admin.security.client_versions'),
@@ -2189,9 +2332,36 @@ export default {
             },
         },
         notifications: {
+            url: 'notifications',
+            title: t('admin.sidebar.notifications'),
+            title_default: 'Notifications',
+            email: {
+                url: 'notifications_email',
+                title: t('admin.sidebar.email'),
+                title_default: 'Email',
+                schema: {
+                    id: 'EmailNotificationsSettings',
+                    component: EmailNotificationsSettings,
+                },
+            },
+            push: {
+                url: 'push',
+                title: t('admin.sidebar.push'),
+                title_default: 'Mobile Push',
+                schema: {
+                    id: 'PushNotificationsSettings',
+                    component: PushNotificationsSettings,
+                },
+            },
         },
         integrations: {
+            url: 'integrations',
+            title: t('admin.sidebar.integrations'),
+            title_default: 'Integrations',
             custom_integrations: {
+                url: 'custom',
+                title: t('admin.sidebar.customIntegrations'),
+                title_default: 'Custom Integrations',
                 schema: {
                     id: 'CustomIntegrationSettings',
                     name: t('admin.integrations.custom'),
@@ -2274,6 +2444,9 @@ export default {
                 },
             },
             external: {
+                url: 'external',
+                title: t('admin.sidebar.external'),
+                title_default: 'External Services',
                 schema: {
                     id: 'ExternalServiceSettings',
                     name: t('admin.integrations.external'),
@@ -2295,13 +2468,20 @@ export default {
             },
         },
         plugins: {
+            url: 'plugins',
+            title: t('admin.sidebar.plugins'),
+            title_default: 'Plugins (Beta)',
             management: {
+                url: 'management',
+                title: t('admin.sidebar.plugins.management'),
+                title_default: 'Management',
                 schema: {
                     id: 'PluginManagementSettings',
                     component: PluginManagement,
                 },
             },
             custom: {
+                url: 'custom/:plugin_id',
                 schema: {
                     id: 'CustomPluginSettings',
                     component: CustomPluginSettings,
@@ -2309,7 +2489,13 @@ export default {
             },
         },
         files: {
+            url: 'files',
+            title: t('admin.sidebar.files'),
+            title_default: 'Files',
             storage: {
+                url: 'storage',
+                title: t('admin.sidebar.storage'),
+                title_default: 'Storage',
                 schema: {
                     id: 'FileSettings',
                     name: t('admin.files.storage'),
@@ -2542,7 +2728,13 @@ export default {
             },
         },
         customization: {
+            url: 'customization',
+            title: t('admin.sidebar.customization'),
+            title_default: 'Customization',
             customBrand: {
+                url: 'custom_brand',
+                title: t('admin.sidebar.customBrand'),
+                title_default: 'Custom Branding',
                 schema: {
                     id: 'CustomBrandSettings',
                     name: t('admin.customization.customBrand'),
@@ -2596,66 +2788,11 @@ export default {
                     ],
                 },
             },
-            emoji: {
-                schema: {
-                    id: 'EmojiSettings',
-                    name: t('admin.customization.emoji'),
-                    name_default: 'Emoji',
-                    settings: [
-                        {
-                            type: Constants.SettingsTypes.TYPE_BOOL,
-                            key: 'ServiceSettings.EnableEmojiPicker',
-                            label: t('admin.customization.enableEmojiPickerTitle'),
-                            label_default: 'Enable Emoji Picker:',
-                            help_text: t('admin.customization.enableEmojiPickerDesc'),
-                            help_text_default: 'The emoji picker allows users to select emoji to add as reactions or use in messages. Enabling the emoji picker with a large number of custom emoji may slow down performance.',
-                        },
-                        {
-                            type: Constants.SettingsTypes.TYPE_BOOL,
-                            key: 'ServiceSettings.EnableCustomEmoji',
-                            label: t('admin.customization.enableCustomEmojiTitle'),
-                            label_default: 'Enable Custom Emoji:',
-                            help_text: t('admin.customization.enableCustomEmojiDesc'),
-                            help_text_default: 'Enable users to create custom emoji for use in messages. When enabled, Custom Emoji settings can be accessed by switching to a team and clicking the three dots above the channel sidebar, and selecting "Custom Emoji".',
-                        },
-                    ],
-                },
-            },
-            gif: {
-                schema: {
-                    id: 'EmojiSettings',
-                    name: t('admin.customization.gif'),
-                    name_default: 'GIF (Beta)',
-                    settings: [
-                        {
-                            type: Constants.SettingsTypes.TYPE_BOOL,
-                            key: 'ServiceSettings.EnableGifPicker',
-                            label: t('admin.customization.enableGifPickerTitle'),
-                            label_default: 'Enable GIF Picker:',
-                            help_text: t('admin.customization.enableGifPickerDesc'),
-                            help_text_default: 'Allow users to select GIFs from the emoji picker via a Gfycat integration.',
-                        },
-                        {
-                            type: Constants.SettingsTypes.TYPE_TEXT,
-                            key: 'ServiceSettings.GfycatApiKey',
-                            label: t('admin.customization.gfycatApiKey'),
-                            label_default: 'Gfycat API Key:',
-                            help_text: t('admin.customization.gfycatApiKeyDescription'),
-                            help_text_default: 'Request an API key at [https://developers.gfycat.com/signup/#](!https://developers.gfycat.com/signup/#). Enter the client ID you receive via email to this field. When blank, uses the default API key provided by Gfycat.',
-                            help_text_markdown: true,
-                        },
-                        {
-                            type: Constants.SettingsTypes.TYPE_TEXT,
-                            key: 'ServiceSettings.GfycatApiSecret',
-                            label: t('admin.customization.gfycatApiSecret'),
-                            label_default: 'Gfycat API Secret:',
-                            help_text: t('admin.customization.gfycatApiSecretDescription'),
-                            help_text_default: 'The API secret generated by Gfycat for your API key. When blank, uses the default API secret provided by Gfycat.',
-                        },
-                    ],
-                },
-            },
             announcement: {
+                url: 'announcement',
+                title: t('admin.sidebar.announcement'),
+                title_default: 'Announcement Banner',
+                isHidden: needsUtils.not(needsUtils.hasLicense),
                 schema: {
                     id: 'AnnouncementSettings',
                     name: t('admin.customization.announcement'),
@@ -2704,7 +2841,75 @@ export default {
                     ],
                 },
             },
+            emoji: {
+                url: 'emoji',
+                title: t('admin.sidebar.emoji'),
+                title_default: 'Emoji',
+                schema: {
+                    id: 'EmojiSettings',
+                    name: t('admin.customization.emoji'),
+                    name_default: 'Emoji',
+                    settings: [
+                        {
+                            type: Constants.SettingsTypes.TYPE_BOOL,
+                            key: 'ServiceSettings.EnableEmojiPicker',
+                            label: t('admin.customization.enableEmojiPickerTitle'),
+                            label_default: 'Enable Emoji Picker:',
+                            help_text: t('admin.customization.enableEmojiPickerDesc'),
+                            help_text_default: 'The emoji picker allows users to select emoji to add as reactions or use in messages. Enabling the emoji picker with a large number of custom emoji may slow down performance.',
+                        },
+                        {
+                            type: Constants.SettingsTypes.TYPE_BOOL,
+                            key: 'ServiceSettings.EnableCustomEmoji',
+                            label: t('admin.customization.enableCustomEmojiTitle'),
+                            label_default: 'Enable Custom Emoji:',
+                            help_text: t('admin.customization.enableCustomEmojiDesc'),
+                            help_text_default: 'Enable users to create custom emoji for use in messages. When enabled, Custom Emoji settings can be accessed by switching to a team and clicking the three dots above the channel sidebar, and selecting "Custom Emoji".',
+                        },
+                    ],
+                },
+            },
+            gif: {
+                url: 'gif',
+                title: t('admin.sidebar.gif'),
+                title_default: 'GIF (Beta)',
+                schema: {
+                    id: 'EmojiSettings',
+                    name: t('admin.customization.gif'),
+                    name_default: 'GIF (Beta)',
+                    settings: [
+                        {
+                            type: Constants.SettingsTypes.TYPE_BOOL,
+                            key: 'ServiceSettings.EnableGifPicker',
+                            label: t('admin.customization.enableGifPickerTitle'),
+                            label_default: 'Enable GIF Picker:',
+                            help_text: t('admin.customization.enableGifPickerDesc'),
+                            help_text_default: 'Allow users to select GIFs from the emoji picker via a Gfycat integration.',
+                        },
+                        {
+                            type: Constants.SettingsTypes.TYPE_TEXT,
+                            key: 'ServiceSettings.GfycatApiKey',
+                            label: t('admin.customization.gfycatApiKey'),
+                            label_default: 'Gfycat API Key:',
+                            help_text: t('admin.customization.gfycatApiKeyDescription'),
+                            help_text_default: 'Request an API key at [https://developers.gfycat.com/signup/#](!https://developers.gfycat.com/signup/#). Enter the client ID you receive via email to this field. When blank, uses the default API key provided by Gfycat.',
+                            help_text_markdown: true,
+                        },
+                        {
+                            type: Constants.SettingsTypes.TYPE_TEXT,
+                            key: 'ServiceSettings.GfycatApiSecret',
+                            label: t('admin.customization.gfycatApiSecret'),
+                            label_default: 'Gfycat API Secret:',
+                            help_text: t('admin.customization.gfycatApiSecretDescription'),
+                            help_text_default: 'The API secret generated by Gfycat for your API key. When blank, uses the default API secret provided by Gfycat.',
+                        },
+                    ],
+                },
+            },
             posts: {
+                url: 'posts',
+                title: t('admin.sidebar.posts'),
+                title_default: 'Posts',
                 schema: {
                     id: 'PostSettings',
                     name: t('admin.customization.posts'),
@@ -2727,6 +2932,9 @@ export default {
                 },
             },
             legal_and_support: {
+                url: 'legal_and_support',
+                title: t('admin.sidebar.legalAndSupport'),
+                title_default: 'Legal and Support',
                 schema: {
                     id: 'LegalAndSupportSettings',
                     name: t('admin.customization.support'),
@@ -2783,7 +2991,20 @@ export default {
                     ],
                 },
             },
+            custom_terms_of_service: {
+                url: 'custom_terms_of_service',
+                title: t('admin.sidebar.customTermsOfService'),
+                title_default: 'Custom Terms of Service (Beta)',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('CustomTermsOfService')),
+                schema: {
+                    id: 'TermsOfServiceSettings',
+                    component: CustomTermsOfServiceSettings,
+                },
+            },
             native_app_links: {
+                url: 'native_app_links',
+                title: t('admin.sidebar.nativeAppLinks'),
+                title_default: 'Mattermost App Links',
                 schema: {
                     id: 'LegalAndSupportSettings',
                     name: t('admin.customization.nativeAppLinks'),
@@ -2818,9 +3039,38 @@ export default {
             },
         },
         compliance: {
+            url: 'compliance',
+            title: t('admin.sidebar.compliance'),
+            title_default: 'Compliance',
+            data_retention: {
+                url: 'data_retention',
+                title: t('admin.sidebar.data_retention'),
+                title_default: 'Data Retention Policy',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('DataRetention')),
+                schema: {
+                    id: 'DataRetentionSettings',
+                    component: DataRetentionSettings,
+                },
+            },
+            message_export: {
+                url: 'message_export',
+                title: t('admin.sidebar.compliance_export'),
+                title_default: 'Compliance Export (Beta)',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('MessageExport')),
+                schema: {
+                    id: 'MessageExportSettings',
+                    component: MessageExportSettings,
+                },
+            },
         },
         advanced: {
+            url: 'advanced',
+            title: t('admin.sidebar.advanced'),
+            title_default: 'Advanced',
             rate: {
+                url: 'rate',
+                title: t('admin.sidebar.rateLimiting'),
+                title_default: 'Rate Limiting',
                 schema: {
                     id: 'ServiceSettings',
                     name: t('admin.rate.title'),
@@ -2908,7 +3158,29 @@ export default {
                     ],
                 },
             },
+            database: {
+                url: 'database',
+                title: t('admin.sidebar.database'),
+                title_default: 'Database',
+                schema: {
+                    id: 'DatabaseSettings',
+                    component: DatabaseSettings,
+                },
+            },
+            elasticsearch: {
+                url: 'elasticsearch',
+                title: t('admin.sidebar.elasticsearch'),
+                title_default: 'Elasticsearch',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('Elasticsearch')),
+                schema: {
+                    id: 'ElasticSearchSettings',
+                    component: ElasticSearchSettings,
+                },
+            },
             developer: {
+                url: 'developer',
+                title: t('admin.sidebar.developer'),
+                title_default: 'Developer',
                 schema: {
                     id: 'ServiceSettings',
                     name: t('admin.developer.title'),
@@ -2944,7 +3216,21 @@ export default {
                     ],
                 },
             },
+            cluster: {
+                url: 'cluster',
+                title: t('admin.sidebar.cluster'),
+                title_default: 'High Availability',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('Cluster')),
+                schema: {
+                    id: 'ClusterSettings',
+                    component: ClusterSettings,
+                },
+            },
             metrics: {
+                url: 'metrics',
+                title: t('admin.sidebar.metrics'),
+                title_default: 'Performance Monitoring',
+                isHidden: needsUtils.not(needsUtils.hasLicenseFeature('Metrics')),
                 schema: {
                     id: 'MetricsSettings',
                     name: t('admin.advance.metrics'),
@@ -2973,6 +3259,9 @@ export default {
                 },
             },
             experimental: {
+                url: 'experimental',
+                title: t('admin.sidebar.experimental'),
+                title_default: 'Experimental',
                 schema: {
                     id: 'ExperimentalSettings',
                     name: t('admin.advance.experimental'),
@@ -3354,12 +3643,20 @@ export default {
     },
     other: {
         license: {
+            url: 'license',
+            title: t('admin.sidebar.license'),
+            title_default: 'Edition and License',
+            isHidden: (config, state, license, enterpriseReady) => !enterpriseReady,
             schema: {
                 id: 'LicenseSettings',
                 component: LicenseSettings,
             },
         },
         audits: {
+            url: 'audits',
+            title: t('admin.sidebar.audits'),
+            title_default: 'Complaince and Auditing',
+            isHidden: needsUtils.not(needsUtils.hasLicense),
             schema: {
                 id: 'Audits',
                 component: Audits,

--- a/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
+++ b/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.jsx.snap
@@ -23,6 +23,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
         }
       >
         <AdminSidebarSection
+          key="system_analytics"
           name="system_analytics"
           parentLink=""
           subsection={false}
@@ -35,6 +36,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           }
         />
         <AdminSidebarSection
+          key="team_analytics"
           name="team_analytics"
           parentLink=""
           subsection={false}
@@ -47,6 +49,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           }
         />
         <AdminSidebarSection
+          key="users"
           name="users"
           parentLink=""
           subsection={false}
@@ -59,6 +62,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           }
         />
         <AdminSidebarSection
+          key="logs"
           name="logs"
           parentLink=""
           subsection={false}
@@ -84,6 +88,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
         }
       >
         <AdminSidebarSection
+          key="general"
           name="general"
           parentLink=""
           subsection={false}
@@ -97,6 +102,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           type="text"
         >
           <AdminSidebarSection
+            key="configuration"
             name="configuration"
             parentLink=""
             subsection={false}
@@ -109,6 +115,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="localization"
             name="localization"
             parentLink=""
             subsection={false}
@@ -121,6 +128,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="users_and_teams"
             name="users_and_teams"
             parentLink=""
             subsection={false}
@@ -133,6 +141,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="privacy"
             name="privacy"
             parentLink=""
             subsection={false}
@@ -145,6 +154,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="logging"
             name="logging"
             parentLink=""
             subsection={false}
@@ -158,6 +168,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="authentication"
           name="authentication"
           parentLink=""
           subsection={false}
@@ -171,6 +182,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           type="text"
         >
           <AdminSidebarSection
+            key="authentication_email"
             name="authentication_email"
             parentLink=""
             subsection={false}
@@ -183,6 +195,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="gitlab"
             name="gitlab"
             parentLink=""
             subsection={false}
@@ -195,6 +208,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="mfa"
             name="mfa"
             parentLink=""
             subsection={false}
@@ -208,6 +222,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="security"
           name="security"
           parentLink=""
           subsection={false}
@@ -221,7 +236,8 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           type="text"
         >
           <AdminSidebarSection
-            name="sign_up"
+            key="signup"
+            name="signup"
             parentLink=""
             subsection={false}
             title={
@@ -233,6 +249,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="password"
             name="password"
             parentLink=""
             subsection={false}
@@ -245,6 +262,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="public_links"
             name="public_links"
             parentLink=""
             subsection={false}
@@ -257,6 +275,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="sessions"
             name="sessions"
             parentLink=""
             subsection={false}
@@ -269,6 +288,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="connections"
             name="connections"
             parentLink=""
             subsection={false}
@@ -282,6 +302,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="notifications"
           name="notifications"
           parentLink=""
           subsection={false}
@@ -295,6 +316,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           type="text"
         >
           <AdminSidebarSection
+            key="notifications_email"
             name="notifications_email"
             parentLink=""
             subsection={false}
@@ -307,6 +329,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="push"
             name="push"
             parentLink=""
             subsection={false}
@@ -320,6 +343,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="integrations"
           name="integrations"
           parentLink=""
           subsection={false}
@@ -333,6 +357,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           type="text"
         >
           <AdminSidebarSection
+            key="custom"
             name="custom"
             parentLink=""
             subsection={false}
@@ -345,6 +370,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="external"
             name="external"
             parentLink=""
             subsection={false}
@@ -358,6 +384,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="plugins"
           name="plugins"
           parentLink=""
           subsection={false}
@@ -371,6 +398,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           type="text"
         >
           <AdminSidebarSection
+            key="management"
             name="management"
             parentLink=""
             subsection={false}
@@ -391,6 +419,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="files"
           name="files"
           parentLink=""
           subsection={false}
@@ -418,6 +447,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="customization"
           name="customization"
           parentLink=""
           subsection={false}
@@ -431,6 +461,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           type="text"
         >
           <AdminSidebarSection
+            key="custom_brand"
             name="custom_brand"
             parentLink=""
             subsection={false}
@@ -443,6 +474,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="emoji"
             name="emoji"
             parentLink=""
             subsection={false}
@@ -455,6 +487,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="gif"
             name="gif"
             parentLink=""
             subsection={false}
@@ -467,6 +500,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="posts"
             name="posts"
             parentLink=""
             subsection={false}
@@ -479,6 +513,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="legal_and_support"
             name="legal_and_support"
             parentLink=""
             subsection={false}
@@ -491,6 +526,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="native_app_links"
             name="native_app_links"
             parentLink=""
             subsection={false}
@@ -504,6 +540,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="advanced"
           name="advanced"
           parentLink=""
           subsection={false}
@@ -517,6 +554,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
           type="text"
         >
           <AdminSidebarSection
+            key="rate"
             name="rate"
             parentLink=""
             subsection={false}
@@ -529,6 +567,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="database"
             name="database"
             parentLink=""
             subsection={false}
@@ -541,6 +580,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="developer"
             name="developer"
             parentLink=""
             subsection={false}
@@ -553,6 +593,7 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
             }
           />
           <AdminSidebarSection
+            key="experimental"
             name="experimental"
             parentLink=""
             subsection={false}
@@ -594,6 +635,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
         }
       >
         <AdminSidebarSection
+          key="system_analytics"
           name="system_analytics"
           parentLink=""
           subsection={false}
@@ -606,6 +648,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           }
         />
         <AdminSidebarSection
+          key="team_analytics"
           name="team_analytics"
           parentLink=""
           subsection={false}
@@ -618,6 +661,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           }
         />
         <AdminSidebarSection
+          key="users"
           name="users"
           parentLink=""
           subsection={false}
@@ -630,6 +674,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           }
         />
         <AdminSidebarSection
+          key="logs"
           name="logs"
           parentLink=""
           subsection={false}
@@ -655,6 +700,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
         }
       >
         <AdminSidebarSection
+          key="general"
           name="general"
           parentLink=""
           subsection={false}
@@ -668,6 +714,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           type="text"
         >
           <AdminSidebarSection
+            key="configuration"
             name="configuration"
             parentLink=""
             subsection={false}
@@ -680,6 +727,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="localization"
             name="localization"
             parentLink=""
             subsection={false}
@@ -692,6 +740,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="users_and_teams"
             name="users_and_teams"
             parentLink=""
             subsection={false}
@@ -704,6 +753,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="privacy"
             name="privacy"
             parentLink=""
             subsection={false}
@@ -716,6 +766,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="logging"
             name="logging"
             parentLink=""
             subsection={false}
@@ -729,6 +780,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="authentication"
           name="authentication"
           parentLink=""
           subsection={false}
@@ -742,6 +794,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           type="text"
         >
           <AdminSidebarSection
+            key="authentication_email"
             name="authentication_email"
             parentLink=""
             subsection={false}
@@ -754,6 +807,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="gitlab"
             name="gitlab"
             parentLink=""
             subsection={false}
@@ -766,6 +820,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="mfa"
             name="mfa"
             parentLink=""
             subsection={false}
@@ -779,6 +834,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="security"
           name="security"
           parentLink=""
           subsection={false}
@@ -792,7 +848,8 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           type="text"
         >
           <AdminSidebarSection
-            name="sign_up"
+            key="signup"
+            name="signup"
             parentLink=""
             subsection={false}
             title={
@@ -804,6 +861,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="password"
             name="password"
             parentLink=""
             subsection={false}
@@ -816,6 +874,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="public_links"
             name="public_links"
             parentLink=""
             subsection={false}
@@ -828,6 +887,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="sessions"
             name="sessions"
             parentLink=""
             subsection={false}
@@ -840,6 +900,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="connections"
             name="connections"
             parentLink=""
             subsection={false}
@@ -853,6 +914,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="notifications"
           name="notifications"
           parentLink=""
           subsection={false}
@@ -866,6 +928,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           type="text"
         >
           <AdminSidebarSection
+            key="notifications_email"
             name="notifications_email"
             parentLink=""
             subsection={false}
@@ -878,6 +941,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="push"
             name="push"
             parentLink=""
             subsection={false}
@@ -891,6 +955,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="integrations"
           name="integrations"
           parentLink=""
           subsection={false}
@@ -904,6 +969,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           type="text"
         >
           <AdminSidebarSection
+            key="custom"
             name="custom"
             parentLink=""
             subsection={false}
@@ -916,6 +982,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="external"
             name="external"
             parentLink=""
             subsection={false}
@@ -929,6 +996,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="plugins"
           name="plugins"
           parentLink=""
           subsection={false}
@@ -942,6 +1010,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           type="text"
         >
           <AdminSidebarSection
+            key="management"
             name="management"
             parentLink=""
             subsection={false}
@@ -955,6 +1024,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="files"
           name="files"
           parentLink=""
           subsection={false}
@@ -982,6 +1052,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="customization"
           name="customization"
           parentLink=""
           subsection={false}
@@ -995,6 +1066,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           type="text"
         >
           <AdminSidebarSection
+            key="custom_brand"
             name="custom_brand"
             parentLink=""
             subsection={false}
@@ -1007,6 +1079,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="emoji"
             name="emoji"
             parentLink=""
             subsection={false}
@@ -1019,6 +1092,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="gif"
             name="gif"
             parentLink=""
             subsection={false}
@@ -1031,6 +1105,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="posts"
             name="posts"
             parentLink=""
             subsection={false}
@@ -1043,6 +1118,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="legal_and_support"
             name="legal_and_support"
             parentLink=""
             subsection={false}
@@ -1055,6 +1131,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="native_app_links"
             name="native_app_links"
             parentLink=""
             subsection={false}
@@ -1068,6 +1145,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           />
         </AdminSidebarSection>
         <AdminSidebarSection
+          key="advanced"
           name="advanced"
           parentLink=""
           subsection={false}
@@ -1081,6 +1159,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
           type="text"
         >
           <AdminSidebarSection
+            key="rate"
             name="rate"
             parentLink=""
             subsection={false}
@@ -1093,6 +1172,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="database"
             name="database"
             parentLink=""
             subsection={false}
@@ -1105,6 +1185,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="developer"
             name="developer"
             parentLink=""
             subsection={false}
@@ -1117,6 +1198,7 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
           <AdminSidebarSection
+            key="experimental"
             name="experimental"
             parentLink=""
             subsection={false}
@@ -1129,6 +1211,1534 @@ exports[`components/AdminSidebar should match snapshot, not render the plugin in
             }
           />
         </AdminSidebarSection>
+      </AdminSidebarCategory>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`components/AdminSidebar should match snapshot, with license (with all feature) 1`] = `
+<div
+  className="admin-sidebar"
+>
+  <Connect(SidebarHeader) />
+  <div
+    className="nav-pills__container"
+  >
+    <ul
+      className="nav nav-pills nav-stacked"
+    >
+      <AdminSidebarCategory
+        icon="fa-bar-chart"
+        parentLink="/admin_console"
+        title={
+          <FormattedMessage
+            defaultMessage="REPORTING"
+            id="admin.sidebar.reports"
+            values={Object {}}
+          />
+        }
+      >
+        <AdminSidebarSection
+          key="system_analytics"
+          name="system_analytics"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Site Statistics"
+              id="admin.sidebar.view_statistics"
+              values={Object {}}
+            />
+          }
+        />
+        <AdminSidebarSection
+          key="team_analytics"
+          name="team_analytics"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Team Statistics"
+              id="admin.sidebar.statistics"
+              values={Object {}}
+            />
+          }
+        />
+        <AdminSidebarSection
+          key="users"
+          name="users"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Users"
+              id="admin.sidebar.users"
+              values={Object {}}
+            />
+          }
+        />
+        <AdminSidebarSection
+          key="logs"
+          name="logs"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Logs"
+              id="admin.sidebar.logs"
+              values={Object {}}
+            />
+          }
+        />
+      </AdminSidebarCategory>
+      <AdminSidebarCategory
+        icon="fa-gear"
+        parentLink="/admin_console"
+        sectionClass="sections--settings"
+        title={
+          <FormattedMessage
+            defaultMessage="SETTINGS"
+            id="admin.sidebar.settings"
+            values={Object {}}
+          />
+        }
+      >
+        <AdminSidebarSection
+          key="general"
+          name="general"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="General"
+              id="admin.sidebar.general"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="configuration"
+            name="configuration"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Configuration"
+                id="admin.sidebar.configuration"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="localization"
+            name="localization"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Localization"
+                id="admin.sidebar.localization"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="users_and_teams"
+            name="users_and_teams"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Users and Teams"
+                id="admin.sidebar.usersAndTeams"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="privacy"
+            name="privacy"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Privacy"
+                id="admin.sidebar.privacy"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="compliance"
+            name="compliance"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Compliance"
+                id="admin.sidebar.compliance"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="logging"
+            name="logging"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Logging"
+                id="admin.sidebar.logging"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="access-control"
+          name="access-control"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Access Control"
+              id="admin.sidebar.access-control"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="groups"
+            name="groups"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Groups"
+                id="admin.sidebar.groups"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="permissions"
+          name="permissions"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Advanced Permissions"
+              id="admin.sidebar.permissions"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="schemes"
+            name="schemes"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Permission Schemes"
+                id="admin.sidebar.schemes"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="authentication"
+          name="authentication"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Authentication"
+              id="admin.sidebar.authentication"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="authentication_email"
+            name="authentication_email"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Email"
+                id="admin.sidebar.email"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="oauth"
+            name="oauth"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="OAuth 2.0"
+                id="admin.sidebar.oauth"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="ldap"
+            name="ldap"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="AD/LDAP"
+                id="admin.sidebar.ldap"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="saml"
+            name="saml"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="SAML 2.0"
+                id="admin.sidebar.saml"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="mfa"
+            name="mfa"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="MFA"
+                id="admin.sidebar.mfa"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="security"
+          name="security"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Security"
+              id="admin.sidebar.security"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="signup"
+            name="signup"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Sign Up"
+                id="admin.sidebar.signUp"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="password"
+            name="password"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Password"
+                id="admin.sidebar.password"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="public_links"
+            name="public_links"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Public Links"
+                id="admin.sidebar.publicLinks"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="sessions"
+            name="sessions"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Sessions"
+                id="admin.sidebar.sessions"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="connections"
+            name="connections"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Connections"
+                id="admin.sidebar.connections"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="notifications"
+          name="notifications"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Notifications"
+              id="admin.sidebar.notifications"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="notifications_email"
+            name="notifications_email"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Email"
+                id="admin.sidebar.email"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="push"
+            name="push"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Mobile Push"
+                id="admin.sidebar.push"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="integrations"
+          name="integrations"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Integrations"
+              id="admin.sidebar.integrations"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="custom"
+            name="custom"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Custom Integrations"
+                id="admin.sidebar.customIntegrations"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="external"
+            name="external"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="External Services"
+                id="admin.sidebar.external"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="plugins"
+          name="plugins"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Plugins (Beta)"
+              id="admin.sidebar.plugins"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="management"
+            name="management"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Management"
+                id="admin.sidebar.plugins.management"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="files"
+          name="files"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Files"
+              id="admin.sidebar.files"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="storage"
+            name="storage"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Storage"
+                id="admin.sidebar.storage"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="customization"
+          name="customization"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Customization"
+              id="admin.sidebar.customization"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="custom_brand"
+            name="custom_brand"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Custom Branding"
+                id="admin.sidebar.customBrand"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="announcement"
+            name="announcement"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Announcement Banner"
+                id="admin.sidebar.announcement"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="emoji"
+            name="emoji"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Emoji"
+                id="admin.sidebar.emoji"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="gif"
+            name="gif"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="GIF (Beta)"
+                id="admin.sidebar.gif"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="posts"
+            name="posts"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Posts"
+                id="admin.sidebar.posts"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="legal_and_support"
+            name="legal_and_support"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Legal and Support"
+                id="admin.sidebar.legalAndSupport"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="custom_terms_of_service"
+            name="custom_terms_of_service"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Custom Terms of Service (Beta)"
+                id="admin.sidebar.customTermsOfService"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="native_app_links"
+            name="native_app_links"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Mattermost App Links"
+                id="admin.sidebar.nativeAppLinks"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="compliance"
+          name="compliance"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Compliance"
+              id="admin.sidebar.compliance"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="data_retention"
+            name="data_retention"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Data Retention Policy"
+                id="admin.sidebar.data_retention"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="message_export"
+            name="message_export"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Compliance Export (Beta)"
+                id="admin.sidebar.compliance_export"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="advanced"
+          name="advanced"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Advanced"
+              id="admin.sidebar.advanced"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="rate"
+            name="rate"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Rate Limiting"
+                id="admin.sidebar.rateLimiting"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="database"
+            name="database"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Database"
+                id="admin.sidebar.database"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="elasticsearch"
+            name="elasticsearch"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Elasticsearch"
+                id="admin.sidebar.elasticsearch"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="developer"
+            name="developer"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Developer"
+                id="admin.sidebar.developer"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="cluster"
+            name="cluster"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="High Availability"
+                id="admin.sidebar.cluster"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="metrics"
+            name="metrics"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Performance Monitoring"
+                id="admin.sidebar.metrics"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="experimental"
+            name="experimental"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Experimental"
+                id="admin.sidebar.experimental"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+      </AdminSidebarCategory>
+      <AdminSidebarCategory
+        icon="fa-wrench"
+        parentLink="/admin_console"
+        title={
+          <FormattedMessage
+            defaultMessage="OTHER"
+            id="admin.sidebar.other"
+            values={Object {}}
+          />
+        }
+      >
+        <AdminSidebarSection
+          key="license"
+          name="license"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Edition and License"
+              id="admin.sidebar.license"
+              values={Object {}}
+            />
+          }
+        />
+        <AdminSidebarSection
+          key="audits"
+          name="audits"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Complaince and Auditing"
+              id="admin.sidebar.audits"
+              values={Object {}}
+            />
+          }
+        />
+      </AdminSidebarCategory>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`components/AdminSidebar should match snapshot, with license (without any explicit feature) 1`] = `
+<div
+  className="admin-sidebar"
+>
+  <Connect(SidebarHeader) />
+  <div
+    className="nav-pills__container"
+  >
+    <ul
+      className="nav nav-pills nav-stacked"
+    >
+      <AdminSidebarCategory
+        icon="fa-bar-chart"
+        parentLink="/admin_console"
+        title={
+          <FormattedMessage
+            defaultMessage="REPORTING"
+            id="admin.sidebar.reports"
+            values={Object {}}
+          />
+        }
+      >
+        <AdminSidebarSection
+          key="system_analytics"
+          name="system_analytics"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Site Statistics"
+              id="admin.sidebar.view_statistics"
+              values={Object {}}
+            />
+          }
+        />
+        <AdminSidebarSection
+          key="team_analytics"
+          name="team_analytics"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Team Statistics"
+              id="admin.sidebar.statistics"
+              values={Object {}}
+            />
+          }
+        />
+        <AdminSidebarSection
+          key="users"
+          name="users"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Users"
+              id="admin.sidebar.users"
+              values={Object {}}
+            />
+          }
+        />
+        <AdminSidebarSection
+          key="logs"
+          name="logs"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Logs"
+              id="admin.sidebar.logs"
+              values={Object {}}
+            />
+          }
+        />
+      </AdminSidebarCategory>
+      <AdminSidebarCategory
+        icon="fa-gear"
+        parentLink="/admin_console"
+        sectionClass="sections--settings"
+        title={
+          <FormattedMessage
+            defaultMessage="SETTINGS"
+            id="admin.sidebar.settings"
+            values={Object {}}
+          />
+        }
+      >
+        <AdminSidebarSection
+          key="general"
+          name="general"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="General"
+              id="admin.sidebar.general"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="configuration"
+            name="configuration"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Configuration"
+                id="admin.sidebar.configuration"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="localization"
+            name="localization"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Localization"
+                id="admin.sidebar.localization"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="users_and_teams"
+            name="users_and_teams"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Users and Teams"
+                id="admin.sidebar.usersAndTeams"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="privacy"
+            name="privacy"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Privacy"
+                id="admin.sidebar.privacy"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="logging"
+            name="logging"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Logging"
+                id="admin.sidebar.logging"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="permissions"
+          name="permissions"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Advanced Permissions"
+              id="admin.sidebar.permissions"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="system-scheme"
+            name="system-scheme"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="System scheme"
+                id="admin.sidebar.system-scheme"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="authentication"
+          name="authentication"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Authentication"
+              id="admin.sidebar.authentication"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="authentication_email"
+            name="authentication_email"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Email"
+                id="admin.sidebar.email"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="oauth"
+            name="oauth"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="OAuth 2.0"
+                id="admin.sidebar.oauth"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="mfa"
+            name="mfa"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="MFA"
+                id="admin.sidebar.mfa"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="security"
+          name="security"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Security"
+              id="admin.sidebar.security"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="signup"
+            name="signup"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Sign Up"
+                id="admin.sidebar.signUp"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="password"
+            name="password"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Password"
+                id="admin.sidebar.password"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="public_links"
+            name="public_links"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Public Links"
+                id="admin.sidebar.publicLinks"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="sessions"
+            name="sessions"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Sessions"
+                id="admin.sidebar.sessions"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="connections"
+            name="connections"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Connections"
+                id="admin.sidebar.connections"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="notifications"
+          name="notifications"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Notifications"
+              id="admin.sidebar.notifications"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="notifications_email"
+            name="notifications_email"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Email"
+                id="admin.sidebar.email"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="push"
+            name="push"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Mobile Push"
+                id="admin.sidebar.push"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="integrations"
+          name="integrations"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Integrations"
+              id="admin.sidebar.integrations"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="custom"
+            name="custom"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Custom Integrations"
+                id="admin.sidebar.customIntegrations"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="external"
+            name="external"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="External Services"
+                id="admin.sidebar.external"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="plugins"
+          name="plugins"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Plugins (Beta)"
+              id="admin.sidebar.plugins"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="management"
+            name="management"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Management"
+                id="admin.sidebar.plugins.management"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="files"
+          name="files"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Files"
+              id="admin.sidebar.files"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="storage"
+            name="storage"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Storage"
+                id="admin.sidebar.storage"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="customization"
+          name="customization"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Customization"
+              id="admin.sidebar.customization"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="custom_brand"
+            name="custom_brand"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Custom Branding"
+                id="admin.sidebar.customBrand"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="announcement"
+            name="announcement"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Announcement Banner"
+                id="admin.sidebar.announcement"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="emoji"
+            name="emoji"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Emoji"
+                id="admin.sidebar.emoji"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="gif"
+            name="gif"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="GIF (Beta)"
+                id="admin.sidebar.gif"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="posts"
+            name="posts"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Posts"
+                id="admin.sidebar.posts"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="legal_and_support"
+            name="legal_and_support"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Legal and Support"
+                id="admin.sidebar.legalAndSupport"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="native_app_links"
+            name="native_app_links"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Mattermost App Links"
+                id="admin.sidebar.nativeAppLinks"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+        <AdminSidebarSection
+          key="advanced"
+          name="advanced"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Advanced"
+              id="admin.sidebar.advanced"
+              values={Object {}}
+            />
+          }
+          type="text"
+        >
+          <AdminSidebarSection
+            key="rate"
+            name="rate"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Rate Limiting"
+                id="admin.sidebar.rateLimiting"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="database"
+            name="database"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Database"
+                id="admin.sidebar.database"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="developer"
+            name="developer"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Developer"
+                id="admin.sidebar.developer"
+                values={Object {}}
+              />
+            }
+          />
+          <AdminSidebarSection
+            key="experimental"
+            name="experimental"
+            parentLink=""
+            subsection={false}
+            title={
+              <FormattedMessage
+                defaultMessage="Experimental"
+                id="admin.sidebar.experimental"
+                values={Object {}}
+              />
+            }
+          />
+        </AdminSidebarSection>
+      </AdminSidebarCategory>
+      <AdminSidebarCategory
+        icon="fa-wrench"
+        parentLink="/admin_console"
+        title={
+          <FormattedMessage
+            defaultMessage="OTHER"
+            id="admin.sidebar.other"
+            values={Object {}}
+          />
+        }
+      >
+        <AdminSidebarSection
+          key="license"
+          name="license"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Edition and License"
+              id="admin.sidebar.license"
+              values={Object {}}
+            />
+          }
+        />
+        <AdminSidebarSection
+          key="audits"
+          name="audits"
+          parentLink=""
+          subsection={false}
+          title={
+            <FormattedMessage
+              defaultMessage="Complaince and Auditing"
+              id="admin.sidebar.audits"
+              values={Object {}}
+            />
+          }
+        />
       </AdminSidebarCategory>
     </ul>
   </div>

--- a/components/admin_console/admin_sidebar/admin_sidebar.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.jsx
@@ -10,6 +10,7 @@ import * as Utils from 'utils/utils.jsx';
 import AdminSidebarCategory from 'components/admin_console/admin_sidebar_category.jsx';
 import AdminSidebarHeader from 'components/admin_console/admin_sidebar_header';
 import AdminSidebarSection from 'components/admin_console/admin_sidebar_section.jsx';
+import AdminDefinition from 'components/admin_console/admin_definition.jsx';
 
 export default class AdminSidebar extends React.Component {
     static get contextTypes() {
@@ -68,267 +69,109 @@ export default class AdminSidebar extends React.Component {
         document.title = Utils.localizeMessage('sidebar_right_menu.console', 'System Console') + currentSiteName;
     }
 
-    render() {
-        let oauthSettings = null;
-        let ldapSettings = null;
-        let samlSettings = null;
-        let clusterSettings = null;
-        let metricsSettings = null;
-        let complianceSettings = null;
-        let customTermsOfServiceSettings = null;
-        let messageExportSettings = null;
-        let complianceSection = null;
-
-        let license = null;
-        let audits = null;
-        let announcement = null;
-
-        if (this.props.buildEnterpriseReady) {
-            license = (
-                <AdminSidebarSection
-                    name='license'
-                    title={
-                        <FormattedMessage
-                            id='admin.sidebar.license'
-                            defaultMessage='Edition and License'
-                        />
-                    }
-                />
-            );
-        }
-
-        if (this.props.license.IsLicensed === 'true') {
-            if (this.props.license.LDAP === 'true') {
-                ldapSettings = (
-                    <AdminSidebarSection
-                        name='ldap'
-                        title={
-                            <FormattedMessage
-                                id='admin.sidebar.ldap'
-                                defaultMessage='AD/LDAP'
-                            />
-                        }
-                    />
-                );
+    renderSettingsMenu = (section) => {
+        const menuEntries = [];
+        Object.values(section).forEach((item) => {
+            if (!item.schema) {
+                return;
             }
 
-            if (this.props.license.Cluster === 'true') {
-                clusterSettings = (
-                    <AdminSidebarSection
-                        name='cluster'
-                        title={
-                            <FormattedMessage
-                                id='admin.sidebar.cluster'
-                                defaultMessage='High Availability'
-                            />
-                        }
-                    />
-                );
+            if (!item.title) {
+                return;
             }
 
-            if (this.props.license.Metrics === 'true') {
-                metricsSettings = (
-                    <AdminSidebarSection
-                        name='metrics'
-                        title={
-                            <FormattedMessage
-                                id='admin.sidebar.metrics'
-                                defaultMessage='Performance Monitoring'
-                            />
-                        }
-                    />
-                );
+            if (item.isHidden && item.isHidden(this.props.config, {}, this.props.license, this.props.buildEnterpriseReady)) {
+                return;
             }
 
-            if (this.props.license.SAML === 'true') {
-                samlSettings = (
-                    <AdminSidebarSection
-                        name='saml'
-                        title={
-                            <FormattedMessage
-                                id='admin.sidebar.saml'
-                                defaultMessage='SAML 2.0'
-                            />
-                        }
+            menuEntries.push((
+                <AdminSidebarSection
+                    key={item.url}
+                    name={item.url}
+                    title={
+                        <FormattedMessage
+                            id={item.title}
+                            defaultMessage={item.title_default}
+                        />
+                    }
+                />
+            ));
+        });
+
+        if (menuEntries.length === 0) {
+            return null;
+        }
+
+        // Special case for plugins entries
+        let extraEntries;
+        if (section.url === 'plugins') {
+            extraEntries = this.renderPluginsMenu();
+        }
+
+        return (
+            <AdminSidebarSection
+                key={section.url}
+                name={section.url}
+                type='text'
+                title={
+                    <FormattedMessage
+                        id={section.title}
+                        defaultMessage={section.title_default}
                     />
-                );
+                }
+            >
+                {menuEntries}
+                {extraEntries}
+            </AdminSidebarSection>
+        );
+    }
+
+    renderRootMenu = (section, icon, title, titleDefault) => {
+        const menuEntries = [];
+        Object.values(section).forEach((item) => {
+            if (!item.title) {
+                return;
             }
 
-            if (this.props.license.Compliance === 'true') {
-                complianceSettings = (
-                    <AdminSidebarSection
-                        name='compliance'
-                        title={
-                            <FormattedMessage
-                                id='admin.sidebar.compliance'
-                                defaultMessage='Compliance'
-                            />
-                        }
-                    />
-                );
+            if (item.isHidden && item.isHidden(this.props.config, {}, this.props.license, this.props.buildEnterpriseReady)) {
+                return;
             }
 
-            if (this.props.license.CustomTermsOfService === 'true') {
-                customTermsOfServiceSettings = (
-                    <AdminSidebarSection
-                        name='custom_terms_of_service'
-                        title={
-                            <FormattedMessage
-                                id='admin.sidebar.customTermsOfService'
-                                defaultMessage='Custom Terms of Service (Beta)'
-                            />
-                        }
+            menuEntries.push((
+                <AdminSidebarSection
+                    key={item.url}
+                    name={item.url}
+                    title={
+                        <FormattedMessage
+                            id={item.title}
+                            defaultMessage={item.title_default}
+                        />
+                    }
+                />
+            ));
+        });
+
+        if (menuEntries.length === 0) {
+            return null;
+        }
+
+        return (
+            <AdminSidebarCategory
+                parentLink='/admin_console'
+                icon={icon}
+                title={
+                    <FormattedMessage
+                        id={title}
+                        defaultMessage={titleDefault}
                     />
-                );
-            }
+                }
+            >
+                {menuEntries}
+            </AdminSidebarCategory>
+        );
+    }
 
-            if (this.props.license.MessageExport === 'true') {
-                messageExportSettings = (
-                    <AdminSidebarSection
-                        name='message_export'
-                        title={
-                            <FormattedMessage
-                                id='admin.sidebar.compliance_export'
-                                defaultMessage='Compliance Export (Beta)'
-                            />
-                        }
-                    />
-                );
-            }
-
-            oauthSettings = (
-                <AdminSidebarSection
-                    name='oauth'
-                    title={
-                        <FormattedMessage
-                            id='admin.sidebar.oauth'
-                            defaultMessage='OAuth 2.0'
-                        />
-                    }
-                />
-            );
-            announcement = (
-                <AdminSidebarSection
-                    name='announcement'
-                    title={
-                        <FormattedMessage
-                            id='admin.sidebar.announcement'
-                            defaultMessage='Announcement Banner'
-                        />
-                    }
-                />
-            );
-        } else {
-            oauthSettings = (
-                <AdminSidebarSection
-                    name='gitlab'
-                    title={
-                        <FormattedMessage
-                            id='admin.sidebar.gitlab'
-                            defaultMessage='GitLab'
-                        />
-                    }
-                />
-            );
-        }
-
-        if (this.props.license.IsLicensed === 'true') {
-            audits = (
-                <AdminSidebarSection
-                    name='audits'
-                    title={
-                        <FormattedMessage
-                            id='admin.sidebar.audits'
-                            defaultMessage='Complaince and Auditing'
-                        />
-                    }
-                />
-            );
-        }
-
-        let otherCategory = null;
-        if (license || audits) {
-            otherCategory = (
-                <AdminSidebarCategory
-                    parentLink='/admin_console'
-                    icon='fa-wrench'
-                    title={
-                        <FormattedMessage
-                            id='admin.sidebar.other'
-                            defaultMessage='OTHER'
-                        />
-                    }
-                >
-                    {license}
-                    {audits}
-                </AdminSidebarCategory>
-            );
-        }
-
-        let elasticSearchSettings = null;
-        if (this.props.license.IsLicensed === 'true' && this.props.license.Elasticsearch === 'true') {
-            elasticSearchSettings = (
-                <AdminSidebarSection
-                    name='elasticsearch'
-                    title={
-                        <FormattedMessage
-                            id='admin.sidebar.elasticsearch'
-                            defaultMessage='Elasticsearch'
-                        />
-                    }
-                />
-            );
-        }
-
-        let dataRetentionSettings = null;
-        if (this.props.license.IsLicensed === 'true' && this.props.license.DataRetention === 'true') {
-            dataRetentionSettings = (
-                <AdminSidebarSection
-                    name='data_retention'
-                    title={
-                        <FormattedMessage
-                            id='admin.sidebar.data_retention'
-                            defaultMessage='Data Retention Policy'
-                        />
-                    }
-                />
-            );
-        }
-
-        const SHOW_CLIENT_VERSIONS = false;
-        let clientVersions = null;
-        if (SHOW_CLIENT_VERSIONS) {
-            clientVersions = (
-                <AdminSidebarSection
-                    name='client_versions'
-                    title={
-                        <FormattedMessage
-                            id='admin.sidebar.client_versions'
-                            defaultMessage='Client Versions'
-                        />
-                    }
-                />
-            );
-        }
-
-        if (dataRetentionSettings || messageExportSettings) {
-            complianceSection = (
-                <AdminSidebarSection
-                    name='compliance'
-                    type='text'
-                    title={
-                        <FormattedMessage
-                            id='admin.sidebar.compliance'
-                            defaultMessage='Compliance'
-                        />
-                    }
-                >
-                    {dataRetentionSettings}
-                    {messageExportSettings}
-                </AdminSidebarSection>
-            );
-        }
-
+    renderPluginsMenu = () => {
         const customPlugins = [];
         if (this.props.config.PluginSettings.Enable) {
             Object.values(this.props.plugins).sort((a, b) => {
@@ -353,59 +196,16 @@ export default class AdminSidebar extends React.Component {
                 );
             });
         }
+        return customPlugins;
+    }
 
+    render() {
         return (
             <div className='admin-sidebar'>
                 <AdminSidebarHeader/>
                 <div className='nav-pills__container'>
                     <ul className='nav nav-pills nav-stacked'>
-                        <AdminSidebarCategory
-                            parentLink='/admin_console'
-                            icon='fa-bar-chart'
-                            title={
-                                <FormattedMessage
-                                    id='admin.sidebar.reports'
-                                    defaultMessage='REPORTING'
-                                />
-                            }
-                        >
-                            <AdminSidebarSection
-                                name='system_analytics'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.view_statistics'
-                                        defaultMessage='Site Statistics'
-                                    />
-                                }
-                            />
-                            <AdminSidebarSection
-                                name='team_analytics'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.statistics'
-                                        defaultMessage='Team Statistics'
-                                    />
-                                }
-                            />
-                            <AdminSidebarSection
-                                name='users'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.users'
-                                        defaultMessage='Users'
-                                    />
-                                }
-                            />
-                            <AdminSidebarSection
-                                name='logs'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.logs'
-                                        defaultMessage='Logs'
-                                    />
-                                }
-                            />
-                        </AdminSidebarCategory>
+                        {this.renderRootMenu(AdminDefinition.reporting, 'fa-bar-chart', 'admin.sidebar.reports', 'REPORTING')}
                         <AdminSidebarCategory
                             sectionClass='sections--settings'
                             parentLink='/admin_console'
@@ -417,430 +217,9 @@ export default class AdminSidebar extends React.Component {
                                 />
                             }
                         >
-                            <AdminSidebarSection
-                                name='general'
-                                type='text'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.general'
-                                        defaultMessage='General'
-                                    />
-                                }
-                            >
-                                <AdminSidebarSection
-                                    name='configuration'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.configuration'
-                                            defaultMessage='Configuration'
-                                        />
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='localization'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.localization'
-                                            defaultMessage='Localization'
-                                        />
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='users_and_teams'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.usersAndTeams'
-                                            defaultMessage='Users and Teams'
-                                        />
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='privacy'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.privacy'
-                                            defaultMessage='Privacy'
-                                        />
-                                    }
-                                />
-                                {complianceSettings}
-                                <AdminSidebarSection
-                                    name='logging'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.logging'
-                                            defaultMessage='Logging'
-                                        />
-                                    }
-                                />
-                            </AdminSidebarSection>
-                            {this.props.license.IsLicensed === 'true' && this.props.license.LDAPGroups === 'true' && this.props.config.ServiceSettings.ExperimentalLdapGroupSync &&
-                                <AdminSidebarSection
-                                    name='access-control'
-                                    type='text'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.access-control'
-                                            defaultMessage='Access Control'
-                                        />
-                                    }
-                                >
-                                    <AdminSidebarSection
-                                        name='groups'
-                                        title={
-                                            <FormattedMessage
-                                                id='admin.sidebar.groups'
-                                                defaultMessage='Groups'
-                                            />
-                                        }
-                                    />
-                                </AdminSidebarSection>
-                            }
-                            {this.props.license.IsLicensed === 'true' &&
-                                <AdminSidebarSection
-                                    name='permissions'
-                                    type='text'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.permissions'
-                                            defaultMessage='Advanced Permissions'
-                                        />
-                                    }
-                                >
-                                    {this.props.license.CustomPermissionsSchemes !== 'true' &&
-                                        <AdminSidebarSection
-                                            name='system-scheme'
-                                            title={
-                                                <FormattedMessage
-                                                    id='admin.sidebar.system-scheme'
-                                                    defaultMessage='System scheme'
-                                                />
-                                            }
-                                        />}
-                                    {this.props.license.CustomPermissionsSchemes === 'true' &&
-                                        <AdminSidebarSection
-                                            name='schemes'
-                                            title={
-                                                <FormattedMessage
-                                                    id='admin.sidebar.schemes'
-                                                    defaultMessage='Permission Schemes'
-                                                />
-                                            }
-                                        />}
-                                </AdminSidebarSection>}
-                            <AdminSidebarSection
-                                name='authentication'
-                                type='text'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.authentication'
-                                        defaultMessage='Authentication'
-                                    />
-                                }
-                            >
-                                <AdminSidebarSection
-                                    name='authentication_email'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.email'
-                                            defaultMessage='Email'
-                                        />
-                                    }
-                                />
-                                {oauthSettings}
-                                {ldapSettings}
-                                {samlSettings}
-                                <AdminSidebarSection
-                                    name='mfa'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.mfa'
-                                            defaultMessage='MFA'
-                                        />
-                                    }
-                                />
-                            </AdminSidebarSection>
-                            <AdminSidebarSection
-                                name='security'
-                                type='text'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.security'
-                                        defaultMessage='Security'
-                                    />
-                                }
-                            >
-                                <AdminSidebarSection
-                                    name='sign_up'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.signUp'
-                                            defaultMessage='Sign Up'
-                                        />
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='password'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.password'
-                                            defaultMessage='Password'
-                                        />
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='public_links'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.publicLinks'
-                                            defaultMessage='Public Links'
-                                        />
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='sessions'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.sessions'
-                                            defaultMessage='Sessions'
-                                        />
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='connections'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.connections'
-                                            defaultMessage='Connections'
-                                        />
-                                    }
-                                />
-                                {clientVersions}
-                            </AdminSidebarSection>
-                            <AdminSidebarSection
-                                name='notifications'
-                                type='text'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.notifications'
-                                        defaultMessage='Notifications'
-                                    />
-                                }
-                            >
-                                <AdminSidebarSection
-                                    name='notifications_email'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.email'
-                                            defaultMessage='Email'
-                                        />
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='push'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.push'
-                                            defaultMessage='Mobile Push'
-                                        />
-                                    }
-                                />
-                            </AdminSidebarSection>
-                            <AdminSidebarSection
-                                name='integrations'
-                                type='text'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.integrations'
-                                        defaultMessage='Integrations'
-                                    />
-                                }
-                            >
-                                <AdminSidebarSection
-                                    name='custom'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.customIntegrations'
-                                            defaultMessage='Custom Integrations'
-                                        />
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='external'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.external'
-                                            defaultMessage='External Services'
-                                        />
-                                    }
-                                />
-                            </AdminSidebarSection>
-                            <AdminSidebarSection
-                                name='plugins'
-                                type='text'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.plugins'
-                                        defaultMessage='Plugins (Beta)'
-                                    />
-                                }
-                            >
-                                <AdminSidebarSection
-                                    name='management'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.plugins.management'
-                                            defaultMessage='Management'
-                                        />
-                                    }
-                                />
-                                {customPlugins}
-                            </AdminSidebarSection>
-                            <AdminSidebarSection
-                                name='files'
-                                type='text'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.files'
-                                        defaultMessage='Files'
-                                    />
-                                }
-                            >
-                                <AdminSidebarSection
-                                    key='storage'
-                                    name='storage'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.storage'
-                                            defaultMessage='Storage'
-                                        />
-                                    }
-                                />
-                            </AdminSidebarSection>
-                            <AdminSidebarSection
-                                name='customization'
-                                type='text'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.customization'
-                                        defaultMessage='Customization'
-                                    />
-                                }
-                            >
-                                <AdminSidebarSection
-                                    name='custom_brand'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.customBrand'
-                                            defaultMessage='Custom Branding'
-                                        />
-                                    }
-                                />
-                                {announcement}
-                                <AdminSidebarSection
-                                    name='emoji'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.emoji'
-                                            defaultMessage='Emoji'
-                                        />
-
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='gif'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.gif'
-                                            defaultMessage='GIF (Beta)'
-                                        />
-
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='posts'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.posts'
-                                            defaultMessage='Posts'
-                                        />
-
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='legal_and_support'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.legalAndSupport'
-                                            defaultMessage='Legal and Support'
-                                        />
-                                    }
-                                />
-                                {customTermsOfServiceSettings}
-                                <AdminSidebarSection
-                                    name='native_app_links'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.nativeAppLinks'
-                                            defaultMessage='Mattermost App Links'
-                                        />
-
-                                    }
-                                />
-                            </AdminSidebarSection>
-                            {complianceSection}
-                            <AdminSidebarSection
-                                name='advanced'
-                                type='text'
-                                title={
-                                    <FormattedMessage
-                                        id='admin.sidebar.advanced'
-                                        defaultMessage='Advanced'
-                                    />
-                                }
-                            >
-                                <AdminSidebarSection
-                                    name='rate'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.rateLimiting'
-                                            defaultMessage='Rate Limiting'
-                                        />
-                                    }
-                                />
-                                <AdminSidebarSection
-                                    name='database'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.database'
-                                            defaultMessage='Database'
-                                        />
-                                    }
-                                />
-                                {elasticSearchSettings}
-                                <AdminSidebarSection
-                                    name='developer'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.developer'
-                                            defaultMessage='Developer'
-                                        />
-                                    }
-                                />
-                                {clusterSettings}
-                                {metricsSettings}
-                                <AdminSidebarSection
-                                    name='experimental'
-                                    title={
-                                        <FormattedMessage
-                                            id='admin.sidebar.experimental'
-                                            defaultMessage='Experimental'
-                                        />
-                                    }
-                                />
-                            </AdminSidebarSection>
+                            {Object.values(AdminDefinition.settings).map(this.renderSettingsMenu)}
                         </AdminSidebarCategory>
-                        {otherCategory}
+                        {this.renderRootMenu(AdminDefinition.other, 'fa-wrench', 'admin.sidebar.other', 'OTHER')}
                     </ul>
                 </div>
             </div>

--- a/components/admin_console/admin_sidebar/admin_sidebar.test.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.test.jsx
@@ -87,4 +87,94 @@ describe('components/AdminSidebar', () => {
         const wrapper = shallow(<AdminSidebar {...props}/>, {context});
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should match snapshot, with license (without any explicit feature)', () => {
+        const props = {
+            license: {
+                IsLicensed: 'true',
+            },
+            config: {
+                PluginSettings: {
+                    Enable: true,
+                    EnableUploads: true,
+                },
+            },
+            buildEnterpriseReady: true,
+            siteName: 'test snap',
+            plugins: {
+                plugin_0: {
+                    active: false,
+                    description: 'The plugin 0.',
+                    id: 'plugin_0',
+                    name: 'Plugin 0',
+                    version: '0.1.0',
+                    settings_schema: {
+                        footer: '',
+                        header: '',
+                        settings: [],
+                    },
+                    webapp: {},
+                },
+            },
+            actions: {
+                getPlugins: jest.fn(),
+            },
+        };
+
+        const context = {router: {}};
+        const wrapper = shallow(<AdminSidebar {...props}/>, {context});
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, with license (with all feature)', () => {
+        const props = {
+            license: {
+                IsLicensed: 'true',
+                DataRetention: 'true',
+                LDAPGroups: 'true',
+                LDAP: 'true',
+                Cluster: 'true',
+                Metrics: 'true',
+                SAML: 'true',
+                Compliance: 'true',
+                CustomTermsOfService: 'true',
+                MessageExport: 'true',
+                Elasticsearch: 'true',
+                CustomPermissionsSchemes: 'true',
+            },
+            config: {
+                PluginSettings: {
+                    Enable: true,
+                    EnableUploads: true,
+                },
+                ServiceSettings: {
+                    ExperimentalLdapGroupSync: true,
+                },
+            },
+            buildEnterpriseReady: true,
+            siteName: 'test snap',
+            plugins: {
+                plugin_0: {
+                    active: false,
+                    description: 'The plugin 0.',
+                    id: 'plugin_0',
+                    name: 'Plugin 0',
+                    version: '0.1.0',
+                    settings_schema: {
+                        footer: '',
+                        header: '',
+                        settings: [],
+                    },
+                    webapp: {},
+                },
+            },
+            actions: {
+                getPlugins: jest.fn(),
+            },
+        };
+
+        const context = {router: {}};
+        const wrapper = shallow(<AdminSidebar {...props}/>, {context});
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -41,7 +41,7 @@ export default class SchemaAdminSettings extends React.Component {
         environmentConfig: PropTypes.object,
         setNavigationBlocked: PropTypes.func,
         schema: PropTypes.object,
-        roles: PropTypes.array,
+        roles: PropTypes.object,
         license: PropTypes.object,
         editRole: PropTypes.func,
     }


### PR DESCRIPTION
#### Summary
The admin definitions are now used to generate the routes and the admin menu
entries. This way we can define entirely new sections in the admin console
without touching anything else.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)