### PR TITLE
MM-14762 Fix hover effect causing post jiggle when zoomed

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -478,6 +478,7 @@ export default class PostList extends React.PureComponent {
                                         initScrollToIndex={this.initScrollToIndex}
                                         onNewItemsMounted={this.onNewItemsMounted}
                                         canLoadMorePosts={this.canLoadMorePosts}
+                                        skipResizeClass='col__reply'
                                     >
                                         {this.renderRow}
                                     </DynamicSizeList>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11993,8 +11993,8 @@
       "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
     },
     "react-window": {
-      "version": "github:sudheerDev/react-window#ccf30388a1a6a7582e0d0573d4cd24d5776ebbaa",
-      "from": "github:sudheerDev/react-window#ccf30388a1a6a7582e0d0573d4cd24d5776ebbaa",
+      "version": "github:mattermost/react-window#cb3b6531136ea040984210d7b04d890c8c6031e2",
+      "from": "github:mattermost/react-window#cb3b6531136ea040984210d7b04d890c8c6031e2",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-select": "2.4.1",
     "react-transition-group": "2.6.0",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "react-window": "github:sudheerDev/react-window#ccf30388a1a6a7582e0d0573d4cd24d5776ebbaa",
+    "react-window": "github:mattermost/react-window#cb3b6531136ea040984210d7b04d890c8c6031e2",
     "rebound": "0.1.0",
     "redux": "4.0.1",
     "redux-batched-actions": "0.4.1",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Will pass a class name to the `DynamicSizeList` to prevent a measureItem calculation when hovering to show the post options causing the posts not to jiggle.
<!--
A description of what this pull request does.
-->

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14762
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)
