### PR TITLE
MM-14820 Fix post menu on mobile view

### DIFF
--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -53,6 +53,11 @@ export default class Post extends React.PureComponent {
          */
         previousPostIsComment: PropTypes.bool,
 
+        /*
+         * Function called when the post options dropdown is opened
+         */
+        togglePostMenu: PropTypes.func,
+
         /**
          * Set to render this comment as a mention
          */
@@ -98,6 +103,10 @@ export default class Post extends React.PureComponent {
     }
 
     handleDropdownOpened = (opened) => {
+        if (this.props.togglePostMenu) {
+            this.props.togglePostMenu(opened);
+        }
+
         this.setState({
             dropdownOpened: opened,
         });

--- a/components/post_view/post_list_row/post_list_row.jsx
+++ b/components/post_view/post_list_row/post_list_row.jsx
@@ -19,6 +19,7 @@ export default class PostListRow extends React.PureComponent {
         fullWidth: PropTypes.bool,
         shouldHighlight: PropTypes.bool,
         loadMorePosts: PropTypes.func,
+        togglePostMenu: PropTypes.func,
     }
 
     render() {
@@ -30,6 +31,7 @@ export default class PostListRow extends React.PureComponent {
                     key={'post ' + (post.id || post.pending_post_id)}
                     post={post}
                     shouldHighlight={this.props.shouldHighlight}
+                    togglePostMenu={this.props.togglePostMenu}
                 />
             );
         }

--- a/components/widgets/menu/menu_wrapper.jsx
+++ b/components/widgets/menu/menu_wrapper.jsx
@@ -42,9 +42,12 @@ export default class MenuWrapper extends React.PureComponent {
         if (this.node.current.contains(e.target)) {
             return;
         }
-        this.setState({open: false});
-        if (this.props.onToggle) {
-            this.props.onToggle(false);
+
+        if (this.state.open) {
+            this.setState({open: false});
+            if (this.props.onToggle) {
+                this.props.onToggle(false);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
With the implementation of virtualized list the position of the post menu in mobile view was incorrect cause of a css style [will-change](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change). With this PR when in mobile view the value of `will-change` is set according to the menu being opened or closed.

Also triggering the close event on the MenuWrapper only if the menu was previously opened.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-14820
