### PR TITLE
MM-14880 Fix Recent posts being hidden on decrease of window height

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -683,7 +683,6 @@
     @include clearfix;
     display: table;
     height: 100%;
-    min-height: 350px;
     padding-bottom: .5em;
     table-layout: fixed;
     width: 100%;


### PR DESCRIPTION
#### Summary
Removing the min-height of 350px. With changes to virtlist the height of child div is viewport height so min-height causes issue
<img width="839" alt="Screenshot 2019-04-11 at 12 14 20 AM" src="https://user-images.githubusercontent.com/4973621/55905072-d8d9b080-5bee-11e9-8fb9-d95f16fbe797.png">

#### Ticket Link
[MM-14880](https://mattermost.atlassian.net/browse/MM-14880)

