### PR TITLE
MM-15892: Disabling leave teams from the main menu for experimentalPrimarTeam enabled

### DIFF
--- a/components/main_menu/__snapshots__/main_menu.test.jsx.snap
+++ b/components/main_menu/__snapshots__/main_menu.test.jsx.snap
@@ -1082,7 +1082,7 @@ exports[`components/Menu should match snapshot with most of the thing enabled 1`
       icon={false}
       id="leaveTeam"
       modalId="leave_team"
-      show={true}
+      show={false}
       text="Leave Team"
     />
   </MenuGroup>
@@ -1408,7 +1408,7 @@ exports[`components/Menu should match snapshot with most of the thing enabled in
       icon={<LeaveTeamIcon />}
       id="leaveTeam"
       modalId="leave_team"
-      show={true}
+      show={false}
       text="Leave Team"
     />
   </MenuGroup>

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -289,7 +289,7 @@ export default class MainMenu extends React.PureComponent {
                     />
                     <MenuItemToggleModalRedux
                         id='leaveTeam'
-                        show={!teamIsGroupConstrained}
+                        show={!teamIsGroupConstrained && !this.props.experimentalPrimaryTeam}
                         modalId={ModalIdentifiers.LEAVE_TEAM}
                         dialogType={LeaveTeamModal}
                         text={localizeMessage('navbar_dropdown.leave', 'Leave Team')}


### PR DESCRIPTION
#### Summary
Disabling leave teams from the main menu for experimentalPrimarTeam enabled

#### Ticket Link
[MM-15892](https://mattermost.atlassian.net/browse/MM-15892)