### PR TITLE
MM-15386 Allow license expiring message to be dismissed and show it as an announcement type

### DIFF
--- a/components/announcement_bar/announcement_bar_controller.jsx
+++ b/components/announcement_bar/announcement_bar_controller.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import ConfigurationAnnouncementBar from './configuration_bar.jsx';
+import ConfigurationAnnouncementBar from './configuration_bar';
 import TextDismissableBar from './text_dismissable_bar.jsx';
 import AnnouncementBar from './announcement_bar.jsx';
 

--- a/components/announcement_bar/configuration_bar/configuration_bar.jsx
+++ b/components/announcement_bar/configuration_bar/configuration_bar.jsx
@@ -13,8 +13,8 @@ import {t} from 'utils/i18n';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
-import AnnouncementBar from './announcement_bar.jsx';
-import TextDismissableBar from './text_dismissable_bar';
+import AnnouncementBar from '../announcement_bar.jsx';
+import TextDismissableBar from '../text_dismissable_bar';
 
 const RENEWAL_LINK = 'https://licensing.mattermost.com/renew';
 
@@ -25,11 +25,19 @@ export default class ConfigurationAnnouncementBar extends React.PureComponent {
         user: PropTypes.object,
         canViewSystemErrors: PropTypes.bool.isRequired,
         totalUsers: PropTypes.number,
+        dismissedExpiringLicense: PropTypes.bool,
+        actions: PropTypes.shape({
+            dismissNotice: PropTypes.func.isRequired,
+        }).isRequired,
     };
 
     static contextTypes = {
         intl: intlShape,
     };
+
+    dismissExpiringLicense = () => {
+        this.props.actions.dismissNotice(AnnouncementBarMessages.LICENSE_EXPIRING);
+    }
 
     render() {
         // System administrators
@@ -69,10 +77,12 @@ export default class ConfigurationAnnouncementBar extends React.PureComponent {
                 );
             }
 
-            if (isLicenseExpiring()) {
+            if (isLicenseExpiring() && !this.props.dismissedExpiringLicense) {
                 return (
                     <AnnouncementBar
-                        type={AnnouncementBarTypes.CRITICAL}
+                        showCloseButton={true}
+                        handleClose={this.dismissExpiringLicense}
+                        type={AnnouncementBarTypes.ANNOUNCEMENT}
                         message={
                             <FormattedMarkdownMessage
                                 id={AnnouncementBarMessages.LICENSE_EXPIRING}

--- a/components/announcement_bar/configuration_bar/index.js
+++ b/components/announcement_bar/configuration_bar/index.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {AnnouncementBarMessages} from 'utils/constants.jsx';
+import {dismissNotice} from 'actions/views/notice';
+
+import ConfigurationBar from './configuration_bar.jsx';
+
+function mapStateToProps(state) {
+    return {
+        dismissedExpiringLicense: Boolean(state.views.notice.hasBeenDismissed[AnnouncementBarMessages.LICENSE_EXPIRING]),
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            dismissNotice,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ConfigurationBar);

--- a/components/announcement_bar/index.js
+++ b/components/announcement_bar/index.js
@@ -11,6 +11,8 @@ import {getDisplayableErrors} from 'mattermost-redux/selectors/errors';
 import {dismissError} from 'mattermost-redux/actions/errors';
 import {getStandardAnalytics} from 'mattermost-redux/actions/admin';
 
+import {dismissNotice} from 'actions/views/notice';
+
 import AnnouncementBarController from './announcement_bar_controller.jsx';
 
 function mapStateToProps(state) {
@@ -41,6 +43,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             getStandardAnalytics,
             dismissError: dismissFirstError,
+            dismissNotice,
         }, dispatch),
     };
 }


### PR DESCRIPTION
#### Summary
The licensing expiring message needs to be dismissable but show again on next refresh. I leveraged the existing action/reducer for dismissing system notices to accomplish this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15386