### PR TITLE
MM-17008: Always displays 'Push Notification Contents' admin console …

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -1830,7 +1830,6 @@ export default {
                         help_text: t('admin.environment.notifications.pushContents.help'),
                         help_text_default: '**Send generic description with only sender name** - Includes only the name of the person who sent the message in push notifications, with no information about channel name or message contents.\n **Send generic description with sender and channel names** - Includes the name of the person who sent the message and the channel it was sent in, but not the message text.\n **Send full message snippet** - Includes a message excerpt in push notifications, which may contain confidential information sent in messages. If your Push Notification Service is outside your firewall, it is *highly recommended* this option only be used with an "https" protocol to encrypt the connection.',
                         help_text_markdown: true,
-                        isHidden: it.isnt(it.licensedForFeature('EmailNotificationContents')),
                         options: [
                             {
                                 value: 'generic_no_channel',


### PR DESCRIPTION
…config field.

#### Summary

Always displays the 'Push Notification Contents' admin console config field.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17008