### PR TITLE
MM-15757 Fix scroll pop caused by long posts in compact view

### DIFF
--- a/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
+++ b/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
@@ -62,7 +62,6 @@ exports[`components/post_view/MessageAttachment should call actions.doPostAction
           <Connect(ShowMore)
             checkOverflow={0}
             isAttachmentText={true}
-            maxHeight={200}
             text="short text"
           >
             <Connect(Markdown)
@@ -194,7 +193,6 @@ exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
           <Connect(ShowMore)
             checkOverflow={0}
             isAttachmentText={true}
-            maxHeight={200}
             text="short text"
           >
             <Connect(Markdown)

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -16,8 +16,6 @@ import ActionButton from '../action_button';
 import ActionMenu from '../action_menu';
 import LinkOnlyRenderer from 'utils/markdown/link_only_renderer';
 
-const MAX_ATTACHMENT_TEXT_HEIGHT = 200;
-
 export default class MessageAttachment extends React.PureComponent {
     static propTypes = {
 
@@ -327,7 +325,6 @@ export default class MessageAttachment extends React.PureComponent {
                 <ShowMore
                     checkOverflow={this.state.checkOverflow}
                     isAttachmentText={true}
-                    maxHeight={MAX_ATTACHMENT_TEXT_HEIGHT}
                     text={attachment.text}
                 >
                     <Markdown

--- a/components/post_view/post_message_view/__snapshots__/post_message_view.test.jsx.snap
+++ b/components/post_view/post_message_view/__snapshots__/post_message_view.test.jsx.snap
@@ -3,7 +3,6 @@
 exports[`components/post_view/PostAttachment should match snapshot 1`] = `
 <Connect(ShowMore)
   checkOverflow={0}
-  maxHeight={600}
   text="post message"
 >
   <div
@@ -41,7 +40,6 @@ exports[`components/post_view/PostAttachment should match snapshot 1`] = `
 exports[`components/post_view/PostAttachment should match snapshot, on Show Less 1`] = `
 <Connect(ShowMore)
   checkOverflow={0}
-  maxHeight={600}
   text="post message"
 >
   <div
@@ -79,7 +77,6 @@ exports[`components/post_view/PostAttachment should match snapshot, on Show Less
 exports[`components/post_view/PostAttachment should match snapshot, on Show More 1`] = `
 <Connect(ShowMore)
   checkOverflow={0}
-  maxHeight={600}
   text="post message"
 >
   <div
@@ -137,7 +134,6 @@ exports[`components/post_view/PostAttachment should match snapshot, on deleted p
 exports[`components/post_view/PostAttachment should match snapshot, on edited post 1`] = `
 <Connect(ShowMore)
   checkOverflow={0}
-  maxHeight={600}
   text="post message"
 >
   <div
@@ -199,7 +195,6 @@ exports[`components/post_view/PostAttachment should match snapshot, on edited po
 exports[`components/post_view/PostAttachment should match snapshot, on ephemeral post 1`] = `
 <Connect(ShowMore)
   checkOverflow={0}
-  maxHeight={600}
   text="post message"
 >
   <div

--- a/components/post_view/post_message_view/post_message_view.jsx
+++ b/components/post_view/post_message_view/post_message_view.jsx
@@ -13,8 +13,6 @@ import PostMarkdown from 'components/post_markdown';
 import Pluggable from 'plugins/pluggable';
 import ShowMore from 'components/post_view/show_more';
 
-const MAX_POST_HEIGHT = 600;
-
 export default class PostMessageView extends React.PureComponent {
     static propTypes = {
 
@@ -167,7 +165,6 @@ export default class PostMessageView extends React.PureComponent {
         return (
             <ShowMore
                 checkOverflow={this.state.checkOverflow}
-                maxHeight={MAX_POST_HEIGHT}
                 text={message}
             >
                 <div

--- a/components/post_view/show_more/__snapshots__/show_more.test.jsx.snap
+++ b/components/post_view/show_more/__snapshots__/show_more.test.jsx.snap
@@ -6,7 +6,11 @@ exports[`components/post_view/ShowMore should match snapshot 1`] = `
 >
   <div
     className="post-message__text-container"
-    style={null}
+    style={
+      Object {
+        "maxHeight": 600,
+      }
+    }
   >
     <div>
       <p>
@@ -66,6 +70,11 @@ exports[`components/post_view/ShowMore should match snapshot, PostAttachment on 
 >
   <div
     className="post-message__text-container"
+    style={
+      Object {
+        "maxHeight": undefined,
+      }
+    }
   />
   <div
     className="post-collapse"
@@ -104,7 +113,11 @@ exports[`components/post_view/ShowMore should match snapshot, PostMessageView on
 >
   <div
     className="post-message__text-container"
-    style={null}
+    style={
+      Object {
+        "maxHeight": 578,
+      }
+    }
   />
   <div
     className="post-collapse"
@@ -143,6 +156,11 @@ exports[`components/post_view/ShowMore should match snapshot, PostMessageView on
 >
   <div
     className="post-message__text-container"
+    style={
+      Object {
+        "maxHeight": undefined,
+      }
+    }
   />
   <div
     className="post-collapse"

--- a/components/post_view/show_more/__snapshots__/show_more.test.jsx.snap
+++ b/components/post_view/show_more/__snapshots__/show_more.test.jsx.snap
@@ -115,7 +115,7 @@ exports[`components/post_view/ShowMore should match snapshot, PostMessageView on
     className="post-message__text-container"
     style={
       Object {
-        "maxHeight": 578,
+        "maxHeight": 600,
       }
     }
   />
@@ -151,6 +151,49 @@ exports[`components/post_view/ShowMore should match snapshot, PostMessageView on
 `;
 
 exports[`components/post_view/ShowMore should match snapshot, PostMessageView on expanded view 1`] = `
+<div
+  className="post-message post-message--expanded post-message--overflow"
+>
+  <div
+    className="post-message__text-container"
+    style={
+      Object {
+        "maxHeight": undefined,
+      }
+    }
+  />
+  <div
+    className="post-collapse"
+  >
+    <div
+      className="post-collapse__gradient"
+      id="collapseGradient"
+    />
+    <div
+      className="post-collapse__show-more"
+    >
+      <div
+        className="post-collapse__show-more-line"
+      />
+      <button
+        className="post-collapse__show-more-button"
+        id="showMoreButton"
+        onClick={[Function]}
+      >
+        <span
+          className="fa fa-angle-up"
+        />
+        Show Less
+      </button>
+      <div
+        className="post-collapse__show-more-line"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/post_view/ShowMore should match snapshot, PostMessageView on expanded view with compactDisplay 1`] = `
 <div
   className="post-message post-message--expanded post-message--overflow"
 >

--- a/components/post_view/show_more/index.js
+++ b/components/post_view/show_more/index.js
@@ -2,8 +2,10 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {get} from 'mattermost-redux/selectors/entities/preferences';
 
 import {getIsRhsExpanded, getIsRhsOpen} from 'selectors/rhs';
+import {Preferences} from 'utils/constants.jsx';
 
 import ShowMore from './show_more';
 
@@ -11,6 +13,7 @@ function mapStateToProps(state) {
     return {
         isRHSExpanded: getIsRhsExpanded(state),
         isRHSOpen: getIsRhsOpen(state),
+        compactDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.MESSAGE_DISPLAY, Preferences.MESSAGE_DISPLAY_DEFAULT) === Preferences.MESSAGE_DISPLAY_COMPACT,
     };
 }
 

--- a/components/post_view/show_more/show_more.jsx
+++ b/components/post_view/show_more/show_more.jsx
@@ -18,10 +18,11 @@ export default class ShowMore extends React.PureComponent {
         isRHSExpanded: PropTypes.bool.isRequired,
         isRHSOpen: PropTypes.bool.isRequired,
         text: PropTypes.string,
+        compactDisplay: PropTypes.bool.isRequired,
     }
     constructor(props) {
-        super(props)
-        this.maxHeight = this.props.isAttachmentText ? MAX_ATTACHMENT_TEXT_HEIGHT : MAX_POST_HEIGHT,
+        super(props);
+        this.maxHeight = this.props.isAttachmentText ? MAX_ATTACHMENT_TEXT_HEIGHT : MAX_POST_HEIGHT;
         this.state = {
             isCollapsed: true,
             isOverflow: false,
@@ -94,6 +95,7 @@ export default class ShowMore extends React.PureComponent {
         const {
             children,
             isAttachmentText,
+            compactDisplay,
         } = this.props;
 
         let className = 'post-message';
@@ -114,8 +116,8 @@ export default class ShowMore extends React.PureComponent {
 
         let attachmentTextOverflow = null;
         if (isOverflow) {
-            if (!isAttachmentText && isCollapsed) {
-                collapsedMaxHeightStyle = collapsedMaxHeightStyle - MARGIN_CHANGE_FOR_COMPACT_POST;
+            if (!isAttachmentText && isCollapsed && compactDisplay) {
+                collapsedMaxHeightStyle -= MARGIN_CHANGE_FOR_COMPACT_POST;
             }
 
             let showIcon = 'fa fa-angle-up';
@@ -145,7 +147,6 @@ export default class ShowMore extends React.PureComponent {
                     </div>
                 </div>
             );
-
 
             className += ' post-message--overflow';
         }

--- a/components/post_view/show_more/show_more.jsx
+++ b/components/post_view/show_more/show_more.jsx
@@ -6,6 +6,10 @@ import React from 'react';
 
 import {localizeMessage} from 'utils/utils.jsx';
 
+const MAX_POST_HEIGHT = 600;
+const MAX_ATTACHMENT_TEXT_HEIGHT = 200;
+const MARGIN_CHANGE_FOR_COMPACT_POST = 22;
+
 export default class ShowMore extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node,
@@ -13,14 +17,16 @@ export default class ShowMore extends React.PureComponent {
         isAttachmentText: PropTypes.bool,
         isRHSExpanded: PropTypes.bool.isRequired,
         isRHSOpen: PropTypes.bool.isRequired,
-        maxHeight: PropTypes.number.isRequired,
         text: PropTypes.string,
     }
-
-    state = {
-        isCollapsed: true,
-        isOverflow: false,
-    };
+    constructor(props) {
+        super(props)
+        this.maxHeight = this.props.isAttachmentText ? MAX_ATTACHMENT_TEXT_HEIGHT : MAX_POST_HEIGHT,
+        this.state = {
+            isCollapsed: true,
+            isOverflow: false,
+        };
+    }
 
     componentDidMount() {
         this.checkTextOverflow();
@@ -63,7 +69,7 @@ export default class ShowMore extends React.PureComponent {
             const textContainer = this.refs.textContainer;
             let isOverflow = false;
 
-            if (textContainer && textContainer.scrollHeight > this.props.maxHeight) {
+            if (textContainer && textContainer.scrollHeight > this.maxHeight) {
                 isOverflow = true;
             }
 
@@ -88,13 +94,12 @@ export default class ShowMore extends React.PureComponent {
         const {
             children,
             isAttachmentText,
-            maxHeight,
         } = this.props;
 
         let className = 'post-message';
         let collapsedMaxHeightStyle;
         if (isCollapsed) {
-            collapsedMaxHeightStyle = isAttachmentText ? {maxHeight} : null;
+            collapsedMaxHeightStyle = this.maxHeight;
             className += ' post-message--collapsed';
         } else {
             className += ' post-message--expanded';
@@ -109,6 +114,10 @@ export default class ShowMore extends React.PureComponent {
 
         let attachmentTextOverflow = null;
         if (isOverflow) {
+            if (!isAttachmentText && isCollapsed) {
+                collapsedMaxHeightStyle = collapsedMaxHeightStyle - MARGIN_CHANGE_FOR_COMPACT_POST;
+            }
+
             let showIcon = 'fa fa-angle-up';
             let showText = localizeMessage('post_info.message.show_less', 'Show Less');
             if (isCollapsed) {
@@ -137,13 +146,14 @@ export default class ShowMore extends React.PureComponent {
                 </div>
             );
 
+
             className += ' post-message--overflow';
         }
 
         return (
             <div className={className}>
                 <div
-                    style={collapsedMaxHeightStyle}
+                    style={{maxHeight: collapsedMaxHeightStyle}}
                     className='post-message__text-container'
                     ref='textContainer'
                 >

--- a/components/post_view/show_more/show_more.test.jsx
+++ b/components/post_view/show_more/show_more.test.jsx
@@ -15,6 +15,7 @@ describe('components/post_view/ShowMore', () => {
         isRHSOpen: false,
         maxHeight: 200,
         text: 'text',
+        compactDisplay: false,
     };
 
     test('should match snapshot', () => {
@@ -50,6 +51,17 @@ describe('components/post_view/ShowMore', () => {
             <ShowMore
                 {...baseProps}
                 isAttachmentText={true}
+            />
+        );
+        wrapper.setState({isOverflow: true, isCollapsed: false});
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, PostMessageView on expanded view with compactDisplay', () => {
+        const wrapper = shallow(
+            <ShowMore
+                {...baseProps}
+                compactDisplay={true}
             />
         );
         wrapper.setState({isOverflow: true, isCollapsed: false});

--- a/plugins/test/__snapshots__/post_type.test.jsx.snap
+++ b/plugins/test/__snapshots__/post_type.test.jsx.snap
@@ -67,7 +67,6 @@ exports[`plugins/PostMessageView should match snapshot with extended post type 1
 exports[`plugins/PostMessageView should match snapshot with no extended post type 1`] = `
 <Connect(ShowMore)
   checkOverflow={0}
-  maxHeight={600}
   text="this is some text"
 >
   <div

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1019,7 +1019,7 @@
                 padding-left: 20px;
             }
 
-            div {
+            div:not(.image-loading__container) {
                 margin-bottom: 0;
             }
 

--- a/sass/responsive/_tablet.scss
+++ b/sass/responsive/_tablet.scss
@@ -270,11 +270,12 @@
         }
 
         &.post--compact {
-            .post-message {
-                &.post-message--overflow {
-                    @include clearfix;
-                    margin-top: 22px;
-                }
+            .post-message--overflow {
+                @include clearfix;
+                margin-top: 22px; //Any value change to this needs to reflect for MARGIN_CHANGE_FOR_COMPACT_POST variable in show_more component
+            }
+            .attachment__body .post-message--overflow {
+                margin-top: 0px; //The above margin was added for wrapping texg in compact view but it isnt needed for attachment text
             }
 
             &.same--root {


### PR DESCRIPTION
#### Summary
In compact view we wrap long posts to a new line. On mount of a post it starts off inline with the username and then if height is more than the max height it wraps to a new line by adding `post-message--overflow` className causing it to push content by `22px`

1. The changes here will decrease the height of long posts by 22px if it is a collapsed post in compact view
2. There is another bug with respect to long post attachments. There is an unintended sideeffect of 22px margin on top added to bot posts caused by adding the above class. 

<img width="1502" alt="Screenshot 2019-05-24 at 2 32 43 PM" src="https://user-images.githubusercontent.com/4973621/58321308-6d187380-7e3b-11e9-9f70-8b0414d5ae02.png">

This PR Fixes above both issues

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15757
