### PR TITLE
MM-16099 Fix for scroll correction when loading channel header

### DIFF
--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -178,7 +178,6 @@ export default class PostList extends React.PureComponent {
         if ((postsAddedAtTop || channelHeaderAdded) && !this.state.atBottom) {
             const scrollValue = snapshot.previousScrollTop + (postlistScrollHeight - snapshot.previousScrollHeight);
             if (scrollValue !== 0 && (scrollValue - snapshot.previousScrollTop) !== 0) {
-
                 //true as third param so chrome can use animationFrame when correcting scroll
                 this.listRef.current.scrollTo(scrollValue, scrollValue - snapshot.previousScrollTop, true);
             }

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -178,7 +178,9 @@ export default class PostList extends React.PureComponent {
         if ((postsAddedAtTop || channelHeaderAdded) && !this.state.atBottom) {
             const scrollValue = snapshot.previousScrollTop + (postlistScrollHeight - snapshot.previousScrollHeight);
             if (scrollValue !== 0 && (scrollValue - snapshot.previousScrollTop) !== 0) {
-                this.listRef.current.scrollTo(scrollValue, scrollValue - snapshot.previousScrollTop, !this.state.atEnd);
+
+                //true as third param so chrome can use animationFrame when correcting scroll
+                this.listRef.current.scrollTo(scrollValue, scrollValue - snapshot.previousScrollTop, true);
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13172,8 +13172,8 @@
       "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
     },
     "react-window": {
-      "version": "github:mattermost/react-window#33c8e71805c7701395e56422db2e9a426132259b",
-      "from": "github:mattermost/react-window#33c8e71805c7701395e56422db2e9a426132259b",
+      "version": "github:mattermost/react-window#1827b16c80919394b2902192097e77adf27bfed8",
+      "from": "github:mattermost/react-window#1827b16c80919394b2902192097e77adf27bfed8",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-select": "2.4.4",
     "react-transition-group": "4.0.1",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "react-window": "github:mattermost/react-window#33c8e71805c7701395e56422db2e9a426132259b",
+    "react-window": "github:mattermost/react-window#1827b16c80919394b2902192097e77adf27bfed8",
     "rebound": "0.1.0",
     "redux": "4.0.1",
     "redux-batched-actions": "0.4.1",


### PR DESCRIPTION
#### Summary
  * The primary fix is to remove cancel animation frame when correcting scroll from react-window library.
  * This also remove the check for `!end` for third param to use animation
    frame for correcting scroll on chrome when loading more posts or channel header is added
     This is to avoid any race condition for correcting scroll correction for posts using animationFrame and overriding it with scroll correction in the same frame with header update state(`atEnd`)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16101

#### Related Pull Requests
https://github.com/mattermost/react-window/pull/17/