### PR TITLE
[MM-14382] Added marked commit that fixes formatted embedded link to italicize when surrounded by asterisks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9517,8 +9517,8 @@
       "integrity": "sha1-GA8fnr74sOY45BZq1S24eb6y/8U="
     },
     "marked": {
-      "version": "github:mattermost/marked#7ad73fe76f2264c533767f9105e7c7cff0fa34f1",
-      "from": "github:mattermost/marked#7ad73fe76f2264c533767f9105e7c7cff0fa34f1"
+      "version": "github:mattermost/marked#2c0c788631f703cad7cdc9fbbdc54ca4b6166b25",
+      "from": "github:mattermost/marked#2c0c788631f703cad7cdc9fbbdc54ca4b6166b25"
     },
     "material-colors": {
       "version": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "localforage": "1.7.3",
     "localforage-observable": "1.4.0",
     "mark.js": "8.11.1",
-    "marked": "github:mattermost/marked#7ad73fe76f2264c533767f9105e7c7cff0fa34f1",
+    "marked": "github:mattermost/marked#2c0c788631f703cad7cdc9fbbdc54ca4b6166b25",
     "mattermost-redux": "github:mattermost/mattermost-redux#c57649018344820122c00b485118415588f2778b",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",


### PR DESCRIPTION
#### Summary
Added marked commit that fixes formatted embedded link to italicize when surrounded by asterisks.

Changes to marked library including tests can be found [here](https://github.com/mattermost/marked/commit/2c0c788631f703cad7cdc9fbbdc54ca4b6166b25).

#### Ticket Link
Jira ticket: [MM-14382](https://mattermost.atlassian.net/browse/MM-14382)
