### PR TITLE
[MM 14801] Don't highlight [at]channel/all/here in usernames

### DIFF
--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -180,7 +180,7 @@ export function autolinkAtMentions(text, tokens) {
     let output = text;
 
     // handle @channel, @all, @here mentions first (purposely excludes trailing punctuation)
-    output = output.replace(/\B@(channel|all|here)/gi, replaceAtMentionWithToken);
+    output = output.replace(/\B@(channel|all|here)\b/gi, replaceAtMentionWithToken);
 
     // handle all other mentions (supports trailing punctuation)
     let match = output.match(AT_MENTION_PATTERN);

--- a/utils/text_formatting.test.jsx
+++ b/utils/text_formatting.test.jsx
@@ -73,12 +73,6 @@ describe('autolinkAtMentions', () => {
     test('@channel, @all, @here should highlight properly with a trailing dash', () => {
         runSuccessfulAtMentionTests('', '-');
     });
-    test('@channel, @all, @here should highlight properly with a trailing underscore', () => {
-        runSuccessfulAtMentionTests('', '_');
-    });
-    test('@channel, @all, @here should highlight when the first part of a word', () => {
-        runSuccessfulAtMentionTests('', 'testing');
-    });
     test('@channel, @all, @here should highlight properly within a typical sentance', () => {
         runSuccessfulAtMentionTests('This is a typical sentance, ', ' check out this sentance!');
     });


### PR DESCRIPTION
#### Summary
[PR 2338](https://github.com/mattermost/mattermost-webapp/pull/2338/files) made [at]all/channel/here mentions more flexible to allow for trailing punctuation. The fix was a bit too flexible, for example incorrectly highlighting `[at]all` in usernames like `[at]allen`, so this PR changes the highlight behaviour to require that [at]all/channel/here mentions be distinct words preventing them from highlighting when at the beginning of a larger word like a username.

**Note**: Since an underscore is not considered to be punctuation by regular expressions, if it is included immediately following an [at]channel/all/here mention, the mention won't highlight. This can't be easily fixed and would require more mana to attempt.

#### Ticket Link
[MM-14801](https://mattermost.atlassian.net/browse/MM-14801)

