### PR TITLE
MM-14134 Do not auto close notifications on Mac desktop app

### DIFF
--- a/utils/notifications.jsx
+++ b/utils/notifications.jsx
@@ -58,7 +58,8 @@ export async function showNotification({title, body, requireInteraction, silent,
         notification.onclick = onClick;
     }
 
-    if (!requireInteraction) {
+    // Mac desktop app notification dismissal is handled by the OS
+    if (!requireInteraction && !UserAgent.isMacApp()) {
         setTimeout(() => {
             notification.close();
         }, Constants.DEFAULT_NOTIFICATION_DURATION);


### PR DESCRIPTION
#### Summary
Mac app notifications are controlled and dismissed as necessary by the OS. By dismissing the notifications for the Mac desktop app we were breaking with app conventions for Mac apps.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14134