### PR TITLE
E2E: Fix flaky tests on system message spec and update markdown spec due to latest structure change

### DIFF
--- a/e2e/cypress/integration/markdown/markdown_image_spec.js
+++ b/e2e/cypress/integration/markdown/markdown_image_spec.js
@@ -17,8 +17,8 @@ describe('Markdown', () => {
 
     const baseUrl = Cypress.config('baseUrl');
 
-    const inlineImage1 = `<h3 class="markdown__heading">In-line Images</h3><p>Mattermost/platform build status:  <a class="theme markdown__link" href="https://travis-ci.org/mattermost/platform" rel="noreferrer" target="_blank"><img alt="Build Status" class="markdown-inline-img" src="${baseUrl}/api/v4/image?url=https%3A%2F%2Ftravis-ci.org%2Fmattermost%2Fplatform.svg%3Fbranch%3Dmaster"></a></p>`;
-    const inlineImage2 = `<h3 class="markdown__heading">In-line Images</h3><p>GitHub favicon:  <img alt="Github" class="markdown-inline-img" src="${baseUrl}/api/v4/image?url=https%3A%2F%2Fgithub.githubassets.com%2Ffavicon.ico"></p>`;
+    const inlineImage1 = `<h3 class="markdown__heading">In-line Images</h3><p>Mattermost/platform build status:  <a class="theme markdown__link" href="https://travis-ci.org/mattermost/platform" rel="noreferrer" target="_blank"><button class="style--none" alt="Build Status" aria-label="file thumbnail"><img alt="image placeholder" src="${baseUrl}/api/v4/image?url=https%3A%2F%2Ftravis-ci.org%2Fmattermost%2Fplatform.svg%3Fbranch%3Dmaster"></button></a></p>`;
+    const inlineImage2 = `<h3 class="markdown__heading">In-line Images</h3><p>GitHub favicon:  <button class="style--none" alt="Github" aria-label="file thumbnail"><img alt="image placeholder" src="${baseUrl}/api/v4/image?url=https%3A%2F%2Fgithub.githubassets.com%2Ffavicon.ico"></button></p>`;
 
     const tests = [
         {name: 'with in-line images 1', fileKey: 'markdown_inline_images_1', expected: inlineImage1},

--- a/e2e/cypress/integration/markdown/markdown_image_spec.js
+++ b/e2e/cypress/integration/markdown/markdown_image_spec.js
@@ -17,8 +17,8 @@ describe('Markdown', () => {
 
     const baseUrl = Cypress.config('baseUrl');
 
-    const inlineImage1 = `<h3 class="markdown__heading">In-line Images</h3><p>Mattermost/platform build status:  <a class="theme markdown__link" href="https://travis-ci.org/mattermost/platform" rel="noreferrer" target="_blank"><button class="style--none" alt="Build Status" aria-label="file thumbnail"><img alt="image placeholder" src="${baseUrl}/api/v4/image?url=https%3A%2F%2Ftravis-ci.org%2Fmattermost%2Fplatform.svg%3Fbranch%3Dmaster"></button></a></p>`;
-    const inlineImage2 = `<h3 class="markdown__heading">In-line Images</h3><p>GitHub favicon:  <button class="style--none" alt="Github" aria-label="file thumbnail"><img alt="image placeholder" src="${baseUrl}/api/v4/image?url=https%3A%2F%2Fgithub.githubassets.com%2Ffavicon.ico"></button></p>`;
+    const inlineImage1 = `<h3 class="markdown__heading">In-line Images</h3><p>Mattermost/platform build status:  <a class="theme markdown__link" href="https://travis-ci.org/mattermost/platform" rel="noreferrer" target="_blank"><button class="style--none" alt="Build Status" aria-label="file thumbnail"><img class="markdown-inline-img" alt="image placeholder" src="${baseUrl}/api/v4/image?url=https%3A%2F%2Ftravis-ci.org%2Fmattermost%2Fplatform.svg%3Fbranch%3Dmaster"></button></a></p>`;
+    const inlineImage2 = `<h3 class="markdown__heading">In-line Images</h3><p>GitHub favicon:  <button class="style--none" alt="Github" aria-label="file thumbnail"><img class="markdown-inline-img" alt="image placeholder" src="${baseUrl}/api/v4/image?url=https%3A%2F%2Fgithub.githubassets.com%2Ffavicon.ico"></button></p>`;
 
     const tests = [
         {name: 'with in-line images 1', fileKey: 'markdown_inline_images_1', expected: inlineImage1},

--- a/e2e/cypress/integration/multi_team/system_message_spec.js
+++ b/e2e/cypress/integration/multi_team/system_message_spec.js
@@ -28,6 +28,17 @@ describe('MM-15240 - no status on a system message', () => {
         // # Login and go to /
         cy.apiLogin('user-1');
         cy.visit('/');
+
+        // # Post a regular message
+        cy.postMessage('Test for no status of a system message');
+
+        // # Update the header
+        cy.getCurrentChannelId().then((channelId) => {
+            cy.apiPatchChannel(
+                channelId,
+                {header: ' Updating header'.repeat(Math.floor(Math.random() * 10))}
+            );
+        });
     });
 
     const displayTypes = ['compact', 'clean'];
@@ -36,14 +47,6 @@ describe('MM-15240 - no status on a system message', () => {
         it(`should have no status with ${type} display`, () => {
             // # Set message display
             cy.apiSaveMessageDisplayPreference(type);
-
-            // # Update the header
-            cy.getCurrentChannelId().then((channelId) => {
-                cy.apiPatchChannel(
-                    channelId,
-                    {header: ' Updating header'.repeat(Math.floor(Math.random() * 10))}
-                );
-            });
 
             // # Get last post
             cy.getLastPostId().then((postId) => {


### PR DESCRIPTION
#### Summary
Fixed flaky test of `multi_team/system_message_spec.js` - It seems to be a race condition between returning a system message vs getting last post ID, after patching a channel.  Fixed by posting a regular message first (to reinit WS connection) and patching a channel in before hook, so that system message is posted before the actual test.

Updated test for `markdown/markdown_image_spec.js` - due to [recent change](https://github.com/mattermost/mattermost-webapp/pull/3065/files#diff-8c8a73f5938837547fb13a6d9a3ab6bdR137)

#### Ticket Link
n/a
