### PR TITLE
MM-14860 Localization for client plugins.

### DIFF
--- a/components/intl_provider/intl_provider.jsx
+++ b/components/intl_provider/intl_provider.jsx
@@ -49,11 +49,9 @@ export default class IntlProvider extends React.PureComponent {
             // Already loaded
             return;
         }
-
         const localeInfo = I18n.getLanguageInfo(locale);
 
-        if (locale === 'en' || !localeInfo) {
-            // English is loaded by default and invalid locales fall back to English, so we should never hit this
+        if (!localeInfo) {
             return;
         }
 

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -187,13 +187,13 @@ export default class Root extends React.Component {
         /*eslint-enable */
 
         const afterIntl = () => {
-            initializePlugins();
-
             if (this.props.location.pathname === '/' && this.props.noAccounts) {
                 this.props.history.push('/signup_user_complete');
             }
 
-            this.setState({configLoaded: true});
+            initializePlugins().then(() => {
+                this.setState({configLoaded: true});
+            });
         };
         if (global.Intl) {
             afterIntl();

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -38,9 +38,9 @@ export async function initializePlugins() {
         return;
     }
 
-    data.forEach((m) => {
-        loadPlugin(m);
-    });
+    await Promise.all(data.map((m) => {
+        return loadPlugin(m);
+    }));
 }
 
 // getPlugins queries the server for all enabled plugins
@@ -65,31 +65,35 @@ const loadedPlugins = {};
 // loadPlugin fetches the web app bundle described by the given manifest, waits for the bundle to
 // load, and then ensures the plugin has been initialized.
 export function loadPlugin(manifest) {
-    // Don't load it again if previously loaded
-    if (loadedPlugins[manifest.id]) {
-        return;
-    }
+    return new Promise((resolve) => {
+        // Don't load it again if previously loaded
+        if (loadedPlugins[manifest.id]) {
+            resolve();
+            return;
+        }
 
-    function onLoad() {
-        initializePlugin(manifest);
-        console.log('Loaded ' + manifest.id + ' plugin'); //eslint-disable-line no-console
-    }
+        function onLoad() {
+            initializePlugin(manifest);
+            console.log('Loaded ' + manifest.id + ' plugin'); //eslint-disable-line no-console
+            resolve();
+        }
 
-    // Backwards compatibility for old plugins
-    let bundlePath = manifest.webapp.bundle_path;
-    if (bundlePath.includes('/static/') && !bundlePath.includes('/static/plugins/')) {
-        bundlePath = bundlePath.replace('/static/', '/static/plugins/');
-    }
+        // Backwards compatibility for old plugins
+        let bundlePath = manifest.webapp.bundle_path;
+        if (bundlePath.includes('/static/') && !bundlePath.includes('/static/plugins/')) {
+            bundlePath = bundlePath.replace('/static/', '/static/plugins/');
+        }
 
-    const script = document.createElement('script');
-    script.id = 'plugin_' + manifest.id;
-    script.type = 'text/javascript';
-    script.src = getSiteURL() + bundlePath;
-    script.onload = onLoad;
-    console.log('Loading ' + manifest.id + ' plugin'); //eslint-disable-line no-console
-    document.getElementsByTagName('head')[0].appendChild(script);
+        const script = document.createElement('script');
+        script.id = 'plugin_' + manifest.id;
+        script.type = 'text/javascript';
+        script.src = getSiteURL() + bundlePath;
+        script.onload = onLoad;
+        console.log('Loading ' + manifest.id + ' plugin'); //eslint-disable-line no-console
+        document.getElementsByTagName('head')[0].appendChild(script);
 
-    loadedPlugins[manifest.id] = true;
+        loadedPlugins[manifest.id] = true;
+    });
 }
 
 // initializePlugin creates a registry specific to the plugin and invokes any initialize function

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -11,6 +11,10 @@ import {
     unregisterPluginReconnectHandler,
 } from 'actions/websocket_actions.jsx';
 
+import {
+    registerPluginTranslationsSource,
+} from 'actions/views/root';
+
 import store from 'stores/redux_store.jsx';
 import {ActionTypes} from 'utils/constants.jsx';
 import {generateId} from 'utils/utils.jsx';
@@ -358,5 +362,9 @@ export default class PluginRegistry {
         });
 
         return id;
+    }
+
+    registerTranslations(getTranslationsForLocale) {
+        registerPluginTranslationsSource(this.id, getTranslationsForLocale);
     }
 }

--- a/reducers/views/i18n.js
+++ b/reducers/views/i18n.js
@@ -3,11 +3,9 @@
 
 import {combineReducers} from 'redux';
 
-import en from 'i18n/en.json';
-
 import {ActionTypes} from 'utils/constants.jsx';
 
-function translations(state = {en}, action) {
+function translations(state = {}, action) {
     switch (action.type) {
     case ActionTypes.RECEIVED_TRANSLATIONS:
         return {


### PR DESCRIPTION
#### Summary
This is a functional, ready to merge, proposal on how webapp side plugin translation could work.

The basic process from the plugin side is to use the new `PluginRegistery.registerTranslations` function to register a callback of the form `getTranslations(locale)` that delivers translations on demand. The plugin is then responsible for providing translations for English, and every language it supports. How to get those translations and if Mattermost the company gets involved is out of the scope of this PR, but it assumes the translation files will live with the plugins.

One consequence of not of this method is to avoid the translations causing a "screen flash" when they load in, webapp plugin loading has been made synchronous with the rendering of the root component. ie. The root component will not render until all plugins have performed their initialization. This both solves the problem for translations and prevents plugins from popping in later. However it does raise the possibility of long plugin initialization slowing down the initial load of the webapp. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14860

#### Related Pull Requests
Demo plugin using this: https://github.com/mattermost/mattermost-plugin-demo/pull/25
