### PR TITLE
MM-15196 Fix missing 'Commented on' after separators

### DIFF
--- a/components/post_view/post/index.js
+++ b/components/post_view/post/index.js
@@ -16,6 +16,16 @@ import {Preferences} from 'utils/constants.jsx';
 
 import Post from './post.jsx';
 
+// isFirstReply returns true when the given post is not part of the same thread as the previous post.
+export function isFirstReply(post, previousPost) {
+    if (post.root_id && previousPost) {
+        // Returns true as long as the previous post is part of a different thread
+        return post.root_id !== previousPost.id && post.root_id !== previousPost.root_id;
+    }
+
+    return true;
+}
+
 export function makeGetReplyCount() {
     return createSelector(
         (state) => state.entities.posts.posts,
@@ -43,13 +53,10 @@ function makeMapStateToProps() {
             previousPost = getPost(state, ownProps.previousPostId);
         }
 
-        let isFirstReply = false;
         let consecutivePostByUser = false;
         let previousPostIsComment = false;
 
         if (previousPost) {
-            isFirstReply = post.root_id ? (post.root_id !== previousPost.id && post.root_id !== previousPost.root_id) : false;
-
             consecutivePostByUser = post.user_id === previousPost.user_id && // The post is by the same user
                 post.create_at - previousPost.create_at <= Posts.POST_COLLAPSE_TIMEOUT && // And was within a short time period
                 !(post.props && post.props.from_webhook) && !(previousPost.props && previousPost.props.from_webhook) && // And neither is from a webhook
@@ -61,7 +68,7 @@ function makeMapStateToProps() {
         return {
             post,
             currentUserId: getCurrentUserId(state),
-            isFirstReply,
+            isFirstReply: isFirstReply(post, previousPost),
             consecutivePostByUser,
             previousPostIsComment,
             replyCount: getReplyCount(state, post),

--- a/components/post_view/post/index.test.js
+++ b/components/post_view/post/index.test.js
@@ -3,7 +3,64 @@
 
 import {Posts} from 'mattermost-redux/constants';
 
-import {makeGetReplyCount} from './index';
+import {isFirstReply, makeGetReplyCount} from './index';
+
+describe('isFirstReply', () => {
+    for (const testCase of [
+        {
+            name: 'a post with nothing above it',
+            post: {root_id: ''},
+            previousPost: null,
+            expected: true,
+        },
+        {
+            name: 'a comment with nothing above it',
+            post: {root_id: 'root'},
+            previousPost: null,
+            expected: true,
+        },
+        {
+            name: 'a post with a regular post above it',
+            post: {root_id: ''},
+            previousPost: {root_id: ''},
+            expected: true,
+        },
+        {
+            name: 'a post with a comment above it',
+            post: {root_id: ''},
+            previousPost: {root_id: 'root'},
+            expected: true,
+        },
+        {
+            name: 'a comment with a regular post above it',
+            post: {root_id: 'root1'},
+            previousPost: {root_id: ''},
+            expected: true,
+        },
+        {
+            name: 'a comment with a comment on another thread above it',
+            post: {root_id: 'root1'},
+            previousPost: {root_id: 'root2'},
+            expected: true,
+        },
+        {
+            name: 'a comment with a comment on the same thread above it',
+            post: {root_id: 'root1'},
+            previousPost: {root_id: 'root1'},
+            expected: false,
+        },
+        {
+            name: 'a comment with its parent above it',
+            post: {root_id: 'root1'},
+            previousPost: {id: 'root1'},
+            expected: false,
+        },
+    ]) {
+        test(testCase.name, () => {
+            expect(isFirstReply(testCase.post, testCase.previousPost)).toBe(testCase.expected);
+        });
+    }
+});
 
 describe('makeGetReplyCount', () => {
     test('should return the number of comments when called on a root post', () => {


### PR DESCRIPTION
The previous version never rendered the "Commented on" line for posts following things that aren't real posts (date separators, new messages line, combined system messages, etc) because `isFirstReply` would always be false. This could be fixed by changing `let isFirstReply = false;` to `let isFirstReply = true;` which matches the mobile app, but I decided to add some tests instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15196