### PR TITLE
[MM-14764] Show file upload options in mobile view

### DIFF
--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -616,7 +616,7 @@ export default class FileUpload extends PureComponent {
                         }}
                     >
                         <a>
-                            {item.icon}&nbsp;
+                            <span className='margin-right'>{item.icon}</span>
                             {item.text}
                         </a>
                     </li>
@@ -660,7 +660,7 @@ export default class FileUpload extends PureComponent {
                         >
                             <li>
                                 <a onClick={this.simulateInputClick}>
-                                    <i className='fa fa-laptop'/>&nbsp;
+                                    <span className='margin-right'><i className='fa fa-laptop'/></span>
                                     <FormattedMessage
                                         id='yourcomputer'
                                         defaultMessage='Your computer'

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -63,6 +63,13 @@ const holders = defineMessages({
 
 const OVERLAY_TIMEOUT = 500;
 
+const customStyles = {
+    left: 'inherit',
+    right: 0,
+    bottom: '100%',
+    top: 'auto',
+};
+
 export default class FileUpload extends PureComponent {
     static propTypes = {
 
@@ -622,12 +629,6 @@ export default class FileUpload extends PureComponent {
                     </li>
                 );
             });
-            const customStyles = {
-                left: 'inherit',
-                right: 0,
-                bottom: '100%',
-                top: 'auto',
-            };
             bodyAction = (
                 <React.Fragment>
                     <input

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -616,12 +616,18 @@ export default class FileUpload extends PureComponent {
                         }}
                     >
                         <a>
-                            {item.icon}
+                            {item.icon}&nbsp;
                             {item.text}
                         </a>
                     </li>
                 );
             });
+            const customStyles = {
+                left: 'inherit',
+                right: 0,
+                bottom: '100%',
+                top: 'auto',
+            };
             bodyAction = (
                 <React.Fragment>
                     <input
@@ -650,10 +656,11 @@ export default class FileUpload extends PureComponent {
                             openLeft={true}
                             openUp={true}
                             ariaLabel={formatMessage({id: 'file_upload.menuAriaLabel', defaultMessage: 'Upload type selector'})}
+                            customStyles={customStyles}
                         >
                             <li>
                                 <a onClick={this.simulateInputClick}>
-                                    <i className='fa fa-laptop'/>
+                                    <i className='fa fa-laptop'/>&nbsp;
                                     <FormattedMessage
                                         id='yourcomputer'
                                         defaultMessage='Your computer'

--- a/components/widgets/menu/menu.jsx
+++ b/components/widgets/menu/menu.jsx
@@ -13,6 +13,7 @@ export default class Menu extends React.PureComponent {
         openUp: PropTypes.bool,
         id: PropTypes.string,
         ariaLabel: PropTypes.string.isRequired,
+        customStyles: PropTypes.object,
     };
 
     constructor(props) {
@@ -29,15 +30,19 @@ export default class Menu extends React.PureComponent {
     }
 
     render() {
-        const {children, openUp, openLeft, id, ariaLabel} = this.props;
-        const styles = {};
-        if (openLeft && !isMobile()) {
-            styles.left = 'inherit';
-            styles.right = 0;
-        }
-        if (openUp && !isMobile()) {
-            styles.bottom = '100%';
-            styles.top = 'auto';
+        const {children, openUp, openLeft, id, ariaLabel, customStyles } = this.props;
+        let styles = {};
+        if (!customStyles) {
+            if (openLeft && !isMobile()) {
+                styles.left = 'inherit';
+                styles.right = 0;
+            }
+            if (openUp && !isMobile()) {
+                styles.bottom = '100%';
+                styles.top = 'auto';
+            }
+        } else {
+            styles = customStyles;
         }
 
         return (

--- a/components/widgets/menu/menu.jsx
+++ b/components/widgets/menu/menu.jsx
@@ -30,9 +30,11 @@ export default class Menu extends React.PureComponent {
     }
 
     render() {
-        const {children, openUp, openLeft, id, ariaLabel, customStyles } = this.props;
+        const {children, openUp, openLeft, id, ariaLabel, customStyles} = this.props;
         let styles = {};
-        if (!customStyles) {
+        if (customStyles) {
+            styles = customStyles;
+        } else {
             if (openLeft && !isMobile()) {
                 styles.left = 'inherit';
                 styles.right = 0;
@@ -41,8 +43,6 @@ export default class Menu extends React.PureComponent {
                 styles.bottom = '100%';
                 styles.top = 'auto';
             }
-        } else {
-            styles = customStyles;
         }
 
         return (

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -167,12 +167,8 @@
             }
 
             .post-body__actions {
-                .MenuWrapper {
-                    .Menu {
-                        &.dropdown-menu {
-                            max-height: 80vh;
-                        }
-                    }
+                .Menu.dropdown-menu {
+                    max-height: 80vh;
                 }
             }
         }

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -165,6 +165,16 @@
                     border-right: none;
                 }
             }
+
+            .post-body__actions {
+                .MenuWrapper {
+                    .Menu {
+                        &.dropdown-menu {
+                            max-height: 80vh;
+                        }
+                    }
+                }
+            }
         }
 
         .msg-typing {


### PR DESCRIPTION
#### Summary
Overrides `<Menu>` component's style when used in `<FileUpload>` to properly display the file upload menu option when enabled in the plugin api's `registerFileUploadMethod`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14764

#### Related Pull Requests
N/A

<img width="395" alt="Screen Shot 2019-04-09 at 9 42 21 AM" src="https://user-images.githubusercontent.com/44858354/55818654-f2261400-5aab-11e9-8f17-fc6bcead0da1.png">