### PR TITLE
MM-14334 Allow plugin setting help text to contain Markdown

### DIFF
--- a/components/admin_console/__snapshots__/help_text.test.jsx.snap
+++ b/components/admin_console/__snapshots__/help_text.test.jsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelpText should render markdown text correctly 1`] = `
+<span
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "This is <strong>HELP TEXT</strong>",
+    }
+  }
+/>
+`;
+
+exports[`HelpText should render plain text correctly 1`] = `
+<span>
+  This is help text
+</span>
+`;
+
+exports[`HelpText should render translated markdown text correctly 1`] = `
+<InjectIntl(FormattedMarkdownMessage)
+  defaultMessage="This is [{object}](https://example.com)"
+  id="help.text.markdown"
+  values={
+    Object {
+      "object": "a help link",
+    }
+  }
+/>
+`;
+
+exports[`HelpText should render translated text correctly 1`] = `
+<FormattedMessage
+  defaultMessage="This is {object}"
+  id="help.text"
+  values={
+    Object {
+      "object": "help text",
+    }
+  }
+/>
+`;

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -54,10 +54,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
       <AdminTextSetting
         disabled={false}
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the text field."
-            id="help-text-a"
-            values={Object {}}
+          <HelpText
+            text="help-text-a"
+            textDefault="This is some help text for the text field."
           />
         }
         id="FirstSettings.settinga"
@@ -79,10 +78,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
           />
         }
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the bool field."
-            id="help-text-b"
-            values={Object {}}
+          <HelpText
+            text="help-text-b"
+            textDefault="This is some help text for the bool field."
           />
         }
         id="FirstSettings.settingb"
@@ -102,10 +100,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
       <DropdownSetting
         disabled={false}
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the dropdown field."
-            id="help-text-c"
-            values={Object {}}
+          <HelpText
+            text="help-text-c"
+            textDefault="This is some help text for the dropdown field."
           />
         }
         id="FirstSettings.settingc"
@@ -135,10 +132,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
       <RadioSetting
         disabled={false}
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the radio field."
-            id="help-text-d"
-            values={Object {}}
+          <HelpText
+            text="help-text-d"
+            textDefault="This is some help text for the radio field."
           />
         }
         id="SecondSettings.settingd"
@@ -167,10 +163,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
       <GeneratedSetting
         disabled={false}
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the generated field."
-            id="help-text-e"
-            values={Object {}}
+          <HelpText
+            text="help-text-e"
+            textDefault="This is some help text for the generated field."
           />
         }
         id="SecondSettings.settinge"
@@ -192,10 +187,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
       <UserAutocompleteSetting
         disabled={false}
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the user autocomplete field."
-            id="help-text-f"
-            values={Object {}}
+          <HelpText
+            text="help-text-f"
+            textDefault="This is some help text for the user autocomplete field."
           />
         }
         id="SecondSettings.settingf"
@@ -208,10 +202,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
       <AdminTextSetting
         disabled={false}
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the number field."
-            id="help-text-g"
-            values={Object {}}
+          <HelpText
+            text="help-text-g"
+            textDefault="This is some help text for the number field."
           />
         }
         id="SecondSettings.settingg"
@@ -226,10 +219,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
       <AdminTextSetting
         disabled={false}
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the number field."
-            id="help-text-h"
-            values={Object {}}
+          <HelpText
+            text="help-text-h"
+            textDefault="This is some help text for the number field."
           />
         }
         id="SecondSettings.settingh"
@@ -260,10 +252,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
       <DropdownSetting
         disabled={false}
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the language field."
-            id="help-text-i"
-            values={Object {}}
+          <HelpText
+            text="help-text-i"
+            textDefault="This is some help text for the language field."
           />
         }
         id="SecondSettings.settingi"
@@ -361,10 +352,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
       <MultiSelectSetting
         disabled={false}
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the multiple-language field."
-            id="help-text-j"
-            values={Object {}}
+          <HelpText
+            text="help-text-j"
+            textDefault="This is some help text for the multiple-language field."
           />
         }
         id="SecondSettings.settingj"
@@ -486,10 +476,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
           }
         }
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the button field."
-            id="help-text-k"
-            values={Object {}}
+          <HelpText
+            text="help-text-k"
+            textDefault="This is some help text for the button field."
           />
         }
         includeDetailedError={true}
@@ -514,10 +503,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
           />
         }
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the second bool field."
-            id="help-text-l"
-            values={Object {}}
+          <HelpText
+            text="help-text-l"
+            textDefault="This is some help text for the second bool field."
           />
         }
         id="FirstSettings.settingl"
@@ -537,10 +525,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
       <ColorSetting
         disabled={false}
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the color field."
-            id="help-text-m"
-            values={Object {}}
+          <HelpText
+            text="help-text-m"
+            textDefault="This is some help text for the color field."
           />
         }
         id="FirstSettings.settingm"
@@ -586,10 +573,9 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
           />
         }
         helpText={
-          <FormattedMessage
-            defaultMessage="This is some help text for the permissions field."
-            id="help-text-o"
-            values={Object {}}
+          <HelpText
+            text="help-text-o"
+            textDefault="This is some help text for the permissions field."
           />
         }
         id="settingo"

--- a/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.jsx.snap
+++ b/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.jsx.snap
@@ -27,9 +27,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
       <AdminTextSetting
         disabled={false}
         helpText={
-          <span>
-            This is some help text for the text field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the text field."
+          />
         }
         id="settinga"
         key="testplugin_text_settinga"
@@ -50,9 +51,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
           />
         }
         helpText={
-          <span>
-            This is some help text for the bool field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the bool field."
+          />
         }
         id="settingb"
         key="testplugin_bool_settingb"
@@ -71,9 +73,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
       <DropdownSetting
         disabled={false}
         helpText={
-          <span>
-            This is some help text for the dropdown field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the dropdown field."
+          />
         }
         id="settingc"
         isDisabled={false}
@@ -102,9 +105,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
       <RadioSetting
         disabled={false}
         helpText={
-          <span>
-            This is some help text for the radio field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the radio field."
+          />
         }
         id="settingd"
         key="testplugin_radio_settingd"
@@ -132,9 +136,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
       <GeneratedSetting
         disabled={false}
         helpText={
-          <span>
-            This is some help text for the generated field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the generated field."
+          />
         }
         id="settinge"
         key="testplugin_generated_settinge"
@@ -155,9 +160,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
       <UserAutocompleteSetting
         disabled={false}
         helpText={
-          <span>
-            This is some help text for the user autocomplete field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the user autocomplete field."
+          />
         }
         id="settingf"
         key="testplugin_userautocomplete_settingf"
@@ -298,9 +304,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
       <AdminTextSetting
         disabled={false}
         helpText={
-          <span>
-            This is some help text for the text field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the text field."
+          />
         }
         id="settinga"
         key="testplugin_text_settinga"
@@ -321,9 +328,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
           />
         }
         helpText={
-          <span>
-            This is some help text for the bool field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the bool field."
+          />
         }
         id="settingb"
         key="testplugin_bool_settingb"
@@ -342,9 +350,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
       <DropdownSetting
         disabled={false}
         helpText={
-          <span>
-            This is some help text for the dropdown field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the dropdown field."
+          />
         }
         id="settingc"
         isDisabled={false}
@@ -373,9 +382,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
       <RadioSetting
         disabled={false}
         helpText={
-          <span>
-            This is some help text for the radio field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the radio field."
+          />
         }
         id="settingd"
         key="testplugin_radio_settingd"
@@ -403,9 +413,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
       <GeneratedSetting
         disabled={false}
         helpText={
-          <span>
-            This is some help text for the generated field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the generated field."
+          />
         }
         id="settinge"
         key="testplugin_generated_settinge"
@@ -426,9 +437,10 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
       <UserAutocompleteSetting
         disabled={false}
         helpText={
-          <span>
-            This is some help text for the user autocomplete field.
-          </span>
+          <HelpText
+            isTranslated={false}
+            text="This is some help text for the user autocomplete field."
+          />
         }
         id="settingf"
         key="testplugin_userautocomplete_settingf"

--- a/components/admin_console/help_text.jsx
+++ b/components/admin_console/help_text.jsx
@@ -1,0 +1,64 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import marked from 'marked';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import FormattedMarkdownMessage from 'components/formatted_markdown_message';
+
+// CustomRenderer renders Markdown text without <p> tags, matching the output of FormattedMarkdownMessage.
+class CustomRenderer extends marked.Renderer {
+    paragraph(text) {
+        return text;
+    }
+}
+
+export default class HelpText extends React.PureComponent {
+    static propTypes = {
+        isMarkdown: PropTypes.bool,
+        isTranslated: PropTypes.bool,
+        text: PropTypes.string.isRequired,
+        textDefault: PropTypes.string,
+        textValues: PropTypes.object,
+    };
+
+    renderTranslated = () => {
+        if (this.props.isMarkdown) {
+            return (
+                <FormattedMarkdownMessage
+                    id={this.props.text}
+                    defaultMessage={this.props.textDefault}
+                    values={this.props.textValues}
+                />
+            );
+        }
+
+        return (
+            <FormattedMessage
+                id={this.props.text}
+                values={this.props.textValues}
+                defaultMessage={this.props.textDefault}
+            />
+        );
+    };
+
+    renderUntranslated = () => {
+        if (this.props.isMarkdown) {
+            const html = marked(this.props.text, {
+                breaks: true,
+                sanitize: true,
+                renderer: new CustomRenderer(),
+            });
+
+            return <span dangerouslySetInnerHTML={{__html: html}}/>;
+        }
+
+        return <span>{this.props.text}</span>;
+    };
+
+    render() {
+        return this.props.isTranslated ? this.renderTranslated() : this.renderUntranslated();
+    }
+}

--- a/components/admin_console/help_text.test.jsx
+++ b/components/admin_console/help_text.test.jsx
@@ -1,0 +1,66 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {shallow} from 'enzyme';
+import React from 'react';
+
+import HelpText from './help_text';
+
+describe('HelpText', () => {
+    const baseProps = {
+        isMarkdown: false,
+        isTranslated: false,
+        text: 'This is help text',
+    };
+
+    test('should render plain text correctly', () => {
+        const wrapper = shallow(<HelpText {...baseProps}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render markdown text correctly', () => {
+        const props = {
+            ...baseProps,
+            isMarkdown: true,
+            text: 'This is **HELP TEXT**',
+        };
+
+        const wrapper = shallow(<HelpText {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render translated text correctly', () => {
+        const props = {
+            ...baseProps,
+            isTranslated: true,
+            text: 'help.text',
+            textDefault: 'This is {object}',
+            textValues: {
+                object: 'help text',
+            },
+        };
+
+        const wrapper = shallow(<HelpText {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render translated markdown text correctly', () => {
+        const props = {
+            ...baseProps,
+            isMarkdown: true,
+            isTranslated: true,
+            text: 'help.text.markdown',
+            textDefault: 'This is [{object}](https://example.com)',
+            textValues: {
+                object: 'a help link',
+            },
+        };
+
+        const wrapper = shallow(<HelpText {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -27,6 +27,7 @@ import SettingsGroup from 'components/admin_console/settings_group.jsx';
 import JobsTable from 'components/admin_console/jobs';
 import FileUploadSetting from 'components/admin_console/file_upload_setting.jsx';
 import RemoveFileSetting from 'components/admin_console/remove_file_setting.jsx';
+import HelpText from 'components/admin_console/help_text';
 import SaveButton from 'components/save_button.jsx';
 import FormError from 'components/form_error.jsx';
 
@@ -286,10 +287,6 @@ export default class SchemaAdminSettings extends React.Component {
             return <span>{''}</span>;
         }
 
-        if (this.props.schema.translate === false) {
-            return <span>{setting.help_text}</span>;
-        }
-
         let helpText;
         let isMarkdown;
         let helpTextValues;
@@ -306,26 +303,15 @@ export default class SchemaAdminSettings extends React.Component {
             helpTextDefault = setting.help_text_default;
         }
 
-        if (typeof helpText === 'string') {
-            if (isMarkdown) {
-                return (
-                    <FormattedMarkdownMessage
-                        id={helpText}
-                        values={helpTextValues}
-                        defaultMessage={helpTextDefault}
-                    />
-                );
-            }
-            return (
-                <FormattedMessage
-                    id={helpText}
-                    defaultMessage={helpTextDefault}
-                    values={helpTextValues}
-                />
-            );
-        }
-
-        return helpText;
+        return (
+            <HelpText
+                isMarkdown={isMarkdown}
+                isTranslated={this.props.schema.translate}
+                text={helpText}
+                textDefault={helpTextDefault}
+                textValues={helpTextValues}
+            />
+        );
     }
 
     renderLabel = (setting) => {


### PR DESCRIPTION
This adds the ability for non-translated text (mainly text coming from a plugin) to contain markdown and moves the logic for rendering that help text into its own component. It's needed for the NPS plugin.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14334

#### Checklist
- Added or updated unit tests
- Has UI changes