### PR TITLE
MM-15343 Rely entirely on post metadata for embedded content

### DIFF
--- a/components/post_view/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
+++ b/components/post_view/post_attachment_opengraph/__snapshots__/post_attachment_opengraph.test.js.snap
@@ -57,8 +57,6 @@ exports[`components/post_view/PostAttachmentOpenGraph Match snapshot for large i
 </div>
 `;
 
-exports[`components/post_view/PostAttachmentOpenGraph Match snapshot for no openGraphData 1`] = `""`;
-
 exports[`components/post_view/PostAttachmentOpenGraph Match snapshot for small image openGraphData 1`] = `
 <div
   className="attachment attachment--opengraph"

--- a/components/post_view/post_attachment_opengraph/index.js
+++ b/components/post_view/post_attachment_opengraph/index.js
@@ -5,17 +5,24 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getOpenGraphMetadataForUrl} from 'mattermost-redux/selectors/entities/posts';
+import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import {editPost} from 'actions/views/posts';
 
+import {Preferences} from 'utils/constants';
+
 import PostAttachmentOpenGraph from './post_attachment_opengraph.jsx';
 
 function mapStateToProps(state, ownProps) {
+    const config = getConfig(state);
+
     return {
         currentUser: getCurrentUser(state),
-        hasImageProxy: getConfig(state).HasImageProxy === 'true',
+        enableLinkPreviews: config.EnableLinkPreviews === 'true',
+        hasImageProxy: config.HasImageProxy === 'true',
         openGraphData: getOpenGraphMetadataForUrl(state, ownProps.link),
+        previewEnabled: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, true),
     };
 }
 

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.jsx
@@ -44,6 +44,16 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
          */
         hasImageProxy: PropTypes.bool.isRequired,
 
+        /**
+         * Whether or not the server has link previews enabled.
+         */
+        enableLinkPreviews: PropTypes.bool.isRequired,
+
+        /**
+         * Whether or not the user has link previews enabled.
+         */
+        previewEnabled: PropTypes.bool.isRequired,
+
         isEmbedVisible: PropTypes.bool,
         toggleEmbedVisibility: PropTypes.func.isRequired,
 
@@ -212,6 +222,10 @@ export default class PostAttachmentOpenGraph extends React.PureComponent {
     }
 
     render() {
+        if (!this.props.previewEnabled || !this.props.enableLinkPreviews) {
+            return null;
+        }
+
         if (!this.props.post || isSystemMessage(this.props.post)) {
             return null;
         }

--- a/components/post_view/post_attachment_opengraph/post_attachment_opengraph.test.js
+++ b/components/post_view/post_attachment_opengraph/post_attachment_opengraph.test.js
@@ -50,7 +50,7 @@ describe('components/post_view/PostAttachmentOpenGraph', () => {
         },
     };
 
-    test('Match snapshot for no openGraphData', () => {
+    test('should render nothing without any data', () => {
         const props = {
             ...baseProps,
             openGraphData: null,
@@ -60,7 +60,33 @@ describe('components/post_view/PostAttachmentOpenGraph', () => {
             <PostAttachmentOpenGraph {...props}/>
         );
 
-        expect(wrapper).toMatchSnapshot();
+        expect(wrapper).toEqual({});
+    });
+
+    test('should render nothing when link previews are disabled on the server', () => {
+        const props = {
+            ...baseProps,
+            enableLinkPreviews: false,
+        };
+
+        const wrapper = shallow(
+            <PostAttachmentOpenGraph {...props}/>
+        );
+
+        expect(wrapper).toEqual({});
+    });
+
+    test('should render nothing when link previews are disabled by the user', () => {
+        const props = {
+            ...baseProps,
+            previewEnabled: false,
+        };
+
+        const wrapper = shallow(
+            <PostAttachmentOpenGraph {...props}/>
+        );
+
+        expect(wrapper).toEqual({});
     });
 
     test('Match snapshot for small image openGraphData', () => {

--- a/components/post_view/post_body/index.js
+++ b/components/post_view/post_body/index.js
@@ -4,12 +4,8 @@
 import {connect} from 'react-redux';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {isCurrentChannelReadOnly, getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-
-import {isEmbedVisible} from 'selectors/posts';
-import {Preferences} from 'utils/constants.jsx';
 
 import PostBody from './post_body.jsx';
 
@@ -31,8 +27,6 @@ function mapStateToProps(state, ownProps) {
         parentPost,
         parentPostUser,
         pluginPostTypes: state.plugins.postTypes,
-        previewEnabled: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.LINK_PREVIEW_DISPLAY, true),
-        isEmbedVisible: isEmbedVisible(state, ownProps.post.id),
         enablePostUsernameOverride,
         isReadOnly: isCurrentChannelReadOnly(state) || channelIsArchived,
     };

--- a/components/post_view/post_body/post_body.jsx
+++ b/components/post_view/post_body/post_body.jsx
@@ -57,11 +57,6 @@ export default class PostBody extends React.PureComponent {
          */
         isFirstReply: PropTypes.bool,
 
-        /**
-         * User's preference to link previews
-         */
-        previewEnabled: PropTypes.bool,
-
         /*
          * Post type components from plugins
          */
@@ -182,7 +177,6 @@ export default class PostBody extends React.PureComponent {
             messageWithAdditionalContent = (
                 <PostBodyAdditionalContent
                     post={this.props.post}
-                    previewEnabled={this.props.previewEnabled}
                     isEmbedVisible={this.props.isEmbedVisible}
                 >
                     {messageWrapper}

--- a/components/post_view/post_body_additional_content/__snapshots__/post_body_additional_content.test.jsx.snap
+++ b/components/post_view/post_body_additional_content/__snapshots__/post_body_additional_content.test.jsx.snap
@@ -1,0 +1,192 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PostBodyAdditionalContent with a YouTube video should render correctly 1`] = `
+<div>
+  <a
+    aria-label="Toggle Embed Visibility"
+    className="post__embed-visibility pull-left"
+    data-expanded={true}
+    key="toggle"
+    onClick={[Function]}
+  />
+  <span>
+    some children
+  </span>
+  <Connect(YoutubeVideo)
+    channelId="channel_id"
+    link="https://www.youtube.com/watch?v=d-YO3v-wJts"
+    show={true}
+  />
+</div>
+`;
+
+exports[`PostBodyAdditionalContent with a YouTube video should render the toggle after a message containing more than just a link 1`] = `
+<div>
+  <span>
+    some children
+  </span>
+  <a
+    aria-label="Toggle Embed Visibility"
+    className="post__embed-visibility "
+    data-expanded={true}
+    key="toggle"
+    onClick={[Function]}
+  />
+  <Connect(YoutubeVideo)
+    channelId="channel_id"
+    link="https://www.youtube.com/watch?v=d-YO3v-wJts"
+    show={true}
+  />
+</div>
+`;
+
+exports[`PostBodyAdditionalContent with a message attachment should render correctly 1`] = `
+<div>
+  <span>
+    some children
+  </span>
+  <MessageAttachmentList
+    attachments={Array []}
+    imagesMetadata={Object {}}
+    postId="post_id_1"
+  />
+</div>
+`;
+
+exports[`PostBodyAdditionalContent with an image preview should render correctly 1`] = `
+<div>
+  <a
+    aria-label="Toggle Embed Visibility"
+    className="post__embed-visibility pull-left"
+    data-expanded={true}
+    key="toggle"
+    onClick={[Function]}
+  />
+  <span>
+    some children
+  </span>
+  <Connect(PostImage)
+    imageMetadata={Object {}}
+    link="https://example.com/image.png"
+    post={
+      Object {
+        "channel_id": "channel_id",
+        "create_at": 1,
+        "id": "post_id_1",
+        "message": "https://example.com/image.png",
+        "metadata": Object {
+          "embeds": Array [
+            Object {
+              "type": "image",
+              "url": "https://example.com/image.png",
+            },
+          ],
+          "images": Object {
+            "https://example.com/image.png": Object {},
+          },
+        },
+        "root_id": "root_id",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`PostBodyAdditionalContent with an image preview should render the toggle after a message containing more than just a link 1`] = `
+<div>
+  <span>
+    some children
+  </span>
+  <a
+    aria-label="Toggle Embed Visibility"
+    className="post__embed-visibility "
+    data-expanded={true}
+    key="toggle"
+    onClick={[Function]}
+  />
+  <Connect(PostImage)
+    imageMetadata={Object {}}
+    link="https://example.com/image.png"
+    post={
+      Object {
+        "channel_id": "channel_id",
+        "create_at": 1,
+        "id": "post_id_1",
+        "message": "This is an image: https://example.com/image.png",
+        "metadata": Object {
+          "embeds": Array [
+            Object {
+              "type": "image",
+              "url": "https://example.com/image.png",
+            },
+          ],
+          "images": Object {
+            "https://example.com/image.png": Object {},
+          },
+        },
+        "root_id": "root_id",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`PostBodyAdditionalContent with an opengraph preview should render correctly 1`] = `
+<div>
+  <span>
+    some children
+  </span>
+  <Connect(PostAttachmentOpenGraph)
+    isEmbedVisible={true}
+    link="https://example.com/image.png"
+    post={
+      Object {
+        "channel_id": "channel_id",
+        "create_at": 1,
+        "id": "post_id_1",
+        "message": "https://example.com/image.png",
+        "metadata": Object {
+          "embeds": Array [
+            Object {
+              "type": "opengraph",
+              "url": "https://example.com/image.png",
+            },
+          ],
+        },
+        "root_id": "root_id",
+      }
+    }
+    toggleEmbedVisibility={[Function]}
+  />
+</div>
+`;
+
+exports[`PostBodyAdditionalContent with an opengraph preview should render the toggle after a message containing more than just a link 1`] = `
+<div>
+  <span>
+    some children
+  </span>
+  <Connect(PostAttachmentOpenGraph)
+    isEmbedVisible={true}
+    link="https://example.com/image.png"
+    post={
+      Object {
+        "channel_id": "channel_id",
+        "create_at": 1,
+        "id": "post_id_1",
+        "message": "This is a link: https://example.com/image.png",
+        "metadata": Object {
+          "embeds": Array [
+            Object {
+              "type": "opengraph",
+              "url": "https://example.com/image.png",
+            },
+          ],
+        },
+        "root_id": "root_id",
+      }
+    }
+    toggleEmbedVisibility={[Function]}
+  />
+</div>
+`;

--- a/components/post_view/post_body_additional_content/index.js
+++ b/components/post_view/post_body_additional_content/index.js
@@ -3,29 +3,22 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
-
-import {getRedirectLocation} from 'mattermost-redux/actions/general';
 
 import {toggleEmbedVisibility} from 'actions/post_actions';
 
-import PostBodyAdditionalContent from './post_body_additional_content.jsx';
+import {isEmbedVisible} from 'selectors/posts';
 
-function mapStateToProps(state) {
-    const config = getConfig(state);
-    const enableLinkPreviews = config.EnableLinkPreviews === 'true';
-    const hasImageProxy = config.HasImageProxy === 'true';
+import PostBodyAdditionalContent from './post_body_additional_content';
 
+function mapStateToProps(state, ownProps) {
     return {
-        enableLinkPreviews,
-        hasImageProxy,
+        isEmbedVisible: isEmbedVisible(state, ownProps.post.id),
     };
 }
 
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            getRedirectLocation,
             toggleEmbedVisibility,
         }, dispatch),
     };

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -4,15 +4,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import * as Utils from 'utils/utils.jsx';
+import MessageAttachmentList from 'components/post_view/message_attachments/message_attachment_list';
+import PostAttachmentOpenGraph from 'components/post_view/post_attachment_opengraph';
+import PostImage from 'components/post_view/post_image';
 import YoutubeVideo from 'components/youtube_video';
-import ViewImageModal from 'components/view_image';
-import Constants from 'utils/constants';
-import * as PostUtils from 'utils/post_utils.jsx';
-
-import MessageAttachmentList from '../message_attachments/message_attachment_list.jsx';
-import PostAttachmentOpenGraph from '../post_attachment_opengraph';
-import PostImage from '../post_image';
 
 export default class PostBodyAdditionalContent extends React.PureComponent {
     static propTypes = {
@@ -25,27 +20,12 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         /**
          * The post's message
          */
-        children: PropTypes.element.isRequired,
-
-        /**
-         * User's preference to link previews
-         */
-        previewEnabled: PropTypes.bool,
+        children: PropTypes.element,
 
         /**
          * Flag passed down to PostBodyAdditionalContent for determining if post embed is visible
          */
         isEmbedVisible: PropTypes.bool,
-
-        /**
-         * Whether link previews are enabled in the first place.
-         */
-        enableLinkPreviews: PropTypes.bool.isRequired,
-
-        /**
-         * If an image proxy is enabled.
-         */
-        hasImageProxy: PropTypes.bool.isRequired,
 
         /**
          * Options specific to text formatting
@@ -57,283 +37,100 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         }).isRequired,
     }
 
-    static defaultProps = {
-        previewEnabled: false,
-    }
-
-    constructor(props) {
-        super(props);
-
-        this.getSlackAttachment = this.getSlackAttachment.bind(this);
-        this.generateToggleableEmbed = this.generateToggleableEmbed.bind(this);
-        this.generateStaticEmbed = this.generateStaticEmbed.bind(this);
-        this.isLinkToggleable = this.isLinkToggleable.bind(this);
-        this.handleLinkLoaded = this.handleLinkLoaded.bind(this);
-        const {embeds} = props.post.metadata;
-        const embedMetadata = embeds && embeds[0];
-        const link = embedMetadata && embedMetadata.url ? embedMetadata.url : Utils.extractFirstLink(props.post.message);
-        const isMetadataImage = embedMetadata && embedMetadata.url ? embedMetadata.type === 'image' : false;
-        this.state = {
-            link,
-            linkLoadError: false,
-            linkLoaded: false,
-            isMetadataImage,
-        };
-    }
-
-    componentDidMount() {
-        // check the availability of the image rendered(if any) in the first render.
-        this.mounted = true;
-        this.preCheckImageLink();
-    }
-
-    componentWillUnmount() {
-        this.mounted = false;
-    }
-
-    UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-        if (nextProps.post.message !== this.props.post.message) {
-            const {embeds} = nextProps.post.metadata;
-            const embedMetadata = embeds && embeds[0];
-            const link = embedMetadata && embedMetadata.url ? embedMetadata.url : Utils.extractFirstLink(nextProps.post.message);
-
-            this.setState({
-                link,
-            }, () => {
-                // check the availability of the image link
-                this.preCheckImageLink();
-            });
-        }
-    }
-
     toggleEmbedVisibility = () => {
         this.props.actions.toggleEmbedVisibility(this.props.post.id);
     }
 
-    getSlackAttachment() {
-        let attachments = [];
-        if (this.props.post.props && this.props.post.props.attachments) {
-            attachments = this.props.post.props.attachments;
-        }
-
-        return (
-            <MessageAttachmentList
-                attachments={attachments}
-                postId={this.props.post.id}
-                key={this.props.post.id}
-                options={this.props.options}
-                imagesMetadata={this.props.post.metadata.images}
-            />
-        );
-    }
-
-    // when image links are collapsed, check if the link is a valid image url and it is available
-    preCheckImageLink() {
-        // check only if embedVisible is false i.e the image are by default hidden/collapsed
-        // if embedVisible is true, the image is rendered, during which image load error is captured
-        if (!this.props.isEmbedVisible && this.isLinkImage(this.state.link)) {
-            const image = new Image();
-            image.src = PostUtils.getImageSrc(this.state.link, this.props.hasImageProxy);
-
-            image.onload = () => {
-                this.handleLinkLoaded();
-            };
-        }
-    }
-
-    isLinkImage(link) {
-        let linkWithoutQuery = link.toLowerCase();
-        if (link.indexOf('?') !== -1) {
-            linkWithoutQuery = linkWithoutQuery.split('?')[0];
-        }
-
-        for (let i = 0; i < Constants.IMAGE_TYPES.length; i++) {
-            const imageType = Constants.IMAGE_TYPES[i];
-
-            if (linkWithoutQuery.endsWith('.' + imageType) || linkWithoutQuery.endsWith('=' + imageType)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    isLinkToggleable() {
-        const link = this.state.link;
-        if (!link) {
-            return false;
-        }
-
-        if (this.state.isMetadataImage) {
-            return true;
-        }
-
-        if (YoutubeVideo.isYoutubeLink(link)) {
-            return true;
-        }
-
-        if (this.isLinkImage(link)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    handleLinkLoaded() {
-        if (this.mounted) {
-            this.setState({
-                linkLoaded: true,
-            });
-        }
-    }
-
-    handleImageClick = () => {
-        this.setState({
-            showPreviewModal: true,
-        });
-    };
-
-    generateToggleableEmbed() {
-        const link = this.state.link;
-        if (!link) {
+    getEmbed = () => {
+        const {metadata} = this.props.post;
+        if (!metadata || !metadata.embeds || metadata.embeds.length === 0) {
             return null;
         }
 
-        if (YoutubeVideo.isYoutubeLink(link)) {
-            return (
-                <YoutubeVideo
-                    channelId={this.props.post.channel_id}
-                    link={link}
-                    show={this.props.isEmbedVisible}
-                    onLinkLoaded={this.handleLinkLoaded}
-                />
-            );
-        }
-
-        if (this.isLinkImage(link)) {
-            const dimensions = this.props.post.metadata && this.props.post.metadata.images && this.props.post.metadata.images[link];
-            return (
-                <PostImage
-                    channelId={this.props.post.channel_id}
-                    link={link}
-                    onLinkLoaded={this.handleLinkLoaded}
-                    handleImageClick={this.handleImageClick}
-                    dimensions={dimensions}
-                />
-            );
-        }
-
-        return null;
+        return metadata.embeds[0];
     }
 
-    generateStaticEmbed() {
-        if (this.props.post.props && this.props.post.props.attachments) {
-            return this.getSlackAttachment();
+    isEmbedToggleable = (embed) => {
+        return embed.type === 'image' || (embed.type === 'opengraph' && YoutubeVideo.isYoutubeLink(embed.url));
+    }
+
+    renderEmbed = (embed) => {
+        switch (embed.type) {
+        case 'image':
+            return (
+                <PostImage
+                    imageMetadata={this.props.post.metadata.images[embed.url]}
+                    link={embed.url}
+                    post={this.props.post}
+                />
+            );
+
+        case 'message_attachment': {
+            let attachments = [];
+            if (this.props.post.props && this.props.post.props.attachments) {
+                attachments = this.props.post.props.attachments;
+            }
+
+            return (
+                <MessageAttachmentList
+                    attachments={attachments}
+                    postId={this.props.post.id}
+                    options={this.props.options}
+                    imagesMetadata={this.props.post.metadata.images}
+                />
+            );
         }
 
-        const link = Utils.extractFirstLink(this.props.post.message);
-        if (link && this.props.enableLinkPreviews && this.props.previewEnabled) {
+        case 'opengraph':
+            if (YoutubeVideo.isYoutubeLink(embed.url)) {
+                return (
+                    <YoutubeVideo
+                        channelId={this.props.post.channel_id}
+                        link={embed.url}
+                        show={this.props.isEmbedVisible}
+                    />
+                );
+            }
+
             return (
                 <PostAttachmentOpenGraph
-                    link={link}
+                    link={embed.url}
                     isEmbedVisible={this.props.isEmbedVisible}
                     post={this.props.post}
                     toggleEmbedVisibility={this.toggleEmbedVisibility}
                 />
             );
-        }
 
-        return null;
+        default:
+            return null;
+        }
     }
 
-    renderImagePreview() {
-        let link = this.state.link;
-        if (!link || !this.isLinkImage(link)) {
-            return null;
-        }
-
-        const captureExt = /(?:\.([^.]+))?$/;
-        if (!captureExt || captureExt.length <= 1) {
-            return null;
-        }
-
-        const ext = captureExt.exec(link)[1];
-
-        link = PostUtils.getImageSrc(link, this.props.hasImageProxy);
-
+    renderToggle = (prependToggle) => {
         return (
-            <ViewImageModal
-                show={this.state.showPreviewModal}
-                onModalDismissed={() => this.setState({showPreviewModal: false})}
-                postId={this.props.post.id}
-                startIndex={0}
-                fileInfos={[{
-                    has_preview_image: false,
-                    link,
-                    extension: ext,
-                }]}
+            <a
+                key='toggle'
+                className={`post__embed-visibility ${prependToggle ? 'pull-left' : ''}`}
+                data-expanded={this.props.isEmbedVisible}
+                aria-label='Toggle Embed Visibility'
+                onClick={this.toggleEmbedVisibility}
             />
         );
     }
 
     render() {
-        if (this.isLinkToggleable() && !this.state.linkLoadError) {
-            // if message has only one line and starts with a link place toggle in this only line
-            // else - place it in new line between message and embed
+        const embed = this.getEmbed();
+
+        if (embed) {
+            const toggleable = this.isEmbedToggleable(embed);
             const prependToggle = (/^\s*https?:\/\/.*$/).test(this.props.post.message);
 
-            const toggle = (
-                <a
-                    key='toggle'
-                    className={`post__embed-visibility ${prependToggle ? 'pull-left' : ''}`}
-                    data-expanded={this.props.isEmbedVisible}
-                    aria-label='Toggle Embed Visibility'
-                    onClick={this.toggleEmbedVisibility}
-                />
-            );
-            const message = (
-                <div key='message'>
-                    {this.props.children}
-                </div>
-            );
-
-            const contents = [message];
-
-            if (this.state.linkLoaded || YoutubeVideo.isYoutubeLink(this.state.link)) {
-                if (prependToggle) {
-                    contents.unshift(toggle);
-                } else {
-                    contents.push(toggle);
-                }
-            }
-
-            if (this.props.isEmbedVisible) {
-                contents.push(
-                    <div
-                        key='embed'
-                        className='post__embed-container'
-                    >
-                        {this.generateToggleableEmbed()}
-                    </div>
-                );
-            }
-            const imagePreview = this.renderImagePreview();
-
             return (
                 <div>
-                    {contents}
-                    {imagePreview}
-                </div>
-            );
-        }
-
-        const staticEmbed = this.generateStaticEmbed();
-
-        if (staticEmbed) {
-            return (
-                <div>
+                    {(toggleable && prependToggle) && this.renderToggle(true)}
                     {this.props.children}
-                    {staticEmbed}
+                    {(toggleable && !prependToggle) && this.renderToggle(false)}
+                    {this.props.isEmbedVisible && this.renderEmbed(embed)}
                 </div>
             );
         }

--- a/components/post_view/post_image/post_image.jsx
+++ b/components/post_view/post_image/post_image.jsx
@@ -5,72 +5,58 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import SizeAwareImage from 'components/size_aware_image';
+import ViewImageModal from 'components/view_image';
+
 import * as PostUtils from 'utils/post_utils.jsx';
 
 export default class PostImage extends React.PureComponent {
     static propTypes = {
-
-        /**
-         * The link to load the image from
-         */
-        link: PropTypes.string.isRequired,
-
-        /**
-         * Function to call when image is loaded
-         */
-        onLinkLoaded: PropTypes.func,
-
-        /**
-         * The function to call if image is clicked
-         */
-        handleImageClick: PropTypes.func,
-
-        /**
-         * If an image proxy is enabled.
-         */
         hasImageProxy: PropTypes.bool.isRequired,
-
-        /**
-         * dimensions for empty space to prevent scroll popup.
-         */
-        dimensions: PropTypes.object,
+        imageMetadata: PropTypes.object.isRequired,
+        link: PropTypes.string.isRequired,
+        post: PropTypes.object.isRequired,
     }
 
-    componentDidMount() {
-        this.mounted = true;
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showModal: false,
+        };
     }
 
-    componentWillUnmount() {
-        this.mounted = false;
-    }
-
-    handleLoadComplete = () => {
-        if (!this.mounted) {
-            return;
-        }
-
-        if (this.props.onLinkLoaded) {
-            this.props.onLinkLoaded();
-        }
-    }
-
-    onImageClick = (e) => {
+    showModal = (e) => {
         e.preventDefault();
-        this.props.handleImageClick();
-    };
+
+        this.setState({showModal: true});
+    }
+
+    hideModal = () => {
+        this.setState({showModal: false});
+    }
 
     render() {
+        const link = PostUtils.getImageSrc(this.props.link, this.props.hasImageProxy);
+
         return (
-            <div
-                className='post__embed-container'
-            >
+            <div className='post__embed-container'>
                 <SizeAwareImage
                     className='img-div attachment__image cursor--pointer'
-                    src={PostUtils.getImageSrc(this.props.link, this.props.hasImageProxy)}
-                    dimensions={this.props.dimensions}
+                    src={link}
+                    dimensions={this.props.imageMetadata}
                     showLoader={true}
-                    onImageLoaded={this.handleLoadComplete}
-                    onClick={this.onImageClick}
+                    onClick={this.showModal}
+                />
+                <ViewImageModal
+                    show={this.state.showModal}
+                    onModalDismissed={this.hideModal}
+                    post={this.props.post}
+                    startIndex={0}
+                    fileInfos={[{
+                        has_preview_image: false,
+                        link,
+                        extension: this.props.imageMetadata.format,
+                    }]}
                 />
             </div>
         );

--- a/components/post_view/post_image/post_image.test.jsx
+++ b/components/post_view/post_image/post_image.test.jsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {shallow} from 'enzyme';
+import React from 'react';
+
+import SizeAwareImage from 'components/size_aware_image';
+import ViewImageModal from 'components/view_image';
+
+import * as PostUtils from 'utils/post_utils.jsx';
+
+import PostImage from './post_image';
+
+describe('PostImage', () => {
+    const baseProps = {
+        hasImageProxy: false,
+        imageMetadata: {
+            format: 'png',
+            height: 400,
+            width: 300,
+        },
+        link: 'https://example.com/image.png',
+        post: {},
+    };
+
+    test('all image URLs should go through the image proxy when enabled', () => {
+        const props = {
+            ...baseProps,
+            hasImageProxy: true,
+        };
+
+        const wrapper = shallow(<PostImage {...props}/>);
+
+        const expectedLink = PostUtils.getImageSrc(props.link, true);
+
+        expect(wrapper.find(SizeAwareImage).prop('src')).toBe(expectedLink);
+        expect(wrapper.find(ViewImageModal).prop('fileInfos')).toMatchObject([{
+            link: expectedLink,
+        }]);
+    });
+});

--- a/components/view_image/index.js
+++ b/components/view_image/index.js
@@ -16,7 +16,7 @@ function mapStateToProps(state, ownProps) {
         canDownloadFiles: canDownloadFiles(config),
         enablePublicLink: config.EnablePublicLink === 'true',
         pluginFilePreviewComponents: state.plugins.components.FilePreview,
-        post: getPost(state, ownProps.postId),
+        post: ownProps.post || getPost(state, ownProps.postId),
     };
 }
 

--- a/components/youtube_video/youtube_video.jsx
+++ b/components/youtube_video/youtube_video.jsx
@@ -17,7 +17,6 @@ export default class YoutubeVideo extends React.PureComponent {
         link: PropTypes.string.isRequired,
         show: PropTypes.bool.isRequired,
         googleDeveloperKey: PropTypes.string,
-        onLinkLoaded: PropTypes.func,
     }
 
     constructor(props) {
@@ -106,7 +105,6 @@ export default class YoutubeVideo extends React.PureComponent {
         } else {
             this.loadWithoutKey();
         }
-        this.props.onLinkLoaded();
     }
 
     loadWithoutKey() {

--- a/components/youtube_video/youtube_video.test.jsx
+++ b/components/youtube_video/youtube_video.test.jsx
@@ -14,7 +14,6 @@ describe('components/YoutubeVideo', () => {
             link: 'https://www.youtube.com/watch?v=xqCoNej8Zxo',
             show: true,
             googleDeveloperKey: 'googledevkey',
-            onLinkLoaded: jest.fn(),
         };
 
         return shallow(<YoutubeVideo {...allProps}/>);

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -239,29 +239,6 @@ export function loopReplacePattern(text, pattern, replacement) {
     return result;
 }
 
-// extracts the first link from the text
-export function extractFirstLink(text) {
-    const pattern = /(^|[\s\n]|<br\/?>)((?:https?|ftp):\/\/[-A-Z0-9+\u0026\u2019@#/%?=()~_|!:,.;]*[-A-Z0-9+\u0026@#/%=~()_|])/i;
-    let inText = text;
-
-    // strip out code blocks
-    inText = inText.replace(/`[^`]*`/g, '');
-
-    // strip out inline markdown images
-    inText = inText.replace(/!\[[^\]]*]\([^)]*\)/g, '');
-
-    // remove markdown *, ~~ and _ characters
-    inText = loopReplacePattern(inText, /(\*|~~)(.*?)\1/, '$2');
-    inText = loopReplacePattern(inText, /([\s\n]|^)_(.*?)_([\s\n]|$)/, '$1$2$3');
-
-    const match = pattern.exec(inText);
-    if (match) {
-        return match[0].trim();
-    }
-
-    return '';
-}
-
 // Taken from http://stackoverflow.com/questions/1068834/object-comparison-in-javascript and modified slightly
 export function areObjectsEqual(x, y) {
     let p;


### PR DESCRIPTION
Instead of using `extractFirstLink` to search the post text for a link, this makes it so that we only look at `post.metadata.embeds` to figure out if the post should show any embedded content (link previews, image previews, message attachments, or YouTube videos). This will fix any scroll pop that happens when the web app tries to show content that hasn't been included with the post metadata.

One important thing to note from this is that the server doesn't understand YouTube links, so we have to look for OpenGraph requests to see if they're actually YouTube links ([link](https://github.com/sudheerDev/mattermost-webapp/compare/MM-14977...mattermost:mm15343b#diff-564aa388e5c66ad77190526b786fbe89R85)). This makes it difficult to fix [MM-15072](https://mattermost.atlassian.net/browse/MM-15072), so I'm going to propose closing it as Won't Fix.

I also took the opportunity to do some cleanup of the `PostBodyAdditionalContent` component since it had a bit of logic in it that could've been separated out a bit better (like moving the `ViewImageModal` component so that it's now part of `PostImage`).

This is based on #2638, so changes specific to this PR can be seen here: https://github.com/sudheerDev/mattermost-webapp/compare/MM-14977...mattermost:mm15343b

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15343

#### Related Pull Requests
#2638 