### PR TITLE
MM-14415: Removes 'can_leave' field.

### DIFF
--- a/components/admin_console/group_settings/group_details/group_details.jsx
+++ b/components/admin_console/group_settings/group_details/group_details.jsx
@@ -85,7 +85,7 @@ export default class GroupDetails extends React.PureComponent {
     addTeams = (teams) => {
         const promises = [];
         for (const team of teams) {
-            promises.push(this.props.actions.link(this.props.groupID, team.id, Groups.SYNCABLE_TYPE_TEAM, {can_leave: true, auto_add: true}));
+            promises.push(this.props.actions.link(this.props.groupID, team.id, Groups.SYNCABLE_TYPE_TEAM, {auto_add: true}));
         }
         return Promise.all(promises).finally(() => this.props.actions.getGroupSyncables(this.props.groupID, Groups.SYNCABLE_TYPE_TEAM));
     }
@@ -93,7 +93,7 @@ export default class GroupDetails extends React.PureComponent {
     addChannels = async (channels) => {
         const promises = [];
         for (const channel of channels) {
-            promises.push(this.props.actions.link(this.props.groupID, channel.id, Groups.SYNCABLE_TYPE_CHANNEL, {can_leave: true, auto_add: true}));
+            promises.push(this.props.actions.link(this.props.groupID, channel.id, Groups.SYNCABLE_TYPE_CHANNEL, {auto_add: true}));
         }
         return Promise.all(promises).finally(() => this.props.actions.getGroupSyncables(this.props.groupID, Groups.SYNCABLE_TYPE_CHANNEL));
     }

--- a/components/admin_console/group_settings/group_details/group_details.test.jsx
+++ b/components/admin_console/group_settings/group_details/group_details.test.jsx
@@ -102,8 +102,8 @@ describe('components/admin_console/group_settings/group_details/GroupDetails', (
         await instance.addChannels([{id: '11111111111111111111111111'}, {id: '22222222222222222222222222'}]);
         expect(actions.getGroupSyncables).toBeCalledWith('xxxxxxxxxxxxxxxxxxxxxxxxxx', 'channel');
         expect(actions.getGroupSyncables).toBeCalledTimes(3);
-        expect(actions.link).toBeCalledWith('xxxxxxxxxxxxxxxxxxxxxxxxxx', '11111111111111111111111111', 'channel', {can_leave: true, auto_add: true});
-        expect(actions.link).toBeCalledWith('xxxxxxxxxxxxxxxxxxxxxxxxxx', '22222222222222222222222222', 'channel', {can_leave: true, auto_add: true});
+        expect(actions.link).toBeCalledWith('xxxxxxxxxxxxxxxxxxxxxxxxxx', '11111111111111111111111111', 'channel', {auto_add: true});
+        expect(actions.link).toBeCalledWith('xxxxxxxxxxxxxxxxxxxxxxxxxx', '22222222222222222222222222', 'channel', {auto_add: true});
         expect(actions.link).toBeCalledTimes(2);
     });
 
@@ -125,8 +125,8 @@ describe('components/admin_console/group_settings/group_details/GroupDetails', (
         await instance.addTeams([{id: '11111111111111111111111111'}, {id: '22222222222222222222222222'}]);
         expect(actions.getGroupSyncables).toBeCalledWith('xxxxxxxxxxxxxxxxxxxxxxxxxx', 'team');
         expect(actions.getGroupSyncables).toBeCalledTimes(3);
-        expect(actions.link).toBeCalledWith('xxxxxxxxxxxxxxxxxxxxxxxxxx', '11111111111111111111111111', 'team', {can_leave: true, auto_add: true});
-        expect(actions.link).toBeCalledWith('xxxxxxxxxxxxxxxxxxxxxxxxxx', '22222222222222222222222222', 'team', {can_leave: true, auto_add: true});
+        expect(actions.link).toBeCalledWith('xxxxxxxxxxxxxxxxxxxxxxxxxx', '11111111111111111111111111', 'team', {auto_add: true});
+        expect(actions.link).toBeCalledWith('xxxxxxxxxxxxxxxxxxxxxxxxxx', '22222222222222222222222222', 'team', {auto_add: true});
         expect(actions.link).toBeCalledTimes(2);
     });
 });


### PR DESCRIPTION
#### Summary
Removes `can_leave` field.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14415

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [x] Has server changes (https://github.com/mattermost/mattermost-server/pull/10426)
- [x] Has redux changes (https://github.com/mattermost/mattermost-redux/pull/790)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)