### PR TITLE
MM-15432 Change isFirstReply to return false for non-comments

### DIFF
--- a/components/post_view/post/index.js
+++ b/components/post_view/post/index.js
@@ -16,14 +16,20 @@ import {Preferences} from 'utils/constants.jsx';
 
 import Post from './post.jsx';
 
-// isFirstReply returns true when the given post is not part of the same thread as the previous post.
+// isFirstReply returns true when the given post a comment that isn't part of the same thread as the previous post.
 export function isFirstReply(post, previousPost) {
-    if (post.root_id && previousPost) {
-        // Returns true as long as the previous post is part of a different thread
-        return post.root_id !== previousPost.id && post.root_id !== previousPost.root_id;
+    if (post.root_id) {
+        if (previousPost) {
+            // Returns true as long as the previous post is part of a different thread
+            return post.root_id !== previousPost.id && post.root_id !== previousPost.root_id;
+        }
+
+        // The previous post is not a real post
+        return true;
     }
 
-    return true;
+    // This post is not a reply
+    return false;
 }
 
 export function makeGetReplyCount() {

--- a/components/post_view/post/index.test.js
+++ b/components/post_view/post/index.test.js
@@ -11,7 +11,7 @@ describe('isFirstReply', () => {
             name: 'a post with nothing above it',
             post: {root_id: ''},
             previousPost: null,
-            expected: true,
+            expected: false,
         },
         {
             name: 'a comment with nothing above it',
@@ -23,13 +23,13 @@ describe('isFirstReply', () => {
             name: 'a post with a regular post above it',
             post: {root_id: ''},
             previousPost: {root_id: ''},
-            expected: true,
+            expected: false,
         },
         {
             name: 'a post with a comment above it',
             post: {root_id: ''},
             previousPost: {root_id: 'root'},
-            expected: true,
+            expected: false,
         },
         {
             name: 'a comment with a regular post above it',


### PR DESCRIPTION
This fixes the issue where concurrent posts made by a single user are always rendered separately.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15432