### PR TITLE
Promote Polish to 'official'

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -307,7 +307,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
             },
             Object {
               "order": 6,
-              "text": "Polski (Beta)",
+              "text": "Polski",
               "value": "pl",
             },
             Object {
@@ -421,7 +421,7 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
             },
             Object {
               "order": 6,
-              "text": "Polski (Beta)",
+              "text": "Polski",
               "value": "pl",
             },
             Object {

--- a/i18n/i18n.jsx
+++ b/i18n/i18n.jsx
@@ -104,7 +104,7 @@ const languages = {
     },
     pl: {
         value: 'pl',
-        name: 'Polski (Beta)',
+        name: 'Polski',
         order: 6,
         url: pl,
     },


### PR DESCRIPTION
This is in preparation for v5.12 release. Polish was promoted back to Beta for v5.9: https://github.com/mattermost/mattermost-webapp/pull/2443