### PR TITLE
MM-13689 Fix leaving top team on sidebar from non-default channel

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -11,8 +11,8 @@ import classNames from 'classnames';
 import Scrollbars from 'react-custom-scrollbars';
 import {SpringSystem, MathUtil} from 'rebound';
 
-import {browserHistory} from 'utils/browser_history';
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
+import {redirectUserToDefaultTeam} from 'actions/global_actions';
 import * as ChannelUtils from 'utils/channel_utils.jsx';
 import {Constants, ModalIdentifiers, SidebarChannelGroups} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -199,7 +199,7 @@ export default class Sidebar extends React.PureComponent {
             this.channelIdIsDisplayedForProps(prevProps.orderedChannelIds, this.props.currentChannel.id)
         ) {
             this.closedDirectChannel = true;
-            browserHistory.push(`/${this.props.currentTeam.name}/channels/${Constants.DEFAULT_CHANNEL}`);
+            redirectUserToDefaultTeam();
             return;
         }
 


### PR DESCRIPTION
#### Summary
This fixes leaving the top team in the team sidebar from a channel other than town square causing the user to end up on a "Channel not found" page. The root of the issue is that leaving a team causes the deletion of all that team's channels from the redux store. This would trigger the code I changed here, which would try to redirect to the team being left. The fix was simply to use our `redirectUserToDefaultTeam` function which is more robust about redirecting the user to the correct place.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13689

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed