### PR TITLE
MM-15753 IE:11 Fix for system message not loading at the top

### DIFF
--- a/components/post_view/post_list_ie/post_list_ie.jsx
+++ b/components/post_view/post_list_ie/post_list_ie.jsx
@@ -406,21 +406,20 @@ export default class PostList extends React.PureComponent {
         }
     }
 
-    loadMorePosts = (e) => {
+    loadMorePosts = async (e) => {
         if (e) {
             e.preventDefault();
         }
 
-        const {posts, postVisibility, channel} = this.props;
+        const {posts, channel} = this.props;
         const postsLength = posts.length;
 
         if (!posts) {
             return;
         }
 
-        this.props.actions.increasePostVisibility(channel.id, posts[postsLength - 1].id).then((moreToLoad) => {
-            this.setState({atEnd: !moreToLoad && postsLength < postVisibility});
-        });
+        const {moreToLoad} = await this.props.actions.increasePostVisibility(channel.id, posts[postsLength - 1].id);
+        this.setState({atEnd: !moreToLoad});
     }
 
     handleScroll = () => {


### PR DESCRIPTION
#### Summary
Before recent changes to `increasePostVisibility` function we used to increment `INCREASE_POST_VISIBILITY ` irrespective of API response. Latest changes to `INCREASE_POST_VISIBILITY` are made such that we increment based on the number of posts so when at the top there are no posts so there is no increase in post length causing the state `atEnd` not set as `postsLength === postVisibility`.

https://github.com/mattermost/mattermost-webapp/blob/5feffaa72346a85c8f613e689d986b75edf7ce96/actions/views/channel.js#L196-L202

Making the change synonymous to change in virt list condition as there are no issue with this logic

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-15753