### PR TITLE
[MM-14767] Sorting BOTs at the bottom of channel member list below offline users is not working

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1242,6 +1242,7 @@ const UserStatusesWeight = {
     dnd: 2,
     offline: 3,
     ooo: 3,
+    bot: 4
 };
 
 /**
@@ -1249,16 +1250,8 @@ const UserStatusesWeight = {
  */
 export function sortUsersByStatusAndDisplayName(users, statusesByUserId) {
     function compareUsers(a, b) {
-        if (a.is_bot) {
-            return 1;
-        }
-
-        if (b.is_bot) {
-            return -1;
-        }
-
-        const aStatus = statusesByUserId[a.id] || UserStatuses.OFFLINE;
-        const bStatus = statusesByUserId[b.id] || UserStatuses.OFFLINE;
+        const aStatus = a.is_bot ? 'bot' : statusesByUserId[a.id] || UserStatuses.OFFLINE;
+        const bStatus = b.is_bot ? 'bot' : statusesByUserId[b.id] || UserStatuses.OFFLINE;
 
         if (UserStatusesWeight[aStatus] !== UserStatusesWeight[bStatus]) {
             return UserStatusesWeight[aStatus] - UserStatusesWeight[bStatus];

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1249,6 +1249,14 @@ const UserStatusesWeight = {
  */
 export function sortUsersByStatusAndDisplayName(users, statusesByUserId) {
     function compareUsers(a, b) {
+        if (a.is_bot) {
+            return 1;
+        }
+
+        if (b.is_bot) {
+            return -1;
+        }
+
         const aStatus = statusesByUserId[a.id] || UserStatuses.OFFLINE;
         const bStatus = statusesByUserId[b.id] || UserStatuses.OFFLINE;
 

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1242,7 +1242,7 @@ const UserStatusesWeight = {
     dnd: 2,
     offline: 3,
     ooo: 3,
-    bot: 4
+    bot: 4,
 };
 
 /**

--- a/utils/utils.test.jsx
+++ b/utils/utils.test.jsx
@@ -104,6 +104,9 @@ describe('Utils.sortUsersByStatusAndDisplayName', () => {
     const userH = {id: 'h', username: 'h_user', nickname: 'ch_nickname', first_name: 'c_first_name', last_name: 'ch_last_name'};
     const userI = {id: 'i', username: 'i_user', nickname: 'bi_nickname', first_name: 'c_first_name', last_name: 'bi_last_name'};
     const userJ = {id: 'j', username: 'j_user', nickname: 'aj_nickname', first_name: 'c_first_name', last_name: 'aj_last_name'};
+    const userK = {id: 'k', username: 'k_bot', nickname: 'ak_nickname', first_name: 'a_first_name', last_name: 'aABot_last_name', is_bot: true};
+    const userL = {id: 'l', username: 'l_bot', nickname: 'al_nickname', first_name: 'b_first_name', last_name: 'aBBot_last_name', is_bot: true};
+    const userM = {id: 'm', username: 'm_bot', nickname: 'am_nickname', first_name: 'c_first_name', last_name: 'aCBot_last_name', is_bot: true};
     const statusesByUserId = {
         a: 'dnd',
         b: 'away',
@@ -115,6 +118,9 @@ describe('Utils.sortUsersByStatusAndDisplayName', () => {
         h: 'away',
         i: 'offline',
         j: 'online',
+        k: 'offline',
+        l: 'offline',
+        m: 'offline',
     };
 
     test('Users sort by status and displayname, TeammateNameDisplay set to username', () => {
@@ -127,16 +133,16 @@ describe('Utils.sortUsersByStatusAndDisplayName', () => {
 
         for (const data of [
             {
-                users: [userF, userA, userB, userC, userD, userE],
-                result: [userD, userE, userF, userB, userA, userC],
+                users: [userM, userK, userL, userF, userA, userB, userC, userD, userE],
+                result: [userD, userE, userF, userB, userA, userC, userK, userL, userM],
             },
             {
-                users: [userJ, userI, userH, userG, userF, userE],
-                result: [userE, userF, userJ, userH, userG, userI],
+                users: [userM, userL, userK, userJ, userI, userH, userG, userF, userE],
+                result: [userE, userF, userJ, userH, userG, userI, userK, userL, userM],
             },
             {
-                users: [userJ, userF, userE, userD],
-                result: [userD, userE, userF, userJ],
+                users: [userL, userM, userK, userJ, userF, userE, userD],
+                result: [userD, userE, userF, userJ, userK, userL, userM],
             },
         ]) {
             const sortedUsers = Utils.sortUsersByStatusAndDisplayName(data.users, statusesByUserId);
@@ -156,16 +162,16 @@ describe('Utils.sortUsersByStatusAndDisplayName', () => {
 
         for (const data of [
             {
-                users: [userF, userA, userB, userC, userD, userE],
-                result: [userF, userE, userD, userB, userA, userC],
+                users: [userM, userK, userL, userF, userA, userB, userC, userD, userE],
+                result: [userF, userE, userD, userB, userA, userC, userK, userL, userM],
             },
             {
-                users: [userJ, userI, userH, userG, userF, userE],
-                result: [userJ, userF, userE, userH, userG, userI],
+                users: [userM, userL, userK, userJ, userI, userH, userG, userF, userE],
+                result: [userJ, userF, userE, userH, userG, userI, userK, userL, userM],
             },
             {
-                users: [userJ, userF, userE, userD],
-                result: [userJ, userF, userE, userD],
+                users: [userL, userM, userK, userJ, userF, userE, userD],
+                result: [userJ, userF, userE, userD, userK, userL, userM],
             },
         ]) {
             const sortedUsers = Utils.sortUsersByStatusAndDisplayName(data.users, statusesByUserId);
@@ -185,16 +191,16 @@ describe('Utils.sortUsersByStatusAndDisplayName', () => {
 
         for (const data of [
             {
-                users: [userF, userA, userB, userC, userD, userE],
-                result: [userD, userF, userE, userB, userA, userC],
+                users: [userM, userK, userL, userF, userA, userB, userC, userD, userE],
+                result: [userD, userF, userE, userB, userA, userC, userK, userL, userM],
             },
             {
-                users: [userJ, userI, userH, userG, userF, userE],
-                result: [userF, userE, userJ, userH, userG, userI],
+                users: [userM, userL, userK, userJ, userI, userH, userG, userF, userE],
+                result: [userF, userE, userJ, userH, userG, userI, userK, userL, userM],
             },
             {
-                users: [userJ, userF, userE, userD],
-                result: [userD, userF, userE, userJ],
+                users: [userL, userM, userK, userJ, userF, userE, userD],
+                result: [userD, userF, userE, userJ, userK, userL, userM],
             },
         ]) {
             const sortedUsers = Utils.sortUsersByStatusAndDisplayName(data.users, statusesByUserId);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Forces bots to the bottom of channel user list

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[Jira](https://mattermost.atlassian.net/browse/MM-14767)
[GitHub](https://github.com/mattermost/mattermost-server/issues/10752)

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has redux changes (May be necessary)
