### PR TITLE
[MM-15195] Bot account can be edited even though it's managed by a plugin

### DIFF
--- a/components/integrations/bots/bot.jsx
+++ b/components/integrations/bots/bot.jsx
@@ -276,37 +276,40 @@ export default class Bot extends React.PureComponent {
             );
         });
 
-        let options = (
-            <div className='item-actions'>
-                <button
-                    id='createToken'
-                    className='style--none color--link'
-                    onClick={this.openCreateToken}
-                >
-                    <FormattedMessage
-                        id='bot.manage.create_token'
-                        defaultMessage='Create New Token'
-                    />
-                </button>
-                {' - '}
-                <Link to={`/${this.props.team.name}/integrations/bots/edit?id=${this.props.bot.user_id}`}>
-                    <FormattedMessage
-                        id='bots.manage.edit'
-                        defaultMessage='Edit'
-                    />
-                </Link>
-                {' - '}
-                <button
-                    className='style--none color--link'
-                    onClick={this.disableBot}
-                >
-                    <FormattedMessage
-                        id='bot.manage.disable'
-                        defaultMessage='Disable'
-                    />
-                </button>
-            </div>
-        );
+        let options;
+        if (ownerUsername !== 'plugin') {
+            options = (
+                <div className='item-actions'>
+                    <button
+                        id='createToken'
+                        className='style--none color--link'
+                        onClick={this.openCreateToken}
+                    >
+                        <FormattedMessage
+                            id='bot.manage.create_token'
+                            defaultMessage='Create New Token'
+                        />
+                    </button>
+                    {' - '}
+                    <Link to={`/${this.props.team.name}/integrations/bots/edit?id=${this.props.bot.user_id}`}>
+                        <FormattedMessage
+                            id='bots.manage.edit'
+                            defaultMessage='Edit'
+                        />
+                    </Link>
+                    {' - '}
+                    <button
+                        className='style--none color--link'
+                        onClick={this.disableBot}
+                    >
+                        <FormattedMessage
+                            id='bot.manage.disable'
+                            defaultMessage='Disable'
+                        />
+                    </button>
+                </div>
+            );
+        }
         if (this.props.bot.delete_at !== 0) {
             options = (
                 <div className='item-actions'>

--- a/components/integrations/bots/bot.test.jsx
+++ b/components/integrations/bots/bot.test.jsx
@@ -27,24 +27,26 @@ describe('components/integrations/bots/Bot', () => {
         expect(wrapper.contains(bot.display_name + ' (@' + bot.username + ')')).toEqual(true);
         expect(wrapper.contains(bot.description)).toEqual(true);
         expect(wrapper.contains('plugin')).toEqual(true);
+
+        // if bot managed by plugin, remove ability to edit from UI
         expect(wrapper.contains(
             <FormattedMessage
                 id='bot.manage.create_token'
                 defaultMessage='Create New Token'
             />
-        )).toEqual(true);
+        )).toEqual(false);
         expect(wrapper.contains(
             <FormattedMessage
                 id='bots.manage.edit'
                 defaultMessage='Edit'
             />
-        )).toEqual(true);
+        )).toEqual(false);
         expect(wrapper.contains(
             <FormattedMessage
                 id='bot.manage.disable'
                 defaultMessage='Disable'
             />
-        )).toEqual(true);
+        )).toEqual(false);
         expect(wrapper.contains(
             <FormattedMessage
                 id='bot.manage.enable'
@@ -106,6 +108,26 @@ describe('components/integrations/bots/Bot', () => {
         );
         expect(wrapper.contains(user.username)).toEqual(true);
         expect(wrapper.contains('plugin')).toEqual(false);
+
+        // if bot is not managed by plugin, ability to edit from UI is retained
+        expect(wrapper.contains(
+            <FormattedMessage
+                id='bot.manage.create_token'
+                defaultMessage='Create New Token'
+            />
+        )).toEqual(true);
+        expect(wrapper.contains(
+            <FormattedMessage
+                id='bots.manage.edit'
+                defaultMessage='Edit'
+            />
+        )).toEqual(true);
+        expect(wrapper.contains(
+            <FormattedMessage
+                id='bot.manage.disable'
+                defaultMessage='Disable'
+            />
+        )).toEqual(true);
     });
 
     it('bot with access tokens', () => {


### PR DESCRIPTION
#### Summary
This PR addresses the case where a bot can be edited through the system console UI, even if the bot is managed by a plugin.  

Before: An admin has the ability to create tokens, edit and disable a bot account through the system console.
![image](https://user-images.githubusercontent.com/7575921/56505305-eb05f980-64e0-11e9-835c-2cc0c28ca751.png)

After: An admin cannot create tokens, edit or disable a bot account through the system console.  However, an admin does retain the ability to disable or delete a token
![image](https://user-images.githubusercontent.com/7575921/56505431-49cb7300-64e1-11e9-86c7-8473b362f7f7.png)

Testing:  We should test that the UI elements do not show up for the plugin managed bot, so the existing tests cases were retained, but the expected result is set to false.  

Testing that create, edit, and disable elements exist were added to an existing test that sets up a bot account that is not managed by a plugin.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15195

#### Related Pull Requests
n/a