### PR TITLE
MM-14810 Fix for channel header loading in center channel

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -281,7 +281,7 @@ export default class PostList extends React.PureComponent {
         } else {
             this.loadingMorePosts = false;
             if (this.mounted && this.props.posts) {
-                const atEnd = !moreToLoad && this.props.posts.length < this.props.postVisibility;
+                const atEnd = !moreToLoad;
                 const newState = {
                     atEnd,
                     autoRetryEnable: true,

--- a/components/post_view/post_list.test.jsx
+++ b/components/post_view/post_list.test.jsx
@@ -3,9 +3,30 @@
 
 import React from 'react';
 import {shallow} from 'enzyme';
+import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 
 import PostList from 'components/post_view/post_list.jsx';
 import {PostListRowListIds} from 'utils/constants.jsx';
+
+const returnDummyPostsAndIds = () => {
+    const postsArray = [];
+    const Ids = [];
+    const createAtValue = 12346;
+    for (var i = 1; i <= 30; i++) {
+        const postCreatedAt = createAtValue + i;
+        postsArray.push({
+            id: `${postCreatedAt}`,
+            message: 'test',
+            create_at: postCreatedAt,
+        });
+        Ids.push(`${postCreatedAt}`);
+    }
+
+    return {
+        postsArray,
+        Ids,
+    };
+}
 
 describe('components/post_view/post_list', () => {
     const posts = [{
@@ -40,19 +61,7 @@ describe('components/post_view/post_list', () => {
     };
 
     test('should return index of loader when all are unread messages in the view and call increasePostVisibility action', () => {
-        const postsArray = [];
-        const Ids = [];
-        const createAtValue = 12346;
-        for (var i = 1; i <= 30; i++) {
-            const postCreatedAt = createAtValue + i;
-            postsArray.push({
-                id: `${postCreatedAt}`,
-                message: 'test',
-                create_at: postCreatedAt,
-            });
-            Ids.push(`${postCreatedAt}`);
-        }
-
+        const {Ids, postsArray} = returnDummyPostsAndIds();
         const postListIds = [...Ids, PostListRowListIds.START_OF_NEW_MESSAGES];
         const props = {
             ...baseProps,
@@ -64,5 +73,21 @@ describe('components/post_view/post_list', () => {
         const initScrollToIndex = wrapper.instance().initScrollToIndex();
         expect(initScrollToIndex).toEqual({index: 31, position: 'start'}); //Loader will be at pos 31
         expect(actions.increasePostVisibility).toHaveBeenCalledTimes(1);
+    });
+
+    test('should set the state of atEnd to true when increasePostVisibility returns moreToLoad false', async () => {
+        const increasePostVisibilityMock = jest.fn().mockResolvedValue({moreToLoad: false});
+        const props = {
+            ...baseProps,
+            actions: {
+                ...baseProps.actions,
+                increasePostVisibility: increasePostVisibilityMock,
+            },
+        };
+        const wrapper = mountWithIntl(<PostList {...props}/>);
+        await wrapper.instance().loadMorePosts();
+        expect(increasePostVisibilityMock).toHaveBeenCalledTimes(1);
+        wrapper.update();
+        expect(wrapper.state('atEnd')).toEqual(true);
     });
 });

--- a/components/post_view/post_list.test.jsx
+++ b/components/post_view/post_list.test.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import {shallow} from 'enzyme';
+
 import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 
 import PostList from 'components/post_view/post_list.jsx';
@@ -26,7 +27,7 @@ const returnDummyPostsAndIds = () => {
         postsArray,
         Ids,
     };
-}
+};
 
 describe('components/post_view/post_list', () => {
     const posts = [{


### PR DESCRIPTION
#### Summary
When posts in channel equals multiple of 30 then center channel does not load the channel header.
`increasePostVisibility` does not increase the postvisibility value when the there are no posts so it equal to this.props.post here. 

#### Ticket Link
[MM-14810](https://mattermost.atlassian.net/browse/MM-14810)

