### PR TITLE
[MM-16105] Revert accidental change to marked's commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "localforage": "1.7.3",
     "localforage-observable": "1.4.0",
     "mark.js": "8.11.1",
-    "marked": "github:mattermost/marked#e57e07f419f85178354a3bbbd60de5302483c436",
+    "marked": "github:mattermost/marked#7041218f9bd64e4bdf9eb2de1b07be57c9050705",
     "mattermost-redux": "github:mattermost/mattermost-redux#0855bc18bcd2edc252dc1aa6f45a296151f7a943",
     "moment-timezone": "0.5.23",
     "pdfjs-dist": "2.0.489",


### PR DESCRIPTION
#### Summary
This fixes the failing unit test by reverting accidental change to marked's commit.  Not sure how it happened, maybe during cherry-pick process 🍒 .

Recent [change](https://github.com/mattermost/mattermost-webapp/pull/2842) to marked was only on master (scheduled to 5.14) but not to 5.12

#### Ticket Link
Jira ticket: [MM-16105](https://mattermost.atlassian.net/browse/MM-16105)
