### PR TITLE
[MM-15039] Revert react-redux to 5.1.1 fixing the issue mostly on profile pop-over and edit channel header components

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -483,7 +483,7 @@ export default class CreateComment extends React.PureComponent {
         if (allowSending) {
             e.persist();
             if (this.refs.textbox) {
-                this.refs.textbox.blur();
+                this.refs.textbox.getWrappedInstance().blur();
             }
 
             if (withClosedCodeBlock && message) {
@@ -545,7 +545,7 @@ export default class CreateComment extends React.PureComponent {
         if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && Utils.isKeyPressed(e, Constants.KeyCodes.UP) && message === '') {
             e.preventDefault();
             if (this.refs.textbox) {
-                this.refs.textbox.blur();
+                this.refs.textbox.getWrappedInstance().blur();
             }
 
             const {data: canEditNow} = this.props.onEditLatestPost();
@@ -668,8 +668,8 @@ export default class CreateComment extends React.PureComponent {
             if (index !== -1) {
                 uploadsInProgress.splice(index, 1);
 
-                if (this.refs.fileUpload && this.refs.fileUpload) {
-                    this.refs.fileUpload.cancelUpload(id);
+                if (this.refs.fileUpload && this.refs.fileUpload.getWrappedInstance()) {
+                    this.refs.fileUpload.getWrappedInstance().cancelUpload(id);
                 }
             }
         } else {
@@ -700,7 +700,7 @@ export default class CreateComment extends React.PureComponent {
     }
 
     getFileUploadTarget = () => {
-        return this.refs.textbox;
+        return this.refs.textbox.getWrappedInstance();
     }
 
     getCreateCommentControls = () => {
@@ -717,7 +717,7 @@ export default class CreateComment extends React.PureComponent {
 
     focusTextbox = (keepFocus = false) => {
         if (this.refs.textbox && (keepFocus || !UserAgent.isMobile())) {
-            this.refs.textbox.focus();
+            this.refs.textbox.getWrappedInstance().focus();
         }
     }
 

--- a/components/create_comment/create_comment.test.jsx
+++ b/components/create_comment/create_comment.test.jsx
@@ -795,7 +795,7 @@ describe('components/CreateComment', () => {
         instance.focusTextbox = jest.fn();
         const blur = jest.fn();
         const focus = jest.fn();
-        instance.refs = {textbox: {blur, focus}};
+        instance.refs = {textbox: {getWrappedInstance: () => ({blur, focus})}};
 
         const commentMsgKey = {
             preventDefault: jest.fn(),

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -350,7 +350,7 @@ export default class CreatePost extends React.Component {
 
         this.setState({orientation});
         if (prevOrientation && orientation !== prevOrientation && (document.activeElement || {}).id === 'post_textbox') {
-            this.refs.textbox.blur();
+            this.refs.textbox.getWrappedInstance().blur();
         }
     }
 
@@ -614,7 +614,7 @@ export default class CreatePost extends React.Component {
 
     focusTextbox = (keepFocus = false) => {
         if (this.refs.textbox && (keepFocus || !UserAgent.isMobile())) {
-            this.refs.textbox.focus();
+            this.refs.textbox.getWrappedInstance().focus();
         }
     }
 
@@ -632,7 +632,7 @@ export default class CreatePost extends React.Component {
         if (allowSending) {
             e.persist();
             if (this.refs.textbox) {
-                this.refs.textbox.blur();
+                this.refs.textbox.getWrappedInstance().blur();
             }
 
             if (withClosedCodeBlock && message) {
@@ -788,8 +788,8 @@ export default class CreatePost extends React.Component {
                     uploadsInProgress,
                 };
 
-                if (this.refs.fileUpload && this.refs.fileUpload) {
-                    this.refs.fileUpload.cancelUpload(id);
+                if (this.refs.fileUpload && this.refs.fileUpload.getWrappedInstance()) {
+                    this.refs.fileUpload.getWrappedInstance().cancelUpload(id);
                 }
             }
         } else {
@@ -846,7 +846,7 @@ export default class CreatePost extends React.Component {
 
     getFileUploadTarget = () => {
         if (this.refs.textbox) {
-            return this.refs.textbox;
+            return this.refs.textbox.getWrappedInstance();
         }
 
         return null;
@@ -902,7 +902,7 @@ export default class CreatePost extends React.Component {
             type = Utils.localizeMessage('create_post.post', Posts.MESSAGE_TYPES.POST);
         }
         if (this.refs.textbox) {
-            this.refs.textbox.blur();
+            this.refs.textbox.getWrappedInstance().blur();
         }
         this.props.actions.setEditingPost(lastPost.id, this.props.commentCountForPost, 'post_textbox', type);
     }

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -237,7 +237,7 @@ describe('components/create_post', () => {
 
     it('onKeyPress textbox should call emitLocalUserTypingEvent', () => {
         const wrapper = shallowWithIntl(createPost());
-        wrapper.instance().refs = {textbox: {blur: jest.fn()}};
+        wrapper.instance().refs = {textbox: {getWrappedInstance: () => ({blur: jest.fn()})}};
 
         const postTextbox = wrapper.find('#post_textbox');
         postTextbox.simulate('KeyPress', {key: KeyCodes.ENTER[0], preventDefault: jest.fn(), persist: jest.fn()});
@@ -618,7 +618,7 @@ describe('components/create_post', () => {
         }));
 
         const instance = wrapper.instance();
-        instance.refs = {textbox: {blur: jest.fn()}};
+        instance.refs = {textbox: {getWrappedInstance: () => ({blur: jest.fn()})}};
 
         instance.handleKeyDown({ctrlKey: true, key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], preventDefault: jest.fn(), persist: jest.fn()});
         setTimeout(() => {

--- a/components/edit_channel_header_modal/edit_channel_header_modal.jsx
+++ b/components/edit_channel_header_modal/edit_channel_header_modal.jsx
@@ -108,13 +108,13 @@ class EditChannelHeaderModal extends React.PureComponent {
 
     focusTextbox = () => {
         if (this.refs.editChannelHeaderTextbox) {
-            this.refs.editChannelHeaderTextbox.focus();
+            this.refs.editChannelHeaderTextbox.getWrappedInstance().focus();
         }
     }
 
     blurTextbox = () => {
         if (this.refs.editChannelHeaderTextbox) {
-            this.refs.editChannelHeaderTextbox.blur();
+            this.refs.editChannelHeaderTextbox.getWrappedInstance().blur();
         }
     }
 

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -238,7 +238,9 @@ export default class EditPostModal extends React.PureComponent {
     }
 
     setEditboxRef = (ref) => {
-        this.editbox = ref;
+        if (ref && ref.getWrappedInstance) {
+            this.editbox = ref.getWrappedInstance();
+        }
 
         if (this.editbox) {
             this.editbox.focus();

--- a/components/file_upload/index.js
+++ b/components/file_upload/index.js
@@ -36,4 +36,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(FileUpload);
+export default connect(mapStateToProps, mapDispatchToProps, null, {withRef: true})(FileUpload);

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -384,7 +384,7 @@ export default class Sidebar extends React.PureComponent {
     }
 
     updateScrollbarOnChannelChange = (channelId) => {
-        const curChannel = this.refs[channelId].refs.channel.getBoundingClientRect();
+        const curChannel = this.refs[channelId].getWrappedInstance().refs.channel.getBoundingClientRect();
         if ((curChannel.top - Constants.CHANNEL_SCROLL_ADJUSTMENT < 0) || (curChannel.top + curChannel.height > this.refs.scrollbar.view.getBoundingClientRect().height)) {
             this.refs.scrollbar.scrollTop(this.refs.scrollbar.view.scrollTop + (curChannel.top - Constants.CHANNEL_SCROLL_ADJUSTMENT));
         }

--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -136,4 +136,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(makeMapStateToProps, mapDispatchToProps, null, {forwardRef: true})(SidebarChannel);
+export default connect(makeMapStateToProps, mapDispatchToProps, null, {withRef: true})(SidebarChannel);

--- a/components/textbox/index.js
+++ b/components/textbox/index.js
@@ -27,4 +27,4 @@ const mapDispatchToProps = (dispatch) => ({
     }, dispatch),
 });
 
-export default connect(makeMapStateToProps, mapDispatchToProps, null, {forwardRef: true})(Textbox);
+export default connect(makeMapStateToProps, mapDispatchToProps, null, {withRef: true})(Textbox);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6635,7 +6635,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6656,12 +6657,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6676,17 +6679,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6803,7 +6809,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6815,6 +6822,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6829,6 +6837,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6836,12 +6845,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6860,6 +6871,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6940,7 +6952,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6952,6 +6965,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7037,7 +7051,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7073,6 +7088,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7092,6 +7108,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7135,12 +7152,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10520,12 +10539,12 @@
       "from": "github:mattermost/mattermost-redux#e360489890ae65b9223c6d30a2e6184ccacf51db",
       "requires": {
         "deep-equal": "1.0.1",
-        "eslint-plugin-header": "2.0.0",
+        "eslint-plugin-header": "3.0.0",
         "form-data": "2.3.3",
         "gfycat-sdk": "1.4.18",
         "harmony-reflect": "1.6.1",
         "isomorphic-fetch": "2.2.1",
-        "mime-db": "1.37.0",
+        "mime-db": "1.38.0",
         "redux": "4.0.1",
         "redux-action-buffer": "1.2.0",
         "redux-batched-actions": "0.4.1",
@@ -10533,14 +10552,19 @@
         "redux-persist": "4.9.1",
         "redux-thunk": "2.3.0",
         "reselect": "4.0.0",
-        "serialize-error": "2.1.0",
+        "serialize-error": "4.0.0",
         "shallow-equals": "1.0.0"
       },
       "dependencies": {
         "eslint-plugin-header": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-2.0.0.tgz",
-          "integrity": "sha512-vISfrajZaWRmToJ3GLULhnrwuaBmDap3arHf2+q0uMW2W+YSjFuCKzh/BcP3Ea5UPT8wN0S8uGz/I+QJkKBIoA=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz",
+          "integrity": "sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ=="
+        },
+        "mime-db": {
+          "version": "1.38.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+          "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
         },
         "redux-persist": {
           "version": "4.9.1",
@@ -10550,6 +10574,14 @@
             "json-stringify-safe": "^5.0.1",
             "lodash": "^4.17.4",
             "lodash-es": "^4.17.4"
+          }
+        },
+        "serialize-error": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-4.0.0.tgz",
+          "integrity": "sha512-MlfOQdCHn71EAG1vraIldjW4jg+ZgvxtQNd/u66QEydFaDN9W+wDMhis7nJl4kOZjxMg38coU/8RbssCeJ0leQ==",
+          "requires": {
+            "type-fest": "^0.3.0"
           }
         }
       }
@@ -10811,7 +10843,8 @@
     "mime-db": {
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.22",
@@ -12910,16 +12943,17 @@
       }
     },
     "react-redux": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-6.0.1.tgz",
-      "integrity": "sha512-T52I52Kxhbqy/6TEfBv85rQSDz6+Y28V/pf52vDWs1YRXG19mcFOGfHnY2HsNFHyhP+ST34Aih98fvt6tqwVcQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
+      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "hoist-non-react-statics": "^3.3.0",
+        "@babel/runtime": "^7.1.2",
+        "hoist-non-react-statics": "^3.1.0",
         "invariant": "^2.2.4",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.2"
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.1",
+        "react-is": "^16.6.0",
+        "react-lifecycles-compat": "^3.0.0"
       }
     },
     "react-router": {
@@ -14050,11 +14084,6 @@
       "requires": {
         "semver": "^5.3.0"
       }
-    },
-    "serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serialize-javascript": {
       "version": "1.6.1",
@@ -15518,6 +15547,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-day-picker": "7.3.0",
     "react-dom": "16.8.6",
     "react-intl": "2.8.0",
-    "react-redux": "6.0.1",
+    "react-redux": "5.1.1",
     "react-router-dom": "5.0.0",
     "react-select": "2.4.2",
     "react-transition-group": "2.7.1",


### PR DESCRIPTION
#### Summary
Seems to be related to recent update of react-redux to v6.0.1 which might not be compatible with react-bootstrap@0.32.4 (per [react-redux discussion](https://github.com/reduxjs/react-redux/issues/1083#issuecomment-441312159)).

I'd suggest to upgrade react-redux to v6/v7 once react-bootstrap releases the stable version of v1.

#### Ticket Link
Jira - [MM-15039](https://mattermost.atlassian.net/browse/MM-15039)
