### PR TITLE
MM-15652 Render header plugin correctly in mobile view

### DIFF
--- a/plugins/mobile_channel_header_plug/__snapshots__/mobile_channel_header_plug.test.jsx.snap
+++ b/plugins/mobile_channel_header_plug/__snapshots__/mobile_channel_header_plug.test.jsx.snap
@@ -41,17 +41,20 @@ exports[`plugins/MobileChannelHeaderPlug should match snapshot with one extended
   theme={Object {}}
 >
   <li
-    className="MenuItem"
-    key="mobileChannelHeaderItemsomeid"
-    role="presentation"
+    className="flex-parent--center"
   >
-    <a
-      href="#"
+    <button
+      className="navbar-toggle navbar-right__icon"
       onClick={[Function]}
-      role="menuitem"
     >
-      some dropdown text
-    </a>
+      <span
+        className="icon navbar-plugin-button"
+      >
+        <i
+          className="fa fa-anchor"
+        />
+      </span>
+    </button>
   </li>
 </MobileChannelHeaderPlug>
 `;

--- a/plugins/mobile_channel_header_plug/mobile_channel_header_plug.jsx
+++ b/plugins/mobile_channel_header_plug/mobile_channel_header_plug.jsx
@@ -27,19 +27,36 @@ export default class MobileChannelHeaderPlug extends React.PureComponent {
     }
 
     createButton = (plug) => {
-        return (
-            <li
-                key={'mobileChannelHeaderItem' + plug.id}
-                role='presentation'
-                className='MenuItem'
-            >
-                <a
-                    role='menuitem'
-                    href='#'
-                    onClick={() => this.fireAction(plug)}
+        const onClick = () => this.fireAction(plug);
+
+        if (this.props.isDropdown) {
+            return (
+                <li
+                    key={'mobileChannelHeaderItem' + plug.id}
+                    role='presentation'
+                    className='MenuItem'
                 >
-                    {plug.dropdownText}
-                </a>
+                    <a
+                        role='menuitem'
+                        href='#'
+                        onClick={onClick}
+                    >
+                        {plug.dropdownText}
+                    </a>
+                </li>
+            );
+        }
+
+        return (
+            <li className='flex-parent--center'>
+                <button
+                    className='navbar-toggle navbar-right__icon'
+                    onClick={onClick}
+                >
+                    <span className='icon navbar-plugin-button'>
+                        {plug.icon}
+                    </span>
+                </button>
             </li>
         );
     }

--- a/plugins/mobile_channel_header_plug/mobile_channel_header_plug.test.jsx
+++ b/plugins/mobile_channel_header_plug/mobile_channel_header_plug.test.jsx
@@ -43,12 +43,12 @@ describe('plugins/MobileChannelHeaderPlug', () => {
         );
         expect(wrapper).toMatchSnapshot();
 
-        // Render a single list item containing an anchor
+        // Render a single list item containing a button
         expect(wrapper.find('li')).toHaveLength(1);
-        expect(wrapper.find('a')).toHaveLength(1);
+        expect(wrapper.find('button')).toHaveLength(1);
 
         wrapper.instance().fireAction = jest.fn();
-        wrapper.find('a').first().simulate('click');
+        wrapper.find('button').first().simulate('click');
         expect(wrapper.instance().fireAction).toHaveBeenCalledTimes(1);
         expect(wrapper.instance().fireAction).toBeCalledWith(testPlug);
     });


### PR DESCRIPTION
This seems to be a regression caused by https://github.com/mattermost/mattermost-webapp/pull/2933. Originally, it rendered the button in both the header and dropdown, then it rendered the text item in both places. Now, it'll render the button in the header and the text in the dropdown.

<img width="651" alt="Screen Shot 2019-07-04 at 1 06 24 PM" src="https://user-images.githubusercontent.com/3277310/60681243-8c53e900-9e5c-11e9-8bad-ee3529d0ee40.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15652