### PR TITLE
MM-16442: finish deprecating has_reactions

### DIFF
--- a/components/post_view/reaction_list/__snapshots__/reactions_list.test.jsx.snap
+++ b/components/post_view/reaction_list/__snapshots__/reactions_list.test.jsx.snap
@@ -1,6 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/ReactionList Should match snapshot for reactions 1`] = `
+exports[`components/ReactionList should render nothing when no reactions 1`] = `
+<div
+  className="post-reaction-list"
+>
+  <div
+    className="post-add-reaction"
+  >
+    <span
+      className="emoji-picker__container"
+    >
+      <EmojiPickerOverlay
+        enableGifPicker={false}
+        onEmojiClick={[Function]}
+        onEmojiClose={[Function]}
+        onHide={[Function]}
+        rightOffset={15}
+        show={false}
+        spaceRequiredAbove={476}
+        spaceRequiredBelow={497}
+        target={[Function]}
+        topOffset={-5}
+      />
+      <OverlayTrigger
+        defaultOverlayShown={false}
+        delayShow={400}
+        overlay={
+          <Tooltip
+            bsClass="tooltip"
+            id="addReactionTooltip"
+            placement="right"
+          >
+            <FormattedMessage
+              defaultMessage="Add reaction"
+              id="reaction_list.addReactionTooltip"
+              values={Object {}}
+            />
+          </Tooltip>
+        }
+        placement="top"
+        trigger={
+          Array [
+            "hover",
+            "focus",
+          ]
+        }
+      >
+        <Connect(ChannelPermissionGate)
+          permissions={
+            Array [
+              "add_reaction",
+            ]
+          }
+          teamId="teamId"
+        >
+          <div
+            className="post-reaction"
+            onClick={[Function]}
+          >
+            <span
+              className="post-reaction__add"
+              id="addReaction-post_id"
+            >
+              +
+            </span>
+          </div>
+        </Connect(ChannelPermissionGate)>
+      </OverlayTrigger>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`components/ReactionList should render when there are reactions 1`] = `
 <div
   className="post-reaction-list"
 >
@@ -9,7 +81,6 @@ exports[`components/ReactionList Should match snapshot for reactions 1`] = `
     key="expressionless"
     post={
       Object {
-        "has_reactions": true,
         "id": "post_id",
       }
     }

--- a/components/post_view/reaction_list/index.js
+++ b/components/post_view/reaction_list/index.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
-import {getReactionsForPosts} from 'mattermost-redux/selectors/entities/posts';
+import {makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {addReaction} from 'actions/post_actions.jsx';
@@ -13,25 +13,22 @@ import {scrollPostList} from 'actions/views/channel';
 
 import ReactionList from './reaction_list.jsx';
 
-function makeMapStateToProps(state, ownProps) {
-    // const getReactionsForPost = makeGetReactionsForPost();
+function makeMapStateToProps() {
+    const getReactionsForPost = makeGetReactionsForPost();
 
-    // return function mapStateToProps(state, ownProps) {
-    const config = getConfig(state);
-    const enableEmojiPicker = config.EnableEmojiPicker === 'true' && !ownProps.isReadOnly;
+    return function mapStateToProps(state, ownProps) {
+        const config = getConfig(state);
+        const enableEmojiPicker = config.EnableEmojiPicker === 'true' && !ownProps.isReadOnly;
 
-    const channel = getChannel(state, ownProps.post.channel_id) || {};
-    const teamId = channel.team_id;
+        const channel = getChannel(state, ownProps.post.channel_id) || {};
+        const teamId = channel.team_id;
 
-    // console.log('ReactionList::mapStateToProps', ownProps.post.id,
-
-    return {
-        teamId,
-        reactions: getReactionsForPosts(state)[ownProps.post.id],
-        enableEmojiPicker,
+        return {
+            teamId,
+            reactions: getReactionsForPost(state, ownProps.post.id),
+            enableEmojiPicker,
+        };
     };
-
-    // };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/components/post_view/reaction_list/index.js
+++ b/components/post_view/reaction_list/index.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
-import {makeGetReactionsForPost} from 'mattermost-redux/selectors/entities/posts';
+import {getReactionsForPosts} from 'mattermost-redux/selectors/entities/posts';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import {addReaction} from 'actions/post_actions.jsx';
@@ -13,22 +13,25 @@ import {scrollPostList} from 'actions/views/channel';
 
 import ReactionList from './reaction_list.jsx';
 
-function makeMapStateToProps() {
-    const getReactionsForPost = makeGetReactionsForPost();
+function makeMapStateToProps(state, ownProps) {
+    // const getReactionsForPost = makeGetReactionsForPost();
 
-    return function mapStateToProps(state, ownProps) {
-        const config = getConfig(state);
-        const enableEmojiPicker = config.EnableEmojiPicker === 'true' && !ownProps.isReadOnly;
+    // return function mapStateToProps(state, ownProps) {
+    const config = getConfig(state);
+    const enableEmojiPicker = config.EnableEmojiPicker === 'true' && !ownProps.isReadOnly;
 
-        const channel = getChannel(state, ownProps.post.channel_id) || {};
-        const teamId = channel.team_id;
+    const channel = getChannel(state, ownProps.post.channel_id) || {};
+    const teamId = channel.team_id;
 
-        return {
-            teamId,
-            reactions: getReactionsForPost(state, ownProps.post.id),
-            enableEmojiPicker,
-        };
+    // console.log('ReactionList::mapStateToProps', ownProps.post.id,
+
+    return {
+        teamId,
+        reactions: getReactionsForPosts(state)[ownProps.post.id],
+        enableEmojiPicker,
     };
+
+    // };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/components/post_view/reaction_list/reaction_list.jsx
+++ b/components/post_view/reaction_list/reaction_list.jsx
@@ -86,7 +86,7 @@ export default class ReactionList extends React.PureComponent {
     }
 
     render() {
-        if (!this.props.post.has_reactions || !this.props.reactions) {
+        if (!this.props.reactions) {
             return null;
         }
 

--- a/components/post_view/reaction_list/reactions_list.test.jsx
+++ b/components/post_view/reaction_list/reactions_list.test.jsx
@@ -18,7 +18,6 @@ describe('components/ReactionList', () => {
 
     const post = {
         id: 'post_id',
-        has_reactions: true,
     };
 
     const teamId = 'teamId';
@@ -36,7 +35,20 @@ describe('components/ReactionList', () => {
         actions,
     };
 
-    test('Should match snapshot for reactions', () => {
+    test('should render nothing when no reactions', () => {
+        const props = {
+            ...baseProps,
+            reactions: {},
+        };
+
+        const wrapper = shallow(
+            <ReactionList {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render when there are reactions', () => {
         const wrapper = shallow(
             <ReactionList {...baseProps}/>
         );


### PR DESCRIPTION
#### Summary
This bit is no longer emitted via a websocket event on a post edit, making it inaccurate to use when the first reaction is added (or the last reaction removed).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16442