### PR TITLE
MM-14391 Reorganize command to reset account settings via API and separate API and UI commands

### DIFF
--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -246,7 +246,10 @@ export default class Post extends React.PureComponent {
                 onMouseLeave={this.unsetHover}
                 onTouchStart={this.setHover}
             >
-                <div className={'post__content ' + centerClass}>
+                <div
+                    id='postContent'
+                    className={'post__content ' + centerClass}
+                >
                     <div className='post__img'>
                         {profilePic}
                     </div>

--- a/cypress/integration/account_settings/display/channel_display_mode_spec.js
+++ b/cypress/integration/account_settings/display/channel_display_mode_spec.js
@@ -9,11 +9,15 @@
 
 describe('Account Settings > Display > Channel Display Mode', () => {
     before(() => {
-        cy.login('user-1');
+        cy.apiLogin('user-1');
 
         // 1. Set default preference of a user on channel and message display
-        cy.updateChannelDisplayModePreference('centered');
-        cy.updateMessageDisplayPreference();
+        cy.apiSaveChannelDisplayModePreference('centered');
+        cy.apiSaveMessageDisplayPreference();
+
+        // Post a message to a channel
+        cy.visit('/');
+        cy.postMessage('Test for channel display mode {enter}');
     });
 
     beforeEach(() => {
@@ -77,8 +81,8 @@ describe('Account Settings > Display > Channel Display Mode', () => {
         cy.get('#sidebarItem_town-square').click();
 
         // * Validate if the post content in center channel is fulled.
-        // * 1179px is fulled width when the viewport width is 1500px
-        cy.get('.post__content').last().should('have.css', 'width', '1179px');
+        // * 1187px is fulled width when the viewport width is 1500px
+        cy.get('.post__content').last().should('have.css', 'width', '1187px');
     });
 
     it('AS13225 Channel display mode setting to "Fixed width, centered"', () => {
@@ -120,15 +124,15 @@ describe('Account Settings > Display > Channel Display Mode', () => {
 
     it('Width of center view when message display is compact and channel display mode is either centered or full', () => {
         // 1. Set message display to compact with channel display mode set to centered
-        cy.updateMessageDisplayPreference('compact');
+        cy.apiSaveMessageDisplayPreference('compact');
 
         // * Verify that the width is at 1000px
         cy.get('.post__content').last().should('have.css', 'width', '1000px');
 
         // 2. Set channel display mode to full (default) with message display in compact
-        cy.updateChannelDisplayModePreference();
+        cy.apiSaveChannelDisplayModePreference();
 
-        // * Verify that the width is at 1123px
-        cy.get('.post__content').last().should('have.css', 'width', '1123px');
+        // * Verify that the width is at 1131px
+        cy.get('.post__content').last().should('have.css', 'width', '1131px');
     });
 });

--- a/cypress/integration/account_settings/display/channel_display_mode_spec.js
+++ b/cypress/integration/account_settings/display/channel_display_mode_spec.js
@@ -80,9 +80,9 @@ describe('Account Settings > Display > Channel Display Mode', () => {
         // 8. Go to channel which has any posts
         cy.get('#sidebarItem_town-square').click();
 
-        // * Validate if the post content in center channel is fulled.
-        // * 1187px is fulled width when the viewport width is 1500px
-        cy.get('.post__content').last().should('have.css', 'width', '1187px');
+        // * Validate if the post content in center channel is full width
+        // by checking the exact class name.
+        cy.get('#postContent').first().invoke('attr', 'class').should('contain', 'post__content').should('not.contain', 'center');
     });
 
     it('AS13225 Channel display mode setting to "Fixed width, centered"', () => {
@@ -117,22 +117,8 @@ describe('Account Settings > Display > Channel Display Mode', () => {
         // 8. Go to channel which has any posts
         cy.get('#sidebarItem_town-square').click();
 
-        //* Validate if the post content in center channel is fixed and centered
-        cy.get('.post__content').last().should('have.css', 'width', '1000px');
-        cy.get('.post__content').last().should('have.class', 'center');
-    });
-
-    it('Width of center view when message display is compact and channel display mode is either centered or full', () => {
-        // 1. Set message display to compact with channel display mode set to centered
-        cy.apiSaveMessageDisplayPreference('compact');
-
-        // * Verify that the width is at 1000px
-        cy.get('.post__content').last().should('have.css', 'width', '1000px');
-
-        // 2. Set channel display mode to full (default) with message display in compact
-        cy.apiSaveChannelDisplayModePreference();
-
-        // * Verify that the width is at 1131px
-        cy.get('.post__content').last().should('have.css', 'width', '1131px');
+        // * Validate if the post content in center channel is fixed and centered
+        // by checking the exact class name.
+        cy.get('#postContent').first().invoke('attr', 'class').should('contain', 'post__content center');
     });
 });

--- a/cypress/integration/account_settings/display/code_theme_colors_spec.js
+++ b/cypress/integration/account_settings/display/code_theme_colors_spec.js
@@ -41,7 +41,7 @@ function navigateToThemeSettings() {
 describe('AS14319 Theme Colors - Code', () => {
     before(() => {
         // 1. Login and navigate to the app
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         // 2. Enter in code block for message

--- a/cypress/integration/account_settings/theme_color/custom_colors_sidebar_styles_spec.js
+++ b/cypress/integration/account_settings/theme_color/custom_colors_sidebar_styles_spec.js
@@ -28,12 +28,12 @@ const testCases = [
 describe('AS14318 Theme Colors - Color Picker', () => {
     before(() => {
         // 1. Set default theme preference
-        cy.updateThemePreference();
+        cy.apiSaveThemePreference();
     });
 
     after(() => {
         // * Revert to default theme preference
-        cy.updateThemePreference();
+        cy.apiSaveThemePreference();
     });
 
     it('Theme Display should render in min setting view', () => {

--- a/cypress/integration/at_mentions/at_mentions_spec.js
+++ b/cypress/integration/at_mentions/at_mentions_spec.js
@@ -71,7 +71,7 @@ describe('at-mention', () => {
 
         // 1. Login and navigate to the app
         cy.get('@receiver').then((receiver) => {
-            cy.login(receiver.username);
+            cy.apiLogin(receiver.username);
         });
 
         cy.visit('/');

--- a/cypress/integration/channel/autocomplete_shown_each_channel_spec.js
+++ b/cypress/integration/channel/autocomplete_shown_each_channel_spec.js
@@ -10,7 +10,7 @@
 describe('Identical Message Drafts', () => {
     before(() => {
         // 1. Login and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         // 2. Clear channel textbox

--- a/cypress/integration/channel/collapsed_message_spec.js
+++ b/cypress/integration/channel/collapsed_message_spec.js
@@ -28,7 +28,7 @@ function verifyExpandedPost() {
 describe('Long message', () => {
     it('M14321 will show more/less content correctly', () => {
         // 1. Login as "user-1" and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         // 2. Post message with kitchen sink markdown text

--- a/cypress/integration/channel/edit_message_spec.js
+++ b/cypress/integration/channel/edit_message_spec.js
@@ -12,7 +12,7 @@
 describe('Edit Message', () => {
     it('M13909 Escape should not close modal when an autocomplete drop down is in use', () => {
         // 1. Login as "user-1" and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         // 2. Post message "Hello"
@@ -66,7 +66,7 @@ describe('Edit Message', () => {
 
     it('M13482 Display correct timestamp for edited message', () => {
         // 1. Login as "user-1" and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         // 2. Post a message

--- a/cypress/integration/channel/header_spec.js
+++ b/cypress/integration/channel/header_spec.js
@@ -10,7 +10,7 @@
 describe('Header', () => {
     before(() => {
         // 1. Login and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
     });
 

--- a/cypress/integration/channel/message_bullets_spec.js
+++ b/cypress/integration/channel/message_bullets_spec.js
@@ -12,7 +12,7 @@
 describe('Message', () => {
     it('M13326 Text in bullet points is the same size as text above and below it', () => {
         // 1. Login and navigate to the app
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         // 2. Enter in text

--- a/cypress/integration/channel/message_draft_spec.js
+++ b/cypress/integration/channel/message_draft_spec.js
@@ -10,7 +10,7 @@
 describe('Message Draft', () => {
     before(() => {
         // 1. Login and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
     });
 

--- a/cypress/integration/channel/message_draft_then_switch_channel_spec.js
+++ b/cypress/integration/channel/message_draft_then_switch_channel_spec.js
@@ -10,7 +10,7 @@
 describe('Message Draft and Switch Channels', () => {
     before(() => {
         // 1. Login and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
     });
 

--- a/cypress/integration/channel/message_edit_post_with_attachment_spec.js
+++ b/cypress/integration/channel/message_edit_post_with_attachment_spec.js
@@ -12,7 +12,7 @@
 describe('MM-13697 Edit Post with attachment', () => {
     before(() => {
         // 1. Login and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
     });
 

--- a/cypress/integration/channel/message_spec.js
+++ b/cypress/integration/channel/message_spec.js
@@ -12,14 +12,14 @@
 describe('Message', () => {
     it('M13701 Consecutive message does not repeat profile info', () => {
         // 1. Login as sysadmin and go to /
-        cy.login('sysadmin');
+        cy.apiLogin('sysadmin');
         cy.visit('/');
 
         // 2. Post a message to force next user message to display a message
         cy.postMessage('Hello');
 
         // 3. Login as "user-1" and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         // 4. Post message "One"
@@ -43,7 +43,7 @@ describe('Message', () => {
 
     it('M14012 Focus move to main input box when a character key is selected', () => {
         // 1. Login and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         // 2. Post message
@@ -73,7 +73,7 @@ describe('Message', () => {
 
     it('M14320 @here., @all. and @channel. (ending in a period) still highlight', () => {
         // 1. Login and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         // 2. Post message

--- a/cypress/integration/channel/system_message_spec.js
+++ b/cypress/integration/channel/system_message_spec.js
@@ -49,7 +49,7 @@ function getLines(e) {
 describe('System Message', () => {
     before(() => {
         // 1. Login and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
         cy.updateTeammateDisplayModePreference();
     });

--- a/cypress/integration/login/login_spec.js
+++ b/cypress/integration/login/login_spec.js
@@ -9,7 +9,7 @@
 
 describe('Login page', () => {
     before(() => {
-        cy.logoutByAPI();
+        cy.apiLogout();
 
         // 1. Go to login page
         cy.visit('/login');

--- a/cypress/integration/markdown/markdown_spec.js
+++ b/cypress/integration/markdown/markdown_spec.js
@@ -33,7 +33,7 @@ const testCases = [
 describe('Markdown message', () => {
     before(() => {
         // 1. Login as "user-1" and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
     });
 

--- a/cypress/integration/search/results_post_comment_spec.js
+++ b/cypress/integration/search/results_post_comment_spec.js
@@ -12,7 +12,7 @@
 describe('Search', () => {
     it('S14548 Search results Right-Hand-Side: Post a comment', () => {
         // 1. Login and navigate to the app
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         const message = `asparagus-${Date.now()}`;

--- a/cypress/integration/team/create_a_team_spec.js
+++ b/cypress/integration/team/create_a_team_spec.js
@@ -12,7 +12,7 @@ import {getRandomInt} from '../../utils';
 describe('Teams Suite', () => {
     before(() => {
         // 1. Login and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
     });
 

--- a/cypress/integration/team/teams_spec.js
+++ b/cypress/integration/team/teams_spec.js
@@ -13,7 +13,7 @@ import users from '../../fixtures/users.json';
 describe('Teams Suite', () => {
     it('TS12995 Cancel out of leaving a team', () => {
         // 1. Login and go to /
-        cy.login('user-1');
+        cy.apiLogin('user-1');
         cy.visit('/');
 
         // * check the team name
@@ -56,7 +56,7 @@ describe('Teams Suite', () => {
         const offTopicURL = `/${teamURL}/channels/off-topic`;
 
         // 1. Login as System Admin
-        cy.login('sysadmin');
+        cy.apiLogin('sysadmin');
         cy.visit('/');
 
         // 2. Create team
@@ -93,7 +93,7 @@ describe('Teams Suite', () => {
         cy.logout();
 
         // 8. Login as user added to Team
-        cy.login(user.username);
+        cy.apiLogin(user.username);
 
         // * The added user sees the new team added to the team sidebar
         cy.get(`#${teamURL}TeamButton`).should('have.attr', 'href').should('contain', teamURL);

--- a/cypress/support/api_commands.js
+++ b/cypress/support/api_commands.js
@@ -1,0 +1,113 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import users from '../fixtures/users.json';
+import theme from '../fixtures/theme.json';
+
+// *****************************************************************************
+// Read more:
+// - https://on.cypress.io/custom-commands on writing Cypress commands
+// - https://api.mattermost.com/ for Mattermost API reference
+// *****************************************************************************
+
+// *****************************************************************************
+// Authentication
+// https://api.mattermost.com/#tag/authentication
+// *****************************************************************************
+
+/**
+ * Login a user directly via API
+ * @param {String} username - e.g. "user-1" (default)
+ */
+Cypress.Commands.add('apiLogin', (username = 'user-1') => {
+    const user = users[username];
+
+    cy.request({
+        url: '/api/v4/users/login',
+        method: 'POST',
+        body: {login_id: user.username, password: user.password},
+    });
+});
+
+/**
+ * Logout a user directly via API
+ */
+Cypress.Commands.add('apiLogout', () => {
+    cy.request({
+        url: '/api/v4/users/logout',
+        method: 'POST',
+    });
+});
+
+// *****************************************************************************
+// Preferences
+// https://api.mattermost.com/#tag/preferences
+// *****************************************************************************
+
+/**
+ * Saves user's preference directly via API
+ * This API assume that the user is logged in and has cookie to access
+ * @param {Array} preference - a list of user's preferences
+ */
+Cypress.Commands.add('apiSaveUserPreference', (preferences = []) => {
+    cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/users/me/preferences',
+        method: 'PUT',
+        body: preferences,
+    });
+});
+
+/**
+ * Saves channel display mode preference of a user directly via API
+ * This API assume that the user is logged in and has cookie to access
+ * @param {String} value - Either "full" (default) or "centered"
+ */
+Cypress.Commands.add('apiSaveChannelDisplayModePreference', (value = 'full') => {
+    cy.getCookie('MMUSERID').then((cookie) => {
+        const preference = {
+            user_id: cookie.value,
+            category: 'display_settings',
+            name: 'channel_display_mode',
+            value,
+        };
+
+        cy.apiSaveUserPreference([preference]);
+    });
+});
+
+/**
+ * Saves message display preference of a user directly via API
+ * This API assume that the user is logged in and has cookie to access
+ * @param {String} value - Either "clean" (default) or "compact"
+ */
+Cypress.Commands.add('apiSaveMessageDisplayPreference', (value = 'clean') => {
+    cy.getCookie('MMUSERID').then((cookie) => {
+        const preference = {
+            user_id: cookie.value,
+            category: 'display_settings',
+            name: 'message_display',
+            value,
+        };
+
+        cy.apiSaveUserPreference([preference]);
+    });
+});
+
+/**
+ * Saves theme preference of a user directly via API
+ * This API assume that the user is logged in and has cookie to access
+ * @param {Object} value - theme object.  Will pass default value if none is provided.
+ */
+Cypress.Commands.add('apiSaveThemePreference', (value = JSON.stringify(theme.default)) => {
+    cy.getCookie('MMUSERID').then((cookie) => {
+        const preference = {
+            user_id: cookie.value,
+            category: 'theme',
+            name: '',
+            value,
+        };
+
+        cy.apiSaveUserPreference([preference]);
+    });
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -5,7 +5,8 @@
 // Read more at: https://on.cypress.io/configuration
 // ***********************************************************
 
-import './commands';
+import './ui_commands';
+import './api_commands';
 import './validators';
 
 // Add login cookies to whitelist to preserve it


### PR DESCRIPTION
#### Summary
__Reorganized command to reset account settings via API__
Use `cy.apiSaveUserPreference()` to update/save account settings by passing `preference` to be saved.

 __Separated API and UI commands__
Intention is to easily identify and properly choose which one is appropriate in a spec file. I foresee the implementation as follow:
- only use UI commands (that driver/control the UI) whenever it's related to the test case, otherwise
- use API commands, usually when doing pre-setup (e.g. create a team/channel or even a post), change in config/settings, etc.

Name format and function signature:
- API command: with prefix of `api` and follows the signature of required parameters at https://api.mattermost.com/

To follow: will update E2E documentation to reflect this info.

#### Ticket Link
Jira - [MM-14391](https://mattermost.atlassian.net/browse/MM-14391)
