### PR TITLE
MM-14741 Add default option to post action dropdown

### DIFF
--- a/components/post_view/message_attachments/action_menu/action_menu.jsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.jsx
@@ -39,7 +39,7 @@ export default class ActionMenu extends React.PureComponent {
 
         if (action.default_option && action.options) {
             selected = action.options.find((option) => option.value === action.default_option);
-            value = selected.text;
+            value = selected ? selected.text : '';
         }
 
         this.state = {

--- a/components/post_view/message_attachments/action_menu/action_menu.jsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.jsx
@@ -34,8 +34,17 @@ export default class ActionMenu extends React.PureComponent {
             }
         }
 
+        let selected;
+        let value = '';
+
+        if (action.default_option && action.options) {
+            selected = action.options.find((option) => option.value === action.default_option);
+            value = selected.text;
+        }
+
         this.state = {
-            value: '',
+            selected,
+            value,
         };
     }
 

--- a/components/post_view/message_attachments/action_menu/action_menu.test.jsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.test.jsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {shallow} from 'enzyme';
+import React from 'react';
+
+import ActionMenu from './action_menu';
+
+describe('components/post_view/message_attachments/ActionMenu', () => {
+    const baseProps = {
+        postId: 'post1',
+        action: {
+            name: 'action',
+            options: [
+                {
+                    text: 'One',
+                    value: '1',
+                },
+                {
+                    text: 'Two',
+                    value: '2',
+                },
+            ],
+        },
+        actions: {
+            selectAttachmentMenuAction: jest.fn(),
+        },
+    };
+
+    test('should start with nothing selected', () => {
+        const wrapper = shallow(<ActionMenu {...baseProps}/>);
+
+        expect(wrapper.state()).toMatchObject({
+            selected: undefined,
+            value: '',
+        });
+    });
+
+    test('should set selected based on default option', () => {
+        const props = {
+            ...baseProps,
+            action: {
+                ...baseProps.action,
+                default_option: '2',
+            },
+        };
+        const wrapper = shallow(<ActionMenu {...props}/>);
+
+        expect(wrapper.state()).toMatchObject({
+            selected: {
+                text: 'Two',
+                value: '2',
+            },
+            value: 'Two',
+        });
+    });
+});


### PR DESCRIPTION
This PR is pretty straightforward. This value starts selected in the dropdown, allowing integrations to "save" a value which we wanted for the NPS plugin.

Server PR: https://github.com/mattermost/mattermost-server/pull/10659
Mobile PR: https://github.com/mattermost/mattermost-mobile/pull/2724

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14741