### PR TITLE
[MM-14709] Scroll to the top of the Account Settings modal when the active tab changes

### DIFF
--- a/components/user_settings/modal/user_settings_modal.jsx
+++ b/components/user_settings/modal/user_settings_modal.jsx
@@ -110,7 +110,7 @@ class UserSettingsModal extends React.Component {
         document.removeEventListener('keydown', this.handleKeyDown);
     }
 
-    componentDidUpdate(_prevProps, prevState) {
+    componentDidUpdate(prevProps, prevState) {
         if (!Utils.isMobile()) {
             $('.settings-content .minimize-settings').perfectScrollbar('update');
         }

--- a/components/user_settings/modal/user_settings_modal.jsx
+++ b/components/user_settings/modal/user_settings_modal.jsx
@@ -110,9 +110,13 @@ class UserSettingsModal extends React.Component {
         document.removeEventListener('keydown', this.handleKeyDown);
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(_prevProps, prevState) {
         if (!Utils.isMobile()) {
             $('.settings-content .minimize-settings').perfectScrollbar('update');
+        }
+
+        if (this.state.active_tab !== prevState.active_tab) {
+            $(ReactDOM.findDOMNode(this.refs.modalBody)).scrollTop(0);
         }
     }
 


### PR DESCRIPTION
#### Summary
Scroll to the top of the Account Settings modal when the active tab changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14709
