### PR TITLE
MM-14138: Allowing to exclude permissions from the roles edition

### DIFF
--- a/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.jsx
@@ -23,6 +23,14 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 import PermissionsTree from '../permissions_tree';
 
+const EXCLUDED_PERMISSIONS = [
+    Permissions.VIEW_MEMBERS,
+    Permissions.JOIN_PUBLIC_TEAMS,
+    Permissions.LIST_PUBLIC_TEAMS,
+    Permissions.JOIN_PRIVATE_TEAMS,
+    Permissions.LIST_PRIVATE_TEAMS,
+];
+
 export default class PermissionSystemSchemeSettings extends React.Component {
     static propTypes = {
         roles: PropTypes.object.isRequired,
@@ -52,14 +60,6 @@ export default class PermissionSystemSchemeSettings extends React.Component {
         };
         this.rolesNeeded = ['system_admin', 'system_user', 'team_admin', 'team_user', 'channel_admin', 'channel_user'];
     }
-
-    excludedPermissions = [
-        Permissions.VIEW_MEMBERS,
-        Permissions.JOIN_PUBLIC_TEAMS,
-        Permissions.LIST_PUBLIC_TEAMS,
-        Permissions.JOIN_PRIVATE_TEAMS,
-        Permissions.LIST_PRIVATE_TEAMS,
-    ]
 
     componentDidMount() {
         this.props.actions.loadRolesIfNeeded(this.rolesNeeded);
@@ -141,17 +141,17 @@ export default class PermissionSystemSchemeSettings extends React.Component {
 
     restoreExcludedPermissions = (roles) => {
         for (const permission of this.props.roles.system_user.permissions) {
-            if (this.excludedPermissions.includes(permission)) {
+            if (EXCLUDED_PERMISSIONS.includes(permission)) {
                 roles.system_user.permissions.push(permission);
             }
         }
         for (const permission of this.props.roles.team_user.permissions) {
-            if (this.excludedPermissions.includes(permission)) {
+            if (EXCLUDED_PERMISSIONS.includes(permission)) {
                 roles.team_user.permissions.push(permission);
             }
         }
         for (const permission of this.props.roles.channel_user.permissions) {
-            if (this.excludedPermissions.includes(permission)) {
+            if (EXCLUDED_PERMISSIONS.includes(permission)) {
                 roles.channel_user.permissions.push(permission);
             }
         }

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.jsx
@@ -28,6 +28,14 @@ import LocalizedInput from 'components/localized_input/localized_input';
 
 import TeamInList from './team_in_list';
 
+const EXCLUDED_PERMISSIONS = [
+    Permissions.VIEW_MEMBERS,
+    Permissions.JOIN_PUBLIC_TEAMS,
+    Permissions.LIST_PUBLIC_TEAMS,
+    Permissions.JOIN_PRIVATE_TEAMS,
+    Permissions.LIST_PRIVATE_TEAMS,
+];
+
 export default class PermissionTeamSchemeSettings extends React.Component {
     static propTypes = {
         schemeId: PropTypes.string,
@@ -67,14 +75,6 @@ export default class PermissionTeamSchemeSettings extends React.Component {
     static defaultProps = {
         scheme: null,
     }
-
-    excludedPermissions = [
-        Permissions.VIEW_MEMBERS,
-        Permissions.JOIN_PUBLIC_TEAMS,
-        Permissions.LIST_PUBLIC_TEAMS,
-        Permissions.JOIN_PRIVATE_TEAMS,
-        Permissions.LIST_PRIVATE_TEAMS,
-    ]
 
     componentDidMount() {
         this.props.actions.loadRolesIfNeeded(['team_admin', 'team_user', 'channel_admin', 'channel_user']);
@@ -192,12 +192,12 @@ export default class PermissionTeamSchemeSettings extends React.Component {
 
     restoreExcludedPermissions = (baseTeam, baseChannel, roles) => {
         for (const permission of baseTeam.permissions) {
-            if (this.excludedPermissions.includes(permission)) {
+            if (EXCLUDED_PERMISSIONS.includes(permission)) {
                 roles.team_user.permissions.push(permission);
             }
         }
         for (const permission of baseChannel.permissions) {
-            if (this.excludedPermissions.includes(permission)) {
+            if (EXCLUDED_PERMISSIONS.includes(permission)) {
                 roles.channel_user.permissions.push(permission);
             }
         }

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.jsx
@@ -5,6 +5,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 
+import Permissions from 'mattermost-redux/constants/permissions';
+
 import {PermissionsScope} from 'utils/constants.jsx';
 import {localizeMessage} from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
@@ -65,6 +67,14 @@ export default class PermissionTeamSchemeSettings extends React.Component {
     static defaultProps = {
         scheme: null,
     }
+
+    excludedPermissions = [
+        Permissions.VIEW_MEMBERS,
+        Permissions.JOIN_PUBLIC_TEAMS,
+        Permissions.LIST_PUBLIC_TEAMS,
+        Permissions.JOIN_PRIVATE_TEAMS,
+        Permissions.LIST_PRIVATE_TEAMS,
+    ]
 
     componentDidMount() {
         this.props.actions.loadRolesIfNeeded(['team_admin', 'team_user', 'channel_admin', 'channel_user']);
@@ -180,6 +190,20 @@ export default class PermissionTeamSchemeSettings extends React.Component {
         };
     }
 
+    restoreExcludedPermissions = (baseTeam, baseChannel, roles) => {
+        for (const permission of baseTeam.permissions) {
+            if (this.excludedPermissions.includes(permission)) {
+                roles.team_user.permissions.push(permission);
+            }
+        }
+        for (const permission of baseChannel.permissions) {
+            if (this.excludedPermissions.includes(permission)) {
+                roles.channel_user.permissions.push(permission);
+            }
+        }
+        return roles;
+    }
+
     handleNameChange = (e) => {
         this.setState({schemeName: e.target.value, saveNeeded: true});
         this.props.actions.setNavigationBlocked(true);
@@ -203,10 +227,15 @@ export default class PermissionTeamSchemeSettings extends React.Component {
 
         this.setState({saving: true});
         if (this.props.schemeId) {
-            const derived = this.deriveRolesFromAllUsers(
+            let derived = this.deriveRolesFromAllUsers(
                 this.props.roles[this.props.scheme.default_team_user_role],
                 this.props.roles[this.props.scheme.default_channel_user_role],
                 allUsers
+            );
+            derived = this.restoreExcludedPermissions(
+                this.props.roles[this.props.scheme.default_team_user_role],
+                this.props.roles[this.props.scheme.default_channel_user_role],
+                derived
             );
             teamUser = derived.team_user;
             channelUser = derived.channel_user;
@@ -216,10 +245,15 @@ export default class PermissionTeamSchemeSettings extends React.Component {
             });
             schemeId = this.props.schemeId;
         } else {
-            const derived = this.deriveRolesFromAllUsers(
+            let derived = this.deriveRolesFromAllUsers(
                 this.props.roles.team_user,
                 this.props.roles.channel_user,
                 allUsers
+            );
+            derived = this.restoreExcludedPermissions(
+                this.props.roles.team_user,
+                this.props.roles.channel_user,
+                derived
             );
             teamUser = derived.team_user;
             channelUser = derived.channel_user;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10516,8 +10516,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#e360489890ae65b9223c6d30a2e6184ccacf51db",
-      "from": "github:mattermost/mattermost-redux#e360489890ae65b9223c6d30a2e6184ccacf51db",
+      "version": "github:mattermost/mattermost-redux#55848d5e56cba3b2b2d1accef367f8cffa28eda2",
+      "from": "github:mattermost/mattermost-redux#55848d5e56cba3b2b2d1accef367f8cffa28eda2",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "localforage-observable": "1.4.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
-    "mattermost-redux": "github:mattermost/mattermost-redux#e360489890ae65b9223c6d30a2e6184ccacf51db",
+    "mattermost-redux": "github:mattermost/mattermost-redux#55848d5e56cba3b2b2d1accef367f8cffa28eda2",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
Allowing to exclude permissions from the roles edition. Before this PR you
should to pass the permission at the lower scope possible of the permission,
independently if it was in the interface or not. This is needed for the
view_members permissions which is not set as lowest scope level, is set by
default at system level.

#### Ticket Link
[MM-14138](https://mattermost.atlassian.net/browse/MM-14138)

#### Related Pull Requests
- Has server changes (mattermost/mattermost-server#10487)
- Has redux changes (mattermost/mattermost-redux#810)