### PR TITLE
Add "Enable plugin health check" boolean setting to admin console

### DIFF
--- a/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
+++ b/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
@@ -61,6 +61,41 @@ exports[`components/PluginManagement should match snapshot 1`] = `
             }
             value={true}
           />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <FormattedMessage
+                defaultMessage="When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin."
+                id="admin.plugins.settings.enableHealthCheckDesc"
+                values={Object {}}
+              />
+            }
+            id="enableHealthCheck"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Health Check: "
+                id="admin.plugins.settings.enableHealthCheck"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
           <div
             className="form-group"
           >
@@ -236,6 +271,41 @@ exports[`components/PluginManagement should match snapshot, No installed plugins
               <FormattedMessage
                 defaultMessage="Enable Plugins: "
                 id="admin.plugins.settings.enable"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <FormattedMessage
+                defaultMessage="When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin."
+                id="admin.plugins.settings.enableHealthCheckDesc"
+                values={Object {}}
+              />
+            }
+            id="enableHealthCheck"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Health Check: "
+                id="admin.plugins.settings.enableHealthCheck"
                 values={Object {}}
               />
             }
@@ -444,6 +514,41 @@ exports[`components/PluginManagement should match snapshot, disabled 1`] = `
             }
             value={false}
           />
+          <BooleanSetting
+            disabled={true}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <FormattedMessage
+                defaultMessage="When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin."
+                id="admin.plugins.settings.enableHealthCheckDesc"
+                values={Object {}}
+              />
+            }
+            id="enableHealthCheck"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Health Check: "
+                id="admin.plugins.settings.enableHealthCheck"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
           <div
             className="form-group"
           >
@@ -545,6 +650,230 @@ exports[`components/PluginManagement should match snapshot, disabled 1`] = `
 </form>
 `;
 
+exports[`components/PluginManagement should match snapshot, health check disabled 1`] = `
+<form
+  className="form-horizontal"
+  onSubmit={[Function]}
+  role="form"
+>
+  <div
+    className="wrapper--fixed"
+  >
+    <AdminHeader>
+      <FormattedMessage
+        defaultMessage="Management"
+        id="admin.plugin.management.title"
+        values={Object {}}
+      />
+    </AdminHeader>
+    <div
+      className="admin-console__wrapper"
+    >
+      <div
+        className="admin-console__content"
+      >
+        <SettingsGroup
+          container={false}
+          id="PluginSettings"
+          show={true}
+        >
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, enables plugins on your Mattermost server. Use plugins to integrate with third-party systems, extend functionality or customize the user interface of your Mattermost server. See [documentation](https://about.mattermost.com/default-plugin-uploads) to learn more."
+                id="admin.plugins.settings.enableDesc"
+              />
+            }
+            id="enable"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Plugins: "
+                id="admin.plugins.settings.enable"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <FormattedMessage
+                defaultMessage="When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin."
+                id="admin.plugins.settings.enableHealthCheckDesc"
+                values={Object {}}
+              />
+            }
+            id="enableHealthCheck"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Health Check: "
+                id="admin.plugins.settings.enableHealthCheck"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
+          />
+          <div
+            className="form-group"
+          >
+            <label
+              className="control-label col-sm-4"
+            >
+              <FormattedMessage
+                defaultMessage="Upload Plugin: "
+                id="admin.plugin.uploadTitle"
+                values={Object {}}
+              />
+            </label>
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="file__upload"
+              >
+                <button
+                  className="btn btn-primary"
+                  disabled={false}
+                >
+                  <FormattedMessage
+                    defaultMessage="Choose File"
+                    id="admin.plugin.choose"
+                    values={Object {}}
+                  />
+                </button>
+                <input
+                  accept=".gz"
+                  disabled={false}
+                  onChange={[Function]}
+                  type="file"
+                />
+              </div>
+              <button
+                className="btn"
+                disabled={true}
+                onClick={[Function]}
+              >
+                <FormattedMessage
+                  defaultMessage="Upload"
+                  id="admin.plugin.upload"
+                  values={Object {}}
+                />
+              </button>
+              <div
+                className="help-text no-margin"
+              />
+              <p
+                className="help-text"
+              >
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="Upload a plugin for your Mattermost server. See [documentation](!https://about.mattermost.com/default-plugin-uploads) to learn more."
+                  id="admin.plugin.uploadDesc"
+                />
+              </p>
+            </div>
+          </div>
+          <div
+            className="form-group"
+          >
+            <label
+              className="control-label col-sm-4"
+            >
+              <FormattedMessage
+                defaultMessage="Installed Plugins: "
+                id="admin.plugin.installedTitle"
+                values={Object {}}
+              />
+            </label>
+            <div
+              className="col-sm-8"
+            >
+              <p
+                className="help-text"
+              >
+                <FormattedHTMLMessage
+                  defaultMessage="Installed plugins on your Mattermost server. Pre-packaged plugins are installed by default, and can be disabled but not removed."
+                  id="admin.plugin.installedDesc"
+                  values={Object {}}
+                />
+              </p>
+              <br />
+            </div>
+          </div>
+        </SettingsGroup>
+      </div>
+    </div>
+    <div
+      className="admin-console-save"
+    >
+      <SaveButton
+        btnClass="btn-primary"
+        disabled={true}
+        extraClasses=""
+        onClick={[Function]}
+        saving={false}
+        savingMessage="Saving Config..."
+      />
+      <div
+        className="error-message"
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <FormError
+          error={null}
+          errors={Array []}
+        />
+      </div>
+      <Overlay
+        animation={[Function]}
+        delayShow={400}
+        placement="top"
+        rootClose={false}
+        show={false}
+      >
+        <Tooltip
+          bsClass="tooltip"
+          id="error-tooltip"
+          placement="right"
+        />
+      </Overlay>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`components/PluginManagement should match snapshot, upload disabled 1`] = `
 <form
   className="form-horizontal"
@@ -592,6 +921,41 @@ exports[`components/PluginManagement should match snapshot, upload disabled 1`] 
               <FormattedMessage
                 defaultMessage="Enable Plugins: "
                 id="admin.plugins.settings.enable"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <FormattedMessage
+                defaultMessage="When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin."
+                id="admin.plugins.settings.enableHealthCheckDesc"
+                values={Object {}}
+              />
+            }
+            id="enableHealthCheck"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Health Check: "
+                id="admin.plugins.settings.enableHealthCheck"
                 values={Object {}}
               />
             }
@@ -781,6 +1145,41 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
               <FormattedMessage
                 defaultMessage="Enable Plugins: "
                 id="admin.plugins.settings.enable"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <FormattedMessage
+                defaultMessage="When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin."
+                id="admin.plugins.settings.enableHealthCheckDesc"
+                values={Object {}}
+              />
+            }
+            id="enableHealthCheck"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Health Check: "
+                id="admin.plugins.settings.enableHealthCheck"
                 values={Object {}}
               />
             }
@@ -1047,6 +1446,41 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             value={true}
           />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <FormattedMessage
+                defaultMessage="When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin."
+                id="admin.plugins.settings.enableHealthCheckDesc"
+                values={Object {}}
+              />
+            }
+            id="enableHealthCheck"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Health Check: "
+                id="admin.plugins.settings.enableHealthCheck"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
           <div
             className="form-group"
           >
@@ -1253,6 +1687,41 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
               <FormattedMessage
                 defaultMessage="Enable Plugins: "
                 id="admin.plugins.settings.enable"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <FormattedMessage
+                defaultMessage="When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin."
+                id="admin.plugins.settings.enableHealthCheckDesc"
+                values={Object {}}
+              />
+            }
+            id="enableHealthCheck"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Health Check: "
+                id="admin.plugins.settings.enableHealthCheck"
                 values={Object {}}
               />
             }
@@ -1487,6 +1956,41 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             value={true}
           />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <FormattedMessage
+                defaultMessage="When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin."
+                id="admin.plugins.settings.enableHealthCheckDesc"
+                values={Object {}}
+              />
+            }
+            id="enableHealthCheck"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Health Check: "
+                id="admin.plugins.settings.enableHealthCheck"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
           <div
             className="form-group"
           >
@@ -1693,6 +2197,41 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
               <FormattedMessage
                 defaultMessage="Enable Plugins: "
                 id="admin.plugins.settings.enable"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <FormattedMessage
+                defaultMessage="When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin."
+                id="admin.plugins.settings.enableHealthCheckDesc"
+                values={Object {}}
+              />
+            }
+            id="enableHealthCheck"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Health Check: "
+                id="admin.plugins.settings.enableHealthCheck"
                 values={Object {}}
               />
             }

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -426,6 +426,7 @@ export default class PluginManagement extends AdminSettings {
     getConfigFromState(config) {
         config.PluginSettings.Enable = this.state.enable;
         config.PluginSettings.EnableUploads = this.state.enableUploads;
+        config.PluginSettings.EnableHealthCheck = this.state.enableHealthCheck;
 
         return config;
     }
@@ -434,6 +435,7 @@ export default class PluginManagement extends AdminSettings {
         const state = {
             enable: config.PluginSettings.Enable,
             enableUploads: config.PluginSettings.EnableUploads,
+            enableHealthCheck: config.PluginSettings.EnableHealthCheck,
         };
 
         return state;
@@ -777,6 +779,26 @@ export default class PluginManagement extends AdminSettings {
                             value={this.state.enable}
                             onChange={this.handleChange}
                             setByEnv={this.isSetByEnv('PluginSettings.Enable')}
+                        />
+
+                        <BooleanSetting
+                            id='enableHealthCheck'
+                            disabled={!enable}
+                            label={
+                                <FormattedMessage
+                                    id='admin.plugins.settings.enableHealthCheck'
+                                    defaultMessage='Enable Health Check: '
+                                />
+                            }
+                            helpText={
+                                <FormattedMessage
+                                    id='admin.plugins.settings.enableHealthCheckDesc'
+                                    defaultMessage='When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin.'
+                                />
+                            }
+                            value={this.state.enableHealthCheck}
+                            onChange={this.handleChange}
+                            setByEnv={this.isSetByEnv('PluginSettings.EnableHealthCheck')}
                         />
 
                         <div className='form-group'>

--- a/components/admin_console/plugin_management/plugin_management.test.jsx
+++ b/components/admin_console/plugin_management/plugin_management.test.jsx
@@ -13,6 +13,7 @@ describe('components/PluginManagement', () => {
         config: {
             PluginSettings: {
                 Enable: true,
+                EnableHealthCheck: true,
                 EnableUploads: true,
             },
         },
@@ -114,6 +115,21 @@ describe('components/PluginManagement', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should match snapshot, health check disabled', () => {
+        const props = {
+            ...defaultProps,
+            config: {
+                ...defaultProps.config,
+                PluginSettings: {
+                    ...defaultProps.config.PluginSettings,
+                    EnableHealthCheck: false,
+                },
+            },
+        };
+        const wrapper = shallow(<PluginManagement {...props}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should match snapshot, upload disabled', () => {
         const props = {
             ...defaultProps,
@@ -134,6 +150,7 @@ describe('components/PluginManagement', () => {
             config: {
                 PluginSettings: {
                     Enable: true,
+                    EnableHealthCheck: true,
                     EnableUploads: true,
                 },
             },
@@ -164,6 +181,7 @@ describe('components/PluginManagement', () => {
             config: {
                 PluginSettings: {
                     Enable: true,
+                    EnableHealthCheck: true,
                     EnableUploads: true,
                 },
             },
@@ -245,6 +263,7 @@ describe('components/PluginManagement', () => {
             config: {
                 PluginSettings: {
                     Enable: true,
+                    EnableHealthCheck: true,
                     EnableUploads: true,
                 },
             },
@@ -298,6 +317,7 @@ describe('components/PluginManagement', () => {
             config: {
                 PluginSettings: {
                     Enable: true,
+                    EnableHealthCheck: true,
                     EnableUploads: true,
                 },
             },
@@ -351,6 +371,7 @@ describe('components/PluginManagement', () => {
             config: {
                 PluginSettings: {
                     Enable: true,
+                    EnableHealthCheck: true,
                     EnableUploads: true,
                 },
             },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1069,6 +1069,8 @@
   "admin.plugins.pluginManagement": "Plugin Management",
   "admin.plugins.settings.enable": "Enable Plugins: ",
   "admin.plugins.settings.enableDesc": "When true, enables plugins on your Mattermost server. Use plugins to integrate with third-party systems, extend functionality or customize the user interface of your Mattermost server. See [documentation](!https://about.mattermost.com/default-plugins) to learn more.",
+  "admin.plugins.settings.enableHealthCheck": "Enable Health Check: ",
+  "admin.plugins.settings.enableHealthCheckDesc": "When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin.",
   "admin.privacy.showEmailDescription": "When false, hides the email address of members from everyone except System Administrators.",
   "admin.privacy.showEmailTitle": "Show Email Address: ",
   "admin.privacy.showFullNameDescription": "When false, hides the full name of members from everyone except System Administrators. Username is shown in place of full name.",


### PR DESCRIPTION
#### Summary

This PR adds a boolean toggle to enable/disable the plugin health check job. It is shown in the Admin Console on the Plugin Management page.

The wording next to the toggle is:

> When true, enables health checks on all active server plugins. If a plugin has crashed or is deemed unhealthy, the server will restart the plugin. If a plugin has crashed three times in one hour, the server will deactivate the plugin.

The constraints of when to deactivate may change in the future so I'm not sure if we want to be that specific here, but wanted to propose for review. It may be better to just to link to docs for info instead.

#### Ticket Link

[Jira Ticket](https://mattermost.atlassian.net/browse/MM-13507)

#### Related Pull Requests

https://github.com/mattermost/mattermost-server/pull/10781

This PR includes changes in i18n/en.json