### PR TITLE
MM-14440: localize on render, not in default props

### DIFF
--- a/components/__snapshots__/save_button.test.jsx.snap
+++ b/components/__snapshots__/save_button.test.jsx.snap
@@ -5,6 +5,33 @@ exports[`components/SaveButton should match snapshot, extraClasses 1`] = `
   className="save-button btn btn-primary some-class"
   disabled={false}
   id="saveSetting"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": "Etc/UTC",
+    }
+  }
   type="submit"
 >
   <LoadingWrapper
@@ -21,6 +48,33 @@ exports[`components/SaveButton should match snapshot, on defaultMessage 1`] = `
   className="save-button btn btn-primary"
   disabled={false}
   id="saveSetting"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": "Etc/UTC",
+    }
+  }
   type="submit"
 >
   <LoadingWrapper
@@ -37,6 +91,33 @@ exports[`components/SaveButton should match snapshot, on defaultMessage 2`] = `
   className="save-button btn btn-primary"
   disabled={false}
   id="saveSetting"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": "Etc/UTC",
+    }
+  }
   type="submit"
 >
   <LoadingWrapper
@@ -53,6 +134,33 @@ exports[`components/SaveButton should match snapshot, on savingMessage 1`] = `
   className="save-button btn btn-primary"
   disabled={true}
   id="saveSetting"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": "Etc/UTC",
+    }
+  }
   type="submit"
 >
   <LoadingWrapper
@@ -69,6 +177,33 @@ exports[`components/SaveButton should match snapshot, on savingMessage 2`] = `
   className="save-button btn btn-primary"
   disabled={true}
   id="saveSetting"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": "Etc/UTC",
+    }
+  }
   type="submit"
 >
   <LoadingWrapper

--- a/components/__snapshots__/setting_item_max.test.jsx.snap
+++ b/components/__snapshots__/setting_item_max.test.jsx.snap
@@ -27,12 +27,10 @@ exports[`components/SettingItemMin should match snapshot 1`] = `
         <hr />
         <SaveButton
           btnClass="btn-primary"
-          defaultMessage="Save"
           disabled={false}
           extraClasses=""
           onClick={[Function]}
           saving={false}
-          savingMessage="Saving"
         />
         <button
           className="btn btn-sm cursor--pointer style--none"
@@ -88,12 +86,10 @@ exports[`components/SettingItemMin should match snapshot, on clientError 1`] = `
         </div>
         <SaveButton
           btnClass="btn-primary"
-          defaultMessage="Save"
           disabled={false}
           extraClasses=""
           onClick={[Function]}
           saving={false}
-          savingMessage="Saving"
         />
         <button
           className="btn btn-sm cursor--pointer style--none"
@@ -149,12 +145,10 @@ exports[`components/SettingItemMin should match snapshot, on serverError 1`] = `
         </div>
         <SaveButton
           btnClass="btn-primary"
-          defaultMessage="Save"
           disabled={false}
           extraClasses=""
           onClick={[Function]}
           saving={false}
-          savingMessage="Saving"
         />
         <button
           className="btn btn-sm cursor--pointer style--none"
@@ -205,7 +199,6 @@ exports[`components/SettingItemMin should match snapshot, with new saveTextButto
           extraClasses=""
           onClick={[Function]}
           saving={false}
-          savingMessage="Saving"
         />
         <button
           className="btn btn-sm cursor--pointer style--none"

--- a/components/admin_console/__snapshots__/message_export_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/message_export_settings.test.jsx.snap
@@ -142,7 +142,6 @@ exports[`components/MessageExportSettings should match snapshot, disabled, actia
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -423,7 +422,6 @@ exports[`components/MessageExportSettings should match snapshot, disabled, globa
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -600,7 +598,6 @@ exports[`components/MessageExportSettings should match snapshot, enabled, actian
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -881,7 +878,6 @@ exports[`components/MessageExportSettings should match snapshot, enabled, global
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}

--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -612,7 +612,6 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}

--- a/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.jsx.snap
+++ b/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.jsx.snap
@@ -181,7 +181,6 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -236,7 +235,6 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -452,7 +450,6 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}

--- a/components/admin_console/custom_terms_of_service_settings/__snapshots__/custom_terms_of_service_settings.test.jsx.snap
+++ b/components/admin_console/custom_terms_of_service_settings/__snapshots__/custom_terms_of_service_settings.test.jsx.snap
@@ -25,7 +25,6 @@ exports[`components/admin_console/CustomTermsOfServiceSettings should match snap
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -85,7 +84,6 @@ exports[`components/admin_console/CustomTermsOfServiceSettings should match snap
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -145,7 +143,6 @@ exports[`components/admin_console/CustomTermsOfServiceSettings should match snap
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -205,7 +202,6 @@ exports[`components/admin_console/CustomTermsOfServiceSettings should match snap
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}

--- a/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/__snapshots__/permission_system_scheme_settings.test.jsx.snap
+++ b/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/__snapshots__/permission_system_scheme_settings.test.jsx.snap
@@ -153,7 +153,6 @@ exports[`components/admin_console/permission_schemes_settings/permission_system_
   >
     <SaveButton
       btnClass="btn-primary"
-      defaultMessage="Save"
       disabled={true}
       extraClasses=""
       onClick={[Function]}
@@ -479,7 +478,6 @@ exports[`components/admin_console/permission_schemes_settings/permission_system_
   >
     <SaveButton
       btnClass="btn-primary"
-      defaultMessage="Save"
       disabled={true}
       extraClasses=""
       onClick={[Function]}
@@ -733,7 +731,6 @@ exports[`components/admin_console/permission_schemes_settings/permission_system_
   >
     <SaveButton
       btnClass="btn-primary"
-      defaultMessage="Save"
       disabled={true}
       extraClasses=""
       onClick={[Function]}

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/__snapshots__/permission_team_scheme_settings.test.jsx.snap
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/__snapshots__/permission_team_scheme_settings.test.jsx.snap
@@ -212,7 +212,6 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
   >
     <SaveButton
       btnClass="btn-primary"
-      defaultMessage="Save"
       disabled={true}
       extraClasses=""
       onClick={[Function]}
@@ -463,7 +462,6 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
   >
     <SaveButton
       btnClass="btn-primary"
-      defaultMessage="Save"
       disabled={true}
       extraClasses=""
       onClick={[Function]}
@@ -720,7 +718,6 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
   >
     <SaveButton
       btnClass="btn-primary"
-      defaultMessage="Save"
       disabled={true}
       extraClasses=""
       onClick={[Function]}
@@ -981,7 +978,6 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
   >
     <SaveButton
       btnClass="btn-primary"
-      defaultMessage="Save"
       disabled={true}
       extraClasses=""
       onClick={[Function]}

--- a/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
+++ b/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
@@ -150,7 +150,6 @@ exports[`components/PluginManagement should match snapshot 1`] = `
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -340,7 +339,6 @@ exports[`components/PluginManagement should match snapshot, No installed plugins
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -498,7 +496,6 @@ exports[`components/PluginManagement should match snapshot, disabled 1`] = `
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -683,7 +680,6 @@ exports[`components/PluginManagement should match snapshot, upload disabled 1`] 
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -931,7 +927,6 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -1147,7 +1142,6 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -1363,7 +1357,6 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -1579,7 +1572,6 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}
@@ -1827,7 +1819,6 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
     >
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={true}
         extraClasses=""
         onClick={[Function]}

--- a/components/multiselect/__snapshots__/multiselect.test.jsx.snap
+++ b/components/multiselect/__snapshots__/multiselect.test.jsx.snap
@@ -86,13 +86,11 @@ exports[`components/multiselect/multiselect should match snapshot 1`] = `
       />
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={false}
         extraClasses=""
         id="saveItems"
         onClick={[Function]}
         saving={false}
-        savingMessage="Saving"
       />
     </div>
     <div
@@ -247,13 +245,11 @@ exports[`components/multiselect/multiselect should match snapshot for page 2 1`]
       />
       <SaveButton
         btnClass="btn-primary"
-        defaultMessage="Save"
         disabled={false}
         extraClasses=""
         id="saveItems"
         onClick={[Function]}
         saving={false}
-        savingMessage="Saving"
       />
     </div>
     <div

--- a/components/save_button.jsx
+++ b/components/save_button.jsx
@@ -20,14 +20,20 @@ export default class SaveButton extends React.PureComponent {
 
     static defaultProps = {
         disabled: false,
-        savingMessage: localizeMessage('save_button.saving', 'Saving'),
-        defaultMessage: localizeMessage('save_button.save', 'Save'),
         btnClass: 'btn-primary',
         extraClasses: '',
     }
 
     render() {
-        const {saving, disabled, savingMessage, defaultMessage, btnClass, extraClasses, ...props} = this.props; // eslint-disable-line no-use-before-define
+        const {
+            saving,
+            disabled,
+            savingMessage = localizeMessage('save_button.saving', 'Saving'),
+            defaultMessage = localizeMessage('save_button.save', 'Save'),
+            btnClass,
+            extraClasses,
+            ...props
+        } = this.props; // eslint-disable-line no-use-before-define
 
         let className = 'save-button btn';
         if (!disabled || saving) {

--- a/components/save_button.jsx
+++ b/components/save_button.jsx
@@ -3,8 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-
-import {localizeMessage} from 'utils/utils.jsx';
+import {intlShape} from 'react-intl';
 
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper.jsx';
 
@@ -24,12 +23,17 @@ export default class SaveButton extends React.PureComponent {
         extraClasses: '',
     }
 
+    static contextTypes = {
+        intl: intlShape,
+    };
+
     render() {
+        const {formatMessage} = this.context.intl;
         const {
             saving,
             disabled,
-            savingMessage = localizeMessage('save_button.saving', 'Saving'),
-            defaultMessage = localizeMessage('save_button.save', 'Save'),
+            savingMessage,
+            defaultMessage,
             btnClass,
             extraClasses,
             ...props
@@ -44,6 +48,9 @@ export default class SaveButton extends React.PureComponent {
             className += ' ' + extraClasses;
         }
 
+        const savingMessageComponent = savingMessage || formatMessage({id: 'save_button.saving', defaultMessage: 'Saving'});
+        const defaultMessageComponent = defaultMessage || formatMessage({id: 'save_button.save', defaultMessage: 'Save'});
+
         return (
             <button
                 type='submit'
@@ -54,9 +61,9 @@ export default class SaveButton extends React.PureComponent {
             >
                 <LoadingWrapper
                     loading={saving}
-                    text={savingMessage}
+                    text={savingMessageComponent}
                 >
-                    {defaultMessage}
+                    {defaultMessageComponent}
                 </LoadingWrapper>
             </button>
         );

--- a/components/save_button.jsx
+++ b/components/save_button.jsx
@@ -33,7 +33,7 @@ export default class SaveButton extends React.PureComponent {
             btnClass,
             extraClasses,
             ...props
-        } = this.props; // eslint-disable-line no-use-before-define
+        } = this.props;
 
         let className = 'save-button btn';
         if (!disabled || saving) {

--- a/components/save_button.test.jsx
+++ b/components/save_button.test.jsx
@@ -2,7 +2,8 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallow} from 'enzyme';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import SaveButton from 'components/save_button.jsx';
 
@@ -12,7 +13,7 @@ describe('components/SaveButton', () => {
     };
 
     test('should match snapshot, on defaultMessage', () => {
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <SaveButton {...baseProps}/>
         );
 
@@ -25,7 +26,7 @@ describe('components/SaveButton', () => {
 
     test('should match snapshot, on savingMessage', () => {
         const props = {...baseProps, saving: true, disabled: true};
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <SaveButton {...props}/>
         );
 
@@ -38,7 +39,7 @@ describe('components/SaveButton', () => {
 
     test('should match snapshot, extraClasses', () => {
         const props = {...baseProps, extraClasses: 'some-class'};
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <SaveButton {...props}/>
         );
 

--- a/components/user_settings/notifications/__snapshots__/manage_auto_responder.test.jsx.snap
+++ b/components/user_settings/notifications/__snapshots__/manage_auto_responder.test.jsx.snap
@@ -158,12 +158,10 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
             <hr />
             <SaveButton
               btnClass="btn-primary"
-              defaultMessage="Save"
               disabled={false}
               extraClasses=""
               onClick={[Function]}
               saving={false}
-              savingMessage="Saving"
             >
               <button
                 className="save-button btn btn-primary"
@@ -447,12 +445,10 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
             <hr />
             <SaveButton
               btnClass="btn-primary"
-              defaultMessage="Save"
               disabled={false}
               extraClasses=""
               onClick={[Function]}
               saving={false}
-              savingMessage="Saving"
             >
               <button
                 className="save-button btn btn-primary"

--- a/components/user_settings/notifications/email_notification_setting/__snapshots__/email_notification_setting.test.jsx.snap
+++ b/components/user_settings/notifications/email_notification_setting/__snapshots__/email_notification_setting.test.jsx.snap
@@ -229,12 +229,10 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
             <hr />
             <SaveButton
               btnClass="btn-primary"
-              defaultMessage="Save"
               disabled={false}
               extraClasses=""
               onClick={[Function]}
               saving={false}
-              savingMessage="Saving"
             >
               <button
                 className="save-button btn btn-primary"
@@ -665,12 +663,10 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
             <hr />
             <SaveButton
               btnClass="btn-primary"
-              defaultMessage="Save"
               disabled={false}
               extraClasses=""
               onClick={[Function]}
               saving={false}
-              savingMessage="Saving"
             >
               <button
                 className="save-button btn btn-primary"


### PR DESCRIPTION
#### Summary
The default saving message for the save button component was localized statically instead of at render time, preventing it from changing with the configured locale.

I wasn't sure how to write a unit test to verify this: if you have any suggestions for mounting with a custom locale, I'd welcome the advice! The unit tests already verify that the message can be overridden, so we're covered on that front.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14440

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)