### PR TITLE
MM-17078 Fix for scroll position with unreads between 30-60

### DIFF
--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -389,7 +389,7 @@ export default class PostList extends React.PureComponent {
         // Calculate how far the post list is from being scrolled to the bottom
         const offsetFromBottom = scrollHeight - clientHeight - scrollOffset;
 
-        return offsetFromBottom <= BUFFER_TO_BE_CONSIDERED_BOTTOM;
+        return offsetFromBottom <= BUFFER_TO_BE_CONSIDERED_BOTTOM && scrollHeight > 0;
     }
 
     updateAtBottom = (atBottom) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13057,8 +13057,8 @@
       "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
     },
     "react-window": {
-      "version": "github:mattermost/react-window#334cf26913792d83f4e471136c1a294489a2963e",
-      "from": "github:mattermost/react-window#334cf26913792d83f4e471136c1a294489a2963e",
+      "version": "github:mattermost/react-window#0ebd2587d702304229ed063c112191606b400939",
+      "from": "github:mattermost/react-window#0ebd2587d702304229ed063c112191606b400939",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-select": "2.4.4",
     "react-transition-group": "2.7.1",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "react-window": "github:mattermost/react-window#334cf26913792d83f4e471136c1a294489a2963e",
+    "react-window": "github:mattermost/react-window#0ebd2587d702304229ed063c112191606b400939",
     "rebound": "0.1.0",
     "redux": "4.0.1",
     "redux-batched-actions": "0.4.1",


### PR DESCRIPTION
#### Summary
Scroll correction happens based on https://github.com/mattermost/mattermost-webapp/blob/5cd69aa0d43560bb1b162dd4a3d326a713a1fd86/components/post_view/post_list_virtualized/post_list_virtualized.jsx#L163 but as scrollheight could be zero initally the state of `atBottom` is set to `true` causing post list to not correct the scroll position

#### Ticket Link

#### Related Pull Requests
using https://github.com/mattermost/react-window/tree/release-5.12 as we need to cherrypick 5.12v hash with this PR https://github.com/mattermost/react-window/pull/21