### PR TITLE
MM-13542 Cypress test for Open edit modal immediately after making a …

### DIFF
--- a/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
+++ b/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
@@ -9,6 +9,7 @@ exports[`components/EditPostModal should disable the button on not canDeletePost
   dialogClassName="edit-modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
+  id="editPostModal"
   keyboard={false}
   manager={
     ModalManager {
@@ -139,6 +140,7 @@ exports[`components/EditPostModal should disable the button on not canEditPost a
   dialogClassName="edit-modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
+  id="editPostModal"
   keyboard={false}
   manager={
     ModalManager {
@@ -269,6 +271,7 @@ exports[`components/EditPostModal should match with default config 1`] = `
   dialogClassName="edit-modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
+  id="editPostModal"
   keyboard={false}
   manager={
     ModalManager {
@@ -399,6 +402,7 @@ exports[`components/EditPostModal should match without emoji picker 1`] = `
   dialogClassName="edit-modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
+  id="editPostModal"
   keyboard={false}
   manager={
     ModalManager {
@@ -508,6 +512,7 @@ exports[`components/EditPostModal should not disable the button on not canDelete
   dialogClassName="edit-modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
+  id="editPostModal"
   keyboard={false}
   manager={
     ModalManager {
@@ -638,6 +643,7 @@ exports[`components/EditPostModal should not disable the button on not canEditPo
   dialogClassName="edit-modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
+  id="editPostModal"
   keyboard={false}
   manager={
     ModalManager {
@@ -768,6 +774,7 @@ exports[`components/EditPostModal should not disable the save button on not canD
   dialogClassName="edit-modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
+  id="editPostModal"
   keyboard={false}
   manager={
     ModalManager {
@@ -898,6 +905,7 @@ exports[`components/EditPostModal should show emojis on emojis click 1`] = `
   dialogClassName="edit-modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
+  id="editPostModal"
   keyboard={false}
   manager={
     ModalManager {
@@ -1028,6 +1036,7 @@ exports[`components/EditPostModal should show errors when it is set in the state
   dialogClassName="edit-modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
+  id="editPostModal"
   keyboard={false}
   manager={
     ModalManager {

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -293,6 +293,7 @@ export default class EditPostModal extends React.PureComponent {
 
         return (
             <Modal
+                id='editPostModal'
                 dialogClassName='edit-modal'
                 show={this.props.editingPost.show}
                 onKeyDown={this.handleKeyDown}

--- a/cypress/integration/channel/edit_message_spec.js
+++ b/cypress/integration/channel/edit_message_spec.js
@@ -109,4 +109,44 @@ describe('Edit Message', () => {
             });
         });
     });
+    it('M13542 Open edit modal immediately after making a post', () => {
+        // 1. Login as "user-1" and go to /
+        cy.apiLogin('user-1');
+        cy.visit('/');
+
+        // 2. Post message "Hello"
+        cy.get('#post_textbox').type('Hello').type('{enter}');
+
+        // 3. Post a second message "World!"
+        // 4. Hit 'enter' key and then immediately (as FAST as you can) hit 'arrow-up' to open the edit box
+        cy.get('#post_textbox').type('World!{enter}{uparrow}');
+        cy.get('#edit_textbox').invoke('val').then((val) => { // eslint-disable-line
+            const editText = val;
+            if (editText === 'Hello') {
+                // 5. If pressed while the new post was still pending, observe the edit box opens for the first post
+                cy.get('#editPostModal').should('be.visible');
+                cy.get('#edit_textbox').type(' New message{enter}');
+                cy.get('#editPostModal').should('be.not.visible');
+
+                // Check the first post and verify that it contains new edited message.
+                cy.get('.post-message__text').eq(1).should('contain', 'Hello New message');
+
+                // Check that the second post remains unchanged with the original message.
+                cy.get('.post-message__text').eq(0).should('contain', 'World!');
+            } else if (editText === 'World!') {
+                // 6. If the edit box open up for the second post, Enter edit text and hit enter, observe the second
+                // message is changed and the first message is unchanged
+                cy.get('#editPostModal').should('be.visible');
+
+                cy.get('#edit_textbox').type(' New message{enter}');
+
+                cy.get('#editPostModal').should('be.not.visible');
+
+                cy.get('.post-message__text').eq(1).should('contain', 'Hello');
+
+                // Check the second post and verify that it contains new edited message.
+                cy.get('.post-message__text').eq(0).should('contain', 'World! New message');
+            }
+        });
+    });
 });


### PR DESCRIPTION
…post
#### Summary
This test is used to check if the edit modal is opened for a previous post when the latest one is still pending.
As we are not able to throttle the network to mimic this condition on realtime using cypress, I've handled the case using some conditional testing.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10040

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
