### PR TITLE
MM-15754 IE:11 Fix for grouping of messages

### DIFF
--- a/components/post_view/post_list_ie/post_list_ie.jsx
+++ b/components/post_view/post_list_ie/post_list_ie.jsx
@@ -522,6 +522,7 @@ export default class PostList extends React.PureComponent {
                     key={'post ' + (post.id || post.pending_post_id)}
                     post={post}
                     shouldHighlight={this.props.focusedPostId === post.id}
+                    previousPostId={posts[i + 1] ? posts[i + 1].id : ''}
                 />
             );
 

--- a/components/post_view/post_list_ie/post_list_ie.jsx
+++ b/components/post_view/post_list_ie/post_list_ie.jsx
@@ -500,6 +500,7 @@ export default class PostList extends React.PureComponent {
     createPosts = (posts) => {
         const postCtls = [];
         let previousPostDay = new Date(0);
+        let previousPostId = '';
         const currentUserId = this.props.currentUserId;
         const lastViewed = this.props.lastViewedAt || 0;
 
@@ -522,7 +523,7 @@ export default class PostList extends React.PureComponent {
                     key={'post ' + (post.id || post.pending_post_id)}
                     post={post}
                     shouldHighlight={this.props.focusedPostId === post.id}
-                    previousPostId={posts[i + 1] ? posts[i + 1].id : ''}
+                    previousPostId={previousPostId}
                 />
             );
 
@@ -571,6 +572,7 @@ export default class PostList extends React.PureComponent {
 
             postCtls.push(postCtl);
             previousPostDay = currentPostDay;
+            previousPostId = post.id;
         }
 
         return postCtls;


### PR DESCRIPTION
#### Summary
With recent changes for virtualised list we added a new prop `previousPostId ` for `<Post>` component which should be added here for IE11 fallback for grouping posts


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15754