### PR TITLE
E2E: add post-verification on Cypress task that the request is successfully completed

### DIFF
--- a/e2e/cypress/integration/at_mentions/at_mentions_spec.js
+++ b/e2e/cypress/integration/at_mentions/at_mentions_spec.js
@@ -78,8 +78,6 @@ function setNotificationSettings(desiredSettings = {first: true, username: true,
 }
 
 describe('at-mention', () => {
-    const baseUrl = Cypress.config('baseUrl');
-
     beforeEach(() => {
         cy.fixture('users').as('usersJSON');
 
@@ -116,7 +114,7 @@ describe('at-mention', () => {
         const message = `@${this.receiver.username} I'm messaging you! ${Date.now()}`;
 
         // # Use another account to post a message @-mentioning our receiver
-        cy.task('postMessageAs', {sender: this.sender, message, channelId: this.channelId, baseUrl});
+        cy.postMessageAs({sender: this.sender, message, channelId: this.channelId});
 
         const body = `@${this.sender.username}: ${message}`;
 
@@ -158,7 +156,7 @@ describe('at-mention', () => {
         const message = `Hey ${this.receiver.username}! I'm messaging you! ${Date.now()}`;
 
         // # Use another account to post a message @-mentioning our receiver
-        cy.task('postMessageAs', {sender: this.sender, message, channelId: this.channelId, baseUrl});
+        cy.postMessageAs({sender: this.sender, message, channelId: this.channelId});
 
         // * Verify stub was not called
         cy.get('@notifySpy').should('be.not.called');
@@ -199,7 +197,7 @@ describe('at-mention', () => {
             const message = `Hey ${mention} I'm message you all! ${Date.now()}`;
 
             // # Use another account to post a message @-mentioning our receiver
-            cy.task('postMessageAs', {sender: this.sender, message, channelId: this.channelId, baseUrl});
+            cy.postMessageAs({sender: this.sender, message, channelId: this.channelId});
 
             // * Verify stub was not called
             cy.get('@notifySpy').should('be.not.called');

--- a/e2e/cypress/integration/channel/message_spec.js
+++ b/e2e/cypress/integration/channel/message_spec.js
@@ -56,7 +56,7 @@ describe('Message', () => {
 
         // # Post a message to force next user message to display a message
         cy.getCurrentChannelId().then((channelId) => {
-            cy.task('postMessageAs', {sender: sysadmin, message: 'Hello', channelId, baseUrl: Cypress.config('baseUrl')});
+            cy.postMessageAs({sender: sysadmin, message: 'Hello', channelId, baseUrl: Cypress.config('baseUrl')});
         });
 
         // # Post message "One"

--- a/e2e/cypress/integration/interactive_menu/basic_options.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options.js
@@ -59,9 +59,7 @@ describe('MM-15887 Interactive menus - basic options', () => {
 
     it('matches elements', () => {
         // # Post an incoming webhook
-        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload}).
-            its('status').
-            should('be.equal', 200);
+        cy.postIncomingWebhook({url: incomingWebhook.url, data: payload});
 
         // # Get message attachment from the last post
         cy.getLastPostId().then((postId) => {
@@ -91,9 +89,7 @@ describe('MM-15887 Interactive menus - basic options', () => {
 
     it('displays selected option and posts ephemeral message', () => {
         // # Post an incoming webhook
-        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload}).
-            its('status').
-            should('be.equal', 200);
+        cy.postIncomingWebhook({url: incomingWebhook.url, data: payload});
 
         // # Get message attachment from the last post
         cy.getLastPostId().then((postId) => {
@@ -122,18 +118,14 @@ describe('MM-15887 Interactive menus - basic options', () => {
         const user1 = users['user-1'];
 
         // # Post an incoming webhook
-        cy.task('postIncomingWebhook', {url: incomingWebhook.url, data: payload}).
-            its('status').
-            should('be.equal', 200);
+        cy.postIncomingWebhook({url: incomingWebhook.url, data: payload});
 
         // # Get last post
         cy.getLastPostId().then((parentMessageId) => {
             const baseUrl = Cypress.config('baseUrl');
 
             // # Post another message
-            cy.task('postMessageAs', {sender: user1, message: 'Just another message', channelId, baseUrl}).
-                its('status').
-                should('be.equal', 201);
+            cy.postMessageAs({sender: user1, message: 'Just another message', channelId, baseUrl});
 
             // # Click comment icon to open RHS
             cy.clickPostCommentIcon(parentMessageId);
@@ -142,9 +134,7 @@ describe('MM-15887 Interactive menus - basic options', () => {
             cy.get('#rhsContainer').should('be.visible');
 
             // # Have another user reply to the webhook message
-            cy.task('postMessageAs', {sender: user1, message: 'Reply to webhook', channelId, rootId: parentMessageId, baseUrl}).
-                its('status').
-                should('be.equal', 201);
+            cy.postMessageAs({sender: user1, message: 'Reply to webhook', channelId, rootId: parentMessageId, baseUrl});
 
             // # Get the latest post
             cy.getLastPostId().then((replyMessageId) => {

--- a/e2e/cypress/integration/search/date_filter_spec.js
+++ b/e2e/cypress/integration/search/date_filter_spec.js
@@ -104,20 +104,18 @@ describe('SF15699 Search Date Filter', () => {
         // # Set user to be a sysadmin, so it can access the system console
         cy.get('@newAdmin').then((user) => {
             newAdmin = user;
-            cy.task('externalRequest', {user: users.sysadmin, method: 'put', baseUrl, path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}}).
-                its('status').
-                should('be.equal', 200);
+            cy.externalRequest({user: users.sysadmin, method: 'put', baseUrl, path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}});
         });
 
         // # Create messages at specific dates in Town Square
         cy.getCurrentChannelId().then((channelId) => {
             // Post message as new admin to Town Square
             cy.get('@newAdmin').then((user) => {
-                cy.task('postMessageAs', {sender: user, message: firstMessage, channelId, createAt: firstDateEarly.ms, baseUrl});
+                cy.postMessageAs({sender: user, message: firstMessage, channelId, createAt: firstDateEarly.ms, baseUrl});
             });
 
             // Post message as sysadmin to Town Square
-            cy.task('postMessageAs', {sender: users.sysadmin, message: secondMessage, channelId, createAt: secondDateEarly.ms, baseUrl});
+            cy.postMessageAs({sender: users.sysadmin, message: secondMessage, channelId, createAt: secondDateEarly.ms, baseUrl});
         });
 
         // # Create messages at same dates in Off Topic channel
@@ -127,11 +125,11 @@ describe('SF15699 Search Date Filter', () => {
 
         cy.getCurrentChannelId().then((channelId) => {
             // Post message as sysadmin to off topic
-            cy.task('postMessageAs', {sender: users.sysadmin, message: firstOffTopicMessage, channelId, createAt: firstDateLater.ms, baseUrl});
+            cy.postMessageAs({sender: users.sysadmin, message: firstOffTopicMessage, channelId, createAt: firstDateLater.ms, baseUrl});
 
             // Post message as new admin to off topic
             cy.get('@newAdmin').then((user) => {
-                cy.task('postMessageAs', {sender: user, message: secondOffTopicMessage, channelId, createAt: secondDateLater.ms, baseUrl});
+                cy.postMessageAs({sender: user, message: secondOffTopicMessage, channelId, createAt: secondDateLater.ms, baseUrl});
             });
         });
     });
@@ -301,10 +299,10 @@ describe('SF15699 Search Date Filter', () => {
 
             // Post same message at different times
             cy.getCurrentChannelId().then((channelId) => {
-                cy.task('postMessageAs', {sender: users.sysadmin, message: 'pretarget ' + identifier, channelId, createAt: preTarget.ms, baseUrl});
-                cy.task('postMessageAs', {sender: users.sysadmin, message: targetAMMessage, channelId, createAt: targetAM.ms, baseUrl});
-                cy.task('postMessageAs', {sender: users.sysadmin, message: targetPMMessage, channelId, createAt: targetPM.ms, baseUrl});
-                cy.task('postMessageAs', {sender: users.sysadmin, message: 'postTarget' + identifier, channelId, createAt: postTarget.ms, baseUrl});
+                cy.postMessageAs({sender: users.sysadmin, message: 'pretarget ' + identifier, channelId, createAt: preTarget.ms, baseUrl});
+                cy.postMessageAs({sender: users.sysadmin, message: targetAMMessage, channelId, createAt: targetAM.ms, baseUrl});
+                cy.postMessageAs({sender: users.sysadmin, message: targetPMMessage, channelId, createAt: targetPM.ms, baseUrl});
+                cy.postMessageAs({sender: users.sysadmin, message: 'postTarget' + identifier, channelId, createAt: postTarget.ms, baseUrl});
             });
 
             // * Verify we only see messages from the expected date, and not outside of it
@@ -352,7 +350,7 @@ describe('SF15699 Search Date Filter', () => {
 
             // # Post message with unique text
             cy.getCurrentChannelId().then((channelId) => {
-                cy.task('postMessageAs', {sender: users.sysadmin, message: targetMessage, channelId, createAt: targetDate.ms, baseUrl});
+                cy.postMessageAs({sender: users.sysadmin, message: targetMessage, channelId, createAt: targetDate.ms, baseUrl});
             });
 
             // # Set clock to custom date, reload page for it to take effect
@@ -415,7 +413,7 @@ describe('SF15699 Search Date Filter', () => {
 
             // # Post message with unique text
             cy.getCurrentChannelId().then((channelId) => {
-                cy.task('postMessageAs', {sender: users.sysadmin, message: targetMessage, channelId, createAt: target.ms, baseUrl});
+                cy.postMessageAs({sender: users.sysadmin, message: targetMessage, channelId, createAt: target.ms, baseUrl});
             });
 
             // * Verify result appears in current timezone

--- a/e2e/cypress/integration/system_console/demoted_user_spec.js
+++ b/e2e/cypress/integration/system_console/demoted_user_spec.js
@@ -21,9 +21,7 @@ describe('System Console', () => {
 
         // # Set user to be a sysadmin, so it can access the system console
         cy.get('@newuser').then((user) => {
-            cy.task('externalRequest', {user: sysadmin, method: 'put', baseUrl, path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}}).
-                its('status').
-                should('be.equal', 200);
+            cy.externalRequest({user: sysadmin, method: 'put', baseUrl, path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}});
         });
 
         // # Visit a page on the system console
@@ -33,9 +31,7 @@ describe('System Console', () => {
 
         // # Change the role of the user back to user
         cy.get('@newuser').then((user) => {
-            cy.task('externalRequest', {user: sysadmin, method: 'put', baseUrl, path: `users/${user.id}/roles`, data: {roles: 'system_user'}}).
-                its('status').
-                should('be.equal', 200);
+            cy.externalRequest({user: sysadmin, method: 'put', baseUrl, path: `users/${user.id}/roles`, data: {roles: 'system_user'}});
         });
 
         // # User should get redirected to town square

--- a/e2e/cypress/plugins/post_message_as.js
+++ b/e2e/cypress/plugins/post_message_as.js
@@ -43,5 +43,5 @@ module.exports = async ({sender, message, channelId, rootId, createAt = 0, baseU
         }
     }
 
-    return {status: response.status, data: response.data, error: response.error};
+    return {status: response.status, data: response.data};
 };

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -7,6 +7,7 @@
 
 import './ui_commands';
 import './api_commands';
+import './task_commands';
 import '@testing-library/cypress/add-commands';
 import 'cypress-file-upload';
 

--- a/e2e/cypress/support/task_commands.js
+++ b/e2e/cypress/support/task_commands.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+* postMessageAs is a task which is wrapped as command with post-verification
+* that a message is successfully posted by the user/sender
+* @param {Object} sender - a user object who will post a message
+* @param {String} message - message in a post
+* @param {Object} channelId - where a post will be posted
+*/
+Cypress.Commands.add('postMessageAs', ({sender, message, channelId, rootId, createAt}) => {
+    const baseUrl = Cypress.config('baseUrl');
+
+    cy.task('postMessageAs', {sender, message, channelId, rootId, createAt, baseUrl}).its('status').should('be.equal', 201);
+});
+
+/**
+* postIncomingWebhook is a task which is wrapped as command with post-verification
+* that the incoming webhook is successfully posted
+* @param {String} url - incoming webhook URL
+* @param {Object} data - payload on incoming webhook
+*/
+Cypress.Commands.add('postIncomingWebhook', ({url, data}) => {
+    cy.task('postIncomingWebhook', {url, data}).its('status').should('be.equal', 200);
+});
+
+/**
+* externalRequest is a task which is wrapped as command with post-verification
+* that the external request is successfully completed
+* @param {Object} user - a user initiating external request
+* @param {String} method - an HTTP method (e.g. get, post, etc)
+* @param {String} path - API path that is relative to Cypress.config().baseUrl
+* @param {Object} data - payload
+*/
+Cypress.Commands.add('externalRequest', ({user, method, path, data}) => {
+    const baseUrl = Cypress.config('baseUrl');
+
+    cy.task('externalRequest', {baseUrl, user, method, path, data}).its('status').should('be.equal', 200);
+});


### PR DESCRIPTION
#### Summary
E2E: add post-verification on Cypress task that the request is successfully completed by wrapping those tasks into commands.

By doing so, Cypress awaits in a certain default period of time that the (http) request is indeed successful before actually doing/verifying next step.  This prevents flakiness due to timing issue especially when dealing with network request.
 
#### Ticket Link
n/a
