### PR TITLE
MM-16112: Fix IE11 syntax error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5915,9 +5915,9 @@
       "dev": true
     },
     "exif2css": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/exif2css/-/exif2css-1.3.0.tgz",
-      "integrity": "sha512-RBjZaFcNumDz3bZiZGsR3Kg2jouyLuRnUPox7yE24WcvK8IhVdShAwSQHEqupGC0/DYDZsiunk+sv8CLmu4Lqg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/exif2css/-/exif2css-1.2.0.tgz",
+      "integrity": "sha1-hDjhFpIVCOPcwwy+JAex1VNeG0U="
     },
     "exit": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "core-js": "2.6.5",
     "css-vars-ponyfill": "2.0.2",
     "emoji-regex": "8.0.0",
-    "exif2css": "1.3.0",
+    "exif2css": "1.2.0",
     "fastclick": "1.0.6",
     "flexsearch": "0.6.22",
     "flux": "3.1.3",


### PR DESCRIPTION
#### Summary
Fix IE11 syntax error because the new version of the library use some
incompatible syntax (for example the backtick character for strings
interpolation).

#### Ticket Link
[MM-16112](https://mattermost.atlassian.net/browse/MM-16112)