### PR TITLE
MM-15919 Fix minor scroll pop for inline markdown images

### DIFF
--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -57,6 +57,11 @@ h6 {
         margin: 5px 0;
         max-height: 500px;
     }
+    div.markdown-inline-img {
+        vertical-align: middle;
+        display: inline-block;
+        width: inherit;
+    }
 }
 
 .post-code {


### PR DESCRIPTION
#### Summary
sizeAwareComponent which was used while loading img as placeholder is an svg wrapped with div tag.
After img loads we replace the placeholder svg but as img has `vertical-align: middle` there is a minor css pop that was caused 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15919
