### PR TITLE
[MM-14354] Fixes multi_select component for removing items

### DIFF
--- a/components/multiselect/multiselect.jsx
+++ b/components/multiselect/multiselect.jsx
@@ -21,7 +21,6 @@ export default class MultiSelect extends React.Component {
         options: PropTypes.arrayOf(PropTypes.object),
         optionRenderer: PropTypes.func,
         values: PropTypes.arrayOf(PropTypes.object),
-        valueKey: PropTypes.string,
         valueRenderer: PropTypes.func,
         handleInput: PropTypes.func,
         handleDelete: PropTypes.func,
@@ -166,10 +165,9 @@ export default class MultiSelect extends React.Component {
             return;
         }
 
-        const valueKey = this.props.valueKey;
         const values = [...this.props.values];
         for (let i = 0; i < values.length; i++) {
-            if (values[i][valueKey] === change.removedValue[valueKey]) {
+            if (values[i].id === change.removedValue.id) {
                 values.splice(i, 1);
                 break;
             }


### PR DESCRIPTION
#### Summary
Removes `valueKey` from the `MultiSelect` component in favour of a fixed `id` key.

#### Ticket Link
[MM-14354](https://mattermost.atlassian.net/browse/MM-14354)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
