### PR TITLE
MM-14484 Remove download attribute from Open external image link

### DIFF
--- a/components/view_image/popover_bar/__snapshots__/popover_bar.test.jsx.snap
+++ b/components/view_image/popover_bar/__snapshots__/popover_bar.test.jsx.snap
@@ -23,7 +23,6 @@ exports[`components/view_image/popover_bar/PopoverBar should match snapshot for 
   >
     <a
       className="text"
-      download="img.png"
       href=""
       rel="noopener noreferrer"
       target="_blank"

--- a/components/view_image/popover_bar/popover_bar.jsx
+++ b/components/view_image/popover_bar/popover_bar.jsx
@@ -57,8 +57,11 @@ export default class PopoverBar extends React.PureComponent {
 
         let downloadLinks = null;
         if (this.props.canDownloadFiles) {
+            const shouldOpenFile = this.props.isExternalFile && !this.props.isDesktopApp;
+
             let downloadLinkText;
-            if (this.props.isExternalFile && !this.props.isDesktopApp) {
+            const downloadLinkProps = {};
+            if (shouldOpenFile) {
                 downloadLinkText = (
                     <FormattedMessage
                         id='view_image_popover.open'
@@ -72,6 +75,8 @@ export default class PopoverBar extends React.PureComponent {
                         defaultMessage='Download'
                     />
                 );
+
+                downloadLinkProps.download = this.props.filename;
             }
 
             downloadLinks = (
@@ -79,10 +84,10 @@ export default class PopoverBar extends React.PureComponent {
                     {publicLink}
                     <a
                         href={this.props.fileURL}
-                        download={this.props.filename}
                         className='text'
                         target='_blank'
                         rel='noopener noreferrer'
+                        {...downloadLinkProps}
                     >
                         {downloadLinkText}
                     </a>


### PR DESCRIPTION
The browser will attempt to download a linked file if that link has the download attribute. We were incorrectly specifying that attribute on a link that should just open an external image.

I'm not sure why this worked correctly (ie it just opened the file) for images that weren't served through the local image proxy, but it's possible it's some browser thing that prevents files from other domains from being downloaded this way.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14484