### PR TITLE
[MM-13500] Add group channel search to the More Direct Channels component

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -176,6 +176,21 @@ export async function loadNewGMIfNeeded(channelId) {
     checkPreference();
 }
 
+export function loadProfilesForGroupChannels(groupChannels) {
+    return (doDispatch, doGetState) => {
+        const state = doGetState();
+        const userIdsInChannels = Selectors.getUserIdsInChannels(state);
+
+        for (const {id} of groupChannels) {
+            const userIdsInGroupChannel = (userIdsInChannels[id] || new Set());
+
+            if (userIdsInGroupChannel.size === 0) {
+                doDispatch(UserActions.getProfilesInChannel(id, 0, Constants.MAX_USERS_IN_GM));
+            }
+        }
+    };
+}
+
 export function loadProfilesForSidebar() {
     loadProfilesForDM();
     loadProfilesForGM();
@@ -267,6 +282,13 @@ export async function loadProfilesForDM() {
     if (profilesToLoad.length > 0) {
         await UserActions.getProfilesByIds(profilesToLoad)(dispatch, getState);
     }
+}
+
+export function searchGroupChannels(term) {
+    return bindClientFunc({
+        clientFunc: Client4.searchGroupChannels,
+        params: [term],
+    });
 }
 
 export async function autocompleteUsersInTeam(username, success) {

--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -181,12 +181,17 @@ export function loadProfilesForGroupChannels(groupChannels) {
         const state = doGetState();
         const userIdsInChannels = Selectors.getUserIdsInChannels(state);
 
-        for (const {id} of groupChannels) {
+        const groupChannelsToFetch = groupChannels.reduce((acc, {id}) => {
             const userIdsInGroupChannel = (userIdsInChannels[id] || new Set());
 
             if (userIdsInGroupChannel.size === 0) {
-                doDispatch(UserActions.getProfilesInChannel(id, 0, Constants.MAX_USERS_IN_GM));
+                acc.push(id);
             }
+            return acc;
+        }, []);
+
+        if (groupChannelsToFetch.length > 0) {
+            doDispatch(UserActions.getProfilesInGroupChannels(groupChannelsToFetch));
         }
     };
 }
@@ -282,13 +287,6 @@ export async function loadProfilesForDM() {
     if (profilesToLoad.length > 0) {
         await UserActions.getProfilesByIds(profilesToLoad)(dispatch, getState);
     }
-}
-
-export function searchGroupChannels(term) {
-    return bindClientFunc({
-        clientFunc: Client4.searchGroupChannels,
-        params: [term],
-    });
 }
 
 export async function autocompleteUsersInTeam(username, success) {

--- a/actions/user_actions.test.js
+++ b/actions/user_actions.test.js
@@ -6,8 +6,6 @@ import configureStore from 'redux-mock-store';
 
 import {Preferences} from 'mattermost-redux/constants';
 
-import {Constants} from 'utils/constants';
-
 import * as UserActions from 'actions/user_actions';
 
 const mockStore = configureStore([thunk]);
@@ -18,6 +16,7 @@ jest.mock('mattermost-redux/actions/users', () => {
         ...original,
         getProfilesInTeam: (...args) => ({type: 'MOCK_GET_PROFILES_IN_TEAM', args}),
         getProfilesInChannel: (...args) => ({type: 'MOCK_GET_PROFILES_IN_CHANNEL', args}),
+        getProfilesInGroupChannels: (...args) => ({type: 'MOCK_GET_PROFILES_IN_GROUP_CHANNELS', args}),
     };
 });
 
@@ -217,7 +216,7 @@ describe('Actions.User', () => {
         const mockedGroupChannels = [{id: 'group_channel_1'}, {id: 'group_channel_2'}];
 
         // as users in group_channel_2 are already loaded, it should only try to load group_channel_1
-        const expectedActions = [{args: ['group_channel_1', 0, Constants.MAX_USERS_IN_GM], type: 'MOCK_GET_PROFILES_IN_CHANNEL'}];
+        const expectedActions = [{args: [['group_channel_1']], type: 'MOCK_GET_PROFILES_IN_GROUP_CHANNELS'}];
         const testStore = await mockStore(initialState);
         await testStore.dispatch(UserActions.loadProfilesForGroupChannels(mockedGroupChannels));
         expect(testStore.getActions()).toEqual(expectedActions);

--- a/actions/user_actions.test.js
+++ b/actions/user_actions.test.js
@@ -6,6 +6,8 @@ import configureStore from 'redux-mock-store';
 
 import {Preferences} from 'mattermost-redux/constants';
 
+import {Constants} from 'utils/constants';
+
 import * as UserActions from 'actions/user_actions';
 
 const mockStore = configureStore([thunk]);
@@ -112,6 +114,9 @@ describe('Actions.User', () => {
             },
             users: {
                 currentUserId: 'current_user_id',
+                profilesInChannel: {
+                    group_channel_2: ['user_1', 'user_2'],
+                },
             },
         },
     };
@@ -206,5 +211,15 @@ describe('Actions.User', () => {
         testStore = await mockStore(initialState);
         await testStore.dispatch(UserActions.loadChannelMembersForProfilesList([], 'current_channel_id'));
         expect(testStore.getActions()).toEqual([]);
+    });
+
+    test('loadProfilesForGroupChannels', async () => {
+        const mockedGroupChannels = [{id: 'group_channel_1'}, {id: 'group_channel_2'}];
+
+        // as users in group_channel_2 are already loaded, it should only try to load group_channel_1
+        const expectedActions = [{args: ['group_channel_1', 0, Constants.MAX_USERS_IN_GM], type: 'MOCK_GET_PROFILES_IN_CHANNEL'}];
+        const testStore = await mockStore(initialState);
+        await testStore.dispatch(UserActions.loadProfilesForGroupChannels(mockedGroupChannels));
+        expect(testStore.getActions()).toEqual(expectedActions);
     });
 });

--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -26,6 +26,7 @@ import {memoizeResult} from 'mattermost-redux/utils/helpers';
 
 import {openDirectChannelToUserId, openGroupChannelToUserIds} from 'actions/channel_actions';
 import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
+import {searchGroupChannels, loadProfilesForGroupChannels} from 'actions/user_actions';
 import {setModalSearchTerm} from 'actions/views/search';
 
 import MoreDirectChannels from './more_direct_channels.jsx';
@@ -89,9 +90,11 @@ function mapDispatchToProps(dispatch) {
             getStatusesByIds,
             getTotalUsersStats,
             loadStatusesForProfilesList,
+            loadProfilesForGroupChannels,
             openDirectChannelToUserId,
             openGroupChannelToUserIds,
             searchProfiles,
+            searchGroupChannels,
             setModalSearchTerm,
         }, dispatch),
     };

--- a/components/more_direct_channels/index.js
+++ b/components/more_direct_channels/index.js
@@ -10,6 +10,7 @@ import {
     getTotalUsersStats,
     searchProfiles,
 } from 'mattermost-redux/actions/users';
+import {searchGroupChannels} from 'mattermost-redux/actions/channels';
 import {
     getCurrentUserId,
     getProfiles as selectProfiles,
@@ -26,7 +27,7 @@ import {memoizeResult} from 'mattermost-redux/utils/helpers';
 
 import {openDirectChannelToUserId, openGroupChannelToUserIds} from 'actions/channel_actions';
 import {loadStatusesForProfilesList} from 'actions/status_actions.jsx';
-import {searchGroupChannels, loadProfilesForGroupChannels} from 'actions/user_actions';
+import {loadProfilesForGroupChannels} from 'actions/user_actions';
 import {setModalSearchTerm} from 'actions/views/search';
 
 import MoreDirectChannels from './more_direct_channels.jsx';

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -55,9 +55,11 @@ export default class MoreDirectChannels extends React.Component {
             getStatusesByIds: PropTypes.func.isRequired,
             getTotalUsersStats: PropTypes.func.isRequired,
             loadStatusesForProfilesList: PropTypes.func.isRequired,
+            loadProfilesForGroupChannels: PropTypes.func.isRequired,
             openDirectChannelToUserId: PropTypes.func.isRequired,
             openGroupChannelToUserIds: PropTypes.func.isRequired,
             searchProfiles: PropTypes.func.isRequired,
+            searchGroupChannels: PropTypes.func.isRequired,
             setModalSearchTerm: PropTypes.func.isRequired,
         }).isRequired,
     }
@@ -109,11 +111,17 @@ export default class MoreDirectChannels extends React.Component {
                 this.searchTimeoutId = setTimeout(
                     async () => {
                         this.setUsersLoadingState(true);
-                        const {data} = await this.props.actions.searchProfiles(searchTerm, {team_id: teamId});
-                        if (data) {
-                            this.props.actions.loadStatusesForProfilesList(data);
-                            this.resetPaging();
+                        const [{data: profilesData}, {data: groupChannelsData}] = await Promise.all([
+                            this.props.actions.searchProfiles(searchTerm, {team_id: teamId}),
+                            this.props.actions.searchGroupChannels(searchTerm),
+                        ]);
+                        if (profilesData) {
+                            this.props.actions.loadStatusesForProfilesList(profilesData);
                         }
+                        if (groupChannelsData) {
+                            this.props.actions.loadProfilesForGroupChannels(groupChannelsData);
+                        }
+                        this.resetPaging();
                         this.setUsersLoadingState(false);
                     },
                     Constants.SEARCH_TIMEOUT_MILLISECONDS

--- a/components/more_direct_channels/more_direct_channels.test.jsx
+++ b/components/more_direct_channels/more_direct_channels.test.jsx
@@ -31,8 +31,10 @@ describe('components/MoreDirectChannels', () => {
             getProfilesInTeam: emptyFunction,
             getStatusesByIds: emptyFunction,
             searchProfiles: emptyFunction,
+            searchGroupChannels: emptyFunction,
             setModalSearchTerm: emptyFunction,
             loadStatusesForProfilesList: emptyFunction,
+            loadProfilesForGroupChannels: emptyFunction,
             openDirectChannelToUserId: jest.fn().mockResolvedValue({data: {name: 'dm'}}),
             openGroupChannelToUserIds: jest.fn().mockResolvedValue({data: {name: 'group'}}),
             getTotalUsersStats: jest.fn(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10533,8 +10533,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#15a952351a5a7fddd4a3eeea3fb9f8cc886d4524",
-      "from": "github:mattermost/mattermost-redux#15a952351a5a7fddd4a3eeea3fb9f8cc886d4524",
+      "version": "github:mattermost/mattermost-redux#130b1882459822e7f78d0e2439d2c616d1dfd7e4",
+      "from": "github:mattermost/mattermost-redux#130b1882459822e7f78d0e2439d2c616d1dfd7e4",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#e57e07f419f85178354a3bbbd60de5302483c436",
-    "mattermost-redux": "github:mattermost/mattermost-redux#15a952351a5a7fddd4a3eeea3fb9f8cc886d4524",
+    "mattermost-redux": "github:mattermost/mattermost-redux#130b1882459822e7f78d0e2439d2c616d1dfd7e4",
     "moment-timezone": "0.5.25",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
Adds the hability to search group channels as the user types their search query in the more direct channels component.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13500

#### Related Pull Requests
- [Has server changes](https://github.com/mattermost/mattermost-server/pull/10805)
- [Has redux changes](https://github.com/mattermost/mattermost-redux/pull/828)
- [Has API docs](https://github.com/mattermost/mattermost-api-reference/pull/445)