### PR TITLE
[MM-15887] E2E: add test for interactive menus - basic options

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -86,6 +86,7 @@
         "func-names": 0,
         "import/no-unresolved": 0,
         "max-nested-callbacks": 0,
+        "no-process-env": 0,
         "no-unused-expressions": 0
       }
     }

--- a/components/post_view/message_attachments/message_attachment_list.jsx
+++ b/components/post_view/message_attachments/message_attachment_list.jsx
@@ -49,7 +49,10 @@ export default class MessageAttachmentList extends React.PureComponent {
         });
 
         return (
-            <div className='attachment__list'>
+            <div
+                id={`messageAttachmentList_${this.props.postId}`}
+                className='attachment__list'
+            >
                 {content}
             </div>
         );

--- a/e2e/cypress/fixtures/hooks/message_menus.json
+++ b/e2e/cypress/fixtures/hooks/message_menus.json
@@ -1,0 +1,26 @@
+{
+    "attachments": [{
+        "pretext": "This is the attachment pretext.",
+        "text": "This is the attachment text.",
+        "actions": [{
+            "name": "Select an option...",
+            "integration": {
+                "url": "http://localhost:3000/message_menus",
+                "context": {
+                    "action": "do_something"
+                }
+            },
+            "type": "select",
+            "options": [{
+                "text": "Option 1",
+                "value": "option1"
+            }, {
+                "text": "Option 2",
+                "value": "option2"
+            }, {
+                "text": "Option 3",
+                "value": "option3"
+            }]
+        }]
+    }]
+}

--- a/e2e/cypress/fixtures/hooks/message_menus_with_datasource.json
+++ b/e2e/cypress/fixtures/hooks/message_menus_with_datasource.json
@@ -1,0 +1,17 @@
+{
+    "attachments": [{
+        "pretext": "This is the attachment pretext.",
+        "text": "This is the attachment text.",
+        "actions": [{
+            "name": "Select an option...",
+            "integration": {
+                "url": "http://localhost:3000/message_menus_datasource",
+                "context": {
+                    "action": "do_something"
+                }
+            },
+            "type": "select",
+            "data_source": "channels"
+        }]
+    }]
+}

--- a/e2e/cypress/integration/interactive_menu/basic_options.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options.js
@@ -59,8 +59,9 @@ describe('MM-15887 Interactive menus - basic options', () => {
 
     it('matches elements', () => {
         // # Post an incoming webhook
-        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload});
-        cy.wait(TIMEOUTS.TINY);
+        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload}).
+            its('status').
+            should('be.equal', 200);
 
         // # Get message attachment from the last post
         cy.getLastPostId().then((postId) => {
@@ -90,8 +91,9 @@ describe('MM-15887 Interactive menus - basic options', () => {
 
     it('displays selected option and posts ephemeral message', () => {
         // # Post an incoming webhook
-        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload});
-        cy.wait(TIMEOUTS.TINY);
+        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload}).
+            its('status').
+            should('be.equal', 200);
 
         // # Get message attachment from the last post
         cy.getLastPostId().then((postId) => {
@@ -106,7 +108,7 @@ describe('MM-15887 Interactive menus - basic options', () => {
             cy.get('.select-suggestion-container > input').should('be.visible').and('have.attr', 'value', options[0].text);
         });
 
-        cy.wait(TIMEOUTS.TINY);
+        cy.wait(TIMEOUTS.SMALL);
 
         cy.getLastPostId().then((postId) => {
             // * Verify that ephemeral message is posted, visible to observer and contains an exact message
@@ -120,15 +122,18 @@ describe('MM-15887 Interactive menus - basic options', () => {
         const user1 = users['user-1'];
 
         // # Post an incoming webhook
-        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload});
-        cy.wait(TIMEOUTS.TINY);
+        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload}).
+            its('status').
+            should('be.equal', 200);
 
         // # Get last post
         cy.getLastPostId().then((parentMessageId) => {
             const baseUrl = Cypress.config('baseUrl');
 
             // # Post another message
-            cy.task('postMessageAs', {sender: user1, message: 'Just another message', channelId, baseUrl});
+            cy.task('postMessageAs', {sender: user1, message: 'Just another message', channelId, baseUrl}).
+                its('status').
+                should('be.equal', 201);
 
             // # Click comment icon to open RHS
             cy.clickPostCommentIcon(parentMessageId);
@@ -137,8 +142,9 @@ describe('MM-15887 Interactive menus - basic options', () => {
             cy.get('#rhsContainer').should('be.visible');
 
             // # Have another user reply to the webhook message
-            cy.task('postMessageAs', {sender: user1, message: 'Reply to webhook', channelId, rootId: parentMessageId, baseUrl});
-            cy.wait(TIMEOUTS.TINY);
+            cy.task('postMessageAs', {sender: user1, message: 'Reply to webhook', channelId, rootId: parentMessageId, baseUrl}).
+                its('status').
+                should('be.equal', 201);
 
             // # Get the latest post
             cy.getLastPostId().then((replyMessageId) => {

--- a/e2e/cypress/integration/interactive_menu/basic_options.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options.js
@@ -1,0 +1,159 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/**
+* Note: This test requires webhook server running. Initiate `npm run start:webhook` to start.
+*/
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+import users from '../../fixtures/users.json';
+import {getMessageMenusPayload} from '../../utils';
+
+const options = [
+    {text: 'Option 1', value: 'option1'},
+    {text: 'Option 2', value: 'option2'},
+    {text: 'Option 3', value: 'option3'},
+];
+const payload = getMessageMenusPayload({options});
+
+let channelId;
+let incomingWebhook;
+
+describe('MM-15887 Interactive menus - basic options', () => {
+    before(() => {
+        if (process.env.NODE_ENV !== 'qa') {
+            // Set AllowedUntrustedInternalConnections to localhost if running in development
+            const newSettings = {
+                ServiceSettings: {AllowedUntrustedInternalConnections: 'localhost'},
+            };
+            cy.apiUpdateConfig(newSettings);
+        }
+
+        // # Login as sysadmin and ensure that teammate name display setting us set to default 'username'
+        cy.apiLogin('sysadmin');
+        cy.apiSaveTeammateNameDisplayPreference('username');
+
+        // # Visit '/' and create incoming webhook
+        cy.visit('/');
+        cy.getCurrentChannelId().then((id) => {
+            channelId = id;
+
+            const newIncomingHook = {
+                channel_id: id,
+                channel_locked: true,
+                description: 'Incoming webhook interactive menu',
+                display_name: 'menuIn' + Date.now(),
+            };
+
+            cy.apiCreateWebhook(newIncomingHook).then((hook) => {
+                incomingWebhook = hook;
+            });
+        });
+    });
+
+    it('matches elements', () => {
+        // # Post an incoming webhook
+        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload});
+        cy.wait(TIMEOUTS.TINY);
+
+        // # Get message attachment from the last post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#messageAttachmentList_${postId}`).as('messageAttachmentList');
+        });
+
+        // * Verify each element of message attachment list
+        cy.get('@messageAttachmentList').within(() => {
+            cy.get('.attachment__thumb-pretext').should('be.visible').and('have.text', 'This is attachment pretext with basic options');
+            cy.get('.post-message__text-container').should('be.visible').and('have.text', 'This is attachment text with basic options');
+            cy.get('.attachment-actions').should('be.visible');
+            cy.get('.select-suggestion-container').should('be.visible');
+            cy.get('.select-suggestion-container > input').should('be.visible').and('have.attr', 'placeholder', 'Select an option...');
+
+            cy.get('#suggestionList').should('not.be.visible');
+            cy.get('.select-suggestion-container > input').click();
+            cy.get('#suggestionList').should('be.visible').children().should('have.length', options.length);
+
+            cy.get('#suggestionList').children().each(($el, index) => {
+                cy.wrap($el).should('have.text', options[index].text);
+            });
+
+            // * Close suggestion list by clicking on other element
+            cy.get('.attachment__thumb-pretext').click();
+        });
+    });
+
+    it('displays selected option and posts ephemeral message', () => {
+        // # Post an incoming webhook
+        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload});
+        cy.wait(TIMEOUTS.TINY);
+
+        // # Get message attachment from the last post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#messageAttachmentList_${postId}`).as('messageAttachmentList');
+        });
+
+        cy.get('@messageAttachmentList').within(() => {
+            // # Select option 1 by typing exact text and press enter
+            cy.get('.select-suggestion-container > input').click().clear().type(`${options[0].text}{enter}`);
+
+            // * Verify that the input is updated with the selected option
+            cy.get('.select-suggestion-container > input').should('be.visible').and('have.attr', 'value', options[0].text);
+        });
+
+        cy.wait(TIMEOUTS.TINY);
+
+        cy.getLastPostId().then((postId) => {
+            // * Verify that ephemeral message is posted, visible to observer and contains an exact message
+            cy.get(`#${postId}_message`).should('be.visible').and('have.class', 'post--ephemeral');
+            cy.get('.post__visibility').should('be.visible').and('have.text', '(Only visible to you)');
+            cy.get(`#postMessageText_${postId}`).should('be.visible').and('have.text', 'Ephemeral | select  option: option1');
+        });
+    });
+
+    it('displays reply in center channel with "commented on [user\'s] message: [text]"', () => {
+        const user1 = users['user-1'];
+
+        // # Post an incoming webhook
+        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload});
+        cy.wait(TIMEOUTS.TINY);
+
+        // # Get last post
+        cy.getLastPostId().then((parentMessageId) => {
+            const baseUrl = Cypress.config('baseUrl');
+
+            // # Post another message
+            cy.task('postMessageAs', {sender: user1, message: 'Just another message', channelId, baseUrl});
+
+            // # Click comment icon to open RHS
+            cy.clickPostCommentIcon(parentMessageId);
+
+            // * Check that the RHS is open
+            cy.get('#rhsContainer').should('be.visible');
+
+            // # Have another user reply to the webhook message
+            cy.task('postMessageAs', {sender: user1, message: 'Reply to webhook', channelId, rootId: parentMessageId, baseUrl});
+            cy.wait(TIMEOUTS.TINY);
+
+            // # Get the latest post
+            cy.getLastPostId().then((replyMessageId) => {
+                // * Verify that the reply is in the channel view with matching text
+                cy.get(`#post_${replyMessageId}`).within(() => {
+                    cy.get('.post__link').should('be.visible').and('have.text', 'Commented on sysadmin\'s message: This is attachment pretext with basic options');
+                    cy.get(`#postMessageText_${replyMessageId}`).should('be.visible').and('have.text', 'Reply to webhook');
+                });
+
+                // * Verify that the reply is in the RHS with matching text
+                cy.get(`#rhsPost_${replyMessageId}`).within(() => {
+                    cy.get('.post__link').should('not.be.visible');
+                    cy.get(`#postMessageText_${replyMessageId}`).should('be.visible').and('have.text', 'Reply to webhook');
+                });
+            });
+        });
+    });
+});

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -4,12 +4,14 @@
 const postMessageAs = require('./post_message_as');
 const externalRequest = require('./external_request');
 const getRecentEmail = require('./get_recent_email');
+const postIncomingWebhook = require('./post_incoming_webhook');
 
-module.exports = (on) => {
+module.exports = (on, config) => {
     on('task', {
         postMessageAs,
         externalRequest,
         getRecentEmail,
+        postIncomingWebhook,
     });
 
     on('before:browser:launch', (browser = {}, args) => {
@@ -19,4 +21,12 @@ module.exports = (on) => {
 
         return args;
     });
+
+    if (process.env.NODE_ENV === 'qa') { // eslint-disable-line no-process-env
+        config.webhookBaseUrl = 'https://cypress.test.mattermost.com/webhook';
+    } else {
+        config.webhookBaseUrl = 'http://localhost:3000';
+    }
+
+    return config;
 };

--- a/e2e/cypress/plugins/post_incoming_webhook.js
+++ b/e2e/cypress/plugins/post_incoming_webhook.js
@@ -4,16 +4,15 @@
 const axios = require('axios');
 
 module.exports = async ({url, data}) => {
-    let success;
-    let error;
     let response;
 
     try {
         response = await axios({method: 'post', url, data});
-        success = true;
     } catch (err) {
-        error = err;
+        if (err.response) {
+            response = err.response;
+        }
     }
 
-    return {body: JSON.stringify(response.body), success, error};
+    return {status: response.status, data: response.data};
 };

--- a/e2e/cypress/plugins/post_incoming_webhook.js
+++ b/e2e/cypress/plugins/post_incoming_webhook.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const axios = require('axios');
+
+module.exports = async ({url, data}) => {
+    let success;
+    let error;
+    let response;
+
+    try {
+        response = await axios({method: 'post', url, data});
+        success = true;
+    } catch (err) {
+        error = err;
+    }
+
+    return {body: JSON.stringify(response.body), success, error};
+};

--- a/e2e/cypress/plugins/post_message_as.js
+++ b/e2e/cypress/plugins/post_message_as.js
@@ -18,23 +18,30 @@ module.exports = async ({sender, message, channelId, rootId, createAt = 0, baseU
         cookieString += nameAndValue + ';';
     });
 
-    const response = await axios({
-        url: `${baseUrl}/api/v4/posts`,
-        headers: {
-            'Content-Type': 'application/json',
-            'X-Requested-With': 'XMLHttpRequest',
-            Cookie: cookieString,
-        },
-        method: 'post',
-        data: {
-            channel_id: channelId,
-            message,
-            type: '',
-            create_at: createAt,
-            parent_id: rootId,
-            root_id: rootId,
-        },
-    });
+    let response;
+    try {
+        response = await axios({
+            url: `${baseUrl}/api/v4/posts`,
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
+                Cookie: cookieString,
+            },
+            method: 'post',
+            data: {
+                channel_id: channelId,
+                message,
+                type: '',
+                create_at: createAt,
+                parent_id: rootId,
+                root_id: rootId,
+            },
+        });
+    } catch (err) {
+        if (err.response) {
+            response = err.response;
+        }
+    }
 
     return {status: response.status, data: response.data, error: response.error};
 };

--- a/e2e/cypress/plugins/post_message_as.js
+++ b/e2e/cypress/plugins/post_message_as.js
@@ -3,7 +3,7 @@
 
 const axios = require('axios');
 
-module.exports = async ({sender, message, channelId, createAt = 0, baseUrl}) => {
+module.exports = async ({sender, message, channelId, rootId, createAt = 0, baseUrl}) => {
     const loginResponse = await axios({
         url: `${baseUrl}/api/v4/users/login`,
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -31,6 +31,8 @@ module.exports = async ({sender, message, channelId, createAt = 0, baseUrl}) => 
             message,
             type: '',
             create_at: createAt,
+            parent_id: rootId,
+            root_id: rootId,
         },
     });
 

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -442,3 +442,23 @@ Cypress.Commands.add('apiGetConfig', () => {
     // # Get current settings
     return cy.request('/api/v4/config');
 });
+
+// *****************************************************************************
+// Webhooks
+// https://api.mattermost.com/#tag/webhooks
+// *****************************************************************************
+
+Cypress.Commands.add('apiCreateWebhook', (hook = {}, isIncoming = true) => {
+    const hookUrl = isIncoming ? '/api/v4/hooks/incoming' : '/api/v4/hooks/outgoing';
+    const options = {
+        url: hookUrl,
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        method: 'POST',
+        body: hook,
+    };
+
+    return cy.request(options).then((response) => {
+        const data = response.body;
+        return {...data, url: isIncoming ? `${Cypress.config().baseUrl}/hooks/${data.id}` : ''};
+    });
+});

--- a/e2e/cypress/utils/index.js
+++ b/e2e/cypress/utils/index.js
@@ -1,6 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import messageMenusData from '../fixtures/hooks/message_menus.json';
+import messageMenusWithDatasourceData from '../fixtures/hooks/message_menus_with_datasource.json';
+
 export function getRandomInt(max) {
     return Math.floor(Math.random() * Math.floor(max));
 }
@@ -19,6 +22,29 @@ export function getEmailMessageSeparator(baseUrl) {
     }
 
     return '\n';
+}
+
+export function getMessageMenusPayload({dataSource, options} = {}) {
+    let data;
+    if (dataSource) {
+        data = messageMenusWithDatasourceData;
+        data.attachments[0].actions[0].data_source = dataSource;
+        data.attachments[0].pretext = `This is attachment pretext with ${dataSource} options`;
+        data.attachments[0].text = `This is attachment text with ${dataSource} options`;
+    } else {
+        data = messageMenusData;
+        data.attachments[0].pretext = 'This is attachment pretext with basic options';
+        data.attachments[0].text = 'This is attachment text with basic options';
+
+        if (options) {
+            data.attachments[0].actions[0].options = options;
+        }
+    }
+
+    const callbackUrl = Cypress.config().webhookBaseUrl + '/message_menus';
+    data.attachments[0].actions[0].integration.url = callbackUrl;
+
+    return data;
 }
 
 export const reUrl = /(https?:\/\/[^ ]*)/;

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -131,6 +131,16 @@
       "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
       "dev": true
     },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -184,6 +194,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
     "asn1": {
@@ -265,6 +281,41 @@
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
       "dev": true
     },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -285,6 +336,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "dev": true
     },
     "cachedir": {
@@ -429,6 +486,33 @@
         "typedarray": "^0.0.6"
       }
     },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -552,6 +636,18 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -562,16 +658,40 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
     "elegant-spinner": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "execa": {
@@ -603,6 +723,61 @@
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
+        }
+      }
     },
     "extend": {
       "version": "3.0.2",
@@ -679,6 +854,32 @@
         "object-assign": "^4.1.0"
       }
     },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
@@ -719,6 +920,18 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "fs-extra": {
       "version": "5.0.0",
@@ -829,6 +1042,27 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -838,6 +1072,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "indent-string": {
@@ -869,6 +1112,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
       "dev": true
     },
     "is-buffer": {
@@ -1267,6 +1516,12 @@
         }
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
     "merge-deep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
@@ -1277,6 +1532,24 @@
         "clone-deep": "^0.2.4",
         "kind-of": "^3.0.2"
       }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.40.0",
@@ -1394,6 +1667,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -1432,6 +1711,15 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -1505,6 +1793,12 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1521,6 +1815,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
     "pend": {
@@ -1559,6 +1859,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "proxy-addr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.0"
+      }
+    },
     "psl": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
@@ -1588,6 +1898,24 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
       "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
       "dev": true
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
     },
     "react-is": {
       "version": "16.8.6",
@@ -1709,6 +2037,70 @@
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true
     },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "dev": true
+    },
     "shallow-clone": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
@@ -1787,6 +2179,12 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
     },
     "stream-to-observable": {
       "version": "0.1.0",
@@ -1867,6 +2265,12 @@
         "rimraf": "^2.6.3"
       }
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -1900,6 +2304,16 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -1910,6 +2324,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "uri-js": {
@@ -1945,10 +2365,22 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,13 +2,16 @@
   "devDependencies": {
     "@testing-library/cypress": "4.0.3",
     "axios": "0.18.1",
+    "body-parser": "1.19.0",
     "cypress": "3.3.2",
     "cypress-file-upload": "3.1.2",
+    "express": "4.17.1",
     "merge-deep": "3.0.2",
     "mocha-junit-reporter": "1.22.0"
   },
   "scripts": {
     "cypress:run": "cypress run",
-    "cypress:open": "cypress open"
+    "cypress:open": "cypress open",
+    "start:webhook": "node webhook_serve.js"
   }
 }

--- a/e2e/webhook_serve.js
+++ b/e2e/webhook_serve.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const express = require('express');
+const bodyParser = require('body-parser');
+const port = 3000;
+
+const server = express();
+server.use(bodyParser.json());
+server.use(bodyParser.urlencoded({extended: true}));
+
+process.title = process.argv[2];
+
+server.post('/message_menus', postMessageMenus);
+
+server.listen(port, () => console.log(`Webhook test server listening on port ${port}!`)); // eslint-disable-line no-console
+
+function postMessageMenus(req, res) {
+    let responseData = {};
+    const {body} = req;
+    if (body && body.context.action === 'do_something') {
+        responseData = {
+            ephemeral_text: `Ephemeral | ${body.type} ${body.data_source} option: ${body.context.selected_option}`,
+        };
+    }
+
+    res.setHeader('Content-Type', 'application/json');
+    return res.json(responseData);
+}


### PR DESCRIPTION
#### Summary
Add E2E for interactive menus - basic options.  This PR covered test cases for the ff:
![Screen Shot 2019-07-06 at 1 04 14 AM](https://user-images.githubusercontent.com/5334504/60736607-1fd70800-9f8a-11e9-8d76-059280368730.png)

__To follow: Test cases for interactive menus with users and channels as options.__

Other changes included:
- add small webhook server with additional `express` and `body-parser` dependencies on `/e2e` subproject.  Such webhook server is exposed as `http://localhost:3000` on local dev and will be `https://cypress.test.masttermost.com/webhook` on Cypress test server (PR to follow on shared pipelines)
- introduced `NODE_ENV=qa` which will be used when running test at Cypress test server. Such will be used to configure other settings like `baseUrl`, `mailboxAPI`, etc. (PR to follow both on the webapp and shared pipelines)

#### Ticket Link
Jira ticket: [MM-15887](https://mattermost.atlassian.net/browse/MM-15887)

