### PR TITLE
MM-17115 Dismissing a banner causes banner overlap in the UI for a non-dismissable banner behind it

### DIFF
--- a/components/announcement_bar/announcement_bar.jsx
+++ b/components/announcement_bar/announcement_bar.jsx
@@ -40,7 +40,7 @@ export default class AnnouncementBar extends React.PureComponent {
         document.body.setAttribute('announcementBarCount', announcementBarCount);
 
         // remove the class on body as it is the last announcementBar
-        if (announcementBarCount == 0) {
+        if (announcementBarCount === 0) {
             document.body.classList.remove('announcement-bar--fixed');
         }
     }

--- a/components/announcement_bar/announcement_bar.jsx
+++ b/components/announcement_bar/announcement_bar.jsx
@@ -26,11 +26,23 @@ export default class AnnouncementBar extends React.PureComponent {
     }
 
     componentDidMount() {
+        let announcementBarCount = document.body.getAttribute('announcementBarCount') || 0;
+        announcementBarCount++;
         document.body.classList.add('announcement-bar--fixed');
+
+        // keeping a track of mounted AnnouncementBars so that on the last AnnouncementBars unmount we can remove the class on body
+        document.body.setAttribute('announcementBarCount', announcementBarCount);
     }
 
     componentWillUnmount() {
-        document.body.classList.remove('announcement-bar--fixed');
+        let announcementBarCount = document.body.getAttribute('announcementBarCount');
+        announcementBarCount--;
+        document.body.setAttribute('announcementBarCount', announcementBarCount);
+
+        // remove the class on body as it is the last announcementBar
+        if (announcementBarCount == 0) {
+            document.body.classList.remove('announcement-bar--fixed');
+        }
     }
 
     handleClose = (e) => {


### PR DESCRIPTION
#### Summary
Do not remove the fixed class on body if there are other announcement bar.
Keep a track of the announcement banners in the UI by adding a count to the body. We don't have a count of the announcement bars in UI so resorting to rather DOM than a react way of doing this.

There are different types of banner so a react state for tracking or children count does not work. Other option is to add redux actions for each mounted component but seems like an overkill.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17115

Note: It is hard to add tests for these as jest has changes about mocking DOM