### PR TITLE
[MM-14344] E2E for email notification

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
     "baseUrl": "http://localhost:8065",
-    "localEmailUrl": "http://localhost:9000",
+    "mailboxAPI": "http://localhost:9000/api/v1/mailbox/",
     "viewportWidth": 1300,
     "defaultCommandTimeout": 20000,
     "taskTimeout": 20000,

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
     "baseUrl": "http://localhost:8065",
+    "localEmailUrl": "http://localhost:9000",
     "viewportWidth": 1300,
     "defaultCommandTimeout": 20000,
     "taskTimeout": 20000,

--- a/cypress/fixtures/users.json
+++ b/cypress/fixtures/users.json
@@ -17,6 +17,7 @@
         "username": "samuel.tucker",
         "password": "user-2",
         "email": "user-2@sample.mattermost.com",
+        "emailname": "user-2",
         "firstName": "Samuel",
         "lastName": "Tucker"
     }

--- a/cypress/integration/email/mention_email_notification_spec.js
+++ b/cypress/integration/email/mention_email_notification_spec.js
@@ -40,6 +40,8 @@ describe('Email notification', () => {
 
             const permalink = bodyText[9].match(reUrl)[0];
             const permalinkPostId = permalink.split('/')[5];
+
+            // # Visit permalink (e.g. click on email link)
             cy.visit(permalink);
 
             const postText = `#postMessageText_${permalinkPostId}`;
@@ -61,6 +63,7 @@ function verifyEmailNotification(response, teamDisplayName, channelDisplayName, 
     expect(status).to.equal(200);
 
     // * Verify that email is addressed to user-2
+    expect(data.to.length).to.equal(1);
     expect(data.to[0]).to.contain(mentionedUser.email);
 
     // * Verify that email is from default feedback email
@@ -73,15 +76,15 @@ function verifyEmailNotification(response, teamDisplayName, channelDisplayName, 
     expect(data.subject).to.contain(`[Mattermost] Notification in ${teamDisplayName}`);
 
     // * Verify that the email body is correct
-    const bodyText = data.body.text.split('\n');
+    const bodyText = data.body.text.split('\r\n');
     expect(bodyText.length).to.equal(16);
-    expect(bodyText[1]).to.contain('You have a new notification.');
-    expect(bodyText[4]).to.contain(`Channel: ${channelDisplayName}`);
-    expect(bodyText[5]).to.contain(`${byUser.username}`);
-    expect(bodyText[7]).to.contain(`${message}`);
+    expect(bodyText[1]).to.equal('You have a new notification.');
+    expect(bodyText[4]).to.equal(`Channel: ${channelDisplayName}`);
+    expect(bodyText[5]).to.contain(`@${byUser.username}`);
+    expect(bodyText[7]).to.equal(`${message}`);
     expect(bodyText[9]).to.contain('Go To Post');
-    expect(bodyText[11]).to.contain('Any questions at all, mail us any time: feedback@mattermost.com');
-    expect(bodyText[12]).to.contain('Best wishes,');
-    expect(bodyText[13]).to.contain('The Mattermost Team');
-    expect(bodyText[15]).to.contain('To change your notification preferences, log in to your team site and go to Account Settings > Notifications.');
+    expect(bodyText[11]).to.equal('Any questions at all, mail us any time: feedback@mattermost.com');
+    expect(bodyText[12]).to.equal('Best wishes,');
+    expect(bodyText[13]).to.equal('The Mattermost Team');
+    expect(bodyText[15]).to.equal('To change your notification preferences, log in to your team site and go to Account Settings > Notifications.');
 }

--- a/cypress/integration/email/mention_email_notification_spec.js
+++ b/cypress/integration/email/mention_email_notification_spec.js
@@ -10,61 +10,78 @@
 /* eslint max-nested-callbacks: ["error", 4] */
 
 import users from '../../fixtures/users.json';
+import * as TIMEOUTS from '../../fixtures/timeouts';
 
-const cypressConfig = require('../../../cypress.json');
+const reUrl = /(https?:\/\/[^ ]*)/;
 
 const user1 = users['user-1'];
 const user2 = users['user-2'];
 
-const text = `@${user2.username}`;
+const text = `Hello @${user2.username}`;
+const feedbackEmail = 'test@example.com';
 
 describe('Email notification', () => {
-    it('post a message that mentions a user', () => {
-        cy.apiLogin('user-1');
-        cy.visit('/');
-        cy.postMessage(`${text}{enter}`);
+    before(() => {
+        cy.apiUpdateConfig({EmailSettings: {FeedbackEmail: feedbackEmail}});
     });
 
-    it('sends email notification with correct email contents', () => {
-        cy.visit(`${cypressConfig.localEmailUrl}`);
-        cy.url().should('include', `${cypressConfig.localEmailUrl}`);
+    it('post a message that mentions a user', () => {
+        cy.apiLogin('user-1');
+        cy.visit('/ad-1/channels/town-square');
+        cy.postMessage(`${text}{enter}`);
 
-        verifyEmailNotification('eligendi', 'Town Square', user2, user1, text);
+        // Wait for a while to ensure that email notification is sent.
+        cy.wait(TIMEOUTS.SMALL);
+
+        cy.task('getRecentEmail', {username: 'user-2'}).then((response) => {
+            verifyEmailNotification(response, 'eligendi', 'Town Square', user2, user1, text, feedbackEmail);
+
+            const bodyText = response.data.body.text.split('\n');
+
+            const permalink = bodyText[9].match(reUrl)[0];
+            const permalinkPostId = permalink.split('/')[5];
+            cy.visit(permalink);
+
+            const postText = `#postMessageText_${permalinkPostId}`;
+            cy.get(postText).should('have.text', text);
+
+            cy.getLastPostId().then((postId) => {
+                // * Should match last post and permalink post IDs
+                expect(permalinkPostId).to.equal(postId);
+            });
+        });
     });
 });
 
-function verifyEmailNotification(teamName, channelDisplayName, mentionedUser, byUser, message, feedbackEmail = 'test@example.com') {
+function verifyEmailNotification(response, teamDisplayName, channelDisplayName, mentionedUser, byUser, message, fromEmail) {
     const isoDate = new Date().toISOString().substring(0, 10);
+    const {data, status} = response;
 
-    const emailName = mentionedUser.emailname || mentionedUser.username;
+    // * Should return success status
+    expect(status).to.equal(200);
 
-    // # Visit local email provider and go directly to a user
-    cy.visit(`${cypressConfig.localEmailUrl}/mailbox?name=${emailName}`);
+    // * Verify that email is addressed to user-2
+    expect(data.to[0]).to.contain(mentionedUser.email);
 
-    // # Click the most recent message
-    cy.get('#message-list').children().last().click();
+    // * Verify that email is from default feedback email
+    expect(data.from).to.contain(fromEmail);
 
-    // * Verify text contents of email header
-    cy.get('.panel-body').should('be.visible').within(() => {
-        cy.get('dl dt').first().should('have.text', 'From:');
-        cy.get('dl dd').first().should('have.text', `<${feedbackEmail}>`);
+    // * Verify that date is current
+    expect(data.date).to.contain(isoDate);
 
-        cy.get('dl dt').eq(1).should('have.text', 'To:');
-        cy.get('dl dd').eq(1).should('contain', `<${mentionedUser.email}>`);
+    // * Verify that the email subject is correct
+    expect(data.subject).to.contain(`[Mattermost] Notification in ${teamDisplayName}`);
 
-        cy.get('dl dt').eq(2).should('have.text', 'Date:');
-        cy.get('dl dd').eq(2).should('contain', `${isoDate}`);
-
-        cy.get('dl dt').last().should('have.text', 'Subject:');
-        cy.get('dl dd').last().should('contain', `[Mattermost] Notification in ${teamName}`);
-    });
-
-    // * Verify text contents of email body
-    cy.get('.message-body').
-        should('contain', 'You have a new notification.').
-        and('contain', `@${byUser.username}`).
-        and('contain', `Channel: ${channelDisplayName}`).
-        and('contain', `${message}`).
-        and('contain', 'Go To Post').
-        and('contain', 'To change your notification preferences, log in to your team site and go to Account Settings > Notifications.');
+    // * Verify that the email body is correct
+    const bodyText = data.body.text.split('\n');
+    expect(bodyText.length).to.equal(16);
+    expect(bodyText[1]).to.contain('You have a new notification.');
+    expect(bodyText[4]).to.contain(`Channel: ${channelDisplayName}`);
+    expect(bodyText[5]).to.contain(`${byUser.username}`);
+    expect(bodyText[7]).to.contain(`${message}`);
+    expect(bodyText[9]).to.contain('Go To Post');
+    expect(bodyText[11]).to.contain('Any questions at all, mail us any time: feedback@mattermost.com');
+    expect(bodyText[12]).to.contain('Best wishes,');
+    expect(bodyText[13]).to.contain('The Mattermost Team');
+    expect(bodyText[15]).to.contain('To change your notification preferences, log in to your team site and go to Account Settings > Notifications.');
 }

--- a/cypress/integration/email/mention_email_notification_spec.js
+++ b/cypress/integration/email/mention_email_notification_spec.js
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/* eslint max-nested-callbacks: ["error", 4] */
+
+import users from '../../fixtures/users.json';
+
+const cypressConfig = require('../../../cypress.json');
+
+const user1 = users['user-1'];
+const user2 = users['user-2'];
+
+const text = `@${user2.username}`;
+
+describe('Email notification', () => {
+    it('post a message that mentions a user', () => {
+        cy.apiLogin('user-1');
+        cy.visit('/');
+        cy.postMessage(`${text}{enter}`);
+    });
+
+    it('sends email notification with correct email contents', () => {
+        cy.visit(`${cypressConfig.localEmailUrl}`);
+        cy.url().should('include', `${cypressConfig.localEmailUrl}`);
+
+        verifyEmailNotification('eligendi', 'Town Square', user2, user1, text);
+    });
+});
+
+function verifyEmailNotification(teamName, channelDisplayName, mentionedUser, byUser, message, feedbackEmail = 'test@example.com') {
+    const isoDate = new Date().toISOString().substring(0, 10);
+
+    const emailName = mentionedUser.emailname || mentionedUser.username;
+
+    // # Visit local email provider and go directly to a user
+    cy.visit(`${cypressConfig.localEmailUrl}/mailbox?name=${emailName}`);
+
+    // # Click the most recent message
+    cy.get('#message-list').children().last().click();
+
+    // * Verify text contents of email header
+    cy.get('.panel-body').should('be.visible').within(() => {
+        cy.get('dl dt').first().should('have.text', 'From:');
+        cy.get('dl dd').first().should('have.text', `<${feedbackEmail}>`);
+
+        cy.get('dl dt').eq(1).should('have.text', 'To:');
+        cy.get('dl dd').eq(1).should('contain', `<${mentionedUser.email}>`);
+
+        cy.get('dl dt').eq(2).should('have.text', 'Date:');
+        cy.get('dl dd').eq(2).should('contain', `${isoDate}`);
+
+        cy.get('dl dt').last().should('have.text', 'Subject:');
+        cy.get('dl dd').last().should('contain', `[Mattermost] Notification in ${teamName}`);
+    });
+
+    // * Verify text contents of email body
+    cy.get('.message-body').
+        should('contain', 'You have a new notification.').
+        and('contain', `@${byUser.username}`).
+        and('contain', `Channel: ${channelDisplayName}`).
+        and('contain', `${message}`).
+        and('contain', 'Go To Post').
+        and('contain', 'To change your notification preferences, log in to your team site and go to Account Settings > Notifications.');
+}

--- a/cypress/plugins/get_recent_email.js
+++ b/cypress/plugins/get_recent_email.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const axios = require('axios');
+
+const cypressConfig = require('../../cypress.json');
+
+module.exports = async ({username}) => {
+    const mailboxUrl = cypressConfig.mailboxAPI + username;
+    let response;
+    let recentEmail;
+
+    try {
+        response = await axios({url: mailboxUrl, method: 'get'});
+        recentEmail = response.data[response.data.length - 1];
+    } catch (error) {
+        return {status: error.status, data: null};
+    }
+
+    let recentEmailMessage;
+    const mailMessageUrl = `${mailboxUrl}/${recentEmail.id}`;
+    try {
+        response = await axios({url: mailMessageUrl, method: 'get'});
+        recentEmailMessage = response.data;
+    } catch (error) {
+        return {status: error.status, data: null};
+    }
+
+    return {status: response.status, data: recentEmailMessage};
+};

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -3,10 +3,12 @@
 
 const postMessageAs = require('./post_message_as');
 const externalRequest = require('./external_request');
+const getRecentEmail = require('./get_recent_email');
 
 module.exports = (on) => {
     on('task', {
         postMessageAs,
         externalRequest,
+        getRecentEmail,
     });
 };


### PR DESCRIPTION
#### Summary
E2E for email notification.

Note: This is submitted on top of https://github.com/mattermost/mattermost-webapp/pull/2840

Particular change for this PR are: https://github.com/mattermost/mattermost-webapp/pull/2833/commits/c1093d0219703a94e0fa119bab98e8205197515a, https://github.com/mattermost/mattermost-webapp/pull/2833/commits/2be3ac1165a52832fc258bb446d8583138c6391b

~~Note that Cypress doesn't allow to visit [second unique domain](https://on.cypress.io/cannot-visit-second-unique-domain).  To work around on this, only visit the local email URL on the next `it` and from there, email contents can be verified.~~

~~This PR only verifies whether a user has received the email notification and with expected content.~~

~~It does not yet cover using the link (e.g. permalink) from email content to go back to the Mattermost instance and verify that the link is working or not.  Need to investigate further on how to save value (as variable) from a second unique domain.~~

#### Ticket Link
Jira ticket: [MM-14344](https://mattermost.atlassian.net/browse/MM-14344)

