### PR TITLE
MM-15399: Properly setting filenames on upload saml certificates

### DIFF
--- a/actions/admin_actions.jsx
+++ b/actions/admin_actions.jsx
@@ -183,7 +183,7 @@ export async function removeLicenseFile(success, error) {
 export async function uploadPublicSamlCertificate(file, success, error) {
     const {data, error: err} = await AdminActions.uploadPublicSamlCertificate(file)(dispatch, getState);
     if (data && success) {
-        success(data);
+        success('saml-public.crt');
     } else if (err && error) {
         error({id: err.server_error_id, ...err});
     }
@@ -192,7 +192,7 @@ export async function uploadPublicSamlCertificate(file, success, error) {
 export async function uploadPrivateSamlCertificate(file, success, error) {
     const {data, error: err} = await AdminActions.uploadPrivateSamlCertificate(file)(dispatch, getState);
     if (data && success) {
-        success(data);
+        success('saml-private.key');
     } else if (err && error) {
         error({id: err.server_error_id, ...err});
     }
@@ -201,7 +201,7 @@ export async function uploadPrivateSamlCertificate(file, success, error) {
 export async function uploadIdpSamlCertificate(file, success, error) {
     const {data, error: err} = await AdminActions.uploadIdpSamlCertificate(file)(dispatch, getState);
     if (data && success) {
-        success(data);
+        success('saml-idp.crt');
     } else if (err && error) {
         error({id: err.server_error_id, ...err});
     }

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -672,10 +672,9 @@ export default class SchemaAdminSettings extends React.Component {
             );
         }
         const uploadFile = (id, file, callback) => {
-            const successCallback = () => {
-                const fileName = file.name;
-                this.handleChange(id, fileName);
-                this.setState({[setting.key]: fileName, [`${setting.key}Error`]: null});
+            const successCallback = (filename) => {
+                this.handleChange(id, filename);
+                this.setState({[setting.key]: filename, [`${setting.key}Error`]: null});
                 if (callback && typeof callback === 'function') {
                     callback();
                 }


### PR DESCRIPTION
#### Summary
Now filenames for uploaded files are defined by the uploader success callback,
and in this cases is used to set properly the file names for the saml
certificates.

#### Ticket Link
[MM-15399](https://mattermost.atlassian.net/browse/MM-15399)