### PR TITLE
[MM-16627] Show connection security setting on team edition

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -903,7 +903,6 @@ export default {
                         label: t('admin.environment.smtp.connectionSecurity.title'),
                         label_default: 'Connection Security:',
                         help_text: DefinitionConstants.CONNECTION_SECURITY_HELP_TEXT_EMAIL,
-                        isHidden: it.isnt(it.licensedForFeature('EmailNotificationContents')),
                         options: [
                             {
                                 value: '',


### PR DESCRIPTION
#### Summary
Changes the admin definition file to allow "Connection Security" setting under "SMTP" to be visible on team edition.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16627