### PR TITLE
MM-16511 Load missing users who start typing 

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -344,7 +344,7 @@ function handleEvent(msg) {
         break;
 
     case SocketEvents.TYPING:
-        handleUserTypingEvent(msg);
+        dispatch(handleUserTypingEvent(msg));
         break;
 
     case SocketEvents.STATUS_CHANGED:

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -33,7 +33,12 @@ import {
 import {clearErrors, logError} from 'mattermost-redux/actions/errors';
 
 import * as TeamActions from 'mattermost-redux/actions/teams';
-import {checkForModifiedUsers, getMe, getStatusesByIds, getProfilesByIds} from 'mattermost-redux/actions/users';
+import {
+    checkForModifiedUsers,
+    getMe,
+    getMissingProfilesByIds,
+    getStatusesByIds,
+} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentUser, getCurrentUserId, getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 import {getMyTeams, getCurrentRelativeTeamUrl, getCurrentTeamId, getCurrentTeamUrl} from 'mattermost-redux/selectors/entities/teams';
@@ -780,39 +785,40 @@ function addedNewDmUser(preference) {
     return preference.category === Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW && preference.value === 'true';
 }
 
-function handleUserTypingEvent(msg) {
-    const state = getState();
-    const config = getConfig(state);
-    const currentUserId = getCurrentUserId(state);
-    const currentUser = getCurrentUser(state);
-    const userId = msg.data.user_id;
+export function handleUserTypingEvent(msg) {
+    return (doDispatch, doGetState) => {
+        const state = doGetState();
+        const config = getConfig(state);
+        const currentUserId = getCurrentUserId(state);
+        const userId = msg.data.user_id;
 
-    const data = {
-        id: msg.broadcast.channel_id + msg.data.parent_id,
-        userId,
-        now: Date.now(),
-    };
+        const data = {
+            id: msg.broadcast.channel_id + msg.data.parent_id,
+            userId,
+            now: Date.now(),
+        };
 
-    dispatch({
-        type: WebsocketEvents.TYPING,
-        data,
-    }, getState);
-
-    setTimeout(() => {
-        dispatch({
-            type: WebsocketEvents.STOP_TYPING,
+        doDispatch({
+            type: WebsocketEvents.TYPING,
             data,
         });
-    }, parseInt(config.TimeBetweenUserTypingUpdatesMilliseconds, 10));
 
-    if (!currentUser && userId !== currentUserId) {
-        getProfilesByIds([userId])(dispatch, getState);
-    }
+        setTimeout(() => {
+            doDispatch({
+                type: WebsocketEvents.STOP_TYPING,
+                data,
+            });
+        }, parseInt(config.TimeBetweenUserTypingUpdatesMilliseconds, 10));
 
-    const status = getStatusForUserId(state, userId);
-    if (status !== General.ONLINE) {
-        getStatusesByIds([userId])(dispatch, getState);
-    }
+        if (userId !== currentUserId) {
+            doDispatch(getMissingProfilesByIds([userId]));
+        }
+
+        const status = getStatusForUserId(state, userId);
+        if (status !== General.ONLINE) {
+            doDispatch(getStatusesByIds([userId]));
+        }
+    };
 }
 
 function handleStatusChangedEvent(msg) {


### PR DESCRIPTION
It looks like [this line](https://github.com/mattermost/mattermost-webapp/pull/910/files#diff-827322d72aefea3f612c4852b30b0de5R552) of the previous logic was backwards, causing it to not actually load missing users. I also changed that line to use `getMissingProfilesByIds` instead of `getProfilesByIds` so that it will only load users that it doesn't already have

This PR is based off of https://github.com/mattermost/mattermost-webapp/pull/3077 so you can see changes specific to it here: https://github.com/mattermost/mattermost-webapp/compare/mm16060...mm16511

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16511