### PR TITLE
Promote Polish from Alpha to Beta

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -421,7 +421,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
             },
             Object {
               "order": 6,
-              "text": "Polski (Alpha)",
+              "text": "Polski (Beta)",
               "value": "pl",
             },
             Object {

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -307,7 +307,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
             },
             Object {
               "order": 6,
-              "text": "Polski (Alpha)",
+              "text": "Polski (Beta)",
               "value": "pl",
             },
             Object {

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -104,7 +104,7 @@ const languages = {
     },
     pl: {
         value: 'pl',
-        name: 'Polski (Alpha)',
+        name: 'Polski (Beta)',
         order: 6,
         url: pl,
     },


### PR DESCRIPTION
#### Summary
Promote Polish from Alpha to Beta. The language has now reached 90%.