### PR TITLE
Fix JS error on cannot read property length of undefined (postListIds)

### DIFF
--- a/components/post_view/post_list/post_list_virtualized.jsx
+++ b/components/post_view/post_list/post_list_virtualized.jsx
@@ -163,8 +163,9 @@ export default class PostList extends React.PureComponent {
 
     getSnapshotBeforeUpdate(prevProps) {
         if (this.postListRef && this.postListRef.current) {
-            const postsAddedAtTop = this.props.postListIds.length !== prevProps.postListIds.length && this.props.postListIds[0] === prevProps.postListIds[0];
-            const channelHeaderAdded = this.props.olderPosts.allLoaded !== prevProps.olderPosts.allLoaded;
+            const {olderPosts, postListIds} = this.props;
+            const postsAddedAtTop = postListIds && postListIds.length !== prevProps.postListIds.length && postListIds[0] === prevProps.postListIds[0];
+            const channelHeaderAdded = olderPosts.allLoaded !== prevProps.olderPosts.allLoaded;
             if ((postsAddedAtTop || channelHeaderAdded) && !this.state.atBottom) {
                 const previousScrollTop = this.postListRef.current.scrollTop;
                 const previousScrollHeight = this.postListRef.current.scrollHeight;


### PR DESCRIPTION
#### Summary
Got an error after leaving all teams.  It breaks as all white screen only with console error of:
<img width="557" alt="Screen Shot 2019-07-11 at 11 25 25 PM" src="https://user-images.githubusercontent.com/5334504/61064540-906fa000-a434-11e9-9a9e-dcdd7db1fb15.png"> 

#### Ticket Link
n/a but Cypress test got it [[link to test report](https://build-push.internal.mattermost.com/job/mattermost-ui-testing/job/mattermost-cypress/104/testReport/(root)/TS14633%20Leave%20all%20teams/Teams_Suite_TS14633_Leave_all_teams/)]
