### PR TITLE
[MM-13500] Searches and loads non-visible GMs in more direct channels

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -20,11 +20,12 @@ import {getBool, makeGetCategory} from 'mattermost-redux/selectors/entities/pref
 import {getCurrentTeamId, getTeamMember} from 'mattermost-redux/selectors/entities/teams';
 import * as Selectors from 'mattermost-redux/selectors/entities/users';
 
+import {filterGroupChannelsMatchingTerm} from 'mattermost-redux/utils/channel_utils';
+
 import {browserHistory} from 'utils/browser_history';
 import {loadStatusesForProfilesList, loadStatusesForProfilesMap} from 'actions/status_actions.jsx';
 import store from 'stores/redux_store.jsx';
 import * as Utils from 'utils/utils.jsx';
-import {groupChannelMatchesTerm} from 'mattermost-redux/utils/channel_utils';
 import {Constants, Preferences, UserStatuses} from 'utils/constants.jsx';
 
 const dispatch = store.dispatch;
@@ -189,14 +190,14 @@ export function loadProfilesForSidebar() {
 export function loadProfilesForMatchingGMs(searchTerm) {
     return (doDispatch, doGetState) => {
         const state = doGetState();
-        const groupChannels = getGroupChannels(state);
+        const matchingGroupChannels = filterGroupChannelsMatchingTerm(getGroupChannels(state), searchTerm);
         const userIdsInChannels = Selectors.getUserIdsInChannels(state);
 
-        for (const groupChannel of groupChannels) { //eslint-disable-line camelcase
-            const userIdsInGroupChannel = (userIdsInChannels[groupChannel.id] || new Set());
+        for (const {id} of matchingGroupChannels) {
+            const userIdsInGroupChannel = (userIdsInChannels[id] || new Set());
 
-            if (groupChannelMatchesTerm(groupChannel, searchTerm) && userIdsInGroupChannel.size === 0) {
-                doDispatch(UserActions.getProfilesInChannel(groupChannel.id, 0, Constants.MAX_USERS_IN_GM));
+            if (userIdsInGroupChannel.size === 0) {
+                doDispatch(UserActions.getProfilesInChannel(id, 0, Constants.MAX_USERS_IN_GM));
             }
         }
     };

--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -11,6 +11,7 @@ import {Preferences as PreferencesRedux} from 'mattermost-redux/constants';
 import {
     getChannel,
     getCurrentChannelId,
+    getGroupChannels,
     getMyChannels,
     getMyChannelMember,
     getChannelMembersInChannels,
@@ -182,6 +183,23 @@ export async function loadNewGMIfNeeded(channelId) {
 export function loadProfilesForSidebar() {
     loadProfilesForDM();
     loadProfilesForGM();
+}
+
+export function loadProfilesForMatchingGMs(searchTerm) {
+    return (doDispatch, doGetState) => {
+        const state = doGetState();
+        const groupChannels = getGroupChannels(state);
+        const userIdsInChannels = Selectors.getUserIdsInChannels(state);
+
+        for (const {id, display_name} of groupChannels) { //eslint-disable-line camelcase
+            const userIdsInGroupChannel = (userIdsInChannels[id] || new Set());
+            const matchesSearchTerm = display_name.split(', ').some((username) => username.startsWith(searchTerm));
+
+            if (matchesSearchTerm && userIdsInGroupChannel.size === 0) {
+                doDispatch(UserActions.getProfilesInChannel(id, 0, Constants.MAX_USERS_IN_GM));
+            }
+        }
+    };
 }
 
 export async function loadProfilesForGM() {

--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -24,6 +24,7 @@ import {browserHistory} from 'utils/browser_history';
 import {loadStatusesForProfilesList, loadStatusesForProfilesMap} from 'actions/status_actions.jsx';
 import store from 'stores/redux_store.jsx';
 import * as Utils from 'utils/utils.jsx';
+import {groupChannelMatchesTerm} from 'mattermost-redux/utils/channel_utils';
 import {Constants, Preferences, UserStatuses} from 'utils/constants.jsx';
 
 const dispatch = store.dispatch;
@@ -191,12 +192,11 @@ export function loadProfilesForMatchingGMs(searchTerm) {
         const groupChannels = getGroupChannels(state);
         const userIdsInChannels = Selectors.getUserIdsInChannels(state);
 
-        for (const {id, display_name} of groupChannels) { //eslint-disable-line camelcase
-            const userIdsInGroupChannel = (userIdsInChannels[id] || new Set());
-            const matchesSearchTerm = display_name.split(', ').some((username) => username.startsWith(searchTerm));
+        for (const groupChannel of groupChannels) { //eslint-disable-line camelcase
+            const userIdsInGroupChannel = (userIdsInChannels[groupChannel.id] || new Set());
 
-            if (matchesSearchTerm && userIdsInGroupChannel.size === 0) {
-                doDispatch(UserActions.getProfilesInChannel(id, 0, Constants.MAX_USERS_IN_GM));
+            if (groupChannelMatchesTerm(groupChannel, searchTerm) && userIdsInGroupChannel.size === 0) {
+                doDispatch(UserActions.getProfilesInChannel(groupChannel.id, 0, Constants.MAX_USERS_IN_GM));
             }
         }
     };

--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -26,6 +26,7 @@ import {memoizeResult} from 'mattermost-redux/utils/helpers';
 
 import {openDirectChannelToUserId, openGroupChannelToUserIds} from 'actions/channel_actions';
 import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
+import {loadProfilesForMatchingGMs} from 'actions/user_actions.jsx';
 import {setModalSearchTerm} from 'actions/views/search';
 
 import MoreDirectChannels from './more_direct_channels.jsx';
@@ -89,6 +90,7 @@ function mapDispatchToProps(dispatch) {
             getStatusesByIds,
             getTotalUsersStats,
             loadStatusesForProfilesList,
+            loadProfilesForMatchingGMs,
             openDirectChannelToUserId,
             openGroupChannelToUserIds,
             searchProfiles,

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -54,6 +54,7 @@ export default class MoreDirectChannels extends React.Component {
             getStatusesByIds: PropTypes.func.isRequired,
             getTotalUsersStats: PropTypes.func.isRequired,
             loadStatusesForProfilesList: PropTypes.func.isRequired,
+            loadProfilesForMatchingGMs: PropTypes.func.isRequired,
             openDirectChannelToUserId: PropTypes.func.isRequired,
             openGroupChannelToUserIds: PropTypes.func.isRequired,
             searchProfiles: PropTypes.func.isRequired,
@@ -109,6 +110,9 @@ export default class MoreDirectChannels extends React.Component {
                     async () => {
                         this.setUsersLoadingState(true);
                         const {data} = await this.props.actions.searchProfiles(searchTerm, {team_id: teamId});
+
+                        this.props.actions.loadProfilesForMatchingGMs(searchTerm);
+
                         if (data) {
                             this.props.actions.loadStatusesForProfilesList(data);
                             this.resetPaging();

--- a/components/more_direct_channels/more_direct_channels.test.jsx
+++ b/components/more_direct_channels/more_direct_channels.test.jsx
@@ -33,6 +33,7 @@ describe('components/MoreDirectChannels', () => {
             searchProfiles: emptyFunction,
             setModalSearchTerm: emptyFunction,
             loadStatusesForProfilesList: emptyFunction,
+            loadProfilesForMatchingGMs: emptyFunction,
             openDirectChannelToUserId: jest.fn().mockResolvedValue({data: {name: 'dm'}}),
             openGroupChannelToUserIds: jest.fn().mockResolvedValue({data: {name: 'group'}}),
             getTotalUsersStats: jest.fn(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10534,8 +10534,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#477150436ac1871d0d63954c4f4f4d16ff692483",
-      "from": "github:mattermost/mattermost-redux#477150436ac1871d0d63954c4f4f4d16ff692483",
+      "version": "github:mattermost/mattermost-redux#db792204a47cfed3c76917e4be4c0c019fda55c3",
+      "from": "github:mattermost/mattermost-redux#db792204a47cfed3c76917e4be4c0c019fda55c3",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10534,8 +10534,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#db792204a47cfed3c76917e4be4c0c019fda55c3",
-      "from": "github:mattermost/mattermost-redux#db792204a47cfed3c76917e4be4c0c019fda55c3",
+      "version": "github:mattermost/mattermost-redux#aa10e21b4938adf580c6be4480819008e1a33eac",
+      "from": "github:mattermost/mattermost-redux#aa10e21b4938adf580c6be4480819008e1a33eac",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "localforage-observable": "1.4.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
-    "mattermost-redux": "github:mattermost/mattermost-redux#db792204a47cfed3c76917e4be4c0c019fda55c3",
+    "mattermost-redux": "github:mattermost/mattermost-redux#aa10e21b4938adf580c6be4480819008e1a33eac",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "localforage-observable": "1.4.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
-    "mattermost-redux": "github:mattermost/mattermost-redux#477150436ac1871d0d63954c4f4f4d16ff692483",
+    "mattermost-redux": "github:mattermost/mattermost-redux#db792204a47cfed3c76917e4be4c0c019fda55c3",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
When a user is searching in the more direct channel modal, this PR adds the logic to search amongst the group channels that are not visible and loads the ones matching with the search term.

#### Ticket Link
[MM-13500](https://mattermost.atlassian.net/browse/MM-13500)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] [Has redux changes](https://github.com/mattermost/mattermost-redux/pull/820)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
