### PR TITLE
[MM-15077] Make the DOM structure of "Mute Channel" and "Leave Channel" be the same with other menu items at channel dropdown

### DIFF
--- a/components/channel_header_dropdown/menu_items/leave_channel/leave_channel.js
+++ b/components/channel_header_dropdown/menu_items/leave_channel/leave_channel.js
@@ -24,6 +24,11 @@ export default class LeaveChannel extends React.PureComponent {
         isDefault: PropTypes.bool.isRequired,
 
         /**
+         * Use for test selector
+         */
+        id: PropTypes.string,
+
+        /**
          * Object with action creators
          */
         actions: PropTypes.shape({
@@ -53,10 +58,11 @@ export default class LeaveChannel extends React.PureComponent {
     }
 
     render() {
-        const {channel, isDefault} = this.props;
+        const {channel, isDefault, id} = this.props;
 
         return (
             <MenuItemAction
+                id={id}
                 show={!isDefault && channel.type !== Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL}
                 onClick={this.handleLeave}
                 text={localizeMessage('channel_header.leave', 'Leave Channel')}

--- a/components/channel_header_dropdown/menu_items/toggle_mute_channel/toggle_mute_channel.js
+++ b/components/channel_header_dropdown/menu_items/toggle_mute_channel/toggle_mute_channel.js
@@ -29,6 +29,11 @@ export default class MenuItemToggleMuteChannel extends React.PureComponent {
         isMuted: PropTypes.bool.isRequired,
 
         /**
+         * Use for test selector
+         */
+        id: PropTypes.string,
+
+        /**
          * Object with action creators
          */
         actions: PropTypes.shape({
@@ -52,8 +57,14 @@ export default class MenuItemToggleMuteChannel extends React.PureComponent {
     }
 
     render() {
+        const {
+            channel,
+            id,
+            isMuted,
+        } = this.props;
+
         let text;
-        if (this.props.isMuted) {
+        if (isMuted) {
             text = localizeMessage('channel_header.unmute', 'Unmute Channel');
         } else {
             text = localizeMessage('channel_header.mute', 'Mute Channel');
@@ -61,7 +72,8 @@ export default class MenuItemToggleMuteChannel extends React.PureComponent {
 
         return (
             <MenuItemAction
-                show={this.props.channel.type !== Constants.DM_CHANNEL}
+                id={id}
+                show={channel.type !== Constants.DM_CHANNEL}
                 onClick={this.handleClick}
                 text={text}
             />

--- a/components/widgets/menu/menu_items/menu_item_action.jsx
+++ b/components/widgets/menu/menu_items/menu_item_action.jsx
@@ -6,12 +6,13 @@ import PropTypes from 'prop-types';
 
 import menuItem from './menu_item.jsx';
 
-export const MenuItemActionImpl = ({onClick, text, extraText}) => (
+export const MenuItemActionImpl = ({onClick, text, extraText, id}) => (
     <button
+        id={id}
         className={'style--none' + (extraText ? ' MenuItem__help' : '')}
         onClick={onClick}
     >
-        <span>{text}</span>
+        {text}
         {extraText && <span className='extra-text'>{extraText}</span>}
     </button>
 );
@@ -19,6 +20,7 @@ MenuItemActionImpl.propTypes = {
     onClick: PropTypes.func.isRequired,
     text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
     extraText: PropTypes.string,
+    id: PropTypes.string,
 };
 
 const MenuItemAction = menuItem(MenuItemActionImpl);

--- a/components/widgets/menu/menu_items/menu_item_action.test.jsx
+++ b/components/widgets/menu/menu_items/menu_item_action.test.jsx
@@ -20,9 +20,7 @@ describe('components/MenuItemAction', () => {
   className="style--none"
   onClick={[MockFunction]}
 >
-  <span>
-    Whatever
-  </span>
+  Whatever
 </button>
 `);
     });
@@ -40,9 +38,7 @@ describe('components/MenuItemAction', () => {
   className="style--none MenuItem__help"
   onClick={[MockFunction]}
 >
-  <span>
-    Whatever
-  </span>
+  Whatever
   <span
     className="extra-text"
   >


### PR DESCRIPTION
#### Summary
Make the DOM structure of "Mute Channel" and "Leave Channel" be the same with other menu items at channel dropdown.
- no visual side-effect (tested)
- that makes it easier for Selenium testing (UI automation in general)
- make the ID (already in placed) take effect into those menu items 

#### Ticket Link
Jira: [MM-15077](https://mattermost.atlassian.net/browse/MM-15077)

Before:
![Screen Shot 2019-04-12 at 1 03 21 AM](https://user-images.githubusercontent.com/5334504/56042270-41e73280-5d6d-11e9-97e3-62fb4f1fcaaa.png)

After:
![Screen Shot 2019-04-12 at 1 21 48 AM](https://user-images.githubusercontent.com/5334504/56042284-490e4080-5d6d-11e9-9e0f-440123e2b45c.png)


