### PR TITLE
[MM-16056] Hide add-to-channel option if user in not part of team

### DIFF
--- a/components/profile_popover/__snapshots__/profile_popover.test.jsx.snap
+++ b/components/profile_popover/__snapshots__/profile_popover.test.jsx.snap
@@ -1,9 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/ProfilePopover should hide add-to-channel option if not on team 1`] = `
+<Popover
+  bsClass="popover"
+  id="user-profile-popover"
+  isInCurrentTeam={false}
+  placement="right"
+  title={
+    <span>
+      <span
+        className="user-popover__username"
+      >
+        @some_username
+      </span>
+    </span>
+  }
+>
+  <img
+    alt="some_username profile image"
+    className="user-popover__image"
+    height="128"
+    key="user-popover-image"
+    src="src"
+    width="128"
+  />
+  <Connect(Pluggable)
+    key="profilePopoverPluggable2"
+    pluggableName="PopoverUserAttributes"
+    status="offline"
+    user={
+      Object {
+        "name": "some name",
+        "username": "some_username",
+      }
+    }
+  />
+  <div
+    className="popover__row first"
+    data-toggle="tooltip"
+    key="user-popover-dm"
+  >
+    <a
+      className="text-nowrap user-popover__email"
+      href="#"
+      onClick={[Function]}
+    >
+      <i
+        className="fa fa-paper-plane"
+        title="Send Message Icon"
+      />
+      <FormattedMessage
+        defaultMessage="Send Message"
+        id="user_profile.send.dm"
+        values={Object {}}
+      />
+    </a>
+  </div>
+  <Connect(Pluggable)
+    key="profilePopoverPluggable3"
+    pluggableName="PopoverUserActions"
+    status="offline"
+    user={
+      Object {
+        "name": "some name",
+        "username": "some_username",
+      }
+    }
+  />
+</Popover>
+`;
+
 exports[`components/ProfilePopover should match snapshot 1`] = `
 <Popover
   bsClass="popover"
   id="user-profile-popover"
+  isInCurrentTeam={true}
   placement="right"
   title={
     <span>

--- a/components/profile_popover/index.js
+++ b/components/profile_popover/index.js
@@ -58,6 +58,7 @@ function mapStateToProps(state, ownProps) {
         enableTimezone: areTimezonesEnabledAndSupported(state),
         isTeamAdmin,
         isChannelAdmin,
+        isInCurrentTeam: Boolean(teamMember),
         canManageAnyChannelMembersInCurrentTeam: canManageAnyChannelMembersInCurrentTeam(state),
         status: getStatusForUserId(state, userId),
         teamUrl: getCurrentRelativeTeamUrl(state),

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -63,12 +63,17 @@ class ProfilePopover extends React.PureComponent {
         /**
          * @internal
          */
+        currentUserId: PropTypes.string.isRequired,
+
+        /**
+         * @internal
+         */
         hasMention: PropTypes.bool,
 
         /**
          * @internal
          */
-        currentUserId: PropTypes.string.isRequired,
+        isInCurrentTeam: PropTypes.bool.isRequired,
 
         /**
          * @internal
@@ -376,7 +381,7 @@ class ProfilePopover extends React.PureComponent {
                 </div>
             );
 
-            if (this.props.canManageAnyChannelMembersInCurrentTeam) {
+            if (this.props.canManageAnyChannelMembersInCurrentTeam && this.props.isInCurrentTeam) {
                 const addToChannelMessage = formatMessage({id: 'user_profile.add_user_to_channel', defaultMessage: 'Add to a Channel'});
                 dataContent.push(
                     <div

--- a/components/profile_popover/profile_popover.test.jsx
+++ b/components/profile_popover/profile_popover.test.jsx
@@ -17,6 +17,7 @@ describe('components/ProfilePopover', () => {
         currentTeamId: 'team_id',
         isChannelAdmin: false,
         isTeamAdmin: false,
+        isInCurrentTeam: true,
         teamUrl: '',
         canManageAnyChannelMembersInCurrentTeam: true,
         actions: {
@@ -55,5 +56,15 @@ describe('components/ProfilePopover', () => {
                 {'bot description'}
             </div>
         )).toEqual(true);
+    });
+
+    test('should hide add-to-channel option if not on team', () => {
+        const props = {...baseProps};
+        props.isInCurrentTeam = false;
+
+        const wrapper = shallowWithIntl(
+            <ProfilePopover {...props}/>
+        ).dive();
+        expect(wrapper).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
This change hides the option to add a user to a channel in the
profile popup if that user is not part of the team. This improves
the experience where the user could not be added to any channels in
the current team anyway.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16056