### PR TITLE
MM-17007 Fix IE11 crash with channel prop error

### DIFF
--- a/components/post_view/post_list_ie/index.js
+++ b/components/post_view/post_list_ie/index.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
-
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {makeGetPostsAroundPost, makeGetPostsInChannel} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
@@ -26,6 +26,7 @@ function makeMapStateToProps() {
             posts: combineUserActivityPosts(posts || []),
             currentUserId: getCurrentUserId(state),
             lastViewedAt: state.views.channel.lastChannelViewTime[ownProps.channelId],
+            channel: getCurrentChannel(state),
         };
     };
 }


### PR DESCRIPTION
#### Summary
Channel prop is required for IE11 which was removed https://github.com/mattermost/mattermost-webapp/pull/3049/files#diff-5d65c7ac490b08b60adf963369908186L58.

The prop wasn't needed for other browsers so instead now adding it to the specific IE file so it can be removed in 5.16v 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17007

