### PR TITLE
MM-15975 scroll pop when loading a channel if the height of loaded posts is low

### DIFF
--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -29,15 +29,13 @@ const OVERSCAN_COUNT_BACKWARD = window.OVERSCAN_COUNT_BACKWARD || 80; // Exposin
 const OVERSCAN_COUNT_FORWARD = window.OVERSCAN_COUNT_FORWARD || 80; // Exposing the value for PM to test will be removed soon
 const HEIGHT_TRIGGER_FOR_MORE_POSTS = window.HEIGHT_TRIGGER_FOR_MORE_POSTS || 1000; // Exposing the value for PM to test will be removed soon
 
-const postListHeightChangeForPadding = 21;
-
 const MAXIMUM_POSTS_FOR_SLICING = {
     channel: 50,
     permalink: 100,
 };
 
 const postListStyle = {
-    padding: '14px 0px 7px', //21px of height difference from autosized list compared to DynamicSizeList. If this is changed change the above variable postListHeightChangeForPadding accordingly
+    padding: '14px 0px 7px',
 };
 
 const virtListStyles = {
@@ -538,7 +536,7 @@ export default class PostList extends React.PureComponent {
                                 {({height, width}) => (
                                     <DynamicSizeList
                                         ref={this.listRef}
-                                        height={height - postListHeightChangeForPadding}
+                                        height={height}
                                         width={width}
                                         className='post-list__dynamic'
                                         itemCount={this.state.postListIds.length}


### PR DESCRIPTION
#### Summary
The deduction of height for dynamic list is not needed as the padding is for inner container and we use outerRef for scroll correction and does not need this.

When loading a channel with posts which does not occupy enough space we make another API call loading posts and the scroll correction here at https://github.com/mattermost/react-window/blob/feature/reverseScroll/src/DynamicSizeList.js#L264-L266
is wrong making the scroll not stay at bottom when new posts are added
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15975
