### PR TITLE
MM-14886 Move file input back to be child of button

### DIFF
--- a/components/file_upload/__snapshots__/file_upload.test.jsx.snap
+++ b/components/file_upload/__snapshots__/file_upload.test.jsx.snap
@@ -4,15 +4,6 @@ exports[`components/FileUpload should match snapshot 1`] = `
 <span
   className=""
 >
-  <input
-    accept=""
-    aria-label="Upload files"
-    className="file-attachment-menu-item-input"
-    multiple={true}
-    onChange={[Function]}
-    onClick={[Function]}
-    type="file"
-  />
   <MenuWrapper
     animationComponent={[Function]}
     className=""
@@ -34,9 +25,7 @@ exports[`components/FileUpload should match snapshot 1`] = `
       openUp={true}
     >
       <li>
-        <a
-          onClick={[Function]}
-        >
+        <a>
           <i
             className="fa fa-laptop"
           />
@@ -44,6 +33,15 @@ exports[`components/FileUpload should match snapshot 1`] = `
             defaultMessage="Your computer"
             id="yourcomputer"
             values={Object {}}
+          />
+          <input
+            accept=""
+            aria-label="Upload files"
+            className="file-attachment-menu-item-input"
+            multiple={true}
+            onChange={[Function]}
+            onClick={[Function]}
+            type="file"
           />
         </a>
       </li>

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -564,10 +564,6 @@ export default class FileUpload extends PureComponent {
         this.setState({menuOpen: false});
     }
 
-    simulateInputClick = () => {
-        this.fileInput.current.click();
-    }
-
     render() {
         const {formatMessage} = this.context.intl;
         let multiple = true;
@@ -624,16 +620,6 @@ export default class FileUpload extends PureComponent {
             });
             bodyAction = (
                 <React.Fragment>
-                    <input
-                        aria-label={formatMessage(holders.uploadFile)}
-                        ref={this.fileInput}
-                        type='file'
-                        className='file-attachment-menu-item-input'
-                        onChange={this.handleChange}
-                        onClick={this.handleLocalFileUploaded}
-                        multiple={multiple}
-                        accept={accept}
-                    />
                     <MenuWrapper>
                         <button
                             type='button'
@@ -652,11 +638,21 @@ export default class FileUpload extends PureComponent {
                             ariaLabel={formatMessage({id: 'file_upload.menuAriaLabel', defaultMessage: 'Upload type selector'})}
                         >
                             <li>
-                                <a onClick={this.simulateInputClick}>
+                                <a>
                                     <i className='fa fa-laptop'/>
                                     <FormattedMessage
                                         id='yourcomputer'
                                         defaultMessage='Your computer'
+                                    />
+                                    <input
+                                        aria-label={formatMessage(holders.uploadFile)}
+                                        ref={this.fileInput}
+                                        type='file'
+                                        className='file-attachment-menu-item-input'
+                                        onChange={this.handleChange}
+                                        onClick={this.handleLocalFileUploaded}
+                                        multiple={multiple}
+                                        accept={accept}
                                     />
                                 </a>
                             </li>


### PR DESCRIPTION
#### Summary
Fixes the mobile view file input overlapping the send message and emoji buttons. Bug was caused by https://github.com/mattermost/mattermost-webapp/pull/2422

@jespino hopefully I didn't break anything you were fixing, if so let me know and we can find a solution that covers all our cases.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14886