### PR TITLE
MM-14755/14756: Hides links and buttons to 'remove from team' and 're…

### DIFF
--- a/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
+++ b/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
@@ -12,6 +12,7 @@ import * as Utils from 'utils/utils.jsx';
 
 export default class ManageTeamsDropdown extends React.Component {
     static propTypes = {
+        team: PropTypes.object.isRequired,
         user: PropTypes.object.isRequired,
         teamMember: PropTypes.object.isRequired,
         onError: PropTypes.func.isRequired,
@@ -44,7 +45,7 @@ export default class ManageTeamsDropdown extends React.Component {
 
     render() {
         const isTeamAdmin = Utils.isAdmin(this.props.teamMember.roles) || this.props.teamMember.scheme_admin;
-
+        const {team} = this.props;
         let title;
         if (isTeamAdmin) {
             title = Utils.localizeMessage('admin.user_item.teamAdmin', 'Team Admin');
@@ -73,6 +74,7 @@ export default class ManageTeamsDropdown extends React.Component {
                         text={Utils.localizeMessage('admin.user_item.makeMember', 'Make Member')}
                     />
                     <MenuItemAction
+                        show={!team.group_constrained}
                         onClick={this.removeFromTeam}
                         text={Utils.localizeMessage('team_members_dropdown.leave_team', 'Remove from Team')}
                     />

--- a/components/channel_members_dropdown/__snapshots__/channel_members_dropdown.test.jsx.snap
+++ b/components/channel_members_dropdown/__snapshots__/channel_members_dropdown.test.jsx.snap
@@ -15,3 +15,13 @@ exports[`components/channel_members_dropdown should match snapshot for channel_m
   />
 </button>
 `;
+
+exports[`components/channel_members_dropdown should match snapshot for group_constrained channel 1`] = `
+<div>
+  <FormattedMessage
+    defaultMessage="Channel Admin"
+    id="channel_members_dropdown.channel_admin"
+    values={Object {}}
+  />
+</div>
+`;

--- a/components/channel_members_dropdown/channel_members_dropdown.jsx
+++ b/components/channel_members_dropdown/channel_members_dropdown.jsx
@@ -115,11 +115,11 @@ export default class ChannelMembersDropdown extends React.Component {
         if (this.props.canChangeMemberRoles) {
             const role = this.renderRole(isChannelAdmin);
 
-            const canRemoveFromChannel = this.props.canRemoveMember && this.props.channel.name !== Constants.DEFAULT_CHANNEL;
+            const canRemoveFromChannel = this.props.canRemoveMember && this.props.channel.name !== Constants.DEFAULT_CHANNEL && !this.props.channel.group_constrained;
             const canMakeChannelMember = isChannelAdmin;
             const canMakeChannelAdmin = supportsChannelAdmin && !isChannelAdmin;
 
-            if ((canMakeChannelMember || canMakeChannelAdmin) && canRemoveFromChannel) {
+            if ((canMakeChannelMember || canMakeChannelAdmin)) {
                 return (
                     <MenuWrapper>
                         <button
@@ -155,7 +155,7 @@ export default class ChannelMembersDropdown extends React.Component {
             }
         }
 
-        if (this.props.canRemoveMember && this.props.channel.name !== Constants.DEFAULT_CHANNEL) {
+        if (this.props.canRemoveMember && this.props.channel.name !== Constants.DEFAULT_CHANNEL && !this.props.channel.group_constrained) {
             return (
                 <button
                     id='removeMember'

--- a/components/channel_members_dropdown/channel_members_dropdown.test.jsx
+++ b/components/channel_members_dropdown/channel_members_dropdown.test.jsx
@@ -112,4 +112,12 @@ describe('components/channel_members_dropdown', () => {
             done();
         });
     });
+
+    test('should match snapshot for group_constrained channel', () => {
+        baseProps.channel.group_constrained = true;
+        const wrapper = shallow(
+            <ChannelMembersDropdown {...baseProps}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/components/channel_members_dropdown/index.js
+++ b/components/channel_members_dropdown/index.js
@@ -14,18 +14,18 @@ import {canManageMembers} from 'utils/channel_utils.jsx';
 import ChannelMembersDropdown from './channel_members_dropdown.jsx';
 
 function mapStateToProps(state, ownProps) {
+    const {channel} = ownProps;
     const canChangeMemberRoles = haveIChannelPermission(
         state,
         {
-            channel: ownProps.channel.id,
-            team: ownProps.channel.team_id,
+            channel: channel.id,
+            team: channel.team_id,
             permission: Permissions.MANAGE_CHANNEL_ROLES,
         }
     );
     const license = getLicense(state);
     const isLicensed = license.IsLicensed === 'true';
-
-    const canRemoveMember = canManageMembers(ownProps.channel);
+    const canRemoveMember = canManageMembers(channel);
 
     return {
         currentUserId: getCurrentUserId(state),

--- a/components/team_members_dropdown/__snapshots__/team_members_dropdown.test.jsx.snap
+++ b/components/team_members_dropdown/__snapshots__/team_members_dropdown.test.jsx.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/team_members_dropdown should match snapshot for team_members_dropdown 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className=""
+>
+  <button
+    aria-expanded="true"
+    className="dropdown-toggle theme color--link style--none"
+    type="button"
+  >
+    <span>
+      <FormattedMessage
+        defaultMessage="Team Admin"
+        id="team_members_dropdown.teamAdmin"
+        values={Object {}}
+      />
+       
+    </span>
+    <DropdownIcon />
+  </button>
+  <div>
+    <Menu
+      ariaLabel="Team member role change"
+      openLeft={true}
+    >
+      <MenuItemAction
+        id="removeFromTeam"
+        onClick={[Function]}
+        show={true}
+        text="Remove From Team"
+      />
+      <MenuItemAction
+        onClick={[Function]}
+        show={false}
+        text="Make Team Admin"
+      />
+      <MenuItemAction
+        onClick={[Function]}
+        show={true}
+        text="Make Member"
+      />
+    </Menu>
+  </div>
+</MenuWrapper>
+`;
+
+exports[`components/team_members_dropdown should match snapshot with group-constrained team 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className=""
+>
+  <button
+    aria-expanded="true"
+    className="dropdown-toggle theme color--link style--none"
+    type="button"
+  >
+    <span>
+      <FormattedMessage
+        defaultMessage="Team Admin"
+        id="team_members_dropdown.teamAdmin"
+        values={Object {}}
+      />
+       
+    </span>
+    <DropdownIcon />
+  </button>
+  <div>
+    <Menu
+      ariaLabel="Team member role change"
+      openLeft={true}
+    >
+      <MenuItemAction
+        id="removeFromTeam"
+        onClick={[Function]}
+        show={false}
+        text="Remove From Team"
+      />
+      <MenuItemAction
+        onClick={[Function]}
+        show={false}
+        text="Make Team Admin"
+      />
+      <MenuItemAction
+        onClick={[Function]}
+        show={true}
+        text="Make Member"
+      />
+    </Menu>
+  </div>
+</MenuWrapper>
+`;

--- a/components/team_members_dropdown/index.js
+++ b/components/team_members_dropdown/index.js
@@ -14,7 +14,7 @@ import {
 import {getUser, updateUserActive} from 'mattermost-redux/actions/users';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
-import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentRelativeTeamUrl, getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import {removeUserFromTeamAndGetStats} from 'actions/team_actions.jsx';
 
@@ -25,6 +25,7 @@ function mapStateToProps(state) {
         currentUser: getCurrentUser(state),
         currentChannelId: getCurrentChannelId(state),
         teamUrl: getCurrentRelativeTeamUrl(state),
+        currentTeam: getCurrentTeam(state),
     };
 }
 

--- a/components/team_members_dropdown/team_members_dropdown.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.jsx
@@ -20,6 +20,7 @@ export default class TeamMembersDropdown extends React.Component {
         currentUser: PropTypes.object.isRequired,
         teamMember: PropTypes.object.isRequired,
         teamUrl: PropTypes.string.isRequired,
+        currentTeam: PropTypes.object.isRequired,
         actions: PropTypes.shape({
             getMyTeamMembers: PropTypes.func.isRequired,
             getMyTeamUnreads: PropTypes.func.isRequired,
@@ -122,8 +123,8 @@ export default class TeamMembersDropdown extends React.Component {
             );
         }
 
-        const teamMember = this.props.teamMember;
-        const user = this.props.user;
+        const {currentTeam, teamMember, user} = this.props;
+
         let currentRoles = (
             <FormattedMessage
                 id='team_members_dropdown.member'
@@ -164,7 +165,7 @@ export default class TeamMembersDropdown extends React.Component {
             showMakeAdmin = false;
         }
 
-        const canRemoveFromTeam = this.props.user.id !== me.id;
+        const canRemoveFromTeam = this.props.user.id !== me.id && !currentTeam.group_constrained;
 
         let makeDemoteModal = null;
         if (this.props.user.id === me.id) {

--- a/components/team_members_dropdown/team_members_dropdown.test.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.test.jsx
@@ -1,0 +1,72 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import TeamMembersDropdown from 'components/team_members_dropdown/team_members_dropdown.jsx';
+
+describe('components/team_members_dropdown', () => {
+    const user = {
+        id: 'user-1',
+        roles: 'team_admin',
+    };
+
+    const user2 = {
+        id: 'user-2',
+        roles: 'team_admin',
+    };
+
+    const team = {
+        id: 'qkh1bxwgkjry3x4sgn5roa8ypy',
+        create_at: 1553808980710,
+        update_at: 1553808980710,
+        delete_at: 0,
+        display_name: 'engineering',
+        name: 'engineering',
+        description: '',
+        email: 'sysadmin@test.com',
+        type: 'O',
+        company_name: '',
+        allowed_domains: '',
+        invite_id: 'sgic8xqghb8iupttw6skeqifuo',
+        allow_open_invite: false,
+        scheme_id: null,
+    };
+
+    const baseProps = {
+        user: user2,
+        currentUser: user,
+        teamMember: {
+            roles: 'channel_admin',
+            scheme_admin: 'system_admin',
+        },
+        teamUrl: '',
+        currentTeam: team,
+        actions: {
+            getMyTeamMembers: jest.fn(),
+            getMyTeamUnreads: jest.fn(),
+            getUser: jest.fn(),
+            getTeamStats: jest.fn(),
+            getChannelStats: jest.fn(),
+            updateTeamMemberSchemeRoles: jest.fn(),
+            removeUserFromTeamAndGetStats: jest.fn(),
+            updateUserActive: jest.fn(),
+        },
+    };
+
+    test('should match snapshot for team_members_dropdown', () => {
+        const wrapper = shallow(
+            <TeamMembersDropdown {...baseProps}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot with group-constrained team', () => {
+        baseProps.currentTeam.group_constrained = true;
+        const wrapper = shallow(
+            <TeamMembersDropdown {...baseProps}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
…move from channel' when the team or channel is group-constrained.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

* Hides options to "Remove From Team" (chat-facing and system console) if the team is group constrained.
* Hides option to "Remove From Channel" if the channel is group constrained.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-14755
and
https://mattermost.atlassian.net/browse/MM-14756

#### Related Pull Requests
none

#### Screen captures

Chat-facing remove channel member:
![Chat-facing remove channel member](https://media.giphy.com/media/ycCozR6VPdBFRDACk5/giphy.gif)

Chat-facing remove team member:
![Chat-facing remove team member](https://media.giphy.com/media/J6P2ryJxlvKKmTs2Cp/giphy.gif)

Admin console remove team member:
![Admin console remove team member](https://media.giphy.com/media/L3bdBIxHIagGKBRGhX/giphy.gif)
