### PR TITLE
MM-14931 Fix markdown checkboxes not being rendered correctly after post edits

### DIFF
--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -33,7 +33,6 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
         return true;
     }
 
-    let checkboxCount = 0;
     const processingInstructions = [
 
         // Workaround to fix MM-14931
@@ -42,8 +41,7 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
             shouldProcessNode: (node) => node.type === 'tag' && node.name === 'input' && node.attribs.type === 'checkbox',
             processNode: (node) => {
                 const attribs = node.attribs || {};
-                node.attribs.key = attribs.checked ? checkboxCount + '_checked' : checkboxCount + '_unchecked';
-                checkboxCount += 1;
+                node.attribs.checked = Boolean(attribs.checked);
 
                 return React.createElement('input', {...node.attribs});
             },

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -33,7 +33,23 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
         return true;
     }
 
-    const processingInstructions = [];
+    let checkboxCount = 0;
+    const processingInstructions = [
+
+        // Workaround to fix MM-14931
+        {
+            replaceChildren: false,
+            shouldProcessNode: (node) => node.type === 'tag' && node.name === 'input' && node.attribs.type === 'checkbox',
+            processNode: (node) => {
+                const attribs = node.attribs || {};
+                node.attribs.key = attribs.checked ? checkboxCount + '_checked' : checkboxCount + '_unchecked';
+                checkboxCount += 1;
+
+                return React.createElement('input', {...node.attribs});
+            },
+        },
+    ];
+
     if (options.hasPluginTooltips) {
         const hrefAttrib = 'href';
         processingInstructions.push({


### PR DESCRIPTION
#### Summary
This is a really weird one. If a checkbox was unedited in the post, the post would not update. I checked to make sure that we were actually re-rendering the Markdown component, which we were, and tracked (with @hmhealey's help) the problem down to the fact that the React key for the checkbox elements was preventing the low-level re-rendering of the checkbox to happen.

My fix is a workaround to change the key based on whether the checkbox is checked or not. Open to other suggestions if others can think of better solutions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14931