### PR TITLE
MM-15749 Allow channel links in brackets

### DIFF
--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -211,13 +211,13 @@ function autolinkChannelMentions(text, tokens, channelNamesMap, team) {
         return alias;
     }
 
-    function replaceChannelMentionWithToken(fullMatch, spacer, mention, channelName) {
+    function replaceChannelMentionWithToken(fullMatch, mention, channelName) {
         let channelNameLower = channelName.toLowerCase();
 
         if (channelMentionExists(channelNameLower)) {
             // Exact match
             const alias = addToken(channelNameLower, mention, escapeHtml(channelNamesMap[channelNameLower].display_name));
-            return spacer + alias;
+            return alias;
         }
 
         // Not an exact match, attempt to truncate any punctuation to see if we can find a channel
@@ -231,7 +231,7 @@ function autolinkChannelMentions(text, tokens, channelNamesMap, team) {
                     const suffix = originalChannelName.substr(c - 1);
                     const alias = addToken(channelNameLower, '~' + channelNameLower,
                         escapeHtml(channelNamesMap[channelNameLower].display_name));
-                    return spacer + alias + suffix;
+                    return alias + suffix;
                 }
             } else {
                 // If the last character is not punctuation, no point in going any further
@@ -243,7 +243,7 @@ function autolinkChannelMentions(text, tokens, channelNamesMap, team) {
     }
 
     let output = text;
-    output = output.replace(/(^|\s)(~([a-z0-9.\-_]*))/gi, replaceChannelMentionWithToken);
+    output = output.replace(/\B(~([a-z0-9.\-_]*))/gi, replaceChannelMentionWithToken);
 
     return output;
 }

--- a/utils/text_formatting_channel_links.test.jsx
+++ b/utils/text_formatting_channel_links.test.jsx
@@ -1,23 +1,21 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import assert from 'assert';
-
 import * as TextFormatting from 'utils/text_formatting.jsx';
 
 describe('TextFormatting.ChannelLinks', () => {
-    it('Not channel links', (done) => {
-        assert.equal(
-            TextFormatting.formatText('~123').trim(),
+    test('Not channel links', () => {
+        expect(
+            TextFormatting.formatText('~123').trim()
+        ).toEqual(
             '<p>~123</p>'
         );
 
-        assert.equal(
-            TextFormatting.formatText('~town-square').trim(),
+        expect(
+            TextFormatting.formatText('~town-square').trim()
+        ).toEqual(
             '<p>~town-square</p>'
         );
-
-        done();
     });
 
     describe('Channel links', () => {
@@ -25,44 +23,72 @@ describe('TextFormatting.ChannelLinks', () => {
             delete window.basename;
         });
 
-        it('should link ~town-square', () => {
-            assert.equal(
+        test('should link ~town-square', () => {
+            expect(
                 TextFormatting.formatText('~town-square', {
                     channelNamesMap: {'town-square': {display_name: 'Town Square'}},
                     team: {name: 'myteam'},
-                }).trim(),
+                }).trim()
+            ).toEqual(
                 '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~Town Square</a></p>'
             );
         });
 
-        it('should link ~town-square followed by a period', () => {
-            assert.equal(
+        test('should link ~town-square followed by a period', () => {
+            expect(
                 TextFormatting.formatText('~town-square.', {
                     channelNamesMap: {'town-square': {display_name: 'Town Square'}},
                     team: {name: 'myteam'},
-                }).trim(),
+                }).trim()
+            ).toEqual(
                 '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~Town Square</a>.</p>'
             );
         });
 
-        it('should link ~town-square, with display_name an HTML string', () => {
-            assert.equal(
+        test('should link ~town-square, with display_name an HTML string', () => {
+            expect(
                 TextFormatting.formatText('~town-square', {
                     channelNamesMap: {'town-square': {display_name: '<b>Reception</b>'}},
                     team: {name: 'myteam'},
-                }).trim(),
+                }).trim()
+            ).toEqual(
                 '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~&lt;b&gt;Reception&lt;/b&gt;</a></p>'
             );
         });
 
-        it('should link ~town-square, with a basename defined', () => {
+        test('should link ~town-square, with a basename defined', () => {
             window.basename = '/subpath';
-            assert.equal(
+            expect(
                 TextFormatting.formatText('~town-square', {
                     channelNamesMap: {'town-square': {display_name: '<b>Reception</b>'}},
                     team: {name: 'myteam'},
-                }).trim(),
+                }).trim()
+            ).toEqual(
                 '<p><a class="mention-link" href="/subpath/myteam/channels/town-square" data-channel-mention="town-square">~&lt;b&gt;Reception&lt;/b&gt;</a></p>'
+            );
+        });
+
+        test('should link in brackets', () => {
+            expect(
+                TextFormatting.formatText('(~town-square)', {
+                    channelNamesMap: {'town-square': {display_name: 'Town Square'}},
+                    team: {name: 'myteam'},
+                }).trim()
+            ).toEqual(
+                '<p>(<a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~Town Square</a>)</p>'
+            );
+        });
+    });
+
+    describe('invalid channel links', () => {
+        test('should not link when a ~ is in the middle of a word', () => {
+            expect(
+                TextFormatting.formatText('aa~town-square', {
+                    channelNamesMap: {'town-square': {display_name: 'Town Square'}},
+                    team: {name: 'myteam'},
+                }).trim()
+            ).toEqual(
+                '<p>aa~town-square</p>'
             );
         });
     });

--- a/utils/text_formatting_channel_links.test.jsx
+++ b/utils/text_formatting_channel_links.test.jsx
@@ -7,13 +7,13 @@ describe('TextFormatting.ChannelLinks', () => {
     test('Not channel links', () => {
         expect(
             TextFormatting.formatText('~123').trim()
-        ).toEqual(
+        ).toBe(
             '<p>~123</p>'
         );
 
         expect(
             TextFormatting.formatText('~town-square').trim()
-        ).toEqual(
+        ).toBe(
             '<p>~town-square</p>'
         );
     });
@@ -29,7 +29,7 @@ describe('TextFormatting.ChannelLinks', () => {
                     channelNamesMap: {'town-square': {display_name: 'Town Square'}},
                     team: {name: 'myteam'},
                 }).trim()
-            ).toEqual(
+            ).toBe(
                 '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~Town Square</a></p>'
             );
         });
@@ -40,7 +40,7 @@ describe('TextFormatting.ChannelLinks', () => {
                     channelNamesMap: {'town-square': {display_name: 'Town Square'}},
                     team: {name: 'myteam'},
                 }).trim()
-            ).toEqual(
+            ).toBe(
                 '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~Town Square</a>.</p>'
             );
         });
@@ -51,7 +51,7 @@ describe('TextFormatting.ChannelLinks', () => {
                     channelNamesMap: {'town-square': {display_name: '<b>Reception</b>'}},
                     team: {name: 'myteam'},
                 }).trim()
-            ).toEqual(
+            ).toBe(
                 '<p><a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~&lt;b&gt;Reception&lt;/b&gt;</a></p>'
             );
         });
@@ -63,7 +63,7 @@ describe('TextFormatting.ChannelLinks', () => {
                     channelNamesMap: {'town-square': {display_name: '<b>Reception</b>'}},
                     team: {name: 'myteam'},
                 }).trim()
-            ).toEqual(
+            ).toBe(
                 '<p><a class="mention-link" href="/subpath/myteam/channels/town-square" data-channel-mention="town-square">~&lt;b&gt;Reception&lt;/b&gt;</a></p>'
             );
         });
@@ -74,7 +74,7 @@ describe('TextFormatting.ChannelLinks', () => {
                     channelNamesMap: {'town-square': {display_name: 'Town Square'}},
                     team: {name: 'myteam'},
                 }).trim()
-            ).toEqual(
+            ).toBe(
                 '<p>(<a class="mention-link" href="/myteam/channels/town-square" data-channel-mention="town-square">~Town Square</a>)</p>'
             );
         });
@@ -87,7 +87,7 @@ describe('TextFormatting.ChannelLinks', () => {
                     channelNamesMap: {'town-square': {display_name: 'Town Square'}},
                     team: {name: 'myteam'},
                 }).trim()
-            ).toEqual(
+            ).toBe(
                 '<p>aa~town-square</p>'
             );
         });

--- a/utils/text_formatting_hashtags.test.jsx
+++ b/utils/text_formatting_hashtags.test.jsx
@@ -180,7 +180,7 @@ describe('TextFormatting.Hashtags with default setting', () => {
         };
         assert.equal(
             TextFormatting.formatText('#~test', options).trim(),
-            '<p>#~test</p>'
+            '<p>#<a class="mention-link" href="/abcd/channels/test" data-channel-mention="test">~Test Channel</a></p>'
         );
 
         assert.equal(


### PR DESCRIPTION
The `(^|\s)` only allowed channel links to appear at the start of the string or after whitespace. This makes it so that they can appear after any non-word character.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15749
