### PR TITLE
[MM-14142] Add recent emoji to local storage every time a user adds emoji or reaction

### DIFF
--- a/actions/emoji_actions.jsx
+++ b/actions/emoji_actions.jsx
@@ -5,10 +5,10 @@ import * as EmojiActions from 'mattermost-redux/actions/emojis';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import store from 'stores/redux_store.jsx';
-import {setGlobalItem} from 'actions/storage';
+import {setRecentEmojis} from 'actions/local_storage';
 import {getEmojiMap, getRecentEmojis} from 'selectors/emojis';
 
-import {ActionTypes, Constants} from 'utils/constants.jsx';
+import {ActionTypes} from 'utils/constants.jsx';
 
 export async function addEmoji(emoji, image, success, error) {
     const {data, error: err} = await EmojiActions.createCustomEmoji(emoji, image)(store.dispatch, store.getState);
@@ -79,6 +79,6 @@ export function addRecentEmoji(alias) {
             recentEmojis.splice(0, recentEmojis.length - MAXIMUM_RECENT_EMOJI);
         }
 
-        dispatch(setGlobalItem(Constants.RECENT_EMOJI_KEY, JSON.stringify(recentEmojis)));
+        dispatch(setRecentEmojis(recentEmojis));
     };
 }

--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -23,7 +23,6 @@ import {ChannelTypes} from 'mattermost-redux/action_types';
 import {browserHistory} from 'utils/browser_history';
 import {handleNewPost} from 'actions/post_actions.jsx';
 import {stopPeriodicStatusUpdates} from 'actions/status_actions.jsx';
-import {setPreviousRecentEmojis} from 'actions/local_storage';
 import {loadProfilesForSidebar} from 'actions/user_actions.jsx';
 import {closeRightHandSide, closeMenu as closeRhsMenu, updateRhsState} from 'actions/views/rhs';
 import {clearUserCookie} from 'actions/views/root';
@@ -239,8 +238,6 @@ export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = tr
     if (userAction) {
         LocalStorageStore.setWasLoggedIn(false);
     }
-
-    dispatch(setPreviousRecentEmojis());
 
     dispatch(logout()).then(() => {
         if (shouldSignalLogout) {

--- a/actions/local_storage.jsx
+++ b/actions/local_storage.jsx
@@ -23,7 +23,7 @@ export function setRecentEmojis(recentEmojis = []) {
     return (dispatch, getState) => {
         const currentUserId = getCurrentUserId(getState());
 
-        LocalStorageStore.setRecentEmojis(currentUserId, recentEmojis.join(','));
+        LocalStorageStore.setRecentEmojis(currentUserId, recentEmojis);
 
         return {data: true};
     };

--- a/actions/local_storage.jsx
+++ b/actions/local_storage.jsx
@@ -5,8 +5,6 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import LocalStorageStore from 'stores/local_storage_store';
 
-import Constants from 'utils/constants.jsx';
-
 // setPreviousTeamId is a pseudo-action that writes not to the Redux store, but back to local
 // storage.
 //
@@ -21,14 +19,11 @@ export function setPreviousTeamId(teamId) {
     };
 }
 
-export function setPreviousRecentEmojis() {
+export function setRecentEmojis(recentEmojis = []) {
     return (dispatch, getState) => {
         const currentUserId = getCurrentUserId(getState());
 
-        const recentEmojis = getState().storage.storage[Constants.RECENT_EMOJI_KEY];
-        if (recentEmojis && recentEmojis.value) {
-            LocalStorageStore.setPreviousRecentEmojis(currentUserId, recentEmojis.value);
-        }
+        LocalStorageStore.setRecentEmojis(currentUserId, recentEmojis.join(','));
 
         return {data: true};
     };

--- a/components/logged_in/logged_in.jsx
+++ b/components/logged_in/logged_in.jsx
@@ -8,15 +8,11 @@ import {Redirect} from 'react-router';
 import {viewChannel} from 'mattermost-redux/actions/channels';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
-import {setGlobalItem} from 'actions/storage';
 import * as WebSocketActions from 'actions/websocket_actions.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 import {getBrowserTimezone} from 'utils/timezone.jsx';
 import store from 'stores/redux_store.jsx';
-import LocalStorageStore from 'stores/local_storage_store';
-
-import Constants from 'utils/constants.jsx';
 
 const dispatch = store.dispatch;
 const getState = store.getState;
@@ -85,13 +81,6 @@ export default class LoggedIn extends React.PureComponent {
         if (!this.props.currentUser) {
             $('#root').attr('class', '');
             GlobalActions.emitUserLoggedOutEvent('/login?redirect_to=' + encodeURIComponent(this.props.location.pathname), true, false);
-        }
-
-        if (this.props.currentUser) {
-            const recentEmojis = LocalStorageStore.getPreviousRecentEmojis(this.props.currentUser.id);
-            if (recentEmojis) {
-                dispatch(setGlobalItem(Constants.RECENT_EMOJI_KEY, recentEmojis));
-            }
         }
 
         $('body').on('mouseenter mouseleave', '.post', function mouseOver(ev) {

--- a/package.json
+++ b/package.json
@@ -161,7 +161,9 @@
     "setupFiles": [
       "jest-canvas-mock"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/tests/setup.js",
+    "setupFilesAfterEnv": [
+      "<rootDir>/tests/setup.js"
+    ],
     "testURL": "http://localhost:8065"
   },
   "jest-junit": {

--- a/selectors/emojis.js
+++ b/selectors/emojis.js
@@ -25,6 +25,6 @@ export const getRecentEmojis = createSelector(
             return [];
         }
 
-        return recentEmojis.split(',');
+        return recentEmojis;
     }
 );

--- a/selectors/emojis.js
+++ b/selectors/emojis.js
@@ -2,10 +2,12 @@
 // See LICENSE.txt for license information.
 
 import {createSelector} from 'reselect';
-import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
 
-import Constants from 'utils/constants.jsx';
-import {getItemFromStorage} from 'selectors/storage';
+import {getCustomEmojisByName} from 'mattermost-redux/selectors/entities/emojis';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
+import LocalStorageStore from 'stores/local_storage_store';
+
 import EmojiMap from 'utils/emoji_map';
 
 export const getEmojiMap = createSelector(
@@ -16,31 +18,13 @@ export const getEmojiMap = createSelector(
 );
 
 export const getRecentEmojis = createSelector(
-    (state) => state.storage,
-    (storage) => {
-        if (!storage || !storage.storage) {
-            return [];
-        }
-
-        let recentEmojis;
-        try {
-            recentEmojis = JSON.parse(getItemFromStorage(storage.storage, Constants.RECENT_EMOJI_KEY, null));
-        } catch (e) {
-            // Errors are handled below
-        }
-
+    getCurrentUserId,
+    (currentUserId) => {
+        const recentEmojis = LocalStorageStore.getRecentEmojis(currentUserId);
         if (!recentEmojis) {
             return [];
         }
 
-        if (recentEmojis.length > 0 && typeof recentEmojis[0] === 'object') {
-            // Prior to PLT-7267, recent emojis were stored with the entire object for the emoji, but this
-            // has been changed to store only the names of the emojis, so we need to change that
-            recentEmojis = recentEmojis.map((emoji) => {
-                return emoji.name || emoji.aliases[0];
-            });
-        }
-
-        return recentEmojis;
-    },
+        return recentEmojis.split(',');
+    }
 );

--- a/selectors/emojis.js
+++ b/selectors/emojis.js
@@ -8,6 +8,8 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import LocalStorageStore from 'stores/local_storage_store';
 
+import {Constants} from 'utils/constants.jsx';
+import {getItemFromStorage} from 'selectors/storage';
 import EmojiMap from 'utils/emoji_map';
 
 export const getEmojiMap = createSelector(
@@ -18,9 +20,12 @@ export const getEmojiMap = createSelector(
 );
 
 export const getRecentEmojis = createSelector(
+    (state) => state.storage,
     getCurrentUserId,
-    (currentUserId) => {
-        const recentEmojis = LocalStorageStore.getRecentEmojis(currentUserId);
+    (storage, currentUserId) => {
+        const recentEmojis = LocalStorageStore.getRecentEmojis(currentUserId) ||
+            JSON.parse(getItemFromStorage(storage.storage, Constants.RECENT_EMOJI_KEY, null)); // Prior to release v5.9, recent emojis were saved as object in localforage.
+
         if (!recentEmojis) {
             return [];
         }

--- a/selectors/emojis.test.js
+++ b/selectors/emojis.test.js
@@ -9,7 +9,6 @@ import * as Selectors from 'selectors/emojis';
 
 describe('Selectors.Emojis', () => {
     it('getRecentEmojis', () => {
-        const recentEmojis = ['rage', 'nauseated_face', 'innocent', '+1', 'sob', 'grinning', 'mm'];
         const userId1 = 'user_id_1';
         const testState = {
             entities: {
@@ -21,6 +20,13 @@ describe('Selectors.Emojis', () => {
 
         assert.deepEqual(Selectors.getRecentEmojis(testState), []);
 
+        const recentEmojis = ['rage', 'nauseated_face', 'innocent', '+1', 'sob', 'grinning', 'mm'];
+        LocalStorageStore.setRecentEmojis(userId1, recentEmojis);
+        setTimeout(() => {
+            assert.deepEqual(Selectors.getRecentEmojis(testState), recentEmojis);
+        }, 0);
+
+        recentEmojis.push('joy');
         LocalStorageStore.setRecentEmojis(userId1, recentEmojis);
         setTimeout(() => {
             assert.deepEqual(Selectors.getRecentEmojis(testState), recentEmojis);

--- a/selectors/emojis.test.js
+++ b/selectors/emojis.test.js
@@ -3,29 +3,27 @@
 
 import assert from 'assert';
 
-import {Constants} from 'utils/constants';
+import LocalStorageStore from 'stores/local_storage_store';
+
 import * as Selectors from 'selectors/emojis';
 
 describe('Selectors.Emojis', () => {
     it('getRecentEmojis', () => {
         const recentEmojis = ['rage', 'nauseated_face', 'innocent', '+1', 'sob', 'grinning', 'mm'];
-        let testState = {
-            storage: {
-                storage: {
-                    [Constants.RECENT_EMOJI_KEY]: {value: JSON.stringify(recentEmojis), timestamp: new Date()},
-                },
-            },
-        };
-
-        assert.deepEqual(Selectors.getRecentEmojis(testState), recentEmojis);
-
-        testState = {
-            storage: {
-                storage: {
+        const userId1 = 'user_id_1';
+        const testState = {
+            entities: {
+                users: {
+                    currentUserId: userId1,
                 },
             },
         };
 
         assert.deepEqual(Selectors.getRecentEmojis(testState), []);
+
+        LocalStorageStore.setRecentEmojis(userId1, recentEmojis);
+        setTimeout(() => {
+            assert.deepEqual(Selectors.getRecentEmojis(testState), recentEmojis);
+        }, 0);
     });
 });

--- a/selectors/emojis.test.js
+++ b/selectors/emojis.test.js
@@ -16,6 +16,7 @@ describe('Selectors.Emojis', () => {
                     currentUserId: userId1,
                 },
             },
+            storage: {storage: {}},
         };
 
         assert.deepEqual(Selectors.getRecentEmojis(testState), []);

--- a/stores/local_storage_store.jsx
+++ b/stores/local_storage_store.jsx
@@ -5,7 +5,7 @@ import {Constants} from 'utils/constants.jsx';
 const getPreviousTeamIdKey = (userId) => ['user_prev_team', userId].join(':');
 const getPreviousChannelNameKey = (userId, teamId) => ['user_team_prev_channel', userId, teamId].join(':');
 const getPenultimateChannelNameKey = (userId, teamId) => ['user_team_penultimate_channel', userId, teamId].join(':');
-const getPreviousRecentEmojisKey = (userId) => ['recent_emojis', userId].join(':');
+const getRecentEmojisKey = (userId) => ['recent_emojis', userId].join(':');
 
 // LocalStorageStore exposes an interface for accessing entries in the localStorage.
 //
@@ -37,12 +37,14 @@ class LocalStorageStoreClass {
         localStorage.setItem(getPreviousTeamIdKey(userId), teamId);
     }
 
-    getPreviousRecentEmojis(userId) {
-        return localStorage.getItem(getPreviousRecentEmojisKey(userId));
+    getRecentEmojis(userId) {
+        return localStorage.getItem(getRecentEmojisKey(userId));
     }
 
-    setPreviousRecentEmojis(userId, recentEmojis) {
-        localStorage.setItem(getPreviousRecentEmojisKey(userId), recentEmojis);
+    setRecentEmojis(userId, recentEmojis = '') {
+        if (recentEmojis) {
+            localStorage.setItem(getRecentEmojisKey(userId), recentEmojis);
+        }
     }
 
     setWasLoggedIn(wasLoggedIn) {

--- a/stores/local_storage_store.jsx
+++ b/stores/local_storage_store.jsx
@@ -38,12 +38,17 @@ class LocalStorageStoreClass {
     }
 
     getRecentEmojis(userId) {
-        return localStorage.getItem(getRecentEmojisKey(userId));
+        const recentEmojis = localStorage.getItem(getRecentEmojisKey(userId));
+        if (!recentEmojis) {
+            return null;
+        }
+
+        return JSON.parse(recentEmojis);
     }
 
-    setRecentEmojis(userId, recentEmojis = '') {
-        if (recentEmojis) {
-            localStorage.setItem(getRecentEmojisKey(userId), recentEmojis);
+    setRecentEmojis(userId, recentEmojis = []) {
+        if (recentEmojis.length) {
+            localStorage.setItem(getRecentEmojisKey(userId), JSON.stringify(recentEmojis));
         }
     }
 

--- a/stores/local_storage_store.test.jsx
+++ b/stores/local_storage_store.test.jsx
@@ -36,8 +36,8 @@ describe('stores/LocalStorageStore', () => {
     test('should persist recent emojis per user', () => {
         const userId1 = 'userId1';
         const userId2 = 'userId2';
-        const recentEmojis1 = ['smile', 'joy', 'grin'].join(',');
-        const recentEmojis2 = ['customEmoji', '+1', 'mattermost'].join(',');
+        const recentEmojis1 = ['smile', 'joy', 'grin'];
+        const recentEmojis2 = ['customEmoji', '+1', 'mattermost'];
 
         assert.equal(LocalStorageStore.getRecentEmojis(userId1), null);
         assert.equal(LocalStorageStore.getRecentEmojis(userId2), null);
@@ -52,11 +52,9 @@ describe('stores/LocalStorageStore', () => {
         LocalStorageStore.setRecentEmojis(userId2, recentEmojis2);
 
         const recentEmojisForUser1 = LocalStorageStore.getRecentEmojis(userId1);
-        assert.equal(recentEmojisForUser1, recentEmojis1);
-        assert.equal(typeof recentEmojisForUser1, 'string');
+        assert.deepEqual(recentEmojisForUser1, recentEmojis1);
 
         const recentEmojisForUser2 = LocalStorageStore.getRecentEmojis(userId2);
-        assert.equal(recentEmojisForUser2, recentEmojis2);
-        assert.equal(typeof recentEmojisForUser2, 'string');
+        assert.deepEqual(recentEmojisForUser2, recentEmojis2);
     });
 });

--- a/stores/local_storage_store.test.jsx
+++ b/stores/local_storage_store.test.jsx
@@ -32,4 +32,31 @@ describe('stores/LocalStorageStore', () => {
         assert.equal(LocalStorageStore.getPreviousChannelName(userId2, teamId1), channel2);
         assert.equal(LocalStorageStore.getPreviousChannelName(userId2, teamId2), channel3);
     });
+
+    test('should persist recent emojis per user', () => {
+        const userId1 = 'userId1';
+        const userId2 = 'userId2';
+        const recentEmojis1 = ['smile', 'joy', 'grin'].join(',');
+        const recentEmojis2 = ['customEmoji', '+1', 'mattermost'].join(',');
+
+        assert.equal(LocalStorageStore.getRecentEmojis(userId1), null);
+        assert.equal(LocalStorageStore.getRecentEmojis(userId2), null);
+
+        LocalStorageStore.setRecentEmojis(userId1, '');
+        LocalStorageStore.setRecentEmojis(userId2, '');
+
+        assert.equal(LocalStorageStore.getRecentEmojis(userId1), null);
+        assert.equal(LocalStorageStore.getRecentEmojis(userId2), null);
+
+        LocalStorageStore.setRecentEmojis(userId1, recentEmojis1);
+        LocalStorageStore.setRecentEmojis(userId2, recentEmojis2);
+
+        const recentEmojisForUser1 = LocalStorageStore.getRecentEmojis(userId1);
+        assert.equal(recentEmojisForUser1, recentEmojis1);
+        assert.equal(typeof recentEmojisForUser1, 'string');
+
+        const recentEmojisForUser2 = LocalStorageStore.getRecentEmojis(userId2);
+        assert.equal(recentEmojisForUser2, recentEmojis2);
+        assert.equal(typeof recentEmojisForUser2, 'string');
+    });
 });

--- a/stores/local_storage_store.test.jsx
+++ b/stores/local_storage_store.test.jsx
@@ -42,8 +42,8 @@ describe('stores/LocalStorageStore', () => {
         assert.equal(LocalStorageStore.getRecentEmojis(userId1), null);
         assert.equal(LocalStorageStore.getRecentEmojis(userId2), null);
 
-        LocalStorageStore.setRecentEmojis(userId1, '');
-        LocalStorageStore.setRecentEmojis(userId2, '');
+        LocalStorageStore.setRecentEmojis(userId1, []);
+        LocalStorageStore.setRecentEmojis(userId2, []);
 
         assert.equal(LocalStorageStore.getRecentEmojis(userId1), null);
         assert.equal(LocalStorageStore.getRecentEmojis(userId2), null);


### PR DESCRIPTION
#### Summary
Add recent emoji to local storage every time a user adds emoji or reaction.  [Recent implementation](https://github.com/mattermost/mattermost-webapp/pull/2376) saves it only after a user logged out.  However, in case of unusual flow like crash (or recent case of session timeout), the recent emojis were not saved as expected.

Also, removed previous implementation of saving recent emojis into the `localforage` in favor of Local Storage.

#### Ticket Link
Jira ticket: [MM-14142](https://mattermost.atlassian.net/browse/MM-14142)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
