### PR TITLE
MM-16090: clear cookie with path but without domain

### DIFF
--- a/actions/views/root.js
+++ b/actions/views/root.js
@@ -74,9 +74,11 @@ export function clearUserCookie() {
     // The server will have set the domain if ServiceSettings.EnableCookiesForSubdomains is true
     // The server will have set a non-default path if Mattermost is also served from a subpath.
     document.cookie = 'MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/';
+    document.cookie = `MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;path=${window.basename}`;
     document.cookie = `MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;domain=${window.location.hostname};path=/`;
     document.cookie = `MMUSERID=;expires=Thu, 01 Jan 1970 00:00:01 GMT;domain=${window.location.hostname};path=${window.basename}`;
     document.cookie = 'MMCSRF=;expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/';
+    document.cookie = `MMCSRF=;expires=Thu, 01 Jan 1970 00:00:01 GMT;path=${window.basename}`;
     document.cookie = `MMCSRF=;expires=Thu, 01 Jan 1970 00:00:01 GMT;domain=${window.location.hostname};path=/`;
     document.cookie = `MMCSRF=;expires=Thu, 01 Jan 1970 00:00:01 GMT;domain=${window.location.hostname};path=${window.basename}`;
 }


### PR DESCRIPTION
#### Summary
The set of cookies cleared was updated as part of adding support for running multiple Mattermost instances across multiple subpaths, but the combination of subdomain and subpath left a case uncovered.

If this cookie is not cleared on logout, the client makes incorrect routing decisions, and ultimately ends up in an infinite loop.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16090