### PR TITLE
[MM-14826] Disable Safari spellcheck on quick switcher

### DIFF
--- a/components/quick_switch_modal/__snapshots__/quick_switch_modal.test.jsx.snap
+++ b/components/quick_switch_modal/__snapshots__/quick_switch_modal.test.jsx.snap
@@ -76,6 +76,7 @@ exports[`components/QuickSwitchModal should match snapshot 1`] = `
       renderNoResults={false}
       replaceAllInputOnSelect={false}
       requiredCharacters={1}
+      spellCheck="false"
       value=""
     />
   </ModalBody>

--- a/components/quick_switch_modal/quick_switch_modal.jsx
+++ b/components/quick_switch_modal/quick_switch_modal.jsx
@@ -283,6 +283,7 @@ export default class QuickSwitchModal extends React.PureComponent {
                         providers={providers}
                         listStyle='bottom'
                         completeOnTab={false}
+                        spellCheck='false'
                         renderDividers={renderDividers}
                         delayInputUpdate={true}
                         openWhenEmpty={true}


### PR DESCRIPTION
This change disables the Safari spellcheck suggestions on the
quick channel switcher input. These suggestions could correct
actual channel and user names.

https://mattermost.atlassian.net/browse/MM-14826