### PR TITLE
[MM-14842] fix dismissing the tooltip when clicking the button

### DIFF
--- a/components/link_tooltip/link_tooltip.jsx
+++ b/components/link_tooltip/link_tooltip.jsx
@@ -45,7 +45,11 @@ export default class LinkTooltip extends React.PureComponent {
 
                 tooltipContainer.show();
                 tooltipContainer.children().on('mouseover', () => clearTimeout(this.hideTimeout));
-                tooltipContainer.children().on('mouseleave', this.hideTooltip);
+                tooltipContainer.children().on('mouseleave', (event) => {
+                    if (event.toElement !== null) {
+                        this.hideTooltip();
+                    }
+                });
 
                 this.popper = new Popper(target, tooltipContainer, {
                     placement: 'bottom',


### PR DESCRIPTION
#### Summary
This PR fixes dismissing the tooltip when clicking the button a few times on the Windows desktop app. It was caused by a bug in older versions of Chromium and currently used in Electron. Sometimes a `click` event fires a `mouseleave` event. I saw that this "self-fired" `mouseleave` event has null in the `toElement` property, so I just added a condition to hide the tooltip only if the `toElement` property of the `mouseleave` event is not null.

Tested on the Windows Desktop app on 4.3 and now it works as expected. I also tested it on Safari, Mac Desktop App, Chrome and Firefox just for sure.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10603
