### PR TITLE
MM-15487: Adding suggestion.archive to the translatable strings

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2819,6 +2819,7 @@
   "status_dropdown.set_ooo.extra": "Automatic Replies are enabled",
   "string.id": "default message",
   "suggestion_list.no_matches": "No items match __{value}__",
+  "suggestion.archive": "Archived Channels",
   "suggestion.mention.all": "Notifies everyone in this channel",
   "suggestion.mention.channel": "Notifies everyone in this channel",
   "suggestion.mention.channels": "My Channels",

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1260,5 +1260,6 @@ t('suggestion.mention.members');
 t('suggestion.mention.moremembers');
 t('suggestion.mention.nonmembers');
 t('suggestion.mention.special');
+t('suggestion.archive');
 
 export default Constants;


### PR DESCRIPTION
#### Summary
Allowing to translate `suggestion.archive` string in the channel switcher.

#### Ticket Link
[MM-15487](https://mattermost.atlassian.net/browse/MM-15487)