### PR TITLE
[MM-14192] Render hyperlinks in Message Attachment title

### DIFF
--- a/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.jsx.snap
+++ b/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.jsx.snap
@@ -19,8 +19,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
         className="banner"
         dangerouslySetInnerHTML={
           Object {
-            "__html": "<h1 class=\\"markdown__heading\\">Header</h1><p><em>This</em> is the <strong>header</strong></p>
-",
+            "__html": "<h1 class=\\"markdown__heading\\">Header</h1><p><em>This</em> is the <strong>header</strong></p>",
           }
         }
       />
@@ -176,8 +175,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
         className="banner"
         dangerouslySetInnerHTML={
           Object {
-            "__html": "<h1 class=\\"markdown__heading\\">Footer</h1><p><em>This</em> is the <strong>footer</strong></p>
-",
+            "__html": "<h1 class=\\"markdown__heading\\">Footer</h1><p><em>This</em> is the <strong>footer</strong></p>",
           }
         }
       />
@@ -294,8 +292,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
         className="banner"
         dangerouslySetInnerHTML={
           Object {
-            "__html": "<h1 class=\\"markdown__heading\\">Header</h1><p><em>This</em> is the <strong>header</strong></p>
-",
+            "__html": "<h1 class=\\"markdown__heading\\">Header</h1><p><em>This</em> is the <strong>header</strong></p>",
           }
         }
       />
@@ -451,8 +448,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
         className="banner"
         dangerouslySetInnerHTML={
           Object {
-            "__html": "<h1 class=\\"markdown__heading\\">Footer</h1><p><em>This</em> is the <strong>footer</strong></p>
-",
+            "__html": "<h1 class=\\"markdown__heading\\">Footer</h1><p><em>This</em> is the <strong>footer</strong></p>",
           }
         }
       />

--- a/components/markdown/__snapshots__/markdown.test.jsx.snap
+++ b/components/markdown/__snapshots__/markdown.test.jsx.snap
@@ -7,24 +7,20 @@ exports[`components/Markdown should not render markdown when formatting is disab
 `;
 
 exports[`components/Markdown should render properly 1`] = `
-Array [
-  <p
-    key="0"
+<p
+  key="0"
+>
+  This 
+  <em
+    key="1"
   >
-    This 
-    <em
-      key="1"
-    >
-      is
-    </em>
-     some 
-    <strong
-      key="3"
-    >
-      Markdown
-    </strong>
-  </p>,
-  "
-",
-]
+    is
+  </em>
+   some 
+  <strong
+    key="3"
+  >
+    Markdown
+  </strong>
+</p>
 `;

--- a/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
+++ b/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
@@ -247,6 +247,50 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
 </div>
 `;
 
+exports[`components/post_view/MessageAttachment should match snapshot when the attachment has a link in the title 1`] = `
+<div
+  className="attachment "
+>
+  <div
+    className="attachment__content"
+  >
+    <div
+      className="clearfix attachment__container attachment__container--undefined"
+    >
+      <h1
+        className="attachment__title"
+      >
+        <Connect(Markdown)
+          message="Do you like https://mattermost.com?"
+          options={
+            Object {
+              "autolinkedUrlSchemes": Array [],
+              "mentionHighlight": false,
+              "renderer": LinkOnlyRenderer {
+                "options": Object {},
+              },
+            }
+          }
+        />
+      </h1>
+      <div>
+        <div
+          className="attachment__body attachment__body--no_thumb"
+          onClick={[Function]}
+        />
+        <div
+          style={
+            Object {
+              "clear": "both",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`components/post_view/MessageAttachment should match snapshot when the attachment has an emoji in the title 1`] = `
 <div
   className="attachment "
@@ -265,8 +309,10 @@ exports[`components/post_view/MessageAttachment should match snapshot when the a
           options={
             Object {
               "autolinkedUrlSchemes": Array [],
-              "markdown": false,
               "mentionHighlight": false,
+              "renderer": LinkOnlyRenderer {
+                "options": Object {},
+              },
             }
           }
         />
@@ -307,8 +353,10 @@ exports[`components/post_view/MessageAttachment should match snapshot when the a
           options={
             Object {
               "autolinkedUrlSchemes": Array [],
-              "markdown": false,
               "mentionHighlight": false,
+              "renderer": LinkOnlyRenderer {
+                "options": Object {},
+              },
             }
           }
         />

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -16,6 +16,7 @@ import SizeAwareImage from 'components/size_aware_image';
 
 import ActionButton from '../action_button';
 import ActionMenu from '../action_menu';
+import LinkOnlyRenderer from 'utils/markdown/link_only_renderer';
 
 const MAX_ATTACHMENT_TEXT_HEIGHT = 200;
 
@@ -314,7 +315,7 @@ export default class MessageAttachment extends React.PureComponent {
                             message={attachment.title}
                             options={{
                                 mentionHighlight: false,
-                                markdown: false,
+                                renderer: new LinkOnlyRenderer(),
                                 autolinkedUrlSchemes: [],
                             }}
                         />

--- a/components/post_view/message_attachments/message_attachment/message_attachment.test.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.test.jsx
@@ -164,4 +164,17 @@ describe('components/post_view/MessageAttachment', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should match snapshot when the attachment has a link in the title', () => {
+        const props = {
+            ...baseProps,
+            attachment: {
+                title: 'Do you like https://mattermost.com?',
+            },
+        };
+
+        const wrapper = shallow(<MessageAttachment {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/utils/__snapshots__/message_html_to_component.test.jsx.snap
+++ b/utils/__snapshots__/message_html_to_component.test.jsx.snap
@@ -18,58 +18,44 @@ Array [
   <p>
     That was some latex!
   </p>,
-  "
-",
 ]
 `;
 
 exports[`messageHtmlToComponent link with enabled a tooltip plugin 1`] = `
-Array [
-  <p>
-    lorem ipsum 
-    <a
-      className="theme markdown__link"
+<p>
+  lorem ipsum 
+  <a
+    className="theme markdown__link"
+    href="http://www.dolor.com"
+    rel="noreferrer"
+    target="_blank"
+  >
+    <LinkTooltip
       href="http://www.dolor.com"
-      rel="noreferrer"
-      target="_blank"
-    >
-      <LinkTooltip
-        href="http://www.dolor.com"
-        title="www.dolor.com"
-      />
-    </a>
-     sit amet
-  </p>,
-  "
-",
-]
+      title="www.dolor.com"
+    />
+  </a>
+   sit amet
+</p>
 `;
 
 exports[`messageHtmlToComponent link without enabled tooltip plugins 1`] = `
-Array [
-  <p>
-    lorem ipsum 
-    <a
-      className="theme markdown__link"
-      href="http://www.dolor.com"
-      rel="noreferrer"
-      target="_blank"
-    >
-      www.dolor.com
-    </a>
-     sit amet
-  </p>,
-  "
-",
-]
+<p>
+  lorem ipsum 
+  <a
+    className="theme markdown__link"
+    href="http://www.dolor.com"
+    rel="noreferrer"
+    target="_blank"
+  >
+    www.dolor.com
+  </a>
+   sit amet
+</p>
 `;
 
 exports[`messageHtmlToComponent plain text 1`] = `
-Array [
-  <p>
-    Hello, world!
-  </p>,
-  "
-",
-]
+<p>
+  Hello, world!
+</p>
 `;

--- a/utils/markdown/index.js
+++ b/utils/markdown/index.js
@@ -23,7 +23,7 @@ export function formatWithRenderer(text, renderer) {
         mangle: false,
     };
 
-    return marked(text, markdownOptions);
+    return (marked(text, markdownOptions)).trim();
 }
 
 export function stripMarkdown(text) {

--- a/utils/markdown/link_only_renderer.jsx
+++ b/utils/markdown/link_only_renderer.jsx
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getScheme} from 'utils/url';
+
+import RemoveMarkdown from './remove_markdown';
+
+export default class LinkOnlyRenderer extends RemoveMarkdown {
+    link(href, title, text) {
+        let outHref = href;
+
+        if (!getScheme(href)) {
+            outHref = `http://${outHref}`;
+        }
+
+        let output = `<a class="theme markdown__link" href="${outHref}" target="_blank"`;
+
+        if (title) {
+            output += ' title="' + title + '"';
+        }
+
+        output += `>${text}</a>`;
+
+        return output;
+    }
+}

--- a/utils/markdown/link_only_renderer.test.jsx
+++ b/utils/markdown/link_only_renderer.test.jsx
@@ -1,0 +1,288 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import LinkOnlyRenderer from 'utils/markdown/link_only_renderer';
+import {formatWithRenderer} from 'utils/markdown';
+
+describe('formatWithRenderer | LinkOnlyRenderer', () => {
+    const testCases = [
+        {
+            description: 'emoji: same',
+            inputText: 'Hey :smile: :+1: :)',
+            outputText: 'Hey :smile: :+1: :)',
+        },
+        {
+            description: 'at-mention: same',
+            inputText: 'Hey @user and @test',
+            outputText: 'Hey @user and @test',
+        },
+        {
+            description: 'channel-link: same',
+            inputText: 'join ~channelname',
+            outputText: 'join ~channelname',
+        },
+        {
+            description: 'codespan: single backtick',
+            inputText: '`single backtick`',
+            outputText: 'single backtick',
+        },
+        {
+            description: 'codespan: double backtick',
+            inputText: '``double backtick``',
+            outputText: 'double backtick',
+        },
+        {
+            description: 'codespan: triple backtick',
+            inputText: '```triple backtick```',
+            outputText: 'triple backtick',
+        },
+        {
+            description: 'codespan: inline code',
+            inputText: 'Inline `code` has ``double backtick`` and ```triple backtick``` around it.',
+            outputText: 'Inline code has double backtick and triple backtick around it.',
+        },
+        {
+            description: 'codespan: multiline codespan',
+            inputText: 'Multiline ```\ncodespan\n```',
+            outputText: 'Multiline codespan',
+        },
+        {
+            description: 'codespan: multiline codespan 2',
+            inputText: 'Multiline ```function(number) {\n  return number + 1;\n}```',
+            outputText: 'Multiline function(number) {   return number + 1; }',
+        },
+        {
+            description: 'codespan: language highlighting',
+            inputText: '```javascript\nvar s = "JavaScript syntax highlighting";\nalert(s);\n```',
+            outputText: 'var s = "JavaScript syntax highlighting"; alert(s);',
+        },
+        {
+            description: 'blockquote:',
+            inputText: '> Hey quote',
+            outputText: 'Hey quote',
+        },
+        {
+            description: 'blockquote: multiline',
+            inputText: '> Hey quote.\n> Hello quote.',
+            outputText: 'Hey quote. Hello quote.',
+        },
+        {
+            description: 'heading: # H1 header',
+            inputText: '# H1 header',
+            outputText: 'H1 header',
+        },
+        {
+            description: 'heading: heading with @user',
+            inputText: '# H1 @user',
+            outputText: 'H1 @user',
+        },
+        {
+            description: 'heading: ## H2 header',
+            inputText: '## H2 header',
+            outputText: 'H2 header',
+        },
+        {
+            description: 'heading: ### H3 header',
+            inputText: '### H3 header',
+            outputText: 'H3 header',
+        },
+        {
+            description: 'heading: #### H4 header',
+            inputText: '#### H4 header',
+            outputText: 'H4 header',
+        },
+        {
+            description: 'heading: ##### H5 header',
+            inputText: '##### H5 header',
+            outputText: 'H5 header',
+        },
+        {
+            description: 'heading: ###### H6 header',
+            inputText: '###### H6 header',
+            outputText: 'H6 header',
+        },
+        {
+            description: 'heading: multiline with header and paragraph',
+            inputText: '###### H6 header\nThis is next line.\nAnother line.',
+            outputText: 'H6 header This is next line. Another line.',
+        },
+        {
+            description: 'heading: multiline with header and list items',
+            inputText: '###### H6 header\n- list item 1\n- list item 2',
+            outputText: 'H6 header list item 1 list item 2',
+        },
+        {
+            description: 'heading: multiline with header and links',
+            inputText: '###### H6 header\n[link 1](https://mattermost.com) - [link 2](https://mattermost.com)',
+            outputText: 'H6 header <a class="theme markdown__link" href="https://mattermost.com" target="_blank">' +
+            'link 1</a> - <a class="theme markdown__link" href="https://mattermost.com" target="_blank">link 2</a>',
+        },
+        {
+            description: 'list: 1. First ordered list item',
+            inputText: '1. First ordered list item',
+            outputText: 'First ordered list item',
+        },
+        {
+            description: 'list: 2. Another item',
+            inputText: '1. 2. Another item',
+            outputText: 'Another item',
+        },
+        {
+            description: 'list: * Unordered sub-list.',
+            inputText: '* Unordered sub-list.',
+            outputText: 'Unordered sub-list.',
+        },
+        {
+            description: 'list: - Or minuses',
+            inputText: '- Or minuses',
+            outputText: 'Or minuses',
+        },
+        {
+            description: 'list: + Or pluses',
+            inputText: '+ Or pluses',
+            outputText: 'Or pluses',
+        },
+        {
+            description: 'list: multiline',
+            inputText: '1. First ordered list item\n2. Another item',
+            outputText: 'First ordered list item Another item',
+        },
+        {
+            description: 'tablerow:)',
+            inputText: 'Markdown | Less | Pretty\n' +
+            '--- | --- | ---\n' +
+            '*Still* | `renders` | **nicely**\n' +
+            '1 | 2 | 3\n',
+            outputText: '',
+        },
+        {
+            description: 'table:',
+            inputText: '| Tables        | Are           | Cool  |\n' +
+            '| ------------- |:-------------:| -----:|\n' +
+            '| col 3 is      | right-aligned | $1600 |\n' +
+            '| col 2 is      | centered      |   $12 |\n' +
+            '| zebra stripes | are neat      |    $1 |\n',
+            outputText: '',
+        },
+        {
+            description: 'strong: Bold with **asterisks** or __underscores__.',
+            inputText: 'Bold with **asterisks** or __underscores__.',
+            outputText: 'Bold with asterisks or underscores.',
+        },
+        {
+            description: 'strong & em: Bold and italics with **asterisks and _underscores_**.',
+            inputText: 'Bold and italics with **asterisks and _underscores_**.',
+            outputText: 'Bold and italics with asterisks and underscores.',
+        },
+        {
+            description: 'em: Italics with *asterisks* or _underscores_.',
+            inputText: 'Italics with *asterisks* or _underscores_.',
+            outputText: 'Italics with asterisks or underscores.',
+        },
+        {
+            description: 'del: Strikethrough ~~strike this.~~',
+            inputText: 'Strikethrough ~~strike this.~~',
+            outputText: 'Strikethrough strike this.',
+        },
+        {
+            description: 'links: [inline-style link](http://localhost:8065)',
+            inputText: '[inline-style link](http://localhost:8065)',
+            outputText: '<a class="theme markdown__link" href="http://localhost:8065" target="_blank">' +
+            'inline-style link</a>',
+        },
+        {
+            description: 'image: ![image link](http://localhost:8065/image)',
+            inputText: '![image link](http://localhost:8065/image)',
+            outputText: 'image link',
+        },
+        {
+            description: 'text: plain',
+            inputText: 'This is plain text.',
+            outputText: 'This is plain text.',
+        },
+        {
+            description: 'text: multiline',
+            inputText: 'This is multiline text.\nHere is the next line.\n',
+            outputText: 'This is multiline text. Here is the next line.',
+        },
+        {
+            description: 'text: &amp; entity',
+            inputText: 'you & me',
+            outputText: 'you &amp; me',
+        },
+        {
+            description: 'text: &lt; entity',
+            inputText: '1<2',
+            outputText: '1&lt;2',
+        },
+        {
+            description: 'text: &gt; entity',
+            inputText: '2>1',
+            outputText: '2&gt;1',
+        },
+        {
+            description: 'text: &#39; entity',
+            inputText: 'he\'s out',
+            outputText: 'he&#39;s out',
+        },
+        {
+            description: 'text: &quot; entity',
+            inputText: 'That is "unique"',
+            outputText: 'That is &quot;unique&quot;',
+        },
+        {
+            description: 'text: multiple entities',
+            inputText: '&<>\'"',
+            outputText: '&amp;&lt;&gt;&#39;&quot;',
+        },
+        {
+            description: 'text: multiple entities',
+            inputText: '"\'><&',
+            outputText: '&quot;&#39;&gt;&lt;&amp;',
+        },
+        {
+            description: 'text: multiple entities',
+            inputText: '&amp;&lt;&gt;&#39;&quot;',
+            outputText: '&amp;&lt;&gt;&#39;&quot;',
+        },
+        {
+            description: 'text: multiple entities',
+            inputText: '&quot;&#39;&gt;&lt;&amp;',
+            outputText: '&quot;&#39;&gt;&lt;&amp;',
+        },
+        {
+            description: 'text: multiple entities',
+            inputText: '&amp;lt;',
+            outputText: '&amp;lt;',
+        },
+        {
+            description: 'text: empty string',
+            inputText: '',
+            outputText: '',
+        },
+        {
+            description: 'link: link without a scheme',
+            inputText: 'Do you like www.mattermost.com?',
+            outputText: 'Do you like <a class="theme markdown__link" href="http://www.mattermost.com" target="_blank">' +
+            'www.mattermost.com</a>?',
+        },
+        {
+            description: 'link: link with a scheme',
+            inputText: 'Do you like http://www.mattermost.com?',
+            outputText: 'Do you like <a class="theme markdown__link" href="http://www.mattermost.com" target="_blank">' +
+            'http://www.mattermost.com</a>?',
+        },
+        {
+            description: 'link: link with a title',
+            inputText: 'Do you like [Mattermost](http://www.mattermost.com)?',
+            outputText: 'Do you like <a class="theme markdown__link" href="http://www.mattermost.com" target="_blank">' +
+            'Mattermost</a>?',
+        },
+    ];
+
+    const linkOnlyRenderer = new LinkOnlyRenderer();
+
+    testCases.forEach((testCase) => it(testCase.description, () => {
+        expect(formatWithRenderer(testCase.inputText, linkOnlyRenderer)).toEqual(testCase.outputText);
+    }));
+});

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -6,7 +6,6 @@ import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
 import emojiRegex from 'emoji-regex';
 
 import {formatWithRenderer} from 'utils/markdown';
-import RemoveMarkdown from 'utils/markdown/remove_markdown';
 import {getEmojiMap} from 'selectors/emojis';
 import store from 'stores/redux_store.jsx';
 
@@ -14,7 +13,6 @@ import Constants from './constants.jsx';
 import * as Emoticons from './emoticons.jsx';
 import * as Markdown from './markdown';
 
-const removeMarkdown = new RemoveMarkdown();
 const punctuation = XRegExp.cache('[^\\pL\\d]');
 
 const AT_MENTION_PATTERN = /\B@([a-z0-9.\-_]*)/gi;
@@ -44,6 +42,7 @@ const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-
 // - team - The current team.
 // - proxyImages - If specified, images are proxied. Defaults to false.
 // - autolinkedUrlSchemes - An array of url schemes that will be allowed for autolinking. Defaults to autolinking with any url scheme.
+// - renderer - a custom renderer object to use in the formatWithRenderer function. Defaults to empty.
 export function formatText(text, inputOptions) {
     if (!text || typeof text !== 'string') {
         return '';
@@ -59,9 +58,8 @@ export function formatText(text, inputOptions) {
         options.searchPatterns = parseSearchTerms(options.searchTerm).map(convertSearchTermToRegex);
     }
 
-    if (options.removeMarkdown) {
-        output = formatWithRenderer(output, removeMarkdown);
-        output = sanitizeHtml(output);
+    if (options.renderer) {
+        output = formatWithRenderer(output, options.renderer);
         output = doFormatText(output, options);
     } else if (!('markdown' in options) || options.markdown) {
         // the markdown renderer will call doFormatText as necessary

--- a/utils/text_formatting.test.jsx
+++ b/utils/text_formatting.test.jsx
@@ -6,6 +6,7 @@ import emojiRegex from 'emoji-regex';
 import {formatText, autolinkAtMentions, highlightSearchTerms, handleUnicodeEmoji} from 'utils/text_formatting.jsx';
 import {getEmojiMap} from 'selectors/emojis';
 import store from 'stores/redux_store.jsx';
+import LinkOnlyRenderer from 'utils/markdown/link_only_renderer';
 
 describe('formatText', () => {
     test('jumbo emoji should be able to handle up to 3 spaces before the emoji character', () => {
@@ -133,5 +134,30 @@ describe('handleUnicodeEmoji', () => {
 
         const output = handleUnicodeEmoji(text, emojiMap, UNICODE_EMOJI_REGEX);
         expect(output).toBe('<span class="emoticon emoticon--unicode">🤟</span>');
+    });
+});
+
+describe('linkOnlyMarkdown', () => {
+    const options = {markdown: false, renderer: new LinkOnlyRenderer()};
+    test('link without a title', () => {
+        const text = 'Do you like https://www.mattermost.com?';
+        const output = formatText(text, options);
+        expect(output).toBe(
+            'Do you like <a class="theme markdown__link" href="https://www.mattermost.com" target="_blank">' +
+            'https://www.mattermost.com</a>?');
+    });
+    test('link with a title', () => {
+        const text = 'Do you like [Mattermost](https://www.mattermost.com)?';
+        const output = formatText(text, options);
+        expect(output).toBe(
+            'Do you like <a class="theme markdown__link" href="https://www.mattermost.com" target="_blank">' +
+            'Mattermost</a>?');
+    });
+    test('link with header signs to skip', () => {
+        const text = '#### Do you like [Mattermost](https://www.mattermost.com)?';
+        const output = formatText(text, options);
+        expect(output).toBe(
+            'Do you like <a class="theme markdown__link" href="https://www.mattermost.com" target="_blank">' +
+            'Mattermost</a>?');
     });
 });


### PR DESCRIPTION
#### Summary
This PR makes it possible to render hyperlinks in Message Attachment title.

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/MM-14192) | Fixes [GitHub issue #10292](https://github.com/mattermost/mattermost-server/issues/10292)

#### Screenshot
![screenshot_20190304_012759](https://user-images.githubusercontent.com/45372453/53704481-3541f700-3e1d-11e9-958f-415d466c2461.png)



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)