### PR TITLE
[MM-16727] Hide Change eMail option for currently logged in user in admin area

### DIFF
--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
@@ -476,7 +476,7 @@ export default class SystemUsersDropdown extends React.PureComponent {
                                 text={Utils.localizeMessage('admin.user_item.resetPwd', 'Reset Password')}
                             />
                             <MenuItemAction
-                                show={!user.auth_service}
+                                show={!user.auth_service && user.id !== this.state.userId}
                                 onClick={this.handleResetEmail}
                                 text={Utils.localizeMessage('admin.user_item.resetEmail', 'Update Email')}
                             />


### PR DESCRIPTION
#### Summary
As a recent change we require the currently authenticated users password to change the eMail as a security measure. Since the currently authenticated users email can be changed in the user settings, we are hiding it in order to avoid a authentication error.

@amyblais @grundleborg Is this intended for 5.13 or 5.14?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16727
