### PR TITLE
MM-8647/MM-14334 Make all plugin setting help text support Markdown 

### DIFF
--- a/components/admin_console/custom_plugin_settings/index.js
+++ b/components/admin_console/custom_plugin_settings/index.js
@@ -21,6 +21,7 @@ function makeGetPluginSchema() {
                 settings = plugin.settings_schema.settings.map((setting) => {
                     return {
                         ...setting,
+                        help_text_markdown: true,
                         label: setting.display_name,
                     };
                 });

--- a/components/admin_console/custom_plugin_settings/index.js
+++ b/components/admin_console/custom_plugin_settings/index.js
@@ -2,22 +2,52 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {createSelector} from 'reselect';
 
 import {getRoles} from 'mattermost-redux/selectors/entities/roles';
 
 import CustomPluginSettings from './custom_plugin_settings.jsx';
 
-function mapStateToProps(state, ownProps) {
-    const pluginId = ownProps.match.params.plugin_id;
-    const plugin = state.entities.admin.plugins[pluginId];
-    const settings = plugin && plugin.settings_schema && plugin.settings_schema.settings && plugin.settings_schema.settings.map((setting) => {
-        return {...setting, label: setting.display_name};
-    });
-    const translate = (plugin && plugin.translate) || false;
-    return {
-        schema: plugin ? {...plugin.settings_schema, id: plugin.id, name: plugin.name, settings, translate} : null,
-        roles: getRoles(state),
+function makeGetPluginSchema() {
+    return createSelector(
+        (state, pluginId) => state.entities.admin.plugins[pluginId],
+        (plugin) => {
+            if (!plugin) {
+                return null;
+            }
+
+            let settings;
+            if (plugin.settings_schema && plugin.settings_schema.settings) {
+                settings = plugin.settings_schema.settings.map((setting) => {
+                    return {
+                        ...setting,
+                        label: setting.display_name,
+                    };
+                });
+            }
+
+            return {
+                ...plugin.settings_schema,
+                id: plugin.id,
+                name: plugin.name,
+                settings,
+                translate: Boolean(plugin.translate),
+            };
+        }
+    );
+}
+
+function makeMapStateToProps() {
+    const getPluginSchema = makeGetPluginSchema();
+
+    return (state, ownProps) => {
+        const pluginId = ownProps.match.params.plugin_id;
+
+        return {
+            schema: getPluginSchema(state, pluginId),
+            roles: getRoles(state),
+        };
     };
 }
 
-export default connect(mapStateToProps)(CustomPluginSettings);
+export default connect(makeMapStateToProps)(CustomPluginSettings);


### PR DESCRIPTION
This is a followup to https://github.com/mattermost/mattermost-server/pull/10425 where I got some push back on having to manually specify `help_text_markdown` on all plugin settings that wanted to use Markdown, so this just adds it to the plugin setting schema for all plugins instead.

Most of this is just refactoring the `CustomPluginSettings` redux connector to use a proper selector since the previous version didn't memoize properly. The only functional change is that `help_text_markdown` is now added to each plugin setting before being passed to the component.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8647
https://mattermost.atlassian.net/browse/MM-14334

#### Checklist
- Has UI changes