### PR TITLE
MM-16837 Set post list date separator based on user timezone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10433,8 +10433,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#2c6354f8ed724141c19725137cf57e309b0d4817",
-      "from": "github:mattermost/mattermost-redux#2c6354f8ed724141c19725137cf57e309b0d4817",
+      "version": "github:mattermost/mattermost-redux#40cecab5d74708d651460515b24115fd75fb334e",
+      "from": "github:mattermost/mattermost-redux#40cecab5d74708d651460515b24115fd75fb334e",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#e57e07f419f85178354a3bbbd60de5302483c436",
-    "mattermost-redux": "github:mattermost/mattermost-redux#2c6354f8ed724141c19725137cf57e309b0d4817",
+    "mattermost-redux": "github:mattermost/mattermost-redux#40cecab5d74708d651460515b24115fd75fb334e",
     "moment-timezone": "0.5.25",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
The post list date separators now will take into account the user timezone

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-16387

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has redux changes (https://github.com/mattermost/mattermost-redux/pull/855)
- Has mobile changes (https://github.com/mattermost/mattermost-mobile/pull/2888)
