### PR TITLE
MM-15830 Fix safari scroll jumps for images

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -31,5 +31,16 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
       xmlns="http://www.w3.org/2000/svg"
     />
   </div>
+  <img
+    alt="image placeholder"
+    onError={[Function]}
+    onLoad={[Function]}
+    src="https://example.com/image.png"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  />
 </Fragment>
 `;

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import LoadingImagePreview from 'components/loading_image_preview';
-import {loadImage} from 'utils/image_utils';
 
 // SizeAwareImage is a component used for rendering images where the dimensions of the image are important for
 // ensuring that the page is laid out correctly.
@@ -55,28 +54,16 @@ export default class SizeAwareImage extends React.PureComponent {
 
     componentDidMount() {
         this.mounted = true;
-        this.loadImage();
-    }
-
-    componentDidUpdate(prevProps) {
-        if (this.props.src !== prevProps.src) {
-            this.loadImage();
-        }
     }
 
     componentWillUnmount() {
         this.mounted = false;
     }
 
-    loadImage = () => {
-        const image = loadImage(this.props.src, this.handleLoad);
-        image.onerror = this.handleError;
-    }
-
     handleLoad = (image) => {
         if (this.mounted) {
-            if (this.props.onImageLoaded && image.height) {
-                this.props.onImageLoaded({height: image.height, width: image.width});
+            if (this.props.onImageLoaded && image.naturalHeight) {
+                this.props.onImageLoaded({height: image.naturalHeight, width: image.naturalWidth});
             }
             this.setState({
                 loaded: true,
@@ -114,8 +101,11 @@ export default class SizeAwareImage extends React.PureComponent {
             ...props
         } = this.props;
 
+        let placeHolder;
+        const shouldShowImg = !dimensions || this.state.loaded;
+
         if (dimensions && dimensions.width && !this.state.loaded) {
-            return (
+            placeHolder = (
                 <div className={`image-loading__container ${this.props.className}`}>
                     <svg
                         xmlns='http://www.w3.org/2000/svg'
@@ -130,11 +120,17 @@ export default class SizeAwareImage extends React.PureComponent {
         Reflect.deleteProperty(props, 'onImageLoadFail');
 
         return (
-            <img
-                alt='image placeholder'
-                {...props}
-                src={src}
-            />
+            <React.Fragment>
+                {placeHolder}
+                <img
+                    alt='image placeholder'
+                    {...props}
+                    src={src}
+                    onLoad={this.handleLoad}
+                    onError={this.handleError}
+                    style={{display: shouldShowImg ? 'initial' : 'none'}}
+                />
+            </React.Fragment>
         );
     }
 

--- a/components/size_aware_image.test.jsx
+++ b/components/size_aware_image.test.jsx
@@ -18,16 +18,19 @@ describe('components/SizeAwareImage', () => {
             width: 300,
         },
         onImageLoaded: jest.fn(),
+        onImageLoadFail: jest.fn(),
         src: 'https://example.com/image.png',
     };
 
     loadImage.mockReturnValue(() => ({}));
 
-    test('should render an svg when first mounted with dimensions', () => {
+    test('should render an svg when first mounted with dimensions and img display set to none', () => {
         const wrapper = mount(<SizeAwareImage {...baseProps}/>);
 
         const viewBox = wrapper.find('svg').prop('viewBox');
         expect(viewBox).toEqual('0 0 300 200');
+        const style = wrapper.find('img').prop('style');
+        expect(style).toHaveProperty('display', 'none');
     });
 
     test('should render a placeholder and has loader when showLoader is true', () => {
@@ -41,12 +44,12 @@ describe('components/SizeAwareImage', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should render the actual image after it is loaded', () => {
+    test('should have display set to initial in loaded state', () => {
         const wrapper = mount(<SizeAwareImage {...baseProps}/>);
         wrapper.setState({loaded: true, error: false});
 
-        const src = wrapper.find('img').prop('src');
-        expect(src).toEqual(baseProps.src);
+        const style = wrapper.find('img').prop('style');
+        expect(style).toHaveProperty('display', 'initial');
     });
 
     test('should render the actual image when first mounted without dimensions', () => {
@@ -61,45 +64,23 @@ describe('components/SizeAwareImage', () => {
         expect(src).toEqual(baseProps.src);
     });
 
-    test('should load image when mounted and when src changes', () => {
-        const wrapper = shallow(<SizeAwareImage {...baseProps}/>);
-
-        expect(loadImage).toHaveBeenCalledTimes(1);
-        expect(loadImage.mock.calls[0][0]).toEqual(baseProps.src);
-
-        const newSrc = 'https://example.com/new_image.png';
-        wrapper.setProps({src: newSrc});
-
-        expect(loadImage).toHaveBeenCalledTimes(2);
-        expect(loadImage.mock.calls[1][0]).toEqual(newSrc);
-    });
-
-    test('should call onImageLoaded on image is loaded', () => {
+    test('should set loaded state when img loads and call onImageLoaded prop', () => {
         const height = 123;
         const width = 1234;
-        loadImage.mockImplementation((src, onLoad) => {
-            onLoad({height, width});
 
-            return {};
-        });
+        const wrapper = shallow(<SizeAwareImage {...baseProps}/>);
 
-        const props = {...baseProps};
-        shallow(<SizeAwareImage {...props}/>);
-
+        wrapper.find('img').prop('onLoad')({naturalHeight: height, naturalWidth: width});
+        expect(wrapper.state('loaded')).toBe(true);
         expect(baseProps.onImageLoaded).toHaveBeenCalledWith({height, width});
     });
 
     test('should call onImageLoadFail when image load fails and should have svg', () => {
-        const onImageLoadFail = jest.fn();
-        const props = {...baseProps, onImageLoadFail};
+        const wrapper = mount(<SizeAwareImage {...baseProps}/>);
 
-        const wrapper = mount(<SizeAwareImage {...props}/>);
-        wrapper.setState({loaded: false});
-        wrapper.instance().handleError();
-        expect(props.onImageLoadFail).toHaveBeenCalled();
+        wrapper.find('img').prop('onError')();
 
         expect(wrapper.state('error')).toBe(true);
-        expect(wrapper.find('img').exists()).toEqual(false);
         expect(wrapper.find('svg').exists()).toEqual(true);
         expect(wrapper.find(LoadingImagePreview).exists()).toEqual(false);
     });


### PR DESCRIPTION
#### Summary
Requesting image through `new Image()` and replacing after download has an issue with safari. 
Once the image is downloaded for `new image()` we replace svg placeholder with `img` tag expecting that it will be served from cache. 

Safari still makes a new call after removing svg placeholder in place and replacing with `img` tag while chrome and firefox handles this smartly. 

**Changes**
Remove the `new Image()` constructor and add an `img` tag with `display: none` so browsers still make the call for image and use onLoad and onError callback with it

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15830
