### PR TITLE
Remove period from OAuth apps description in Main Menu > Integrations

### DIFF
--- a/components/integrations/integrations.jsx
+++ b/components/integrations/integrations.jsx
@@ -145,7 +145,7 @@ export default class Integrations extends React.Component {
                         description={
                             <FormattedMessage
                                 id='integrations.oauthApps.description'
-                                defaultMessage='Auth 2.0 allows external applications to make authorized requests to the Mattermost API.'
+                                defaultMessage='Auth 2.0 allows external applications to make authorized requests to the Mattermost API'
                             />
                         }
                         link={'/' + this.props.team.name + '/integrations/oauth2-apps'}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2275,7 +2275,7 @@
   "integrations.help.appDirectory": "App Directory",
   "integrations.incomingWebhook.description": "Incoming webhooks allow external integrations to send messages",
   "integrations.incomingWebhook.title": "Incoming Webhook",
-  "integrations.oauthApps.description": "OAuth 2.0 allows external applications to make authorized requests to the Mattermost API.",
+  "integrations.oauthApps.description": "OAuth 2.0 allows external applications to make authorized requests to the Mattermost API",
   "integrations.oauthApps.title": "OAuth 2.0 Applications",
   "integrations.outgoingWebhook.description": "Outgoing webhooks allow external integrations to receive and respond to messages",
   "integrations.outgoingWebhook.title": "Outgoing Webhook",


### PR DESCRIPTION
None of the other descriptions have a period.

![image](https://user-images.githubusercontent.com/13119842/54579872-dd3def80-49db-11e9-89e2-bde30bb8c827.png)
