### PR TITLE
[MM-16096] Pass post's root_id to getPostThread

### DIFF
--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -42,11 +42,12 @@ export function updateRhsState(rhsState, channelId) {
 
 export function selectPostFromRightHandSideSearch(post) {
     return async (dispatch, getState) => {
-        await dispatch(PostActions.getPostThread(post.id));
+        const postRootId = Utils.getRootId(post);
+        await dispatch(PostActions.getPostThread(postRootId));
 
         dispatch({
             type: ActionTypes.SELECT_POST,
-            postId: Utils.getRootId(post),
+            postId: postRootId,
             channelId: post.channel_id,
             previousRhsState: getRhsState(getState()),
         });

--- a/actions/views/rhs.test.js
+++ b/actions/views/rhs.test.js
@@ -115,7 +115,7 @@ describe('rhs view actions', () => {
             store.dispatch(selectPostFromRightHandSideSearch(post));
 
             const compareStore = mockStore(initialState);
-            compareStore.dispatch(PostActions.getPostThread(post.id));
+            compareStore.dispatch(PostActions.getPostThread(post.root_id));
 
             expect(store.getActions()[0]).toEqual(compareStore.getActions()[0]);
         });


### PR DESCRIPTION
#### Summary
Pass an RHS post's root_id to getPostThread so the reply thread is shown when clicking Reply.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16096