### PR TITLE
MM-15080 Use event emitter to scroll to bottom when sending post

### DIFF
--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -5,13 +5,14 @@ import {batchActions} from 'redux-batched-actions';
 
 import {leaveChannel as leaveChannelRedux, joinChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import * as PostActions from 'mattermost-redux/actions/posts';
+import {autocompleteUsers} from 'mattermost-redux/actions/users';
 import {Posts} from 'mattermost-redux/constants';
 import {getChannel, getChannelByName, getCurrentChannel, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentRelativeTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getUserByUsername} from 'mattermost-redux/selectors/entities/users';
 import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
 import {isFavoriteChannel} from 'mattermost-redux/utils/channel_utils';
-import {autocompleteUsers} from 'mattermost-redux/actions/users';
+import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
 import {getLastViewedChannelName} from 'selectors/local_storage';
@@ -200,5 +201,11 @@ export function increasePostVisibility(channelId, beforePostId) {
             moreToLoad: posts ? posts.order.length >= Posts.POST_CHUNK_SIZE / 2 : false,
             error: result.error,
         };
+    };
+}
+
+export function scrollPostListToBottom() {
+    return () => {
+        EventEmitter.emit('scroll_post_list_to_bottom');
     };
 }

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -231,6 +231,8 @@ export default class CreatePost extends React.Component {
              * Function to get the users timezones in the channel
              */
             getChannelTimezones: PropTypes.func.isRequired,
+
+            scrollPostListToBottom: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -583,6 +585,7 @@ export default class CreatePost extends React.Component {
         post = hookResult.data;
 
         actions.onSubmitPost(post, draft.fileInfos);
+        actions.scrollPostListToBottom();
 
         this.setState({
             submitting: false,

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -61,26 +61,26 @@ const currentUsersLatestPostProp = {id: 'b', root_id: 'a', channel_id: currentCh
 
 const commentCountForPostProp = 10;
 
-function emptyFunction() {} //eslint-disable-line no-empty-function
 const actionsProp = {
-    addMessageIntoHistory: emptyFunction,
-    moveHistoryIndexBack: emptyFunction,
-    moveHistoryIndexForward: emptyFunction,
-    addReaction: emptyFunction,
-    removeReaction: emptyFunction,
-    clearDraftUploads: emptyFunction,
-    onSubmitPost: emptyFunction,
-    selectPostFromRightHandSideSearchByPostId: emptyFunction,
-    setDraft: emptyFunction,
-    setEditingPost: emptyFunction,
-    openModal: emptyFunction,
+    addMessageIntoHistory: jest.fn(),
+    moveHistoryIndexBack: jest.fn(),
+    moveHistoryIndexForward: jest.fn(),
+    addReaction: jest.fn(),
+    removeReaction: jest.fn(),
+    clearDraftUploads: jest.fn(),
+    onSubmitPost: jest.fn(),
+    selectPostFromRightHandSideSearchByPostId: jest.fn(),
+    setDraft: jest.fn(),
+    setEditingPost: jest.fn(),
+    openModal: jest.fn(),
     executeCommand: async () => {
         return {data: true};
     },
-    getChannelTimezones: emptyFunction,
+    getChannelTimezones: jest.fn(),
     runMessageWillBePostedHooks: async (post) => {
         return {data: post};
     },
+    scrollPostListToBottom: jest.fn(),
 };
 
 function createPost({

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -29,6 +29,7 @@ import {Posts, Preferences as PreferencesRedux} from 'mattermost-redux/constants
 import {connectionErrorCount} from 'selectors/views/system';
 
 import {addReaction, createPost, setEditingPost} from 'actions/post_actions.jsx';
+import {scrollPostListToBottom} from 'actions/views/channel';
 import {selectPostFromRightHandSideSearchByPostId} from 'actions/views/rhs';
 import {executeCommand} from 'actions/command';
 import {runMessageWillBePostedHooks} from 'actions/hooks';
@@ -117,6 +118,7 @@ function mapDispatchToProps(dispatch) {
             executeCommand,
             getChannelTimezones,
             runMessageWillBePostedHooks,
+            scrollPostListToBottom,
         }, dispatch),
     };
 }

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -5,7 +5,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {DynamicSizeList} from 'react-window';
+
 import {debounce} from 'mattermost-redux/actions/helpers';
+import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import LoadingScreen from 'components/loading_screen.jsx';
 
@@ -128,6 +130,8 @@ export default class PostList extends React.PureComponent {
         this.props.actions.checkAndSetMobileView();
 
         window.addEventListener('resize', this.handleWindowResize);
+
+        EventEmitter.addListener('scroll_post_list_to_bottom', this.scrollToBottom);
     }
 
     getSnapshotBeforeUpdate(prevProps, prevState) {
@@ -170,6 +174,8 @@ export default class PostList extends React.PureComponent {
     componentWillUnmount() {
         this.mounted = false;
         window.removeEventListener('resize', this.handleWindowResize);
+
+        EventEmitter.removeListener('scroll_post_list_to_bottom', this.scrollToBottom);
     }
 
     static getDerivedStateFromProps(props, state) {


### PR DESCRIPTION
As I mentioned before, inferring this from the redux state is really, really difficult, so we're just going to use an event to trigger the post list to scroll to the bottom because it's very straightforward to do that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15080

