### PR TITLE
MM-15285: Fixing IE11 initialization problems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5784,9 +5784,9 @@
       "dev": true
     },
     "exif2css": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/exif2css/-/exif2css-1.3.0.tgz",
-      "integrity": "sha512-RBjZaFcNumDz3bZiZGsR3Kg2jouyLuRnUPox7yE24WcvK8IhVdShAwSQHEqupGC0/DYDZsiunk+sv8CLmu4Lqg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/exif2css/-/exif2css-1.2.0.tgz",
+      "integrity": "sha1-hDjhFpIVCOPcwwy+JAex1VNeG0U="
     },
     "exit": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "compass-mixins": "0.12.10",
     "core-js": "2.6.5",
     "emoji-regex": "8.0.0",
-    "exif2css": "1.3.0",
+    "exif2css": "1.2.0",
     "fastclick": "1.0.6",
     "flexsearch": "0.6.22",
     "flux": "3.1.3",

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -102,7 +102,7 @@ function initializePlugin(manifest) {
     // Initialize the plugin
     const plugin = window.plugins[manifest.id];
     const registry = new PluginRegistry(manifest.id);
-    if (plugin.initialize) {
+    if (plugin && plugin.initialize) {
         plugin.initialize(registry, store);
     }
 }


### PR DESCRIPTION
#### Summary
Revert to the previous exif2css version (compatible with IE11) and checking bad
plugin initialization 

#### Ticket Link
[MM-15285](https://mattermost.atlassian.net/browse/MM-15285)

#### Related Pull Requests
- Has redux changes mattermost/mattermost-redux#822