### PR TITLE
MM-14929 Fix shortened image links not showing a preview

### DIFF
--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -73,10 +73,12 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         const {metadata} = props.post;
         const embedMetadata = metadata && metadata.embeds && metadata.embeds[0];
         const link = embedMetadata && embedMetadata.url ? embedMetadata.url : Utils.extractFirstLink(props.post.message);
+        const isMetadataImage = embedMetadata && embedMetadata.url ? embedMetadata.type === 'image' : false;
         this.state = {
             link,
             linkLoadError: false,
             linkLoaded: false,
+            isMetadataImage,
         };
     }
 
@@ -187,6 +189,10 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
             return false;
         }
 
+        if (this.state.isMetadataImage) {
+            return true;
+        }
+
         if (YoutubeVideo.isYoutubeLink(link)) {
             return true;
         }
@@ -229,7 +235,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
             );
         }
 
-        if (this.isLinkImage(link)) {
+        if (this.isLinkImage(link) || this.state.isMetadataImage) {
             const dimensions = this.props.post.metadata && this.props.post.metadata.images && this.props.post.metadata.images[link];
             return (
                 <PostImage


### PR DESCRIPTION
#### Summary
The PostBodyAdditionalContent was treating these links as opengraph links since the links didn't look like images to it. The fix is to check if the type of the embed is image and use that as a condition.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14929