### PR TITLE
Fix desktop-app dots menu openUp

### DIFF
--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -199,7 +199,9 @@ export default class DotMenu extends Component {
 
     refCallback = (ref) => {
         if (ref) {
-            const {y, height} = ref.rect();
+            const rect = ref.rect();
+            const y = rect.y || rect.top;
+            const height = rect.height;
             const windowHeight = window.innerHeight;
             if ((y + height) > (windowHeight - MENU_BOTTOM_MARGIN)) {
                 this.setState({openUp: true});


### PR DESCRIPTION
#### Summary
Because a difference between the return of `getBoundingClientRect` between web
browsers and desktop app, the dots menu was opening down when you were near the
bottom of the screen, now is opening up in that same situation.

#### Ticket Link
[MM-14518](https://mattermost.atlassian.net/browse/MM-14518)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed