### PR TITLE
MM-15010 Adding Cypress test for - Pinning or un-pinning older post d…

### DIFF
--- a/components/search_results_header/search_results_header.jsx
+++ b/components/search_results_header/search_results_header.jsx
@@ -129,6 +129,7 @@ export default class SearchResultsHeader extends React.Component {
                         </OverlayTrigger>
                     </button>
                     <button
+                        id='searchResultsCloseButton'
                         type='button'
                         className='sidebar--right__close'
                         aria-label='Close'

--- a/cypress/integration/onboarding/messaging/message_pinning_unpinning_spec.js
+++ b/cypress/integration/onboarding/messaging/message_pinning_unpinning_spec.js
@@ -1,0 +1,103 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/*eslint max-nested-callbacks: ["error", 5]*/
+
+const pinnedPosts = [];
+
+/**
+* Pin post by cliking on [...] then 'Pin to channel', and add the pinned post to pinnedPosts
+* @param {String} postId - post ID of the post to pin
+*/
+function pinPost(nthPost) {
+    cy.getNthPostId(nthPost).then((postId) => {
+        cy.clickPostDotMenu(postId);
+        cy.get(`#pin_post_${postId}`).click();
+        pinnedPosts.push(postId);
+    });
+}
+
+describe('Messaging', () => {
+    before(() => {
+        // Login and go to /
+        cy.apiLogin('user-1');
+        cy.visit('/');
+    });
+
+    // Unpin all posts at the end of the test
+    after(() => {
+        pinnedPosts.forEach((pinnedPost) => {
+            cy.apiUnpinPosts(pinnedPost);
+        });
+    });
+
+    it('M15010 Pinning or un-pinning older post does not cause it to display at bottom of channel', () => {
+        cy.get('#sidebarItem_saepe-5').click();
+
+        // 1. Ensure there are a couple of pinned posts in the channel already:
+        // 1a. Pin 10th and 15th newest posts
+        pinPost(10);
+        pinPost(15);
+
+        // 1b. Click on Pinned Posts channel header button
+        cy.get('#channelHeaderPinButton').click();
+
+        // 1c. Verify the pinned posts (10 & 15) are added to the Pinned Posts list on the right hand side
+        cy.get('#search-items-container').children().should('have.length', 2);
+
+        // 1d. Close out of the Pinned Post side bar
+        cy.get('#searchResultsCloseButton').click();
+
+        // 2. Get postId for the 20th (from the last) post
+        const olderPost = 20;
+        cy.getNthPostId(olderPost).then((postId) => {
+            // 3. Scroll up to the 20th last post
+            cy.get(`#post_${postId}`).scrollIntoView();
+
+            // 4. Click [...] > Pin to channel
+            pinPost(olderPost);
+
+            // 5. Store the post message of the 20th post as pinnedPostText
+            cy.get(`#postMessageText_${postId}`).invoke('text').then((pinnedPostText) => {
+                // 6. Store the last post ID as lastPostId
+                cy.getLastPostId().then((lastPostId) => {
+                    // 7. Scroll down to the last post
+                    cy.get(`#post_${lastPostId}`).scrollIntoView();
+
+                    // * Verify that message just pinned does not display at bottom in center channel as newest in channel
+                    cy.get(`#postMessageText_${lastPostId}`).should('not.contain', pinnedPostText);
+
+                    // 8. Click pin icon to view pinned posts in right-hand-side
+                    cy.get('#channelHeaderPinButton').click();
+
+                    // * Verify that there are now 3 pinned messages in the right-hand-side
+                    cy.get('#search-items-container').children().should('have.length', 3);
+
+                    // * Verify sorted by newest at top: 1st post is the newest, and 3rd post is the oldest
+                    cy.get('#search-items-container').children().eq(0).get(`#postMessageText_${lastPostId}`);
+                    cy.get('#search-items-container').children().eq(2).get(`#postMessageText_${postId}`).and('contain', pinnedPostText);
+
+                    // 9. Scroll back up to the post pinned in step 4.
+                    cy.get(`#post_${postId}`).scrollIntoView();
+
+                    // * When un-pinned in center, post disappears from pinned posts list in right-hand-side:
+                    // 10. Click [...] > Un-pin from channel
+                    cy.clickPostDotMenu(postId);
+                    cy.get(`#unpin_post_${postId}`).click();
+
+                    // * Right-hand-side only has 2 initially pinned posts
+                    cy.get('#search-items-container').children().should('have.length', 2);
+
+                    // * Right-hand-side does not have the post pinned in step 4.
+                    cy.get('#search-items-container').children().should('not.contain', `#postMessageText_${postId}`);
+                });
+            });
+        });
+    });
+});

--- a/cypress/integration/onboarding/messaging/message_pinning_unpinning_spec.js
+++ b/cypress/integration/onboarding/messaging/message_pinning_unpinning_spec.js
@@ -38,7 +38,7 @@ describe('Messaging', () => {
     });
 
     it('M15010 Pinning or un-pinning older post does not cause it to display at bottom of channel', () => {
-        cy.get('#sidebarItem_saepe-5').click();
+        cy.get('#sidebarItem_saepe-5').click({force: true});
 
         // 1. Ensure there are a couple of pinned posts in the channel already:
         // 1a. Pin 10th and 15th newest posts

--- a/cypress/support/api_commands.js
+++ b/cypress/support/api_commands.js
@@ -222,7 +222,7 @@ Cypress.Commands.add('apiSaveThemePreference', (value = JSON.stringify(theme.def
 /**
  * Saves Enable Open Server settings config details of a user directly via API
  * This API assume that the sysadmin user is logged in for the changes
- @param {Boolean} enable - flag for EnableOpenServer in config. Passes true for default if none is provided.
+ * @param {Boolean} enable - flag for EnableOpenServer in config. Passes true for default if none is provided.
  */
 Cypress.Commands.add('apiEnableOpenServer', (enable = true) => {
     config.TeamSettings.EnableOpenServer = enable;
@@ -231,5 +231,22 @@ Cypress.Commands.add('apiEnableOpenServer', (enable = true) => {
         url: '/api/v4/config',
         method: 'PUT',
         body: config,
+    });
+});
+
+// *****************************************************************************
+// Pinned Posts
+// *****************************************************************************
+
+/**
+* Unpins pinned posts of given postID directly via API
+* This API assume that the user is logged in and has cookie to access
+* @param {Object} postId - Post ID of the pinned post to unpin
+*/
+Cypress.Commands.add('apiUnpinPosts', (postId) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/posts/' + postId + '/unpin',
+        method: 'POST',
     });
 });

--- a/cypress/support/ui_commands.js
+++ b/cypress/support/ui_commands.js
@@ -234,6 +234,17 @@ Cypress.Commands.add('getLastPostIdWithRetry', () => {
 });
 
 /**
+* Get post ID for nth newest post
+* .eq() is 0-based index, hence nthPost-2 to get the nth post
+@param {Integer} nthPost - nth newest post
+*/
+Cypress.Commands.add('getNthPostId', (nthPost) => {
+    return cy.get('#postListContent [id^=post]:first').parent().parent().siblings().eq(nthPost - 2).find('[id^=post]:first').invoke('attr', 'id').then((nthPostId) => {
+        return nthPostId.replace('post_', '');
+    });
+});
+
+/**
  * Post message from a file instantly post a message in a textbox
  * instead of typing into it which takes longer period of time.
  * @param {String} file - includes path and filename relative to cypress/fixtures


### PR DESCRIPTION
#### Summary
Added E2E test using `cypress` for  "Pinning or un-pinning older post does not cause it to display at bottom of channel"

1. Added `message_pinning_unpinning_spec.js` for E2E test
2. Added `apiUnpinPosts()` method in `api_commands.js` to easily unpin posts at the end of test
3. Added `getNthPostId()` method in `ui_commands.js` to find and navigate nth number of post in the CENTER display

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10575
Jira: https://mattermost.atlassian.net/browse/MM-15010

