### PR TITLE
[MM-14191] Render emojis in Interactive Message Buttons

### DIFF
--- a/components/post_view/message_attachments/__snapshots__/action_button.test.jsx.snap
+++ b/components/post_view/message_attachments/__snapshots__/action_button.test.jsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/post_view/message_attachments/action_button.jsx should match snapshot 1`] = `
+<button
+  data-action-cookie="cookie-contents"
+  data-action-id="action_id_1"
+  key="action_id_1"
+  onClick={[MockFunction]}
+>
+  <Connect(Markdown)
+    message="action_name_1"
+    options={
+      Object {
+        "autolinkedUrlSchemes": Array [],
+        "markdown": false,
+        "mentionHighlight": false,
+      }
+    }
+  />
+</button>
+`;

--- a/components/post_view/message_attachments/action_button.jsx
+++ b/components/post_view/message_attachments/action_button.jsx
@@ -4,6 +4,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import Markdown from 'components/markdown';
+
 export default class ActionButton extends React.PureComponent {
     static propTypes = {
         action: PropTypes.object.isRequired,
@@ -19,7 +21,14 @@ export default class ActionButton extends React.PureComponent {
                 key={action.id}
                 onClick={handleAction}
             >
-                {action.name}
+                <Markdown
+                    message={action.name}
+                    options={{
+                        mentionHighlight: false,
+                        markdown: false,
+                        autolinkedUrlSchemes: [],
+                    }}
+                />
             </button>
         );
     }

--- a/components/post_view/message_attachments/action_button.test.jsx
+++ b/components/post_view/message_attachments/action_button.test.jsx
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import ActionButton from 'components/post_view/message_attachments/action_button';
+
+describe('components/post_view/message_attachments/action_button.jsx', () => {
+    const baseProps = {
+        action: {id: 'action_id_1', name: 'action_name_1', cookie: 'cookie-contents'},
+        handleAction: jest.fn(),
+
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(<ActionButton {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should call handleAction on click', () => {
+        const wrapper = shallow(<ActionButton {...baseProps}/>);
+
+        wrapper.find('button').simulate('click');
+
+        expect(baseProps.handleAction).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
#### Summary
This PR makes it possible to render emojis in Interactive Message Buttons.

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/MM-14191) | Fixes [GitHub issue #10290](https://github.com/mattermost/mattermost-server/issues/10290)

##### Screenshoot
![Screenshot_20190310_222309](https://user-images.githubusercontent.com/45372453/54091683-2e6a3580-4383-11e9-9851-55f8d751b5e1.png)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
