### PR TITLE
MM-17128 Fix for JavaScript error when posting: Cannot read property 'override_icon_url' of undefined

### DIFF
--- a/actions/views/create_comment.jsx
+++ b/actions/views/create_comment.jsx
@@ -82,6 +82,7 @@ export function submitPost(channelId, rootId, draft) {
             user_id: userId,
             create_at: time,
             metadata: {},
+            props: {},
         };
 
         const hookResult = await dispatch(runMessageWillBePostedHooks(post));

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -606,6 +606,7 @@ export default class CreatePost extends React.Component {
         post.create_at = time;
         post.parent_id = this.state.parentId;
         post.metadata = {};
+        post.props = {};
         const hookResult = await actions.runMessageWillBePostedHooks(post);
 
         if (hookResult.error) {

--- a/components/post_profile_picture/post_profile_picture.jsx
+++ b/components/post_profile_picture/post_profile_picture.jsx
@@ -51,8 +51,13 @@ export default class PostProfilePicture extends React.PureComponent {
 
     getPostIconURL = (defaultURL, fromAutoResponder, fromWebhook) => {
         const {enablePostIconOverride, hasImageProxy, post} = this.props;
-        const postIconOverrideURL = post.props.override_icon_url;
-        const useUserIcon = post.props.use_user_icon;
+        const postProps = post.props;
+        let postIconOverrideURL = '';
+        let useUserIcon = '';
+        if (post.props) {
+            postIconOverrideURL = post.props.override_icon_url;
+            useUserIcon = post.props.use_user_icon;
+        }
 
         if (this.props.compactDisplay) {
             return '';

--- a/components/post_profile_picture/post_profile_picture.jsx
+++ b/components/post_profile_picture/post_profile_picture.jsx
@@ -54,9 +54,9 @@ export default class PostProfilePicture extends React.PureComponent {
         const postProps = post.props;
         let postIconOverrideURL = '';
         let useUserIcon = '';
-        if (post.props) {
-            postIconOverrideURL = post.props.override_icon_url;
-            useUserIcon = post.props.use_user_icon;
+        if (postProps) {
+            postIconOverrideURL = postProps.override_icon_url;
+            useUserIcon = postProps.use_user_icon;
         }
 
         if (this.props.compactDisplay) {


### PR DESCRIPTION
#### Summary
  * The profile_picture component now looks for post.props keys to override images but as temp messages made on client does not have any props object this causes JS error

  * Adding props object for comment and main text boxes

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17128