### PR TITLE
[MM-14018] Ignore leading/trailing colon in emoji picker search

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -112,6 +112,10 @@ function getEmojiFilename(emoji) {
     return emoji.filename || emoji.id;
 }
 
+export function filterEmojiSearchInput(input) {
+    return input.toLowerCase().replace(/^:|:$/g, '');
+}
+
 const EMOJIS_PER_PAGE = 200;
 const LOAD_MORE_AT_PIXELS_FROM_BOTTOM = 500;
 
@@ -258,7 +262,7 @@ export default class EmojiPicker extends React.PureComponent {
 
     handleFilterChange(e) {
         e.preventDefault();
-        const filter = e.target.value.toLowerCase();
+        const filter = filterEmojiSearchInput(e.target.value);
 
         if (this.props.customEmojisEnabled && filter && filter.trim() !== '') {
             this.props.actions.searchCustomEmojis(filter);

--- a/components/emoji_picker/emoji_picker.test.jsx
+++ b/components/emoji_picker/emoji_picker.test.jsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {filterEmojiSearchInput} from 'components/emoji_picker/emoji_picker';
+
+describe('components/emoji_picker/EmojiPicker', () => {
+    const testCases = [
+        {input: 'smile', output: 'smile'},
+        {input: 'SMILE', output: 'smile'},
+        {input: ':smile', output: 'smile'},
+        {input: ':SMILE', output: 'smile'},
+        {input: 'smile:', output: 'smile'},
+        {input: 'SMILE:', output: 'smile'},
+        {input: ':smile:', output: 'smile'},
+        {input: ':SMILE:', output: 'smile'},
+    ];
+
+    testCases.forEach((testCase) => {
+        test(`'${testCase.input}' should return '${testCase.output}'`, () => {
+            expect(filterEmojiSearchInput(testCase.input)).toEqual(testCase.output);
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
Creates a helper function which is called in the EmojiPicker component and strips leading/trailing colons from the input.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/MM-14018
https://github.com/mattermost/mattermost-server/issues/10276

#### Related Pull Requests
None