### PR TITLE
[MM-15942] Split user profile details by whitespace during autocomplete

### DIFF
--- a/components/suggestion/at_mention_provider/at_mention_provider.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_provider.jsx
@@ -3,7 +3,7 @@
 
 import XRegExp from 'xregexp';
 
-import {getSuggestionsSplitByMultiple} from 'mattermost-redux/utils/user_utils';
+import {getSuggestionsSplitBy, getSuggestionsSplitByMultiple} from 'mattermost-redux/utils/user_utils';
 
 import {Constants} from 'utils/constants.jsx';
 
@@ -59,13 +59,16 @@ export default class AtMentionProvider extends Provider {
             profileSuggestions.push(...usernameSuggestions);
         }
         if (profile.first_name) {
-            profileSuggestions.push(profile.first_name.toLowerCase());
+            const firstNameSuggestions = getSuggestionsSplitBy(profile.first_name.toLowerCase(), ' ');
+            profileSuggestions.push(...firstNameSuggestions);
         }
         if (profile.last_name) {
-            profileSuggestions.push(profile.last_name.toLowerCase());
+            const lastNameSuggestions = getSuggestionsSplitBy(profile.last_name.toLowerCase(), ' ');
+            profileSuggestions.push(...lastNameSuggestions);
         }
         if (profile.nickname) {
-            profileSuggestions.push(profile.nickname.toLowerCase());
+            const nicknameSuggestions = getSuggestionsSplitBy(profile.nickname.toLowerCase(), ' ');
+            profileSuggestions.push(...nicknameSuggestions);
         }
 
         return profileSuggestions;

--- a/components/suggestion/at_mention_provider/at_mention_provider.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_provider.jsx
@@ -58,18 +58,10 @@ export default class AtMentionProvider extends Provider {
             const usernameSuggestions = getSuggestionsSplitByMultiple(profile.username.toLowerCase(), Constants.AUTOCOMPLETE_SPLIT_CHARACTERS);
             profileSuggestions.push(...usernameSuggestions);
         }
-        if (profile.first_name) {
-            const firstNameSuggestions = getSuggestionsSplitBy(profile.first_name.toLowerCase(), ' ');
-            profileSuggestions.push(...firstNameSuggestions);
-        }
-        if (profile.last_name) {
-            const lastNameSuggestions = getSuggestionsSplitBy(profile.last_name.toLowerCase(), ' ');
-            profileSuggestions.push(...lastNameSuggestions);
-        }
-        if (profile.nickname) {
-            const nicknameSuggestions = getSuggestionsSplitBy(profile.nickname.toLowerCase(), ' ');
-            profileSuggestions.push(...nicknameSuggestions);
-        }
+        [profile.first_name, profile.last_name, profile.nickname].forEach((property) => {
+            const suggestions = getSuggestionsSplitBy(property.toLowerCase(), ' ');
+            profileSuggestions.push(...suggestions);
+        });
 
         return profileSuggestions;
     }

--- a/components/suggestion/at_mention_provider/at_mention_provider.test.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_provider.test.jsx
@@ -12,7 +12,7 @@ describe('components/suggestion/at_mention_provider/AtMentionProvider', () => {
     const userid2 = {id: 'userid2', username: 'user2', first_name: 'd', last_name: 'e', nickname: 'f'};
     const userid4 = {id: 'userid4', username: 'user4', first_name: 'X', last_name: 'Y', nickname: 'Z'};
     const userid5 = {id: 'userid5', username: 'user5', first_name: 'out', last_name: 'out', nickname: 'out'};
-    const userid6 = {id: 'userid6', username: 'user.six-split', first_name: 'out', last_name: 'out', nickname: 'out'};
+    const userid6 = {id: 'userid6', username: 'user.six-split', first_name: 'out Junior', last_name: 'out', nickname: 'out'};
 
     const baseParams = {
         currentUserId: 'userid1',
@@ -372,6 +372,108 @@ describe('components/suggestion/at_mention_provider/AtMentionProvider', () => {
                 resolve({data: {
                     users: [userid4],
                     out_of_channel: [userid5, userid6],
+                }});
+            })),
+        };
+
+        const provider = new AtMentionProvider(params);
+        const resultCallback = jest.fn();
+        expect(provider.handlePretextChanged(pretext, resultCallback)).toEqual(true);
+
+        expect(resultCallback).toHaveBeenNthCalledWith(1, {
+            matchedPretext,
+            terms: [],
+            items: [],
+            component: AtMentionSuggestion,
+        });
+
+        jest.runAllTimers();
+
+        expect(resultCallback).toHaveBeenNthCalledWith(2, {
+            matchedPretext,
+            terms: [
+                '',
+            ],
+            items: [
+                {type: Constants.MENTION_MORE_MEMBERS, loading: true},
+            ],
+            component: AtMentionSuggestion,
+        });
+
+        await Promise.resolve().then(() => {
+            expect(resultCallback).toHaveBeenNthCalledWith(3, {
+                matchedPretext,
+                terms: [
+                    '@user.six-split',
+                ],
+                items: [
+                    {type: Constants.MENTION_NONMEMBERS, ...userid6},
+                ],
+                component: AtMentionSuggestion,
+            });
+        });
+    });
+
+    it('should suggest for username match "@-split"', async () => {
+        const pretext = '@-split';
+        const matchedPretext = '@-split';
+        const params = {
+            ...baseParams,
+            autocompleteUsersInChannel: jest.fn().mockImplementation(() => new Promise((resolve) => {
+                resolve({data: {
+                    users: [],
+                    out_of_channel: [userid6],
+                }});
+            })),
+        };
+
+        const provider = new AtMentionProvider(params);
+        const resultCallback = jest.fn();
+        expect(provider.handlePretextChanged(pretext, resultCallback)).toEqual(true);
+
+        expect(resultCallback).toHaveBeenNthCalledWith(1, {
+            matchedPretext,
+            terms: [],
+            items: [],
+            component: AtMentionSuggestion,
+        });
+
+        jest.runAllTimers();
+
+        expect(resultCallback).toHaveBeenNthCalledWith(2, {
+            matchedPretext,
+            terms: [
+                '',
+            ],
+            items: [
+                {type: Constants.MENTION_MORE_MEMBERS, loading: true},
+            ],
+            component: AtMentionSuggestion,
+        });
+
+        await Promise.resolve().then(() => {
+            expect(resultCallback).toHaveBeenNthCalledWith(3, {
+                matchedPretext,
+                terms: [
+                    '@user.six-split',
+                ],
+                items: [
+                    {type: Constants.MENTION_NONMEMBERS, ...userid6},
+                ],
+                component: AtMentionSuggestion,
+            });
+        });
+    });
+
+    it('should suggest for username match "@junior"', async () => {
+        const pretext = '@junior';
+        const matchedPretext = '@junior';
+        const params = {
+            ...baseParams,
+            autocompleteUsersInChannel: jest.fn().mockImplementation(() => new Promise((resolve) => {
+                resolve({data: {
+                    users: [],
+                    out_of_channel: [userid6],
                 }});
             })),
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10459,8 +10459,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#40cecab5d74708d651460515b24115fd75fb334e",
-      "from": "github:mattermost/mattermost-redux#40cecab5d74708d651460515b24115fd75fb334e",
+      "version": "github:mattermost/mattermost-redux#15a952351a5a7fddd4a3eeea3fb9f8cc886d4524",
+      "from": "github:mattermost/mattermost-redux#15a952351a5a7fddd4a3eeea3fb9f8cc886d4524",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#e57e07f419f85178354a3bbbd60de5302483c436",
-    "mattermost-redux": "github:mattermost/mattermost-redux#40cecab5d74708d651460515b24115fd75fb334e",
+    "mattermost-redux": "github:mattermost/mattermost-redux#15a952351a5a7fddd4a3eeea3fb9f8cc886d4524",
     "moment-timezone": "0.5.25",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
This commit adds suggestions for `first_name`, `last_name` and
`nickname` when matching for autocompletion, so a user with last name
"Smith Junior" will now be matched by the term `@junior`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15942

#### Related Pull Requests
- [Has enterprise changes](https://github.com/mattermost/enterprise/pull/445)
- [Has redux changes](https://github.com/mattermost/mattermost-redux/pull/846)
