### PR TITLE
MM-15706 Fetch plugin manifests after uploading a new plugin

### DIFF
--- a/components/admin_console/plugin_management/index.js
+++ b/components/admin_console/plugin_management/index.js
@@ -3,7 +3,14 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {getPluginStatuses, removePlugin, uploadPlugin, enablePlugin, disablePlugin} from 'mattermost-redux/actions/admin';
+import {
+    getPlugins,
+    getPluginStatuses,
+    removePlugin,
+    uploadPlugin,
+    enablePlugin,
+    disablePlugin,
+} from 'mattermost-redux/actions/admin';
 
 import PluginManagement from './plugin_management.jsx';
 
@@ -19,6 +26,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             uploadPlugin,
             removePlugin,
+            getPlugins,
             getPluginStatuses,
             enablePlugin,
             disablePlugin,

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -399,6 +399,7 @@ export default class PluginManagement extends AdminSettings {
         actions: PropTypes.shape({
             uploadPlugin: PropTypes.func.isRequired,
             removePlugin: PropTypes.func.isRequired,
+            getPlugins: PropTypes.func.isRequired,
             getPluginStatuses: PropTypes.func.isRequired,
             enablePlugin: PropTypes.func.isRequired,
             disablePlugin: PropTypes.func.isRequired,
@@ -479,6 +480,9 @@ export default class PluginManagement extends AdminSettings {
             return;
         }
 
+        this.setState({loading: true});
+        await this.props.actions.getPlugins();
+
         let msg = `Successfully uploaded plugin from ${file.name}`;
         if (this.state.overwriting) {
             msg = `Successfully updated plugin from ${file.name}`;
@@ -491,6 +495,7 @@ export default class PluginManagement extends AdminSettings {
             lastMessage: msg,
             overwriting: false,
             uploading: false,
+            loading: false,
         });
     }
 

--- a/components/admin_console/plugin_management/plugin_management.test.jsx
+++ b/components/admin_console/plugin_management/plugin_management.test.jsx
@@ -86,6 +86,7 @@ describe('components/PluginManagement', () => {
         actions: {
             uploadPlugin: jest.fn(),
             removePlugin: jest.fn(),
+            getPlugins: jest.fn().mockResolvedValue([]),
             getPluginStatuses: jest.fn().mockResolvedValue([]),
             enablePlugin: jest.fn(),
             disablePlugin: jest.fn(),
@@ -141,6 +142,7 @@ describe('components/PluginManagement', () => {
             actions: {
                 uploadPlugin: jest.fn(),
                 removePlugin: jest.fn(),
+                getPlugins: jest.fn().mockResolvedValue([]),
                 getPluginStatuses: jest.fn().mockResolvedValue([]),
                 enablePlugin: jest.fn(),
                 disablePlugin: jest.fn(),
@@ -227,6 +229,7 @@ describe('components/PluginManagement', () => {
             actions: {
                 uploadPlugin: jest.fn(),
                 removePlugin: jest.fn(),
+                getPlugins: jest.fn().mockResolvedValue([]),
                 getPluginStatuses: jest.fn().mockResolvedValue([]),
                 enablePlugin: jest.fn(),
                 disablePlugin: jest.fn(),
@@ -279,6 +282,7 @@ describe('components/PluginManagement', () => {
             actions: {
                 uploadPlugin: jest.fn(),
                 removePlugin: jest.fn(),
+                getPlugins: jest.fn().mockResolvedValue([]),
                 getPluginStatuses: jest.fn().mockResolvedValue([]),
                 enablePlugin: jest.fn(),
                 disablePlugin: jest.fn(),
@@ -331,6 +335,7 @@ describe('components/PluginManagement', () => {
             actions: {
                 uploadPlugin: jest.fn(),
                 removePlugin: jest.fn(),
+                getPlugins: jest.fn().mockResolvedValue([]),
                 getPluginStatuses: jest.fn().mockResolvedValue([]),
                 enablePlugin: jest.fn(),
                 disablePlugin: jest.fn(),
@@ -385,6 +390,7 @@ describe('components/PluginManagement', () => {
             actions: {
                 uploadPlugin: jest.fn(),
                 removePlugin: jest.fn(),
+                getPlugins: jest.fn().mockResolvedValue([]),
                 getPluginStatuses: jest.fn().mockResolvedValue([]),
                 enablePlugin: jest.fn(),
                 disablePlugin: jest.fn(),


### PR DESCRIPTION
#### Summary
The settings page for the plugin was not being added to the sidebar or to the buttons next to "Enable" and "Remove" because we did not have the plugin manifest telling us we needed to display settings. The fix is to re-fetch the plugin manifests after uploading a new plugin.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15076
