### PR TITLE
MM-16795 - Updating bootstrap tooltips

### DIFF
--- a/components/admin_console/admin_sidebar/admin_sidebar.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.jsx
@@ -307,7 +307,6 @@ export default class AdminSidebar extends React.Component {
                                         onClick={this.handleClearFilter}
                                     >
                                         <OverlayTrigger
-                                            trigger={['hover', 'focus']}
                                             delayShow={Constants.OVERLAY_TIME_DELAY}
                                             placement='bottom'
                                             overlay={filterClearTooltip}

--- a/components/admin_console/permission_schemes_settings/permissions_scheme_summary/permissions_scheme_summary.jsx
+++ b/components/admin_console/permission_schemes_settings/permissions_scheme_summary/permissions_scheme_summary.jsx
@@ -133,7 +133,6 @@ export default class PermissionsSchemeSummary extends React.Component {
         if (teams.length > MAX_TEAMS_PER_SCHEME_SUMMARY) {
             extraTeams = (
                 <OverlayTrigger
-                    trigger={['hover', 'focus']}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='bottom'
                     overlay={

--- a/components/analytics/table_chart.jsx
+++ b/components/analytics/table_chart.jsx
@@ -49,7 +49,6 @@ export default class TableChart extends React.PureComponent {
                                             <tr key={'table-entry-' + item.name}>
                                                 <td>
                                                     <OverlayTrigger
-                                                        trigger={['hover', 'focus']}
                                                         delayShow={Constants.OVERLAY_TIME_DELAY}
                                                         placement='top'
                                                         overlay={tooltip}

--- a/components/announcement_bar/announcement_bar.jsx
+++ b/components/announcement_bar/announcement_bar.jsx
@@ -93,7 +93,6 @@ export default class AnnouncementBar extends React.PureComponent {
                 style={barStyle}
             >
                 <OverlayTrigger
-                    trigger={['hover', 'focus']}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='bottom'
                     overlay={announcementTooltip}

--- a/components/change_url_modal/change_url_modal.jsx
+++ b/components/change_url_modal/change_url_modal.jsx
@@ -213,7 +213,6 @@ export default class ChangeURLModal extends React.PureComponent {
                             <div className='col-sm-9'>
                                 <div className={urlClass}>
                                     <OverlayTrigger
-                                        trigger={['hover', 'focus']}
                                         delayShow={Constants.OVERLAY_TIME_DELAY}
                                         placement='top'
                                         overlay={urlTooltip}

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -448,7 +448,6 @@ export default class ChannelHeader extends React.PureComponent {
 
             toggleFavorite = (
                 <OverlayTrigger
-                    trigger={['hover', 'focus']}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='bottom'
                     overlay={toggleFavoriteTooltip}
@@ -478,7 +477,6 @@ export default class ChannelHeader extends React.PureComponent {
         if (channelMuted) {
             muteTrigger = (
                 <OverlayTrigger
-                    trigger={['hover', 'focus']}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='bottom'
                     overlay={channelMutedTooltip}

--- a/components/common/comment_icon.jsx
+++ b/components/common/comment_icon.jsx
@@ -55,23 +55,24 @@ export default class CommentIcon extends React.PureComponent {
         );
 
         return (
-            <OverlayTrigger
-                className='hidden-xs'
-                trigger={['hover', 'click']}
-                delayShow={500}
-                placement='top'
-                overlay={tooltip}
+            <button
+                id={`${this.props.location}_commentIcon_${this.props.postId}`}
+                aria-label={localizeMessage('post_info.comment_icon.tooltip.reply', 'Reply').toLowerCase()}
+                className={iconStyle + ' color--link style--none ' + this.props.extraClass}
+                onClick={this.props.handleCommentClick}
             >
-                <button
-                    id={`${this.props.location}_commentIcon_${this.props.postId}`}
-                    aria-label={localizeMessage('post_info.comment_icon.tooltip.reply', 'Reply').toLowerCase()}
-                    className={iconStyle + ' color--link style--none ' + this.props.extraClass}
-                    onClick={this.props.handleCommentClick}
+                <OverlayTrigger
+                    className='hidden-xs'
+                    delayShow={500}
+                    placement='top'
+                    overlay={tooltip}
                 >
-                    <ReplyIcon className='comment-icon'/>
-                    {commentCountSpan}
-                </button>
-            </OverlayTrigger>
+                    <span className='d-flex'>
+                        <ReplyIcon className='comment-icon'/>
+                        {commentCountSpan}
+                    </span>
+                </OverlayTrigger>
+            </button>
         );
     }
 }

--- a/components/copy_text.jsx
+++ b/components/copy_text.jsx
@@ -47,7 +47,6 @@ export default class CopyText extends React.PureComponent {
 
         return (
             <OverlayTrigger
-                trigger={['hover', 'focus']}
                 delayShow={Constants.OVERLAY_TIME_DELAY}
                 placement='top'
                 overlay={tooltip}

--- a/components/create_team/components/team_url/team_url.jsx
+++ b/components/create_team/components/team_url/team_url.jsx
@@ -200,7 +200,6 @@ export default class TeamUrl extends React.PureComponent {
                             <div className='col-sm-11'>
                                 <div className='input-group input-group--limit'>
                                     <OverlayTrigger
-                                        trigger={['hover', 'focus']}
                                         delayShow={Constants.OVERLAY_TIME_DELAY}
                                         placement='top'
                                         overlay={urlTooltip}

--- a/components/file_attachment/__snapshots__/filename_overlay.test.jsx.snap
+++ b/components/file_attachment/__snapshots__/filename_overlay.test.jsx.snap
@@ -70,7 +70,7 @@ exports[`components/file_attachment/FilenameOverlay should match snapshot, stand
       trigger={
         Array [
           "hover",
-          "click",
+          "focus",
         ]
       }
     >
@@ -107,7 +107,7 @@ exports[`components/file_attachment/FilenameOverlay should match snapshot, with 
       trigger={
         Array [
           "hover",
-          "click",
+          "focus",
         ]
       }
     >

--- a/components/file_attachment/filename_overlay.jsx
+++ b/components/file_attachment/filename_overlay.jsx
@@ -61,7 +61,6 @@ export default class FilenameOverlay extends React.PureComponent {
         if (compactDisplay) {
             filenameOverlay = (
                 <OverlayTrigger
-                    trigger={['hover', 'focus']}
                     delayShow={1000}
                     placement='top'
                     overlay={<Tooltip id='file-name__tooltip'>{fileName}</Tooltip>}
@@ -88,7 +87,6 @@ export default class FilenameOverlay extends React.PureComponent {
                         rel='noopener noreferrer'
                     >
                         <OverlayTrigger
-                            trigger={['hover', 'click']}
                             delayShow={1000}
                             placement='top'
                             overlay={

--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -380,7 +380,6 @@ export default class AddBot extends React.Component {
         let imageURL = '';
         let removeImageIcon = (
             <OverlayTrigger
-                trigger={['hover', 'focus']}
                 delayShow={OVERLAY_TIME_DELAY}
                 placement='right'
                 overlay={(

--- a/components/popover_list_members/__snapshots__/popover_list_members.test.jsx.snap
+++ b/components/popover_list_members/__snapshots__/popover_list_members.test.jsx.snap
@@ -4,35 +4,35 @@ exports[`components/PopoverListMembers should match snapshot 1`] = `
 <div
   id="channelMember"
 >
-  <OverlayTrigger
-    defaultOverlayShown={false}
-    delayShow={400}
-    overlay={
-      <Tooltip
-        bsClass="tooltip"
-        id="channelMembersTooltip"
-        placement="right"
-      >
-        <FormattedMessage
-          defaultMessage="Members"
-          id="channel_header.channelMembers"
-          values={Object {}}
-        />
-      </Tooltip>
-    }
-    placement="bottom"
-    trigger={
-      Array [
-        "hover",
-        "click",
-      ]
-    }
+  <button
+    aria-label="members"
+    className="style--none member-popover__trigger channel-header__icon wide "
+    id="member_popover"
+    onClick={[Function]}
   >
-    <button
-      aria-label="members"
-      className="style--none member-popover__trigger channel-header__icon wide "
-      id="member_popover"
-      onClick={[Function]}
+    <OverlayTrigger
+      defaultOverlayShown={false}
+      delayShow={400}
+      overlay={
+        <Tooltip
+          bsClass="tooltip"
+          id="channelMembersTooltip"
+          placement="right"
+        >
+          <FormattedMessage
+            defaultMessage="Members"
+            id="channel_header.channelMembers"
+            values={Object {}}
+          />
+        </Tooltip>
+      }
+      placement="bottom"
+      trigger={
+        Array [
+          "hover",
+          "focus",
+        ]
+      }
     >
       <div>
         <span
@@ -47,8 +47,8 @@ exports[`components/PopoverListMembers should match snapshot 1`] = `
           id="channelMemberIcon"
         />
       </div>
-    </button>
-  </OverlayTrigger>
+    </OverlayTrigger>
+  </button>
   <Overlay
     animation={[Function]}
     onHide={[Function]}
@@ -111,35 +111,35 @@ exports[`components/PopoverListMembers should match snapshot with archived chann
 <div
   id="channelMember"
 >
-  <OverlayTrigger
-    defaultOverlayShown={false}
-    delayShow={400}
-    overlay={
-      <Tooltip
-        bsClass="tooltip"
-        id="channelMembersTooltip"
-        placement="right"
-      >
-        <FormattedMessage
-          defaultMessage="Members"
-          id="channel_header.channelMembers"
-          values={Object {}}
-        />
-      </Tooltip>
-    }
-    placement="bottom"
-    trigger={
-      Array [
-        "hover",
-        "click",
-      ]
-    }
+  <button
+    aria-label="members"
+    className="style--none member-popover__trigger channel-header__icon wide "
+    id="member_popover"
+    onClick={[Function]}
   >
-    <button
-      aria-label="members"
-      className="style--none member-popover__trigger channel-header__icon wide "
-      id="member_popover"
-      onClick={[Function]}
+    <OverlayTrigger
+      defaultOverlayShown={false}
+      delayShow={400}
+      overlay={
+        <Tooltip
+          bsClass="tooltip"
+          id="channelMembersTooltip"
+          placement="right"
+        >
+          <FormattedMessage
+            defaultMessage="Members"
+            id="channel_header.channelMembers"
+            values={Object {}}
+          />
+        </Tooltip>
+      }
+      placement="bottom"
+      trigger={
+        Array [
+          "hover",
+          "focus",
+        ]
+      }
     >
       <div>
         <span
@@ -154,8 +154,8 @@ exports[`components/PopoverListMembers should match snapshot with archived chann
           id="channelMemberIcon"
         />
       </div>
-    </button>
-  </OverlayTrigger>
+    </OverlayTrigger>
+  </button>
   <Overlay
     animation={[Function]}
     onHide={[Function]}
@@ -218,35 +218,35 @@ exports[`components/PopoverListMembers should match snapshot with group-constrai
 <div
   id="channelMember"
 >
-  <OverlayTrigger
-    defaultOverlayShown={false}
-    delayShow={400}
-    overlay={
-      <Tooltip
-        bsClass="tooltip"
-        id="channelMembersTooltip"
-        placement="right"
-      >
-        <FormattedMessage
-          defaultMessage="Members"
-          id="channel_header.channelMembers"
-          values={Object {}}
-        />
-      </Tooltip>
-    }
-    placement="bottom"
-    trigger={
-      Array [
-        "hover",
-        "click",
-      ]
-    }
+  <button
+    aria-label="members"
+    className="style--none member-popover__trigger channel-header__icon wide "
+    id="member_popover"
+    onClick={[Function]}
   >
-    <button
-      aria-label="members"
-      className="style--none member-popover__trigger channel-header__icon wide "
-      id="member_popover"
-      onClick={[Function]}
+    <OverlayTrigger
+      defaultOverlayShown={false}
+      delayShow={400}
+      overlay={
+        <Tooltip
+          bsClass="tooltip"
+          id="channelMembersTooltip"
+          placement="right"
+        >
+          <FormattedMessage
+            defaultMessage="Members"
+            id="channel_header.channelMembers"
+            values={Object {}}
+          />
+        </Tooltip>
+      }
+      placement="bottom"
+      trigger={
+        Array [
+          "hover",
+          "focus",
+        ]
+      }
     >
       <div>
         <span
@@ -261,8 +261,8 @@ exports[`components/PopoverListMembers should match snapshot with group-constrai
           id="channelMemberIcon"
         />
       </div>
-    </button>
-  </OverlayTrigger>
+    </OverlayTrigger>
+  </button>
   <Overlay
     animation={[Function]}
     onHide={[Function]}
@@ -334,35 +334,35 @@ exports[`components/PopoverListMembers should match state when showChannelInvite
 <div
   id="channelMember"
 >
-  <OverlayTrigger
-    defaultOverlayShown={false}
-    delayShow={400}
-    overlay={
-      <Tooltip
-        bsClass="tooltip"
-        id="channelMembersTooltip"
-        placement="right"
-      >
-        <FormattedMessage
-          defaultMessage="Members"
-          id="channel_header.channelMembers"
-          values={Object {}}
-        />
-      </Tooltip>
-    }
-    placement="bottom"
-    trigger={
-      Array [
-        "hover",
-        "click",
-      ]
-    }
+  <button
+    aria-label="members"
+    className="style--none member-popover__trigger channel-header__icon wide "
+    id="member_popover"
+    onClick={[Function]}
   >
-    <button
-      aria-label="members"
-      className="style--none member-popover__trigger channel-header__icon wide "
-      id="member_popover"
-      onClick={[Function]}
+    <OverlayTrigger
+      defaultOverlayShown={false}
+      delayShow={400}
+      overlay={
+        <Tooltip
+          bsClass="tooltip"
+          id="channelMembersTooltip"
+          placement="right"
+        >
+          <FormattedMessage
+            defaultMessage="Members"
+            id="channel_header.channelMembers"
+            values={Object {}}
+          />
+        </Tooltip>
+      }
+      placement="bottom"
+      trigger={
+        Array [
+          "hover",
+          "focus",
+        ]
+      }
     >
       <div>
         <span
@@ -377,8 +377,8 @@ exports[`components/PopoverListMembers should match state when showChannelInvite
           id="channelMemberIcon"
         />
       </div>
-    </button>
-  </OverlayTrigger>
+    </OverlayTrigger>
+  </button>
   <Overlay
     animation={[Function]}
     onHide={[Function]}

--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -219,18 +219,17 @@ export default class PopoverListMembers extends React.Component {
 
         return (
             <div id='channelMember'>
-                <OverlayTrigger
-                    trigger={['hover', 'click']}
-                    delayShow={Constants.OVERLAY_TIME_DELAY}
-                    placement='bottom'
-                    overlay={channelMembersTooltip}
+                <button
+                    id='member_popover'
+                    aria-label={ariaLabel}
+                    className={'style--none member-popover__trigger channel-header__icon wide ' + (this.state.showPopover ? 'active' : '')}
+                    ref='member_popover_target'
+                    onClick={this.handleGetProfilesInChannel}
                 >
-                    <button
-                        id='member_popover'
-                        aria-label={ariaLabel}
-                        className={'style--none member-popover__trigger channel-header__icon wide ' + (this.state.showPopover ? 'active' : '')}
-                        ref='member_popover_target'
-                        onClick={this.handleGetProfilesInChannel}
+                    <OverlayTrigger
+                        delayShow={Constants.OVERLAY_TIME_DELAY}
+                        placement='bottom'
+                        overlay={channelMembersTooltip}
                     >
                         <div>
                             <span
@@ -245,8 +244,8 @@ export default class PopoverListMembers extends React.Component {
                                 aria-hidden='true'
                             />
                         </div>
-                    </button>
-                </OverlayTrigger>
+                    </OverlayTrigger>
+                </button>
                 <Overlay
                     rootClose={true}
                     onHide={this.closePopover}

--- a/components/post_view/channel_intro_message/channel_intro_message.jsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.jsx
@@ -566,6 +566,7 @@ function createSetHeaderButton(channel) {
         >
             {(message) => (
                 <ToggleModalButtonRedux
+                    modalId='editChannelHeaderModal'
                     accessibilityLabel={message}
                     className={'intro-links color--link'}
                     dialogType={EditChannelHeaderModal}

--- a/components/post_view/channel_intro_message/channel_intro_message.jsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.jsx
@@ -571,7 +571,6 @@ function createSetHeaderButton(channel) {
                     className={'intro-links color--link'}
                     dialogType={EditChannelHeaderModal}
                     dialogProps={{channel}}
-                    modalId={'setChannelHeader'}
                 >
                     <EditIcon/>
                     {message}

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -236,7 +236,6 @@ export default class PostInfo extends React.PureComponent {
         if (post.props && post.props.card) {
             postInfoIcon = (
                 <OverlayTrigger
-                    trigger={['hover', 'focus']}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='top'
                     overlay={

--- a/components/post_view/post_reaction/__snapshots__/post_reaction.test.jsx.snap
+++ b/components/post_view/post_reaction/__snapshots__/post_reaction.test.jsx.snap
@@ -22,43 +22,43 @@ exports[`components/post_view/PostReaction should match snapshot 1`] = `
       target={[MockFunction]}
       topOffset={-7}
     />
-    <OverlayTrigger
-      className="hidden-xs"
-      defaultOverlayShown={false}
-      delayShow={500}
-      overlay={
-        <Tooltip
-          bsClass="tooltip"
-          className="hidden-xs"
-          id="reaction-icon-tooltip"
-          placement="right"
-        >
-          <FormattedMessage
-            defaultMessage="Add Reaction"
-            id="post_info.tooltip.add_reactions"
-            values={Object {}}
-          />
-        </Tooltip>
-      }
-      placement="top"
-      trigger={
-        Array [
-          "hover",
-          "click",
-        ]
-      }
+    <button
+      aria-label="add reaction"
+      className="reacticon__container color--link style--none"
+      id="CENTER_reaction_post_id_1"
+      onClick={[MockFunction]}
     >
-      <button
-        aria-label="add reaction"
-        className="reacticon__container color--link style--none"
-        id="CENTER_reaction_post_id_1"
-        onClick={[MockFunction]}
+      <OverlayTrigger
+        className="hidden-xs"
+        defaultOverlayShown={false}
+        delayShow={500}
+        overlay={
+          <Tooltip
+            bsClass="tooltip"
+            className="hidden-xs"
+            id="reaction-icon-tooltip"
+            placement="right"
+          >
+            <FormattedMessage
+              defaultMessage="Add Reaction"
+              id="post_info.tooltip.add_reactions"
+              values={Object {}}
+            />
+          </Tooltip>
+        }
+        placement="top"
+        trigger={
+          Array [
+            "hover",
+            "focus",
+          ]
+        }
       >
         <EmojiIcon
           className="icon icon--emoji"
         />
-      </button>
-    </OverlayTrigger>
+      </OverlayTrigger>
+    </button>
   </div>
 </Connect(ChannelPermissionGate)>
 `;

--- a/components/post_view/post_reaction/post_reaction.jsx
+++ b/components/post_view/post_reaction/post_reaction.jsx
@@ -76,32 +76,31 @@ export default class PostReaction extends React.PureComponent {
                         spaceRequiredAbove={spaceRequiredAbove}
                         spaceRequiredBelow={spaceRequiredBelow}
                     />
-                    <OverlayTrigger
-                        className='hidden-xs'
-                        trigger={['hover', 'click']}
-                        delayShow={500}
-                        placement='top'
-                        overlay={
-                            <Tooltip
-                                id='reaction-icon-tooltip'
-                                className='hidden-xs'
-                            >
-                                <FormattedMessage
-                                    id='post_info.tooltip.add_reactions'
-                                    defaultMessage='Add Reaction'
-                                />
-                            </Tooltip>
-                        }
+                    <button
+                        id={`${location}_reaction_${postId}`}
+                        aria-label={localizeMessage('post_info.tooltip.add_reactions', 'Add Reaction').toLowerCase()}
+                        className='reacticon__container color--link style--none'
+                        onClick={this.props.toggleEmojiPicker}
                     >
-                        <button
-                            id={`${location}_reaction_${postId}`}
-                            aria-label={localizeMessage('post_info.tooltip.add_reactions', 'Add Reaction').toLowerCase()}
-                            className='reacticon__container color--link style--none'
-                            onClick={this.props.toggleEmojiPicker}
+                        <OverlayTrigger
+                            className='hidden-xs'
+                            delayShow={500}
+                            placement='top'
+                            overlay={
+                                <Tooltip
+                                    id='reaction-icon-tooltip'
+                                    className='hidden-xs'
+                                >
+                                    <FormattedMessage
+                                        id='post_info.tooltip.add_reactions'
+                                        defaultMessage='Add Reaction'
+                                    />
+                                </Tooltip>
+                            }
                         >
                             <EmojiIcon className='icon icon--emoji'/>
-                        </button>
-                    </OverlayTrigger>
+                        </OverlayTrigger>
+                    </button>
                 </div>
             </ChannelPermissionGate>
         );

--- a/components/post_view/reaction/__snapshots__/reaction.test.jsx.snap
+++ b/components/post_view/reaction/__snapshots__/reaction.test.jsx.snap
@@ -1,307 +1,315 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/post_view/Reaction should disable add reaction when you do not have permissions 1`] = `
-<OverlayTrigger
-  defaultOverlayShown={false}
-  delayShow={1000}
-  onEnter={[Function]}
-  overlay={
-    <Tooltip
-      bsClass="tooltip"
-      id="post_id_1-smile-reaction"
-      placement="right"
-    >
-      <FormattedMessage
-        defaultMessage="{users} {reactionVerb} with {emoji}"
-        id="reaction.reacted"
-        values={
-          Object {
-            "emoji": <b>
-              :smile:
-            </b>,
-            "reactionVerb": <FormattedMessage
-              defaultMessage="reacted"
-              id="reaction.reactionVerb.users"
-              values={Object {}}
-            />,
-            "users": <b>
-              <FormattedMessage
-                defaultMessage="{users} and {otherUsers, number} other {otherUsers, plural, one {user} other {users}}"
-                id="reaction.usersAndOthersReacted"
-                values={
-                  Object {
-                    "otherUsers": 2,
-                    "users": "username_2",
+<button
+  aria-label="react with smile"
+  className="style--none post-reaction post-reaction--read-only"
+  id="postReaction-post_id_1-smile"
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={1000}
+    onEnter={[Function]}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="post_id_1-smile-reaction"
+        placement="right"
+      >
+        <FormattedMessage
+          defaultMessage="{users} {reactionVerb} with {emoji}"
+          id="reaction.reacted"
+          values={
+            Object {
+              "emoji": <b>
+                :smile:
+              </b>,
+              "reactionVerb": <FormattedMessage
+                defaultMessage="reacted"
+                id="reaction.reactionVerb.users"
+                values={Object {}}
+              />,
+              "users": <b>
+                <FormattedMessage
+                  defaultMessage="{users} and {otherUsers, number} other {otherUsers, plural, one {user} other {users}}"
+                  id="reaction.usersAndOthersReacted"
+                  values={
+                    Object {
+                      "otherUsers": 2,
+                      "users": "username_2",
+                    }
                   }
-                }
-              />
-            </b>,
+                />
+              </b>,
+            }
+          }
+        />
+        <br />
+      </Tooltip>
+    }
+    placement="top"
+    shouldUpdatePosition={true}
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <span>
+      <span
+        className="post-reaction__emoji emoticon"
+        style={
+          Object {
+            "backgroundImage": "url(emoji_image_url)",
           }
         }
       />
-      <br />
-    </Tooltip>
-  }
-  placement="top"
-  shouldUpdatePosition={true}
-  trigger={
-    Array [
-      "hover",
-      "click",
-    ]
-  }
->
-  <button
-    aria-label="react with smile"
-    className="style--none post-reaction post-reaction--read-only"
-    id="postReaction-post_id_1-smile"
-  >
-    <span
-      className="post-reaction__emoji emoticon"
-      style={
-        Object {
-          "backgroundImage": "url(emoji_image_url)",
-        }
-      }
-    />
-    <span
-      className="post-reaction__count"
-    >
-      2
+      <span
+        className="post-reaction__count"
+      >
+        2
+      </span>
     </span>
-  </button>
-</OverlayTrigger>
+  </OverlayTrigger>
+</button>
 `;
 
 exports[`components/post_view/Reaction should disable remove reaction when you do not have permissions 1`] = `
-<OverlayTrigger
-  defaultOverlayShown={false}
-  delayShow={1000}
-  onEnter={[Function]}
-  overlay={
-    <Tooltip
-      bsClass="tooltip"
-      id="post_id_1-smile-reaction"
-      placement="right"
-    >
-      <FormattedMessage
-        defaultMessage="{users} {reactionVerb} with {emoji}"
-        id="reaction.reacted"
-        values={
-          Object {
-            "emoji": <b>
-              :smile:
-            </b>,
-            "reactionVerb": <FormattedMessage
-              defaultMessage="reacted"
-              id="reaction.reactionVerb.youAndUsers"
-              values={Object {}}
-            />,
-            "users": <b>
-              <FormattedMessage
-                defaultMessage="{users} and {otherUsers, number} other {otherUsers, plural, one {user} other {users}}"
-                id="reaction.usersAndOthersReacted"
-                values={
-                  Object {
-                    "otherUsers": 2,
-                    "users": "You",
+<button
+  aria-label="react with smile"
+  className="style--none post-reaction post-reaction--read-only post-reaction--current-user"
+  id="postReaction-post_id_1-smile"
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={1000}
+    onEnter={[Function]}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="post_id_1-smile-reaction"
+        placement="right"
+      >
+        <FormattedMessage
+          defaultMessage="{users} {reactionVerb} with {emoji}"
+          id="reaction.reacted"
+          values={
+            Object {
+              "emoji": <b>
+                :smile:
+              </b>,
+              "reactionVerb": <FormattedMessage
+                defaultMessage="reacted"
+                id="reaction.reactionVerb.youAndUsers"
+                values={Object {}}
+              />,
+              "users": <b>
+                <FormattedMessage
+                  defaultMessage="{users} and {otherUsers, number} other {otherUsers, plural, one {user} other {users}}"
+                  id="reaction.usersAndOthersReacted"
+                  values={
+                    Object {
+                      "otherUsers": 2,
+                      "users": "You",
+                    }
                   }
-                }
-              />
-            </b>,
+                />
+              </b>,
+            }
+          }
+        />
+        <br />
+      </Tooltip>
+    }
+    placement="top"
+    shouldUpdatePosition={true}
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <span>
+      <span
+        className="post-reaction__emoji emoticon"
+        style={
+          Object {
+            "backgroundImage": "url(emoji_image_url)",
           }
         }
       />
-      <br />
-    </Tooltip>
-  }
-  placement="top"
-  shouldUpdatePosition={true}
-  trigger={
-    Array [
-      "hover",
-      "click",
-    ]
-  }
->
-  <button
-    aria-label="react with smile"
-    className="style--none post-reaction post-reaction--read-only post-reaction--current-user"
-    id="postReaction-post_id_1-smile"
-  >
-    <span
-      className="post-reaction__emoji emoticon"
-      style={
-        Object {
-          "backgroundImage": "url(emoji_image_url)",
-        }
-      }
-    />
-    <span
-      className="post-reaction__count"
-    >
-      2
+      <span
+        className="post-reaction__count"
+      >
+        2
+      </span>
     </span>
-  </button>
-</OverlayTrigger>
+  </OverlayTrigger>
+</button>
 `;
 
 exports[`components/post_view/Reaction should match snapshot 1`] = `
-<OverlayTrigger
-  defaultOverlayShown={false}
-  delayShow={1000}
-  onEnter={[Function]}
-  overlay={
-    <Tooltip
-      bsClass="tooltip"
-      id="post_id_1-smile-reaction"
-      placement="right"
-    >
-      <FormattedMessage
-        defaultMessage="{users} {reactionVerb} with {emoji}"
-        id="reaction.reacted"
-        values={
-          Object {
-            "emoji": <b>
-              :smile:
-            </b>,
-            "reactionVerb": <FormattedMessage
-              defaultMessage="reacted"
-              id="reaction.reactionVerb.users"
-              values={Object {}}
-            />,
-            "users": <b>
-              <FormattedMessage
-                defaultMessage="{users} and {otherUsers, number} other {otherUsers, plural, one {user} other {users}}"
-                id="reaction.usersAndOthersReacted"
-                values={
-                  Object {
-                    "otherUsers": 2,
-                    "users": "username_2",
+<button
+  aria-label="react with smile"
+  className="style--none post-reaction"
+  id="postReaction-post_id_1-smile"
+  onClick={[Function]}
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={1000}
+    onEnter={[Function]}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="post_id_1-smile-reaction"
+        placement="right"
+      >
+        <FormattedMessage
+          defaultMessage="{users} {reactionVerb} with {emoji}"
+          id="reaction.reacted"
+          values={
+            Object {
+              "emoji": <b>
+                :smile:
+              </b>,
+              "reactionVerb": <FormattedMessage
+                defaultMessage="reacted"
+                id="reaction.reactionVerb.users"
+                values={Object {}}
+              />,
+              "users": <b>
+                <FormattedMessage
+                  defaultMessage="{users} and {otherUsers, number} other {otherUsers, plural, one {user} other {users}}"
+                  id="reaction.usersAndOthersReacted"
+                  values={
+                    Object {
+                      "otherUsers": 2,
+                      "users": "username_2",
+                    }
                   }
-                }
-              />
-            </b>,
+                />
+              </b>,
+            }
+          }
+        />
+        <br />
+        <FormattedMessage
+          defaultMessage="(click to add)"
+          id="reaction.clickToAdd"
+          values={Object {}}
+        />
+      </Tooltip>
+    }
+    placement="top"
+    shouldUpdatePosition={true}
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <span>
+      <span
+        className="post-reaction__emoji emoticon"
+        style={
+          Object {
+            "backgroundImage": "url(emoji_image_url)",
           }
         }
       />
-      <br />
-      <FormattedMessage
-        defaultMessage="(click to add)"
-        id="reaction.clickToAdd"
-        values={Object {}}
-      />
-    </Tooltip>
-  }
-  placement="top"
-  shouldUpdatePosition={true}
-  trigger={
-    Array [
-      "hover",
-      "click",
-    ]
-  }
->
-  <button
-    aria-label="react with smile"
-    className="style--none post-reaction"
-    id="postReaction-post_id_1-smile"
-    onClick={[Function]}
-  >
-    <span
-      className="post-reaction__emoji emoticon"
-      style={
-        Object {
-          "backgroundImage": "url(emoji_image_url)",
-        }
-      }
-    />
-    <span
-      className="post-reaction__count"
-    >
-      2
+      <span
+        className="post-reaction__count"
+      >
+        2
+      </span>
     </span>
-  </button>
-</OverlayTrigger>
+  </OverlayTrigger>
+</button>
 `;
 
 exports[`components/post_view/Reaction should match snapshot when a current user reacted to a post 1`] = `
-<OverlayTrigger
-  defaultOverlayShown={false}
-  delayShow={1000}
-  onEnter={[Function]}
-  overlay={
-    <Tooltip
-      bsClass="tooltip"
-      id="post_id_1-smile-reaction"
-      placement="right"
-    >
-      <FormattedMessage
-        defaultMessage="{users} {reactionVerb} with {emoji}"
-        id="reaction.reacted"
-        values={
-          Object {
-            "emoji": <b>
-              :smile:
-            </b>,
-            "reactionVerb": <FormattedMessage
-              defaultMessage="reacted"
-              id="reaction.reactionVerb.youAndUsers"
-              values={Object {}}
-            />,
-            "users": <b>
-              <FormattedMessage
-                defaultMessage="{users} and {otherUsers, number} other {otherUsers, plural, one {user} other {users}}"
-                id="reaction.usersAndOthersReacted"
-                values={
-                  Object {
-                    "otherUsers": 1,
-                    "users": "You",
+<button
+  aria-label="remove reaction smile"
+  className="style--none post-reaction post-reaction--current-user"
+  id="postReaction-post_id_1-smile"
+  onClick={[Function]}
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    delayShow={1000}
+    onEnter={[Function]}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="post_id_1-smile-reaction"
+        placement="right"
+      >
+        <FormattedMessage
+          defaultMessage="{users} {reactionVerb} with {emoji}"
+          id="reaction.reacted"
+          values={
+            Object {
+              "emoji": <b>
+                :smile:
+              </b>,
+              "reactionVerb": <FormattedMessage
+                defaultMessage="reacted"
+                id="reaction.reactionVerb.youAndUsers"
+                values={Object {}}
+              />,
+              "users": <b>
+                <FormattedMessage
+                  defaultMessage="{users} and {otherUsers, number} other {otherUsers, plural, one {user} other {users}}"
+                  id="reaction.usersAndOthersReacted"
+                  values={
+                    Object {
+                      "otherUsers": 1,
+                      "users": "You",
+                    }
                   }
-                }
-              />
-            </b>,
+                />
+              </b>,
+            }
+          }
+        />
+        <br />
+        <FormattedMessage
+          defaultMessage="(click to remove)"
+          id="reaction.clickToRemove"
+          values={Object {}}
+        />
+      </Tooltip>
+    }
+    placement="top"
+    shouldUpdatePosition={true}
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <span>
+      <span
+        className="post-reaction__emoji emoticon"
+        style={
+          Object {
+            "backgroundImage": "url(emoji_image_url)",
           }
         }
       />
-      <br />
-      <FormattedMessage
-        defaultMessage="(click to remove)"
-        id="reaction.clickToRemove"
-        values={Object {}}
-      />
-    </Tooltip>
-  }
-  placement="top"
-  shouldUpdatePosition={true}
-  trigger={
-    Array [
-      "hover",
-      "click",
-    ]
-  }
->
-  <button
-    aria-label="remove reaction smile"
-    className="style--none post-reaction post-reaction--current-user"
-    id="postReaction-post_id_1-smile"
-    onClick={[Function]}
-  >
-    <span
-      className="post-reaction__emoji emoticon"
-      style={
-        Object {
-          "backgroundImage": "url(emoji_image_url)",
-        }
-      }
-    />
-    <span
-      className="post-reaction__count"
-    >
-      2
+      <span
+        className="post-reaction__count"
+      >
+        2
+      </span>
     </span>
-  </button>
-</OverlayTrigger>
+  </OverlayTrigger>
+</button>
 `;
 
 exports[`components/post_view/Reaction should return null/empty if no emojiImageUrl 1`] = `""`;

--- a/components/post_view/reaction/reaction.jsx
+++ b/components/post_view/reaction/reaction.jsx
@@ -235,37 +235,38 @@ export default class Reaction extends React.PureComponent {
         }
 
         return (
-            <OverlayTrigger
-                trigger={['hover', 'click']}
-                delayShow={1000}
-                placement='top'
-                shouldUpdatePosition={true}
-                overlay={
-                    <Tooltip id={`${this.props.post.id}-${this.props.emojiName}-reaction`}>
-                        {tooltip}
-                        <br/>
-                        {clickTooltip}
-                    </Tooltip>
-                }
-                onEnter={this.loadMissingProfiles}
+            <button
+                id={`postReaction-${this.props.post.id}-${this.props.emojiName}`}
+                aria-label={ariaLabelEmoji}
+                className={`style--none ${className}`}
+                onClick={handleClick}
             >
-                <button
-                    id={`postReaction-${this.props.post.id}-${this.props.emojiName}`}
-                    aria-label={ariaLabelEmoji}
-                    className={`style--none ${className}`}
-                    onClick={handleClick}
+                <OverlayTrigger
+                    delayShow={1000}
+                    placement='top'
+                    shouldUpdatePosition={true}
+                    overlay={
+                        <Tooltip id={`${this.props.post.id}-${this.props.emojiName}-reaction`}>
+                            {tooltip}
+                            <br/>
+                            {clickTooltip}
+                        </Tooltip>
+                    }
+                    onEnter={this.loadMissingProfiles}
                 >
-                    <span
-                        className='post-reaction__emoji emoticon'
-                        style={{backgroundImage: 'url(' + this.props.emojiImageUrl + ')'}}
-                    />
-                    <span
-                        className='post-reaction__count'
-                    >
-                        {this.props.reactionCount}
+                    <span>
+                        <span
+                            className='post-reaction__emoji emoticon'
+                            style={{backgroundImage: 'url(' + this.props.emojiImageUrl + ')'}}
+                        />
+                        <span
+                            className='post-reaction__count'
+                        >
+                            {this.props.reactionCount}
+                        </span>
                     </span>
-                </button>
-            </OverlayTrigger>
+                </OverlayTrigger>
+            </button>
         );
     }
 }

--- a/components/post_view/reaction_list/reaction_list.jsx
+++ b/components/post_view/reaction_list/reaction_list.jsx
@@ -150,7 +150,6 @@ export default class ReactionList extends React.PureComponent {
                         topOffset={-5}
                     />
                     <OverlayTrigger
-                        trigger={['hover', 'focus']}
                         placement='top'
                         delayShow={Constants.OVERLAY_TIME_DELAY}
                         overlay={addReactionTooltip}

--- a/components/rename_channel_modal/rename_channel_modal.jsx
+++ b/components/rename_channel_modal/rename_channel_modal.jsx
@@ -313,7 +313,6 @@ export class RenameChannelModal extends React.PureComponent {
 
                             <div className='input-group input-group--limit'>
                                 <OverlayTrigger
-                                    trigger={['hover', 'focus']}
                                     delayShow={Constants.OVERLAY_TIME_DELAY}
                                     placement='top'
                                     overlay={urlTooltip}

--- a/components/rhs_card_header/rhs_card_header.jsx
+++ b/components/rhs_card_header/rhs_card_header.jsx
@@ -115,7 +115,6 @@ export default class RhsCardHeader extends React.Component {
                     className='sidebar--right__back'
                 >
                     <OverlayTrigger
-                        trigger={['hover', 'focus']}
                         delayShow={Constants.OVERLAY_TIME_DELAY}
                         placement='top'
                         overlay={backToResultsTooltip}
@@ -153,7 +152,6 @@ export default class RhsCardHeader extends React.Component {
                         onClick={this.props.actions.toggleRhsExpanded}
                     >
                         <OverlayTrigger
-                            trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='top'
                             overlay={expandSidebarTooltip}
@@ -171,7 +169,6 @@ export default class RhsCardHeader extends React.Component {
                             </FormattedMessage>
                         </OverlayTrigger>
                         <OverlayTrigger
-                            trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='top'
                             overlay={shrinkSidebarTooltip}
@@ -196,7 +193,6 @@ export default class RhsCardHeader extends React.Component {
                         onClick={this.props.actions.closeRightHandSide}
                     >
                         <OverlayTrigger
-                            trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='top'
                             overlay={closeSidebarTooltip}

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -384,7 +384,6 @@ export default class RhsComment extends React.PureComponent {
         if (post.props && post.props.card) {
             postInfoIcon = (
                 <OverlayTrigger
-                    trigger={['hover', 'focus']}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='top'
                     overlay={

--- a/components/rhs_header_post/rhs_header_post.jsx
+++ b/components/rhs_header_post/rhs_header_post.jsx
@@ -117,7 +117,6 @@ export default class RhsHeaderPost extends React.Component {
                     className='sidebar--right__back'
                 >
                     <OverlayTrigger
-                        trigger={['hover', 'focus']}
                         delayShow={Constants.OVERLAY_TIME_DELAY}
                         placement='top'
                         overlay={backToResultsTooltip}
@@ -155,7 +154,6 @@ export default class RhsHeaderPost extends React.Component {
                         onClick={this.props.actions.toggleRhsExpanded}
                     >
                         <OverlayTrigger
-                            trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='top'
                             overlay={expandSidebarTooltip}
@@ -173,7 +171,6 @@ export default class RhsHeaderPost extends React.Component {
                             </FormattedMessage>
                         </OverlayTrigger>
                         <OverlayTrigger
-                            trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='top'
                             overlay={shrinkSidebarTooltip}
@@ -200,7 +197,6 @@ export default class RhsHeaderPost extends React.Component {
                     >
 
                         <OverlayTrigger
-                            trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='top'
                             overlay={closeSidebarTooltip}

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -281,7 +281,6 @@ export default class RhsRootPost extends React.PureComponent {
         if (this.props.post.props && this.props.post.props.card) {
             postInfoIcon = (
                 <OverlayTrigger
-                    trigger={['hover', 'focus']}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='top'
                     overlay={

--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -284,7 +284,6 @@ export default class SearchBar extends React.Component {
                                 onClick={this.handleClear}
                             >
                                 <OverlayTrigger
-                                    trigger={['hover', 'focus']}
                                     delayShow={Constants.OVERLAY_TIME_DELAY}
                                     placement='bottom'
                                     overlay={searchClearTooltip}

--- a/components/search_results_header/search_results_header.jsx
+++ b/components/search_results_header/search_results_header.jsx
@@ -56,7 +56,6 @@ export default class SearchResultsHeader extends React.Component {
                         onClick={this.props.actions.toggleRhsExpanded}
                     >
                         <OverlayTrigger
-                            trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='top'
                             overlay={expandSidebarTooltip}
@@ -74,7 +73,6 @@ export default class SearchResultsHeader extends React.Component {
                             </FormattedMessage>
                         </OverlayTrigger>
                         <OverlayTrigger
-                            trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='top'
                             overlay={shrinkSidebarTooltip}
@@ -100,7 +98,6 @@ export default class SearchResultsHeader extends React.Component {
                         onClick={this.props.actions.closeRightHandSide}
                     >
                         <OverlayTrigger
-                            trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='top'
                             overlay={closeSidebarTooltip}

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -247,7 +247,6 @@ export default class SearchResultsItem extends React.PureComponent {
             if (post.props && post.props.card) {
                 postInfoIcon = (
                     <OverlayTrigger
-                        trigger={['hover', 'focus']}
                         delayShow={Constants.OVERLAY_TIME_DELAY}
                         placement='top'
                         overlay={

--- a/components/select_team/components/__snapshots__/select_team_item.test.jsx.snap
+++ b/components/select_team/components/__snapshots__/select_team_item.test.jsx.snap
@@ -303,7 +303,6 @@ exports[`components/select_team/components/SelectTeamItem should match snapshot,
                   Array [
                     "hover",
                     "focus",
-                    "click",
                   ]
                 }
               >
@@ -352,7 +351,6 @@ exports[`components/select_team/components/SelectTeamItem should match snapshot,
       Array [
         "hover",
         "focus",
-        "click",
       ]
     }
   >

--- a/components/select_team/components/select_team_item.jsx
+++ b/components/select_team/components/select_team_item.jsx
@@ -41,7 +41,6 @@ export default class SelectTeamItem extends React.PureComponent {
 
         return (
             <OverlayTrigger
-                trigger={['hover', 'focus', 'click']}
                 delayShow={1000}
                 placement='top'
                 overlay={descriptionTooltip}

--- a/components/setting_picture.jsx
+++ b/components/setting_picture.jsx
@@ -181,7 +181,6 @@ export default class SettingPicture extends Component {
                         {imageElement}
                     </div>
                     <OverlayTrigger
-                        trigger={['hover', 'focus']}
                         delayShow={Constants.OVERLAY_TIME_DELAY}
                         placement='right'
                         overlay={(

--- a/components/sidebar/channel_create.jsx
+++ b/components/sidebar/channel_create.jsx
@@ -19,16 +19,11 @@ export default class ChannelCreate extends React.PureComponent {
         canCreatePrivateChannel: PropTypes.bool.isRequired,
     };
 
-    getTooltipTriggers = () => {
-        return ['hover', 'click'];
-    };
-
     renderPublic = () => {
         if (!this.props.canCreatePublicChannel) {
             return null;
         }
 
-        const tooltipTriggers = this.getTooltipTriggers();
         const ariaLabelPublic = `${Utils.localizeMessage('sidebar.createChannel', 'Create new public channel').toLowerCase()}`;
 
         const tooltip = (
@@ -41,22 +36,21 @@ export default class ChannelCreate extends React.PureComponent {
         );
 
         return (
-            <OverlayTrigger
-                trigger={tooltipTriggers}
-                delayShow={500}
-                placement='top'
-                overlay={tooltip}
+            <button
+                id='createPublicChannel'
+                aria-label={ariaLabelPublic}
+                type='button'
+                className='add-channel-btn cursor--pointer style--none'
+                onClick={this.props.createPublicChannel}
             >
-                <button
-                    id='createPublicChannel'
-                    aria-label={ariaLabelPublic}
-                    type='button'
-                    className='add-channel-btn cursor--pointer style--none'
-                    onClick={this.props.createPublicChannel}
+                <OverlayTrigger
+                    delayShow={500}
+                    placement='top'
+                    overlay={tooltip}
                 >
-                    {'+'}
-                </button>
-            </OverlayTrigger>
+                    <span>{'+'}</span>
+                </OverlayTrigger>
+            </button>
         );
     };
 
@@ -65,7 +59,6 @@ export default class ChannelCreate extends React.PureComponent {
             return null;
         }
 
-        const tooltipTriggers = this.getTooltipTriggers();
         const ariaLabelPrivate = `${Utils.localizeMessage('sidebar.createGroup', 'Create new private channel').toLowerCase()}`;
 
         const tooltip = (
@@ -78,27 +71,25 @@ export default class ChannelCreate extends React.PureComponent {
         );
 
         return (
-            <OverlayTrigger
-                trigger={tooltipTriggers}
-                delayShow={500}
-                placement='top'
-                overlay={tooltip}
+            <button
+                id='createPrivateChannel'
+                aria-label={ariaLabelPrivate}
+                type='button'
+                className='add-channel-btn cursor--pointer style--none'
+                onClick={this.props.createPrivateChannel}
             >
-                <button
-                    id='createPrivateChannel'
-                    aria-label={ariaLabelPrivate}
-                    type='button'
-                    className='add-channel-btn cursor--pointer style--none'
-                    onClick={this.props.createPrivateChannel}
+                <OverlayTrigger
+                    delayShow={500}
+                    placement='top'
+                    overlay={tooltip}
                 >
-                    {'+'}
-                </button>
-            </OverlayTrigger>
+                    <span>{'+'}</span>
+                </OverlayTrigger>
+            </button>
         );
     };
 
     renderDirect = () => {
-        const tooltipTriggers = this.getTooltipTriggers();
         const ariaLabelDM = Utils.localizeMessage('sidebar.createDirectMessage', 'Create new direct message').toLowerCase();
         const tooltip = (
             <Tooltip
@@ -113,27 +104,25 @@ export default class ChannelCreate extends React.PureComponent {
         );
 
         return (
-            <OverlayTrigger
-                trigger={tooltipTriggers}
-                className='hidden-xs'
-                delayShow={500}
-                placement='top'
-                overlay={tooltip}
+            <button
+                id='addDirectChannel'
+                aria-label={ariaLabelDM}
+                className='add-channel-btn cursor--pointer style--none'
+                onClick={this.props.createDirectMessage}
             >
-                <button
-                    id='addDirectChannel'
-                    aria-label={ariaLabelDM}
-                    className='add-channel-btn cursor--pointer style--none'
-                    onClick={this.props.createDirectMessage}
+                <OverlayTrigger
+                    className='hidden-xs'
+                    delayShow={500}
+                    placement='top'
+                    overlay={tooltip}
                 >
-                    {'+'}
-                </button>
-            </OverlayTrigger>
+                    <span>{'+'}</span>
+                </OverlayTrigger>
+            </button>
         );
     };
 
     renderCombined = () => {
-        const tooltipTriggers = this.getTooltipTriggers();
         const {canCreatePublicChannel, canCreatePrivateChannel} = this.props;
 
         if (canCreatePublicChannel && !canCreatePrivateChannel) {
@@ -161,21 +150,20 @@ export default class ChannelCreate extends React.PureComponent {
         );
 
         return (
-            <OverlayTrigger
-                trigger={tooltipTriggers}
-                className='hidden-xs'
-                delayShow={500}
-                placement='top'
-                overlay={tooltip}
+            <button
+                type='button'
+                className='add-channel-btn cursor--pointer style--none'
+                onClick={this.props.createPublicDirectChannel}
             >
-                <button
-                    type='button'
-                    className='add-channel-btn cursor--pointer style--none'
-                    onClick={this.props.createPublicDirectChannel}
+                <OverlayTrigger
+                    className='hidden-xs'
+                    delayShow={500}
+                    placement='top'
+                    overlay={tooltip}
                 >
-                    {'+'}
-                </button>
-            </OverlayTrigger>
+                    <span>{'+'}</span>
+                </OverlayTrigger>
+            </button>
         );
     };
 

--- a/components/sidebar/header/sidebar_header_dropdown_button.jsx
+++ b/components/sidebar/header/sidebar_header_dropdown_button.jsx
@@ -50,7 +50,6 @@ export default class SidebarHeaderDropdownButton extends React.PureComponent {
         if (this.props.teamDescription) {
             teamNameWithToolTip = (
                 <OverlayTrigger
-                    trigger={['hover', 'focus']}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='bottom'
                     overlay={<Tooltip id='team-name__tooltip'>{this.props.teamDescription}</Tooltip>}
@@ -68,7 +67,6 @@ export default class SidebarHeaderDropdownButton extends React.PureComponent {
             >
                 {tutorialTip}
                 <OverlayTrigger
-                    trigger={['hover', 'focus']}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='right'
                     overlay={mainMenuToolTip}

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
@@ -39,8 +39,6 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
         channelIsArchived: PropTypes.bool.isRequired,
     }
 
-    overlayTriggerAttr = ['hover', 'focus']
-
     trackChannelSelectedEvent = () => {
         mark('SidebarChannelLink#click');
         trackEvent('ui', 'ui_channel_selected');
@@ -154,7 +152,6 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
             );
             element = (
                 <OverlayTrigger
-                    trigger={this.overlayTriggerAttr}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='top'
                     overlay={displayNameToolTip}

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link_close_button.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link_close_button.jsx
@@ -17,8 +17,6 @@ export default class SidebarChannelButtonOrLinkCloseButton extends React.PureCom
         badge: PropTypes.bool,
     }
 
-    overlayTriggerAttr = ['hover', 'focus']
-
     handleClose = (e) => {
         e.stopPropagation();
         e.preventDefault();
@@ -51,7 +49,6 @@ export default class SidebarChannelButtonOrLinkCloseButton extends React.PureCom
 
             closeButton = (
                 <OverlayTrigger
-                    trigger={this.overlayTriggerAttr}
                     delayShow={1000}
                     placement='top'
                     overlay={removeTooltip}

--- a/components/team_sidebar/components/team_button.jsx
+++ b/components/team_sidebar/components/team_button.jsx
@@ -112,7 +112,6 @@ export default class TeamButton extends React.Component {
         const toolTip = this.props.tip || localizeMessage('team.button.name_undefined', 'Name undefined');
         const btn = (
             <OverlayTrigger
-                trigger={['hover', 'focus']}
                 delayShow={Constants.OVERLAY_TIME_DELAY}
                 placement={this.props.placement}
                 overlay={

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -306,7 +306,6 @@ export default class CustomThemeChooser extends React.Component {
                                 {codeThemeOptions}
                             </select>
                             <OverlayTrigger
-                                trigger={['hover', 'focus']}
                                 placement='top'
                                 overlay={popoverContent}
                                 ref='headerOverlay'

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -372,16 +372,19 @@
         font-weight: 700;
         text-decoration: none;
         border-radius: 50%;
-        margin: -7px 0;
-        width: 28px;
-        height: 28px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
         line-height: 0;
 
         &:hover {
             color: #666666;
+        }
+
+        span {
+            margin: -7px 0;
+            width: 28px;
+            height: 28px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
         }
     }
 }


### PR DESCRIPTION
#### Summary
MM-16795 - Updating bootstrap tooltips
**We do not need to give the hover and focus to the trigger as that is the default, additionally, I moved the OverlayTriggers in some cases inside the buttons, so I no longer need to have a `click` event for the tooltips.**

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16795