### PR TITLE
MM-15403 Fixes highlight for date separators and new messages line on post hover

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -2078,21 +2078,23 @@
 
     &.top .post {
         padding-top: 22px; // this is based off of 8px padding for post + 1em
+        &.same--root.same--user {
+            padding-top: 1em;
+        }
     }
 
     &.bottom .post {
         padding-bottom: 1em;
-    }
-
-    .post.same--root.same--user {
-        padding: 0 0.5em 1em 1.5em;
+        &.same--root.same--user {
+            padding-bottom: 1em;
+        }
     }
 }
 
 .post-list__dynamic {
     .date-separator, .new-separator {
         z-index: 1;
-        height: 0px;
+        height: 1px;
         margin-bottom: 1em;
         margin-top: -1em;
     }


### PR DESCRIPTION
 * Fixes a regression with consecutive posts padding
<img width="955" alt="Screenshot 2019-06-01 at 3 55 10 PM" src="https://user-images.githubusercontent.com/4973621/58747286-b6457480-8486-11e9-8a63-bfe1b6757046.png">

 * Changes height to 1px for date separator and new message line as height is needed for virt list to correct scroll to position when `new messages` separator exists

https://mattermost.atlassian.net/browse/MM-15403

#### Related Pull Requests
Regression caused by https://github.com/mattermost/mattermost-webapp/pull/2806