### PR TITLE
[MM-14973] Remove password length limit from reset password form (closes #10523)

### DIFF
--- a/components/admin_console/reset_password_modal/reset_password_modal.jsx
+++ b/components/admin_console/reset_password_modal/reset_password_modal.jsx
@@ -149,7 +149,6 @@ export default class ResetPasswordModal extends React.Component {
                             type='password'
                             ref='currentPassword'
                             className='form-control'
-                            maxLength='22'
                             autoFocus={true}
                             tabIndex='1'
                         />
@@ -193,7 +192,6 @@ export default class ResetPasswordModal extends React.Component {
                                         type='password'
                                         ref='password'
                                         className='form-control'
-                                        maxLength='22'
                                         autoFocus={newPasswordFocus}
                                         tabIndex='1'
                                     />


### PR DESCRIPTION
#### Summary
This PR removes the max length enforcement for the password reset form in the admin UI. The password length will now only be validated by the serverside (which has currently a max length of 72):

https://github.com/mattermost/mattermost-server/blob/584ec68755a22c3caec24a1a7da432111a9ac344/model/user.go#L267

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14973
https://github.com/mattermost/mattermost-server/issues/10523

