### PR TITLE
MM-14707 Open dropdowns near the bottom of user lists upwards

### DIFF
--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
@@ -19,6 +19,8 @@ import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 import Menu from 'components/widgets/menu/menu';
 import MenuItemAction from 'components/widgets/menu/menu_items/menu_item_action';
 
+const ROWS_FROM_BOTTOM_TO_OPEN_UP = 5;
+
 export default class SystemUsersDropdown extends React.Component {
     static propTypes = {
 
@@ -72,6 +74,8 @@ export default class SystemUsersDropdown extends React.Component {
          */
         onError: PropTypes.func.isRequired,
         currentUser: PropTypes.object.isRequired,
+        index: PropTypes.number.isRequired,
+        totalUsers: PropTypes.number.isRequired,
         actions: PropTypes.shape({
             updateUserActive: PropTypes.func.isRequired,
             revokeAllSessions: PropTypes.func.isRequired,
@@ -361,6 +365,12 @@ export default class SystemUsersDropdown extends React.Component {
         const deactivateMemberModal = this.renderDeactivateMemberModal();
         const revokeSessionsModal = this.renderRevokeSessionsModal();
 
+        const {index, totalUsers} = this.props;
+        let openUp = false;
+        if (totalUsers - index <= ROWS_FROM_BOTTOM_TO_OPEN_UP) {
+            openUp = true;
+        }
+
         return (
             <React.Fragment>
                 {deactivateMemberModal}
@@ -376,6 +386,7 @@ export default class SystemUsersDropdown extends React.Component {
                     <div>
                         <Menu
                             openLeft={true}
+                            openUp={openUp}
                             ariaLabel={Utils.localizeMessage('admin.user_item.menuAriaLabel', 'User Actions Menu')}
                         >
                             <MenuItemAction

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.test.js
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.test.js
@@ -25,6 +25,8 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
         onError: jest.fn(),
         currentUser: user,
         teamUrl: 'teamUrl',
+        index: 0,
+        totalUsers: 10,
         actions: {
             updateUserActive: jest.fn(() => Promise.resolve({})),
             revokeAllSessions: jest.fn().mockResolvedValue({data: true}),

--- a/components/channel_members_dropdown/__snapshots__/channel_members_dropdown.test.jsx.snap
+++ b/components/channel_members_dropdown/__snapshots__/channel_members_dropdown.test.jsx.snap
@@ -25,3 +25,19 @@ exports[`components/channel_members_dropdown should match snapshot for group_con
   />
 </div>
 `;
+
+exports[`components/channel_members_dropdown should match snapshot opening dropdown upwards 1`] = `
+<button
+  className="btn btn-danger btn-message"
+  disabled={false}
+  id="removeMember"
+  onClick={[Function]}
+  type="button"
+>
+  <FormattedMessage
+    defaultMessage="Remove Member"
+    id="channel_members_dropdown.remove_member"
+    values={Object {}}
+  />
+</button>
+`;

--- a/components/channel_members_dropdown/channel_members_dropdown.jsx
+++ b/components/channel_members_dropdown/channel_members_dropdown.jsx
@@ -13,6 +13,8 @@ import Menu from 'components/widgets/menu/menu';
 import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 import MenuItemAction from 'components/widgets/menu/menu_items/menu_item_action';
 
+const ROWS_FROM_BOTTOM_TO_OPEN_UP = 3;
+
 export default class ChannelMembersDropdown extends React.Component {
     static propTypes = {
         channel: PropTypes.object.isRequired,
@@ -22,6 +24,8 @@ export default class ChannelMembersDropdown extends React.Component {
         isLicensed: PropTypes.bool.isRequired,
         canChangeMemberRoles: PropTypes.bool.isRequired,
         canRemoveMember: PropTypes.bool.isRequired,
+        index: PropTypes.number.isRequired,
+        totalUsers: PropTypes.number.isRequired,
         actions: PropTypes.shape({
             getChannelStats: PropTypes.func.isRequired,
             updateChannelMemberSchemeRoles: PropTypes.func.isRequired,
@@ -120,6 +124,12 @@ export default class ChannelMembersDropdown extends React.Component {
             const canMakeChannelAdmin = supportsChannelAdmin && !isChannelAdmin;
 
             if ((canMakeChannelMember || canMakeChannelAdmin)) {
+                const {index, totalUsers} = this.props;
+                let openUp = false;
+                if (totalUsers - index <= ROWS_FROM_BOTTOM_TO_OPEN_UP) {
+                    openUp = true;
+                }
+
                 return (
                     <MenuWrapper>
                         <button
@@ -131,6 +141,7 @@ export default class ChannelMembersDropdown extends React.Component {
                         </button>
                         <Menu
                             openLeft={true}
+                            openUp={openUp}
                             ariaLabel={Utils.localizeMessage('channel_members_dropdown.menuAriaLabel', 'Channel member role change')}
                         >
                             <MenuItemAction

--- a/components/channel_members_dropdown/channel_members_dropdown.test.jsx
+++ b/components/channel_members_dropdown/channel_members_dropdown.test.jsx
@@ -61,6 +61,17 @@ describe('components/channel_members_dropdown', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should match snapshot opening dropdown upwards', () => {
+        const wrapper = shallow(
+            <ChannelMembersDropdown
+                {...baseProps}
+                index={4}
+                totalUsers={5}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('If a removal is in progress do not execute another removal', () => {
         const wrapper = shallow(
             <ChannelMembersDropdown {...baseProps}/>

--- a/components/channel_members_dropdown/channel_members_dropdown.test.jsx
+++ b/components/channel_members_dropdown/channel_members_dropdown.test.jsx
@@ -39,6 +39,8 @@ describe('components/channel_members_dropdown', () => {
         isLicensed: true,
         canChangeMemberRoles: false,
         canRemoveMember: true,
+        index: 0,
+        totalUsers: 10,
         actions: {
             removeChannelMember: jest.fn().mockImplementation(() => {
                 const error = {

--- a/components/team_members_dropdown/__snapshots__/team_members_dropdown.test.jsx.snap
+++ b/components/team_members_dropdown/__snapshots__/team_members_dropdown.test.jsx.snap
@@ -47,6 +47,53 @@ exports[`components/team_members_dropdown should match snapshot for team_members
 </MenuWrapper>
 `;
 
+exports[`components/team_members_dropdown should match snapshot opening dropdown upwards 1`] = `
+<MenuWrapper
+  animationComponent={[Function]}
+  className=""
+>
+  <button
+    aria-expanded="true"
+    className="dropdown-toggle theme color--link style--none"
+    type="button"
+  >
+    <span>
+      <FormattedMessage
+        defaultMessage="Team Admin"
+        id="team_members_dropdown.teamAdmin"
+        values={Object {}}
+      />
+       
+    </span>
+    <DropdownIcon />
+  </button>
+  <div>
+    <Menu
+      ariaLabel="Team member role change"
+      openLeft={true}
+      openUp={true}
+    >
+      <MenuItemAction
+        id="removeFromTeam"
+        onClick={[Function]}
+        show={true}
+        text="Remove From Team"
+      />
+      <MenuItemAction
+        onClick={[Function]}
+        show={false}
+        text="Make Team Admin"
+      />
+      <MenuItemAction
+        onClick={[Function]}
+        show={true}
+        text="Make Member"
+      />
+    </Menu>
+  </div>
+</MenuWrapper>
+`;
+
 exports[`components/team_members_dropdown should match snapshot with group-constrained team 1`] = `
 <MenuWrapper
   animationComponent={[Function]}

--- a/components/team_members_dropdown/__snapshots__/team_members_dropdown.test.jsx.snap
+++ b/components/team_members_dropdown/__snapshots__/team_members_dropdown.test.jsx.snap
@@ -24,6 +24,7 @@ exports[`components/team_members_dropdown should match snapshot for team_members
     <Menu
       ariaLabel="Team member role change"
       openLeft={true}
+      openUp={false}
     >
       <MenuItemAction
         id="removeFromTeam"
@@ -70,6 +71,7 @@ exports[`components/team_members_dropdown should match snapshot with group-const
     <Menu
       ariaLabel="Team member role change"
       openLeft={true}
+      openUp={false}
     >
       <MenuItemAction
         id="removeFromTeam"

--- a/components/team_members_dropdown/team_members_dropdown.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.jsx
@@ -14,6 +14,8 @@ import Menu from 'components/widgets/menu/menu';
 import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 import MenuItemAction from 'components/widgets/menu/menu_items/menu_item_action';
 
+const ROWS_FROM_BOTTOM_TO_OPEN_UP = 3;
+
 export default class TeamMembersDropdown extends React.Component {
     static propTypes = {
         user: PropTypes.object.isRequired,
@@ -21,6 +23,8 @@ export default class TeamMembersDropdown extends React.Component {
         teamMember: PropTypes.object.isRequired,
         teamUrl: PropTypes.string.isRequired,
         currentTeam: PropTypes.object.isRequired,
+        index: PropTypes.number.isRequired,
+        totalUsers: PropTypes.number.isRequired,
         actions: PropTypes.shape({
             getMyTeamMembers: PropTypes.func.isRequired,
             getMyTeamUnreads: PropTypes.func.isRequired,
@@ -218,6 +222,12 @@ export default class TeamMembersDropdown extends React.Component {
             return <div>{currentRoles}</div>;
         }
 
+        const {index, totalUsers} = this.props;
+        let openUp = false;
+        if (totalUsers - index <= ROWS_FROM_BOTTOM_TO_OPEN_UP) {
+            openUp = true;
+        }
+
         return (
             <MenuWrapper>
                 <button
@@ -231,6 +241,7 @@ export default class TeamMembersDropdown extends React.Component {
                 <div>
                     <Menu
                         openLeft={true}
+                        openUp={openUp}
                         ariaLabel={Utils.localizeMessage('team_members_dropdown.menuAriaLabel', 'Team member role change')}
                     >
                         <MenuItemAction

--- a/components/team_members_dropdown/team_members_dropdown.test.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.test.jsx
@@ -43,6 +43,8 @@ describe('components/team_members_dropdown', () => {
         },
         teamUrl: '',
         currentTeam: team,
+        index: 0,
+        totalUsers: 10,
         actions: {
             getMyTeamMembers: jest.fn(),
             getMyTeamUnreads: jest.fn(),

--- a/components/team_members_dropdown/team_members_dropdown.test.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.test.jsx
@@ -64,6 +64,17 @@ describe('components/team_members_dropdown', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should match snapshot opening dropdown upwards', () => {
+        const wrapper = shallow(
+            <TeamMembersDropdown
+                {...baseProps}
+                index={4}
+                totalUsers={5}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should match snapshot with group-constrained team', () => {
         baseProps.currentTeam.group_constrained = true;
         const wrapper = shallow(

--- a/components/user_list.jsx
+++ b/components/user_list.jsx
@@ -40,6 +40,8 @@ export default class UserList extends React.Component {
                         actions={this.props.actions}
                         actionProps={this.props.actionProps}
                         actionUserProps={this.props.actionUserProps[user.id]}
+                        index={index}
+                        totalUsers={users.length}
                         userCount={(index >= 0 && index < Constants.TEST_ID_COUNT) ? index : -1}
                     />
                 );

--- a/components/user_list_row/user_list_row.jsx
+++ b/components/user_list_row/user_list_row.jsx
@@ -20,6 +20,8 @@ export default class UserListRow extends React.Component {
         actions: PropTypes.arrayOf(PropTypes.func),
         actionProps: PropTypes.object,
         actionUserProps: PropTypes.object,
+        index: PropTypes.number,
+        totalUsers: PropTypes.number,
         userCount: PropTypes.number,
     };
 
@@ -38,6 +40,8 @@ export default class UserListRow extends React.Component {
                     <Action
                         key={index.toString()}
                         user={this.props.user}
+                        index={this.props.index}
+                        totalUsers={this.props.totalUsers}
                         {...this.props.actionProps}
                         {...this.props.actionUserProps}
                     />

--- a/components/user_list_row_with_error/user_list_row_with_error.jsx
+++ b/components/user_list_row_with_error/user_list_row_with_error.jsx
@@ -19,6 +19,8 @@ export default class UserListRowWithError extends React.Component {
         actions: PropTypes.arrayOf(PropTypes.func),
         actionProps: PropTypes.object,
         actionUserProps: PropTypes.object,
+        index: PropTypes.number,
+        totalUsers: PropTypes.number,
         userCount: PropTypes.number,
     };
 
@@ -50,6 +52,8 @@ export default class UserListRowWithError extends React.Component {
                     <Action
                         key={index.toString()}
                         user={this.props.user}
+                        index={this.props.index}
+                        totalUsers={this.props.totalUsers}
                         {...this.props.actionProps}
                         {...this.props.actionUserProps}
                         onError={this.onError}


### PR DESCRIPTION
#### Summary
The problem was that the dropdowns near the bottom of user lists would open downwards and increase the size of the div they were in. The solution I came up with was to open the dropdown upwards for the last X items in a user list. I'm not terribly happy with how it's implemented but I'm not sure of a better way of doing it. Definitely open to suggestions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14707