### PR TITLE
MM-15322 Change PostList.checkBottom to use onScroll

### DIFF
--- a/components/post_view/index.js
+++ b/components/post_view/index.js
@@ -78,7 +78,6 @@ function makeMapStateToProps() {
 
         return {
             channel,
-            lastViewedAt,
             postVisibility,
             postListIds: postIds,
             channelLoading,

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -325,21 +325,22 @@ export default class PostList extends React.PureComponent {
     }
 
     checkBottom = (scrollOffset) => {
+        this.updateAtBottom(this.isAtBottom(scrollOffset));
+    }
+
+    isAtBottom = (scrollOffset) => {
         // Calculate how far the post list is from being scrolled to the bottom
         const postList = this.postListRef.current;
-        window.plr = postList;
         const offsetFromBottom = (postList.scrollHeight - postList.parentElement.clientHeight) - scrollOffset;
 
-        if (offsetFromBottom === 0) {
-            if (!this.state.atBottom) {
-                this.setState({
-                    atBottom: true,
-                    lastViewedBottom: Date.now(),
-                });
-            }
-        } else if (this.state.atBottom) {
+        return offsetFromBottom === 0;
+    }
+
+    updateAtBottom = (atBottom) => {
+        if (atBottom !== this.state.atBottom) {
+            // Update lastViewedBottom when the list reaches or leaves the bottom
             this.setState({
-                atBottom: false,
+                atBottom,
                 lastViewedBottom: Date.now(),
             });
         }

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -60,11 +60,6 @@ export default class PostList extends React.PureComponent {
         channel: PropTypes.object.isRequired,
 
         /**
-         * The last time the channel was viewed, sets the new message separator
-         */
-        lastViewedAt: PropTypes.number,
-
-        /**
          * Set to focus this post
          */
         focusedPostId: PropTypes.string,
@@ -103,10 +98,10 @@ export default class PostList extends React.PureComponent {
             atEnd: false,
             loadingFirstSetOfPosts: Boolean(!props.postListIds || props.channelLoading),
             isScrolling: false,
-            lastViewed: props.lastViewedAt,
             autoRetryEnable: true,
             isMobile,
             atBottom: true,
+            lastViewedBottom: Date.now(),
             postListIds: [channelIntroMessage],
             topPostId: '',
             postMenuOpened: false,
@@ -116,7 +111,7 @@ export default class PostList extends React.PureComponent {
         };
 
         this.listRef = React.createRef();
-        this.postlistRef = React.createRef();
+        this.postListRef = React.createRef();
         if (isMobile) {
             this.scrollStopAction = new DelayedAction(this.handleScrollStop);
         }
@@ -135,12 +130,12 @@ export default class PostList extends React.PureComponent {
     }
 
     getSnapshotBeforeUpdate(prevProps, prevState) {
-        if (this.postlistRef && this.postlistRef.current) {
+        if (this.postListRef && this.postListRef.current) {
             const postsAddedAtTop = this.state.postListIds.length !== prevState.postListIds.length && this.state.postListIds[0] === prevState.postListIds[0];
             const channelHeaderAdded = this.state.atEnd !== prevState.atEnd && this.state.postListIds.length === prevState.postListIds.length;
             if (postsAddedAtTop || channelHeaderAdded) {
-                const previousScrollTop = this.postlistRef.current.scrollTop;
-                const previousScrollHeight = this.postlistRef.current.scrollHeight;
+                const previousScrollTop = this.postListRef.current.scrollTop;
+                const previousScrollHeight = this.postListRef.current.scrollHeight;
 
                 return {
                     previousScrollTop,
@@ -156,11 +151,11 @@ export default class PostList extends React.PureComponent {
             this.loadPosts(this.props.channel.id, this.props.focusedPostId);
         }
 
-        if (!this.postlistRef.current || !snapshot) {
+        if (!this.postListRef.current || !snapshot) {
             return;
         }
 
-        const postlistScrollHeight = this.postlistRef.current.scrollHeight;
+        const postlistScrollHeight = this.postListRef.current.scrollHeight;
         const postsAddedAtTop = this.state.postListIds.length !== prevState.postListIds.length && this.state.postListIds[0] === prevState.postListIds[0];
         const channelHeaderAdded = this.state.atEnd !== prevState.atEnd && this.state.postListIds.length === prevState.postListIds.length;
         if (postsAddedAtTop || channelHeaderAdded) {
@@ -325,6 +320,29 @@ export default class PostList extends React.PureComponent {
                 this.scrollStopAction.fireAfter(Constants.SCROLL_DELAY);
             }
         }
+
+        this.checkBottom(scrollOffset);
+    }
+
+    checkBottom = (scrollOffset) => {
+        // Calculate how far the post list is from being scrolled to the bottom
+        const postList = this.postListRef.current;
+        window.plr = postList;
+        const offsetFromBottom = (postList.scrollHeight - postList.parentElement.clientHeight) - scrollOffset;
+
+        if (offsetFromBottom === 0) {
+            if (!this.state.atBottom) {
+                this.setState({
+                    atBottom: true,
+                    lastViewedBottom: Date.now(),
+                });
+            }
+        } else if (this.state.atBottom) {
+            this.setState({
+                atBottom: false,
+                lastViewedBottom: Date.now(),
+            });
+        }
     }
 
     handleScrollStop = () => {
@@ -349,27 +367,8 @@ export default class PostList extends React.PureComponent {
         });
     }
 
-    checkBottom = (visibleStartIndex) => {
-        if (visibleStartIndex === 0) {
-            if (!this.state.atBottom) {
-                this.setState({
-                    atBottom: true,
-                    lastViewed: new Date().getTime(),
-                });
-            }
-        } else if (this.state.atBottom) {
-            this.setState({
-                atBottom: false,
-            });
-        }
-    }
-
-    onItemsRendered = ({
-        visibleStartIndex,
-        visibleStopIndex,
-    }) => {
+    onItemsRendered = ({visibleStartIndex}) => {
         this.updateFloatingTimestamp(visibleStartIndex);
-        this.checkBottom(visibleStopIndex);
     }
 
     initScrollToIndex = () => {
@@ -457,7 +456,7 @@ export default class PostList extends React.PureComponent {
             newMessagesBelow = (
                 <NewMessagesBelow
                     atBottom={this.state.atBottom}
-                    lastViewedBottom={this.state.lastViewed}
+                    lastViewedBottom={this.state.lastViewedBottom}
                     postIds={this.state.postListIds}
                     onClick={this.scrollToBottom}
                 />
@@ -507,7 +506,7 @@ export default class PostList extends React.PureComponent {
                                         initScrollToIndex={this.initScrollToIndex}
                                         canLoadMorePosts={this.canLoadMorePosts}
                                         skipResizeClass='col__reply'
-                                        innerRef={this.postlistRef}
+                                        innerRef={this.postListRef}
                                         style={{...virtListStyles, ...dynamicListStyle}}
                                         innerListStyle={postListStyle}
                                     >

--- a/components/post_view/post_list.test.jsx
+++ b/components/post_view/post_list.test.jsx
@@ -153,31 +153,98 @@ describe('PostList', () => {
         });
     });
 
-    describe('onItemsRendered', () => {
-        test('should set state atBottom false when visibleStopIndex is not 0', () => {
+    describe('onScroll', () => {
+        test('should call checkBottom', () => {
             const wrapper = shallow(<PostList {...baseProps}/>);
-            wrapper.setState({atBottom: true});
-            wrapper.instance().onItemsRendered({visibleStartIndex: 4, visibleStopIndex: 1});
-            expect(wrapper.state('atBottom')).toEqual(false);
+            wrapper.instance().checkBottom = jest.fn();
+
+            const scrollOffset = 1234;
+
+            wrapper.instance().onScroll({
+                scrollDirection: 'forward',
+                scrollOffset,
+                scrollUpdateWasRequested: false,
+            });
+
+            expect(wrapper.instance().checkBottom).toHaveBeenCalledWith(scrollOffset);
         });
     });
+
+    describe('isAtBottom', () => {
+        const scrollHeight = 1000;
+        const parentClientHeight = 500;
+
+        for (const testCase of [
+            {
+                name: 'when viewing the top of the post list',
+                scrollOffset: 0,
+                expected: false,
+            },
+            {
+                name: 'when 1 pixel from the bottom',
+                scrollOffset: 499,
+                expected: false,
+            },
+            {
+                name: 'when at the bottom',
+                scrollOffset: 500,
+                expected: true,
+            },
+        ]) {
+            test(testCase.name, () => {
+                const wrapper = shallow(<PostList {...baseProps}/>);
+                wrapper.instance().postListRef = {
+                    current: {
+                        scrollHeight,
+                        parentElement: {
+                            clientHeight: parentClientHeight,
+                        },
+                    },
+                };
+
+                expect(wrapper.instance().isAtBottom(testCase.scrollOffset)).toBe(testCase.expected);
+            });
+        }
+    });
+
+    describe('updateAtBottom', () => {
+        test('should update atBottom and lastViewedBottom when atBottom changes', () => {
+            const wrapper = shallow(<PostList {...baseProps}/>);
+            wrapper.setState({lastViewedBottom: 1234});
+
+            wrapper.instance().updateAtBottom(false);
+
+            expect(wrapper.state('atBottom')).toBe(false);
+            expect(wrapper.state('lastViewedBottom')).not.toBe(1234);
+        });
+
+        test('should not update lastViewedBottom when atBottom does not change', () => {
+            const wrapper = shallow(<PostList {...baseProps}/>);
+            wrapper.setState({lastViewedBottom: 1234});
+
+            wrapper.instance().updateAtBottom(true);
+
+            expect(wrapper.state('lastViewedBottom')).toBe(1234);
+        });
+    });
+
     describe('Scroll correction logic on mount of posts at the top', () => {
         test('should return previous scroll position from getSnapshotBeforeUpdate', () => {
             const wrapper = shallow(<PostList {...baseProps}/>);
             const instance = wrapper.instance();
             instance.componentDidUpdate = jest.fn();
 
-            instance.postlistRef = {current: {scrollTop: 10, scrollHeight: 100}};
+            instance.postListRef = {current: {scrollTop: 10, scrollHeight: 100}};
             wrapper.setState({atEnd: true});
             expect(instance.componentDidUpdate).toHaveBeenCalledTimes(1);
             expect(instance.componentDidUpdate.mock.calls[0][2]).toEqual({previousScrollTop: 10, previousScrollHeight: 100});
 
-            instance.postlistRef = {current: {scrollTop: 30, scrollHeight: 200}};
+            instance.postListRef = {current: {scrollTop: 30, scrollHeight: 200}};
             wrapper.setState({atEnd: false});
             expect(instance.componentDidUpdate).toHaveBeenCalledTimes(2);
             expect(instance.componentDidUpdate.mock.calls[1][2]).toEqual({previousScrollTop: 30, previousScrollHeight: 200});
 
-            instance.postlistRef = {current: {scrollTop: 40, scrollHeight: 400}};
+            instance.postListRef = {current: {scrollTop: 40, scrollHeight: 400}};
             wrapper.setProps({postListIds: [
                 'post1',
                 'post2',

--- a/components/post_view/post_list.test.jsx
+++ b/components/post_view/post_list.test.jsx
@@ -17,7 +17,6 @@ describe('PostList', () => {
     const baseProps = {
         channel: {id: 'channel'},
         focusedPostId: '',
-        lastViewedAt: 0,
         postListIds: [
             'post1',
             'post2',


### PR DESCRIPTION
The previous version of this used onItemsRendered to trigger checkBottom, but that only triggers when the rendered posts changes, so it couldn't be as accurate as the versions before it. It also has some issues because it only allows us to check when the second post from the bottom became visible (`visibleStopIndex` would be 0 as long as the second post was visible). Changing it to `onScroll` lets us tell more accurately when the list is at the bottom.

The other change here is that `this.state.lastViewedBottom` is now updated when you reach the bottom and then again when you leave it. This also caused a bug where you'd scroll to the bottom, receive some posts, and then you'd scroll back up and the "New Messages" would appear.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15322