### PR TITLE
Fix failing test with interactive menus

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,5 +1,6 @@
 {
     "baseUrl": "http://localhost:8065",
+    "webhookBaseUrl": "http://localhost:3000",
     "viewportWidth": 1300,
     "defaultCommandTimeout": 20000,
     "taskTimeout": 20000,

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,6 +1,5 @@
 {
     "baseUrl": "http://localhost:8065",
-    "webhookBaseUrl": "http://localhost:3000",
     "viewportWidth": 1300,
     "defaultCommandTimeout": 20000,
     "taskTimeout": 20000,
@@ -9,5 +8,8 @@
     "reporterOptions": {
         "mochaFile": "results/results-[hash].xml",
         "toConsole": false
+    },
+    "env": {
+        "webhookBaseUrl": "http://localhost:3000"
     }
 }

--- a/e2e/cypress/integration/interactive_menu/basic_options.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options.js
@@ -27,17 +27,15 @@ let incomingWebhook;
 
 describe('MM-15887 Interactive menus - basic options', () => {
     before(() => {
-        if (process.env.NODE_ENV !== 'qa') {
-            // Set required ServiceSettings
-            const newSettings = {
-                ServiceSettings: {
-                    AllowedUntrustedInternalConnections: 'localhost',
-                    EnablePostUsernameOverride: true,
-                    EnablePostIconOverride: true,
-                },
-            };
-            cy.apiUpdateConfig(newSettings);
-        }
+        // Set required ServiceSettings
+        const newSettings = {
+            ServiceSettings: {
+                AllowedUntrustedInternalConnections: 'localhost',
+                EnablePostUsernameOverride: true,
+                EnablePostIconOverride: true,
+            },
+        };
+        cy.apiUpdateConfig(newSettings);
 
         // # Login as sysadmin and ensure that teammate name display setting us set to default 'username'
         cy.apiLogin('sysadmin');

--- a/e2e/cypress/integration/interactive_menu/basic_options.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options.js
@@ -28,9 +28,13 @@ let incomingWebhook;
 describe('MM-15887 Interactive menus - basic options', () => {
     before(() => {
         if (process.env.NODE_ENV !== 'qa') {
-            // Set AllowedUntrustedInternalConnections to localhost if running in development
+            // Set required ServiceSettings
             const newSettings = {
-                ServiceSettings: {AllowedUntrustedInternalConnections: 'localhost'},
+                ServiceSettings: {
+                    AllowedUntrustedInternalConnections: 'localhost',
+                    EnablePostUsernameOverride: true,
+                    EnablePostIconOverride: true,
+                },
             };
             cy.apiUpdateConfig(newSettings);
         }
@@ -140,7 +144,7 @@ describe('MM-15887 Interactive menus - basic options', () => {
             cy.getLastPostId().then((replyMessageId) => {
                 // * Verify that the reply is in the channel view with matching text
                 cy.get(`#post_${replyMessageId}`).within(() => {
-                    cy.get('.post__link').should('be.visible').and('have.text', 'Commented on sysadmin\'s message: This is attachment pretext with basic options');
+                    cy.get('.post__link').should('be.visible').and('have.text', 'Commented on webhook\'s message: This is attachment pretext with basic options');
                     cy.get(`#postMessageText_${replyMessageId}`).should('be.visible').and('have.text', 'Reply to webhook');
                 });
 

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -22,11 +22,5 @@ module.exports = (on, config) => {
         return args;
     });
 
-    if (process.env.NODE_ENV === 'qa') { // eslint-disable-line no-process-env
-        config.webhookBaseUrl = 'https://cypress.test.mattermost.com/webhook';
-    } else {
-        config.webhookBaseUrl = 'http://localhost:3000';
-    }
-
     return config;
 };

--- a/e2e/cypress/utils/index.js
+++ b/e2e/cypress/utils/index.js
@@ -41,7 +41,7 @@ export function getMessageMenusPayload({dataSource, options} = {}) {
         }
     }
 
-    const callbackUrl = Cypress.config().webhookBaseUrl + '/message_menus';
+    const callbackUrl = Cypress.env().webhookBaseUrl + '/message_menus';
     data.attachments[0].actions[0].integration.url = callbackUrl;
 
     return data;


### PR DESCRIPTION
#### Summary
Fix failing test with interactive menus.

Note: Since the mattermost instance both in local and test server interacts with each other via local network, it's no longer necessary to use full domain name as `webhookBaseUrl ` as it will only complicate things. 

Carlos fixed the webhook server in CI.

#### Ticket Link
n/a
