### PR TITLE
MM-15791] New messages indicator doesn't clear after viewing the message

### DIFF
--- a/components/post_view/post_list_virtualized/index.js
+++ b/components/post_view/post_list_virtualized/index.js
@@ -11,18 +11,18 @@ import {
 import {makePreparePostIdsForPostList} from 'mattermost-redux/utils/post_list';
 import {memoizeResult} from 'mattermost-redux/utils/helpers';
 
-import {getFirstPostId} from 'utils/post_utils.jsx';
+import {getLatestPostId} from 'utils/post_utils.jsx';
 
 import PostList from './post_list_virtualized.jsx';
 
-const getLatestPostId = memoizeResult((postIds) => getFirstPostId(postIds));
+const memoizedGetLatestPostId = memoizeResult((postIds) => getLatestPostId(postIds));
 
 function makeMapStateToProps() {
     const getPostIdsAroundPost = makeGetPostIdsAroundPost();
     const preparePostIdsForPostList = makePreparePostIdsForPostList();
     return function mapStateToProps(state, ownProps) {
         let postIds;
-        let lastPostTimeStamp = 0;
+        let latestPostTimeStamp = 0;
         const lastViewedAt = state.views.channel.lastChannelViewTime[ownProps.channelId];
         if (ownProps.focusedPostId) {
             postIds = getPostIdsAroundPost(state, ownProps.focusedPostId, ownProps.channelId, {postsBeforeCount: -1});
@@ -32,14 +32,14 @@ function makeMapStateToProps() {
 
         if (postIds) {
             postIds = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
-            const lastPostId = getLatestPostId(postIds);
-            const lastPost = getPost(state, lastPostId);
-            lastPostTimeStamp = lastPost.create_at;
+            const latestPostId = memoizedGetLatestPostId(postIds);
+            const latestPost = getPost(state, latestPostId);
+            latestPostTimeStamp = latestPost.create_at;
         }
 
         return {
             postListIds: postIds,
-            lastPostTimeStamp,
+            latestPostTimeStamp,
         };
     };
 }

--- a/components/post_view/post_list_virtualized/index.js
+++ b/components/post_view/post_list_virtualized/index.js
@@ -6,17 +6,23 @@ import {connect} from 'react-redux';
 import {
     getPostIdsInChannel,
     makeGetPostIdsAroundPost,
+    getPost,
 } from 'mattermost-redux/selectors/entities/posts';
 import {makePreparePostIdsForPostList} from 'mattermost-redux/utils/post_list';
+import {memoizeResult} from 'mattermost-redux/utils/helpers';
+
+import {getFirstPostId} from 'utils/post_utils.jsx';
 
 import PostList from './post_list_virtualized.jsx';
+
+const getLatestPostId = memoizeResult((postIds) => getFirstPostId(postIds));
 
 function makeMapStateToProps() {
     const getPostIdsAroundPost = makeGetPostIdsAroundPost();
     const preparePostIdsForPostList = makePreparePostIdsForPostList();
-
     return function mapStateToProps(state, ownProps) {
         let postIds;
+        let lastPostTimeStamp = 0;
         const lastViewedAt = state.views.channel.lastChannelViewTime[ownProps.channelId];
         if (ownProps.focusedPostId) {
             postIds = getPostIdsAroundPost(state, ownProps.focusedPostId, ownProps.channelId, {postsBeforeCount: -1});
@@ -26,10 +32,14 @@ function makeMapStateToProps() {
 
         if (postIds) {
             postIds = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
+            const lastPostId = getLatestPostId(postIds);
+            const lastPost = getPost(state, lastPostId);
+            lastPostTimeStamp = lastPost.create_at;
         }
 
         return {
             postListIds: postIds,
+            lastPostTimeStamp,
         };
     };
 }

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -75,6 +75,8 @@ export default class PostList extends React.PureComponent {
          */
         channelLoading: PropTypes.bool,
 
+        lastPostTimeStamp: PropTypes.number,
+
         actions: PropTypes.shape({
 
             loadInitialPosts: PropTypes.func.isRequired,
@@ -376,15 +378,21 @@ export default class PostList extends React.PureComponent {
     isAtBottom = (scrollOffset, scrollHeight, clientHeight) => {
         // Calculate how far the post list is from being scrolled to the bottom
         const offsetFromBottom = scrollHeight - clientHeight - scrollOffset;
+
         return offsetFromBottom <= BUFFER_TO_BE_CONSIDERED_BOTTOM;
     }
 
     updateAtBottom = (atBottom) => {
         if (atBottom !== this.state.atBottom) {
             // Update lastViewedBottom when the list reaches or leaves the bottom
+            let lastViewedBottom = Date.now();
+            if (this.props.lastPostTimeStamp > Date.now()) {
+                lastViewedBottom = this.props.lastPostTimeStamp;
+            }
+
             this.setState({
                 atBottom,
-                lastViewedBottom: Date.now(),
+                lastViewedBottom,
             });
         }
     }

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -386,7 +386,7 @@ export default class PostList extends React.PureComponent {
         if (atBottom !== this.state.atBottom) {
             // Update lastViewedBottom when the list reaches or leaves the bottom
             let lastViewedBottom = Date.now();
-            if (this.props.latestPostTimeStamp > Date.now()) {
+            if (this.props.latestPostTimeStamp > lastViewedBottom) {
                 lastViewedBottom = this.props.latestPostTimeStamp;
             }
 

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -14,7 +14,7 @@ import LoadingScreen from 'components/loading_screen.jsx';
 
 import Constants, {PostListRowListIds, EventTypes} from 'utils/constants.jsx';
 import DelayedAction from 'utils/delayed_action.jsx';
-import {getLastPostId, getPreviousPostId} from 'utils/post_utils.jsx';
+import {getOldestPostId, getPreviousPostId} from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import FloatingTimestamp from 'components/post_view/floating_timestamp';
@@ -292,7 +292,7 @@ export default class PostList extends React.PureComponent {
     };
 
     getOldestVisiblePostId = () => {
-        return getLastPostId(this.state.postListIds);
+        return getOldestPostId(this.state.postListIds);
     }
 
     togglePostMenu = (opened) => {
@@ -415,7 +415,7 @@ export default class PostList extends React.PureComponent {
         }
 
         this.setState({
-            topPostId: getLastPostId(this.props.postListIds.slice(visibleTopItem)),
+            topPostId: getOldestPostId(this.props.postListIds.slice(visibleTopItem)),
         });
     }
 
@@ -436,7 +436,7 @@ export default class PostList extends React.PureComponent {
         const newMessagesSeparatorIndex = this.getNewMessagesSeparatorIndex(this.state.postListIds);
 
         if (newMessagesSeparatorIndex > 0) {
-            const topMostPostIndex = this.state.postListIds.indexOf(getLastPostId(this.state.postListIds));
+            const topMostPostIndex = this.state.postListIds.indexOf(getOldestPostId(this.state.postListIds));
             if (newMessagesSeparatorIndex === topMostPostIndex + 1) {
                 this.loadMorePosts();
                 return {

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -75,7 +75,7 @@ export default class PostList extends React.PureComponent {
          */
         channelLoading: PropTypes.bool,
 
-        lastPostTimeStamp: PropTypes.number,
+        latestPostTimeStamp: PropTypes.number,
 
         actions: PropTypes.shape({
 
@@ -386,8 +386,8 @@ export default class PostList extends React.PureComponent {
         if (atBottom !== this.state.atBottom) {
             // Update lastViewedBottom when the list reaches or leaves the bottom
             let lastViewedBottom = Date.now();
-            if (this.props.lastPostTimeStamp > Date.now()) {
-                lastViewedBottom = this.props.lastPostTimeStamp;
+            if (this.props.latestPostTimeStamp > Date.now()) {
+                lastViewedBottom = this.props.latestPostTimeStamp;
             }
 
             this.setState({

--- a/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
@@ -24,6 +24,7 @@ describe('PostList', () => {
             'post3',
             DATE_LINE + 1551711600000,
         ],
+        lastPostTimeStamp: 12345,
         postVisibility: 10,
         actions: {
             checkAndSetMobileView: jest.fn(),
@@ -236,6 +237,28 @@ describe('PostList', () => {
             wrapper.instance().updateAtBottom(true);
 
             expect(wrapper.state('lastViewedBottom')).toBe(1234);
+        });
+
+        test('should update lastViewedBottom with lastPostTimeStamp as that is greater than Date.now()', () => {
+            Date.now = jest.fn().mockReturnValue(12344);
+
+            const wrapper = shallow(<PostList {...baseProps}/>);
+            wrapper.setState({lastViewedBottom: 1234});
+
+            wrapper.instance().updateAtBottom(false);
+
+            expect(wrapper.state('lastViewedBottom')).toBe(12345);
+        });
+
+        test('should update lastViewedBottom with Date.now() as it is greater than lastPostTimeStamp', () => {
+            Date.now = jest.fn().mockReturnValue(12346);
+
+            const wrapper = shallow(<PostList {...baseProps}/>);
+            wrapper.setState({lastViewedBottom: 1234});
+
+            wrapper.instance().updateAtBottom(false);
+
+            expect(wrapper.state('lastViewedBottom')).toBe(12346);
         });
     });
 

--- a/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
@@ -24,7 +24,7 @@ describe('PostList', () => {
             'post3',
             DATE_LINE + 1551711600000,
         ],
-        lastPostTimeStamp: 12345,
+        latestPostTimeStamp: 12345,
         postVisibility: 10,
         actions: {
             checkAndSetMobileView: jest.fn(),
@@ -239,7 +239,7 @@ describe('PostList', () => {
             expect(wrapper.state('lastViewedBottom')).toBe(1234);
         });
 
-        test('should update lastViewedBottom with lastPostTimeStamp as that is greater than Date.now()', () => {
+        test('should update lastViewedBottom with latestPostTimeStamp as that is greater than Date.now()', () => {
             Date.now = jest.fn().mockReturnValue(12344);
 
             const wrapper = shallow(<PostList {...baseProps}/>);
@@ -250,7 +250,7 @@ describe('PostList', () => {
             expect(wrapper.state('lastViewedBottom')).toBe(12345);
         });
 
-        test('should update lastViewedBottom with Date.now() as it is greater than lastPostTimeStamp', () => {
+        test('should update lastViewedBottom with Date.now() as it is greater than latestPostTimeStamp', () => {
             Date.now = jest.fn().mockReturnValue(12346);
 
             const wrapper = shallow(<PostList {...baseProps}/>);

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -235,7 +235,7 @@ function isIdNotPost(postId) {
     );
 }
 
-// getLastPostId returns the most recent post ID in the given list of post IDs. This function is copied from
+// getLastPostId returns the oldest valid post ID in the given list of post IDs. This function is copied from
 // mattermost-redux, except it also includes additional special IDs that are only used in the web app.
 export function getLastPostId(postIds) {
     for (let i = postIds.length - 1; i >= 0; i--) {
@@ -278,6 +278,31 @@ export function getPreviousPostId(postIds, startIndex) {
 
         // This is a post ID
         return itemId;
+    }
+
+    return '';
+}
+
+// getFirstPostId returns the most recent valid post ID in the given list of post IDs. This function is copied from
+// mattermost-redux, except it also includes additional special IDs that are only used in the web app.
+export function getFirstPostId(postIds) {
+    for (let i = 0; i < postIds.length; i++) {
+        const item = postIds[i];
+
+        if (isIdNotPost(item)) {
+            // This is not a post at all
+            continue;
+        }
+
+        if (PostListUtils.isCombinedUserActivityPost(item)) {
+            // This is a combined post, so find the lastest post ID from it
+            const combinedIds = PostListUtils.getPostIdsForCombinedUserActivityPost(item);
+
+            return combinedIds[0];
+        }
+
+        // This is a post ID
+        return item;
     }
 
     return '';

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -235,9 +235,9 @@ function isIdNotPost(postId) {
     );
 }
 
-// getLastPostId returns the oldest valid post ID in the given list of post IDs. This function is copied from
+// getOldestPostId returns the oldest valid post ID in the given list of post IDs. This function is copied from
 // mattermost-redux, except it also includes additional special IDs that are only used in the web app.
-export function getLastPostId(postIds) {
+export function getOldestPostId(postIds) {
     for (let i = postIds.length - 1; i >= 0; i--) {
         const item = postIds[i];
 
@@ -283,9 +283,9 @@ export function getPreviousPostId(postIds, startIndex) {
     return '';
 }
 
-// getFirstPostId returns the most recent valid post ID in the given list of post IDs. This function is copied from
+// getLatestPostId returns the most recent valid post ID in the given list of post IDs. This function is copied from
 // mattermost-redux, except it also includes additional special IDs that are only used in the web app.
-export function getFirstPostId(postIds) {
+export function getLatestPostId(postIds) {
     for (let i = 0; i < postIds.length; i++) {
         const item = postIds[i];
 

--- a/utils/post_utils.test.jsx
+++ b/utils/post_utils.test.jsx
@@ -569,3 +569,35 @@ describe('PostUtils.getPreviousPostId', () => {
         assert.equal(postId, 'post1');
     });
 });
+
+describe('PostUtils.getFirstPostId', () => {
+    test('Should not return MANUAL_TRIGGER_LOAD_MESSAGES', () => {
+        const postId = PostUtils.getFirstPostId([PostListRowListIds.MANUAL_TRIGGER_LOAD_MESSAGES, 'postId1', 'postId2']);
+        assert.equal(postId, 'postId1');
+    });
+
+    test('Should not return MORE_MESSAGES_LOADER', () => {
+        const postId = PostUtils.getFirstPostId([PostListRowListIds.MORE_MESSAGES_LOADER, 'postId1', 'postId2']);
+        assert.equal(postId, 'postId1');
+    });
+
+    test('Should not return CHANNEL_INTRO_MESSAGE', () => {
+        const postId = PostUtils.getFirstPostId([PostListRowListIds.CHANNEL_INTRO_MESSAGE, 'postId1', 'postId2']);
+        assert.equal(postId, 'postId1');
+    });
+
+    test('Should not return dateline', () => {
+        const postId = PostUtils.getFirstPostId(['date-1558290600000', 'postId1', 'postId2']);
+        assert.equal(postId, 'postId1');
+    });
+
+    test('Should not return START_OF_NEW_MESSAGES', () => {
+        const postId = PostUtils.getFirstPostId([PostListRowListIds.START_OF_NEW_MESSAGES, 'postId1', 'postId2']);
+        assert.equal(postId, 'postId1');
+    });
+
+    test('Should return first postId from combined system messages', () => {
+        const postId = PostUtils.getFirstPostId(['user-activity-post1_post2_post3', 'postId1', 'postId2']);
+        assert.equal(postId, 'post1');
+    });
+});

--- a/utils/post_utils.test.jsx
+++ b/utils/post_utils.test.jsx
@@ -526,29 +526,29 @@ describe('PostUtils.postMessageOnKeyPress', () => {
     }
 });
 
-describe('PostUtils.getLastPostId', () => {
+describe('PostUtils.getOldestPostId', () => {
     test('Should not return MANUAL_TRIGGER_LOAD_MESSAGES', () => {
-        const postId = PostUtils.getLastPostId(['postId1', 'postId2', PostListRowListIds.MANUAL_TRIGGER_LOAD_MESSAGES]);
+        const postId = PostUtils.getOldestPostId(['postId1', 'postId2', PostListRowListIds.MANUAL_TRIGGER_LOAD_MESSAGES]);
         assert.equal(postId, 'postId2');
     });
 
     test('Should not return MORE_MESSAGES_LOADER', () => {
-        const postId = PostUtils.getLastPostId(['postId1', 'postId2', PostListRowListIds.MORE_MESSAGES_LOADER]);
+        const postId = PostUtils.getOldestPostId(['postId1', 'postId2', PostListRowListIds.MORE_MESSAGES_LOADER]);
         assert.equal(postId, 'postId2');
     });
 
     test('Should not return CHANNEL_INTRO_MESSAGE', () => {
-        const postId = PostUtils.getLastPostId(['postId1', 'postId2', PostListRowListIds.CHANNEL_INTRO_MESSAGE]);
+        const postId = PostUtils.getOldestPostId(['postId1', 'postId2', PostListRowListIds.CHANNEL_INTRO_MESSAGE]);
         assert.equal(postId, 'postId2');
     });
 
     test('Should not return dateline', () => {
-        const postId = PostUtils.getLastPostId(['postId1', 'postId2', 'date-1558290600000']);
+        const postId = PostUtils.getOldestPostId(['postId1', 'postId2', 'date-1558290600000']);
         assert.equal(postId, 'postId2');
     });
 
     test('Should not return START_OF_NEW_MESSAGES', () => {
-        const postId = PostUtils.getLastPostId(['postId1', 'postId2', PostListRowListIds.START_OF_NEW_MESSAGES]);
+        const postId = PostUtils.getOldestPostId(['postId1', 'postId2', PostListRowListIds.START_OF_NEW_MESSAGES]);
         assert.equal(postId, 'postId2');
     });
 });
@@ -570,34 +570,34 @@ describe('PostUtils.getPreviousPostId', () => {
     });
 });
 
-describe('PostUtils.getFirstPostId', () => {
+describe('PostUtils.getLatestPostId', () => {
     test('Should not return MANUAL_TRIGGER_LOAD_MESSAGES', () => {
-        const postId = PostUtils.getFirstPostId([PostListRowListIds.MANUAL_TRIGGER_LOAD_MESSAGES, 'postId1', 'postId2']);
+        const postId = PostUtils.getLatestPostId([PostListRowListIds.MANUAL_TRIGGER_LOAD_MESSAGES, 'postId1', 'postId2']);
         assert.equal(postId, 'postId1');
     });
 
     test('Should not return MORE_MESSAGES_LOADER', () => {
-        const postId = PostUtils.getFirstPostId([PostListRowListIds.MORE_MESSAGES_LOADER, 'postId1', 'postId2']);
+        const postId = PostUtils.getLatestPostId([PostListRowListIds.MORE_MESSAGES_LOADER, 'postId1', 'postId2']);
         assert.equal(postId, 'postId1');
     });
 
     test('Should not return CHANNEL_INTRO_MESSAGE', () => {
-        const postId = PostUtils.getFirstPostId([PostListRowListIds.CHANNEL_INTRO_MESSAGE, 'postId1', 'postId2']);
+        const postId = PostUtils.getLatestPostId([PostListRowListIds.CHANNEL_INTRO_MESSAGE, 'postId1', 'postId2']);
         assert.equal(postId, 'postId1');
     });
 
     test('Should not return dateline', () => {
-        const postId = PostUtils.getFirstPostId(['date-1558290600000', 'postId1', 'postId2']);
+        const postId = PostUtils.getLatestPostId(['date-1558290600000', 'postId1', 'postId2']);
         assert.equal(postId, 'postId1');
     });
 
     test('Should not return START_OF_NEW_MESSAGES', () => {
-        const postId = PostUtils.getFirstPostId([PostListRowListIds.START_OF_NEW_MESSAGES, 'postId1', 'postId2']);
+        const postId = PostUtils.getLatestPostId([PostListRowListIds.START_OF_NEW_MESSAGES, 'postId1', 'postId2']);
         assert.equal(postId, 'postId1');
     });
 
     test('Should return first postId from combined system messages', () => {
-        const postId = PostUtils.getFirstPostId(['user-activity-post1_post2_post3', 'postId1', 'postId2']);
+        const postId = PostUtils.getLatestPostId(['user-activity-post1_post2_post3', 'postId1', 'postId2']);
         assert.equal(postId, 'post1');
     });
 });


### PR DESCRIPTION
#### Summary
For few timezones server is ahead of timezones causing `Date.now()` used for not showing `new messages` indicator to show even after scrolling to the bottom. So instead of using `Date.now()` alone we are comparing with lastPost timestamp of `create_at` and using which ever is greater.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15791

