### PR TITLE
MM-16648 - Updating bot badge in center channel

### DIFF
--- a/components/user_profile/__snapshots__/user_profile.test.jsx.snap
+++ b/components/user_profile/__snapshots__/user_profile.test.jsx.snap
@@ -23,12 +23,12 @@ exports[`components/UserProfile should match snapshot 1`] = `
       className="user-popover"
     >
       nickname
-      <BotBadge
-        className="badge-popoverlist"
-        show={false}
-      />
     </div>
   </OverlayTrigger>
+  <BotBadge
+    className="badge-popoverlist"
+    show={false}
+  />
 </Fragment>
 `;
 

--- a/components/user_profile/user_profile.jsx
+++ b/components/user_profile/user_profile.jsx
@@ -85,12 +85,12 @@ export default class UserProfile extends PureComponent {
                 >
                     <div className='user-popover'>
                         {name}
-                        <BotBadge
-                            show={Boolean(user && user.is_bot)}
-                            className='badge-popoverlist'
-                        />
                     </div>
                 </OverlayTrigger>
+                <BotBadge
+                    show={Boolean(user && user.is_bot)}
+                    className='badge-popoverlist'
+                />
             </React.Fragment>
         );
     }


### PR DESCRIPTION
#### Summary
MM-16648 - Updating bot badge in center channel
Looks like the bot tag is being used in different ways. Just making them consistent.
So the badge for the bot needs to sit outside the `user-popover`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16648