### PR TITLE
[MM-14784] UI Automation: Write an automated test using `cypress` for "An ellipsis indicates the channel header is too long - DM

### DIFF
--- a/cypress/integration/channel/header_spec.js
+++ b/cypress/integration/channel/header_spec.js
@@ -53,5 +53,11 @@ describe('Header', () => {
 
         // * Check if channel header description has ellipsis
         cy.get('#channelHeaderDescription').ellipsis(true);
+
+        // 6. Click the header to see the whole text
+        cy.get('#channelHeaderDescription').click();
+
+        // * Check that no elippsis is present
+        cy.get('#header-popover > div.popover-content').should('have.html', `<blockquote>\n<p>${header}</p>\n</blockquote>`);
     });
 });

--- a/cypress/integration/channel/header_spec.js
+++ b/cypress/integration/channel/header_spec.js
@@ -39,12 +39,19 @@ describe('Header', () => {
     });
 
     it('M14784 - An ellipsis indicates the channel header is too long - DM', () => {
+        // 3. Open Account Setting and enable Compact View on the Display tab
         cy.changeMessageDisplaySetting('COMPACT');
-        const header = 'quote newheader newheader newheader newheader newheader newheader newheader newheader newheader newheader';
+
+        // 4. Open a DM with user named 'user-2'
         cy.get('#directChannel > .add-channel-btn').click().wait(100);
         cy.focused().type('user-2', {force: true}).type('{enter}', {force: true}).wait(500);
         cy.get('#saveItems').click();
+
+        // 5. Update DM channel header
+        const header = 'quote newheader newheader newheader newheader newheader newheader newheader newheader newheader newheader';
         cy.updateChannelHeader('>' + header);
+
+        // * Check if channel header description has ellipsis
         cy.get('#channelHeaderDescription').ellipsis(true);
     });
 });

--- a/cypress/integration/channel/header_spec.js
+++ b/cypress/integration/channel/header_spec.js
@@ -37,4 +37,14 @@ describe('Header', () => {
         cy.get('#channelHeaderDescription > span > blockquote').should('be.visible');
         cy.get('#channelHeaderDescription').should('have.html', `<span><blockquote> <p class="markdown__paragraph-inline">${header}</p></blockquote></span>`);
     });
+
+    it('M14784 - An ellipsis indicates the channel header is too long - DM', () => {
+        cy.changeMessageDisplaySetting('COMPACT');
+        const header = 'quote newheader newheader newheader newheader newheader newheader newheader newheader newheader newheader';
+        cy.get('#directChannel > .add-channel-btn').click().wait(100);
+        cy.focused().type('user-2', {force: true}).type('{enter}', {force: true}).wait(500);
+        cy.get('#saveItems').click();
+        cy.updateChannelHeader('>' + header);
+        cy.get('#channelHeaderDescription').ellipsis(true);
+    });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Wrote an automated test using `cypress` for "An ellipsis indicates the channel header is too long - DM

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10520

