### PR TITLE
[PLT-4951] Don't send notifications if thread is showing in RHS

### DIFF
--- a/actions/notification_actions.jsx
+++ b/actions/notification_actions.jsx
@@ -64,6 +64,11 @@ export function sendDesktopNotification(post, msgProps) {
             return;
         }
 
+        const rhsPostId = state.views.rhs.selectedPostId;
+        if (rhsPostId !== '' && rhsPostId === post.root_id && state.views.browser.focused) {
+            return;
+        }
+
         const config = getConfig(state);
         let username = '';
         if (post.props.override_username && config.EnablePostUsernameOverride === 'true') {

--- a/actions/notification_actions.test.jsx
+++ b/actions/notification_actions.test.jsx
@@ -1,0 +1,166 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+
+import {Posts} from 'mattermost-redux/constants';
+
+import * as Actions from 'actions/notification_actions';
+
+import * as Utils from 'utils/utils.jsx';
+
+const mockStore = configureStore([thunk]);
+
+jest.mock('utils/utils.jsx', () => ({
+    ...jest.requireActual('utils/utils.jsx'),
+    notifyMe: jest.fn(),
+    ding: jest.fn(),
+}));
+
+const latestPost = {
+    id: 'latest_post_id',
+    user_id: 'current_user_id',
+    message: 'test msg',
+    channel_id: 'current_channel_id',
+};
+
+const initialState = {
+    entities: {
+        channels: {
+            currentChannelId: 'current_channel_id',
+            myMembers: {
+                current_channel_id: {
+                    channel_id: 'current_channel_id',
+                    user_id: 'current_user_id',
+                    roles: 'channel_role',
+                    mention_count: 1,
+                    msg_count: 9,
+                },
+                new_post_channel_id: {
+                    channel_id: 'new_post_channel_id',
+                    user_id: 'current_user_id',
+                    roles: 'channel_role',
+                    mention_count: 0,
+                    msg_count: 0,
+                },
+            },
+            channels: {
+                current_channel_id: {
+                    id: 'current_channel_id',
+                    name: 'default-name',
+                    display_name: 'Default',
+                    delete_at: 0,
+                    type: 'O',
+                    total_msg_count: 10,
+                    team_id: 'team_id',
+                },
+            },
+            channelsInTeam: {
+                'team-id': ['current_channel_id'],
+            },
+        },
+        teams: {
+            currentTeamId: 'team-id',
+            teams: {
+                'team-id': {
+                    id: 'team_id',
+                    name: 'team-1',
+                    displayName: 'Team 1',
+                },
+            },
+            myMembers: {
+                'team-id': {roles: 'team_role'},
+            },
+        },
+        users: {
+            currentUserId: 'current_user_id',
+            profiles: {
+                current_user_id: {roles: 'system_role'},
+            },
+            statuses: {
+                current_user_id: 'online',
+            },
+        },
+        posts: {
+            posts: {
+                [latestPost.id]: latestPost,
+            },
+            postsInChannel: {
+                current_channel_id: [
+                    {order: [latestPost.id], recent: true},
+                ],
+            },
+            postsInThread: {},
+            messagesHistory: {
+                index: {
+                    [Posts.MESSAGE_TYPES.COMMENT]: 0,
+                },
+                messages: ['test message'],
+            },
+        },
+        preferences: {
+            myPreferences: {
+                'display_settings--name_format': {
+                    category: 'display_settings',
+                    name: 'name_format',
+                    user_id: 'current_user_id',
+                    value: 'username',
+                },
+            },
+        },
+        roles: {
+            roles: {
+                system_role: {
+                    permissions: [],
+                },
+                team_role: {
+                    permissions: [],
+                },
+                channel_role: {
+                    permissions: [],
+                },
+            },
+        },
+        general: {
+            license: {IsLicensed: 'false'},
+            serverVersion: '5.4.0',
+            config: {PostEditTimeLimit: -1},
+        },
+    },
+};
+
+describe('Actions.Notification', () => {
+    test('preventNotificationIfThreadedRHS', async () => {
+        const newPost = {
+            id: 'new_post_id',
+            root_id: 'new_post_root_id',
+            channel_id: 'new_post_channel_id',
+            message: 'new message',
+            user_id: 'new_post_user_id',
+            props: {},
+        };
+        const webSocketProps = {
+            team_id: 'team_id',
+            mentions: JSON.stringify(['current_user_id']),
+            post: JSON.stringify(newPost),
+        };
+
+        const store = await mockStore({
+            ...initialState,
+            views: {
+                ...initialState.views,
+                browser: {
+                    focused: true,
+                },
+                rhs: {
+                    selectedPostId: newPost.root_id,
+                },
+            },
+        });
+
+        await store.dispatch(Actions.sendDesktopNotification(newPost, webSocketProps));
+        expect(Utils.notifyMe).not.toHaveBeenCalled();
+        expect(Utils.ding).not.toHaveBeenCalled();
+    });
+});

--- a/actions/notification_actions.test.jsx
+++ b/actions/notification_actions.test.jsx
@@ -33,99 +33,40 @@ const initialState = {
                 current_channel_id: {
                     channel_id: 'current_channel_id',
                     user_id: 'current_user_id',
-                    roles: 'channel_role',
                     mention_count: 1,
                     msg_count: 9,
                 },
                 new_post_channel_id: {
                     channel_id: 'new_post_channel_id',
                     user_id: 'current_user_id',
-                    roles: 'channel_role',
-                    mention_count: 0,
-                    msg_count: 0,
                 },
             },
             channels: {
                 current_channel_id: {
                     id: 'current_channel_id',
-                    name: 'default-name',
-                    display_name: 'Default',
-                    delete_at: 0,
                     type: 'O',
                     total_msg_count: 10,
-                    team_id: 'team_id',
                 },
-            },
-            channelsInTeam: {
-                'team-id': ['current_channel_id'],
-            },
-        },
-        teams: {
-            currentTeamId: 'team-id',
-            teams: {
-                'team-id': {
-                    id: 'team_id',
-                    name: 'team-1',
-                    displayName: 'Team 1',
+                new_post_channel_id: {
+                    id: 'new_post_channel_id',
+                    type: 'O',
                 },
-            },
-            myMembers: {
-                'team-id': {roles: 'team_role'},
             },
         },
         users: {
             currentUserId: 'current_user_id',
             profiles: {
-                current_user_id: {roles: 'system_role'},
+                current_user_id: {},
             },
             statuses: {
                 current_user_id: 'online',
             },
         },
-        posts: {
-            posts: {
-                [latestPost.id]: latestPost,
-            },
-            postsInChannel: {
-                current_channel_id: [
-                    {order: [latestPost.id], recent: true},
-                ],
-            },
-            postsInThread: {},
-            messagesHistory: {
-                index: {
-                    [Posts.MESSAGE_TYPES.COMMENT]: 0,
-                },
-                messages: ['test message'],
-            },
-        },
         preferences: {
-            myPreferences: {
-                'display_settings--name_format': {
-                    category: 'display_settings',
-                    name: 'name_format',
-                    user_id: 'current_user_id',
-                    value: 'username',
-                },
-            },
-        },
-        roles: {
-            roles: {
-                system_role: {
-                    permissions: [],
-                },
-                team_role: {
-                    permissions: [],
-                },
-                channel_role: {
-                    permissions: [],
-                },
-            },
+            myPreferences: {},
         },
         general: {
-            license: {IsLicensed: 'false'},
-            serverVersion: '5.4.0',
-            config: {PostEditTimeLimit: -1},
+            config: {},
         },
     },
 };

--- a/actions/notification_actions.test.jsx
+++ b/actions/notification_actions.test.jsx
@@ -4,8 +4,6 @@
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 
-import {Posts} from 'mattermost-redux/constants';
-
 import * as Actions from 'actions/notification_actions';
 
 import * as Utils from 'utils/utils.jsx';
@@ -17,13 +15,6 @@ jest.mock('utils/utils.jsx', () => ({
     notifyMe: jest.fn(),
     ding: jest.fn(),
 }));
-
-const latestPost = {
-    id: 'latest_post_id',
-    user_id: 'current_user_id',
-    message: 'test msg',
-    channel_id: 'current_channel_id',
-};
 
 const initialState = {
     entities: {

--- a/actions/post_utils.js
+++ b/actions/post_utils.js
@@ -83,9 +83,23 @@ export function setChannelReadAndView(post, websocketMessageProps) {
             return;
         }
 
+        // in this case, marking as unread is prevented instead of marking as read being called,
+        // because there might be other unread messages in the channel and that would mark them as read
+        const postShowsOnCurrentRHS =
+              state.views.rhs &&
+              state.views.rhs.selectedPostId !== '' &&
+              state.views.rhs.selectedPostId === post.root_id &&
+              state.views.browser &&
+              state.views.browser.focused;
+
         let markAsRead = false;
         let markAsReadOnServer = false;
-        if (
+        let markAsUnread = true;
+        if (postShowsOnCurrentRHS) {
+            markAsRead = false;
+            markAsReadOnServer = false;
+            markAsUnread = false;
+        } else if (
             post.user_id === getCurrentUserId(state) &&
             !isSystemMessage(post) &&
             !isFromWebhook(post)
@@ -103,7 +117,7 @@ export function setChannelReadAndView(post, websocketMessageProps) {
         if (markAsRead) {
             dispatch(markChannelAsRead(post.channel_id, null, markAsReadOnServer));
             dispatch(markChannelAsViewed(post.channel_id));
-        } else {
+        } else if (markAsUnread) {
             dispatch(markChannelAsUnread(websocketMessageProps.team_id, post.channel_id, websocketMessageProps.mentions));
         }
     };

--- a/actions/post_utils.test.js
+++ b/actions/post_utils.test.js
@@ -125,7 +125,7 @@ describe('actions/post_utils', () => {
 
     test('setChannelReadAndView', async () => {
         let testStore = await mockStore(initialState);
-        const newPost = {id: 'new_post_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
+        const newPost = {id: 'new_post_id', root_id: 'new_post_root_id', channel_id: 'current_channel_id', message: 'new message', type: Constants.PostTypes.ADD_TO_CHANNEL};
         const websocketProps = {team_id: 'team_id', mentions: ['current_user_id']};
 
         await testStore.dispatch(PostActionsUtils.setChannelReadAndView(newPost, websocketProps));
@@ -140,5 +140,21 @@ describe('actions/post_utils', () => {
         newPost.user_id = 'current_user_id';
         await testStore.dispatch(PostActionsUtils.setChannelReadAndView(newPost, websocketProps));
         expect(testStore.getActions()).toEqual([MARK_CHANNEL_AS_READ, MARK_CHANNEL_AS_VIEWED]);
+
+        testStore = await mockStore({
+            ...initialState,
+            views: {
+                ...initialState.views,
+                browser: {
+                    focused: true,
+                },
+                rhs: {
+                    selectedPostId: newPost.root_id,
+                },
+            },
+        });
+
+        await testStore.dispatch(PostActionsUtils.setChannelReadAndView(newPost, websocketProps));
+        expect(testStore.getActions()).toEqual(EMPTY_ACTION);
     });
 });


### PR DESCRIPTION
If MM is focused and the notification is a reply to a thread
that is being shown in the RHS, then ignore it even if it's
in another channel - and don't make it bold (unread).

https://mattermost.atlassian.net/browse/PLT-4951

Fixes https://github.com/mattermost/mattermost-server/issues/7718
