### PR TITLE
MM-14863 Fix new messages line present at previous pos on next visit to channel

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -55,6 +55,7 @@ export function emitChannelClickEvent(channel) {
             fail();
         }
     }
+
     function switchToChannel(chan) {
         const state = getState();
         const getMyChannelMemberPromise = dispatch(getMyChannelMember(chan.id));
@@ -95,6 +96,9 @@ export function emitChannelClickEvent(channel) {
             data: chan.id,
             channel: chan,
             member: member || {},
+        }, {
+            type: ActionTypes.MARK_LAST_CHANNEL_READ,
+            channelId: oldChannelId,
         }]));
     }
 

--- a/reducers/views/channel.js
+++ b/reducers/views/channel.js
@@ -38,10 +38,10 @@ function postVisibility(state = {}, action) {
 
 function lastChannelViewTime(state = {}, action) {
     switch (action.type) {
-    case ActionTypes.SELECT_CHANNEL_WITH_MEMBER: {
-        if (action.member) {
+    case ActionTypes.MARK_LAST_CHANNEL_READ: {
+        if (action.channelId) {
             const nextState = {...state};
-            nextState[action.data] = action.member.last_viewed_at;
+            nextState[action.channelId] = Date.now();
             return nextState;
         }
         return state;

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -168,6 +168,7 @@ export const ActionTypes = keyMirror({
 
     INCREMENT_WS_ERROR_COUNT: null,
     RESET_WS_ERROR_COUNT: null,
+    MARK_LAST_CHANNEL_READ: null,
 });
 
 export const ModalIdentifiers = {


### PR DESCRIPTION
#### Summary
We use `lastChannelViewTime` state value for showing the position of new message indicator.
Whenever channel is switched we store the value of `last_viewed_at` into the state but when we switch to a channel with unread messages this value most likely will be previous `last_viewed_at`. So this needs another switch to the same channel to update the state with the new `last_viewed_at`.

Resolution here is to store the timestamp of channel when leaving instead of entering this way we mark it to the timestamp when user leaves the channel marking anything above as read.

#### Ticket Link
[MM-14863](https://mattermost.atlassian.net/browse/MM-14863)
