### PR TITLE
MM-15756 Scroll correction fix for addition of channel header when at bottom

### DIFF
--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -147,8 +147,8 @@ export default class PostList extends React.PureComponent {
     getSnapshotBeforeUpdate(prevProps, prevState) {
         if (this.postListRef && this.postListRef.current) {
             const postsAddedAtTop = this.state.postListIds.length !== prevState.postListIds.length && this.state.postListIds[0] === prevState.postListIds[0];
-            const channelHeaderAdded = this.state.atEnd !== prevState.atEnd && this.state.postListIds.length === prevState.postListIds.length;
-            if (postsAddedAtTop || channelHeaderAdded) {
+            const channelHeaderAdded = this.state.atEnd !== prevState.atEnd;
+            if ((postsAddedAtTop || channelHeaderAdded) && !this.state.atBottom) {
                 const previousScrollTop = this.postListRef.current.scrollTop;
                 const previousScrollHeight = this.postListRef.current.scrollHeight;
 
@@ -172,8 +172,8 @@ export default class PostList extends React.PureComponent {
 
         const postlistScrollHeight = this.postListRef.current.scrollHeight;
         const postsAddedAtTop = this.state.postListIds.length !== prevState.postListIds.length && this.state.postListIds[0] === prevState.postListIds[0];
-        const channelHeaderAdded = this.state.atEnd !== prevState.atEnd && this.state.postListIds.length === prevState.postListIds.length;
-        if (postsAddedAtTop || channelHeaderAdded) {
+        const channelHeaderAdded = this.state.atEnd !== prevState.atEnd;
+        if ((postsAddedAtTop || channelHeaderAdded) && !this.state.atBottom) {
             const scrollValue = snapshot.previousScrollTop + (postlistScrollHeight - snapshot.previousScrollHeight);
             if (scrollValue !== 0 && (scrollValue - snapshot.previousScrollTop) !== 0) {
                 this.listRef.current.scrollTo(scrollValue, scrollValue - snapshot.previousScrollTop, !this.state.atEnd);
@@ -360,7 +360,7 @@ export default class PostList extends React.PureComponent {
         const postList = this.postListRef.current;
         const offsetFromBottom = (postList.scrollHeight - postList.parentElement.clientHeight) - scrollOffset;
 
-        return offsetFromBottom === 0;
+        return offsetFromBottom <= 0;
     }
 
     updateAtBottom = (atBottom) => {

--- a/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
@@ -191,6 +191,11 @@ describe('PostList', () => {
                 scrollOffset: 500,
                 expected: true,
             },
+            {
+                name: 'when clientHeight is less than scrollHeight', // scrollHeight is a state calue in virt list and can be one cycle off when compared to actual value
+                scrollOffset: 501,
+                expected: true,
+            },
         ]) {
             test(testCase.name, () => {
                 const wrapper = shallow(<PostList {...baseProps}/>);
@@ -236,7 +241,7 @@ describe('PostList', () => {
             instance.componentDidUpdate = jest.fn();
 
             instance.postListRef = {current: {scrollTop: 10, scrollHeight: 100}};
-            wrapper.setState({atEnd: true});
+            wrapper.setState({atEnd: true, atBottom: false});
             expect(instance.componentDidUpdate).toHaveBeenCalledTimes(1);
             expect(instance.componentDidUpdate.mock.calls[0][2]).toEqual({previousScrollTop: 10, previousScrollHeight: 100});
 
@@ -257,6 +262,28 @@ describe('PostList', () => {
 
             expect(instance.componentDidUpdate).toHaveBeenCalledTimes(3);
             expect(instance.componentDidUpdate.mock.calls[2][2]).toEqual({previousScrollTop: 40, previousScrollHeight: 400});
+        });
+
+        test('should not return previous scroll position from getSnapshotBeforeUpdate as list is at bottom', () => {
+            const wrapper = shallow(<PostList {...baseProps}/>);
+            const instance = wrapper.instance();
+            instance.componentDidUpdate = jest.fn();
+
+            instance.postListRef = {current: {scrollTop: 10, scrollHeight: 100}};
+            wrapper.setState({atEnd: true, atBottom: true});
+            expect(instance.componentDidUpdate.mock.calls[0][2]).toEqual(null);
+            wrapper.setState({atEnd: false});
+            instance.postListRef = {current: {scrollTop: 40, scrollHeight: 400}};
+            wrapper.setProps({postListIds: [
+                'post1',
+                'post2',
+                'post3',
+                'post4',
+                'post5',
+                DATE_LINE + 1551711600000,
+            ]});
+
+            expect(instance.componentDidUpdate.mock.calls[2][2]).toEqual(null);
         });
     });
 

--- a/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
@@ -192,7 +192,7 @@ describe('PostList', () => {
                 expected: true,
             },
             {
-                name: 'when clientHeight is less than scrollHeight', // scrollHeight is a state calue in virt list and can be one cycle off when compared to actual value
+                name: 'when clientHeight is less than scrollHeight', // scrollHeight is a state value in virt list and can be one cycle off when compared to actual value
                 scrollOffset: 501,
                 expected: true,
             },


### PR DESCRIPTION
* Exclude scroll correction when channel header is added at the top when atBottom state is true.

If channel header is added at the top we let virt list correct the scroll. Virt list can keep view at the bottom when at bottom. 

https://mattermost.atlassian.net/browse/MM-15756