### PR TITLE
MM-14861 Fix safari perf issues

### DIFF
--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -24,8 +24,8 @@ import ScrollToBottomArrows from './scroll_to_bottom_arrows';
 const MAX_NUMBER_OF_AUTO_RETRIES = 3;
 
 const MAX_EXTRA_PAGES_LOADED = 10;
-const OVERSCAN_COUNT_BACKWARD = window.OVERSCAN_COUNT_BACKWARD || 50; // Exposing the value for PM to test will be removed soon
-const OVERSCAN_COUNT_FORWARD = window.OVERSCAN_COUNT_FORWARD || 100; // Exposing the value for PM to test will be removed soon
+const OVERSCAN_COUNT_BACKWARD = window.OVERSCAN_COUNT_BACKWARD || 80; // Exposing the value for PM to test will be removed soon
+const OVERSCAN_COUNT_FORWARD = window.OVERSCAN_COUNT_FORWARD || 80; // Exposing the value for PM to test will be removed soon
 const HEIGHT_TRIGGER_FOR_MORE_POSTS = window.HEIGHT_TRIGGER_FOR_MORE_POSTS || 1000; // Exposing the value for PM to test will be removed soon
 
 const postListHeightChangeForPadding = 21;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13023,8 +13023,8 @@
       "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
     },
     "react-window": {
-      "version": "github:mattermost/react-window#37f2e6551d776b62be4d22922969250259886236",
-      "from": "github:mattermost/react-window#37f2e6551d776b62be4d22922969250259886236",
+      "version": "github:mattermost/react-window#7c90ad5774a6bd4c7f4d0ccb6a7037eef8f120c4",
+      "from": "github:mattermost/react-window#7c90ad5774a6bd4c7f4d0ccb6a7037eef8f120c4",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-select": "2.4.2",
     "react-transition-group": "2.7.1",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "react-window": "github:mattermost/react-window#37f2e6551d776b62be4d22922969250259886236",
+    "react-window": "github:mattermost/react-window#7c90ad5774a6bd4c7f4d0ccb6a7037eef8f120c4",
     "rebound": "0.1.0",
     "redux": "4.0.1",
     "redux-batched-actions": "0.4.1",


### PR DESCRIPTION
 * Changing overscan counts to be same for virtualized list

After loading new posts at the top the scroll correction moves the scroll down making a change in scrollDirection state in virt list. 
Change in scroll direction causes a mount of another 50 posts because overscan forward is different when compared to overscan backward. This makes it js thread a little busy responding to further interactions



Related PR https://github.com/mattermost/react-window/pull/11/