### PR TITLE
[MM-13950] Prevents loading the URL of data images

### DIFF
--- a/components/view_image/view_image.jsx
+++ b/components/view_image/view_image.jsx
@@ -140,7 +140,7 @@ export default class ViewImageModal extends React.PureComponent {
         const fileInfo = this.props.fileInfos[index];
         const fileType = Utils.getFileType(fileInfo.extension);
 
-        if (fileType === FileTypes.IMAGE) {
+        if (fileType === FileTypes.IMAGE && Boolean(fileInfo.id)) {
             let previewUrl;
             if (fileInfo.has_image_preview) {
                 previewUrl = getFilePreviewUrl(fileInfo.id);


### PR DESCRIPTION
#### Summary
Modifies the `ViewImage` component so it only tries to load the URL of an image if it has one.

#### Ticket Link
[MM-13950](https://mattermost.atlassian.net/browse/MM-13950)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
