### PR TITLE
MM-14800 Fix missing messages when switching to a team not previously loaded

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -163,7 +163,6 @@ export default class PostList extends React.PureComponent {
         }
 
         if (prevProps.channelLoading && !this.props.channelLoading) {
-            this.currentChannelId = this.props.channel.id;
             this.loadPosts(this.props.channel.id, this.props.focusedPostId);
         }
     }

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -112,6 +112,7 @@ export default class PostList extends React.PureComponent {
 
         this.loadingPosts = false;
         this.extraPagesLoaded = 0;
+
         const channelIntroMessage = PostListRowListIds.CHANNEL_INTRO_MESSAGE;
         const isMobile = Utils.isMobile();
         this.state = {
@@ -162,6 +163,7 @@ export default class PostList extends React.PureComponent {
         }
 
         if (prevProps.channelLoading && !this.props.channelLoading) {
+            this.currentChannelId = this.props.channel.id;
             this.loadPosts(this.props.channel.id, this.props.focusedPostId);
         }
     }
@@ -260,7 +262,7 @@ export default class PostList extends React.PureComponent {
             }
         } else {
             this.loadingPosts = false;
-            if (this.mounted) {
+            if (this.mounted && this.props.posts) {
                 const atEnd = !moreToLoad && this.props.posts.length < this.props.postVisibility;
                 const newState = {
                     atEnd,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
With the recent changes for the virtualized list we added a gate to identify if the channel was being loaded but there was a case when you switched teams when you were viewing a DM channel previously and that flag was never set correctly as the team was selected before the new channel got selected, thus the channel was never marked as being loaded causing the switch not to load the first set of posts in the channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14800
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

