### PR TITLE
MM-14873 Add API command to create and delete a team and channel

### DIFF
--- a/components/sidebar/header/dropdown/index.js
+++ b/components/sidebar/header/dropdown/index.js
@@ -23,6 +23,7 @@ function mapStateToProps(state) {
         currentUser,
         teamDescription: currentTeam.description,
         teamDisplayName: currentTeam.display_name,
+        teamId: currentTeam.id,
         showTutorialTip,
     };
 }

--- a/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
+++ b/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
@@ -20,6 +20,7 @@ export default class SidebarHeaderDropdown extends React.PureComponent {
     static propTypes = {
         teamDescription: PropTypes.string.isRequired,
         teamDisplayName: PropTypes.string.isRequired,
+        teamId: PropTypes.string.isRequired,
         currentUser: PropTypes.object,
         showTutorialTip: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
@@ -74,6 +75,7 @@ export default class SidebarHeaderDropdown extends React.PureComponent {
                     teamDescription={this.props.teamDescription}
                     currentUser={this.props.currentUser}
                     teamDisplayName={this.props.teamDisplayName}
+                    teamId={this.props.teamId}
                 />
                 <MainMenu id='sidebarDropdownMenu'/>
             </MenuWrapper>

--- a/components/sidebar/header/sidebar_header_dropdown_button.jsx
+++ b/components/sidebar/header/sidebar_header_dropdown_button.jsx
@@ -15,6 +15,7 @@ export default class SidebarHeaderDropdownButton extends React.PureComponent {
     static propTypes = {
         showTutorialTip: PropTypes.bool.isRequired,
         teamDescription: PropTypes.string.isRequired,
+        teamId: PropTypes.string.isRequired,
         currentUser: PropTypes.object.isRequired,
         teamDisplayName: PropTypes.string.isRequired,
     };
@@ -40,6 +41,7 @@ export default class SidebarHeaderDropdownButton extends React.PureComponent {
             <h1
                 id='headerTeamName'
                 className='team__name'
+                data-teamid={this.props.teamId}
             >
                 {this.props.teamDisplayName}
             </h1>

--- a/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -1,18 +1,36 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {getRandomInt} from '../../../utils';
+
 // ***************************************************************
 // - [number] indicates a test step (e.g. 1. Go to a page)
 // - [*] indicates an assertion (e.g. * Check the title)
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-/* eslint max-nested-callbacks: ["error", 3] */
+/* eslint max-nested-callbacks: ["error", 4] */
+
+let testChannel;
+const channelDisplayName = `Channel Switcher ${getRandomInt(9999).toString()}`;
 
 describe('Account Settings > Sidebar > Channel Switcher', () => {
     before(() => {
+        cy.visit('/');
+        cy.getCurrentTeamId().then((teamId) => {
+            cy.apiCreateChannel(teamId, 'channel-switcher', channelDisplayName).then((response) => {
+                testChannel = response.body;
+            });
+        });
+
         // 1. Go to Account Settings with "user-1"
         cy.toAccountSettingsModal('user-1');
+    });
+
+    after(() => {
+        cy.getCurrentChannelId().then((channelId) => {
+            cy.apiDeleteChannel(channelId);
+        });
     });
 
     it('should render in min setting view', () => {
@@ -111,8 +129,8 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // * Channel switcher hint should be visible
         cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use ↑↓ to browse, ↵ to select, ESC to dismiss.');
 
-        // 4. Type "nesciunt" on Channel switcher input
-        cy.get('#quickSwitchInput').type('nesciunt');
+        // 4. Type channel display name} on Channel switcher input
+        cy.get('#quickSwitchInput').type(channelDisplayName);
         cy.wait(500);  // eslint-disable-line
 
         // * Suggestion list should be visible
@@ -121,9 +139,9 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // 5. Press enter
         cy.get('#quickSwitchInput').type('{enter}');
 
-        // * Verify that it redirected into "nesciunt" as selected channel
-        cy.url().should('include', '/ad-1/channels/sequi-7');
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'nesciunt');
+        // * Verify that it redirected into "channel-switcher" as selected channel
+        cy.url().should('include', '/ad-1/channels/' + testChannel.name);
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', channelDisplayName);
     });
 
     it('set channel switcher setting to On and test on press of Ctrl/Cmd+K', () => {
@@ -140,8 +158,8 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // * Channel switcher hint should be visible
         cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use ↑↓ to browse, ↵ to select, ESC to dismiss.');
 
-        // 4. Type "comm" on Channel switcher input
-        cy.get('#quickSwitchInput').type('comm');
+        // 4. Type channel display name on Channel switcher input
+        cy.get('#quickSwitchInput').type(channelDisplayName);
         cy.wait(500);  // eslint-disable-line
 
         // * Suggestion list should be visible
@@ -150,9 +168,9 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // 5. Press enter
         cy.get('#quickSwitchInput').type('{enter}');
 
-        // * Verify that it redirected into "commodi" as selected channel
-        cy.url().should('include', '/ad-1/channels/autem-2');
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'commodi');
+        // * Verify that it redirected into "channel-switcher" as selected channel
+        cy.url().should('include', '/ad-1/channels/' + testChannel.name);
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', channelDisplayName);
     });
 
     it('AS13216 Using CTRL/CMD+K if Channel Switcher is hidden in the LHS', () => {
@@ -168,8 +186,8 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // * Channel switcher hint should be visible
         cy.get('#quickSwitchHint').should('be.visible').should('contain', 'Type to find a channel. Use ↑↓ to browse, ↵ to select, ESC to dismiss.');
 
-        // 3. Type "comm" on Channel switcher input
-        cy.get('#quickSwitchInput').type('comm');
+        // 3. Type channel display name on Channel switcher input
+        cy.get('#quickSwitchInput').type(channelDisplayName);
         cy.wait(500);  // eslint-disable-line
 
         // * Suggestion list should be visible
@@ -178,8 +196,8 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // 4. Press enter
         cy.get('#quickSwitchInput').type('{enter}');
 
-        // * Verify that it redirected into "commodi" as selected channel
-        cy.url().should('include', '/ad-1/channels/autem-2');
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'commodi');
+        // * Verify that it redirected into "channel-switcher" as selected channel
+        cy.url().should('include', '/ad-1/channels/' + testChannel.name);
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', channelDisplayName);
     });
 });

--- a/cypress/support/api_commands.js
+++ b/cypress/support/api_commands.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {getRandomInt} from '../utils';
+
 import users from '../fixtures/users.json';
 import theme from '../fixtures/theme.json';
 
@@ -36,6 +38,104 @@ Cypress.Commands.add('apiLogout', () => {
     cy.request({
         url: '/api/v4/users/logout',
         method: 'POST',
+    });
+});
+
+// *****************************************************************************
+// Channels
+// https://api.mattermost.com/#tag/channels
+// *****************************************************************************
+
+/**
+ * Creates a channel directly via API
+ * This API assume that the user is logged in and has cookie to access
+ * @param {String} teamId - The team ID of the team to create the channel on
+ * @param {String} name - The unique handle for the channel, will be present in the channel URL
+ * @param {String} displayName - The non-unique UI name for the channel
+ * @param {String} type - 'O' for a public channel (default), 'P' for a private channel
+ * @param {String} purpose - A short description of the purpose of the channel
+ * @param {String} header - Markdown-formatted text to display in the header of the channel
+ * All parameters required except purpose and header
+ */
+Cypress.Commands.add('apiCreateChannel', (teamId, name, displayName, type = 'O', purpose = '', header = '') => {
+    const uniqueName = `${name}-${getRandomInt(9999).toString()}`;
+
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/channels',
+        method: 'POST',
+        body: {
+            team_id: teamId,
+            name: uniqueName,
+            display_name: displayName,
+            type,
+            purpose,
+            header,
+        },
+    }).then((response) => {
+        return response;
+    });
+});
+
+/**
+ * Deletes a channel directly via API
+ * This API assume that the user is logged in and has cookie to access
+ * @param {String} channelId - The channel ID to be deleted
+ * All parameter required
+ */
+Cypress.Commands.add('apiDeleteChannel', (channelId) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/channels/' + channelId,
+        method: 'DELETE',
+    }).then((response) => {
+        return response;
+    });
+});
+
+// *****************************************************************************
+// Teams
+// https://api.mattermost.com/#tag/teams
+// *****************************************************************************
+
+/**
+ * Creates a team directly via API
+ * This API assume that the user is logged in and has cookie to access
+ * @param {String} name - Unique handler for a team, will be present in the team URL
+ * @param {String} displayName - Non-unique UI name for the team
+ * @param {String} type - 'O' for open (default), 'I' for invite only
+ * All parameters required
+ */
+Cypress.Commands.add('apiCreateTeam', (name, displayName, type = 'O') => {
+    const uniqueName = `${name}-${getRandomInt(9999).toString()}`;
+
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/teams',
+        method: 'POST',
+        body: {
+            name: uniqueName,
+            display_name: displayName,
+            type,
+        },
+    }).then((response) => {
+        return response;
+    });
+});
+
+/**
+ * Deletes a team directly via API
+ * This API assume that the user is logged in and has cookie to access
+ * @param {String} teamId - The team ID to be deleted
+ * All parameter required
+ */
+Cypress.Commands.add('apiDeleteTeam', (teamId, permanent = false) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/teams/' + teamId + (permanent ? '/?permanent=true' : ''),
+        method: 'DELETE',
+    }).then((response) => {
+        return response;
     });
 });
 

--- a/cypress/support/api_commands.js
+++ b/cypress/support/api_commands.js
@@ -24,7 +24,7 @@ import theme from '../fixtures/theme.json';
 Cypress.Commands.add('apiLogin', (username = 'user-1') => {
     const user = users[username];
 
-    cy.request({
+    return cy.request({
         url: '/api/v4/users/login',
         method: 'POST',
         body: {login_id: user.username, password: user.password},
@@ -35,7 +35,7 @@ Cypress.Commands.add('apiLogin', (username = 'user-1') => {
  * Logout a user directly via API
  */
 Cypress.Commands.add('apiLogout', () => {
-    cy.request({
+    return cy.request({
         url: '/api/v4/users/logout',
         method: 'POST',
     });
@@ -142,7 +142,7 @@ Cypress.Commands.add('apiDeleteTeam', (teamId, permanent = false) => {
  * @param {Array} preference - a list of user's preferences
  */
 Cypress.Commands.add('apiSaveUserPreference', (preferences = []) => {
-    cy.request({
+    return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
         url: '/api/v4/users/me/preferences',
         method: 'PUT',
@@ -156,7 +156,7 @@ Cypress.Commands.add('apiSaveUserPreference', (preferences = []) => {
  * @param {String} value - Either "full" (default) or "centered"
  */
 Cypress.Commands.add('apiSaveChannelDisplayModePreference', (value = 'full') => {
-    cy.getCookie('MMUSERID').then((cookie) => {
+    return cy.getCookie('MMUSERID').then((cookie) => {
         const preference = {
             user_id: cookie.value,
             category: 'display_settings',
@@ -164,7 +164,7 @@ Cypress.Commands.add('apiSaveChannelDisplayModePreference', (value = 'full') => 
             value,
         };
 
-        cy.apiSaveUserPreference([preference]);
+        return cy.apiSaveUserPreference([preference]);
     });
 });
 
@@ -174,7 +174,7 @@ Cypress.Commands.add('apiSaveChannelDisplayModePreference', (value = 'full') => 
  * @param {String} value - Either "clean" (default) or "compact"
  */
 Cypress.Commands.add('apiSaveMessageDisplayPreference', (value = 'clean') => {
-    cy.getCookie('MMUSERID').then((cookie) => {
+    return cy.getCookie('MMUSERID').then((cookie) => {
         const preference = {
             user_id: cookie.value,
             category: 'display_settings',
@@ -182,7 +182,7 @@ Cypress.Commands.add('apiSaveMessageDisplayPreference', (value = 'clean') => {
             value,
         };
 
-        cy.apiSaveUserPreference([preference]);
+        return cy.apiSaveUserPreference([preference]);
     });
 });
 
@@ -192,7 +192,7 @@ Cypress.Commands.add('apiSaveMessageDisplayPreference', (value = 'clean') => {
  * @param {Object} value - theme object.  Will pass default value if none is provided.
  */
 Cypress.Commands.add('apiSaveThemePreference', (value = JSON.stringify(theme.default)) => {
-    cy.getCookie('MMUSERID').then((cookie) => {
+    return cy.getCookie('MMUSERID').then((cookie) => {
         const preference = {
             user_id: cookie.value,
             category: 'theme',
@@ -200,6 +200,6 @@ Cypress.Commands.add('apiSaveThemePreference', (value = JSON.stringify(theme.def
             value,
         };
 
-        cy.apiSaveUserPreference([preference]);
+        return cy.apiSaveUserPreference([preference]);
     });
 });

--- a/cypress/support/api_commands.js
+++ b/cypress/support/api_commands.js
@@ -72,8 +72,6 @@ Cypress.Commands.add('apiCreateChannel', (teamId, name, displayName, type = 'O',
             purpose,
             header,
         },
-    }).then((response) => {
-        return response;
     });
 });
 
@@ -88,8 +86,6 @@ Cypress.Commands.add('apiDeleteChannel', (channelId) => {
         headers: {'X-Requested-With': 'XMLHttpRequest'},
         url: '/api/v4/channels/' + channelId,
         method: 'DELETE',
-    }).then((response) => {
-        return response;
     });
 });
 
@@ -118,8 +114,6 @@ Cypress.Commands.add('apiCreateTeam', (name, displayName, type = 'O') => {
             display_name: displayName,
             type,
         },
-    }).then((response) => {
-        return response;
     });
 });
 
@@ -134,8 +128,6 @@ Cypress.Commands.add('apiDeleteTeam', (teamId, permanent = false) => {
         headers: {'X-Requested-With': 'XMLHttpRequest'},
         url: '/api/v4/teams/' + teamId + (permanent ? '/?permanent=true' : ''),
         method: 'DELETE',
-    }).then((response) => {
-        return response;
     });
 });
 


### PR DESCRIPTION
#### Summary
Add API commands to create and delete a team and channel.

This fixes the issue at `channel_switcher_spec` where it sometimes failed when a hardcoded channel is not present in the initial sample data.  So such spec is done by creating a channel on pre-setup.

This is submitted on top of https://github.com/mattermost/mattermost-webapp/pull/2600.  Particular commit of this PR is at https://github.com/mattermost/mattermost-webapp/commit/633373e91197d096cf7bb8e663377c47142f1e7e.

#### Ticket Link
Jira ticket: [MM-14873](https://mattermost.atlassian.net/browse/MM-14873)
