### PR TITLE
MM-14341 Add client-side messageWillBePosted hook

### DIFF
--- a/actions/hooks.js
+++ b/actions/hooks.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export function runMessageWillBePostedHooks(originalPost) {
+    return async (dispatch, getState) => {
+        const hooks = getState().plugins.components.MessageWillBePosted;
+        if (!hooks || hooks.length === 0) {
+            return {data: originalPost};
+        }
+
+        let post = originalPost;
+
+        for (const hook of hooks) {
+            const result = await hook.hook(post); // eslint-disable-line no-await-in-loop
+
+            if (result.error) {
+                return {
+                    error: result.error,
+                };
+            }
+
+            post = result.post;
+        }
+
+        return {data: post};
+    };
+}

--- a/actions/hooks.js
+++ b/actions/hooks.js
@@ -13,13 +13,15 @@ export function runMessageWillBePostedHooks(originalPost) {
         for (const hook of hooks) {
             const result = await hook.hook(post); // eslint-disable-line no-await-in-loop
 
-            if (result.error) {
-                return {
-                    error: result.error,
-                };
-            }
+            if (result) {
+                if (result.error) {
+                    return {
+                        error: result.error,
+                    };
+                }
 
-            post = result.post;
+                post = result.post;
+            }
         }
 
         return {data: post};

--- a/actions/hooks.test.js
+++ b/actions/hooks.test.js
@@ -131,4 +131,28 @@ describe('runMessageWillBePostedHooks', () => {
         expect(result).toEqual({data: {message: 'testasync'}});
         expect(hook).toHaveBeenCalledWith(post);
     });
+
+    test('should assume post is unchanged if a hook returns undefined', async () => {
+        const hook1 = jest.fn();
+        const hook2 = jest.fn((post) => ({post: {...post, message: post.message + 'b'}}));
+
+        const store = mockStore({
+            plugins: {
+                components: {
+                    MessageWillBePosted: [
+                        {hook: hook1},
+                        {hook: hook2},
+                    ],
+                },
+            },
+        });
+        const post = {message: 'test'};
+
+        const result = await store.dispatch(runMessageWillBePostedHooks(post));
+
+        expect(result).toEqual({data: {message: 'testb'}});
+        expect(hook1).toHaveBeenCalledWith(post);
+        expect(hook2).toHaveBeenCalled();
+        expect(hook2).toHaveBeenCalledWith(post);
+    });
 });

--- a/actions/hooks.test.js
+++ b/actions/hooks.test.js
@@ -1,0 +1,134 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import {runMessageWillBePostedHooks} from './hooks';
+
+const mockStore = configureStore([thunk]);
+
+describe('runMessageWillBePostedHooks', () => {
+    test('should do nothing when no hooks are registered', async () => {
+        const store = mockStore({
+            plugins: {
+                components: {},
+            },
+        });
+        const post = {message: 'test'};
+
+        const result = await store.dispatch(runMessageWillBePostedHooks(post));
+
+        expect(result).toEqual({data: post});
+    });
+
+    test('should pass the post through every hook', async () => {
+        const hook1 = jest.fn((post) => ({post}));
+        const hook2 = jest.fn((post) => ({post}));
+        const hook3 = jest.fn((post) => ({post}));
+
+        const store = mockStore({
+            plugins: {
+                components: {
+                    MessageWillBePosted: [
+                        {hook: hook1},
+                        {hook: hook2},
+                        {hook: hook3},
+                    ],
+                },
+            },
+        });
+        const post = {message: 'test'};
+
+        const result = await store.dispatch(runMessageWillBePostedHooks(post));
+
+        expect(result).toEqual({data: post});
+        expect(hook1).toHaveBeenCalledWith(post);
+        expect(hook2).toHaveBeenCalledWith(post);
+        expect(hook3).toHaveBeenCalledWith(post);
+    });
+
+    test('should return an error when a hook rejects the post', async () => {
+        const hook1 = jest.fn((post) => ({post}));
+        const hook2 = jest.fn(() => ({error: {message: 'an error occurred'}}));
+        const hook3 = jest.fn((post) => ({post}));
+
+        const store = mockStore({
+            plugins: {
+                components: {
+                    MessageWillBePosted: [
+                        {hook: hook1},
+                        {hook: hook2},
+                        {hook: hook3},
+                    ],
+                },
+            },
+        });
+        const post = {message: 'test'};
+
+        const result = await store.dispatch(runMessageWillBePostedHooks(post));
+
+        expect(result).toEqual({error: {message: 'an error occurred'}});
+        expect(hook1).toHaveBeenCalledWith(post);
+        expect(hook2).toHaveBeenCalledWith(post);
+        expect(hook3).not.toHaveBeenCalled();
+    });
+
+    test('should pass the result of each hook to the next', async () => {
+        const hook1 = jest.fn((post) => ({post: {...post, message: post.message + 'a'}}));
+        const hook2 = jest.fn((post) => ({post: {...post, message: post.message + 'b'}}));
+        const hook3 = jest.fn((post) => ({post: {...post, message: post.message + 'c'}}));
+
+        const store = mockStore({
+            plugins: {
+                components: {
+                    MessageWillBePosted: [
+                        {hook: hook1},
+                        {hook: hook2},
+                        {hook: hook3},
+                    ],
+                },
+            },
+        });
+        const post = {message: 'test'};
+
+        const result = await store.dispatch(runMessageWillBePostedHooks(post));
+
+        expect(result).toEqual({data: {message: 'testabc'}});
+        expect(hook1).toHaveBeenCalledWith(post);
+        expect(hook2).toHaveBeenCalled();
+        expect(hook2).not.toHaveBeenCalledWith(post);
+        expect(hook3).toHaveBeenCalled();
+        expect(hook3).not.toHaveBeenCalledWith(post);
+    });
+
+    test('should wait for async hooks', async () => {
+        jest.useFakeTimers();
+
+        const hook = jest.fn((post) => {
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    resolve({post: {...post, message: post.message + 'async'}});
+                }, 100);
+
+                jest.runAllTimers();
+            });
+        });
+
+        const store = mockStore({
+            plugins: {
+                components: {
+                    MessageWillBePosted: [
+                        {hook},
+                    ],
+                },
+            },
+        });
+        const post = {message: 'test'};
+
+        const result = await store.dispatch(runMessageWillBePostedHooks(post));
+
+        expect(result).toEqual({data: {message: 'testasync'}});
+        expect(hook).toHaveBeenCalledWith(post);
+    });
+});

--- a/actions/views/create_comment.jsx
+++ b/actions/views/create_comment.jsx
@@ -17,6 +17,7 @@ import {isPostPendingOrFailed} from 'mattermost-redux/utils/post_utils';
 
 import * as PostActions from 'actions/post_actions.jsx';
 import {executeCommand} from 'actions/command';
+import {runMessageWillBePostedHooks} from 'actions/hooks';
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import EmojiMap from 'utils/emoji_map';
 import {getPostDraft} from 'selectors/rhs';
@@ -59,14 +60,14 @@ export function makeOnMoveHistoryIndex(rootId, direction) {
 }
 
 export function submitPost(channelId, rootId, draft) {
-    return (dispatch, getState) => {
+    return async (dispatch, getState) => {
         const state = getState();
 
         const userId = getCurrentUserId(state);
 
         const time = Utils.getTimestamp();
 
-        const post = {
+        let post = {
             file_ids: [],
             message: draft.message,
             channel_id: channelId,
@@ -77,7 +78,14 @@ export function submitPost(channelId, rootId, draft) {
             create_at: time,
         };
 
-        dispatch(PostActions.createPost(post, draft.fileInfos));
+        const hookResult = await dispatch(runMessageWillBePostedHooks(post));
+        if (hookResult.error) {
+            return {error: hookResult.error};
+        }
+
+        post = hookResult.data;
+
+        return dispatch(PostActions.createPost(post, draft.fileInfos));
     };
 }
 

--- a/actions/views/create_comment.jsx
+++ b/actions/views/create_comment.jsx
@@ -118,7 +118,7 @@ export function submitCommand(channelId, rootId, draft) {
 
         if (error) {
             if (error.sendMessage) {
-                dispatch(submitPost(channelId, rootId, draft));
+                await dispatch(submitPost(channelId, rootId, draft));
             } else {
                 throw (error);
             }

--- a/actions/views/create_comment.test.jsx
+++ b/actions/views/create_comment.test.jsx
@@ -23,6 +23,7 @@ import {
 import {setGlobalItem, actionOnGlobalItemsWithPrefix} from 'actions/storage';
 import * as PostActions from 'actions/post_actions.jsx';
 import {executeCommand} from 'actions/command';
+import * as HookActions from 'actions/hooks';
 import {StoragePrefixes} from 'utils/constants';
 
 /* eslint-disable global-require */
@@ -47,6 +48,10 @@ jest.mock('actions/command', () => ({
 
 jest.mock('actions/global_actions.jsx', () => ({
     emitUserCommentedEvent: jest.fn(),
+}));
+
+jest.mock('actions/hooks', () => ({
+    runMessageWillBePostedHooks: jest.fn((post) => () => ({data: post})),
 }));
 
 jest.mock('actions/post_actions.jsx', () => ({
@@ -213,9 +218,10 @@ describe('rhs view actions', () => {
             user_id: currentUserId,
         };
 
-        test('it call PostActions.createPost with post', () => {
-            store.dispatch(submitPost(channelId, rootId, draft));
+        test('it call PostActions.createPost with post', async () => {
+            await store.dispatch(submitPost(channelId, rootId, draft));
 
+            expect(HookActions.runMessageWillBePostedHooks).toHaveBeenCalled();
             expect(PostActions.createPost).toHaveBeenCalled();
 
             expect(lastCall(PostActions.createPost.mock.calls)[0]).toEqual(
@@ -223,6 +229,15 @@ describe('rhs view actions', () => {
             );
 
             expect(lastCall(PostActions.createPost.mock.calls)[1]).toBe(draft.fileInfos);
+        });
+
+        test('it does not call PostActions.createPost when hooks fail', async () => {
+            HookActions.runMessageWillBePostedHooks.mockImplementation(() => () => ({error: {message: 'An error occurred'}}));
+
+            await store.dispatch(submitPost(channelId, rootId, draft));
+
+            expect(HookActions.runMessageWillBePostedHooks).toHaveBeenCalled();
+            expect(PostActions.createPost).not.toHaveBeenCalled();
         });
     });
 
@@ -255,8 +270,8 @@ describe('rhs view actions', () => {
 
         const draft = {message: 'test msg'};
 
-        test('it calls executeCommand', () => {
-            store.dispatch(submitCommand(channelId, rootId, draft));
+        test('it calls executeCommand', async () => {
+            await store.dispatch(submitCommand(channelId, rootId, draft));
 
             expect(executeCommand).toHaveBeenCalled();
 
@@ -267,7 +282,7 @@ describe('rhs view actions', () => {
             expect(lastCall(executeCommand.mock.calls)[1]).toEqual(args);
         });
 
-        test('it calls submitPost on error.sendMessage', () => {
+        test('it calls submitPost on error.sendMessage', async () => {
             jest.mock('actions/channel_actions.jsx', () => ({
                 executeCommand: jest.fn((message, _args, resolve, reject) => reject({sendMessage: 'test'})),
             }));
@@ -276,7 +291,7 @@ describe('rhs view actions', () => {
 
             const {submitCommand: remockedSubmitCommand} = require('actions/views/create_comment');
 
-            store.dispatch(remockedSubmitCommand(channelId, rootId, draft));
+            await store.dispatch(remockedSubmitCommand(channelId, rootId, draft));
 
             const expectedActions = [{args: ['test msg', {channel_id: '4j5j4k3k34j4', parent_id: 'fc234c34c23', root_id: 'fc234c34c23', team_id: '4j5nmn4j3'}], type: 'MOCK_ACTIONS_COMMAND_EXECUTE'}];
             expect(store.getActions()).toEqual(expectedActions);

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -79,6 +79,9 @@ const actionsProp = {
         return {data: true};
     },
     getChannelTimezones: emptyFunction,
+    runMessageWillBePostedHooks: async (post) => {
+        return {data: post};
+    },
 };
 
 function createPost({
@@ -376,7 +379,7 @@ describe('components/create_post', () => {
         expect(GlobalActions.showChannelNameUpdateModal).toHaveBeenCalledWith(currentChannelProp);
     });
 
-    it('onSubmit test for "/unknown" message ', () => {
+    it('onSubmit test for "/unknown" message ', async () => {
         jest.mock('actions/channel_actions.jsx', () => ({
             executeCommand: jest.fn((message, _args, resolve) => resolve()),
         }));
@@ -387,12 +390,11 @@ describe('components/create_post', () => {
             message: '/unknown',
         });
 
-        const form = wrapper.find('#create_post');
-        form.simulate('Submit', {preventDefault: jest.fn()});
+        await wrapper.instance().handleSubmit({preventDefault: jest.fn()});
         expect(wrapper.state('submitting')).toBe(false);
     });
 
-    it('onSubmit test for addReaction message', () => {
+    it('onSubmit test for addReaction message', async () => {
         const addReaction = jest.fn();
 
         const wrapper = shallowWithIntl(
@@ -408,8 +410,7 @@ describe('components/create_post', () => {
             message: '+:smile:',
         });
 
-        const form = wrapper.find('#create_post');
-        form.simulate('Submit', {preventDefault: jest.fn()});
+        await wrapper.instance().handleSubmit({preventDefault: jest.fn()});
         expect(addReaction).toHaveBeenCalledWith('a', 'smile');
     });
 
@@ -716,7 +717,7 @@ describe('components/create_post', () => {
         expect(wrapper.state('showPostDeletedModal')).toBe(false);
     });
 
-    it('Should have called actions.onSubmitPost on sendMessage', () => {
+    it('Should have called actions.onSubmitPost on sendMessage', async () => {
         const onSubmitPost = jest.fn();
         const wrapper = shallowWithIntl(createPost({
             actions: {
@@ -725,7 +726,7 @@ describe('components/create_post', () => {
             },
         }));
         const post = {message: 'message', file_ids: []};
-        wrapper.instance().sendMessage(post);
+        await wrapper.instance().sendMessage(post);
 
         expect(onSubmitPost).toHaveBeenCalledTimes(1);
         expect(onSubmitPost.mock.calls[0][0]).toEqual(post);
@@ -835,7 +836,7 @@ describe('components/create_post', () => {
         });
         expect(wrapper.find('[id="postServerError"]').exists()).toBe(false);
 
-        wrapper.instance().handleSubmit({preventDefault: jest.fn()});
+        await wrapper.instance().handleSubmit({preventDefault: jest.fn()});
 
         expect(onSubmitPost).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -32,6 +32,7 @@ import {postListScrollChangeToBottom} from 'actions/global_actions.jsx';
 import {addReaction, createPost, setEditingPost} from 'actions/post_actions.jsx';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
 import {executeCommand} from 'actions/command';
+import {runMessageWillBePostedHooks} from 'actions/hooks';
 import {getPostDraft, getIsRhsExpanded} from 'selectors/rhs';
 import {getCurrentLocale} from 'selectors/i18n';
 import {getEmojiMap} from 'selectors/emojis';
@@ -118,6 +119,7 @@ function mapDispatchToProps(dispatch) {
             openModal,
             executeCommand,
             getChannelTimezones,
+            runMessageWillBePostedHooks,
         }, dispatch),
     };
 }

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -288,6 +288,33 @@ export default class PluginRegistry {
         unregisterPluginReconnectHandler(this.id);
     }
 
+    // Register a hook that will be called when a message is posted by the user before it
+    // is sent to the server. Accepts a function that receives the post as an argument.
+    //
+    // To reject a post, return an object containing an error such as
+    //     {error: {message: 'Rejected'}}
+    // To modify or allow the post without modifcation, return an object containing the post
+    // such as
+    //     {post: {...}}
+    //
+    // If the hook function is asynchronous, the message will not be sent to the server
+    // until the hook returns.
+    registerMessageWillBePostedHook(hook) {
+        const id = generateId();
+
+        store.dispatch({
+            type: ActionTypes.RECEIVED_PLUGIN_COMPONENT,
+            name: 'MessageWillBePosted',
+            data: {
+                id,
+                pluginId: this.id,
+                hook,
+            },
+        });
+
+        return id;
+    }
+
     // Register a hook that will be called before a message is formatted into Markdown.
     // Accepts a function that receives the unmodified post and the message (potentially
     // already modified by other hooks) as arguments. This function must return a string


### PR DESCRIPTION
This hook is needed for the NPS plugin because we wanted to show a confirmation modal for written feedback so that users know their feedback is being sent to Mattermost.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14341

#### Checklist
- Added or updated unit tests (required for all new features)
