### PR TITLE
[MM-15530] Enforce default SAML certificate names

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2655,6 +2655,19 @@ export default {
                 id: 'SamlSettings',
                 name: t('admin.authentication.saml'),
                 name_default: 'SAML 2.0',
+                onConfigSave: (config, oldConfig) => {
+                    const newConfig = {...config};
+                    const certificatesKeys = Object.keys(Constants.SAML_CERTIFICATES_CONFIG_DEFAULTS);
+                    for (const key of certificatesKeys) {
+                        // The names of the certificate files are being renamed in the backend, so if the new config
+                        // value is not empty (certificate being removed) and it's different (so the certificate has
+                        // just been uploaded), we default to the same value that the server is enforcing
+                        if (newConfig.SamlSettings[key] !== '' && oldConfig.SamlSettings[key] !== newConfig.SamlSettings[key]) {
+                            newConfig.SamlSettings[key] = Constants.SAML_CERTIFICATES_CONFIG_DEFAULTS[key];
+                        }
+                    }
+                    return newConfig;
+                },
                 settings: [
                     {
                         type: Constants.SettingsTypes.TYPE_BOOL,

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -643,11 +643,11 @@ export default class SchemaAdminSettings extends React.Component {
             const removeFile = (id, callback) => {
                 const successCallback = () => {
                     this.handleChange(setting.key, '');
-                    this.setState({[setting.key]: null, [`${setting.key}Error`]: null});
+                    this.setState({[setting.key]: '', [`${setting.key}Error`]: null});
                 };
                 const errorCallback = (error) => {
                     callback();
-                    this.setState({[setting.key]: null, [`${setting.key}Error`]: error.message});
+                    this.setState({[setting.key]: '', [`${setting.key}Error`]: error.message});
                 };
                 setting.remove_action(successCallback, errorCallback);
             };

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1249,6 +1249,11 @@ export const Constants = {
     CHANNEL_ID_LENGTH: 26,
     TRANSPARENT_PIXEL: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
     TRIPLE_BACK_TICKS: /```/g,
+    SAML_CERTIFICATES_CONFIG_DEFAULTS: {
+        PrivateKeyFile: 'saml-private.key',
+        PublicCertificateFile: 'saml-public.crt',
+        IdpCertificateFile: 'saml-idp.crt',
+    },
 };
 
 export const AcceptedProfileImageTypes = ['image/jpeg', 'image/png', 'image/bmp'];


### PR DESCRIPTION
#### Summary
As per [MM-14294](https://mattermost.atlassian.net/browse/MM-14294) we are enforcing the SAML certificate names, rewriting them on the server after they are uploaded. If a user uploads a certificate and then saves the configuration, the value that is set is the original filename, causing the server to fail when opening the file.

This PR ensures that if a certificate is uploaded, the final name that is sent with the rest of the configuration is the same default that the server is enforcing. It modifies as well the `UPLOAD_FILE_TYPE` config block, to set the config value to empty string instead of `null`, which was causing a bad pointer access and an empty response from the server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15530