### PR TITLE
MM-15725: Fixing NONE security in SMTP admin console config

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -904,7 +904,7 @@ export default {
                         isHidden: it.isnt(it.licensedForFeature('EmailNotificationContents')),
                         options: [
                             {
-                                value: 'none',
+                                value: '',
                                 display_name: t('admin.environment.smtp.connectionSecurity.option.none'),
                                 display_name_default: 'None',
                             },


### PR DESCRIPTION
#### Summary
Fixing NONE security in SMTP admin console config. The server expected '', and was sent 'none'.

#### Ticket Link
[MM-15725](https://mattermost.atlassian.net/browse/MM-15725)