### PR TITLE
MM-14334 Fix translation of system console help text

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -55,6 +55,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         disabled={false}
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-a"
             textDefault="This is some help text for the text field."
           />
@@ -79,6 +80,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         }
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-b"
             textDefault="This is some help text for the bool field."
           />
@@ -101,6 +103,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         disabled={false}
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-c"
             textDefault="This is some help text for the dropdown field."
           />
@@ -133,6 +136,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         disabled={false}
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-d"
             textDefault="This is some help text for the radio field."
           />
@@ -164,6 +168,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         disabled={false}
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-e"
             textDefault="This is some help text for the generated field."
           />
@@ -188,6 +193,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         disabled={false}
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-f"
             textDefault="This is some help text for the user autocomplete field."
           />
@@ -203,6 +209,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         disabled={false}
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-g"
             textDefault="This is some help text for the number field."
           />
@@ -220,6 +227,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         disabled={false}
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-h"
             textDefault="This is some help text for the number field."
           />
@@ -253,6 +261,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         disabled={false}
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-i"
             textDefault="This is some help text for the language field."
           />
@@ -353,6 +362,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         disabled={false}
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-j"
             textDefault="This is some help text for the multiple-language field."
           />
@@ -477,6 +487,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         }
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-k"
             textDefault="This is some help text for the button field."
           />
@@ -504,6 +515,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         }
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-l"
             textDefault="This is some help text for the second bool field."
           />
@@ -526,6 +538,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         disabled={false}
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-m"
             textDefault="This is some help text for the color field."
           />
@@ -574,6 +587,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
         }
         helpText={
           <HelpText
+            isTranslated={true}
             text="help-text-o"
             textDefault="This is some help text for the permissions field."
           />

--- a/components/admin_console/help_text.jsx
+++ b/components/admin_console/help_text.jsx
@@ -24,6 +24,10 @@ export default class HelpText extends React.PureComponent {
         textValues: PropTypes.object,
     };
 
+    static defaultProps = {
+        isTranslated: true,
+    };
+
     renderTranslated = () => {
         if (this.props.isMarkdown) {
             return (


### PR DESCRIPTION
Before my recent changes to add the `HelpText` component, system console pages where `schema.translate` was undefined were treated as translated. This fixes that by setting a default value for the prop.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14334