### PR TITLE
[MM-17003] Fix stuck up/down arrow keys in modals

### DIFF
--- a/utils/a11y_controller.js
+++ b/utils/a11y_controller.js
@@ -70,7 +70,7 @@ export default class A11yController {
     }
 
     get navInProgress() {
-        return this.regions && this.regions.length && this.activeRegion;
+        return this.regions && this.regions.length && this.activeRegion && !this.modalIsOpen && !this.popupIsOpen;
     }
 
     get activeRegionIndex() {


### PR DESCRIPTION
#### Summary
This PR fixes a bug whereby the new accessibility controller doesn't correctly 'turn off' when a modal is open, preventing up/down arrow keys from working in `<textarea>`'s for instance.

#### Ticket Link
[MM-17003](https://mattermost.atlassian.net/browse/MM-17003)

