### PR TITLE
Fix attempt to use non-string as aria-label

### DIFF
--- a/components/sidebar/sidebar_channel/__snapshots__/sidebar_channel.test.jsx.snap
+++ b/components/sidebar/sidebar_channel/__snapshots__/sidebar_channel.test.jsx.snap
@@ -153,17 +153,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     channelName="channel-name"
     channelStatus="test"
     channelType="D"
-    displayName={
-      <FormattedMessage
-        defaultMessage="{displayname} (you)"
-        id="sidebar.directchannel.you"
-        values={
-          Object {
-            "displayname": "Channel display name",
-          }
-        }
-      />
-    }
+    displayName="Channel display name (you)"
     handleClose={[Function]}
     hasDraft={true}
     link="/current-team/messages/@undefined"
@@ -325,17 +315,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     channelName="channel-name"
     channelStatus="test"
     channelType="D"
-    displayName={
-      <FormattedMessage
-        defaultMessage="{displayname} (you)"
-        id="sidebar.directchannel.you"
-        values={
-          Object {
-            "displayname": "Channel display name",
-          }
-        }
-      />
-    }
+    displayName="Channel display name (you)"
     handleClose={[Function]}
     hasDraft={false}
     link="/current-team/messages/@undefined"

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import {intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {browserHistory} from 'utils/browser_history';
@@ -151,6 +151,10 @@ export default class SidebarChannel extends React.PureComponent {
         }).isRequired,
     }
 
+    static contextTypes = {
+        intl: intlShape.isRequired,
+    }
+
     isLeaving = false;
 
     handleLeavePublicChannel = () => {
@@ -269,15 +273,12 @@ export default class SidebarChannel extends React.PureComponent {
 
         let displayName = '';
         if (this.props.currentUserId === this.props.channelTeammateId) {
-            displayName = (
-                <FormattedMessage
-                    id='sidebar.directchannel.you'
-                    defaultMessage='{displayname} (you)'
-                    values={{
-                        displayname: this.props.channelDisplayName,
-                    }}
-                />
-            );
+            displayName = this.context.intl.formatMessage({
+                id: 'sidebar.directchannel.you',
+                defaultMessage: '{displayname} (you)',
+            }, {
+                displayname: this.props.channelDisplayName,
+            });
         } else {
             displayName = this.props.channelDisplayName;
         }

--- a/components/sidebar/sidebar_channel/sidebar_channel.test.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.test.jsx
@@ -2,10 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallow} from 'enzyme';
 
-import {Constants} from 'utils/constants.jsx';
-import SidebarChannel from 'components/sidebar/sidebar_channel/sidebar_channel.jsx';
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
+import {Constants} from 'utils/constants';
+
+import SidebarChannel from './sidebar_channel';
 
 /* eslint-disable global-require */
 
@@ -80,7 +81,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
 
     test('should match snapshot, on channel show', () => {
         const props = defaultProps;
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <SidebarChannel {...props}/>
         );
         expect(wrapper).toMatchSnapshot();
@@ -89,7 +90,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
 
     test('should match snapshot, on channel hide', () => {
         const props = {...defaultProps, shouldHideChannel: true};
-        const wrapper = shallow(
+        const wrapper = shallowWithIntl(
             <SidebarChannel {...props}/>
         );
         expect(wrapper).toMatchSnapshot();
@@ -115,7 +116,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStringified: JSON.stringify(channel),
         };
 
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -125,7 +126,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             ...defaultProps,
             active: true,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -136,7 +137,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             currentUserId: 'myself',
             channelTeammateId: 'myself',
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -148,7 +149,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelTeammateId: 'myself',
             hasDraft: true,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -162,7 +163,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelType: Constants.OPEN_CHANNEL,
             channelDisplayName: 'Town Square',
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).toBeCalled();
     });
@@ -173,7 +174,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             membership: {mention_count: 3},
             unreadMentions: 4,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -184,7 +185,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             membership: {mention_count: 3},
             unreadMentions: 0,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -199,7 +200,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -214,7 +215,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -229,7 +230,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -244,7 +245,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -262,7 +263,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -280,7 +281,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -298,7 +299,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -316,7 +317,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -335,7 +336,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             },
         };
 
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         wrapper.instance().handleLeaveDirectChannel();
         expect(savePreferences).toBeCalledWith('user-id', [{user_id: 'user-id', category: Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: 'teammate-id', value: 'false'}]);
         expect(trackEvent).toBeCalledWith('ui', 'ui_direct_channel_x_button_clicked');
@@ -356,7 +357,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             },
         };
 
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         wrapper.instance().handleLeaveDirectChannel();
         expect(savePreferences).toBeCalledWith('user-id', [{user_id: 'user-id', category: Constants.Preferences.CATEGORY_GROUP_CHANNEL_SHOW, name: 'test-channel-id', value: 'false'}]);
         expect(trackEvent).toBeCalledWith('ui', 'ui_direct_channel_x_button_clicked');
@@ -379,7 +380,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             active: true,
         };
 
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         wrapper.instance().handleLeaveDirectChannel();
         expect(savePreferences).toBeCalledWith('user-id', [{user_id: 'user-id', category: Constants.Preferences.CATEGORY_GROUP_CHANNEL_SHOW, name: 'test-channel-id', value: 'false'}]);
         expect(trackEvent).toBeCalledWith('ui', 'ui_direct_channel_x_button_clicked');
@@ -400,7 +401,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             active: true,
         };
 
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         const instance = wrapper.instance();
         instance.isLeaving = true;
         instance.handleLeaveDirectChannel();
@@ -421,7 +422,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             },
         };
 
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         wrapper.instance().handleLeavePublicChannel();
         expect(leaveChannel).toBeCalledWith('test-channel-id');
         expect(trackEvent).toBeCalledWith('ui', 'ui_public_channel_x_button_clicked');
@@ -437,7 +438,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelDisplayName: 'Channel display name',
         };
 
-        const wrapper = shallow(<SidebarChannel {...props}/>);
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         wrapper.instance().handleLeavePrivateChannel();
         expect(showLeavePrivateChannelModal).toBeCalledWith({id: 'test-channel-id', display_name: 'Channel display name'});
         expect(trackEvent).toBeCalledWith('ui', 'ui_private_channel_x_button_clicked');

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
@@ -23,10 +23,7 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
         channelType: PropTypes.string.isRequired,
         channelId: PropTypes.string.isRequired,
         channelName: PropTypes.string.isRequired,
-        displayName: PropTypes.oneOfType([
-            PropTypes.string,
-            PropTypes.object,
-        ]).isRequired,
+        displayName: PropTypes.string.isRequired,
         channelStatus: PropTypes.string,
         handleClose: PropTypes.func,
         hasDraft: PropTypes.bool.isRequired,


### PR DESCRIPTION
`SidebarChannelButtonOrLink` could receive either a string or a `FormattedMessage` as its `displayName` prop, but it was treating it as if it was always a string. This changes it so that it only ever receives a string.
