### PR TITLE
MM-14635 Automated test using cypress for Channel name already exists

### DIFF
--- a/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
+++ b/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
@@ -1926,13 +1926,13 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
             </p>
             <div
               className="form-group has-error"
-              id="createChannelError"
             >
               <div
                 className="col-sm-12"
               >
                 <p
                   className="input__help error"
+                  id="createChannelError"
                 >
                   server error
                 </p>

--- a/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
+++ b/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
@@ -130,7 +130,7 @@ exports[`components/NewChannelModal should match snapshot, display only private 
             <LocalizedInput
               autoFocus={true}
               className="form-control"
-              id="newPublicChannelName"
+              id="newChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -193,7 +193,7 @@ exports[`components/NewChannelModal should match snapshot, display only private 
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelPurpose"
+              id="newChannelPurpose"
               maxLength="250"
               onChange={[Function]}
               placeholder="E.g.: \\"A channel to file bugs and improvements\\""
@@ -242,7 +242,7 @@ exports[`components/NewChannelModal should match snapshot, display only private 
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelHeader"
+              id="newChannelHeader"
               maxLength="1024"
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
@@ -268,6 +268,7 @@ exports[`components/NewChannelModal should match snapshot, display only private 
       >
         <button
           className="btn btn-link"
+          id="cancelNewChannel"
           onBlur={[Function]}
           onClick={[MockFunction]}
           tabIndex="8"
@@ -281,6 +282,7 @@ exports[`components/NewChannelModal should match snapshot, display only private 
         </button>
         <button
           className="btn btn-primary"
+          id="submitNewChannel"
           onClick={[Function]}
           tabIndex="4"
           type="submit"
@@ -427,7 +429,7 @@ exports[`components/NewChannelModal should match snapshot, display only public c
             <LocalizedInput
               autoFocus={true}
               className="form-control"
-              id="newPublicChannelName"
+              id="newChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -490,7 +492,7 @@ exports[`components/NewChannelModal should match snapshot, display only public c
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelPurpose"
+              id="newChannelPurpose"
               maxLength="250"
               onChange={[Function]}
               placeholder="E.g.: \\"A channel to file bugs and improvements\\""
@@ -539,7 +541,7 @@ exports[`components/NewChannelModal should match snapshot, display only public c
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelHeader"
+              id="newChannelHeader"
               maxLength="1024"
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
@@ -565,6 +567,7 @@ exports[`components/NewChannelModal should match snapshot, display only public c
       >
         <button
           className="btn btn-link"
+          id="cancelNewChannel"
           onBlur={[Function]}
           onClick={[MockFunction]}
           tabIndex="8"
@@ -578,6 +581,7 @@ exports[`components/NewChannelModal should match snapshot, display only public c
         </button>
         <button
           className="btn btn-primary"
+          id="submitNewChannel"
           onClick={[Function]}
           tabIndex="4"
           type="submit"
@@ -764,7 +768,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
             <LocalizedInput
               autoFocus={true}
               className="form-control"
-              id="newPublicChannelName"
+              id="newChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -827,7 +831,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelPurpose"
+              id="newChannelPurpose"
               maxLength="250"
               onChange={[Function]}
               placeholder="E.g.: \\"A channel to file bugs and improvements\\""
@@ -876,7 +880,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelHeader"
+              id="newChannelHeader"
               maxLength="1024"
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
@@ -902,6 +906,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
       >
         <button
           className="btn btn-link"
+          id="cancelNewChannel"
           onBlur={[Function]}
           onClick={[MockFunction]}
           tabIndex="8"
@@ -915,6 +920,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
         </button>
         <button
           className="btn btn-primary"
+          id="submitNewChannel"
           onClick={[Function]}
           tabIndex="4"
           type="submit"
@@ -1101,7 +1107,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
             <LocalizedInput
               autoFocus={true}
               className="form-control"
-              id="newPublicChannelName"
+              id="newChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -1164,7 +1170,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelPurpose"
+              id="newChannelPurpose"
               maxLength="250"
               onChange={[Function]}
               placeholder="E.g.: \\"A channel to file bugs and improvements\\""
@@ -1213,7 +1219,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelHeader"
+              id="newChannelHeader"
               maxLength="1024"
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
@@ -1239,6 +1245,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
       >
         <button
           className="btn btn-link"
+          id="cancelNewChannel"
           onBlur={[Function]}
           onClick={[MockFunction]}
           tabIndex="8"
@@ -1252,6 +1259,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
         </button>
         <button
           className="btn btn-primary"
+          id="submitNewChannel"
           onClick={[Function]}
           tabIndex="4"
           type="submit"
@@ -1438,7 +1446,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
             <LocalizedInput
               autoFocus={true}
               className="form-control"
-              id="newPublicChannelName"
+              id="newChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -1511,7 +1519,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelPurpose"
+              id="newChannelPurpose"
               maxLength="250"
               onChange={[Function]}
               placeholder="E.g.: \\"A channel to file bugs and improvements\\""
@@ -1560,7 +1568,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelHeader"
+              id="newChannelHeader"
               maxLength="1024"
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
@@ -1586,6 +1594,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
       >
         <button
           className="btn btn-link"
+          id="cancelNewChannel"
           onBlur={[Function]}
           onClick={[MockFunction]}
           tabIndex="8"
@@ -1599,6 +1608,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
         </button>
         <button
           className="btn btn-primary"
+          id="submitNewChannel"
           onClick={[Function]}
           tabIndex="4"
           type="submit"
@@ -1785,7 +1795,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
             <LocalizedInput
               autoFocus={true}
               className="form-control"
-              id="newPublicChannelName"
+              id="newChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -1848,7 +1858,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelPurpose"
+              id="newChannelPurpose"
               maxLength="250"
               onChange={[Function]}
               placeholder="E.g.: \\"A channel to file bugs and improvements\\""
@@ -1897,7 +1907,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
           >
             <textarea
               className="form-control no-resize"
-              id="newPublicChannelHeader"
+              id="newChannelHeader"
               maxLength="1024"
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
@@ -1916,6 +1926,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
             </p>
             <div
               className="form-group has-error"
+              id="createChannelError"
             >
               <div
                 className="col-sm-12"
@@ -1936,6 +1947,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
       >
         <button
           className="btn btn-link"
+          id="cancelNewChannel"
           onBlur={[Function]}
           onClick={[MockFunction]}
           tabIndex="8"
@@ -1949,6 +1961,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
         </button>
         <button
           className="btn btn-primary"
+          id="submitNewChannel"
           onClick={[Function]}
           tabIndex="4"
           type="submit"
@@ -2135,7 +2148,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
             <LocalizedInput
               autoFocus={true}
               className="form-control"
-              id="newPrivateChannelName"
+              id="newChannelName"
               maxLength={22}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -2198,7 +2211,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
           >
             <textarea
               className="form-control no-resize"
-              id="newPrivateChannelPurpose"
+              id="newChannelPurpose"
               maxLength="250"
               onChange={[Function]}
               placeholder="E.g.: \\"A channel to file bugs and improvements\\""
@@ -2247,7 +2260,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
           >
             <textarea
               className="form-control no-resize"
-              id="newPrivateChannelHeader"
+              id="newChannelHeader"
               maxLength="1024"
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
@@ -2273,6 +2286,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
       >
         <button
           className="btn btn-link"
+          id="cancelNewChannel"
           onBlur={[Function]}
           onClick={[MockFunction]}
           tabIndex="8"
@@ -2286,6 +2300,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
         </button>
         <button
           className="btn btn-primary"
+          id="submitNewChannel"
           onClick={[Function]}
           tabIndex="4"
           type="submit"

--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -183,17 +183,13 @@ export default class NewChannelModal extends React.PureComponent {
         }
 
         if (this.props.serverError) {
-            serverError = <div className='form-group has-error'><div className='col-sm-12'><p className='input__help error'>{this.props.serverError}</p></div></div>;
-        }
-
-        let inputPrefixId = '';
-        switch (this.props.channelType) {
-        case 'P':
-            inputPrefixId = 'newPrivateChannel';
-            break;
-        case 'O':
-            inputPrefixId = 'newPublicChannel';
-            break;
+            serverError = (
+                <div
+                    id='createChannelError'
+                    className='form-group has-error'
+                >
+                    <div className='col-sm-12'><p className='input__help error'>{this.props.serverError}</p></div></div>
+            );
         }
 
         const publicChannelDesc = (
@@ -323,7 +319,7 @@ export default class NewChannelModal extends React.PureComponent {
                                 </label>
                                 <div className='col-sm-9'>
                                     <LocalizedInput
-                                        id={inputPrefixId + 'Name'}
+                                        id='newChannelName'
                                         onChange={this.handleChange}
                                         type='text'
                                         ref='display_name'
@@ -369,7 +365,7 @@ export default class NewChannelModal extends React.PureComponent {
                                 </div>
                                 <div className='col-sm-9'>
                                     <textarea
-                                        id={inputPrefixId + 'Purpose'}
+                                        id='newChannelPurpose'
                                         className='form-control no-resize'
                                         ref='channel_purpose'
                                         rows='4'
@@ -404,7 +400,7 @@ export default class NewChannelModal extends React.PureComponent {
                                 </div>
                                 <div className='col-sm-9'>
                                     <textarea
-                                        id={inputPrefixId + 'Header'}
+                                        id='newChannelHeader'
                                         className='form-control no-resize'
                                         ref='channel_header'
                                         rows='4'
@@ -426,11 +422,12 @@ export default class NewChannelModal extends React.PureComponent {
                         </Modal.Body>
                         <Modal.Footer>
                             <button
+                                id='cancelNewChannel'
                                 type='button'
                                 className='btn btn-link'
                                 onClick={this.props.onModalDismissed}
                                 tabIndex='8'
-                                onBlur={() => document.getElementById(`${inputPrefixId}Name`).focus()}
+                                onBlur={() => document.getElementById('newChannelName').focus()}
                             >
                                 <FormattedMessage
                                     id='channel_modal.cancel'
@@ -438,6 +435,7 @@ export default class NewChannelModal extends React.PureComponent {
                                 />
                             </button>
                             <button
+                                id='submitNewChannel'
                                 onClick={this.handleSubmit}
                                 type='submit'
                                 className='btn btn-primary'

--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -184,11 +184,16 @@ export default class NewChannelModal extends React.PureComponent {
 
         if (this.props.serverError) {
             serverError = (
-                <div
-                    id='createChannelError'
-                    className='form-group has-error'
-                >
-                    <div className='col-sm-12'><p className='input__help error'>{this.props.serverError}</p></div></div>
+                <div className='form-group has-error'>
+                    <div className='col-sm-12'>
+                        <p
+                            id='createChannelError'
+                            className='input__help error'
+                        >
+                            {this.props.serverError}
+                        </p>
+                    </div>
+                </div>
             );
         }
 

--- a/cypress/integration/onboarding/multi_team/existing_channel_name_spec.js
+++ b/cypress/integration/onboarding/multi_team/existing_channel_name_spec.js
@@ -9,98 +9,81 @@
 
 /*eslint max-nested-callbacks: ["error", 3]*/
 
+/*
+function: verifyExistingChannelError
+arg - channelTypeID:        ID of public or private channel to create
+arg - newChannelName:       New channel name to assign
+
+This function clicks on #createPublicChannel or #createPrivateChannel.
+Types `newChannelName` provided in the #newChannelName input.
+Clicks the 'Create New Channel' button.
+Then verifies that an error message 'A channel with that name already exists on the same team' is shown.
+*/
+function verifyExistingChannelError(channelTypeID, newChannelName) {
+    // Click on '+' button for Public or Private Channel
+    cy.get(channelTypeID).click();
+
+    // Type `newChannelName` in the input field for new channel
+    cy.get('#newChannelName').type(newChannelName);
+
+    // Click 'Create New Channel' button
+    cy.get('#submitNewChannel').click();
+
+    // * User gets a message saying "A channel with that name already exists on the same team"
+    cy.get('#createChannelError').contains('A channel with that name already exists on the same team');
+}
+
+/*
+function: channelNameTest
+arg - channelTypeHeading:   PUBLIC CHANNELS or PRIVATE CHANNELS
+arg - channelName:          Existing channel name that is also being tested for error
+
+var - origChannelLength:    The original number of channels in PUBLIC CHANNELS or PRIVATE CHANNELS
+
+This function stores the number of channels in public or private channels as origChannelLength.
+Verifies that the channel name picked exists.
+Attempts creating a public channel with the existing `channelName`, which should return error as implemented in `verifyExistingChannelError`.
+Then atempts createing a private channel with the existing `channelName`, which should return error as implemented in `verifyExistingChannelError`.
+Verifies that the number of channels under PUBLIC and PRIVATE CHANNELS are still the same.
+Closes out of the New Channel Modal.
+*/
+function channelNameTest(channelTypeHeading, channelName) {
+    // 1. Find how many public channels there are and store as origChannelLength
+    cy.get('#sidebarChannelContainer').children().contains(channelTypeHeading).parent().parent().siblings().its('length').then((origChannelLength) => {
+        // * Verify channel `channelName` exists
+        cy.get('#sidebarChannelContainer').should('contain', channelName);
+
+        // * Verify new public channel cannot be created with existing public channel name; see verifyExistingChannelError function
+        verifyExistingChannelError('#createPublicChannel', channelName);
+
+        // 2. Click on Cancel button to move out of New Channel Modal
+        cy.get('#cancelNewChannel').contains('Cancel').click();
+
+        // * Verify new private channel cannot be created with existing public channel name:
+        verifyExistingChannelError('#createPrivateChannel', channelName);
+
+        // * Verify the number of channels is still the same as before (by comparing it to origChannelLenth)
+        cy.get('#sidebarChannelContainer').children().contains(channelTypeHeading).parent().parent().siblings().its('length').should('eq', origChannelLength);
+
+        // 3. Click on Cancel button to move out of New Channel Modal
+        cy.get('#cancelNewChannel').contains('Cancel').click();
+    });
+}
+
 describe('Channel', () => {
     before(() => {
-        // 1. Login and go to /
+        // Login and go to /
         cy.apiLogin('user-1');
         cy.visit('/');
     });
 
-    // * Verify new public or private channel cannot be created with existing public channel name:
     it('M14635 Should not create new channel with existing public channel name', () => {
-        // 2. Find how many public channels there are and store as origPublicChannelLenth
-        cy.get('#sidebarChannelContainer').children().contains('PUBLIC CHANNELS').parent().parent().siblings().its('length').then(($origPublicChannelLength) => {
-            // * Verify new public channel cannot be created with existing public channel name:
-            // 3. Verify channel with name 'Town Square' exists
-            cy.get('#sidebarChannelContainer').should('contain', 'Town Square');
-
-            // 4. Click on '+' button for Public Channel
-            cy.get('#createPublicChannel').click();
-
-            // 5. Type 'Town Square' in the input field for new public channel
-            cy.get('#newPublicChannelName').type('Town Square');
-
-            //6. Click 'Create New Channel' button
-            cy.get('button[type=submit]').click();
-
-            // * User gets a message saying "A channel with that name already exists on the same team"
-            cy.get('p').contains('A channel with that name already exists on the same team');
-
-            // 7. Click on Cancel button to move out of New Channel dialog
-            cy.get('button').contains('Cancel').click();
-
-            // * Verify new private channel cannot be created with existing public channel name:
-            // 8. Click on '+' button for Private Channel
-            cy.get('#createPrivateChannel').click();
-
-            // 9. Type 'Town Square' in the input field for new private channel
-            cy.get('#newPrivateChannelName').type('Town Square');
-
-            // 10. Click 'Create New Channel' button
-            cy.get('button[type=submit]').click();
-
-            // * User gets a message saying "A channel with that name already exists on the same team"
-            cy.get('p').contains('A channel with that name already exists on the same team');
-
-            // * Verify the number of Public Channels is still the same as before (by comparing it to origPublicChannelLenth)
-            cy.get('#sidebarChannelContainer').children().contains('PUBLIC CHANNELS').parent().parent().siblings().its('length').should('eq', $origPublicChannelLength);
-        });
-
-        // 11. Exit out of the New Channel dialog
-        cy.get('button').contains('Cancel').click();
+        // * Verify new public or private channel cannot be created with existing public channel name:
+        channelNameTest('PUBLIC CHANNELS', 'Town Square');
     });
 
-    // * Verify new public or private channel cannot be created with existing private channel name:
     it('Should not create new channel with existing private channel name', () => {
-        // 12. Find how many public channels there are and store as origPrivateChannelLenth
-        cy.get('#sidebarChannelContainer').children().contains('PRIVATE CHANNELS').parent().parent().siblings().its('length').then(($origPrivateChannelLength) => {
-            // * Verify new public channel cannot be created with existing private channel name:
-            // 13. Verify a private channel
-            cy.get('#sidebarItem_autem-2').should('contain', 'commodi');
-
-            // 14. Click on '+' button for Public Channel
-            cy.get('#createPublicChannel').click();
-
-            // 15. Type 'commodi' in the input field for new public channel
-            cy.get('#newPublicChannelName').type('commodi');
-
-            // 16. Click 'Create New Channel' button
-            cy.get('button[type=submit]').click();
-
-            // * User gets a message saying "A channel with that name already exists on the same team"
-            cy.get('p').contains('A channel with that name already exists on the same team');
-
-            // 17. Click on Cancel button to move out of New Channel dialog
-            cy.get('button').contains('Cancel').click();
-
-            // * Verify new private channel cannot be created with existing private channel name:
-            // 18. Click on '+' button for Private Channel
-            cy.get('#createPrivateChannel').click();
-
-            // 19. Type 'commodi' in the input field for new private channel
-            cy.get('#newPrivateChannelName').type('commodi');
-
-            // 20. Click 'Create New Channel' button
-            cy.get('button[type=submit]').click();
-
-            // * User gets a message saying "A channel with that name already exists on the same team"
-            cy.get('p').contains('A channel with that name already exists on the same team');
-
-            // * Verify the number of Private Channels is still the same as before (by comparing it to origPrivateChannelLenth)
-            cy.get('#sidebarChannelContainer').children().contains('PRIVATE CHANNELS').parent().parent().siblings().its('length').should('eq', $origPrivateChannelLength);
-
-            // 21. Exit out of the New Channel dialog
-            cy.get('button').contains('Cancel').click();
-        });
+        // * Verify new public or private channel cannot be created with existing private channel name:
+        channelNameTest('PRIVATE CHANNELS', 'commodi');
     });
 });

--- a/cypress/integration/onboarding/multi_team/existing_channel_name_spec.js
+++ b/cypress/integration/onboarding/multi_team/existing_channel_name_spec.js
@@ -1,0 +1,106 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/*eslint max-nested-callbacks: ["error", 3]*/
+
+describe('Channel', () => {
+    before(() => {
+        // 1. Login and go to /
+        cy.apiLogin('user-1');
+        cy.visit('/');
+    });
+
+    // * Verify new public or private channel cannot be created with existing public channel name:
+    it('M14635 Should not create new channel with existing public channel name', () => {
+        // 2. Find how many public channels there are and store as origPublicChannelLenth
+        cy.get('#sidebarChannelContainer').children().contains('PUBLIC CHANNELS').parent().parent().siblings().its('length').then(($origPublicChannelLength) => {
+            // * Verify new public channel cannot be created with existing public channel name:
+            // 3. Verify channel with name 'Town Square' exists
+            cy.get('#sidebarChannelContainer').should('contain', 'Town Square');
+
+            // 4. Click on '+' button for Public Channel
+            cy.get('#createPublicChannel').click();
+
+            // 5. Type 'Town Square' in the input field for new public channel
+            cy.get('#newPublicChannelName').type('Town Square');
+
+            //6. Click 'Create New Channel' button
+            cy.get('button[type=submit]').click();
+
+            // * User gets a message saying "A channel with that name already exists on the same team"
+            cy.get('p').contains('A channel with that name already exists on the same team');
+
+            // 7. Click on Cancel button to move out of New Channel dialog
+            cy.get('button').contains('Cancel').click();
+
+            // * Verify new private channel cannot be created with existing public channel name:
+            // 8. Click on '+' button for Private Channel
+            cy.get('#createPrivateChannel').click();
+
+            // 9. Type 'Town Square' in the input field for new private channel
+            cy.get('#newPrivateChannelName').type('Town Square');
+
+            // 10. Click 'Create New Channel' button
+            cy.get('button[type=submit]').click();
+
+            // * User gets a message saying "A channel with that name already exists on the same team"
+            cy.get('p').contains('A channel with that name already exists on the same team');
+
+            // * Verify the number of Public Channels is still the same as before (by comparing it to origPublicChannelLenth)
+            cy.get('#sidebarChannelContainer').children().contains('PUBLIC CHANNELS').parent().parent().siblings().its('length').should('eq', $origPublicChannelLength);
+        });
+
+        // 11. Exit out of the New Channel dialog
+        cy.get('button').contains('Cancel').click();
+    });
+
+    // * Verify new public or private channel cannot be created with existing private channel name:
+    it('Should not create new channel with existing private channel name', () => {
+        // 12. Find how many public channels there are and store as origPrivateChannelLenth
+        cy.get('#sidebarChannelContainer').children().contains('PRIVATE CHANNELS').parent().parent().siblings().its('length').then(($origPrivateChannelLength) => {
+            // * Verify new public channel cannot be created with existing private channel name:
+            // 13. Verify a private channel
+            cy.get('#sidebarItem_autem-2').should('contain', 'commodi');
+
+            // 14. Click on '+' button for Public Channel
+            cy.get('#createPublicChannel').click();
+
+            // 15. Type 'commodi' in the input field for new public channel
+            cy.get('#newPublicChannelName').type('commodi');
+
+            // 16. Click 'Create New Channel' button
+            cy.get('button[type=submit]').click();
+
+            // * User gets a message saying "A channel with that name already exists on the same team"
+            cy.get('p').contains('A channel with that name already exists on the same team');
+
+            // 17. Click on Cancel button to move out of New Channel dialog
+            cy.get('button').contains('Cancel').click();
+
+            // * Verify new private channel cannot be created with existing private channel name:
+            // 18. Click on '+' button for Private Channel
+            cy.get('#createPrivateChannel').click();
+
+            // 19. Type 'commodi' in the input field for new private channel
+            cy.get('#newPrivateChannelName').type('commodi');
+
+            // 20. Click 'Create New Channel' button
+            cy.get('button[type=submit]').click();
+
+            // * User gets a message saying "A channel with that name already exists on the same team"
+            cy.get('p').contains('A channel with that name already exists on the same team');
+
+            // * Verify the number of Private Channels is still the same as before (by comparing it to origPrivateChannelLenth)
+            cy.get('#sidebarChannelContainer').children().contains('PRIVATE CHANNELS').parent().parent().siblings().its('length').should('eq', $origPrivateChannelLength);
+
+            // 21. Exit out of the New Channel dialog
+            cy.get('button').contains('Cancel').click();
+        });
+    });
+});

--- a/cypress/integration/onboarding/multi_team/existing_channel_name_spec.js
+++ b/cypress/integration/onboarding/multi_team/existing_channel_name_spec.js
@@ -82,7 +82,7 @@ describe('Channel', () => {
         channelNameTest('PUBLIC CHANNELS', 'Town Square');
     });
 
-    it('Should not create new channel with existing private channel name', () => {
+    it('M14635 Should not create new channel with existing private channel name', () => {
         // * Verify new public or private channel cannot be created with existing private channel name:
         channelNameTest('PRIVATE CHANNELS', 'commodi');
     });

--- a/cypress/integration/onboarding/multi_team/existing_channel_name_spec.js
+++ b/cypress/integration/onboarding/multi_team/existing_channel_name_spec.js
@@ -9,15 +9,10 @@
 
 /*eslint max-nested-callbacks: ["error", 3]*/
 
-/*
-function: verifyExistingChannelError
-arg - channelTypeID:        ID of public or private channel to create
-arg - newChannelName:       New channel name to assign
-
-This function clicks on #createPublicChannel or #createPrivateChannel.
-Types `newChannelName` provided in the #newChannelName input.
-Clicks the 'Create New Channel' button.
-Then verifies that an error message 'A channel with that name already exists on the same team' is shown.
+/**
+* Creates a channel with existing name and verify that error is shown
+* @param {String} channelTypeID - ID of public or private channel to create
+* @param {String} newChannelName - New channel name to assign
 */
 function verifyExistingChannelError(channelTypeID, newChannelName) {
     // Click on '+' button for Public or Private Channel
@@ -33,19 +28,11 @@ function verifyExistingChannelError(channelTypeID, newChannelName) {
     cy.get('#createChannelError').contains('A channel with that name already exists on the same team');
 }
 
-/*
-function: channelNameTest
-arg - channelTypeHeading:   PUBLIC CHANNELS or PRIVATE CHANNELS
-arg - channelName:          Existing channel name that is also being tested for error
-
-var - origChannelLength:    The original number of channels in PUBLIC CHANNELS or PRIVATE CHANNELS
-
-This function stores the number of channels in public or private channels as origChannelLength.
-Verifies that the channel name picked exists.
-Attempts creating a public channel with the existing `channelName`, which should return error as implemented in `verifyExistingChannelError`.
-Then atempts createing a private channel with the existing `channelName`, which should return error as implemented in `verifyExistingChannelError`.
-Verifies that the number of channels under PUBLIC and PRIVATE CHANNELS are still the same.
-Closes out of the New Channel Modal.
+/**
+* Attempts to create public and private channels with existing `channelName` and verifies error
+* @param {String} channelTypeHeading - PUBLIC CHANNELS or PRIVATE CHANNELS
+* @param {String} channelName - Existing channel name that is also being tested for error
+* var - origChannelLength:    The original number of channels in PUBLIC CHANNELS or PRIVATE CHANNELS
 */
 function channelNameTest(channelTypeHeading, channelName) {
     // 1. Find how many public channels there are and store as origChannelLength


### PR DESCRIPTION
MM-14635 Adding automated test using Cypress for Channel Name Already Exists

#### Summary
Added E2E test using `cypress` for "Channel name already exists"

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10473