### PR TITLE
MM-14302 Make combined user activity message timestamp unclickable

### DIFF
--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -262,8 +262,8 @@ export default class PostInfo extends React.PureComponent {
         const showPostTime = this.props.hover || this.props.showTimeWithoutHover;
         let postTime;
         if (showPostTime) {
-            // timestamp should not be a permalink if the post has been deleted, is ephemeral message, or is pending
-            const isPermalink = !(isEphemeral || Posts.POST_DELETED === post.state || ReduxPostUtils.isPostPendingOrFailed(post));
+            // timestamp should not be a permalink if the post has been deleted, is ephemeral message, is pending, or is combined activity
+            const isPermalink = !(isEphemeral || Posts.POST_DELETED === post.state || ReduxPostUtils.isPostPendingOrFailed(post) || post.type === Posts.POST_TYPES.COMBINED_USER_ACTIVITY);
 
             postTime = (
                 <PostTime


### PR DESCRIPTION
#### Summary
Make combined user activity message timestamp unclickable since they aren't "real" posts and don't have a working post ID, which is required for permalinks.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14032

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed