### PR TITLE
MM-16907 White screen when disabling Join/Leave Messages and switching to a specific channel

### DIFF
--- a/components/post_view/post_list_virtualized/index.js
+++ b/components/post_view/post_list_virtualized/index.js
@@ -30,7 +30,7 @@ function makeMapStateToProps() {
             postIds = getPostIdsInChannel(state, ownProps.channelId);
         }
 
-        if (postIds) {
+        if (postIds && postIds.length) {
             postIds = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
             const latestPostId = memoizedGetLatestPostId(postIds);
             const latestPost = getPost(state, latestPostId);


### PR DESCRIPTION
#### Summary
Added a check for postIds length before checking for last post in the channel. 

![joinleavecrash](https://user-images.githubusercontent.com/4973621/61158684-55926880-a517-11e9-92fa-bb23fc16f954.jpg)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16907

