### PR TITLE
MM-16034 Fix for IE Not removing new message indicator

### DIFF
--- a/components/post_view/post_list_ie/post_list_ie.jsx
+++ b/components/post_view/post_list_ie/post_list_ie.jsx
@@ -649,13 +649,13 @@ export default class PostList extends React.PureComponent {
                     createAt={topPostCreateAt}
                 />
                 <ScrollToBottomArrows
-                    isScrolling={this.state.atBottom}
-                    atBottom={this.checkBottom()}
+                    isScrolling={this.state.isScrolling}
+                    atBottom={this.atBottom}
                     onClick={this.scrollToBottom}
                 />
                 {!this.props.focusedPostId && (
                     <NewMessagesBelow
-                        atBottom={this.state.atBottom}
+                        atBottom={this.atBottom}
                         lastViewedBottom={this.state.lastViewed}
                         onClick={this.scrollToBottom}
                         channelId={this.props.channel.id}


### PR DESCRIPTION
#### Summary
There is no state.atBottom any more this was removed in an earlier refactor changing it to kind-of how it used to https://github.com/mattermost/mattermost-webapp/blob/release-5.11/components/post_view/post_list.jsx#L661-L663 albeit with the added props for `new messages component`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16034

