### PR TITLE
Auto focus search box in admin console

### DIFF
--- a/components/admin_console/admin_sidebar/admin_sidebar.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.jsx
@@ -54,11 +54,16 @@ export default class AdminSidebar extends React.Component {
             filter: '',
         };
         this.idx = null;
+        this.searchRef = React.createRef();
     }
 
     componentDidMount() {
         if (this.props.config.PluginSettings.Enable) {
             this.props.actions.getPlugins();
+        }
+
+        if (this.searchRef.current) {
+            this.searchRef.current.focus();
         }
 
         this.updateTitle();
@@ -294,6 +299,7 @@ export default class AdminSidebar extends React.Component {
                                     onChange={this.onFilterChange}
                                     value={this.state.filter}
                                     placeholder={Utils.localizeMessage('admin.sidebar.filter', 'Find settings')}
+                                    ref={this.searchRef}
                                 />
                                 {this.state.filter &&
                                     <div


### PR DESCRIPTION
#### Summary
Add auto focus when you access the admin console into the search box to allow
you to directly go to the admin console and start typing

#### Ticket Link
[MM-16589](https://mattermost.atlassian.net/browse/MM-16589)