### PR TITLE
MM-15068: Impossible to join directly to team by url if is not in the first 200 visible teams

### DIFF
--- a/components/needs_team/index.js
+++ b/components/needs_team/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 import {withRouter} from 'react-router-dom';
 
 import {fetchMyChannelsAndMembers, markChannelAsRead, viewChannel} from 'mattermost-redux/actions/channels';
-import {getMyTeamUnreads, getTeams, selectTeam} from 'mattermost-redux/actions/teams';
+import {getMyTeamUnreads, getTeamByName, selectTeam} from 'mattermost-redux/actions/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
@@ -42,7 +42,7 @@ function mapDispatchToProps(dispatch) {
             getMyTeamUnreads,
             viewChannel,
             markChannelAsRead,
-            getTeams,
+            getTeamByName,
             addUserToTeam,
             setPreviousTeamId,
             selectTeam,

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -24,7 +24,6 @@ let lastTime = (new Date()).getTime();
 const WAKEUP_CHECK_INTERVAL = 30000; // 30 seconds
 const WAKEUP_THRESHOLD = 60000; // 60 seconds
 const UNREAD_CHECK_TIME_MILLISECONDS = 10000;
-const TEAMS_PER_PAGE = 200;
 
 export default class NeedsTeam extends React.Component {
     static propTypes = {
@@ -38,7 +37,7 @@ export default class NeedsTeam extends React.Component {
             getMyTeamUnreads: PropTypes.func.isRequired,
             viewChannel: PropTypes.func.isRequired,
             markChannelAsRead: PropTypes.func.isRequired,
-            getTeams: PropTypes.func.isRequired,
+            getTeamByName: PropTypes.func.isRequired,
             addUserToTeam: PropTypes.func.isRequired,
             selectTeam: PropTypes.func.isRequired,
             setPreviousTeamId: PropTypes.func.isRequired,
@@ -159,8 +158,7 @@ export default class NeedsTeam extends React.Component {
     }
 
     joinTeam = async (props) => {
-        const openTeams = await this.props.actions.getTeams(0, TEAMS_PER_PAGE);
-        const team = openTeams.data.find((teamObj) => teamObj.name === props.match.params.team);
+        const {data: team} = await this.props.actions.getTeamByName(props.match.params.team);
         if (team) {
             const {error} = await props.actions.addUserToTeam(team.id, props.currentUser && props.currentUser.id);
             if (error) {

--- a/components/needs_team/needs_team.test.jsx
+++ b/components/needs_team/needs_team.test.jsx
@@ -45,21 +45,18 @@ describe('components/needs_team', () => {
         },
     };
 
-    const teamData = [
-        ...teamsList,
-        {
-            id: 'kemjcpu9bi877yegqjs18ndp4d',
-            invite_id: 'kemjcpu9bi877yegqjs18ndp4a',
-            name: 'new',
-        },
-    ];
+    const teamData = {
+        id: 'kemjcpu9bi877yegqjs18ndp4d',
+        invite_id: 'kemjcpu9bi877yegqjs18ndp4a',
+        name: 'new',
+    };
 
     const actions = {
         fetchMyChannelsAndMembers: jest.fn().mockResolvedValue({data: true}),
         getMyTeamUnreads: jest.fn(),
         viewChannel: jest.fn(),
         markChannelAsRead: jest.fn(),
-        getTeams: jest.fn().mockResolvedValue({data: teamData}),
+        getTeamByName: jest.fn().mockResolvedValue({data: teamData}),
         addUserToTeam: jest.fn().mockResolvedValue({data: true}),
         selectTeam: jest.fn(),
         setPreviousTeamId: jest.fn(),


### PR DESCRIPTION
#### Summary
Before this commit to try to join a team we get the list of teams (limited to
200), and match the correct team using the name. Now we get directly the team
by name, this allow us to join any team, not only that teams that are in the
list of the first 200 teams.

#### Ticket Link
[MM-15068](https://mattermost.atlassian.net/browse/MM-15068)