### PR TITLE
[MM-14588] Do not mark channel as read when adding user to a channel via profile popover

### DIFF
--- a/components/add_user_to_channel_modal/add_user_to_channel_modal.jsx
+++ b/components/add_user_to_channel_modal/add_user_to_channel_modal.jsx
@@ -157,7 +157,7 @@ export default class AddUserToChannelModal extends React.Component {
 
         this.setState({saving: true});
 
-        this.props.actions.addChannelMember(channelId, user.id).then(({error}) => {
+        this.props.actions.addChannelMember(channelId, user.id, '', false).then(({error}) => {
             if (error) {
                 this.handleSubmitError(error);
             } else {

--- a/components/add_user_to_channel_modal/add_user_to_channel_modal.test.jsx
+++ b/components/add_user_to_channel_modal/add_user_to_channel_modal.test.jsx
@@ -189,7 +189,8 @@ describe('components/AddUserToChannelModal', () => {
             wrapper.setState({selectedChannelId: 'someChannelId'});
             wrapper.instance().handleSubmit();
             expect(wrapper.state().saving).toBe(true);
-            expect(props.actions.addChannelMember).toBeCalled();
+            expect(props.actions.addChannelMember).toBeCalledTimes(1);
+            expect(props.actions.addChannelMember).toBeCalledWith('someChannelId', 'someUserId', '', false);
         });
 
         test('should match state when save is successful', async () => {


### PR DESCRIPTION
#### Summary
Do not mark channel as read when adding user to a channel via profile popover

Note:  Will update mattermost-redux commit once related change is merged.

#### Ticket Link
Jira ticket: [MM-14588](https://mattermost.atlassian.net/browse/MM-14588)

#### Related Pull Requests
- Has server changes (https://github.com/mattermost/mattermost-server/pull/10680)
- Has redux changes (https://github.com/mattermost/mattermost-redux/pull/818)
- Has mobile changes (not applicable)
