### PR TITLE
MM-14970 Fix for Posts ovelapping with each other

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1943,6 +1943,11 @@
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
+    "batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -4224,6 +4229,14 @@
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
+    },
+    "element-resize-detector": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.1.15.tgz",
+      "integrity": "sha512-16/5avDegXlUxytGgaumhjyQoM6hpp5j3+L79sYq5hlXfTNRy5WMMuTVWkZU3egp/CokCmTmvf18P3KeB57Iog==",
+      "requires": {
+        "batch-processor": "^1.0.0"
+      }
     },
     "elliptic": {
       "version": "6.4.1",
@@ -11993,10 +12006,11 @@
       "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
     },
     "react-window": {
-      "version": "github:sudheerDev/react-window#af0431f59c64823139a5e796707e1fdacfc3fd4f",
-      "from": "github:sudheerDev/react-window#af0431f59c64823139a5e796707e1fdacfc3fd4f",
+      "version": "github:sudheerDev/react-window#f93fd8c55d042961face846e2c87303ce6c74888",
+      "from": "github:sudheerDev/react-window#f93fd8c55d042961face846e2c87303ce6c74888",
       "requires": {
         "@babel/runtime": "^7.0.0",
+        "element-resize-detector": "^1.1.15",
         "memoize-one": "^3.1.1"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11993,8 +11993,8 @@
       "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
     },
     "react-window": {
-      "version": "github:sudheerDev/react-window#ccf30388a1a6a7582e0d0573d4cd24d5776ebbaa",
-      "from": "github:sudheerDev/react-window#ccf30388a1a6a7582e0d0573d4cd24d5776ebbaa",
+      "version": "github:sudheerDev/react-window#af0431f59c64823139a5e796707e1fdacfc3fd4f",
+      "from": "github:sudheerDev/react-window#af0431f59c64823139a5e796707e1fdacfc3fd4f",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-select": "2.4.1",
     "react-transition-group": "2.6.0",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "react-window": "github:sudheerDev/react-window#ccf30388a1a6a7582e0d0573d4cd24d5776ebbaa",
+    "react-window": "github:sudheerDev/react-window#af0431f59c64823139a5e796707e1fdacfc3fd4f",
     "rebound": "0.1.0",
     "redux": "4.0.1",
     "redux-batched-actions": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-select": "2.4.1",
     "react-transition-group": "2.6.0",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "react-window": "github:sudheerDev/react-window#af0431f59c64823139a5e796707e1fdacfc3fd4f",
+    "react-window": "github:sudheerDev/react-window#f93fd8c55d042961face846e2c87303ce6c74888",
     "rebound": "0.1.0",
     "redux": "4.0.1",
     "redux-batched-actions": "0.4.1",


### PR DESCRIPTION
#### Summary
  Fixes posts overlapping with each other
  * This happens because of posts changing height after mount. We were using mutation observer to check for changes in DOM that trigger recalculations for arranging posts in view. Normal cases of collapse, expand of links or changing text etc trigger the recalculations as they are changing DOM. But with posts where the height changes because of image load there is no DOM change causing no trigger for recalculations causing an overlap.
  Solution: Added a new https://github.com/wnr/element-resize-detector library which uses scroll change in posts to trigger recalculations. Ideally this would have been enough to remove Mutation observer but with this being slightly slow in propagating changes i am still keeping it.
https://github.com/sudheerDev/react-window/commit/af0431f59c64823139a5e796707e1fdacfc3fd4f

Safari and FF takes an extra frame for scroll correction causing jump to the right post when loading more posts
  * This happens because of an requestAnimationFrame added for correction which is only needed for chrome. Chrome does not correct the scroll position at times without request animation frame and loads another set of posts before correcting. requesting another frame prevents this behaviour but causes jump for other browsers 
  Solution: Use request animation frame callback only for chrome
https://github.com/sudheerDev/react-window/commit/71be4d8366d278b2364313248bd2864b44ff2826


#### Ticket Link
[MM-14970](https://mattermost.atlassian.net/browse/MM-14790)
[MM-14791](https://mattermost.atlassian.net/browse/MM-14791)
