### PR TITLE
Revert elasticsearch autocompletion flag in the System Console

### DIFF
--- a/components/admin_console/elasticsearch_settings.jsx
+++ b/components/admin_console/elasticsearch_settings.jsx
@@ -36,7 +36,6 @@ export default class ElasticsearchSettings extends AdminSettings {
         config.ElasticsearchSettings.Sniff = this.state.sniff;
         config.ElasticsearchSettings.EnableIndexing = this.state.enableIndexing;
         config.ElasticsearchSettings.EnableSearching = this.state.enableSearching;
-        config.ElasticsearchSettings.EnableAutocomplete = this.state.enableAutocomplete;
 
         return config;
     }
@@ -49,7 +48,6 @@ export default class ElasticsearchSettings extends AdminSettings {
             sniff: config.ElasticsearchSettings.Sniff,
             enableIndexing: config.ElasticsearchSettings.EnableIndexing,
             enableSearching: config.ElasticsearchSettings.EnableSearching,
-            enableAutocomplete: config.ElasticsearchSettings.EnableAutocomplete,
             configTested: true,
             canSave: true,
             canPurgeAndIndex: config.ElasticsearchSettings.EnableIndexing,
@@ -61,7 +59,6 @@ export default class ElasticsearchSettings extends AdminSettings {
             if (value === false) {
                 this.setState({
                     enableSearching: false,
-                    enableAutocomplete: false,
                 });
             } else {
                 this.setState({
@@ -78,7 +75,7 @@ export default class ElasticsearchSettings extends AdminSettings {
             });
         }
 
-        if (id !== 'enableSearching' && id !== 'enableAutocomplete') {
+        if (id !== 'enableSearching') {
             this.setState({
                 canPurgeAndIndex: false,
             });
@@ -371,25 +368,6 @@ export default class ElasticsearchSettings extends AdminSettings {
                     disabled={!this.state.enableIndexing || !this.state.configTested}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.EnableSearching')}
-                />
-                <BooleanSetting
-                    id='enableAutocomplete'
-                    label={
-                        <FormattedMessage
-                            id='admin.elasticsearch.enableAutocompleteTitle'
-                            defaultMessage='Enable Elasticsearch for autocomplete queries:'
-                        />
-                    }
-                    helpText={
-                        <FormattedMessage
-                            id='admin.elasticsearch.enableAutocompleteDescription'
-                            defaultMessage='Requires a successful connection to the Elasticsearch server. When true, Elasticsearch will be used for all autocompletion queries on users and channels using the latest index. Autocompletion results may be incomplete until a bulk index of the existing users and channels database is finished. When false, database autocomplete is used.'
-                        />
-                    }
-                    value={this.state.enableAutocomplete}
-                    disabled={!this.state.enableIndexing || !this.state.configTested}
-                    onChange={this.handleSettingChanged}
-                    setByEnv={this.isSetByEnv('ElasticsearchSettings.EnableAutocomplete')}
                 />
             </SettingsGroup>
         );


### PR DESCRIPTION
#### Summary
This removes the Elasticsearch autocompletion flag in the system console

#### Related Pull Requests
- [Related server PR](https://github.com/mattermost/mattermost-server/pull/10578)
- [Related enterprise PR](https://github.com/mattermost/enterprise/pull/417)