### PR TITLE
MM-15041 Fix for center channel to be at last post when textbox expands

### DIFF
--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -14,6 +14,7 @@ import CommandProvider from 'components/suggestion/command_provider.jsx';
 import EmoticonProvider from 'components/suggestion/emoticon_provider.jsx';
 import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
 import SuggestionList from 'components/suggestion/suggestion_list.jsx';
+import {postListScrollChange} from 'actions/global_actions';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -114,6 +115,7 @@ export default class Textbox extends React.Component {
     }
 
     handleHeightChange = (height, maxHeight) => {
+        postListScrollChange();
         if (this.props.onHeightChange) {
             this.props.onHeightChange(height, maxHeight);
         }


### PR DESCRIPTION
#### Summary
This should have been a part of https://github.com/mattermost/mattermost-webapp/pull/2622/files with changes from https://github.com/mattermost/mattermost-webapp/pull/2447/files#diff-4ad88f36a09a5f303774e31aa60afd2cL119 lines. This change was lost during a conflict resolution with
https://github.com/mattermost/mattermost-webapp/pull/2531 

#### Ticket Link
[MM-15041](https://mattermost.atlassian.net/browse/MM-15041)

