### PR TITLE
MM-15562 Add a way to unregister post type components

### DIFF
--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -255,6 +255,16 @@ export default class PluginRegistry {
         });
     }
 
+    // Unregister a component that provided a custom body for posts with a specific type.
+    // Accepts a string id.
+    // Returns undefined in all cases.
+    unregisterPostTypeComponent(componentId) {
+        store.dispatch({
+            type: ActionTypes.REMOVED_PLUGIN_POST_COMPONENT,
+            id: componentId,
+        });
+    }
+
     // Register a reducer against the Redux store. It will be accessible in redux state
     // under "state['plugins-<yourpluginid>']"
     // Accepts a reducer. Returns undefined.


### PR DESCRIPTION
This is needed for the NPS plugin because it stops using its custom post component at small screen sizes when there's not enough room to display it properly.

The `REMOVED_PLUGIN_POST_COMPONENT` action is already handled by the correct reducer, but there was nothing that actually emitted it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15562