### PR TITLE
[MM-13694] Modify helper text of SiteName config field to specify the default value

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2554,7 +2554,7 @@ export default {
                             label: t('admin.team.siteNameTitle'),
                             label_default: 'Site Name:',
                             help_text: t('admin.team.siteNameDescription'),
-                            help_text_default: 'Name of service shown in login screens and UI.',
+                            help_text_default: 'Name of service shown in login screens and UI. When not specified, it defaults to "Mattermost".',
                             placeholder: t('admin.team.siteNameExample'),
                             placeholder_default: 'E.g.: "Mattermost"',
                             max_length: Constants.MAX_SITENAME_LENGTH,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1409,7 +1409,7 @@
   "admin.team.showFullname": "Show first and last name",
   "admin.team.showNickname": "Show nickname if one exists, otherwise show first and last name",
   "admin.team.showUsername": "Show username (default)",
-  "admin.team.siteNameDescription": "Name of service shown in login screens and UI.",
+  "admin.team.siteNameDescription": "Name of service shown in login screens and UI. When not specified, it defaults to \"Mattermost\".",
   "admin.team.siteNameExample": "E.g.: \"Mattermost\"",
   "admin.team.siteNameTitle": "Site Name:",
   "admin.team.teamCreationDescription": "When false, only System Administrators can create teams.",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -1328,7 +1328,7 @@
   "admin.team.showFullname": "본명으로 보기",
   "admin.team.showNickname": "별명이 있으면 별명으로, 없으면 본명으로 보기",
   "admin.team.showUsername": "사용자명으로 보기 (기본)",
-  "admin.team.siteNameDescription": "Name of service shown in login screens and UI.",
+  "admin.team.siteNameDescription": "Name of service shown in login screens and UI. When not specified, it defaults to \"Mattermost\".",
   "admin.team.siteNameExample": "예시 \"Mattermost\"",
   "admin.team.siteNameTitle": "사이트 이름:",
   "admin.team.teamCreationDescription": "When false, only System Administrators can create teams.",


### PR DESCRIPTION
#### Summary
This PR modifies the helper text of the `SiteName` config field to specify the default value that will be set if the field is left empty.

#### Ticket Link
[MM-13694](https://mattermost.atlassian.net/browse/MM-13694)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] [Has server changes (please link)](https://github.com/mattermost/mattermost-server/pull/10406)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
