### PR TITLE
MM-14320: Adds e2e test to check @-mentions highlight with dots (#10368)

### DIFF
--- a/components/confirm_modal.jsx
+++ b/components/confirm_modal.jsx
@@ -168,6 +168,7 @@ export default class ConfirmModal extends React.Component {
                 show={this.props.show}
                 onHide={this.props.onCancel}
                 onExited={this.props.onExited}
+                id='confirmModal'
             >
                 <Modal.Header closeButton={false}>
                     <Modal.Title>{this.props.title}</Modal.Title>
@@ -183,6 +184,7 @@ export default class ConfirmModal extends React.Component {
                         type='button'
                         className={this.props.confirmButtonClass}
                         onClick={this.handleConfirm}
+                        id='confirmModalButton'
                     >
                         {this.props.confirmButtonText}
                     </button>

--- a/cypress/integration/channel/message_spec.js
+++ b/cypress/integration/channel/message_spec.js
@@ -70,4 +70,26 @@ describe('Message', () => {
             cy.focused().should('contain', 'AA');
         });
     });
+
+    it('M14320 @here., @all. and @channel. (ending in a period) still highlight', () => {
+        // 1. Login and go to /
+        cy.login('user-1');
+        cy.visit('/');
+
+        // 2. Post message
+        cy.postMessage('@here. @all. @channel.');
+
+        cy.getLastPostId().then((postId) => {
+            const divPostId = `#postMessageText_${postId}`;
+
+            // * Check that the message contains the whole content sent ie. mentions with dots.
+            cy.get(divPostId).find('p').should('have', '@here. @all. @channel.');
+
+            // * Check that only the at-mention are inside span.mention--highlight
+            cy.get(divPostId).find('.mention--highlight').
+                first().should('have', '@here').should('not.have', '.').
+                next().should('have', '@all').should('not.have', '.').
+                next().should('have', '@channel').should('not.have', '.');
+        });
+    });
 });

--- a/cypress/integration/channel/message_spec.js
+++ b/cypress/integration/channel/message_spec.js
@@ -79,6 +79,18 @@ describe('Message', () => {
         // 2. Post message
         cy.postMessage('@here. @all. @channel.');
 
+        // * Check that confirm modal is displayed
+        cy.get('#confirmModal').should('be.visible');
+
+        // 3. Confirm multiple mentions
+        cy.get('#confirmModalButton').click();
+
+        // * Check that confirm modal is closed
+        cy.get('#confirmModal').should('not.be.visible');
+
+        // 4 Waiting create post is done
+        cy.wait(500); // eslint-disable-line
+
         cy.getLastPostId().then((postId) => {
             const divPostId = `#postMessageText_${postId}`;
 


### PR DESCRIPTION
Adds e2e test to check at-here., at-all., at-channel. highlight with dots.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10368

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
