### PR TITLE
Fix flaky tests on some specs

### DIFF
--- a/cypress/integration/channel/message_draft_spec.js
+++ b/cypress/integration/channel/message_draft_spec.js
@@ -7,34 +7,40 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+/*eslint max-nested-callbacks: ["error", 3]*/
+
+let testTeam;
+
 describe('Message Draft', () => {
     before(() => {
-        // # Login and go to /
-        cy.apiLogin('user-1');
-        cy.visit('/');
+        // # Login as new user
+        cy.loginAsNewUser();
+
+        // # Create new team and visit its URL
+        cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
+            testTeam = response.body;
+            cy.visit(`/${testTeam.name}`);
+        });
     });
 
     it('M13473 Message Draft - Pencil Icon', () => {
         // # Got to a test channel on the side bar
-        cy.get('#sidebarItem_town-square').scrollIntoView();
         cy.get('#sidebarItem_town-square').should('be.visible').click();
 
         // * Validate if the channel has been opened
-        cy.url().should('include', '/ad-1/channels/town-square');
+        cy.url().should('include', `/${testTeam.name}/channels/town-square`);
 
         // * Validate if the draft icon is not visible on the sidebar before making a draft
-        cy.get('#sidebarItem_town-square').scrollIntoView();
         cy.get('#sidebarItem_town-square #draftIcon').should('be.not.visible');
 
         // # Type in some text into the text area of the opened channel
         cy.get('#post_textbox').type('comm');
 
         // # Go to another test channel without submitting the draft in the previous channel
-        cy.get('#sidebarItem_autem-2').scrollIntoView();
-        cy.get('#sidebarItem_autem-2').should('be.visible').click();
+        cy.get('#sidebarItem_off-topic').should('be.visible').click();
 
         // * Validate if the newly navigated channel is open
-        cy.url().should('include', '/ad-1/channels/autem-2');
+        cy.url().should('include', `/${testTeam.name}/channels/off-topic`);
 
         // * Validate if the draft icon is visible on side bar on the previous channel with a draft
         cy.get('#sidebarItem_town-square #draftIcon').should('be.visible');

--- a/cypress/integration/channel/message_draft_then_switch_channel_spec.js
+++ b/cypress/integration/channel/message_draft_then_switch_channel_spec.js
@@ -7,37 +7,43 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+/*eslint max-nested-callbacks: ["error", 3]*/
+
 import * as TIMEOUTS from '../../fixtures/timeouts';
+
+let testTeam;
 
 describe('Message Draft and Switch Channels', () => {
     before(() => {
-        // # Login and go to /
-        cy.apiLogin('user-1');
-        cy.visit('/');
+        // # Login as new user
+        cy.loginAsNewUser();
+
+        // # Create new team and visit its URL
+        cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
+            testTeam = response.body;
+            cy.visit(`/${testTeam.name}`);
+        });
     });
 
     it('M14358 Message Draft Pencil Icon Visible in Channel Switcher', () => {
         // # In a test channel, type some text in the message input box
         // # Do not send the post
-        cy.get('#sidebarItem_town-square').scrollIntoView();
         cy.get('#sidebarItem_town-square').should('be.visible').click();
 
         // * Validate if the channel has been opened
-        cy.url().should('include', '/channels/town-square');
+        cy.url().should('include', `/${testTeam.name}/channels/town-square`);
 
         // * Validate if the draft icon is not visible on the sidebar before making a draft
-        cy.get('#sidebarItem_town-square').scrollIntoView();
         cy.get('#sidebarItem_town-square #draftIcon').should('be.not.visible');
 
         // Type in some text into the text area of the opened channel
         cy.get('#post_textbox').type('message draft test');
 
         // # Switch to another channel
-        cy.get('#sidebarItem_autem-2').scrollIntoView();
-        cy.get('#sidebarItem_autem-2').should('be.visible').click();
+        cy.get('#sidebarItem_off-topic').should('be.visible').click();
 
         // * Validate if the newly navigated channel is open
-        cy.url().should('include', '/channels/autem-2');
+        cy.url().should('include', `/${testTeam.name}/channels/off-topic`);
 
         // # Press CTRL/CMD+K
         cy.typeCmdOrCtrl().type('K', {release: true});

--- a/cypress/integration/channel/message_edit_post_with_attachment_spec.js
+++ b/cypress/integration/channel/message_edit_post_with_attachment_spec.js
@@ -13,13 +13,10 @@ describe('MM-13697 Edit Post with attachment', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('Pasted text should be pasted where the cursor is', () => {
-        // # Got to a test channel on the side bar
-        cy.get('#sidebarItem_town-square').scrollIntoView();
-
         // * Validate if the channel has been opened
         cy.url().should('include', '/ad-1/channels/town-square');
 

--- a/cypress/integration/integrations/integrations_spec.js
+++ b/cypress/integration/integrations/integrations_spec.js
@@ -164,6 +164,9 @@ describe('Integrations page', () => {
         // # Save
         cy.get('#saveBot').click();
 
+        // # Close the Add dialog
+        cy.get('#doneButton').click();
+
         // * Make sure we are done saving
         cy.url().should('contain', '/integrations/bots');
 

--- a/cypress/support/ui_commands.js
+++ b/cypress/support/ui_commands.js
@@ -332,7 +332,7 @@ Cypress.Commands.add('customColors', (dropdownInt, dropdownName) => {
     cy.get('.theme-elements__header').should('be.visible', 'contain', 'Center Channel Styles');
     cy.get('.theme-elements__header').should('be.visible', 'contain', 'Link and BUtton Sytles');
     cy.get('.padding-top').should('be.visible', 'contain', 'Import theme Colors from Slack');
-    cy.get('#saveSetting').should('be.visible', 'contain', 'Save');
+    cy.get('#saveSetting').scrollIntoView().should('be.visible', 'contain', 'Save');
     cy.get('#cancelSetting').should('be.visible', 'contain', 'Cancel');
 
     cy.get('.theme-elements__header').eq(dropdownInt).should('contain', dropdownName).click();


### PR DESCRIPTION
#### Summary
Fix flaky tests the following specs
- channel/message_draft_spec.js 
- channel/message_draft_then_switch_channel_spec.js
- channel/message_edit_post_with_attachment_spec.js 
- integrations/integrations_spec.js
- account_settings/theme_color/custom_colors_sidebar_styles_spec.js

Fixes made:
1) `scrollIntoView` to channel sidebar
- whenever there are many channels in the sidebar and with unreads, `scrollIntoView` is still not enough to position a channel item.  It's still covered by `More Unreads (top/bottom)`.  In this scenario, it may be better to test with new user with new team so that there's only 2 channels in the sidebar.
2) Others are either missing step or having unnecessary step.

#### Ticket Link
none
