### PR TITLE
MM-16018 Fix for image click to open image preview modal

### DIFF
--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -60,8 +60,9 @@ export default class SizeAwareImage extends React.PureComponent {
         this.mounted = false;
     }
 
-    handleLoad = (image) => {
+    handleLoad = (event) => {
         if (this.mounted) {
+            const image = event.target;
             if (this.props.onImageLoaded && image.naturalHeight) {
                 this.props.onImageLoaded({height: image.naturalHeight, width: image.naturalWidth});
             }

--- a/components/size_aware_image.test.jsx
+++ b/components/size_aware_image.test.jsx
@@ -70,7 +70,7 @@ describe('components/SizeAwareImage', () => {
 
         const wrapper = shallow(<SizeAwareImage {...baseProps}/>);
 
-        wrapper.find('img').prop('onLoad')({naturalHeight: height, naturalWidth: width});
+        wrapper.find('img').prop('onLoad')({target: {naturalHeight: height, naturalWidth: width}});
         expect(wrapper.state('loaded')).toBe(true);
         expect(baseProps.onImageLoaded).toHaveBeenCalledWith({height, width});
     });


### PR DESCRIPTION
onLoad triggers event with target as a key with image object so the check should be looking for event.target.naturalHeight

Fixes: https://mattermost.atlassian.net/browse/MM-16018

#### Related Pull Requests
Regression caused by: https://github.com/mattermost/mattermost-webapp/pull/2891