### PR TITLE
MM-15583 Fix static embeds being hidden when image previews are collapsed

### DIFF
--- a/components/post_view/post_body_additional_content/__snapshots__/post_body_additional_content.test.jsx.snap
+++ b/components/post_view/post_body_additional_content/__snapshots__/post_body_additional_content.test.jsx.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PostBodyAdditionalContent with a YouTube video should not render content when isEmbedVisible is false 1`] = `
+<div>
+  <a
+    aria-label="Toggle Embed Visibility"
+    className="post__embed-visibility pull-left"
+    data-expanded={false}
+    key="toggle"
+    onClick={[Function]}
+  />
+  <span>
+    some children
+  </span>
+</div>
+`;
+
 exports[`PostBodyAdditionalContent with a YouTube video should render correctly 1`] = `
 <div>
   <a

--- a/components/post_view/post_body_additional_content/post_body_additional_content.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.jsx
@@ -57,6 +57,10 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
     renderEmbed = (embed) => {
         switch (embed.type) {
         case 'image':
+            if (!this.props.isEmbedVisible) {
+                return null;
+            }
+
             return (
                 <PostImage
                     imageMetadata={this.props.post.metadata.images[embed.url]}
@@ -83,6 +87,10 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
 
         case 'opengraph':
             if (YoutubeVideo.isYoutubeLink(embed.url)) {
+                if (!this.props.isEmbedVisible) {
+                    return null;
+                }
+
                 return (
                     <YoutubeVideo
                         channelId={this.props.post.channel_id}
@@ -130,7 +138,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
                     {(toggleable && prependToggle) && this.renderToggle(true)}
                     {this.props.children}
                     {(toggleable && !prependToggle) && this.renderToggle(false)}
-                    {this.props.isEmbedVisible && this.renderEmbed(embed)}
+                    {this.renderEmbed(embed)}
                 </div>
             );
         }

--- a/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
@@ -5,7 +5,9 @@ import {shallow} from 'enzyme';
 import React from 'react';
 
 import MessageAttachmentList from 'components/post_view/message_attachments/message_attachment_list';
+import PostAttachmentOpenGraph from 'components/post_view/post_attachment_opengraph';
 import PostImage from 'components/post_view/post_image';
+import YoutubeVideo from 'components/youtube_video';
 
 import PostBodyAdditionalContent from './post_body_additional_content';
 
@@ -28,6 +30,7 @@ describe('PostBodyAdditionalContent', () => {
 
     describe('with an image preview', () => {
         const imageUrl = 'https://example.com/image.png';
+        const imageMetadata = {}; // This can be empty since we're checking equality with ===
 
         const imageBaseProps = {
             ...baseProps,
@@ -50,7 +53,8 @@ describe('PostBodyAdditionalContent', () => {
             const wrapper = shallow(<PostBodyAdditionalContent {...imageBaseProps}/>);
 
             expect(wrapper).toMatchSnapshot();
-            expect(wrapper.find(PostImage).prop('imageMetadata')).toBe(imageBaseProps.post.metadata.images[imageUrl]);
+            expect(wrapper.find(PostImage)).toExist();
+            expect(wrapper.find(PostImage).prop('imageMetadata')).toBe(imageMetadata);
         });
 
         test('should render the toggle after a message containing more than just a link', () => {
@@ -66,29 +70,54 @@ describe('PostBodyAdditionalContent', () => {
 
             expect(wrapper).toMatchSnapshot();
         });
-    });
 
-    describe('with a message attachment', () => {
-        test('should render correctly', () => {
+        test('should not render content when isEmbedVisible is false', () => {
             const props = {
-                ...baseProps,
-                post: {
-                    ...baseProps.post,
-                    metadata: {
-                        embeds: [{
-                            type: 'message_attachment',
-                        }],
-                    },
-                    props: {
-                        attachments: [],
-                    },
-                },
+                ...imageBaseProps,
+                isEmbedVisible: false,
             };
 
             const wrapper = shallow(<PostBodyAdditionalContent {...props}/>);
 
+            expect(wrapper.find(PostImage)).not.toExist();
+        });
+    });
+
+    describe('with a message attachment', () => {
+        const attachments = []; // This can be empty since we're checking equality with ===
+
+        const messageAttachmentBaseProps = {
+            ...baseProps,
+            post: {
+                ...baseProps.post,
+                metadata: {
+                    embeds: [{
+                        type: 'message_attachment',
+                    }],
+                },
+                props: {
+                    attachments,
+                },
+            },
+        };
+
+        test('should render correctly', () => {
+            const wrapper = shallow(<PostBodyAdditionalContent {...messageAttachmentBaseProps}/>);
+
             expect(wrapper).toMatchSnapshot();
-            expect(wrapper.find(MessageAttachmentList).prop('attachments')).toBe(props.post.props.attachments);
+            expect(wrapper.find(MessageAttachmentList)).toExist();
+            expect(wrapper.find(MessageAttachmentList).prop('attachments')).toBe(attachments);
+        });
+
+        test('should render content when isEmbedVisible is false', () => {
+            const props = {
+                ...messageAttachmentBaseProps,
+                isEmbedVisible: false,
+            };
+
+            const wrapper = shallow(<PostBodyAdditionalContent {...props}/>);
+
+            expect(wrapper.find(MessageAttachmentList)).toExist();
         });
     });
 
@@ -112,6 +141,7 @@ describe('PostBodyAdditionalContent', () => {
         test('should render correctly', () => {
             const wrapper = shallow(<PostBodyAdditionalContent {...ogBaseProps}/>);
 
+            expect(wrapper.find(PostAttachmentOpenGraph)).toExist();
             expect(wrapper).toMatchSnapshot();
         });
 
@@ -128,12 +158,23 @@ describe('PostBodyAdditionalContent', () => {
 
             expect(wrapper).toMatchSnapshot();
         });
+
+        test('should render content when isEmbedVisible is false', () => {
+            const props = {
+                ...ogBaseProps,
+                isEmbedVisible: false,
+            };
+
+            const wrapper = shallow(<PostBodyAdditionalContent {...props}/>);
+
+            expect(wrapper.find(PostAttachmentOpenGraph)).toExist();
+        });
     });
 
     describe('with a YouTube video', () => {
         const youtubeUrl = 'https://www.youtube.com/watch?v=d-YO3v-wJts';
 
-        const imageBaseProps = {
+        const youtubeBaseProps = {
             ...baseProps,
             post: {
                 ...baseProps.post,
@@ -148,22 +189,35 @@ describe('PostBodyAdditionalContent', () => {
         };
 
         test('should render correctly', () => {
-            const wrapper = shallow(<PostBodyAdditionalContent {...imageBaseProps}/>);
+            const wrapper = shallow(<PostBodyAdditionalContent {...youtubeBaseProps}/>);
 
+            expect(wrapper.find(YoutubeVideo)).toExist();
             expect(wrapper).toMatchSnapshot();
         });
 
         test('should render the toggle after a message containing more than just a link', () => {
             const props = {
-                ...imageBaseProps,
+                ...youtubeBaseProps,
                 post: {
-                    ...imageBaseProps.post,
+                    ...youtubeBaseProps.post,
                     message: 'This is a video: ' + youtubeUrl,
                 },
             };
 
             const wrapper = shallow(<PostBodyAdditionalContent {...props}/>);
 
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('should not render content when isEmbedVisible is false', () => {
+            const props = {
+                ...youtubeBaseProps,
+                isEmbedVisible: false,
+            };
+
+            const wrapper = shallow(<PostBodyAdditionalContent {...props}/>);
+
+            expect(wrapper.find(YoutubeVideo)).not.toExist();
             expect(wrapper).toMatchSnapshot();
         });
     });

--- a/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
+++ b/components/post_view/post_body_additional_content/post_body_additional_content.test.jsx
@@ -43,7 +43,7 @@ describe('PostBodyAdditionalContent', () => {
                         url: imageUrl,
                     }],
                     images: {
-                        [imageUrl]: {},
+                        [imageUrl]: imageMetadata,
                     },
                 },
             },
@@ -53,7 +53,7 @@ describe('PostBodyAdditionalContent', () => {
             const wrapper = shallow(<PostBodyAdditionalContent {...imageBaseProps}/>);
 
             expect(wrapper).toMatchSnapshot();
-            expect(wrapper.find(PostImage)).toExist();
+            expect(wrapper.find(PostImage).exists()).toBe(true);
             expect(wrapper.find(PostImage).prop('imageMetadata')).toBe(imageMetadata);
         });
 
@@ -79,7 +79,7 @@ describe('PostBodyAdditionalContent', () => {
 
             const wrapper = shallow(<PostBodyAdditionalContent {...props}/>);
 
-            expect(wrapper.find(PostImage)).not.toExist();
+            expect(wrapper.find(PostImage).exists()).toBe(false);
         });
     });
 
@@ -105,7 +105,7 @@ describe('PostBodyAdditionalContent', () => {
             const wrapper = shallow(<PostBodyAdditionalContent {...messageAttachmentBaseProps}/>);
 
             expect(wrapper).toMatchSnapshot();
-            expect(wrapper.find(MessageAttachmentList)).toExist();
+            expect(wrapper.find(MessageAttachmentList).exists()).toBe(true);
             expect(wrapper.find(MessageAttachmentList).prop('attachments')).toBe(attachments);
         });
 
@@ -117,7 +117,7 @@ describe('PostBodyAdditionalContent', () => {
 
             const wrapper = shallow(<PostBodyAdditionalContent {...props}/>);
 
-            expect(wrapper.find(MessageAttachmentList)).toExist();
+            expect(wrapper.find(MessageAttachmentList).exists()).toBe(true);
         });
     });
 
@@ -141,7 +141,7 @@ describe('PostBodyAdditionalContent', () => {
         test('should render correctly', () => {
             const wrapper = shallow(<PostBodyAdditionalContent {...ogBaseProps}/>);
 
-            expect(wrapper.find(PostAttachmentOpenGraph)).toExist();
+            expect(wrapper.find(PostAttachmentOpenGraph).exists()).toBe(true);
             expect(wrapper).toMatchSnapshot();
         });
 
@@ -167,7 +167,7 @@ describe('PostBodyAdditionalContent', () => {
 
             const wrapper = shallow(<PostBodyAdditionalContent {...props}/>);
 
-            expect(wrapper.find(PostAttachmentOpenGraph)).toExist();
+            expect(wrapper.find(PostAttachmentOpenGraph).exists()).toBe(true);
         });
     });
 
@@ -191,7 +191,7 @@ describe('PostBodyAdditionalContent', () => {
         test('should render correctly', () => {
             const wrapper = shallow(<PostBodyAdditionalContent {...youtubeBaseProps}/>);
 
-            expect(wrapper.find(YoutubeVideo)).toExist();
+            expect(wrapper.find(YoutubeVideo).exists()).toBe(true);
             expect(wrapper).toMatchSnapshot();
         });
 
@@ -217,7 +217,7 @@ describe('PostBodyAdditionalContent', () => {
 
             const wrapper = shallow(<PostBodyAdditionalContent {...props}/>);
 
-            expect(wrapper.find(YoutubeVideo)).not.toExist();
+            expect(wrapper.find(YoutubeVideo).exists()).toBe(false);
             expect(wrapper).toMatchSnapshot();
         });
     });


### PR DESCRIPTION
The naming of the props `isEmbedVisible` (whether or not an image preview/YouTube video is collapsed or the image in an OpenGraph preview is collapsed), `enableLinkPreviews` (whether or not the server has OpenGraph previews enabled), and `previewEnabled` (whether or not the user has OpenGraph previews enabled) are confusing.

This is a followup to fix a bug caused by #2764

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15583