### PR TITLE
[MM-16533] User deactivation does not work when "Disable bot accounts when owner is deactivated" is set to False

### DIFF
--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
@@ -144,10 +144,8 @@ export default class SystemUsersDropdown extends React.PureComponent {
                 Constants.Integrations.START_PAGE_NUM,
                 Constants.Integrations.PAGE_SIZE,
             );
-            this.setState({showDeactivateMemberModal: true});
-        } else {
-            this.setState({showDeactivateMemberModal: true});
         }
+        this.setState({showDeactivateMemberModal: true});
     }
 
     handleDeactivateMember = () => {

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
@@ -140,13 +140,13 @@ export default class SystemUsersDropdown extends React.PureComponent {
     handleShowDeactivateMemberModal = async (e) => {
         e.preventDefault();
         if (this.shouldDisableBotsWhenOwnerIsDeactivated()) {
-            const {data} = await this.props.actions.loadBots(
+            await this.props.actions.loadBots(
                 Constants.Integrations.START_PAGE_NUM,
-                Constants.Integrations.PAGE_SIZE
+                Constants.Integrations.PAGE_SIZE,
             );
-            if (data) {
-                this.setState({loading: false, showDeactivateMemberModal: true});
-            }
+            this.setState({showDeactivateMemberModal: true});
+        } else {
+            this.setState({showDeactivateMemberModal: true});
         }
     }
 


### PR DESCRIPTION
#### Summary
- Should always display `deactivateMemberModal`, no matter what `DisableBotsWhenOwnerIsDeactivated` is set to.
- Fixed another possible bug -- if there was no data returned from a redux action (or no bots?), the `deactivateMemberModal` wouldn't have opened. There's no reason (that I can see) to make that conditional on the returned data.
- Not sure why the community member introduced the `loading` state variable -- it isn't used in the rest of the file. @sudheerDev?

#### Ticket Link
- Fixes [MM-16533](https://mattermost.atlassian.net/browse/MM-16533)

#### Related Pull Requests
#2879 