### PR TITLE
MM-14520: restore pretext changed event on composition

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -317,7 +317,6 @@ export default class SuggestionBox extends React.Component {
         const textbox = this.getTextbox();
         const pretext = textbox.value.substring(0, textbox.selectionStart) + e.data;
 
-        this.pretext = pretext;
         this.handlePretextChanged(pretext);
         if (this.props.onComposition) {
             this.props.onComposition();

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -318,6 +318,7 @@ export default class SuggestionBox extends React.Component {
         const pretext = textbox.value.substring(0, textbox.selectionStart) + e.data;
 
         this.pretext = pretext;
+        this.handlePretextChanged(pretext);
         if (this.props.onComposition) {
             this.props.onComposition();
         }

--- a/components/suggestion/suggestion_box.test.jsx
+++ b/components/suggestion/suggestion_box.test.jsx
@@ -93,4 +93,21 @@ describe('components/SuggestionBox', () => {
         wrapper.setProps({...baseProps, contextId: 'new'});
         expect(instance.handlePretextChanged.mock.calls.length).toBe(1);
     });
+
+    test('should force pretext change on composition update', () => {
+        const wrapper = shallow(
+            <SuggestionBox
+                {...baseProps}
+            />
+        );
+        const instance = wrapper.instance();
+        instance.handlePretextChanged = jest.fn();
+        instance.getTextbox = jest.fn().mockReturnValue({value: ''});
+
+        instance.handleCompositionUpdate({data: '@ㅈ'});
+        expect(instance.handlePretextChanged).toBeCalledWith('@ㅈ');
+
+        instance.handleCompositionUpdate({data: '@저'});
+        expect(instance.handlePretextChanged).toBeCalledWith('@저');
+    });
 });


### PR DESCRIPTION
#### Summary
This addresses a regression from ripping out the SuggestionStore in which we no longer emitted pretext changed events while composing CJK characters.

Credit to @hmhealey for helping me track down the /real/ regression:
https://github.com/mattermost/mattermost-webapp/commit/5084127a59c0c48cec19c98979aa0bf833d6912d#diff-2a2de998d52194b5219f10c4d805c40fL302

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14520

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)