### PR TITLE
[MM-17086] Don’t run a11y navigation in IE11

### DIFF
--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -145,7 +145,9 @@ export default class Root extends React.Component {
         };
 
         // Keyboard navigation for accessibility
-        this.a11yController = new A11yController();
+        if (!UserAgent.isInternetExplorer()) {
+            this.a11yController = new A11yController();
+        }
     }
 
     onConfigLoaded = () => {


### PR DESCRIPTION
#### Summary
Purposely disables a11y navigation controller in IE11.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17086