### PR TITLE
MM-14731 Prevent getRedirectLocation calls when metadata is present

### DIFF
--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -70,9 +70,10 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         this.generateStaticEmbed = this.generateStaticEmbed.bind(this);
         this.isLinkToggleable = this.isLinkToggleable.bind(this);
         this.handleLinkLoaded = this.handleLinkLoaded.bind(this);
-
+        const embedMetadata = props.post.metadata && props.post.metadata.embeds && props.post.metadata.embeds[0];
+        const link = embedMetadata && embedMetadata.url ? embedMetadata.url : Utils.extractFirstLink(props.post.message);
         this.state = {
-            link: Utils.extractFirstLink(props.post.message),
+            link,
             linkLoadError: false,
             linkLoaded: false,
         };
@@ -80,7 +81,10 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
 
     componentDidMount() {
         // check the availability of the image rendered(if any) in the first render.
-        this.loadShortenedImageLink();
+        const embedMetadata = this.props.post.metadata && this.props.post.metadata.embeds && this.props.post.metadata.embeds[0];
+        if (!embedMetadata || (embedMetadata && !embedMetadata.url)) {
+            this.loadShortenedImageLink();
+        }
         this.preCheckImageLink();
         this.mounted = true;
     }
@@ -107,11 +111,16 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
         if (nextProps.post.message !== this.props.post.message) {
+            const embedMetadata = nextProps.post.metadata.embeds && nextProps.post.metadata.embeds[0];
+            const link = embedMetadata && embedMetadata.url ? embedMetadata.url : Utils.extractFirstLink(nextProps.post.message);
+
             this.setState({
-                link: Utils.extractFirstLink(nextProps.post.message),
+                link,
             }, () => {
                 // check the availability of the image link
-                this.loadShortenedImageLink();
+                if (!embedMetadata || (embedMetadata && !embedMetadata.url)) {
+                    this.loadShortenedImageLink();
+                }
                 this.preCheckImageLink();
             });
         }

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -81,7 +81,8 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
 
     componentDidMount() {
         // check the availability of the image rendered(if any) in the first render.
-        const embedMetadata = this.props.post.metadata && this.props.post.metadata.embeds && this.props.post.metadata.embeds[0];
+        const {metadata} = this.props.post;
+        const embedMetadata = metadata && metadata.embeds && metadata.embeds[0];
         if (!embedMetadata || !embedMetadata.url) {
             this.loadShortenedImageLink();
         }
@@ -111,7 +112,8 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
 
     UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
         if (nextProps.post.message !== this.props.post.message) {
-            const embedMetadata = nextProps.post.metadata.embeds && nextProps.post.metadata.embeds[0];
+            const {metadata} = nextProps.post;
+            const embedMetadata = metadata && metadata.embeds && metadata.embeds[0];
             const link = embedMetadata && embedMetadata.url ? embedMetadata.url : Utils.extractFirstLink(nextProps.post.message);
 
             this.setState({

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -82,13 +82,13 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
 
     componentDidMount() {
         // check the availability of the image rendered(if any) in the first render.
+        this.mounted = true;
         const {metadata} = this.props.post;
-        const embedMetadata = metadata && metadata.embeds && metadata.embeds[0];
-        if (!embedMetadata || !embedMetadata.url) {
+
+        if (!metadata) {
             this.loadShortenedImageLink();
         }
         this.preCheckImageLink();
-        this.mounted = true;
     }
 
     componentWillUnmount() {
@@ -121,7 +121,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
                 link,
             }, () => {
                 // check the availability of the image link
-                if (!embedMetadata || !embedMetadata.url) {
+                if (!metadata) {
                     this.loadShortenedImageLink();
                 }
                 this.preCheckImageLink();

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -70,7 +70,8 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         this.generateStaticEmbed = this.generateStaticEmbed.bind(this);
         this.isLinkToggleable = this.isLinkToggleable.bind(this);
         this.handleLinkLoaded = this.handleLinkLoaded.bind(this);
-        const embedMetadata = props.post.metadata && props.post.metadata.embeds && props.post.metadata.embeds[0];
+        const {metadata} = props.post;
+        const embedMetadata = metadata && metadata.embeds && metadata.embeds[0];
         const link = embedMetadata && embedMetadata.url ? embedMetadata.url : Utils.extractFirstLink(props.post.message);
         this.state = {
             link,

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -82,7 +82,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
     componentDidMount() {
         // check the availability of the image rendered(if any) in the first render.
         const embedMetadata = this.props.post.metadata && this.props.post.metadata.embeds && this.props.post.metadata.embeds[0];
-        if (!embedMetadata || (embedMetadata && !embedMetadata.url)) {
+        if (!embedMetadata || !embedMetadata.url) {
             this.loadShortenedImageLink();
         }
         this.preCheckImageLink();

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -118,7 +118,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
                 link,
             }, () => {
                 // check the availability of the image link
-                if (!embedMetadata || (embedMetadata && !embedMetadata.url)) {
+                if (!embedMetadata || !embedMetadata.url) {
                     this.loadShortenedImageLink();
                 }
                 this.preCheckImageLink();

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -96,7 +96,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
     }
 
     async loadShortenedImageLink() {
-        if (!this.isLinkImage(this.state.link) && !YoutubeVideo.isYoutubeLink(this.state.link) && this.props.enableLinkPreviews) {
+        if (this.state.link && !this.isLinkImage(this.state.link) && !YoutubeVideo.isYoutubeLink(this.state.link) && this.props.enableLinkPreviews) {
             const {data} = await this.props.actions.getRedirectLocation(this.state.link);
             const {link} = this.state;
             if (data && data.location && this.mounted) {

--- a/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
@@ -92,4 +92,69 @@ describe('components/post_view/PostBodyAdditionalContent', () => {
         expect(fileInfos.length).toBe(1);
         expect(fileInfos[0].link).toBe(PostUtils.getImageSrc(link, true));
     });
+
+    test('should call getRedirectLocation call as there is no metadata', () => {
+        const link = 'http://example.com/';
+
+        const props = {
+            ...baseProps,
+            hasImageProxy: true,
+            post: {
+                ...post,
+                message: link,
+                metadata: {},
+            },
+        };
+
+        const wrapper = shallow(
+            <PostBodyAdditionalContent {...props}>
+                <div/>
+            </PostBodyAdditionalContent>
+        );
+
+        expect(baseProps.actions.getRedirectLocation).toHaveBeenCalledTimes(1);
+
+        wrapper.setProps({
+            post: {
+                ...props.post,
+                message: 'http://example.com/new',
+            },
+        });
+        expect(baseProps.actions.getRedirectLocation).toHaveBeenCalledTimes(2);
+    });
+
+    test('should not call getRedirectLocation call as there is metadata available', () => {
+        const link = 'http://example.com/';
+
+        const props = {
+            ...baseProps,
+            hasImageProxy: true,
+            post: {
+                ...post,
+                message: link,
+                metadata: {
+                    embeds: [{
+                        url: link,
+                        type: 'opengraph',
+                    }],
+                },
+            },
+        };
+
+        const wrapper = shallow(
+            <PostBodyAdditionalContent {...props}>
+                <div/>
+            </PostBodyAdditionalContent>
+        );
+
+        expect(baseProps.actions.getRedirectLocation).not.toHaveBeenCalled();
+
+        wrapper.setProps({
+            post: {
+                ...props.post,
+                message: 'http://example.com/new',
+            },
+        });
+        expect(baseProps.actions.getRedirectLocation).not.toHaveBeenCalled();
+    });
 });

--- a/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
@@ -102,7 +102,6 @@ describe('components/post_view/PostBodyAdditionalContent', () => {
             post: {
                 ...post,
                 message: link,
-                metadata: {},
             },
         };
 


### PR DESCRIPTION
#### Summary
This PR prevents the requests for getRedirectLocation urls when metadata is available.
With virtualised post list posts get mounted/unmounted often on scroll making this very expensive as each post call makes two redux actions of request and success triggering a whole lot of mapStateToProps calls. 
For more context https://community-daily.mattermost.com/core/pl/h77ykgojwbb37bcngp91y49sia

#### Ticket Link
[MM-14731](https://mattermost.atlassian.net/browse/MM-14731)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
