### PR TITLE
Hide loading indicator for pinned and flagged posts

### DIFF
--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -197,7 +197,7 @@ export default class SearchResults extends React.PureComponent {
         }
 
         let loadingMorePostsComponent = null;
-        if (!this.props.isSearchAtEnd) {
+        if (!this.props.isSearchAtEnd && !this.props.isFlaggedPosts && !this.props.isPinnedPosts) {
             loadingMorePostsComponent = (
                 <div className='loading-screen'>
                     <div className='loading__content'>


### PR DESCRIPTION
#### Summary
Follow-up fix for #2684 where I didn't account for flagged or pinned posts not needing the loading more indicator.