### PR TITLE
small fixes for failing tests

### DIFF
--- a/e2e/cypress/integration/channel/message_reaction_spec.js
+++ b/e2e/cypress/integration/channel/message_reaction_spec.js
@@ -34,7 +34,7 @@ describe("Click another user's emoji reaction to add it", () => {
             cy.get('#emoji-1f641').click();
 
             // * The number shown on the reaction is incremented by 1
-            cy.get(`#postReaction-${postId}-slightly_frowning_face > .post-reaction__count`).should('contain', '1');
+            cy.get(`#postReaction-${postId}-slightly_frowning_face .post-reaction__count`).should('have.text', '1');
         });
 
         // # Logout
@@ -53,7 +53,7 @@ describe("Click another user's emoji reaction to add it", () => {
                 and('eq', 'rgba(35, 137, 215, 0.1)');
 
             // * The number shown on the "slightly_frowning_face" reaction is incremented by 1
-            cy.get(`#postReaction-${postId}-slightly_frowning_face > .post-reaction__count`).should('contain', '2');
+            cy.get(`#postReaction-${postId}-slightly_frowning_face .post-reaction__count`).should('have.text', '2');
 
             // # Click on the + icon
             cy.get(`#addReaction-${postId}`).click({force: true});
@@ -71,13 +71,13 @@ describe("Click another user's emoji reaction to add it", () => {
             cy.get(`#postReaction-${postId}-scream`).should('be.visible');
 
             // # Click on the "slightly_frowning_face" emoji
-            cy.get(`#postReaction-${postId}-slightly_frowning_face > .post-reaction__emoji`).click();
+            cy.get(`#postReaction-${postId}-slightly_frowning_face .post-reaction__emoji`).click();
 
             // * The number shown on the "slightly_frowning_face" reaction  is decremented by 1
-            cy.get(`#postReaction-${postId}-slightly_frowning_face > .post-reaction__count`).should('contain', '1');
+            cy.get(`#postReaction-${postId}-slightly_frowning_face .post-reaction__count`).should('have.text', '1');
 
             // # Click on the "scream" emoji
-            cy.get(`#postReaction-${postId}-scream > .post-reaction__emoji`).click();
+            cy.get(`#postReaction-${postId}-scream .post-reaction__emoji`).click();
 
             // * The "scream" emoji is removed
             cy.get(`#postReaction-${postId}-scream`).should('be.not.visible');

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -125,6 +125,7 @@ function isMac() {
 Cypress.Commands.add('postMessage', (message) => {
     cy.get('#post_textbox', {timeout: TIMEOUTS.LARGE}).clear().type(message).type('{enter}');
     cy.wait(TIMEOUTS.TINY);
+    cy.get('#post_textbox').should('have.value', '');
 });
 
 Cypress.Commands.add('postMessageReplyInRHS', (message) => {


### PR DESCRIPTION
#### Summary
message_reaction_spec: 
- Selectors were not working, changed them to work.
- Switched assertions to 'have.text'

ui_commands:
- Now check for textbox to be clear before continuing. This should fix this [build error](https://build-push.internal.mattermost.com/job/mattermost-ui-testing/job/mattermost-cypress/115/testReport/junit/(root)/MM-15012%20-%20Emojis%20are%20not%20jumbo%20when%20accompanied%20by%20text/Messaging_MM_15012___Emojis_are_not_jumbo_when_accompanied_by_text/), or at least fail in a better way. This may also help other flaky tests if they somehow continue before a message is truly posted.


#### Ticket Link
N/A