### PR TITLE
[MM-15013] Show recently used emojis first in suggestions

### DIFF
--- a/components/suggestion/emoticon_provider.jsx
+++ b/components/suggestion/emoticon_provider.jsx
@@ -16,8 +16,8 @@ import {compareEmojis} from 'utils/emoji_utils.jsx';
 import Suggestion from './suggestion.jsx';
 import Provider from './provider.jsx';
 
-const MIN_EMOTICON_LENGTH = 2;
-const EMOJI_CATEGORY_SUGGESTION_BLACKLIST = ['skintone'];
+export const MIN_EMOTICON_LENGTH = 2;
+export const EMOJI_CATEGORY_SUGGESTION_BLACKLIST = ['skintone'];
 
 class EmoticonSuggestion extends Suggestion {
     render() {
@@ -99,11 +99,15 @@ export default class EmoticonProvider extends Provider {
 
         // Check for named emoji
         for (const [name, emoji] of emojiMap) {
+            if (EMOJI_CATEGORY_SUGGESTION_BLACKLIST.includes(emoji.category)) {
+                continue;
+            }
+
             if (emoji.aliases) {
                 // This is a system emoji so it may have multiple names
                 for (const alias of emoji.aliases) {
-                    if (!EMOJI_CATEGORY_SUGGESTION_BLACKLIST.includes(emoji.category) && alias.indexOf(partialName) !== -1) {
-                        const matchedArray = recentEmojis.includes(alias) ?
+                    if (alias.indexOf(partialName) !== -1) {
+                        const matchedArray = recentEmojis.includes(alias) || recentEmojis.includes(name) ?
                             recentMatched :
                             matched;
 
@@ -118,7 +122,11 @@ export default class EmoticonProvider extends Provider {
                     continue;
                 }
 
-                matched.push({name, emoji});
+                const matchedArray = recentEmojis.includes(name) ?
+                    recentMatched :
+                    matched;
+
+                matchedArray.push({name, emoji});
             }
         }
 

--- a/components/suggestion/emoticon_provider.test.jsx
+++ b/components/suggestion/emoticon_provider.test.jsx
@@ -1,0 +1,174 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import EmojiMap from 'utils/emoji_map';
+import {getEmojiMap, getRecentEmojis} from 'selectors/emojis';
+
+import EmoticonProvider, {
+    MIN_EMOTICON_LENGTH,
+    EMOJI_CATEGORY_SUGGESTION_BLACKLIST,
+} from 'components/suggestion/emoticon_provider.jsx';
+
+jest.mock('selectors/emojis', () => ({
+    getEmojiMap: jest.fn(),
+    getRecentEmojis: jest.fn(),
+}));
+
+describe('components/EmoticonProvider', () => {
+    const resultsCallback = jest.fn();
+    const emoticonProvider = new EmoticonProvider();
+    const customEmojis = new Map([
+        ['thumbsdown-custom', {name: 'thumbsdown-custom', category: 'custom'}],
+        ['thumbsup-custom', {name: 'thumbsup-custom', category: 'custom'}],
+        ['lithuania-custom', {name: 'lithuania-custom', category: 'custom'}],
+    ]);
+    const emojiMap = new EmojiMap(customEmojis);
+
+    it('should not suggest emojis when partial name < MIN_EMOTICON_LENGTH', () => {
+        for (let i = 0; i < MIN_EMOTICON_LENGTH; i++) {
+            const pretext = `:${'s'.repeat(i)}`;
+            emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+            expect(resultsCallback).not.toHaveBeenCalled();
+        }
+    });
+
+    it('should suggest emojis when partial name >= MIN_EMOTICON_LENGTH', () => {
+        getEmojiMap.mockReturnValue(emojiMap);
+        getRecentEmojis.mockReturnValue([]);
+
+        for (const i of [MIN_EMOTICON_LENGTH, MIN_EMOTICON_LENGTH + 1]) {
+            const pretext = `:${'s'.repeat(i)}`;
+
+            emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+            expect(resultsCallback).toHaveBeenCalled();
+        }
+    });
+
+    it('should order suggested emojis', () => {
+        const pretext = ':thu';
+        const recentEmojis = ['smile'];
+        getEmojiMap.mockReturnValue(emojiMap);
+        getRecentEmojis.mockReturnValue(recentEmojis);
+
+        emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+        expect(resultsCallback).toHaveBeenCalled();
+        const args = resultsCallback.mock.calls[0][0];
+        expect(args.items.length).toEqual(6);
+        expect(args.items[0].name).toEqual('thumbsdown');
+        expect(args.items[1].name).toEqual('thumbsdown-custom');
+        expect(args.items[2].name).toEqual('thumbsup');
+        expect(args.items[3].name).toEqual('thumbsup-custom');
+        expect(args.items[4].name).toEqual('lithuania');
+        expect(args.items[5].name).toEqual('lithuania-custom');
+    });
+
+    it('should not suggest emojis if no match', () => {
+        const pretext = ':supercalifragilisticexpialidocious';
+        const recentEmojis = ['smile'];
+
+        getEmojiMap.mockReturnValue(emojiMap);
+        getRecentEmojis.mockReturnValue(recentEmojis);
+
+        emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+        expect(resultsCallback).toHaveBeenCalled();
+        const args = resultsCallback.mock.calls[0][0];
+        expect(args.items.length).toEqual(0);
+    });
+
+    it('should exclude blackisted emojis from suggested emojis', () => {
+        const pretext = ':blacklisted';
+        const recentEmojis = ['blacklisted-1'];
+
+        const blacklistedEmojis = EMOJI_CATEGORY_SUGGESTION_BLACKLIST.map((category, index) => {
+            const name = `blacklisted-${index}`;
+            return [name, {name, category}];
+        });
+        const customEmojisWithBlacklist = new Map([
+            ...blacklistedEmojis,
+            ['not-blacklisted', {name: 'not-blacklisted', category: 'custom'}],
+        ]);
+        const emojiMapWithBlacklist = new EmojiMap(customEmojisWithBlacklist);
+
+        getEmojiMap.mockReturnValue(emojiMapWithBlacklist);
+        getRecentEmojis.mockReturnValue(recentEmojis);
+
+        emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+        expect(resultsCallback).toHaveBeenCalled();
+        const args = resultsCallback.mock.calls[0][0];
+        expect(args.items.length).toEqual(1);
+        expect(args.items[0].name).toEqual('not-blacklisted');
+    });
+
+    it('should suggest emojis ordered by recently used first (system only)', () => {
+        const pretext = ':thu';
+        const emojis = ['lithuania', 'smile'];
+        for (const thumbsup of ['+1', 'thumbsup']) {
+            const recentEmojis = [...emojis, thumbsup];
+            getEmojiMap.mockReturnValue(emojiMap);
+            getRecentEmojis.mockReturnValue(recentEmojis);
+
+            emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+            expect(resultsCallback).toHaveBeenCalled();
+            const args = resultsCallback.mock.calls[0][0];
+            expect(args.items.length).toEqual(6);
+            expect(args.items[0].name).toEqual('thumbsup');
+            expect(args.items[1].name).toEqual('lithuania');
+            expect(args.items[2].name).toEqual('thumbsdown');
+            expect(args.items[3].name).toEqual('thumbsdown-custom');
+            expect(args.items[4].name).toEqual('thumbsup-custom');
+            expect(args.items[5].name).toEqual('lithuania-custom');
+        }
+    });
+
+    it('should suggest emojis ordered by recently used first (custom only)', () => {
+        const pretext = ':thu';
+        const recentEmojis = ['lithuania-custom', 'thumbsdown-custom', 'smile'];
+        getEmojiMap.mockReturnValue(emojiMap);
+        getRecentEmojis.mockReturnValue(recentEmojis);
+
+        emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+        expect(resultsCallback).toHaveBeenCalled();
+        const args = resultsCallback.mock.calls[0][0];
+        expect(args.items.length).toEqual(6);
+        expect(args.items[0].name).toEqual('thumbsdown-custom');
+        expect(args.items[1].name).toEqual('lithuania-custom');
+        expect(args.items[2].name).toEqual('thumbsdown');
+        expect(args.items[3].name).toEqual('thumbsup');
+        expect(args.items[4].name).toEqual('thumbsup-custom');
+        expect(args.items[5].name).toEqual('lithuania');
+    });
+
+    it('should suggest emojis ordered by recently used first (custom and system)', () => {
+        const pretext = ':thu';
+        const recentEmojis = ['thumbsdown-custom', 'lithuania-custom', 'thumbsup', '-1', 'smile'];
+        getEmojiMap.mockReturnValue(emojiMap);
+        getRecentEmojis.mockReturnValue(recentEmojis);
+
+        emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+        expect(resultsCallback).toHaveBeenCalled();
+        const args = resultsCallback.mock.calls[0][0];
+        expect(args.items.length).toEqual(6);
+        expect(args.items[0].name).toEqual('thumbsdown');
+        expect(args.items[1].name).toEqual('thumbsdown-custom');
+        expect(args.items[2].name).toEqual('thumbsup');
+        expect(args.items[3].name).toEqual('lithuania-custom');
+        expect(args.items[4].name).toEqual('thumbsup-custom');
+        expect(args.items[5].name).toEqual('lithuania');
+    });
+
+    it('should suggest emojis ordered by recently used first with partial name match', () => {
+        const pretext = ':umbs';
+        const recentEmojis = ['lithuania-custom', 'thumbsup-custom', '+1', 'smile'];
+        getEmojiMap.mockReturnValue(emojiMap);
+        getRecentEmojis.mockReturnValue(recentEmojis);
+
+        emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+        expect(resultsCallback).toHaveBeenCalled();
+        const args = resultsCallback.mock.calls[0][0];
+        expect(args.items.length).toEqual(4);
+        expect(args.items[0].name).toEqual('thumbsup');
+        expect(args.items[1].name).toEqual('thumbsup-custom');
+        expect(args.items[2].name).toEqual('thumbsdown');
+        expect(args.items[3].name).toEqual('thumbsdown-custom');
+    });
+});


### PR DESCRIPTION
#### Summary
In order to check if the alias exists in recents, the alias must first contain the partial name. For an emoji like thumbsup which is saved in recents as `+1` and has aliases `+1` and `thumbsup`, a partial name of `thu` will only match the `thumbsup` alias, however, the check for this alias in recents will fail. With this PR I also check if the name exists in recents so that the emoji is included in the suggested results. I've also applied this name check for custom emojis so that they too are included first if recently used.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15013

