### PR TITLE
MM-15046: Adding AnyTeamPermissionGate and used with emojis permissions

### DIFF
--- a/components/emoji/emoji_list_item/emoji_list_item.jsx
+++ b/components/emoji/emoji_list_item/emoji_list_item.jsx
@@ -8,7 +8,7 @@ import Permissions from 'mattermost-redux/constants/permissions';
 import {Client4} from 'mattermost-redux/client';
 
 import DeleteEmoji from 'components/emoji/delete_emoji_modal.jsx';
-import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
+import AnyTeamPermissionGate from 'components/permissions_gates/any_team_permission_gate';
 
 export default class EmojiListItem extends React.Component {
     static propTypes = {
@@ -50,26 +50,17 @@ export default class EmojiListItem extends React.Component {
         let deleteButton = null;
         if (emoji.creator_id === this.props.currentUserId) {
             deleteButton = (
-                <TeamPermissionGate
-                    teamId={this.props.currentTeam.id}
-                    permissions={[Permissions.DELETE_EMOJIS]}
-                >
+                <AnyTeamPermissionGate permissions={[Permissions.DELETE_EMOJIS]}>
                     <DeleteEmoji onDelete={this.handleDelete}/>
-                </TeamPermissionGate>
+                </AnyTeamPermissionGate>
             );
         } else {
             deleteButton = (
-                <TeamPermissionGate
-                    teamId={this.props.currentTeam.id}
-                    permissions={[Permissions.DELETE_EMOJIS]}
-                >
-                    <TeamPermissionGate
-                        teamId={this.props.currentTeam.id}
-                        permissions={[Permissions.DELETE_OTHERS_EMOJIS]}
-                    >
+                <AnyTeamPermissionGate permissions={[Permissions.DELETE_EMOJIS]}>
+                    <AnyTeamPermissionGate permissions={[Permissions.DELETE_OTHERS_EMOJIS]}>
                         <DeleteEmoji onDelete={this.handleDelete}/>
-                    </TeamPermissionGate>
-                </TeamPermissionGate>
+                    </AnyTeamPermissionGate>
+                </AnyTeamPermissionGate>
             );
         }
 

--- a/components/emoji/emoji_page.jsx
+++ b/components/emoji/emoji_page.jsx
@@ -9,7 +9,7 @@ import {Link} from 'react-router-dom';
 import Permissions from 'mattermost-redux/constants/permissions';
 
 import * as Utils from 'utils/utils.jsx';
-import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
+import AnyTeamPermissionGate from 'components/permissions_gates/any_team_permission_gate';
 
 import EmojiList from './emoji_list';
 
@@ -56,10 +56,7 @@ export default class EmojiPage extends React.Component {
                             defaultMessage='Custom Emoji'
                         />
                     </h1>
-                    <TeamPermissionGate
-                        teamId={this.props.teamId}
-                        permissions={[Permissions.CREATE_EMOJIS]}
-                    >
+                    <AnyTeamPermissionGate permissions={[Permissions.CREATE_EMOJIS]}>
                         <Link
                             className='add-link'
                             to={'/' + this.props.teamName + '/emoji/add'}
@@ -74,7 +71,7 @@ export default class EmojiPage extends React.Component {
                                 />
                             </button>
                         </Link>
-                    </TeamPermissionGate>
+                    </AnyTeamPermissionGate>
                 </div>
                 <EmojiList scrollToTop={this.props.scrollToTop}/>
             </div>

--- a/components/permissions_gates/any_team_permission_gate/__snapshots__/any_team_permission_gate.test.jsx.snap
+++ b/components/permissions_gates/any_team_permission_gate/__snapshots__/any_team_permission_gate.test.jsx.snap
@@ -1,6 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/permissions_gates TeamPermissionGate should match snapshot when user have at least on of the permissions 1`] = `
+exports[`components/permissions_gates TeamPermissionGate should match snapshot when user doesn't have permission 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(AnyTeamPermissionGate)
+    permissions={
+      Array [
+        "invalid_permission",
+      ]
+    }
+  >
+    <AnyTeamPermissionGate
+      dispatch={[Function]}
+      hasPermission={false}
+      invert={false}
+      permissions={
+        Array [
+          "invalid_permission",
+        ]
+      }
+    />
+  </Connect(AnyTeamPermissionGate)>
+</Provider>
+`;
+
+exports[`components/permissions_gates TeamPermissionGate should match snapshot when user have at least one of the permissions 1`] = `
 <Provider
   store={
     Object {
@@ -217,40 +251,6 @@ exports[`components/permissions_gates TeamPermissionGate should match snapshot w
       permissions={
         Array [
           "other_permission",
-        ]
-      }
-    />
-  </Connect(AnyTeamPermissionGate)>
-</Provider>
-`;
-
-exports[`components/permissions_gates TeamPermissionGate should match snapshot when user haven't permission 1`] = `
-<Provider
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
->
-  <Connect(AnyTeamPermissionGate)
-    permissions={
-      Array [
-        "invalid_permission",
-      ]
-    }
-  >
-    <AnyTeamPermissionGate
-      dispatch={[Function]}
-      hasPermission={false}
-      invert={false}
-      permissions={
-        Array [
-          "invalid_permission",
         ]
       }
     />

--- a/components/permissions_gates/any_team_permission_gate/__snapshots__/any_team_permission_gate.test.jsx.snap
+++ b/components/permissions_gates/any_team_permission_gate/__snapshots__/any_team_permission_gate.test.jsx.snap
@@ -1,0 +1,298 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/permissions_gates TeamPermissionGate should match snapshot when user have at least on of the permissions 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(AnyTeamPermissionGate)
+    permissions={
+      Array [
+        "test_team_permission",
+        "not_existing_permission",
+      ]
+    }
+  >
+    <AnyTeamPermissionGate
+      dispatch={[Function]}
+      hasPermission={true}
+      invert={false}
+      permissions={
+        Array [
+          "test_team_permission",
+          "not_existing_permission",
+        ]
+      }
+    >
+      <p>
+        Valid permission (shown)
+      </p>
+    </AnyTeamPermissionGate>
+  </Connect(AnyTeamPermissionGate)>
+</Provider>
+`;
+
+exports[`components/permissions_gates TeamPermissionGate should match snapshot when user have permission 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(AnyTeamPermissionGate)
+    permissions={
+      Array [
+        "test_team_permission",
+      ]
+    }
+  >
+    <AnyTeamPermissionGate
+      dispatch={[Function]}
+      hasPermission={true}
+      invert={false}
+      permissions={
+        Array [
+          "test_team_permission",
+        ]
+      }
+    >
+      <p>
+        Valid permission (shown)
+      </p>
+    </AnyTeamPermissionGate>
+  </Connect(AnyTeamPermissionGate)>
+</Provider>
+`;
+
+exports[`components/permissions_gates TeamPermissionGate should match snapshot when user have permission and use invert 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(AnyTeamPermissionGate)
+    invert={true}
+    permissions={
+      Array [
+        "test_team_permission",
+      ]
+    }
+  >
+    <AnyTeamPermissionGate
+      dispatch={[Function]}
+      hasPermission={true}
+      invert={true}
+      permissions={
+        Array [
+          "test_team_permission",
+        ]
+      }
+    />
+  </Connect(AnyTeamPermissionGate)>
+</Provider>
+`;
+
+exports[`components/permissions_gates TeamPermissionGate should match snapshot when user have permission system wide 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(AnyTeamPermissionGate)
+    permissions={
+      Array [
+        "test_system_permission",
+      ]
+    }
+  >
+    <AnyTeamPermissionGate
+      dispatch={[Function]}
+      hasPermission={true}
+      invert={false}
+      permissions={
+        Array [
+          "test_system_permission",
+        ]
+      }
+    >
+      <p>
+        Valid permission (shown)
+      </p>
+    </AnyTeamPermissionGate>
+  </Connect(AnyTeamPermissionGate)>
+</Provider>
+`;
+
+exports[`components/permissions_gates TeamPermissionGate should match snapshot when user have the permission in other team 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(AnyTeamPermissionGate)
+    permissions={
+      Array [
+        "other_permission",
+      ]
+    }
+  >
+    <AnyTeamPermissionGate
+      dispatch={[Function]}
+      hasPermission={true}
+      invert={false}
+      permissions={
+        Array [
+          "other_permission",
+        ]
+      }
+    >
+      <p>
+        Valid permission (shown)
+      </p>
+    </AnyTeamPermissionGate>
+  </Connect(AnyTeamPermissionGate)>
+</Provider>
+`;
+
+exports[`components/permissions_gates TeamPermissionGate should match snapshot when user have the permission in other team and use invert 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(AnyTeamPermissionGate)
+    invert={true}
+    permissions={
+      Array [
+        "other_permission",
+      ]
+    }
+  >
+    <AnyTeamPermissionGate
+      dispatch={[Function]}
+      hasPermission={true}
+      invert={true}
+      permissions={
+        Array [
+          "other_permission",
+        ]
+      }
+    />
+  </Connect(AnyTeamPermissionGate)>
+</Provider>
+`;
+
+exports[`components/permissions_gates TeamPermissionGate should match snapshot when user haven't permission 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(AnyTeamPermissionGate)
+    permissions={
+      Array [
+        "invalid_permission",
+      ]
+    }
+  >
+    <AnyTeamPermissionGate
+      dispatch={[Function]}
+      hasPermission={false}
+      invert={false}
+      permissions={
+        Array [
+          "invalid_permission",
+        ]
+      }
+    />
+  </Connect(AnyTeamPermissionGate)>
+</Provider>
+`;
+
+exports[`components/permissions_gates TeamPermissionGate should match snapshot when user not have permission and use invert 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(AnyTeamPermissionGate)
+    invert={true}
+    permissions={
+      Array [
+        "invalid_permission",
+      ]
+    }
+  >
+    <AnyTeamPermissionGate
+      dispatch={[Function]}
+      hasPermission={false}
+      invert={true}
+      permissions={
+        Array [
+          "invalid_permission",
+        ]
+      }
+    >
+      <p>
+        Invalid permission but inverted (shown)
+      </p>
+    </AnyTeamPermissionGate>
+  </Connect(AnyTeamPermissionGate)>
+</Provider>
+`;

--- a/components/permissions_gates/any_team_permission_gate/any_team_permission_gate.jsx
+++ b/components/permissions_gates/any_team_permission_gate/any_team_permission_gate.jsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class AnyTeamPermissionGate extends React.Component {
+    static defaultProps = {
+        invert: false,
+    }
+
+    static propTypes = {
+
+        /**
+         * Permissions enough to pass the gate (binary OR)
+         */
+        permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+
+        /**
+         * Has permission
+         */
+        hasPermission: PropTypes.bool.isRequired,
+
+        /**
+         * Invert the permission (used for else)
+         */
+        invert: PropTypes.bool.isRequired,
+
+        /**
+         * Content protected by the permissions gate
+         */
+        children: PropTypes.node.isRequired,
+    };
+
+    render() {
+        if (this.props.hasPermission && !this.props.invert) {
+            return this.props.children;
+        }
+        if (!this.props.hasPermission && this.props.invert) {
+            return this.props.children;
+        }
+        return null;
+    }
+}

--- a/components/permissions_gates/any_team_permission_gate/any_team_permission_gate.test.jsx
+++ b/components/permissions_gates/any_team_permission_gate/any_team_permission_gate.test.jsx
@@ -71,7 +71,7 @@ describe('components/permissions_gates', () => {
 
             expect(wrapper).toMatchSnapshot();
         });
-        test('should match snapshot when user have at least on of the permissions', () => {
+        test('should match snapshot when user have at least one of the permissions', () => {
             const wrapper = mount(
                 <Provider store={store}>
                     <AnyTeamPermissionGate permissions={['test_team_permission', 'not_existing_permission']}>
@@ -124,7 +124,7 @@ describe('components/permissions_gates', () => {
 
             expect(wrapper).toMatchSnapshot();
         });
-        test('should match snapshot when user haven\'t permission', () => {
+        test('should match snapshot when user doesn\'t have permission', () => {
             const wrapper = mount(
                 <Provider store={store}>
                     <AnyTeamPermissionGate

--- a/components/permissions_gates/any_team_permission_gate/any_team_permission_gate.test.jsx
+++ b/components/permissions_gates/any_team_permission_gate/any_team_permission_gate.test.jsx
@@ -1,0 +1,154 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {mount} from 'enzyme';
+import {Provider} from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import AnyTeamPermissionGate from 'components/permissions_gates/any_team_permission_gate';
+
+describe('components/permissions_gates', () => {
+    const mockStore = configureStore();
+    const state = {
+        entities: {
+            channels: {
+                myMembers: {
+                    channel_id: {channel_id: 'channel_id', roles: 'channel_role'},
+                },
+            },
+            teams: {
+                teams: {
+                    team_id: {id: 'team_id'},
+                    team_id2: {id: 'team_id2'},
+                },
+                myMembers: {
+                    team_id: {team_id: 'team_id', roles: 'team_role'},
+                    team_id2: {team_id: 'team_id2', roles: 'team_role2'},
+                },
+            },
+            users: {
+                currentUserId: 'user_id',
+                profiles: {
+                    user_id: {
+                        id: 'user_id',
+                        roles: 'system_role',
+                    },
+                },
+            },
+            roles: {
+                roles: {
+                    system_role: {permissions: ['test_system_permission']},
+                    team_role: {permissions: ['test_team_permission']},
+                    team_role2: {permissions: ['other_permission']},
+                    channel_role: {permissions: ['test_channel_permission']},
+                },
+            },
+        },
+    };
+    const store = mockStore(state);
+
+    describe('TeamPermissionGate', () => {
+        test('should match snapshot when user have permission', () => {
+            const wrapper = mount(
+                <Provider store={store}>
+                    <AnyTeamPermissionGate permissions={['test_team_permission']}>
+                        <p>{'Valid permission (shown)'}</p>
+                    </AnyTeamPermissionGate>
+                </Provider>
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+        test('should match snapshot when user have the permission in other team', () => {
+            const wrapper = mount(
+                <Provider store={store}>
+                    <AnyTeamPermissionGate permissions={['other_permission']}>
+                        <p>{'Valid permission (shown)'}</p>
+                    </AnyTeamPermissionGate>
+                </Provider>
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+        test('should match snapshot when user have at least on of the permissions', () => {
+            const wrapper = mount(
+                <Provider store={store}>
+                    <AnyTeamPermissionGate permissions={['test_team_permission', 'not_existing_permission']}>
+                        <p>{'Valid permission (shown)'}</p>
+                    </AnyTeamPermissionGate>
+                </Provider>
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+        test('should match snapshot when user have permission and use invert', () => {
+            const wrapper = mount(
+                <Provider store={store}>
+                    <AnyTeamPermissionGate
+                        permissions={['test_team_permission']}
+                        invert={true}
+                    >
+                        <p>{'Valid permission but inverted (not shown)'}</p>
+                    </AnyTeamPermissionGate>
+                </Provider>
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+        test('should match snapshot when user not have permission and use invert', () => {
+            const wrapper = mount(
+                <Provider store={store}>
+                    <AnyTeamPermissionGate
+                        permissions={['invalid_permission']}
+                        invert={true}
+                    >
+                        <p>{'Invalid permission but inverted (shown)'}</p>
+                    </AnyTeamPermissionGate>
+                </Provider>
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+        test('should match snapshot when user have the permission in other team and use invert', () => {
+            const wrapper = mount(
+                <Provider store={store}>
+                    <AnyTeamPermissionGate
+                        permissions={['other_permission']}
+                        invert={true}
+                    >
+                        <p>{'Valid permission but inverted (not shown)'}</p>
+                    </AnyTeamPermissionGate>
+                </Provider>
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+        test('should match snapshot when user haven\'t permission', () => {
+            const wrapper = mount(
+                <Provider store={store}>
+                    <AnyTeamPermissionGate
+                        permissions={['invalid_permission']}
+                    >
+                        <p>{'Invalid permission (not shown)'}</p>
+                    </AnyTeamPermissionGate>
+                </Provider>
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+        test('should match snapshot when user have permission system wide', () => {
+            const wrapper = mount(
+                <Provider store={store}>
+                    <AnyTeamPermissionGate
+                        permissions={['test_system_permission']}
+                    >
+                        <p>{'Valid permission (shown)'}</p>
+                    </AnyTeamPermissionGate>
+                </Provider>
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+    });
+});

--- a/components/permissions_gates/any_team_permission_gate/index.js
+++ b/components/permissions_gates/any_team_permission_gate/index.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
+import {getMyTeams} from 'mattermost-redux/selectors/entities/teams';
+
+import AnyTeamPermissionGate from './any_team_permission_gate.jsx';
+
+function mapStateToProps(state, ownProps) {
+    const teams = getMyTeams(state);
+    for (const team of teams) {
+        for (const permission of ownProps.permissions) {
+            if (haveITeamPermission(state, {team: team.id, permission})) {
+                return {hasPermission: true};
+            }
+        }
+    }
+
+    return {hasPermission: false};
+}
+
+export default connect(mapStateToProps)(AnyTeamPermissionGate);


### PR DESCRIPTION
#### Summary
Emojis permissions have the special property of been granted from any team
admin role, so if you have the permission at any team, you are able to do the
actions in all the teams. I added a new permissions gate call
"AnyTeamPermissionGate" which deal with that and used for the emojis
permissions.

#### Ticket Link
[MM-15046](https://mattermost.atlassian.net/browse/MM-15046)