### PR TITLE
Fix bot badges on manage team members

### DIFF
--- a/components/user_list_row/user_list_row.jsx
+++ b/components/user_list_row/user_list_row.jsx
@@ -101,7 +101,7 @@ export default class UserListRow extends React.Component {
                         {Utils.displayEntireNameForUser(this.props.user)}
                         <BotBadge
                             className='badge-popoverlist'
-                            show={this.props.user.is_bot}
+                            show={Boolean(this.props.user.is_bot)}
                         />
                     </div>
                     <div


### PR DESCRIPTION
#### Summary
Bot badges where showing up always on view team members.

#### Ticket Link
[MM-15479](https://mattermost.atlassian.net/browse/MM-15479)