### PR TITLE
MM-15320 Use new header to calculate file loading progress for gzipped responses

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1158,7 +1158,14 @@ export function loadImage(url, onLoad, onProgress) {
     request.onload = onLoad;
     request.onprogress = (e) => {
         if (onProgress) {
-            const completedPercentage = Math.round((e.loaded / e.total) * 100);
+            let total = 0;
+            if (e.lengthComputable) {
+                total = e.total;
+            } else {
+                total = parseInt(e.target.getResponseHeader('X-Uncompressed-Content-Length'), 10);
+            }
+
+            const completedPercentage = Math.round((e.loaded / total) * 100);
 
             onProgress(completedPercentage);
         }


### PR DESCRIPTION
#### Summary
Use new header to calculate file loading progress for gzipped responses. See https://github.com/mattermost/mattermost-server/pull/10836 for more details.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15320

#### Related Pull Requests
- Has server changes (https://github.com/mattermost/mattermost-server/pull/10836)