### PR TITLE
MM-14198 Close RHS when viewing thread or pinned posts for a channel user was removed from

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -33,8 +33,11 @@ import {getMyTeams, getCurrentRelativeTeamUrl, getCurrentTeamId, getCurrentTeamU
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getChannel, getCurrentChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
+import {getSelectedChannelId} from 'selectors/rhs';
+
 import {openModal} from 'actions/views/modals';
 import {incrementWsErrorCount, resetWsErrorCount} from 'actions/views/system';
+import {closeRightHandSide} from 'actions/views/rhs';
 
 import {browserHistory} from 'utils/browser_history';
 import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
@@ -601,7 +604,7 @@ function handleUserAddedEvent(msg) {
     }
 }
 
-function handleUserRemovedEvent(msg) {
+export function handleUserRemovedEvent(msg) {
     const state = getState();
     const currentChannel = getCurrentChannel(state) || {};
     const currentUserId = getCurrentUserId(state);
@@ -609,9 +612,12 @@ function handleUserRemovedEvent(msg) {
     if (msg.broadcast.user_id === currentUserId) {
         dispatch(loadChannelsForCurrentUser());
 
-        if (msg.data.channel_id === currentChannel.id) {
-            GlobalActions.emitCloseRightHandSide();
+        const rhsChannelId = getSelectedChannelId(state);
+        if (msg.data.channel_id === rhsChannelId) {
+            dispatch(closeRightHandSide());
+        }
 
+        if (msg.data.channel_id === currentChannel.id) {
             if (msg.data.remover_id === msg.broadcast.user_id) {
                 browserHistory.push(getCurrentRelativeTeamUrl(state));
             } else {


### PR DESCRIPTION
#### Summary
Improved the logic of when to close the RHS after a user is removed from a channel to only close it when you're viewing a thread or pinned posts in the RHS for that channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14198

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)