### PR TITLE
MM-15888 Add E2E for interactive dialogs

### DIFF
--- a/components/interactive_dialog/interactive_dialog.jsx
+++ b/components/interactive_dialog/interactive_dialog.jsx
@@ -145,6 +145,7 @@ export default class InteractiveDialog extends React.Component {
         if (iconUrl) {
             icon = (
                 <img
+                    id='interactiveDialogIconUrl'
                     alt={'modal title icon'}
                     className='more-modal__image'
                     width='36'
@@ -156,6 +157,7 @@ export default class InteractiveDialog extends React.Component {
 
         return (
             <Modal
+                id='interactiveDialogModal'
                 dialogClassName='a11y__modal about-modal'
                 show={this.state.show}
                 onHide={this.onHide}
@@ -200,6 +202,7 @@ export default class InteractiveDialog extends React.Component {
                 </Modal.Body>}
                 <Modal.Footer>
                     <button
+                        id='interactiveDialogCancel'
                         type='button'
                         className='btn btn-link cancel-button'
                         onClick={this.onHide}
@@ -210,6 +213,7 @@ export default class InteractiveDialog extends React.Component {
                         />
                     </button>
                     <SpinnerButton
+                        id='interactiveDialogSubmit'
                         type='button'
                         className='btn btn-primary save-button'
                         onClick={this.handleSubmit}

--- a/e2e/cypress/integration/interactive_dialog/interactive_dialog_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/interactive_dialog_spec.js
@@ -1,0 +1,222 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/**
+* Note: This test requires webhook server running. Initiate `npm run start:webhook` to start.
+*/
+
+const webhookUtils = require('../../../utils/webhook_utils');
+
+let createdCommand;
+let fullDialog;
+
+describe('ID15888 Interactive Dialog', () => {
+    before(() => {
+        // Set required ServiceSettings
+        const newSettings = {
+            ServiceSettings: {
+                AllowedUntrustedInternalConnections: 'localhost',
+                EnablePostUsernameOverride: true,
+                EnablePostIconOverride: true,
+            },
+        };
+        cy.apiUpdateConfig(newSettings);
+
+        // # Login as sysadmin and ensure that teammate name display setting us set to default 'username'
+        cy.apiLogin('sysadmin');
+        cy.apiSaveTeammateNameDisplayPreference('username');
+
+        // # Create new team and create command on it
+        cy.apiCreateTeam('test-team', 'Test Team').then((teamResponse) => {
+            const team = teamResponse.body;
+            cy.visit(`/${team.name}`);
+
+            const webhookBaseUrl = Cypress.env().webhookBaseUrl;
+
+            const command = {
+                auto_complete: false,
+                description: 'Test for dialog',
+                display_name: 'Dialog',
+                icon_url: '',
+                method: 'P',
+                team_id: team.id,
+                trigger: 'dialog',
+                url: `${webhookBaseUrl}/dialog_request`,
+                username: '',
+            };
+
+            cy.apiCreateCommand(command).then(({data}) => {
+                createdCommand = data;
+                fullDialog = webhookUtils.getFullDialog(createdCommand.id, webhookBaseUrl);
+            });
+        });
+    });
+
+    it('UI check', () => {
+        // # Post a slash command
+        cy.postMessage(`/${createdCommand.trigger}`);
+
+        // * Verify that the interactive dialog modal open up
+        cy.get('#interactiveDialogModal').should('be.visible').within(() => {
+            // * Verify that the header of modal contains icon URL, title and close button
+            cy.get('.modal-header').should('be.visible').within(($elForm) => {
+                cy.get('#interactiveDialogIconUrl').should('be.visible').and('have.attr', 'src', fullDialog.dialog.icon_url);
+                cy.get('#interactiveDialogModalLabel').should('be.visible').and('have.text', fullDialog.dialog.title);
+                cy.wrap($elForm).find('button.close').should('be.visible').and('contain', '×').and('contain', 'Close');
+
+                cy.get('#interactiveDialogModalLabel').should('be.visible').and('have.text', fullDialog.dialog.title);
+            });
+
+            // * Verify that the body contains all the elements
+            cy.get('.modal-body').should('be.visible').children().each(($elForm, index) => {
+                const element = fullDialog.dialog.elements[index];
+
+                cy.wrap($elForm).find('label.control-label').scrollIntoView().should('be.visible').and('have.text', `${element.display_name} ${element.optional ? '(optional)' : '*'}`);
+
+                if (['someuserselector', 'somechannelselector', 'someoptionselector'].includes(element.name)) {
+                    cy.wrap($elForm).find('input').should('be.visible').and('have.attr', 'autocomplete', 'off').and('have.attr', 'placeholder', element.placeholder);
+                } else {
+                    cy.wrap($elForm).find(`#${element.name}`).should('be.visible').and('have.value', element.default).and('have.attr', 'placeholder', element.placeholder);
+                }
+
+                if (element.help_text) {
+                    cy.wrap($elForm).find('.help-text').should('be.visible').and('have.text', element.help_text);
+                }
+            });
+
+            // * Verify that the footer contains cancel and submit buttons
+            cy.get('.modal-footer').should('be.visible').within(($elForm) => {
+                cy.wrap($elForm).find('#interactiveDialogCancel').should('be.visible').and('have.text', 'Cancel');
+                cy.wrap($elForm).find('#interactiveDialogSubmit').should('be.visible').and('have.text', 'Submit');
+            });
+
+            closeInteractiveDialog();
+        });
+    });
+
+    it('Cancel button works', () => {
+        // # Post a slash command
+        cy.postMessage(`/${createdCommand.trigger}`);
+
+        // * Verify that the interactive dialog modal open up
+        cy.get('#interactiveDialogModal').should('be.visible');
+
+        // # Click cancel from the modal
+        cy.get('#interactiveDialogCancel').click();
+
+        // * Verify that the interactive dialog modal is closed
+        cy.get('#interactiveDialogModal').should('not.be.visible');
+    });
+
+    it('"X" closes the dialog', () => {
+        // # Post a slash command
+        cy.postMessage(`/${createdCommand.trigger}`);
+
+        // * Verify that the interactive dialog modal open up
+        cy.get('#interactiveDialogModal').should('be.visible');
+
+        // # Click "X" button from the modal
+        cy.get('.modal-header').should('be.visible').within(($elForm) => {
+            cy.wrap($elForm).find('button.close').should('be.visible').click();
+        });
+
+        // * Verify that the interactive dialog modal is closed
+        cy.get('#interactiveDialogModal').should('not.be.visible');
+    });
+
+    it('Correct error messages displayed if empty form is submitted', () => {
+        // # Post a slash command
+        cy.postMessage(`/${createdCommand.trigger}`);
+
+        // * Verify that the interactive dialog modal open up
+        cy.get('#interactiveDialogModal').should('be.visible');
+
+        // # Click submit button from the modal
+        cy.get('#interactiveDialogSubmit').click();
+
+        // * Verify that the interactive dialog modal is still open
+        cy.get('#interactiveDialogModal').should('be.visible');
+
+        // * Verify that not optional element without text value shows an error and vice versa
+        cy.get('.modal-body').should('be.visible').children().each(($elForm, index) => {
+            const element = fullDialog.dialog.elements[index];
+
+            if (!element.optional && !element.default) {
+                cy.wrap($elForm).find('div.error-text').scrollIntoView().should('be.visible').and('have.text', 'This field is required.').and('have.css', 'color', 'rgb(253, 89, 96)');
+            } else {
+                cy.wrap($elForm).find('div.error-text').should('not.be.visible');
+            }
+        });
+
+        closeInteractiveDialog();
+    });
+
+    it('Email validation', () => {
+        // # Post a slash command
+        cy.postMessage(`/${createdCommand.trigger}`);
+
+        // * Verify that the interactive dialog modal open up
+        cy.get('#interactiveDialogModal').should('be.visible');
+
+        // # Enter invalid and valid email
+        // Verify that error is: shown for invalid email and not shown for valid email.
+        [
+            {valid: false, value: 'invalid-email'},
+            {valid: true, value: 'test@mattermost.com'},
+        ].forEach((testCase) => {
+            cy.get('#someemail').scrollIntoView().type(testCase.value);
+
+            cy.get('#interactiveDialogSubmit').click();
+
+            cy.get('.modal-body').should('be.visible').children().eq(1).within(($elForm) => {
+                if (testCase.valid) {
+                    cy.wrap($elForm).find('div.error-text').should('not.be.visible');
+                } else {
+                    cy.wrap($elForm).find('div.error-text').should('be.visible').and('have.text', 'Must be a valid email address.').and('have.css', 'color', 'rgb(253, 89, 96)');
+                }
+            });
+        });
+
+        closeInteractiveDialog();
+    });
+
+    it('Number validation', () => {
+        cy.postMessage(`/${createdCommand.trigger}`);
+
+        cy.get('#interactiveDialogModal').should('be.visible');
+
+        // # Enter invalid and valid number
+        // Verify that error is: shown for invalid number and not shown for valid number.
+        [
+            {valid: false, value: 'invalid-number'},
+            {valid: true, value: 12},
+        ].forEach((testCase) => {
+            cy.get('#somenumber').scrollIntoView().type(testCase.value);
+
+            cy.get('#interactiveDialogSubmit').click();
+
+            cy.get('.modal-body').should('be.visible').children().eq(2).within(($elForm) => {
+                if (testCase.valid) {
+                    cy.wrap($elForm).find('div.error-text').should('not.be.visible');
+                } else {
+                    cy.wrap($elForm).find('div.error-text').should('be.visible').and('have.text', 'This field is required.').and('have.css', 'color', 'rgb(253, 89, 96)');
+                }
+            });
+        });
+
+        closeInteractiveDialog();
+    });
+});
+
+function closeInteractiveDialog() {
+    cy.get('.modal-header').should('be.visible').within(($elForm) => {
+        cy.wrap($elForm).find('button.close').should('be.visible').click();
+    });
+    cy.get('#interactiveDialogModal').should('not.be.visible');
+}

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -156,6 +156,30 @@ Cypress.Commands.add('apiPatchChannel', (channelId, channelData) => {
 });
 
 // *****************************************************************************
+// Commands
+// https://api.mattermost.com/#tag/commands
+// *****************************************************************************
+
+/**
+ * Creates a command directly via API
+ * This API assume that the user is logged in and has required permission to create a command
+ * @param {Object} command - command to be created
+ */
+Cypress.Commands.add('apiCreateCommand', (command = {}) => {
+    const options = {
+        url: '/api/v4/commands',
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        method: 'POST',
+        body: command,
+    };
+
+    return cy.request(options).then((response) => {
+        expect(response.status).to.equal(201);
+        return {data: response.body, status: response.status};
+    });
+});
+
+// *****************************************************************************
 // Teams
 // https://api.mattermost.com/#tag/teams
 // *****************************************************************************

--- a/e2e/utils/webhook_utils.js
+++ b/e2e/utils/webhook_utils.js
@@ -1,0 +1,154 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+function getFullDialog(triggerId, webhookBaseUrl) {
+    return {
+        trigger_id: triggerId,
+        url: `${webhookBaseUrl}/dialog_submit`,
+        dialog: {
+            callback_id: 'somecallbackid',
+            title: 'Test Title',
+            icon_url:
+                'http://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
+            elements: [
+                {
+                    display_name: 'Display Name',
+                    name: 'realname',
+                    type: 'text',
+                    subtype: '',
+                    default: 'default text',
+                    placeholder: 'placeholder',
+                    help_text:
+                        'This a regular input in an interactive dialog triggered by a test integration.',
+                    optional: false,
+                    min_length: 0,
+                    max_length: 0,
+                    data_source: '',
+                    options: null,
+                },
+                {
+                    display_name: 'Email',
+                    name: 'someemail',
+                    type: 'text',
+                    subtype: 'email',
+                    default: '',
+                    placeholder: 'placeholder@bladekick.com',
+                    help_text:
+                        'This a regular email input in an interactive dialog triggered by a test integration.',
+                    optional: false,
+                    min_length: 0,
+                    max_length: 0,
+                    data_source: '',
+                    options: null,
+                },
+                {
+                    display_name: 'Number',
+                    name: 'somenumber',
+                    type: 'text',
+                    subtype: 'number',
+                    default: '',
+                    placeholder: '',
+                    help_text: '',
+                    optional: false,
+                    min_length: 0,
+                    max_length: 0,
+                    data_source: '',
+                    options: null,
+                },
+                {
+                    display_name: 'Display Name Long Text Area',
+                    name: 'realnametextarea',
+                    type: 'textarea',
+                    subtype: '',
+                    default: '',
+                    placeholder: 'placeholder',
+                    help_text: '',
+                    optional: true,
+                    min_length: 5,
+                    max_length: 100,
+                    data_source: '',
+                    options: null,
+                },
+                {
+                    display_name: 'User Selector',
+                    name: 'someuserselector',
+                    type: 'select',
+                    subtype: '',
+                    default: '',
+                    placeholder: 'Select a user...',
+                    help_text: '',
+                    optional: false,
+                    min_length: 0,
+                    max_length: 0,
+                    data_source: 'users',
+                    options: null,
+                },
+                {
+                    display_name: 'Channel Selector',
+                    name: 'somechannelselector',
+                    type: 'select',
+                    subtype: '',
+                    default: '',
+                    placeholder: 'Select a channel...',
+                    help_text: 'Choose a channel from the list.',
+                    optional: true,
+                    min_length: 0,
+                    max_length: 0,
+                    data_source: 'channels',
+                    options: null,
+                },
+                {
+                    display_name: 'Option Selector',
+                    name: 'someoptionselector',
+                    type: 'select',
+                    subtype: '',
+                    default: '',
+                    placeholder: 'Select an option...',
+                    help_text: '',
+                    optional: false,
+                    min_length: 0,
+                    max_length: 0,
+                    data_source: '',
+                    options: [
+                        {
+                            text: 'Option1',
+                            value: 'opt1',
+                        },
+                        {
+                            text: 'Option2',
+                            value: 'opt2',
+                        },
+                        {
+                            text: 'Option3',
+                            value: 'opt3',
+                        },
+                    ],
+                },
+            ],
+            submit_label: 'Submit',
+            notify_on_cancel: true,
+            state: 'somestate',
+        },
+    };
+}
+
+function getSimpleDialog(triggerId, webhookBaseUrl) {
+    return {
+        trigger_id: triggerId,
+        url: `${webhookBaseUrl}/dialog_submit`,
+        dialog: {
+            callback_id: 'somecallbackid',
+            title: 'Test Title',
+            icon_url:
+                'http://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
+            submit_label: 'Submit Test',
+            notify_on_cancel: true,
+            state: 'somestate',
+        },
+    };
+}
+
+module.exports = {
+    getFullDialog,
+    getSimpleDialog,
+};

--- a/e2e/webhook_serve.js
+++ b/e2e/webhook_serve.js
@@ -3,6 +3,10 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
+const axios = require('axios');
+
+const webhookUtils = require('./utils/webhook_utils');
+
 const port = 3000;
 
 const server = express();
@@ -13,6 +17,8 @@ process.title = process.argv[2];
 
 server.get('/', (req, res) => res.send('I\'m alive!\n'));
 server.post('/message_menus', postMessageMenus);
+server.post('/dialog_request', onDialogRequest);
+server.post('/dialog_submit', onDialogSubmit);
 
 server.listen(port, () => console.log(`Webhook test server listening on port ${port}!`)); // eslint-disable-line no-console
 
@@ -27,4 +33,42 @@ function postMessageMenus(req, res) {
 
     res.setHeader('Content-Type', 'application/json');
     return res.json(responseData);
+}
+
+async function openDialog(triggerId) {
+    const webhookBaseUrl = process.env.CYPRESS_webhookBaseUrl || 'http://localhost:3000';
+    const dialog = webhookUtils.getFullDialog(triggerId, webhookBaseUrl);
+
+    const baseUrl = process.env.CYPRESS_baseUrl || 'http://localhost:8065';
+    await axios({
+        method: 'post',
+        url: `${baseUrl}/api/v4/actions/dialogs/open`,
+        data: dialog,
+    });
+}
+
+function onDialogRequest(req, res) {
+    const {body} = req;
+    const triggerId = body.trigger_id;
+    if (body.trigger_id) {
+        openDialog(triggerId);
+    }
+
+    res.setHeader('Content-Type', 'application/json');
+    return res.json({text: 'Triggered via slash command!'});
+}
+
+function onDialogSubmit(req, res) {
+    const {body} = req;
+
+    res.setHeader('Content-Type', 'application/json');
+
+    let message;
+    if (body.cancelled) {
+        message = 'Dialog cancelled';
+    } else {
+        message = 'Dialog submitted';
+    }
+
+    return res.json({text: message});
 }


### PR DESCRIPTION
#### Summary
Add tests for interactive dialogs.  This includes the following:
- UI check
- Cancel button works
- "X" closes the dialog
- Correct error messages displayed if empty form is submitted
- Email validation
- Number validation

To follow:
- Selecting a Number with the up/down arrows within the "Number Selector" field
- Individual "User" and "Channel" screens are scrollable
- Dropdown arrow to the right of selector field

Note:  Will submit PR to shared pipelines to add required env variable (`CYPRESS_webhookBaseUrl`)

#### Ticket Link
Jira ticket: [MM-15888](https://mattermost.atlassian.net/browse/MM-15888)

