### PR TITLE
Added test SC17020 - Revoke All Sessions from System Console

### DIFF
--- a/components/confirm_modal.jsx
+++ b/components/confirm_modal.jsx
@@ -156,6 +156,7 @@ export default class ConfirmModal extends React.Component {
                     type='button'
                     className='btn btn-link btn-cancel'
                     onClick={this.handleCancel}
+                    id='cancelModalButton'
                 >
                     {cancelText}
                 </button>

--- a/e2e/cypress/integration/system_console/revoke_all_sessions.js
+++ b/e2e/cypress/integration/system_console/revoke_all_sessions.js
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+const buttonTheme = {backgroundColor: 'rgba(0, 0, 0, 0.7)', color: 'rgb(255, 255, 255)'};
+
+describe('System Console', () => {
+    it('SC17020 - Revoke All Sessions from System Console', () => {
+        // # Login as System Admin
+        cy.apiLogin('sysadmin').as('sysadmin');
+
+        cy.visit('/admin_console/user_management/users');
+
+        // * Verify the presence of Revoke All Sessions button
+        cy.get('#revoke-all-users').should('be.visible').and('have.css', 'background-color', buttonTheme.backgroundColor).
+            and('have.css', 'color', buttonTheme.color);
+
+        cy.get('#revoke-all-users').click();
+
+        // * Verify the confirmation message when users clicks on the Revoke All Sessions button
+        cy.get('.modal-title').should('be.visible').should('contain', 'Revoke all sessions in the system');
+        cy.get('.modal-body').should('be.visible').should('contain', 'This action revokes all sessions in the system. All users will be logged out from all devices. Are you sure you want to revoke all sessions?');
+        cy.get('#confirmModalButton').should('be.visible').should('have.class', 'btn-danger');
+
+        // # Click on Cancel button in the confirmation message
+        cy.get('.modal-footer .btn-cancel').click();
+
+        // * Verify if Confirmation message is closed and session is still active
+        cy.get('.modal-title').should('not.be.visible');
+        cy.get('.modal-body').should('not.be.visible');
+        cy.visit('/admin_console/user_management/users');
+        cy.get('#revoke-all-users').should('be.visible');
+
+        // # Click on the Revoke All Sessions button and confirm
+        cy.get('#revoke-all-users').click();
+        cy.get('#confirmModalButton').click();
+
+        // * Verify if Admin User's session is expired and is redirected to login page
+        cy.get('#login_section').should('be.visible');
+    });
+});

--- a/e2e/cypress/integration/system_console/revoke_all_sessions.js
+++ b/e2e/cypress/integration/system_console/revoke_all_sessions.js
@@ -10,8 +10,8 @@
 import users from '../../fixtures/users.json';
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
-describe('System Console', () => {
-    it('SC17020 - Revoke All Sessions from System Console', () => {
+describe('SC17020 - Revoke All Sessions from System Console', () => {
+    it('Verify for System Admin', () => {
         // # Login as System Admin
         cy.apiLogin('sysadmin');
 
@@ -31,8 +31,8 @@ describe('System Console', () => {
         // * Verify if Confirmation message is closed
         cy.get('#confirmModal').should('not.exist');
 
-        // # Reload the page and verify if the Admin's session is still active
-        cy.visit('/admin_console/user_management/users');
+        // * Verify if the Admin's session is still active and user is still in the same page
+        cy.url().should('contain', '/admin_console/user_management/users');
 
         // * Verify if the Admin's Session is still active and click on it and then confirm
         cy.get('#revoke-all-users').should('be.visible').click();
@@ -40,7 +40,9 @@ describe('System Console', () => {
 
         // * Verify if Admin User's session is expired and is redirected to login page
         cy.get('#login_section').should('be.visible');
+    });
 
+    it('Verify for Regular Member', () => {
         // # Login as a regular member and navigate to Town Square Chat channel
         cy.apiLogin('user-1').as('user1');
         cy.visit('/');

--- a/e2e/cypress/integration/system_console/revoke_all_sessions.js
+++ b/e2e/cypress/integration/system_console/revoke_all_sessions.js
@@ -44,7 +44,7 @@ describe('SC17020 - Revoke All Sessions from System Console', () => {
 
     it('Verify for Regular Member', () => {
         // # Login as a regular member and navigate to Town Square Chat channel
-        cy.apiLogin('user-1').as('user1');
+        cy.apiLogin('user-1');
         cy.visit('/');
         cy.get('#sidebarItem_town-square').click();
 

--- a/e2e/cypress/integration/system_console/revoke_all_sessions.js
+++ b/e2e/cypress/integration/system_console/revoke_all_sessions.js
@@ -26,7 +26,7 @@ describe('SC17020 - Revoke All Sessions from System Console', () => {
         cy.get('#confirmModalButton').should('be.visible').and('have.class', 'btn-danger');
 
         // # Click on Cancel button in the confirmation message
-        cy.get('.modal-footer .btn-cancel').click();
+        cy.get('#cancelModalButton').click();
 
         // * Verify if Confirmation message is closed
         cy.get('#confirmModal').should('not.exist');

--- a/e2e/cypress/integration/system_console/revoke_all_sessions.js
+++ b/e2e/cypress/integration/system_console/revoke_all_sessions.js
@@ -52,7 +52,7 @@ describe('SC17020 - Revoke All Sessions from System Console', () => {
         const baseUrl = Cypress.config('baseUrl');
         cy.externalRequest({user: users.sysadmin, method: 'post', baseUrl, path: 'users/sessions/revoke/all'}).then(() => {
             // * Verify if the regular member is logged out and redirected to login page
-            cy.wait(TIMEOUTS.SMALL).get('#login_section').should('be.visible');
+            cy.get('#login_section', {timeout: TIMEOUTS.LARGE}).should('be.visible');
         });
     });
 });


### PR DESCRIPTION
#### Summary
Added test to verify Revoke All Sessions functionality in the System Console. This includes the following steps:
1. Login as System Admin and navigate to Users page. 
2. Check if the Revoke All Sessions button is displayed. 
3. Click on the Revoke All Sessions button. A message "This action revokes all sessions in the system. All users will be logged out from all devices. Are you sure you want to revoke all sessions?" should be displayed. 
4. Click on Cancel in the confirmation message. The user's session should still be active. 
5. Click on the Revoke All Session button and confirm. 
6. Check if the current user is logged out and redirected to the login page.

#### Ticket Link
JIRA Ticket: [MM-17020](https://mattermost.atlassian.net/browse/MM-17020)

#### Related Pull Requests
None

#### Note
This test expects the changes mentioned in the PR to be merged to the master branch. 
https://github.com/mattermost/mattermost-webapp/pull/3033

Until the PR is merged, it could be tested on the [PR instance](https://mattermost-webapp-pr-3033.test.mattermost.cloud). Credentials for `sysadmin` user is mentioned [here](https://github.com/mattermost/mattermost-webapp/pull/3033) and needs to be changed in the file `cypress/fixtures/users.json` 
