### PR TITLE
Remove beta label from O365 SSO

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -3166,7 +3166,7 @@ export default {
                             {
                                 value: Constants.OFFICE365_SERVICE,
                                 display_name: t('admin.oauth.office365'),
-                                display_name_default: 'Office 365 (Beta)',
+                                display_name_default: 'Office 365',
                                 isHidden: it.isnt(it.licensedForFeature('Office365OAuth')),
                                 help_text: t('admin.office365.EnableMarkdownDesc'),
                                 help_text_default: '1. [Log in](!https://login.microsoftonline.com/) to your Microsoft or Office 365 account. Make sure it`s the account on the same [tenant](!https://msdn.microsoft.com/en-us/library/azure/jj573650.aspx#Anchor_0) that you would like users to log in with.\n2. Go to [https://apps.dev.microsoft.com](!https://apps.dev.microsoft.com), click **Go to app list** > **Add an app** and use "Mattermost - your-company-name" as the **Application Name**.\n3. Under **Application Secrets**, click **Generate New Password** and paste it to the **Application Secret Password** field below.\n4. Under **Platforms**, click **Add Platform**, choose **Web** and enter **your-mattermost-url/signup/office365/complete** (example: http://localhost:8065/signup/office365/complete) under **Redirect URIs**. Also uncheck **Allow Implicit Flow**.\n5. Finally, click **Save** and then paste the **Application ID** below.',

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -882,7 +882,7 @@
   "admin.oauth.gitlab": "GitLab",
   "admin.oauth.google": "Google Apps",
   "admin.oauth.off": "Do not allow sign-in via an OAuth 2.0 provider",
-  "admin.oauth.office365": "Office 365 (Beta)",
+  "admin.oauth.office365": "Office 365",
   "admin.oauth.providerDescription": "When true, Mattermost can act as an OAuth 2.0 service provider allowing Mattermost to authorize API requests from external applications. See [documentation](!https://docs.mattermost.com/developer/oauth-2-0-applications.html) to learn more.",
   "admin.oauth.providerTitle": "Enable OAuth 2.0 Service Provider: ",
   "admin.oauth.select": "Select OAuth 2.0 service provider:",


### PR DESCRIPTION
This is following 
1. Mobile support added in v1.18 on Apr 16
2. Updated instruction for Office 365 SSO that covers the new Azure App Registration method. https://github.com/mattermost/docs/pull/2829