### PR TITLE
Fix failing E2E test due to recent DOM structure change

### DIFF
--- a/components/file_upload/__snapshots__/file_upload.test.jsx.snap
+++ b/components/file_upload/__snapshots__/file_upload.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`components/FileUpload should match snapshot 1`] = `
     <input
       accept=""
       aria-label="Upload files"
+      id="fileUploadInput"
       multiple={true}
       onChange={[Function]}
       onClick={[Function]}

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -612,6 +612,7 @@ export default class FileUpload extends PureComponent {
                         <AttachmentIcon/>
                     </button>
                     <input
+                        id='fileUploadInput'
                         tabIndex='-1'
                         aria-label={formatMessage(holders.uploadFile)}
                         ref={this.fileInput}

--- a/e2e/cypress/integration/channel/message_draft_with_attachment_then_switch_channel_spec.js
+++ b/e2e/cypress/integration/channel/message_draft_with_attachment_then_switch_channel_spec.js
@@ -31,13 +31,8 @@ describe('Message Draft with attachment and Switch Channels', () => {
                 // # Validate if the draft icon is not visible on the sidebar before making a draft
                 cy.get(`#sidebarItem_${testChannel1.name} #draftIcon`).should('be.not.visible');
 
-                // # Attach image in text area
-                cy.fixture('mattermost-icon.png').then((fileContent) => {
-                    cy.get('#fileUploadButton input').upload(
-                        {fileContent, fileName: 'mattermost-icon.png', mimeType: 'image/png'},
-                        {subjectType: 'drag-n-drop'},
-                    );
-                });
+                // # Upload a file on center view
+                cy.fileUpload('#fileUploadInput');
             });
 
             cy.apiCreateChannel(teamId, channelName2, channelName2, 'O', 'Test channel').then((response) => {
@@ -50,8 +45,7 @@ describe('Message Draft with attachment and Switch Channels', () => {
                 cy.url().should('include', '/channels/' + testChannel2.name);
 
                 // # Validate if the draft icon is visible in side bar for the previous channel
-                cy.get('#publicChannel').scrollIntoView();
-                cy.get(`#sidebarItem_${testChannel1.name} #draftIcon`).should('be.visible');
+                cy.get(`#sidebarItem_${testChannel1.name} #draftIcon`).scrollIntoView().should('be.visible');
             });
         });
     });

--- a/e2e/cypress/integration/channel/message_edit_post_with_attachment_spec.js
+++ b/e2e/cypress/integration/channel/message_edit_post_with_attachment_spec.js
@@ -24,13 +24,8 @@ describe('MM-13697 Edit Post with attachment', () => {
         // * Validate if the channel has been opened
         cy.url().should('include', '/ad-1/channels/town-square');
 
-        // # Attach image
-        cy.fixture('mattermost-icon.png').then((fileContent) => {
-            cy.get('#fileUploadButton input').upload(
-                {fileContent, fileName: 'mattermost-icon.png', mimeType: 'image/png'},
-                {subjectType: 'drag-n-drop'},
-            );
-        });
+        // # Upload a file on center view
+        cy.fileUpload('#fileUploadInput');
 
         // # Type 'This is sample text' and submit
         cy.postMessage('This is sample text');

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -368,3 +368,22 @@ Cypress.Commands.add('updateChannelHeader', (text) => {
         type('{enter}').
         wait(TIMEOUTS.TINY);
 });
+
+// ***********************************************************
+// File Upload
+// ************************************************************
+
+/**
+ * Upload a file on target input given a filename and mime type
+ * @param {String} targetInput - Target input to upload a file
+ * @param {String} fileName - Filename to upload from the fixture
+ * @param {String} mimeType - Mime type of a file
+ */
+Cypress.Commands.add('fileUpload', (targetInput, fileName = 'mattermost-icon.png', mimeType = 'image/png') => {
+    cy.fixture(fileName).then((fileContent) => {
+        cy.get(targetInput).upload(
+            {fileContent, fileName, mimeType},
+            {subjectType: 'input', force: true},
+        );
+    });
+});


### PR DESCRIPTION
#### Summary
Fix failing E2E test due to [recent DOM structure change](https://github.com/mattermost/mattermost-webapp/pull/3136/files#diff-39ad15d3a8de7143757521997af3381bL603).

Also, 
- refactor file upload command (change subject to input and set force to true)
- scroll channel name into view (solve flakiness when there are too many channels in the sidebar)

#### Ticket Link
none