### PR TITLE
M-16214 Fix styling of Set a Header in channel intro

### DIFF
--- a/components/post_view/channel_intro_message/channel_intro_message.jsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.jsx
@@ -568,6 +568,7 @@ function createSetHeaderButton(channel) {
             {(message) => (
                 <ToggleModalButtonRedux
                     accessibilityLabel={message}
+                    className='intro-links color--link'
                 >
                     <EditIcon/>
                     {message}

--- a/components/post_view/channel_intro_message/channel_intro_message.jsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.jsx
@@ -10,6 +10,7 @@ import {Permissions} from 'mattermost-redux/constants';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {Constants} from 'utils/constants';
 import ChannelInviteModal from 'components/channel_invite_modal';
+import EditChannelHeaderModal from 'components/edit_channel_header_modal';
 import ProfilePicture from 'components/profile_picture.jsx';
 import ToggleModalButtonRedux from 'components/toggle_modal_button_redux';
 import ToggleModalButton from 'components/toggle_modal_button.jsx';
@@ -568,7 +569,9 @@ function createSetHeaderButton(channel) {
             {(message) => (
                 <ToggleModalButtonRedux
                     accessibilityLabel={message}
-                    className='intro-links color--link'
+                    className={'intro-links color--link'}
+                    dialogType={EditChannelHeaderModal}
+                    dialogProps={{channel}}
                 >
                     <EditIcon/>
                     {message}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When adding the accessibility for the Dialog the styles were removed, this PR adds it back

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-16214
