### PR TITLE
MM-1447: check post?.metadata?.files, not just metadata

### DIFF
--- a/components/file_attachment_list/index.js
+++ b/components/file_attachment_list/index.js
@@ -19,7 +19,7 @@ function makeMapStateToProps() {
         const fileInfos = selectFilesForPost(state, postId);
 
         let fileCount = 0;
-        if (ownProps.post.metadata) {
+        if (ownProps.post.metadata && ownProps.post.metadata.files) {
             fileCount = (ownProps.post.metadata.files || []).length;
         } else if (ownProps.post.file_ids) {
             fileCount = ownProps.post.file_ids.length;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9497,8 +9497,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#7cdad4bd96d10ac7b69e8f9de8443f7fc7a116e5",
-      "from": "github:mattermost/mattermost-redux#7cdad4bd96d10ac7b69e8f9de8443f7fc7a116e5",
+      "version": "github:mattermost/mattermost-redux#375eaa8160811653b90fa953c92b7cb38f38e45a",
+      "from": "github:mattermost/mattermost-redux#375eaa8160811653b90fa953c92b7cb38f38e45a",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "localforage": "1.7.3",
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#7ad73fe76f2264c533767f9105e7c7cff0fa34f1",
-    "mattermost-redux": "github:mattermost/mattermost-redux#7cdad4bd96d10ac7b69e8f9de8443f7fc7a116e5",
+    "mattermost-redux": "github:mattermost/mattermost-redux#375eaa8160811653b90fa953c92b7cb38f38e45a",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
On receiving a post from the server, the redux actions will strip out the contents of metadata.files, but leave the metadata object intact (and empty). Some actions take that data and re-emit it back to the store, leading to a race condition where code that doesn't properly check metadata.files will conclude there are no files at all.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14447

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [x] Has redux changes: https://github.com/mattermost/mattermost-redux/pull/791