### PR TITLE
MM-16907 Fix for White screen when disabling Join/Leave Messages and switching to a specific channel

### DIFF
--- a/components/post_view/post_list_virtualized/index.js
+++ b/components/post_view/post_list_virtualized/index.js
@@ -33,9 +33,13 @@ function makeMapStateToProps() {
 
         if (postListChunk && postListChunk.length) {
             postIds = preparePostIdsForPostList(state, {postIds: postListChunk, lastViewedAt, indicateNewMessages: true});
-            const latestPostId = memoizedGetLatestPostId(postIds);
-            const latestPost = getPost(state, latestPostId);
-            latestPostTimeStamp = latestPost.create_at;
+
+            // postListChunk can exist but postIds might be emoty because of filter of join leave messages
+            if (postIds.length) {
+                const latestPostId = memoizedGetLatestPostId(postIds);
+                const latestPost = getPost(state, latestPostId);
+                latestPostTimeStamp = latestPost.create_at;
+            }
         }
 
         return {

--- a/components/post_view/post_list_virtualized/index.js
+++ b/components/post_view/post_list_virtualized/index.js
@@ -22,16 +22,17 @@ function makeMapStateToProps() {
     const preparePostIdsForPostList = makePreparePostIdsForPostList();
     return function mapStateToProps(state, ownProps) {
         let postIds;
+        let postListChunk;
         let latestPostTimeStamp = 0;
         const lastViewedAt = state.views.channel.lastChannelViewTime[ownProps.channelId];
         if (ownProps.focusedPostId) {
-            postIds = getPostIdsAroundPost(state, ownProps.focusedPostId, ownProps.channelId, {postsBeforeCount: -1});
+            postListChunk = getPostIdsAroundPost(state, ownProps.focusedPostId, ownProps.channelId, {postsBeforeCount: -1});
         } else {
-            postIds = getPostIdsInChannel(state, ownProps.channelId);
+            postListChunk = getPostIdsInChannel(state, ownProps.channelId);
         }
 
-        if (postIds && postIds.length) {
-            postIds = preparePostIdsForPostList(state, {postIds, lastViewedAt, indicateNewMessages: true});
+        if (postListChunk && postListChunk.length) {
+            postIds = preparePostIdsForPostList(state, {postIds: postListChunk, lastViewedAt, indicateNewMessages: true});
             const latestPostId = memoizedGetLatestPostId(postIds);
             const latestPost = getPost(state, latestPostId);
             latestPostTimeStamp = latestPost.create_at;
@@ -40,6 +41,7 @@ function makeMapStateToProps() {
         return {
             postListIds: postIds,
             latestPostTimeStamp,
+            postListChunk,
         };
     };
 }

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -55,6 +55,11 @@ export default class PostList extends React.PureComponent {
         postListIds: PropTypes.array,
 
         /**
+         * Array of actual Ids in the channel which includes system messages as individual postIds
+         */
+        postListChunk: PropTypes.array,
+
+        /**
          * The number of posts that should be rendered
          */
         postVisibility: PropTypes.number,
@@ -302,7 +307,7 @@ export default class PostList extends React.PureComponent {
     };
 
     getOldestVisiblePostId = () => {
-        return getOldestPostId(this.state.postListIds);
+        return getOldestPostId(this.props.postListChunk);
     }
 
     togglePostMenu = (opened) => {
@@ -487,7 +492,9 @@ export default class PostList extends React.PureComponent {
         if (this.extraPagesLoaded > MAX_EXTRA_PAGES_LOADED) {
             // Prevent this from loading a lot of pages in a channel with only hidden messages
             // Enable load more messages manual link
-            this.setState({autoRetryEnable: false});
+            if (this.state.autoRetryEnable) {
+                this.setState({autoRetryEnable: false});
+            }
             return;
         }
 

--- a/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
@@ -24,6 +24,12 @@ describe('PostList', () => {
             'post3',
             DATE_LINE + 1551711600000,
         ],
+        postListChunk: [
+            'post1',
+            'post2',
+            'post3',
+            DATE_LINE + 1551711600000,
+        ],
         latestPostTimeStamp: 12345,
         postVisibility: 10,
         actions: {


### PR DESCRIPTION
  * The crash happens because of the recursive setState call of autoRetryEnable.
    After calling `MAX_EXTRA_PAGES_LOADED` we are setting state to disable autoretry but if the
    call is recursively made few times in fast intervals then setState causing infinite loop in react

  * Adding a new prop `postListchunk` because the filtered system messages cause issue for
    loading more posts as they will never be part of posListIds we basically end up calling APIs with
    same postId

Note: making PR to 5.13v branch. I will make a new PR to master as there will be minor changes for bi-directional scroll
