### PR TITLE
[MM-16149] Fix username validation message for Bot creation.

### DIFF
--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -277,7 +277,6 @@ export default class AddBot extends React.Component {
                 return;
             }
         } else {
-            const result = await this.props.actions.createBot(bot);
             const usernameError = Utils.isValidUsername(bot.username);
             if (usernameError) {
                 this.setState({
@@ -285,7 +284,10 @@ export default class AddBot extends React.Component {
                     error: usernameError,
                 });
                 return;
-            } else if (result) {
+            }
+
+            const result = await this.props.actions.createBot(bot);
+            if (result) {
                 data = result.data;
                 error = result.error;
             } else {

--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -278,7 +278,14 @@ export default class AddBot extends React.Component {
             }
         } else {
             const result = await this.props.actions.createBot(bot);
-            if (result) {
+            const usernameError = Utils.isValidUsername(bot.username);
+            if (usernameError) {
+                this.setState({
+                    adding: false,
+                    error: usernameError,
+                });
+                return;
+            } else if (result) {
                 data = result.data;
                 error = result.error;
             } else {


### PR DESCRIPTION
#### Summary
This pull request leverages the `isValidUsername()` utils function to verify the username.  Previously, the verification was done server-side with a createBot submission.  The problem with this method is that serverside validation does not check that a username only begins with an alpha character `[a-z]`.  

#### QA
Here is a screen capture of the new validation error.  Please note/verify the following:
1. Error adjusts according to incorrect username types.
2. Note the `Create Bot Account` button does not change with an invalid username submission.

![image](https://user-images.githubusercontent.com/7575921/59803214-749f3100-92b0-11e9-96b1-9426ce799f5a.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16149

#### Additional Notes Regarding Possible Server-Side validation
Whether server-side enforcement should be addressed is debatable, but the change would affect more than a few tests.  See Jira ticket link comments for detail of files affected.

This code is where user validation is performed. 
https://github.com/mattermost/mattermost-server/blob/33789a35238434dbddc2260bd88f6fb05c17d85f/model/user.go#L692

To properly enforce that a username must begin with an alpha character, the additional code could be added.
```go
var validFirstUsernameChar = regexp.MustCompile(`^[a-z]`)
```

```go
if !validFirstUsernameChar.MatchString(s) {
		return false
}
```


