### PR TITLE
Creating the concept of RedirectChannel and use it before the DefaultChannel when we are redirecting the user

### DIFF
--- a/actions/command.js
+++ b/actions/command.js
@@ -4,9 +4,9 @@
 import {Client4} from 'mattermost-redux/client';
 import {unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
-import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannel, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentRelativeTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {IntegrationTypes} from 'mattermost-redux/action_types';
 
 import {openModal} from 'actions/views/modals';
@@ -75,7 +75,9 @@ export function executeCommand(message, args) {
                 if (isFavoriteChannel(channel)) {
                     dispatch(unfavoriteChannel(channel.id));
                 }
-                browserHistory.push(`${getCurrentRelativeTeamUrl(state)}/channels/${Constants.DEFAULT_CHANNEL}`);
+                const currentTeamId = getCurrentTeamId(state);
+                const redirectChannel = getRedirectChannelNameForTeam(state, currentTeamId);
+                browserHistory.push(`${getCurrentRelativeTeamUrl(state)}/channels/${redirectChannel}`);
                 return {data: true};
             }
             break;

--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -6,7 +6,7 @@ import {batchActions} from 'redux-batched-actions';
 import {leaveChannel as leaveChannelRedux, joinChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import * as PostActions from 'mattermost-redux/actions/posts';
 import {Posts} from 'mattermost-redux/constants';
-import {getChannel, getChannelByName, getCurrentChannel, getDefaultChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, getChannelByName, getCurrentChannel, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentRelativeTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getUserByUsername} from 'mattermost-redux/selectors/entities/users';
 import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
@@ -36,7 +36,7 @@ export function goToLastViewedChannel() {
         let channelToSwitchTo = getChannelByName(state, getLastViewedChannelName(state));
 
         if (currentChannel.id === channelToSwitchTo.id) {
-            channelToSwitchTo = getDefaultChannel(state);
+            channelToSwitchTo = getChannelByName(state, getRedirectChannelNameForTeam(state, getCurrentTeamId(state)));
         }
 
         return dispatch(switchToChannel(channelToSwitchTo));
@@ -99,7 +99,9 @@ export function leaveChannel(channelId) {
         }
 
         const teamUrl = getCurrentRelativeTeamUrl(state);
-        browserHistory.push(teamUrl + '/channels/' + Constants.DEFAULT_CHANNEL);
+        const currentTeamId = getCurrentTeamId(state);
+        const redirectChannel = getRedirectChannelNameForTeam(state, currentTeamId);
+        browserHistory.push(teamUrl + '/channels/' + redirectChannel);
 
         const {error} = await dispatch(leaveChannelRedux(channelId));
         if (error) {

--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -99,9 +99,7 @@ export function leaveChannel(channelId) {
         }
 
         const teamUrl = getCurrentRelativeTeamUrl(state);
-        const currentTeamId = getCurrentTeamId(state);
-        const redirectChannel = getRedirectChannelNameForTeam(state, currentTeamId);
-        browserHistory.push(teamUrl + '/channels/' + redirectChannel);
+        browserHistory.push(teamUrl);
 
         const {error} = await dispatch(leaveChannelRedux(channelId));
         if (error) {

--- a/actions/views/channel.test.js
+++ b/actions/views/channel.test.js
@@ -109,7 +109,7 @@ describe('channel view actions', () => {
     describe('leaveChannel', () => {
         test('leave a channel successfully', async () => {
             await store.dispatch(Actions.leaveChannel('channelid'));
-            expect(browserHistory.push).toHaveBeenCalledWith(`/${team1.name}/channels/town-square`);
+            expect(browserHistory.push).toHaveBeenCalledWith(`/${team1.name}`);
             expect(leaveChannel).toHaveBeenCalledWith('channelid');
         });
     });

--- a/actions/views/channel.test.js
+++ b/actions/views/channel.test.js
@@ -49,7 +49,7 @@ describe('channel view actions', () => {
         entities: {
             users: {
                 currentUserId: 'userid1',
-                profiles: {userid1: {id: 'userid1', username: 'username1'}, userid2: {id: 'userid2', username: 'username2'}},
+                profiles: {userid1: {id: 'userid1', username: 'username1', roles: 'system_user'}, userid2: {id: 'userid2', username: 'username2', roles: 'system_user'}},
                 profilesInChannel: {},
             },
             teams: {
@@ -63,6 +63,12 @@ describe('channel view actions', () => {
             },
             general: {
                 config: {},
+                serverVersion: '5.12.0',
+            },
+            roles: {
+                roles: {
+                    system_user: {permissions: ['join_public_channels']},
+                },
             },
             preferences: {
                 myPreferences: {},

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -38,7 +38,7 @@ import {Client4} from 'mattermost-redux/client';
 import {getCurrentUser, getCurrentUserId, getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 import {getMyTeams, getCurrentRelativeTeamUrl, getCurrentTeamId, getCurrentTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getChannel, getCurrentChannel, getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, getCurrentChannel, getCurrentChannelId, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 
 import {getSelectedChannelId} from 'selectors/rhs';
 
@@ -569,7 +569,9 @@ function handleDeleteTeamEvent(msg) {
 
         if (newTeamId) {
             dispatch({type: TeamTypes.SELECT_TEAM, data: newTeamId});
-            browserHistory.push(`${getCurrentTeamUrl(getState())}/channels/${Constants.DEFAULT_CHANNEL}`);
+            const globalState = getState();
+            const redirectChannel = getRedirectChannelNameForTeam(globalState, newTeamId);
+            browserHistory.push(`${getCurrentTeamUrl(globalState)}/channels/${redirectChannel}`);
         } else {
             browserHistory.push('/');
         }
@@ -708,7 +710,9 @@ function handleChannelDeletedEvent(msg) {
     const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
     if (getCurrentChannelId(state) === msg.data.channel_id && !viewArchivedChannels) {
         const teamUrl = getCurrentRelativeTeamUrl(state);
-        browserHistory.push(teamUrl + '/channels/' + Constants.DEFAULT_CHANNEL);
+        const currentTeamId = getCurrentTeamId(state);
+        const redirectChannel = getRedirectChannelNameForTeam(state, currentTeamId);
+        browserHistory.push(teamUrl + '/channels/' + redirectChannel);
     }
 
     dispatch({type: ChannelTypes.RECEIVED_CHANNEL_DELETED, data: {id: msg.data.channel_id, team_id: msg.broadcast.team_id, deleteAt: msg.data.delete_at, viewArchivedChannels}});

--- a/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
+++ b/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
@@ -25,7 +25,6 @@ export default class AdminNavbarDropdown extends React.Component {
         locale: PropTypes.string.isRequired,
         navigationBlocked: PropTypes.bool,
         teams: PropTypes.arrayOf(PropTypes.object).isRequired,
-        redirectChannelPerTeam: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             deferNavigation: PropTypes.func,
         }).isRequired,
@@ -41,7 +40,7 @@ export default class AdminNavbarDropdown extends React.Component {
     };
 
     render() {
-        const {locale, teams, redirectChannelPerTeam} = this.props;
+        const {locale, teams} = this.props;
         const teamToRender = []; // Array of team components
         let switchTeams;
 
@@ -52,7 +51,7 @@ export default class AdminNavbarDropdown extends React.Component {
                 teamToRender.push(
                     <MenuItemBlockableLink
                         key={'team_' + team.name}
-                        to={'/' + team.name + `/channels/${redirectChannelPerTeam[team.id]}`}
+                        to={'/' + team.name}
                         text={Utils.localizeMessage('navbar_dropdown.switchTo', 'Switch to ') + ' ' + team.display_name}
                     />
                 );

--- a/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
+++ b/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
@@ -9,7 +9,7 @@ import * as GlobalActions from 'actions/global_actions.jsx';
 
 import {filterAndSortTeamsByDisplayName} from 'utils/team_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
-import {Constants, ModalIdentifiers} from 'utils/constants.jsx';
+import {ModalIdentifiers} from 'utils/constants.jsx';
 
 import AboutBuildModal from 'components/about_build_modal';
 
@@ -25,6 +25,7 @@ export default class AdminNavbarDropdown extends React.Component {
         locale: PropTypes.string.isRequired,
         navigationBlocked: PropTypes.bool,
         teams: PropTypes.arrayOf(PropTypes.object).isRequired,
+        redirectChannelPerTeam: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             deferNavigation: PropTypes.func,
         }).isRequired,
@@ -40,7 +41,7 @@ export default class AdminNavbarDropdown extends React.Component {
     };
 
     render() {
-        const {locale, teams} = this.props;
+        const {locale, teams, redirectChannelPerTeam} = this.props;
         const teamToRender = []; // Array of team components
         let switchTeams;
 
@@ -51,7 +52,7 @@ export default class AdminNavbarDropdown extends React.Component {
                 teamToRender.push(
                     <MenuItemBlockableLink
                         key={'team_' + team.name}
-                        to={'/' + team.name + `/channels/${Constants.DEFAULT_CHANNEL}`}
+                        to={'/' + team.name + `/channels/${redirectChannelPerTeam[team.id]}`}
                         text={Utils.localizeMessage('navbar_dropdown.switchTo', 'Switch to ') + ' ' + team.display_name}
                     />
                 );

--- a/components/admin_console/admin_navbar_dropdown/index.js
+++ b/components/admin_console/admin_navbar_dropdown/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getMyTeams} from 'mattermost-redux/selectors/entities/teams';
+import {getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 
 import {deferNavigation} from 'actions/admin_actions.jsx';
 import {getCurrentLocale} from 'selectors/i18n';
@@ -13,10 +14,17 @@ import {getNavigationBlocked} from 'selectors/views/admin';
 import AdminNavbarDropdown from './admin_navbar_dropdown.jsx';
 
 function mapStateToProps(state) {
+    const teams = getMyTeams(state);
+    const redirectChannelPerTeam = {};
+    for (const team of Object.values(teams)) {
+        redirectChannelPerTeam[team.id] = getRedirectChannelNameForTeam(state, team.id);
+    }
+
     return {
         locale: getCurrentLocale(state),
-        teams: getMyTeams(state),
+        teams,
         navigationBlocked: getNavigationBlocked(state),
+        redirectChannelPerTeam,
     };
 }
 

--- a/components/admin_console/admin_navbar_dropdown/index.js
+++ b/components/admin_console/admin_navbar_dropdown/index.js
@@ -5,7 +5,6 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getMyTeams} from 'mattermost-redux/selectors/entities/teams';
-import {getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 
 import {deferNavigation} from 'actions/admin_actions.jsx';
 import {getCurrentLocale} from 'selectors/i18n';
@@ -14,17 +13,10 @@ import {getNavigationBlocked} from 'selectors/views/admin';
 import AdminNavbarDropdown from './admin_navbar_dropdown.jsx';
 
 function mapStateToProps(state) {
-    const teams = getMyTeams(state);
-    const redirectChannelPerTeam = {};
-    for (const team of Object.values(teams)) {
-        redirectChannelPerTeam[team.id] = getRedirectChannelNameForTeam(state, team.id);
-    }
-
     return {
         locale: getCurrentLocale(state),
-        teams,
+        teams: getMyTeams(state),
         navigationBlocked: getNavigationBlocked(state),
-        redirectChannelPerTeam,
     };
 }
 

--- a/components/channel_header_dropdown/index.js
+++ b/components/channel_header_dropdown/index.js
@@ -7,6 +7,7 @@ import {
     getCurrentUser,
     getUserStatuses,
 } from 'mattermost-redux/selectors/entities/users';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {
     getCurrentChannel,
     isCurrentChannelDefault,
@@ -14,6 +15,7 @@ import {
     isCurrentChannelMuted,
     isCurrentChannelArchived,
     isCurrentChannelReadOnly,
+    getRedirectChannelNameForTeam,
 } from 'mattermost-redux/selectors/entities/channels';
 
 import {getPenultimateViewedChannelName} from 'selectors/local_storage';
@@ -56,7 +58,7 @@ const mapStateToProps = (state) => ({
     isMuted: isCurrentChannelMuted(state),
     isReadonly: isCurrentChannelReadOnly(state),
     isArchived: isCurrentChannelArchived(state),
-    penultimateViewedChannelName: getPenultimateViewedChannelName(state) || Constants.DEFAULT_CHANNEL,
+    penultimateViewedChannelName: getPenultimateViewedChannelName(state) || getRedirectChannelNameForTeam(state, getCurrentTeamId(state)),
 });
 
 const mobileMapStateToProps = (state) => ({

--- a/components/create_team/components/team_url/team_url.jsx
+++ b/components/create_team/components/team_url/team_url.jsx
@@ -139,7 +139,7 @@ export default class TeamUrl extends React.PureComponent {
         const {data, error} = await createTeam(teamSignup.team);
 
         if (data) {
-            this.props.history.push('/' + data.name + '/channels/town-square');
+            this.props.history.push('/' + data.name + '/channels/' + Constants.DEFAULT_CHANNEL);
             trackEvent('signup', 'signup_team_03_complete');
         } else if (error) {
             this.setState({nameError: error.message});

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -58,6 +58,7 @@ class LoginController extends React.Component {
         samlLoginButtonText: PropTypes.string,
         siteName: PropTypes.string,
         initializing: PropTypes.bool,
+        defaultChannel: PropTypes.string.isRequired,
         actions: PropTypes.shape({
             login: PropTypes.func.isRequired,
             addUserToTeamFromInvite: PropTypes.func.isRequired,
@@ -331,7 +332,7 @@ class LoginController extends React.Component {
         } else if (team) {
             browserHistory.push(`/${team.name}`);
         } else if (experimentalPrimaryTeam) {
-            browserHistory.push(`/${experimentalPrimaryTeam}/channels/${Constants.DEFAULT_CHANNEL}`);
+            browserHistory.push(`/${experimentalPrimaryTeam}/channels/${this.props.defaultChannel}`);
         } else {
             GlobalActions.redirectUserToDefaultTeam();
         }

--- a/components/login/login_controller/login_controller.test.jsx
+++ b/components/login/login_controller/login_controller.test.jsx
@@ -31,6 +31,7 @@ describe('components/login/LoginController', () => {
         ldapLoginFieldName: '',
         samlLoginButtonText: '',
         siteName: '',
+        defaultChannel: 'default-channel',
         actions: {
             login: jest.fn(),
             addUserToTeamFromInvite: jest.fn(),

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -11,6 +11,7 @@ import {Permissions} from 'mattermost-redux/constants';
 import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 
 import * as UserAgent from 'utils/user_agent.jsx';
+import Constants from 'utils/constants.jsx';
 
 import logoImage from 'images/logo.png';
 
@@ -72,7 +73,7 @@ export default class SelectTeam extends React.Component {
 
         const {data, error} = await this.props.actions.addUserToTeam(team.id, this.props.currentUserId);
         if (data) {
-            this.props.history.push(`/${team.name}/channels/town-square`);
+            this.props.history.push(`/${team.name}/channels/${Constants.DEFAULT_CHANNEL}`);
         } else if (error) {
             this.setState({
                 error,

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -192,7 +192,8 @@ export default class Sidebar extends React.PureComponent {
     }
 
     componentDidUpdate(prevProps) {
-        // if the active channel disappeared (which can happen when dm channels autoclose), go to town square
+        // if the active channel disappeared (which can happen when dm channels
+        // autoclose), go to user default channel in team
         if (this.props.currentTeam === prevProps.currentTeam &&
             this.props.currentChannel.id === prevProps.currentChannel.id &&
             !this.channelIdIsDisplayedForProps(this.props.orderedChannelIds, this.props.currentChannel.id) &&

--- a/components/sidebar/sidebar.test.jsx
+++ b/components/sidebar/sidebar.test.jsx
@@ -136,6 +136,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             switchToChannelById: jest.fn(),
             openModal: jest.fn(),
         },
+        redirectChannel: 'default-channel',
         canCreatePublicChannel: true,
         canCreatePrivateChannel: true,
     };

--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -11,8 +11,10 @@ import {
     getChannelsNameMapInCurrentTeam,
     makeGetChannel,
     shouldHideDefaultChannel,
+    getRedirectChannelNameForTeam,
 } from 'mattermost-redux/selectors/entities/channels';
 import {getMyChannelMemberships} from 'mattermost-redux/selectors/entities/common';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getUserIdsInChannels, getUser} from 'mattermost-redux/selectors/entities/users';
 import {getInt, getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -122,6 +124,7 @@ function makeMapStateToProps() {
             membersCount,
             shouldHideChannel,
             channelIsArchived: channel.delete_at !== 0,
+            redirectChannel: getRedirectChannelNameForTeam(state, getCurrentTeamId(state)),
         };
     };
 }

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -142,6 +142,8 @@ export default class SidebarChannel extends React.PureComponent {
 
         channelIsArchived: PropTypes.bool.isRequired,
 
+        redirectChannel: PropTypes.string.isRequired,
+
         actions: PropTypes.shape({
             savePreferences: PropTypes.func.isRequired,
             leaveChannel: PropTypes.func.isRequired,
@@ -186,7 +188,7 @@ export default class SidebarChannel extends React.PureComponent {
         }
 
         if (this.props.active) {
-            browserHistory.push(`/${this.props.currentTeamName}/channels/${Constants.DEFAULT_CHANNEL}`);
+            browserHistory.push(`/${this.props.currentTeamName}/channels/${this.props.redirectChannel}`);
         }
     }
 

--- a/components/sidebar/sidebar_channel/sidebar_channel.test.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.test.jsx
@@ -65,6 +65,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
         membersCount: 8,
         showUnreadForMsgs: true,
         shouldHideChannel: false,
+        redirectChannel: 'test-default-channel',
         actions: {
             savePreferences: jest.fn(),
             leaveChannel: jest.fn(),
@@ -382,7 +383,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
         wrapper.instance().handleLeaveDirectChannel();
         expect(savePreferences).toBeCalledWith('user-id', [{user_id: 'user-id', category: Constants.Preferences.CATEGORY_GROUP_CHANNEL_SHOW, name: 'test-channel-id', value: 'false'}]);
         expect(trackEvent).toBeCalledWith('ui', 'ui_direct_channel_x_button_clicked');
-        expect(browserHistory.push).toBeCalledWith('/current-team/channels/town-square');
+        expect(browserHistory.push).toBeCalledWith('/current-team/channels/test-default-channel');
         expect(props.actions.openLhs).not.toBeCalled();
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10534,8 +10534,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#29e65f58b0fb536e6923b270aa848208986f01ab",
-      "from": "github:mattermost/mattermost-redux#29e65f58b0fb536e6923b270aa848208986f01ab",
+      "version": "github:mattermost/mattermost-redux#477150436ac1871d0d63954c4f4f4d16ff692483",
+      "from": "github:mattermost/mattermost-redux#477150436ac1871d0d63954c4f4f4d16ff692483",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "localforage-observable": "1.4.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
-    "mattermost-redux": "github:mattermost/mattermost-redux#29e65f58b0fb536e6923b270aa848208986f01ab",
+    "mattermost-redux": "github:mattermost/mattermost-redux#477150436ac1871d0d63954c4f4f4d16ff692483",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/stores/local_storage_store.jsx
+++ b/stores/local_storage_store.jsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {Constants} from 'utils/constants.jsx';
+import {getRedirectChannelNameForTeam} from 'utils/channel_utils.jsx';
 
 const getPreviousTeamIdKey = (userId) => ['user_prev_team', userId].join(':');
 const getPreviousChannelNameKey = (userId, teamId) => ['user_team_prev_channel', userId, teamId].join(':');
@@ -14,7 +14,7 @@ const getRecentEmojisKey = (userId) => ['recent_emojis', userId].join(':');
 // of the Redux store so as to allow them to be used on re-login.
 class LocalStorageStoreClass {
     getPreviousChannelName(userId, teamId) {
-        return localStorage.getItem(getPreviousChannelNameKey(userId, teamId)) || Constants.DEFAULT_CHANNEL;
+        return localStorage.getItem(getPreviousChannelNameKey(userId, teamId)) || getRedirectChannelNameForTeam(teamId);
     }
 
     setPreviousChannelName(userId, teamId, channelName) {
@@ -22,7 +22,7 @@ class LocalStorageStoreClass {
     }
 
     getPenultimateChannelName(userId, teamId) {
-        return localStorage.getItem(getPenultimateChannelNameKey(userId, teamId)) || Constants.DEFAULT_CHANNEL;
+        return localStorage.getItem(getPenultimateChannelNameKey(userId, teamId)) || getRedirectChannelNameForTeam(teamId);
     }
 
     setPenultimateChannelName(userId, teamId, channelName) {

--- a/utils/channel_utils.jsx
+++ b/utils/channel_utils.jsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
+import {getRedirectChannelNameForTeam as getRedirectChannelNameForTeamRedux} from 'mattermost-redux/selectors/entities/channels';
 import Permissions from 'mattermost-redux/constants/permissions';
 
 import store from 'stores/redux_store.jsx';
@@ -46,4 +47,8 @@ export function findNextUnreadChannelId(curChannelId, allChannelIds, unreadChann
     }
 
     return -1;
+}
+
+export function getRedirectChannelNameForTeam(teamId) {
+    return getRedirectChannelNameForTeamRedux(store.getState(), teamId);
 }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {Client4} from 'mattermost-redux/client';
 import {Posts} from 'mattermost-redux/constants';
-import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getChannel, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTeammateNameDisplaySetting, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';
@@ -144,9 +144,12 @@ export function notifyMe(title, body, channel, teamId, silent) {
                 browserHistory.push(getTeamRelativeUrl(team) + '/channels/' + channel.name);
             } else if (teamId) {
                 const team = getTeam(state, teamId);
-                browserHistory.push(getTeamRelativeUrl(team) + `/channels/${Constants.DEFAULT_CHANNEL}`);
+                const redirectChannel = getRedirectChannelNameForTeam(state, teamId);
+                browserHistory.push(getTeamRelativeUrl(team) + `/channels/${redirectChannel}`);
             } else {
-                browserHistory.push(getCurrentRelativeTeamUrl(state) + `/channels/${Constants.DEFAULT_CHANNEL}`);
+                const currentTeamId = getCurrentTeamId(state);
+                const redirectChannel = getRedirectChannelNameForTeam(state, currentTeamId);
+                browserHistory.push(getCurrentRelativeTeamUrl(state) + `/channels/${redirectChannel}`);
             }
         },
     }).catch(() => {


### PR DESCRIPTION
#### Summary
Changing the concept of default channel (town square) to the concept of
redirect channel, by default will be town square, but in certaing situations it
will be your first existing channel in the team. Concretely if you are not allowed to join to public channels, and you are not member of the town-square channel (guest accounts will be in this situation), you will be redirected to your first channel in the current team.

#### Ticket Link
[MM-14639](https://mattermost.atlassian.net/browse/MM-14639)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Needs to be implemented in mobile (mattermost/mattermost-mobile#2674)
- [x] Has server changes (mattermost/mattermost-server#10511)
- [x] Has redux changes (mattermost/mattermost-redux#799)