### PR TITLE
MM-14530 Displays emoji in poll after the poll is ended.

### DIFF
--- a/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
+++ b/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
@@ -402,7 +402,15 @@ exports[`components/post_view/MessageAttachment should match value on getFieldsT
           className="attachment-field__caption"
           width="50%"
         >
-          title_1
+          <Connect(Markdown)
+            message="title_1"
+            options={
+              Object {
+                "markdown": false,
+                "mentionHighlight": false,
+              }
+            }
+          />
         </th>
       </tr>
     </thead>
@@ -427,7 +435,15 @@ exports[`components/post_view/MessageAttachment should match value on getFieldsT
           className="attachment-field__caption"
           width="50%"
         >
-          title_2
+          <Connect(Markdown)
+            message="title_2"
+            options={
+              Object {
+                "markdown": false,
+                "mentionHighlight": false,
+              }
+            }
+          />
         </th>
       </tr>
     </thead>

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -164,6 +164,7 @@ export default class MessageAttachment extends React.PureComponent {
         let rowPos = 0;
         let lastWasLong = false;
         let nrTables = 0;
+        const markdown = {markdown: false, mentionHighlight: false};
 
         fields.forEach((field, i) => {
             if (rowPos === 2 || !(field.short === true) || lastWasLong) {
@@ -196,7 +197,10 @@ export default class MessageAttachment extends React.PureComponent {
                     key={'attachment__field-caption-' + i + '__' + nrTables}
                     width='50%'
                 >
-                    {field.title}
+                    <Markdown
+                        message={field.title}
+                        options={markdown}
+                    />
                 </th>
             );
 


### PR DESCRIPTION
#### Summary
Emoji is displayed after the poll ends. 
![image](https://user-images.githubusercontent.com/15200562/57043387-3b393600-6c1c-11e9-9ea7-9d3096eddf33.png)

#### Ticket Link
Fixes: [MM-14530] Render emojis in Message Attachment field titles

Fixes https://github.com/mattermost/mattermost-server/issues/10433



[MM-14530]: https://mattermost.atlassian.net/browse/MM-14530