### PR TITLE
MM-13483 Cleared search term should not reappear as RHS is reopened

### DIFF
--- a/cypress/integration/channel/header_spec.js
+++ b/cypress/integration/channel/header_spec.js
@@ -70,4 +70,28 @@ describe('Header', () => {
 
         cy.apiSaveMessageDisplayPreference();
     });
+    it('S13483 - Cleared search term should not reappear as RHS is opened and closed', () => {
+        // # Place the focus on the search box and search for something
+        cy.get('#searchFormContainer').click();
+        cy.get('#searchBox').type('London{enter}');
+
+        // # Clear the search text
+        cy.get('#searchBox').clear();
+
+        // # Verify the Search side bar opens up
+        cy.get('#sidebar-right').should('be.visible').and('contain', 'Search Results');
+
+        // # Close the search side bar
+        cy.get('#searchResultsCloseButton').should('be.visible').click();
+
+        // # Verify that the cleared search text does not appear on the search box
+        cy.get('#searchBox').should('be.visible').and('be.empty');
+
+        // # Click the pin icon to open the pinned posts RHS
+        cy.get('#channelHeaderPinButton').should('be.visible').click();
+        cy.get('#sidebar-right').should('be.visible').and('contain', 'Pinned posts in');
+
+        // # Verify that the Search term input box is still cleared and search term does not reappear when RHS opens
+        cy.get('#searchBox').should('be.visible').and('be.empty');
+    });
 });


### PR DESCRIPTION
#### Summary
This PR includes automations tests to verify that the cleared search term does not reappear when RHS is reopened

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/10038
