### PR TITLE
MM-16283 Render markdown in bot account descriptions

### DIFF
--- a/components/integrations/bots/bot.jsx
+++ b/components/integrations/bots/bot.jsx
@@ -8,6 +8,7 @@ import {Link} from 'react-router-dom';
 import {FormattedMessage} from 'react-intl';
 
 import ConfirmModal from 'components/confirm_modal.jsx';
+import Markdown from 'components/markdown';
 import SaveButton from 'components/save_button.jsx';
 import WarningIcon from 'components/icon/warning_icon';
 import * as Utils from 'utils/utils.jsx';
@@ -462,7 +463,7 @@ export default class Bot extends React.PureComponent {
                         {options}
                     </div>
                     <div className='bot-details__description'>
-                        {description}
+                        <Markdown message={description}/>
                     </div>
                     <div className='light small'>
                         <FormattedMessage

--- a/components/integrations/bots/bot.test.jsx
+++ b/components/integrations/bots/bot.test.jsx
@@ -6,6 +6,8 @@ import {shallow} from 'enzyme';
 
 import {FormattedMessage} from 'react-intl';
 
+import Markdown from 'components/markdown';
+
 import TestHelper from 'tests/helpers/client-test-helper';
 
 import Bot from './bot.jsx';
@@ -25,7 +27,7 @@ describe('components/integrations/bots/Bot', () => {
         );
 
         expect(wrapper.contains(bot.display_name + ' (@' + bot.username + ')')).toEqual(true);
-        expect(wrapper.contains(bot.description)).toEqual(true);
+        expect(wrapper.contains(<Markdown message={bot.description}/>)).toEqual(true);
         expect(wrapper.contains('plugin')).toEqual(true);
 
         // if bot managed by plugin, remove ability to edit from UI
@@ -67,7 +69,7 @@ describe('components/integrations/bots/Bot', () => {
             />
         );
         expect(wrapper.contains(bot.display_name + ' (@' + bot.username + ')')).toEqual(true);
-        expect(wrapper.contains(bot.description)).toEqual(true);
+        expect(wrapper.contains(<Markdown message={bot.description}/>)).toEqual(true);
         expect(wrapper.contains('plugin')).toEqual(true);
         expect(wrapper.contains(
             <FormattedMessage


### PR DESCRIPTION
Markdown is already supported when the bot's description is displayed in the header of a DM with it, so this just makes it consistent by also rendering it in the bot list

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16283