### PR TITLE
MM-14810 Fix for infinite loop caused by loading channels with content less than screen height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11993,8 +11993,8 @@
       "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
     },
     "react-window": {
-      "version": "github:mattermost/react-window#cb3b6531136ea040984210d7b04d890c8c6031e2",
-      "from": "github:mattermost/react-window#cb3b6531136ea040984210d7b04d890c8c6031e2",
+      "version": "github:mattermost/react-window#8ce4b9551c26da7693fa5173956fe40469aab918",
+      "from": "github:mattermost/react-window#8ce4b9551c26da7693fa5173956fe40469aab918",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-select": "2.4.1",
     "react-transition-group": "2.6.0",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "react-window": "github:mattermost/react-window#cb3b6531136ea040984210d7b04d890c8c6031e2",
+    "react-window": "github:mattermost/react-window#8ce4b9551c26da7693fa5173956fe40469aab918",
     "rebound": "0.1.0",
     "redux": "4.0.1",
     "redux-batched-actions": "0.4.1",


### PR DESCRIPTION
#### Summary
This causes a infinite loop mainly because of the https://github.com/mattermost/react-window/pull/2/files as itemData array even when same the comparision of array !== array can fail. This causes an infinite loop for `loadMorePosts` function

#### Ticket Link
(MM-14810)[https://mattermost.atlassian.net/browse/MM-14810]