### PR TITLE
harden rhs sidebar to a plugin reinstall

### DIFF
--- a/plugins/rhs_plugin/index.js
+++ b/plugins/rhs_plugin/index.js
@@ -12,7 +12,8 @@ function mapStateToProps(state) {
     const rhsPlugins = state.plugins.components.RightHandSidebarComponent;
     const pluginId = getPluginId(state);
 
-    const pluginName = rhsPlugins.find((element) => element.id === pluginId).title;
+    const plugin = rhsPlugins.find((element) => element.id === pluginId);
+    const pluginName = plugin ? plugin.title : '';
 
     return {
         title: pluginName,


### PR DESCRIPTION
#### Summary
When a plugin is uninstalled and reinstalled, an exception can occur
accessing the `title` attribute of a `find` operation that yields no results. I came across this trying to re-deploy the GitHub plugin during local development.

#### Ticket Link
None.