### PR TITLE
[MM-15459] Add mechanism to prevent suggestion close when clicking suggestion list

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -174,8 +174,6 @@ export default class SuggestionBox extends React.Component {
             allowDividers: true,
             presentationType: 'text',
         };
-
-        this.preventSuggestionListClose = this.preventSuggestionListClose.bind(this);
     }
 
     componentDidMount() {
@@ -242,7 +240,7 @@ export default class SuggestionBox extends React.Component {
         }, delay);
     }
 
-    preventSuggestionListClose() {
+    preventSuggestionListClose = () => {
         this.preventSuggestionListCloseFlag = true;
     }
 

--- a/components/suggestion/suggestion_list.jsx
+++ b/components/suggestion/suggestion_list.jsx
@@ -17,6 +17,7 @@ export default class SuggestionList extends React.PureComponent {
         renderDividers: PropTypes.bool,
         renderNoResults: PropTypes.bool,
         onCompleteWord: PropTypes.func.isRequired,
+        preventClose: PropTypes.func,
         pretext: PropTypes.string.isRequired,
         cleared: PropTypes.bool.isRequired,
         matchedPretext: PropTypes.array.isRequired,
@@ -167,6 +168,7 @@ export default class SuggestionList extends React.PureComponent {
                     id='suggestionList'
                     ref='content'
                     className={contentClass}
+                    onMouseDown={this.props.preventClose}
                 >
                     {items}
                 </div>


### PR DESCRIPTION
#### Summary
The scrollbar of the suggestion list is not detected as the `relatedTarget` of the `focusOut` event when clicked, so a `preventSuggestionListClose` function has been added that sets a flag as part of any `mouseDown` event inside the suggestion box. This flag prevents the list to be closed, hence allows the scrollbar to function properly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15459
