### PR TITLE
[MM-14751] Take group_constrained into account when adding users to teams and channels

### DIFF
--- a/actions/global_actions.test.js
+++ b/actions/global_actions.test.js
@@ -16,6 +16,10 @@ jest.mock('actions/views/lhs', () => ({
     close: jest.fn(),
 }));
 
+jest.mock('mattermost-redux/actions/users', () => ({
+    loadMe: () => ({type: 'MOCK_RECEIVED_ME'}),
+}));
+
 describe('actions/global_actions', () => {
     test('redirectUserToDefaultTeam', async () => {
         browserHistory.push = jest.fn();

--- a/components/add_users_to_team/add_users_to_team.jsx
+++ b/components/add_users_to_team/add_users_to_team.jsx
@@ -20,7 +20,9 @@ const MAX_SELECTABLE_VALUES = 20;
 
 export default class AddUsersToTeam extends React.Component {
     static propTypes = {
-        currentTeam: PropTypes.object,
+        currentTeamName: PropTypes.string.isRequired,
+        currentTeamId: PropTypes.string.isRequired,
+        currentTeamGroupConstrained: PropTypes.bool,
         searchTerm: PropTypes.string.isRequired,
         users: PropTypes.array.isRequired,
         onHide: PropTypes.func,
@@ -31,6 +33,10 @@ export default class AddUsersToTeam extends React.Component {
             addUsersToTeam: PropTypes.func.isRequired,
             loadStatusesForProfilesList: PropTypes.func.isRequired,
         }).isRequired,
+    }
+
+    static defaultProps = {
+        currentTeamGroupConstrained: false,
     }
 
     constructor(props) {
@@ -49,7 +55,7 @@ export default class AddUsersToTeam extends React.Component {
     }
 
     componentDidMount() {
-        this.props.actions.getProfilesNotInTeam(this.props.currentTeam.id, this.props.currentTeam.group_constrained, 0, USERS_PER_PAGE * 2).then(() => {
+        this.props.actions.getProfilesNotInTeam(this.props.currentTeamId, this.props.currentTeamGroupConstrained, 0, USERS_PER_PAGE * 2).then(() => {
             this.setUsersLoadingState(false);
         });
     }
@@ -66,7 +72,7 @@ export default class AddUsersToTeam extends React.Component {
             this.searchTimeoutId = setTimeout(
                 async () => {
                     this.setUsersLoadingState(true);
-                    const {data} = await this.props.actions.searchProfiles(searchTerm, {not_in_team_id: this.props.currentTeam.id, group_constrained: this.props.currentTeam.group_constrained});
+                    const {data} = await this.props.actions.searchProfiles(searchTerm, {not_in_team_id: this.props.currentTeamId, group_constrained: this.props.currentTeamGroupConstrained});
                     if (data) {
                         this.props.actions.loadStatusesForProfilesList(data);
                     }
@@ -112,7 +118,7 @@ export default class AddUsersToTeam extends React.Component {
 
         this.setState({saving: true});
 
-        const {error} = await this.props.actions.addUsersToTeam(this.props.currentTeam.id, userIds);
+        const {error} = await this.props.actions.addUsersToTeam(this.props.currentTeamId, userIds);
         this.handleResponse(error);
         if (!error) {
             this.handleHide();
@@ -138,7 +144,7 @@ export default class AddUsersToTeam extends React.Component {
     handlePageChange = (page, prevPage) => {
         if (page > prevPage) {
             this.setUsersLoadingState(true);
-            this.props.actions.getProfilesNotInTeam(this.props.currentTeam.id, page + 1, USERS_PER_PAGE).then(() => {
+            this.props.actions.getProfilesNotInTeam(this.props.currentTeamId, page + 1, USERS_PER_PAGE).then(() => {
                 this.setUsersLoadingState(false);
             });
         }
@@ -248,7 +254,7 @@ export default class AddUsersToTeam extends React.Component {
                             defaultMessage='Add New Members To {teamName} Team'
                             values={{
                                 teamName: (
-                                    <strong>{this.props.currentTeam.name}</strong>
+                                    <strong>{this.props.currentTeamName}</strong>
                                 ),
                             }}
                         />

--- a/components/add_users_to_team/add_users_to_team.jsx
+++ b/components/add_users_to_team/add_users_to_team.jsx
@@ -20,8 +20,7 @@ const MAX_SELECTABLE_VALUES = 20;
 
 export default class AddUsersToTeam extends React.Component {
     static propTypes = {
-        currentTeamName: PropTypes.string.isRequired,
-        currentTeamId: PropTypes.string.isRequired,
+        currentTeam: PropTypes.object,
         searchTerm: PropTypes.string.isRequired,
         users: PropTypes.array.isRequired,
         onHide: PropTypes.func,
@@ -50,7 +49,7 @@ export default class AddUsersToTeam extends React.Component {
     }
 
     componentDidMount() {
-        this.props.actions.getProfilesNotInTeam(this.props.currentTeamId, 0, USERS_PER_PAGE * 2).then(() => {
+        this.props.actions.getProfilesNotInTeam(this.props.currentTeam.id, this.props.currentTeam.group_constrained, 0, USERS_PER_PAGE * 2).then(() => {
             this.setUsersLoadingState(false);
         });
     }
@@ -67,7 +66,7 @@ export default class AddUsersToTeam extends React.Component {
             this.searchTimeoutId = setTimeout(
                 async () => {
                     this.setUsersLoadingState(true);
-                    const {data} = await this.props.actions.searchProfiles(searchTerm, {not_in_team_id: this.props.currentTeamId});
+                    const {data} = await this.props.actions.searchProfiles(searchTerm, {not_in_team_id: this.props.currentTeam.id, group_constrained: this.props.currentTeam.group_constrained});
                     if (data) {
                         this.props.actions.loadStatusesForProfilesList(data);
                     }
@@ -113,7 +112,7 @@ export default class AddUsersToTeam extends React.Component {
 
         this.setState({saving: true});
 
-        const {error} = await this.props.actions.addUsersToTeam(this.props.currentTeamId, userIds);
+        const {error} = await this.props.actions.addUsersToTeam(this.props.currentTeam.id, userIds);
         this.handleResponse(error);
         if (!error) {
             this.handleHide();
@@ -139,7 +138,7 @@ export default class AddUsersToTeam extends React.Component {
     handlePageChange = (page, prevPage) => {
         if (page > prevPage) {
             this.setUsersLoadingState(true);
-            this.props.actions.getProfilesNotInTeam(this.props.currentTeamId, page + 1, USERS_PER_PAGE).then(() => {
+            this.props.actions.getProfilesNotInTeam(this.props.currentTeam.id, page + 1, USERS_PER_PAGE).then(() => {
                 this.setUsersLoadingState(false);
             });
         }
@@ -249,7 +248,7 @@ export default class AddUsersToTeam extends React.Component {
                             defaultMessage='Add New Members To {teamName} Team'
                             values={{
                                 teamName: (
-                                    <strong>{this.props.currentTeamName}</strong>
+                                    <strong>{this.props.currentTeam.name}</strong>
                                 ),
                             }}
                         />

--- a/components/add_users_to_team/add_users_to_team.test.jsx
+++ b/components/add_users_to_team/add_users_to_team.test.jsx
@@ -34,7 +34,7 @@ describe('components/AddUsersToTeam', () => {
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find(Modal).exists()).toBe(true);
         expect(actions.getProfilesNotInTeam).toHaveBeenCalledTimes(1);
-        expect(actions.getProfilesNotInTeam).toHaveBeenCalledWith('current_team_id', 0, 100);
+        expect(actions.getProfilesNotInTeam).toHaveBeenCalledWith('current_team_id', false, 0, 100);
     });
 
     test('should match state when onHide is called', () => {

--- a/components/add_users_to_team/index.js
+++ b/components/add_users_to_team/index.js
@@ -30,7 +30,9 @@ function mapStateToProps(state) {
     const modalId = ModalIdentifiers.ADD_USER_TO_TEAM;
 
     return {
-        currentTeam: team,
+        currentTeamName: team.display_name,
+        currentTeamId: team.id,
+        currentTeamGroupConstrained: team.group_constrained,
         searchTerm,
         users,
         show: isModalOpen(state, modalId),

--- a/components/add_users_to_team/index.js
+++ b/components/add_users_to_team/index.js
@@ -30,8 +30,7 @@ function mapStateToProps(state) {
     const modalId = ModalIdentifiers.ADD_USER_TO_TEAM;
 
     return {
-        currentTeamName: team.display_name,
-        currentTeamId: team.id,
+        currentTeam: team,
         searchTerm,
         users,
         show: isModalOpen(state, modalId),

--- a/components/channel_invite_modal/channel_invite_modal.jsx
+++ b/components/channel_invite_modal/channel_invite_modal.jsx
@@ -57,7 +57,7 @@ export default class ChannelInviteModal extends React.Component {
     };
 
     componentDidMount() {
-        this.props.actions.getProfilesNotInChannel(this.props.channel.team_id, this.props.channel.id, 0).then(() => {
+        this.props.actions.getProfilesNotInChannel(this.props.channel.team_id, this.props.channel.id, this.props.channel.group_constrained, 0).then(() => {
             this.setUsersLoadingState(false);
         });
         this.props.actions.getTeamStats(this.props.channel.team_id);
@@ -89,7 +89,7 @@ export default class ChannelInviteModal extends React.Component {
     handlePageChange = (page, prevPage) => {
         if (page > prevPage) {
             this.setUsersLoadingState(true);
-            this.props.actions.getProfilesNotInChannel(this.props.channel.team_id, this.props.channel.id, page + 1, USERS_PER_PAGE).then(() => {
+            this.props.actions.getProfilesNotInChannel(this.props.channel.team_id, this.props.channel.id, this.props.channel.group_constrained, page + 1, USERS_PER_PAGE).then(() => {
                 this.setUsersLoadingState(false);
             });
         }
@@ -130,7 +130,7 @@ export default class ChannelInviteModal extends React.Component {
         this.searchTimeoutId = setTimeout(
             () => {
                 this.setUsersLoadingState(true);
-                searchUsers(term, this.props.channel.team_id, {not_in_channel_id: this.props.channel.id}).then(() => {
+                searchUsers(term, this.props.channel.team_id, {not_in_channel_id: this.props.channel.id, group_constrained: this.props.channel.group_constrained}).then(() => {
                     this.setUsersLoadingState(false);
                 });
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10499,8 +10499,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#6c48a6546d6b0148c06c88602f64af985a28d359",
-      "from": "github:mattermost/mattermost-redux#6c48a6546d6b0148c06c88602f64af985a28d359",
+      "version": "github:mattermost/mattermost-redux#429ac99932207fa21441d05482e36a0597c80515",
+      "from": "github:mattermost/mattermost-redux#429ac99932207fa21441d05482e36a0597c80515",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "localforage-observable": "1.4.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
-    "mattermost-redux": "github:mattermost/mattermost-redux#6c48a6546d6b0148c06c88602f64af985a28d359",
+    "mattermost-redux": "github:mattermost/mattermost-redux#429ac99932207fa21441d05482e36a0597c80515",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
Uses team and channel `group_constrained` property when loading users to add.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14751

#### Related Pull Requests
- [Has server changes](https://github.com/mattermost/mattermost-server/pull/10678)
- [Has redux changes](https://github.com/mattermost/mattermost-redux/pull/817)
- [Has mobile changes](https://github.com/mattermost/mattermost-mobile/pull/2737)