### PR TITLE
MM-17042: Add ability to run "tagged" cypress e2e tests

### DIFF
--- a/e2e/cypress/integration/login/login_spec.js
+++ b/e2e/cypress/integration/login/login_spec.js
@@ -9,7 +9,7 @@
 
 let config;
 
-describe('Login page', () => {
+describe('@smoke Login page', () => {
     before(() => {
         // Disable other auth options
         const newSettings = {

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -80,3 +80,40 @@ Cypress.on('test:after:run', (test, runnable) => {
 beforeEach(() => {
     Cypress.Cookies.preserveOnce('MMAUTHTOKEN', 'MMUSERID', 'MMCSRF');
 });
+
+before(function() {
+    this.test.parent.suites.forEach(checkSuite);
+});
+
+const shouldSkip = (test) => {
+    const tags = Cypress.env('tags');
+
+    if (tags) {
+        return !tags.map((tag) => {
+            return test.fullTitle().includes(tag);
+        }).some((result) => {
+            return result === true;
+        });
+    }
+
+    return false;
+};
+
+const checkSuite = (suite) => {
+    if (suite.pending) {
+        return;
+    }
+
+    if (shouldSkip(suite)) {
+        suite.pending = true;
+        return;
+    }
+
+    (suite.tests || []).forEach((test) => {
+        if (shouldSkip(test)) {
+            test.pending = true;
+        }
+    });
+
+    (suite.suites || []).forEach(checkSuite);
+};


### PR DESCRIPTION
#### Summary
You can use tags like ` npx cypress run --env tags='["@smoke"]'`. Note that it needs to be a string like that so the JSON is parsed correctly. Calling a command like that will ONLY run tests that have @smoke somewhere in it's full title. Tagging a parent describe block will then run all the tests within it, or alternatively you could target a test somewhere deeply nested. Tests not run are marked pending when it comes to results. 

I went and added `@smoke` to our login_spec.js as a starting point, we can identify more smoke tests (or other tags, perhaps `@enterprise'?) in later PRs.

#### Ticket Link
[JIRA](https://mattermost.atlassian.net/browse/MM-17042)