### PR TITLE
[MM-14746] Show Remove MFA Item in System Console only for Users that enabled MFA

### DIFF
--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
@@ -338,7 +338,7 @@ export default class SystemUsersDropdown extends React.Component {
         let showMakeNotActive = !Utils.isSystemAdmin(user.roles);
         let showManageTeams = true;
         let showRevokeSessions = true;
-        const showMfaReset = this.props.mfaEnabled && !!user.mfa_active && !user.is_bot;
+        const showMfaReset = this.props.mfaEnabled && Boolean(user.mfa_active) && !user.is_bot;
 
         if (user.delete_at > 0) {
             currentRoles = (
@@ -410,7 +410,7 @@ export default class SystemUsersDropdown extends React.Component {
                                 text={Utils.localizeMessage('admin.user_item.resetMfa', 'Remove MFA')}
                             />
                             <MenuItemAction
-                                show={!!user.auth_service && this.props.experimentalEnableAuthenticationTransfer && !user.is_bot}
+                                show={Boolean(user.auth_service) && this.props.experimentalEnableAuthenticationTransfer && !user.is_bot}
                                 onClick={this.handleResetPassword}
                                 text={Utils.localizeMessage('admin.user_item.switchToEmail', 'Switch to Email/Password')}
                             />

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
@@ -338,7 +338,7 @@ export default class SystemUsersDropdown extends React.Component {
         let showMakeNotActive = !Utils.isSystemAdmin(user.roles);
         let showManageTeams = true;
         let showRevokeSessions = true;
-        const showMfaReset = this.props.mfaEnabled && user.mfa_active && !user.is_bot;
+        const showMfaReset = this.props.mfaEnabled && !!user.mfa_active && !user.is_bot;
 
         if (user.delete_at > 0) {
             currentRoles = (
@@ -410,7 +410,7 @@ export default class SystemUsersDropdown extends React.Component {
                                 text={Utils.localizeMessage('admin.user_item.resetMfa', 'Remove MFA')}
                             />
                             <MenuItemAction
-                                show={user.auth_service && this.props.experimentalEnableAuthenticationTransfer && !user.is_bot}
+                                show={!!user.auth_service && this.props.experimentalEnableAuthenticationTransfer && !user.is_bot}
                                 onClick={this.handleResetPassword}
                                 text={Utils.localizeMessage('admin.user_item.switchToEmail', 'Switch to Email/Password')}
                             />


### PR DESCRIPTION
#### Summary
Currently the `Remove MFA` option is always shown in the User Dropdown in the system console. The PR fixes that non-boolean types are passed a show prop,  since when `mfa_active`  is false the property is not send to the client, so `user.mfa_active === undefined`, and `undefined` is for `show === true`.

#### Ticket Link
https://mattermost.atlassian.net/projects/MM/issues/MM-14746
