### PR TITLE
MM-14927 Made the real SiteURL be used in incoming webhook URLs

### DIFF
--- a/components/integrations/__snapshots__/installed_incoming_webhook.test.jsx.snap
+++ b/components/integrations/__snapshots__/installed_incoming_webhook.test.jsx.snap
@@ -36,7 +36,7 @@ exports[`components/integrations/InstalledIncomingWebhook should match snapshot 
           id="installed_integrations.url"
           values={
             Object {
-              "url": "http://localhost:8065/hooks/9w96t4nhbfdiij64wfqors4i1r",
+              "url": "https://some.url/path/hooks/9w96t4nhbfdiij64wfqors4i1r",
             }
           }
         />
@@ -44,7 +44,7 @@ exports[`components/integrations/InstalledIncomingWebhook should match snapshot 
           <CopyText
             defaultMessage="Copy"
             idMessage="integrations.copy"
-            value="http://localhost:8065/hooks/9w96t4nhbfdiij64wfqors4i1r"
+            value="https://some.url/path/hooks/9w96t4nhbfdiij64wfqors4i1r"
           />
         </span>
       </span>

--- a/components/integrations/confirm_integration/__snapshots__/confirm_integration.test.jsx.snap
+++ b/components/integrations/confirm_integration/__snapshots__/confirm_integration.test.jsx.snap
@@ -123,14 +123,14 @@ exports[`components/integrations/ConfirmIntegration should match snapshot, incom
         id="add_incoming_webhook.url"
         values={
           Object {
-            "url": "http://localhost:8065/hooks/r5tpgt4iepf45jt768jz84djic",
+            "url": "https://some.url/path/hooks/r5tpgt4iepf45jt768jz84djic",
           }
         }
       />
       <CopyText
         defaultMessage="Copy webhook URL"
         idMessage="integrations.copy_webhook_url"
-        value="http://localhost:8065/hooks/r5tpgt4iepf45jt768jz84djic"
+        value="https://some.url/path/hooks/r5tpgt4iepf45jt768jz84djic"
       />
     </p>
     <div

--- a/components/integrations/confirm_integration/__snapshots__/confirm_integration.test.jsx.snap
+++ b/components/integrations/confirm_integration/__snapshots__/confirm_integration.test.jsx.snap
@@ -128,8 +128,8 @@ exports[`components/integrations/ConfirmIntegration should match snapshot, incom
         }
       />
       <CopyText
-        defaultMessage="Copy Client Secret"
-        idMessage="integrations.copy_client_secret"
+        defaultMessage="Copy webhook URL"
+        idMessage="integrations.copy_webhook_url"
         value="http://localhost:8065/hooks/r5tpgt4iepf45jt768jz84djic"
       />
     </p>

--- a/components/integrations/confirm_integration/confirm_integration.jsx
+++ b/components/integrations/confirm_integration/confirm_integration.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
-import {getSiteURL} from 'utils/url.jsx';
 import {browserHistory} from 'utils/browser_history';
 import {Constants, ErrorPageTypes} from 'utils/constants.jsx';
 import CopyText from 'components/copy_text.jsx';
@@ -59,7 +58,7 @@ export default class ConfirmIntegration extends React.Component {
         const outgoingHook = this.props.outgoingHooks[this.state.id];
         const oauthApp = this.props.oauthApps[this.state.id];
         const bot = this.props.bots[this.state.id];
-        const siteURL = this.props.siteURL || getSiteURL();
+        const siteURL = this.props.siteURL;
 
         if (this.state.type === Constants.Integrations.COMMAND && command) {
             const commandToken = command.token;

--- a/components/integrations/confirm_integration/confirm_integration.jsx
+++ b/components/integrations/confirm_integration/confirm_integration.jsx
@@ -6,11 +6,11 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
+import {getSiteURL} from 'utils/url.jsx';
 import {browserHistory} from 'utils/browser_history';
 import {Constants, ErrorPageTypes} from 'utils/constants.jsx';
 import CopyText from 'components/copy_text.jsx';
 import BackstageHeader from 'components/backstage/components/backstage_header.jsx';
-import {getSiteURL} from 'utils/url.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 export default class ConfirmIntegration extends React.Component {
@@ -23,6 +23,7 @@ export default class ConfirmIntegration extends React.Component {
             incomingHooks: PropTypes.object,
             outgoingHooks: PropTypes.object,
             bots: PropTypes.object,
+            siteURL: PropTypes.string,
         };
     }
 
@@ -58,6 +59,7 @@ export default class ConfirmIntegration extends React.Component {
         const outgoingHook = this.props.outgoingHooks[this.state.id];
         const oauthApp = this.props.oauthApps[this.state.id];
         const bot = this.props.bots[this.state.id];
+        const siteURL = this.props.siteURL || getSiteURL();
 
         if (this.state.type === Constants.Integrations.COMMAND && command) {
             const commandToken = command.token;
@@ -91,7 +93,7 @@ export default class ConfirmIntegration extends React.Component {
                 </p>
             );
         } else if (this.state.type === Constants.Integrations.INCOMING_WEBHOOK && incomingHook) {
-            const incomingHookToken = getSiteURL() + '/hooks/' + incomingHook.id;
+            const incomingHookToken = siteURL + '/hooks/' + incomingHook.id;
 
             headerText = (
                 <FormattedMessage
@@ -117,8 +119,8 @@ export default class ConfirmIntegration extends React.Component {
                         }}
                     />
                     <CopyText
-                        idMessage='integrations.copy_client_secret'
-                        defaultMessage='Copy Client Secret'
+                        idMessage='integrations.copy_webhook_url'
+                        defaultMessage='Copy webhook URL'
                         value={incomingHookToken}
                     />
                 </p>

--- a/components/integrations/confirm_integration/confirm_integration.test.jsx
+++ b/components/integrations/confirm_integration/confirm_integration.test.jsx
@@ -32,6 +32,7 @@ describe('components/integrations/ConfirmIntegration', () => {
     const incomingHooks = {[id]: {id}};
     const outgoingHooks = {[id]: {id, token}};
     const bots = {[userId]: bot};
+    const siteURL = 'https://some.url/path';
 
     const props = {
         team,
@@ -41,6 +42,7 @@ describe('components/integrations/ConfirmIntegration', () => {
         incomingHooks,
         outgoingHooks,
         bots,
+        siteURL,
     };
 
     test('should match snapshot, oauthApps case', () => {

--- a/components/integrations/confirm_integration/index.js
+++ b/components/integrations/confirm_integration/index.js
@@ -3,17 +3,21 @@
 
 import {connect} from 'react-redux';
 import {getCommands, getOAuthApps, getIncomingHooks, getOutgoingHooks} from 'mattermost-redux/selectors/entities/integrations';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getBotAccounts} from 'mattermost-redux/selectors/entities/bots';
 
 import ConfirmIntegration from './confirm_integration.jsx';
 
 function mapStateToProps(state) {
+    const config = getConfig(state);
+
     return {
         commands: getCommands(state),
         oauthApps: getOAuthApps(state),
         incomingHooks: getIncomingHooks(state),
         outgoingHooks: getOutgoingHooks(state),
         bots: getBotAccounts(state),
+        siteURL: config.SiteURL,
     };
 }
 

--- a/components/integrations/confirm_integration/index.js
+++ b/components/integrations/confirm_integration/index.js
@@ -6,10 +6,19 @@ import {getCommands, getOAuthApps, getIncomingHooks, getOutgoingHooks} from 'mat
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getBotAccounts} from 'mattermost-redux/selectors/entities/bots';
 
+import {getSiteURL} from 'utils/url.jsx';
+
 import ConfirmIntegration from './confirm_integration.jsx';
 
 function mapStateToProps(state) {
     const config = getConfig(state);
+
+    // If we have a configured SiteURL, that is not a loopback, use it
+    let siteURL = getSiteURL();
+    if (config.SiteURL &&
+        !config.SiteURL.match(/localhost|127(?:\.[0-9]+){0,2}\.[0-9]+|(?:0*:)*?:?0*1/g)) {
+        siteURL = config.SiteURL;
+    }
 
     return {
         commands: getCommands(state),
@@ -17,7 +26,7 @@ function mapStateToProps(state) {
         incomingHooks: getIncomingHooks(state),
         outgoingHooks: getOutgoingHooks(state),
         bots: getBotAccounts(state),
-        siteURL: config.SiteURL,
+        siteURL,
     };
 }
 

--- a/components/integrations/installed_incoming_webhook.jsx
+++ b/components/integrations/installed_incoming_webhook.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
-import {getSiteURL} from 'utils/url.jsx';
 import {t} from 'utils/i18n';
 
 import CopyText from 'components/copy_text.jsx';
@@ -69,6 +68,11 @@ export default class InstalledIncomingWebhook extends React.PureComponent {
         *  Data used for filtering of webhook based on filter prop
         */
         channel: PropTypes.object,
+
+        /**
+        *  External site URL
+        */
+        siteURL: PropTypes.string,
     }
 
     constructor(props) {
@@ -85,6 +89,7 @@ export default class InstalledIncomingWebhook extends React.PureComponent {
         const incomingWebhook = this.props.incomingWebhook;
         const channel = this.props.channel;
         const filter = this.props.filter ? this.props.filter.toLowerCase() : '';
+        const siteURL = this.props.siteURL;
 
         if (!matchesFilter(incomingWebhook, channel, filter)) {
             return null;
@@ -134,7 +139,7 @@ export default class InstalledIncomingWebhook extends React.PureComponent {
             );
         }
 
-        const incomingWebhookId = getSiteURL() + '/hooks/' + incomingWebhook.id;
+        const incomingWebhookId = siteURL + '/hooks/' + incomingWebhook.id;
 
         return (
             <div className='backstage-list__item'>

--- a/components/integrations/installed_incoming_webhook.test.jsx
+++ b/components/integrations/installed_incoming_webhook.test.jsx
@@ -43,6 +43,7 @@ describe('components/integrations/InstalledIncomingWebhook', () => {
                     id: '1jiw9kphbjrntfyrm7xpdcya4o',
                     name: 'town-square',
                 }}
+                siteURL='https://some.url/path'
             />
         );
         expect(wrapper).toMatchSnapshot();

--- a/components/integrations/installed_incoming_webhooks/index.js
+++ b/components/integrations/installed_incoming_webhooks/index.js
@@ -12,6 +12,8 @@ import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
+import {getSiteURL} from 'utils/url.jsx';
+
 import {loadIncomingHooksAndProfilesForTeam} from 'actions/integration_actions';
 
 import InstalledIncomingWebhooks from './installed_incoming_webhooks.jsx';
@@ -26,6 +28,14 @@ function mapStateToProps(state) {
         filter((incomingWebhook) => incomingWebhook.team_id === teamId);
     const enableIncomingWebhooks = config.EnableIncomingWebhooks === 'true';
 
+    // If we have a configured SiteURL, that is not a loopback, use it
+    let siteURL = getSiteURL();
+
+    if (config.SiteURL &&
+        !config.SiteURL.match(/localhost|127(?:\.[0-9]+){0,2}\.[0-9]+|(?:0*:)*?:?0*1/g)) {
+        siteURL = config.SiteURL;
+    }
+
     return {
         incomingWebhooks,
         channels: getAllChannels(state),
@@ -33,6 +43,7 @@ function mapStateToProps(state) {
         teamId,
         canManageOthersWebhooks,
         enableIncomingWebhooks,
+        siteURL,
     };
 }
 

--- a/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.jsx
+++ b/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.jsx
@@ -66,6 +66,11 @@ export default class InstalledIncomingWebhooks extends React.PureComponent {
         * Whether or not incoming webhooks are enabled.
         */
         enableIncomingWebhooks: PropTypes.bool,
+
+        /**
+        * External site URL
+        */
+        siteURL: PropTypes.string,
     }
 
     constructor(props) {
@@ -114,6 +119,7 @@ export default class InstalledIncomingWebhooks extends React.PureComponent {
         map((incomingWebhook) => {
             const canChange = this.props.canManageOthersWebhooks || this.props.user.id === incomingWebhook.user_id;
             const channel = this.props.channels[incomingWebhook.channel_id];
+            const siteURL = this.props.siteURL;
             return (
                 <InstalledIncomingWebhook
                     key={incomingWebhook.id}
@@ -123,6 +129,7 @@ export default class InstalledIncomingWebhooks extends React.PureComponent {
                     canChange={canChange}
                     team={this.props.team}
                     channel={channel}
+                    siteURL={siteURL}
                 />
             );
         });


### PR DESCRIPTION
#### Summary
Use config.SiteURL if available, rather than getSiteURL() which points at window.location rather than the configured SiteURL.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14927