### PR TITLE
MM-15227 Permalink is not loading more posts into the view when reacheded to the top

### DIFF
--- a/components/post_view/post_list_virtualized/index.js
+++ b/components/post_view/post_list_virtualized/index.js
@@ -19,7 +19,7 @@ function makeMapStateToProps() {
         let postIds;
         const lastViewedAt = state.views.channel.lastChannelViewTime[ownProps.channelId];
         if (ownProps.focusedPostId) {
-            postIds = getPostIdsAroundPost(state, ownProps.focusedPostId, ownProps.channelId);
+            postIds = getPostIdsAroundPost(state, ownProps.focusedPostId, ownProps.channelId, {postsBeforeCount: -1});
         } else {
             postIds = getPostIdsInChannel(state, ownProps.channelId);
         }


### PR DESCRIPTION
Selector `getPostIdsAroundPost` takes options arguments for slicing the required posts

https://github.com/mattermost/mattermost-redux/blob/master/src/selectors/entities/posts.js#L131-L134

As with virtualised list we can return the entire post chunk so adding `-1` index as option so selector can return all the posts in the chunk. With bi-directional scrolling we can add `-1` for `postsAfterCount` as well given we add the initial range to mount for virtualised list