### PR TITLE
Generate short summary to easily pickup for reporting

### DIFF
--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -36,11 +36,13 @@ function generateStatsFieldValue(stats, failedFullTitles) {
 | :fast_forward: Skipped | ${stats.skipped} |
 `;
 
+    // If present, add full title of failing tests.
+    // Only show per maximum number of failed titles with the last item as "more..." if failing tests are more than that.
     let failedTests;
     if (failedFullTitles && failedFullTitles.length > 0) {
         const failed = failedFullTitles;
         if (failed.length > MAX_FAILED_TITLES) {
-            failedTests = failed.slice(0, 4).map((f) => `- ${f}`).join('\n');
+            failedTests = failed.slice(0, MAX_FAILED_TITLES - 1).map((f) => `- ${f}`).join('\n');
             failedTests += '\n- more...';
         } else {
             failedTests = failed.map((f) => `- ${f}`).join('\n');

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -1,12 +1,77 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable no-await-in-loop */
+/* eslint-disable no-await-in-loop, no-console */
 
 const cypress = require('cypress');
 const fse = require('fs-extra');
 const {merge} = require('mochawesome-merge');
 const generator = require('mochawesome-report-generator');
+
+const MAX_FAILED_TITLES = 5;
+
+function getAllTests(results) {
+    const tests = [];
+    results.forEach((result) => {
+        result.tests.forEach((test) => tests.push(test));
+
+        if (result.suites.length > 0) {
+            getAllTests(result.suites).forEach((test) => tests.push(test));
+        }
+    });
+
+    return tests;
+}
+
+function generateStatsFieldValue(stats, failedFullTitles) {
+    let statsFieldValue = `
+| Key | Value |
+|:---|:---|
+| Passing Rate | ${stats.passPercent.toFixed(2)}% |
+| Duration | ${(stats.duration / (60 * 1000)).toFixed(2)} mins |
+| Suites | ${stats.suites} |
+| Tests | ${stats.tests} |
+| :white_check_mark: Passed | ${stats.passes} |
+| :x: Failed | ${stats.failures} |
+| :fast_forward: Skipped | ${stats.skipped} |
+`;
+
+    let failedTests;
+    if (failedFullTitles && failedFullTitles.length > 0) {
+        const failed = failedFullTitles;
+        if (failed.length > MAX_FAILED_TITLES) {
+            failedTests = failed.slice(0, 4).map((f) => `- ${f}`).join('\n');
+            failedTests += '\n- more...';
+        } else {
+            failedTests = failed.map((f) => `- ${f}`).join('\n');
+        }
+    }
+
+    if (failedTests) {
+        statsFieldValue += '###### Failed Tests:\n' + failedTests;
+    }
+
+    return statsFieldValue;
+}
+
+function generateShortSummary(report) {
+    const {results, stats} = report;
+    const tests = getAllTests(results);
+
+    const failedFullTitles = tests.filter((t) => t.fail).map((t) => t.fullTitle);
+    const statsFieldValue = generateStatsFieldValue(stats, failedFullTitles);
+
+    return {
+        stats,
+        statsFieldValue,
+    };
+}
+
+function writeJsonToFile(jsonObject, filename, dir) {
+    fse.writeJson(`${dir}/${filename}`, jsonObject).
+        then(() => console.log('Success!')).
+        catch((err) => console.error(err));
+}
 
 async function runTests() {
     await fse.remove('results');
@@ -48,6 +113,10 @@ async function runTests() {
 
     // Merge all json reports into one single json report
     const jsonReport = await merge({reportDir: mochawesomeReportDir});
+
+    // Generate short summary to easily pickup via hook
+    const summary = generateShortSummary(jsonReport);
+    writeJsonToFile(summary, 'summary.json', mochawesomeReportDir);
 
     // Generate the html report file
     await generator.create(jsonReport, {reportDir: mochawesomeReportDir});


### PR DESCRIPTION
#### Summary
This generates short test summary to easily view stats without actually opening the report link.

![Screen Shot 2019-07-22 at 10 43 03 AM](https://user-images.githubusercontent.com/5334504/61604789-868c3f00-ac75-11e9-91c6-b710c165a4b1.png)

#### Ticket Link
none
