### PR TITLE
[MM-15872] Update AD/LDAP Feature Flag Description in Experimental Settings to correct location

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -3853,7 +3853,7 @@ export default {
                         label: t('admin.experimental.experimentalLdapGroupSync.title'),
                         label_default: 'Enable AD/LDAP Group Sync:',
                         help_text: t('admin.experimental.experimentalLdapGroupSync.desc'),
-                        help_text_default: 'When true, enables **AD/LDAP Group Sync** configurable under **Access Controls > Groups**. See [documentation](!https://mattermost.com/pl/default-ldap-group-sync) to learn more.',
+                        help_text_default: 'When true, enables **AD/LDAP Group Sync** configurable under **User Management > Groups**. See [documentation](!https://mattermost.com/pl/default-ldap-group-sync) to learn more.',
                         help_text_markdown: true,
                     },
                     {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -494,7 +494,7 @@
   "admin.experimental.experimentalFeatures": "Experimental Features",
   "admin.experimental.experimentalHideTownSquareinLHS.desc": "When true, hides Town Square in the left-hand sidebar if there are no unread messages in the channel. When false, Town Square is always visible in the left-hand sidebar even if all messages have been read.",
   "admin.experimental.experimentalHideTownSquareinLHS.title": "Town Square is Hidden in Left-Hand Sidebar:",
-  "admin.experimental.experimentalLdapGroupSync.desc": "When true, enables **AD/LDAP Group Sync** configurable under **Access Controls > Groups**. See [documentation](!https://mattermost.com/pl/default-ldap-group-sync) to learn more.",
+  "admin.experimental.experimentalLdapGroupSync.desc": "When true, enables **AD/LDAP Group Sync** configurable under **User Management > Groups**. See [documentation](!https://mattermost.com/pl/default-ldap-group-sync) to learn more.",
   "admin.experimental.experimentalLdapGroupSync.title": "Enable AD/LDAP Group Sync:",
   "admin.experimental.experimentalPrimaryTeam.desc": "The primary team of which users on the server are members. When a primary team is set, the options to join other teams or leave the primary team are disabled.",
   "admin.experimental.experimentalPrimaryTeam.example": "E.g.: \"teamname\"",


### PR DESCRIPTION
#### Summary
Fixes reference to group settings page in the enable AD/LDAP sync setting: was ‘Access Controls’ now under ‘User Management’

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15872