### PR TITLE
[MM-13800] Fix adding emoji to recent list when reacting to a post

### DIFF
--- a/components/post_view/reaction_list/index.js
+++ b/components/post_view/reaction_list/index.js
@@ -4,10 +4,12 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {addReaction, getReactionsForPost as getReactionsForPostAction} from 'mattermost-redux/actions/posts';
+import {getReactionsForPost as getReactionsForPostAction} from 'mattermost-redux/actions/posts';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+
+import {addReaction} from 'actions/post_actions.jsx';
 
 import ReactionList from './reaction_list.jsx';
 


### PR DESCRIPTION
#### Summary
Fix adding emoji to recent list when reacting to a post by using the one (`addReaction`) from post_actions since it's also dispatching `addRecentEmoji`.

Note: This is resubmitted due to Jenkins issue - https://github.com/mattermost/mattermost-webapp/pull/2445

#### Ticket Link
Jira ticket: [MM-13800](https://mattermost.atlassian.net/browse/MM-13800)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
