### PR TITLE
removed white background from team icons

### DIFF
--- a/sass/components/_permissions.scss
+++ b/sass/components/_permissions.scss
@@ -355,7 +355,6 @@
         .team-btn__image {
             border-radius: 4px;
             overflow: hidden;
-            background-color: white;
             background-repeat: round;
             background-size: contain;
             height: 100%;

--- a/sass/layout/_team-button.scss
+++ b/sass/layout/_team-button.scss
@@ -61,7 +61,6 @@
     .team-btn__image {
         @include clearfix;
         @include background-size(100% 100%);
-        background-color: $white;
         background-repeat: no-repeat;
         width: 43px;
         height: 100%;


### PR DESCRIPTION
#### Summary
This PR contains the work for removing hard-coded white background from team-icons in the select team sidebar on the left.


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/11621