### PR TITLE
MM-14350: Fixes relative link under custom subpath.

### DIFF
--- a/components/admin_console/group_settings/__snapshots__/group_settings.test.jsx.snap
+++ b/components/admin_console/group_settings/__snapshots__/group_settings.test.jsx.snap
@@ -29,8 +29,13 @@ For more information on Groups, please see [documentation](!https://www.mattermo
   <AdminPanel
     className=""
     id="ldap_groups"
-    subtitleDefault="Link and configure groups from your AD/LDAP to Mattermost. Please ensure you have configured a [group filter](/admin_console/authentication/ldap)."
+    subtitleDefault="Link and configure groups from your AD/LDAP to Mattermost. Please ensure you have configured a [group filter](http://localhost:8065/admin_console/authentication/ldap)."
     subtitleId="admin.group_settings.ldapGroupsDescription"
+    subtitleValues={
+      Object {
+        "siteURL": "http://localhost:8065",
+      }
+    }
     titleDefault="AD/LDAP Groups"
     titleId="admin.group_settings.ldapGroupsTitle"
   >

--- a/components/admin_console/group_settings/group_settings.jsx
+++ b/components/admin_console/group_settings/group_settings.jsx
@@ -9,8 +9,11 @@ import GroupsList from 'components/admin_console/group_settings/groups_list';
 import AdminPanel from 'components/widgets/admin_console/admin_panel.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
+import {getSiteURL} from 'utils/url.jsx';
+
 export default class GroupSettings extends React.PureComponent {
     render = () => {
+        const siteURL = getSiteURL();
         return (
             <div className='wrapper--fixed'>
                 <h3 className='admin-console-header'>
@@ -34,7 +37,8 @@ export default class GroupSettings extends React.PureComponent {
                     titleId={t('admin.group_settings.ldapGroupsTitle')}
                     titleDefault='AD/LDAP Groups'
                     subtitleId={t('admin.group_settings.ldapGroupsDescription')}
-                    subtitleDefault='Link and configure groups from your AD/LDAP to Mattermost. Please ensure you have configured a [group filter](/admin_console/authentication/ldap).'
+                    subtitleDefault={`Link and configure groups from your AD/LDAP to Mattermost. Please ensure you have configured a [group filter](${siteURL}/admin_console/authentication/ldap).`}
+                    subtitleValues={{siteURL}}
                 >
                     <GroupsList/>
                 </AdminPanel>

--- a/components/widgets/admin_console/admin_panel.jsx
+++ b/components/widgets/admin_console/admin_panel.jsx
@@ -27,6 +27,7 @@ const AdminPanel = (props) => (
                     <FormattedMarkdownMessage
                         id={props.subtitleId}
                         defaultMessage={props.subtitleDefault}
+                        values={props.subtitleValues}
                     />
                 </span>
             </div>
@@ -48,6 +49,7 @@ AdminPanel.propTypes = {
     titleDefault: PropTypes.string.isRequired,
     subtitleId: PropTypes.string.isRequired,
     subtitleDefault: PropTypes.string.isRequired,
+    subtitleValues: PropTypes.object,
     onHeaderClick: PropTypes.func,
     button: PropTypes.node,
 };

--- a/components/widgets/admin_console/admin_panel.test.jsx
+++ b/components/widgets/admin_console/admin_panel.test.jsx
@@ -14,6 +14,7 @@ describe('components/widgets/admin_console/AdminPanel', () => {
         titleDefault: 'test-title-default',
         subtitleId: 'test-subtitle-id',
         subtitleDefault: 'test-subtitle-default',
+        subtitleValues: {foo: 'bar'},
         onHeaderClick: null,
         button: null,
     };
@@ -41,6 +42,11 @@ describe('components/widgets/admin_console/AdminPanel', () => {
         <InjectIntl(FormattedMarkdownMessage)
           defaultMessage="test-subtitle-default"
           id="test-subtitle-id"
+          values={
+            Object {
+              "foo": "bar",
+            }
+          }
         />
       </span>
     </div>
@@ -80,6 +86,11 @@ describe('components/widgets/admin_console/AdminPanel', () => {
         <InjectIntl(FormattedMarkdownMessage)
           defaultMessage="test-subtitle-default"
           id="test-subtitle-id"
+          values={
+            Object {
+              "foo": "bar",
+            }
+          }
         />
       </span>
     </div>
@@ -126,6 +137,11 @@ describe('components/widgets/admin_console/AdminPanel', () => {
         <InjectIntl(FormattedMarkdownMessage)
           defaultMessage="test-subtitle-default"
           id="test-subtitle-id"
+          values={
+            Object {
+              "foo": "bar",
+            }
+          }
         />
       </span>
     </div>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -598,7 +598,7 @@
   "admin.group_settings.groups_list.unlink_selected": "Unlink Selected Groups",
   "admin.group_settings.groupsPageTitle": "Groups",
   "admin.group_settings.introBanner": "Groups are a way to organize users and apply actions to all users within that group.\nFor more information on Groups, please see [documentation](!https://www.mattermost.com/default-ad-ldap-groups).",
-  "admin.group_settings.ldapGroupsDescription": "Link and configure groups from your AD/LDAP to Mattermost. Please ensure you have configured a [group filter](/admin_console/authentication/ldap).",
+  "admin.group_settings.ldapGroupsDescription": "Link and configure groups from your AD/LDAP to Mattermost. Please ensure you have configured a [group filter]({siteURL}/admin_console/authentication/ldap).",
   "admin.group_settings.ldapGroupsTitle": "AD/LDAP Groups",
   "admin.group_settings.next": "Next",
   "admin.group_settings.prev": "Previous",


### PR DESCRIPTION
#### Summary
1) Adds a parameter `AdminPanel` to use values in translation strings.
2) Prefixes a relative URL in an admin panel to use the site url config value so that the link works in the case of a Mattermost instance using a custom subpath.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14350

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)