### PR TITLE
Do not open user list dropdowns upwards for short lists

### DIFF
--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
@@ -367,7 +367,7 @@ export default class SystemUsersDropdown extends React.Component {
 
         const {index, totalUsers} = this.props;
         let openUp = false;
-        if (totalUsers - index <= ROWS_FROM_BOTTOM_TO_OPEN_UP) {
+        if (totalUsers > ROWS_FROM_BOTTOM_TO_OPEN_UP && totalUsers - index <= ROWS_FROM_BOTTOM_TO_OPEN_UP) {
             openUp = true;
         }
 

--- a/components/channel_members_dropdown/channel_members_dropdown.jsx
+++ b/components/channel_members_dropdown/channel_members_dropdown.jsx
@@ -126,7 +126,7 @@ export default class ChannelMembersDropdown extends React.Component {
             if ((canMakeChannelMember || canMakeChannelAdmin)) {
                 const {index, totalUsers} = this.props;
                 let openUp = false;
-                if (totalUsers - index <= ROWS_FROM_BOTTOM_TO_OPEN_UP) {
+                if (totalUsers > ROWS_FROM_BOTTOM_TO_OPEN_UP && totalUsers - index <= ROWS_FROM_BOTTOM_TO_OPEN_UP) {
                     openUp = true;
                 }
 

--- a/components/team_members_dropdown/team_members_dropdown.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.jsx
@@ -224,7 +224,7 @@ export default class TeamMembersDropdown extends React.Component {
 
         const {index, totalUsers} = this.props;
         let openUp = false;
-        if (totalUsers - index <= ROWS_FROM_BOTTOM_TO_OPEN_UP) {
+        if (totalUsers > ROWS_FROM_BOTTOM_TO_OPEN_UP && totalUsers - index <= ROWS_FROM_BOTTOM_TO_OPEN_UP) {
             openUp = true;
         }
 


### PR DESCRIPTION
Follow-up to #2670 to fix the case where short lists open the dropdown upwards instead of downwards.