### PR TITLE
MM-14791 Safari and FF scroll correction issue when loading more posts

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -21,6 +21,9 @@ const POSTS_PER_PAGE = Constants.POST_CHUNK_SIZE / 2;
 const MAX_NUMBER_OF_AUTO_RETRIES = 3;
 
 const MAX_EXTRA_PAGES_LOADED = 10;
+const OVERSCAN_COUNT_BACKWARD = window.OVERSCAN_COUNT_BACKWARD || 50; // Exposing the value for PM to test will be removed soon
+const OVERSCAN_COUNT_FORWARD = window.OVERSCAN_COUNT_FORWARD || 100; // Exposing the value for PM to test will be removed soon
+const HEIGHT_TRIGGER_FOR_MORE_POSTS = window.HEIGHT_TRIGGER_FOR_MORE_POSTS || 1000; // Exposing the value for PM to test will be removed soon
 
 export default class PostList extends React.PureComponent {
     static propTypes = {
@@ -297,7 +300,7 @@ export default class PostList extends React.PureComponent {
     onScroll = ({scrollDirection, scrollOffset, scrollUpdateWasRequested}) => {
         const isNotLoadingPosts = !this.state.postsLoading && !this.loadingPosts;
         const didUserScrollBackwards = scrollDirection === 'backward' && !scrollUpdateWasRequested;
-        const isOffsetWithInRange = scrollOffset < 1000;
+        const isOffsetWithInRange = scrollOffset < HEIGHT_TRIGGER_FOR_MORE_POSTS;
         if (isNotLoadingPosts && didUserScrollBackwards && isOffsetWithInRange && !this.state.atEnd) {
             this.loadingPosts = true;
             this.loadMorePosts();
@@ -471,7 +474,8 @@ export default class PostList extends React.PureComponent {
                                         itemCount={this.state.postListIds.length}
                                         itemData={this.state.postListIds}
                                         itemKey={this.itemKey}
-                                        overscanCount={100}
+                                        overscanCountForward={OVERSCAN_COUNT_FORWARD}
+                                        overscanCountBackward={OVERSCAN_COUNT_BACKWARD}
                                         onScroll={this.onScroll}
                                         onItemsRendered={this.onItemsRendered}
                                         initScrollToIndex={this.initScrollToIndex}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11993,8 +11993,8 @@
       "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
     },
     "react-window": {
-      "version": "github:sudheerDev/react-window#ccf30388a1a6a7582e0d0573d4cd24d5776ebbaa",
-      "from": "github:sudheerDev/react-window#ccf30388a1a6a7582e0d0573d4cd24d5776ebbaa",
+      "version": "github:sudheerDev/react-window#e1c298a26c7db32253ba332bc2057dd242d5d8cd",
+      "from": "github:sudheerDev/react-window#e1c298a26c7db32253ba332bc2057dd242d5d8cd",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-select": "2.4.1",
     "react-transition-group": "2.6.0",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "react-window": "github:sudheerDev/react-window#ccf30388a1a6a7582e0d0573d4cd24d5776ebbaa",
+    "react-window": "github:sudheerDev/react-window#e1c298a26c7db32253ba332bc2057dd242d5d8cd",
     "rebound": "0.1.0",
     "redux": "4.0.1",
     "redux-batched-actions": "0.4.1",


### PR DESCRIPTION
#### Summary
This is part of https://github.com/mattermost/mattermost-webapp/pull/2551
Safari and FF takes an extra frame for scroll correction causing jump to the right post when loading more posts

This happens because of an requestAnimationFrame added for correction which is only needed for chrome. Chrome does not correct the scroll position at times without request animation frame and loads another set of posts before correcting. requesting another frame prevents this behaviour but causes jump for other browsers
Solution: Use request animation frame callback only for chrome
sudheerDev/react-window@71be4d8

#### Ticket Link
[MM-14791](https://mattermost.atlassian.net/browse/MM-14791)
