### PR TITLE
[MM-17003] Only trap a11y keyboard events when needed

### DIFF
--- a/utils/a11y_controller.js
+++ b/utils/a11y_controller.js
@@ -453,6 +453,9 @@ export default class A11yController {
             this.a11yKeyEngaged = true;
             break;
         case isKeyPressed(event, Constants.KeyCodes.TILDE):
+            if (!this.regions || !this.regions.length) {
+                return;
+            }
             if (modifierKeys.ctrlIsPressed) {
                 this.a11yKeyEngaged = true;
                 event.preventDefault();
@@ -475,7 +478,7 @@ export default class A11yController {
             }
             break;
         case isKeyPressed(event, Constants.KeyCodes.UP):
-            if (!this.navInProgress) {
+            if (!this.navInProgress || !this.sections || !this.sections.length) {
                 return;
             }
             this.a11yKeyEngaged = true;
@@ -487,7 +490,7 @@ export default class A11yController {
             }
             break;
         case isKeyPressed(event, Constants.KeyCodes.DOWN):
-            if (!this.navInProgress) {
+            if (!this.navInProgress || !this.sections || !this.sections.length) {
                 return;
             }
             this.a11yKeyEngaged = true;


### PR DESCRIPTION
#### Summary
This PR modifies the a11y_controller to only trap a11y keyboard events when elements actually exist for the keyboard event type. Fixes a bug preventing up/down arrow keys from working in comment textareas.

#### Ticket Link
[MM-17003](https://mattermost.atlassian.net/browse/MM-17003)