### PR TITLE
[MM-16534] if user has bots, but the bots are disabled, don't show warning that bots will be disabled

### DIFF
--- a/components/admin_console/system_users/system_users_dropdown/__snapshots__/system_users_dropdown.test.js.snap
+++ b/components/admin_console/system_users/system_users_dropdown/__snapshots__/system_users_dropdown.test.js.snap
@@ -32,7 +32,39 @@ exports[`components/admin_console/system_users/system_users_dropdown/system_user
 </div>
 `;
 
-exports[`components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx renderDeactivateMemberModal should render the bot accounts warning in case the user do has any bot accounts 1`] = `
+exports[`components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx renderDeactivateMemberModal should not render the bot accounts warning. owner_id has no enabled bot accounts 1`] = `
+<div>
+  <InjectIntl(FormattedMarkdownMessage)
+    defaultMessage="This action deactivates {username}. They will be logged out and not have access to any teams or channels on this system.\\\\n"
+    id="deactivate_member_modal.desc"
+    values={
+      Object {
+        "username": "some-user",
+      }
+    }
+  />
+  <InjectIntl(FormattedMarkdownMessage)
+    defaultMessage="Are you sure you want to deactivate {username}?"
+    id="deactivate_member_modal.desc.confirm"
+    values={
+      Object {
+        "username": "some-user",
+      }
+    }
+  />
+  <strong>
+    <br />
+    <br />
+    <FormattedMessage
+      defaultMessage="You must also deactivate this user in the SSO provider or they will be reactivated on next login or sync."
+      id="deactivate_member_modal.sso_warning"
+      values={Object {}}
+    />
+  </strong>
+</div>
+`;
+
+exports[`components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx renderDeactivateMemberModal should render the bot accounts warning. owner_id has enabled bot accounts 1`] = `
 <div>
   <InjectIntl(FormattedMarkdownMessage)
     defaultMessage="This action deactivates {username}.\\\\n \\\\n * They will be logged out and not have access to any teams or channels on this system.\\\\n * Bot accounts they manage will be disabled along with their integrations. To enable them again, go to Integrations > Bot Accounts. [Learn more about bot accounts](!https://mattermost.com/pl/default-bot-accounts).\\\\n \\\\n \\\\n"

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.jsx
@@ -210,7 +210,7 @@ export default class SystemUsersDropdown extends React.PureComponent {
         let messageForUsersWithBotAccounts;
         if (this.shouldDisableBotsWhenOwnerIsDeactivated()) {
             for (const bot of Object.values(this.props.bots)) {
-                if (bot.owner_id === user.id) {
+                if ((bot.owner_id === user.id) && this.state.showDeactivateMemberModal && (bot.delete_at === 0)) {
                     messageForUsersWithBotAccounts = (
                         <FormattedMarkdownMessage
                             id='deactivate_member_modal.desc.for_users_with_bot_accounts'

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.test.js
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.test.js
@@ -145,7 +145,7 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
         expect(modal.prop('message')).toMatchSnapshot();
     });
 
-    test('renderDeactivateMemberModal should render the bot accounts warning in case the user do has any bot accounts', async () => {
+    test('renderDeactivateMemberModal should render the bot accounts warning. owner_id has enabled bot accounts', async () => {
         const overrideProps = {
             config: {
                 ServiceSettings: {
@@ -153,12 +153,33 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
                 },
             },
             bots: {
-                1: {owner_id: '1'},
-                2: {owner_id: '1'},
-                3: {owner_id: 'user_id'},
+                1: {owner_id: '1', delete_at: 0},
+                2: {owner_id: '1', delete_at: 0},
+                3: {owner_id: 'user_id', delete_at: 0},
             },
         };
         const wrapper = shallow(<SystemUsersDropdown {...{...requiredProps, ...overrideProps}}/>);
+        wrapper.setState({showDeactivateMemberModal: true});
+
+        const modal = wrapper.wrap(wrapper.instance().renderDeactivateMemberModal());
+        expect(modal.prop('message')).toMatchSnapshot();
+    });
+
+    test('renderDeactivateMemberModal should not render the bot accounts warning. owner_id has no enabled bot accounts', async () => {
+        const overrideProps = {
+            config: {
+                ServiceSettings: {
+                    DisableBotsWhenOwnerIsDeactivated: true,
+                },
+            },
+            bots: {
+                1: {owner_id: '1', delete_at: 0},
+                2: {owner_id: '1', delete_at: 0},
+                3: {owner_id: 'user_id', delete_at: 1234},
+            },
+        };
+        const wrapper = shallow(<SystemUsersDropdown {...{...requiredProps, ...overrideProps}}/>);
+        wrapper.setState({showDeactivateMemberModal: true});
 
         const modal = wrapper.wrap(wrapper.instance().renderDeactivateMemberModal());
         expect(modal.prop('message')).toMatchSnapshot();


### PR DESCRIPTION
#### Summary
This pull request will change the behavior when a user, that also owns bots is being disabled.

If a user owns bots, and the user is disabled, a warning is shown stating bots will also be disabled.

**Previous functionality**
- Bot warning message is shown regardless if the owner's bots were active or disabled.

**New Functionality**
- Bot warning shown if any of owner's bots are not disabled.
- No bot warning shown if all of owner's bots are disabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16534