### PR TITLE
[MM-14881] Migrates getSuggestion functions to mattermost-redux

### DIFF
--- a/components/suggestion/at_mention_provider/at_mention_provider.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_provider.jsx
@@ -3,8 +3,9 @@
 
 import XRegExp from 'xregexp';
 
+import {getSuggestionsSplitByMultiple} from 'mattermost-redux/utils/user_utils';
+
 import {Constants} from 'utils/constants.jsx';
-import {getSuggestionsSplitByMultiple} from 'utils/utils.jsx';
 
 import Provider from '../provider.jsx';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10486,8 +10486,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#cd943d124340cdad729c2b97db510332bcec2659",
-      "from": "github:mattermost/mattermost-redux#cd943d124340cdad729c2b97db510332bcec2659",
+      "version": "github:mattermost/mattermost-redux#e360489890ae65b9223c6d30a2e6184ccacf51db",
+      "from": "github:mattermost/mattermost-redux#e360489890ae65b9223c6d30a2e6184ccacf51db",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "localforage-observable": "1.4.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
-    "mattermost-redux": "github:mattermost/mattermost-redux#cd943d124340cdad729c2b97db510332bcec2659",
+    "mattermost-redux": "github:mattermost/mattermost-redux#e360489890ae65b9223c6d30a2e6184ccacf51db",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -3,7 +3,6 @@
 
 import $ from 'jquery';
 import React from 'react';
-import _ from 'lodash';
 import {FormattedMessage} from 'react-intl';
 
 import {Client4} from 'mattermost-redux/client';
@@ -1677,19 +1676,4 @@ export function enableDevModeFeatures() {
             throw new Error('Map.length is not supported. Use Map.size instead.');
         },
     });
-}
-
-// Splits the term by a splitStr and composes a list of the parts of
-// the split concatenated with the rest, forming a set of suggesitons
-// matchable with startsWith
-//
-// E.g.: for "one.two.three" by "." it would yield
-// ["one.two.three", "two.three", "three"]
-export function getSuggestionsSplitBy(term, splitStr) {
-    const splitTerm = term.split(splitStr);
-    return splitTerm.map((st, i) => splitTerm.slice(i).join(splitStr));
-}
-
-export function getSuggestionsSplitByMultiple(term, splitStrs) {
-    return _.uniq(_.flatMap(splitStrs, (splitStr) => getSuggestionsSplitBy(term, splitStr)));
 }

--- a/utils/utils.test.jsx
+++ b/utils/utils.test.jsx
@@ -705,21 +705,3 @@ describe('Utils.enableDevModeFeatures', () => {
         });
     });
 });
-
-describe('Utils.getSuggestionsSplitBy', () => {
-    test('correct suggestions when splitting by a character', () => {
-        const term = 'one.two.three';
-        const expectedSuggestions = ['one.two.three', 'two.three', 'three'];
-
-        expect(Utils.getSuggestionsSplitBy(term, '.')).toEqual(expectedSuggestions);
-    });
-});
-
-describe('Utils.getSuggestionsSplitByMultiple', () => {
-    test('correct suggestions when splitting by multiple characters', () => {
-        const term = 'one.two-three';
-        const expectedSuggestions = ['one.two-three', 'two-three', 'three'];
-
-        expect(Utils.getSuggestionsSplitByMultiple(term, ['.', '-'])).toEqual(expectedSuggestions);
-    });
-});


### PR DESCRIPTION
#### Summary
Removes the `getSuggestions` functions and imports them from `mattermost-redux`.

#### Ticket Link
[MM-14881](https://mattermost.atlassian.net/browse/MM-14881)

#### Related Pull Requests
- [Link to the redux PR](https://github.com/mattermost/mattermost-redux/pull/808)
