### PR TITLE
Add missing default values for required props

### DIFF
--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -80,6 +80,7 @@ export default class DotMenu extends Component {
         isReadOnly: false,
         pluginMenuItems: [],
         location: Locations.CENTER,
+        enableEmojiPicker: false,
     }
 
     constructor(props) {

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -92,6 +92,10 @@ export default class SearchResultsItem extends React.PureComponent {
         }).isRequired,
     };
 
+    static defaultProps = {
+        isBot: false,
+    };
+
     constructor(props) {
         super(props);
 


### PR DESCRIPTION
#### Summary
This fixes JS console warnings for missing required props. These warnings were found while debugging [MM-15083](https://mattermost.atlassian.net/browse/MM-15083)