### PR TITLE
Fix postlist connector when channel is undefined

### DIFF
--- a/components/post_view/index.js
+++ b/components/post_view/index.js
@@ -61,7 +61,7 @@ function makeMapStateToProps() {
         const channel = getChannel(state, ownProps.channelId);
         const team = getTeamByName(state, ownProps.match.params.team);
         let teammate;
-        if (channel.type === Constants.DM_CHANNEL && channel.teammate_id) {
+        if (channel && channel.type === Constants.DM_CHANNEL && channel.teammate_id) {
             teammate = getUser(state, channel.teammate_id);
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The selector `getChannel` in post list sometimes can return `undefined`. We are adding a null/undefined check to avoid the connector from crashing

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
