### PR TITLE
MM-14403 Remove channel from unreads section properly when clicking on permalink

### DIFF
--- a/components/permalink_view/actions.js
+++ b/components/permalink_view/actions.js
@@ -63,6 +63,7 @@ export function focusPost(postId, returnTo = '') {
         dispatch({
             type: ActionTypes.RECEIVED_FOCUSED_POST,
             data: postId,
+            channelId,
         });
 
         dispatch(loadChannelsForCurrentUser());

--- a/reducers/views/channel.js
+++ b/reducers/views/channel.js
@@ -108,6 +108,13 @@ function keepChannelIdAsUnread(state = null, action) {
         return null;
     }
 
+    case ActionTypes.RECEIVED_FOCUSED_POST: {
+        if (state && action.channelId !== state.id) {
+            return null;
+        }
+        return state;
+    }
+
     case UserTypes.LOGOUT_SUCCESS:
         return null;
     default:


### PR DESCRIPTION
#### Summary
Remove channel from unreads section properly when clicking on permalink. The issue was that the action `SELECT_CHANNEL_WITH_MEMBER` was not being dispatched when a post was focused (e.g. switching to permalink mode). I opted to add handling for the `RECEIVED_FOCUSED_POST` action type in the `keepChannelIdAsUnread` reducer to clear the channel if the permalink was for a different channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14403