### PR TITLE
Quick fix to setup file config of Jest for v23

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,9 +157,7 @@
     "setupFiles": [
       "jest-canvas-mock"
     ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/tests/setup.js"
-    ],
+    "setupTestFrameworkScriptFile": "<rootDir>/tests/setup.js",
     "testURL": "http://localhost:8065"
   },
   "jest-junit": {


### PR DESCRIPTION
#### Summary
Our master and release-5.9 branch have different major version of Jest that requires different config for setup file.
- For master with Jest v24 - `setupFilesAfterEnv` with array values
- For release-5.9 with Jest v23 - `setupTestFrameworkScriptFile ` with string value

(By the way, last offender is me that broke release-5.9 branch.)

#### Ticket Link
none
