### PR TITLE
MM-15976 Replace forced refresh with banner alerting users that a new version is available

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -13,7 +13,6 @@ import {
     selectChannel,
 } from 'mattermost-redux/actions/channels';
 import {logout, loadMe} from 'mattermost-redux/actions/users';
-import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId, getTeam, getMyTeams, getMyTeamMember, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
@@ -39,7 +38,6 @@ import WebSocketClient from 'client/web_websocket_client.jsx';
 import {ActionTypes, Constants, PostTypes, RHSStates} from 'utils/constants.jsx';
 import {filterAndSortTeamsByDisplayName} from 'utils/team_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
-import {equalServerVersions} from 'utils/server_version';
 
 const dispatch = store.dispatch;
 const getState = store.getState;
@@ -72,7 +70,6 @@ export function emitChannelClickEvent(channel) {
             // Mark previous and next channel as read
             dispatch(markChannelAsRead(chan.id, oldChannelId));
             dispatch(markChannelAsViewed(chan.id, oldChannelId));
-            reloadIfServerVersionChanged();
         });
 
         if (chan.delete_at === 0) {
@@ -321,17 +318,4 @@ export async function redirectUserToDefaultTeam() {
     } else {
         browserHistory.push('/select_team');
     }
-}
-
-let serverVersion = '';
-
-export function reloadIfServerVersionChanged() {
-    const newServerVersion = Client4.getServerVersion();
-
-    if (serverVersion && !equalServerVersions(serverVersion, newServerVersion)) {
-        console.log(`Detected version update from ${serverVersion} to ${newServerVersion}; refreshing the page`); //eslint-disable-line no-console
-        window.location.reload(true);
-    }
-
-    serverVersion = newServerVersion;
 }

--- a/components/admin_console/admin_console.jsx
+++ b/components/admin_console/admin_console.jsx
@@ -9,7 +9,6 @@ import {Route, Switch, Redirect} from 'react-router-dom';
 
 import AnnouncementBar from 'components/announcement_bar';
 import SystemNotice from 'components/system_notice';
-import {reloadIfServerVersionChanged} from 'actions/global_actions.jsx';
 import ModalController from 'components/modal_controller';
 
 import SchemaAdminSettings from 'components/admin_console/schema_admin_settings';
@@ -54,7 +53,6 @@ export default class AdminConsole extends React.Component {
         this.props.actions.getConfig();
         this.props.actions.getEnvironmentConfig();
         this.props.actions.loadRolesIfNeeded(['channel_user', 'team_user', 'system_user', 'channel_admin', 'team_admin', 'system_admin']);
-        reloadIfServerVersionChanged();
     }
 
     onFilterChange = (filter) => {

--- a/components/admin_console/system_users/system_users.jsx
+++ b/components/admin_console/system_users/system_users.jsx
@@ -7,7 +7,6 @@ import {FormattedMessage} from 'react-intl';
 import {debounce} from 'mattermost-redux/actions/helpers';
 
 import {getStandardAnalytics} from 'actions/admin_actions.jsx';
-import {reloadIfServerVersionChanged} from 'actions/global_actions.jsx';
 import {Constants, UserSearchOptions, SearchUserTeamFilter, SearchUserOptionsFilter} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n.jsx';
@@ -93,7 +92,7 @@ export default class SystemUsers extends React.Component {
 
     componentDidMount() {
         this.loadDataForTeam(this.props.teamId, this.props.filter);
-        this.props.actions.getTeams(0, 1000).then(reloadIfServerVersionChanged);
+        this.props.actions.getTeams(0, 1000);
     }
 
     componentWillUnmount() {

--- a/components/announcement_bar/announcement_bar.jsx
+++ b/components/announcement_bar/announcement_bar.jsx
@@ -33,12 +33,6 @@ export default class AnnouncementBar extends React.PureComponent {
         document.body.classList.remove('announcement-bar--fixed');
     }
 
-    componentDidUpdate(prevProps) {
-        if (this.props.showCloseButton !== prevProps.showCloseButton) {
-            this.setBodyClass(!this.props.showCloseButton);
-        }
-    }
-
     handleClose = (e) => {
         e.preventDefault();
         if (this.props.handleClose) {

--- a/components/announcement_bar/announcement_bar_controller.jsx
+++ b/components/announcement_bar/announcement_bar_controller.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import ConfigurationAnnouncementBar from './configuration_bar';
+import VersionBar from './version_bar';
 import TextDismissableBar from './text_dismissable_bar.jsx';
 import AnnouncementBar from './announcement_bar.jsx';
 
@@ -53,6 +54,7 @@ export default class AnnouncementBarController extends React.PureComponent {
             <React.Fragment>
                 {adminConfiguredAnnouncementBar}
                 {errorBar}
+                <VersionBar/>
                 <ConfigurationAnnouncementBar
                     config={this.props.config}
                     license={this.props.license}

--- a/components/announcement_bar/version_bar/__snapshots__/version_bar.test.jsx.snap
+++ b/components/announcement_bar/version_bar/__snapshots__/version_bar.test.jsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/VersionBar should match snapshot - bar rendered after server version change 1`] = `""`;
+
+exports[`components/VersionBar should match snapshot - bar rendered after server version change 2`] = `
+<AnnouncementBar
+  color=""
+  handleClose={null}
+  message={
+    <React.Fragment>
+      <FormattedMessage
+        defaultMessage="A new version of Mattermost is available."
+        id="version_bar.new"
+        values={Object {}}
+      />
+       
+      <a
+        onClick={[Function]}
+      >
+        <FormattedMessage
+          defaultMessage="Refresh the app now."
+          id="version_bar.refresh"
+          values={Object {}}
+        />
+      </a>
+    </React.Fragment>
+  }
+  showCloseButton={false}
+  textColor=""
+  type="announcement"
+/>
+`;

--- a/components/announcement_bar/version_bar/__snapshots__/version_bar.test.jsx.snap
+++ b/components/announcement_bar/version_bar/__snapshots__/version_bar.test.jsx.snap
@@ -18,11 +18,12 @@ exports[`components/VersionBar should match snapshot - bar rendered after server
         onClick={[Function]}
       >
         <FormattedMessage
-          defaultMessage="Refresh the app now."
+          defaultMessage="Refresh the app now"
           id="version_bar.refresh"
           values={Object {}}
         />
       </a>
+      .
     </React.Fragment>
   }
   showCloseButton={false}

--- a/components/announcement_bar/version_bar/index.js
+++ b/components/announcement_bar/version_bar/index.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+
+import VersionBar from './version_bar.jsx';
+
+function mapStateToProps(state) {
+    return {
+        serverVersion: state.entities.general.serverVersion,
+    };
+}
+
+export default connect(mapStateToProps)(VersionBar);

--- a/components/announcement_bar/version_bar/version_bar.jsx
+++ b/components/announcement_bar/version_bar/version_bar.jsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {FormattedMessage} from 'react-intl';
+
+import {equalServerVersions} from 'utils/server_version.jsx';
+import {AnnouncementBarTypes} from 'utils/constants.jsx';
+
+import AnnouncementBar from '../announcement_bar.jsx';
+
+export default class VersionBar extends React.PureComponent {
+    static propTypes = {
+        serverVersion: PropTypes.string,
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.serverVersionAtConstruction = props.serverVersion;
+    }
+
+    reloadPage = () => {
+        window.location.reload();
+    }
+
+    render() {
+        if (!equalServerVersions(this.serverVersionAtConstruction, this.props.serverVersion)) {
+            return (
+                <AnnouncementBar
+                    type={AnnouncementBarTypes.ANNOUNCEMENT}
+                    message={
+                        <React.Fragment>
+                            <FormattedMessage
+                                id='version_bar.new'
+                                defaultMessage='A new version of Mattermost is available.'
+                            />
+                            {' '}
+                            <a onClick={this.reloadPage}>
+                                <FormattedMessage
+                                    id='version_bar.refresh'
+                                    defaultMessage='Refresh the app now.'
+                                />
+                            </a>
+                        </React.Fragment>
+                    }
+                />
+            );
+        }
+
+        return null;
+    }
+}

--- a/components/announcement_bar/version_bar/version_bar.jsx
+++ b/components/announcement_bar/version_bar/version_bar.jsx
@@ -41,9 +41,10 @@ export default class VersionBar extends React.PureComponent {
                             <a onClick={this.reloadPage}>
                                 <FormattedMessage
                                     id='version_bar.refresh'
-                                    defaultMessage='Refresh the app now.'
+                                    defaultMessage='Refresh the app now'
                                 />
                             </a>
+                            {'.'}
                         </React.Fragment>
                     }
                 />

--- a/components/announcement_bar/version_bar/version_bar.test.jsx
+++ b/components/announcement_bar/version_bar/version_bar.test.jsx
@@ -1,0 +1,22 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import VersionBar from 'components/announcement_bar/version_bar/version_bar.jsx';
+import AnnouncementBar from 'components/announcement_bar/announcement_bar.jsx';
+
+describe('components/VersionBar', () => {
+    test('should match snapshot - bar rendered after server version change', () => {
+        const wrapper = shallow(
+            <VersionBar serverVersion='5.11.0.5.11.0.844f70a08ead47f06232ecb6fcad63d2.true'/>
+        );
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(AnnouncementBar).exists()).toBe(false);
+
+        wrapper.setProps({serverVersion: '5.12.0.dev.83ea110da12da84442f92b4634a1e0e2.true'});
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(AnnouncementBar).exists()).toBe(true);
+    });
+});

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3303,7 +3303,7 @@
   "user.settings.tokens.tokenLoading": "Loading...",
   "user.settings.tokens.userAccessTokensNone": "No personal access tokens.",
   "version_bar.new": "A new version of Mattermost is available.",
-  "version_bar.refresh": "Refresh the app now.",
+  "version_bar.refresh": "Refresh the app now",
   "view_image_popover.download": "Download",
   "view_image_popover.file": "File {count, number} of {total, number}",
   "view_image_popover.open": "Open",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3302,6 +3302,8 @@
   "user.settings.tokens.tokenId": "Token ID: ",
   "user.settings.tokens.tokenLoading": "Loading...",
   "user.settings.tokens.userAccessTokensNone": "No personal access tokens.",
+  "version_bar.new": "A new version of Mattermost is available.",
+  "version_bar.refresh": "Refresh the app now.",
   "view_image_popover.download": "Download",
   "view_image_popover.file": "File {count, number} of {total, number}",
   "view_image_popover.open": "Open",

--- a/sass/components/_announcement-bar.scss
+++ b/sass/components/_announcement-bar.scss
@@ -1,9 +1,8 @@
 @charset 'UTF-8';
 
 .announcement-bar {
-    background-color: darken($primary-color, 5%);
+    background-color: #113166;
     color: $white;
-    padding: 2px 30px;
     min-height: $announcement-bar-height;
     position: fixed;
     text-align: center;
@@ -11,7 +10,7 @@
     width: 100%;
     z-index: 9999;
     overflow: hidden;
-    padding: 1px 30px;
+    padding: 5px 30px;
     max-height: $announcement-bar-height;
 
     > span {
@@ -41,7 +40,7 @@
             position: absolute;
             right: 0;
             text-decoration: none;
-            top: -2px;
+            top: 1px;
 
             &:hover {
                 color: $white;

--- a/sass/utils/_variables.scss
+++ b/sass/utils/_variables.scss
@@ -17,7 +17,7 @@ $highlight-color: #fcea8d;
 
 // Page Variables
 $border-gray: 1px solid #ddd;
-$announcement-bar-height: 24px;
+$announcement-bar-height: 32px;
 
 // Random variables
 $border-rad: 2px;


### PR DESCRIPTION
#### Summary
To avoid refreshing the app on users without telling them, we now show a banner alerting them that a new version is available with a link to refresh the app.

Proposing this for 5.13 since it's a good quality of life improvement.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15976