### PR TITLE
MM-16243 Fix for empty space caused by faiied link preview image

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -39,6 +39,7 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
     style={
       Object {
         "height": 1,
+        "overflow": "hidden",
         "position": "absolute",
         "top": 0,
         "visibility": "hidden",

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -121,7 +121,7 @@ export default class SizeAwareImage extends React.PureComponent {
         Reflect.deleteProperty(props, 'onImageLoadFail');
 
         if (!this.state.loaded && dimensions) {
-            imageStyleChangesOnLoad = {position: 'absolute', top: 0, height: 1, width: 1, visibility: 'hidden'};
+            imageStyleChangesOnLoad = {position: 'absolute', top: 0, height: 1, width: 1, visibility: 'hidden', overflow: 'hidden'};
         }
 
         return (


### PR DESCRIPTION
#### Summary
Problem:
The image behind is supposed to occupy only 1px height and 1px width so it can trigger a download of image and swap it later for svg placeholder in place.
The css behind this is weird as it takes up space even with the specified dimensions and visible on fail causing extra space beneath in scroll container.

Solution:
Add `overflow:hidden` as part of conditional styles to hide the extra empty space created. These conditional styles if image downloads

![Jun-11-2019 22-12-50](https://user-images.githubusercontent.com/4973621/59290700-ce8f6d80-8c96-11e9-90bc-ad04a75286c8.gif)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16243