### PR TITLE
move MessageWillBePostedHook to doSubmit function

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -367,7 +367,10 @@ export default class CreatePost extends React.Component {
     }
 
     doSubmit = async (e) => {
-        const {actions} = this.props;
+        const {
+            actions,
+            currentUserId,
+        } = this.props;
         const channelId = this.props.currentChannel.id;
         if (e) {
             e.preventDefault();
@@ -377,12 +380,16 @@ export default class CreatePost extends React.Component {
             return;
         }
 
-        let ignoreSlash = false;
-        const serverError = this.state.serverError;
-
+        const time = Utils.getTimestamp();
+        const userId = currentUserId;
         let post = {};
         post.file_ids = [];
         post.message = this.state.message;
+        post.channel_id = channelId;
+        post.pending_post_id = `${userId}:${time}`;
+        post.user_id = userId;
+        post.create_at = time;
+        post.parent_id = this.state.parentId;
 
         if (post.message.trim().length === 0 && this.props.draft.fileInfos.length === 0) {
             return;
@@ -407,6 +414,8 @@ export default class CreatePost extends React.Component {
             return;
         }
 
+        let ignoreSlash = false;
+        const serverError = this.state.serverError;
         if (serverError && isErrorInvalidSlashCommand(serverError) && serverError.submittedMessage === post.message) {
             post.message = serverError.submittedMessage;
             ignoreSlash = true;
@@ -577,21 +586,22 @@ export default class CreatePost extends React.Component {
     sendMessage = async (originalPost) => {
         const {
             actions,
-            currentChannel,
-            currentUserId,
+
+            // currentChannel,
+            // currentUserId,
             draft,
         } = this.props;
 
         const post = originalPost;
 
-        post.channel_id = currentChannel.id;
+        // post.channel_id = currentChannel.id;
 
-        const time = Utils.getTimestamp();
-        const userId = currentUserId;
-        post.pending_post_id = `${userId}:${time}`;
-        post.user_id = userId;
-        post.create_at = time;
-        post.parent_id = this.state.parentId;
+        // const time = Utils.getTimestamp();
+        // const userId = currentUserId;
+        // post.pending_post_id = `${userId}:${time}`;
+        // post.user_id = userId;
+        // post.create_at = time;
+        // post.parent_id = this.state.parentId;
 
         // const hookResult = await actions.runMessageWillBePostedHooks(post);
 

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -413,7 +413,7 @@ describe('components/create_post', () => {
         expect(addReaction).toHaveBeenCalledWith('a', 'smile');
     });
 
-    it('onSubmit test for removeReaction message', () => {
+    it('onSubmit test for removeReaction message', async () => {
         const removeReaction = jest.fn();
 
         const wrapper = shallowWithIntl(
@@ -429,8 +429,7 @@ describe('components/create_post', () => {
             message: '-:smile:',
         });
 
-        const form = wrapper.find('#create_post');
-        form.simulate('Submit', {preventDefault: jest.fn()});
+        await wrapper.instance().handleSubmit({preventDefault: jest.fn()});
         expect(removeReaction).toHaveBeenCalledWith('a', 'smile');
     });
 


### PR DESCRIPTION
#### Summary
I was trying to intercept a message with the hook `MessageWillBePostedHook` to make one plugin that I'm developing open a dialog box when the user issue a slash command, similar we do for the `/header` for example. However, I notice when I issue the custom slash it gets executed and the hook just intercepts that after the slash return the message.

So, I was experimenting to move the hook to another part of the code and moving to the `doSubmit` seems to work, however, I'm not sure if this is the best place.
Also, we need to figure out the best place to make the same in the `create_comment`.

I will need your help @hmhealey and @crspeller 😄 