### PR TITLE
[MM-14733] Fetch Config after Login to fix race permission for MFA Enforce Screen

### DIFF
--- a/components/logged_in/index.js
+++ b/components/logged_in/index.js
@@ -3,6 +3,7 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {getClientConfig} from 'mattermost-redux/actions/general';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -30,6 +31,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             autoUpdateTimezone,
+            getClientConfig,
         }, dispatch),
     };
 }

--- a/components/logged_in/logged_in.jsx
+++ b/components/logged_in/logged_in.jsx
@@ -28,6 +28,7 @@ export default class LoggedIn extends React.PureComponent {
         enableTimezone: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             autoUpdateTimezone: PropTypes.func.isRequired,
+            getClientConfig: PropTypes.func.isRequired,
         }).isRequired,
         showTermsOfService: PropTypes.bool.isRequired,
     }
@@ -52,6 +53,9 @@ export default class LoggedIn extends React.PureComponent {
         if (this.props.enableTimezone) {
             this.props.actions.autoUpdateTimezone(getBrowserTimezone());
         }
+
+        // Fetch new client config to avoid that Enforce MFA Updates are not synced to client during login flow
+        this.props.actions.getClientConfig();
 
         // Make sure the websockets close and reset version
         $(window).on('beforeunload',

--- a/components/logged_in/logged_in.test.jsx
+++ b/components/logged_in/logged_in.test.jsx
@@ -18,6 +18,7 @@ describe('components/logged_in/LoggedIn', () => {
         enableTimezone: false,
         actions: {
             autoUpdateTimezone: jest.fn(),
+            getClientConfig: jest.fn(),
         },
         showTermsOfService: false,
         location: {


### PR DESCRIPTION
#### Summary
Currently the config is initially fetched, when the user then idles for some time on the login screen and during that time the admin enables `EnforceMFA`, the user won't be redirected to the enforce MFA screen. In order to fix this, after the Login was successful we fetch the client config another time to ensure the latest settings are available in the client.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14733
