### PR TITLE
MM-16458 Fix for large markdown images causing a scroll pop

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -18,6 +18,12 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
   </div>
   <div
     className="image-loading__container undefined"
+    style={
+      Object {
+        "maxHeight": 200,
+        "maxWidth": 300,
+      }
+    }
   >
     <svg
       style={

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -114,7 +114,10 @@ export default class SizeAwareImage extends React.PureComponent {
 
         if (dimensions && dimensions.width && !this.state.loaded) {
             placeHolder = (
-                <div className={`image-loading__container ${this.props.className}`} style={{maxWidth: dimensions.width, maxHeight: dimensions.height}}>
+                <div
+                    className={`image-loading__container ${this.props.className}`}
+                    style={{maxWidth: dimensions.width, maxHeight: dimensions.height}}
+                >
                     <svg
                         xmlns='http://www.w3.org/2000/svg'
                         viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -114,7 +114,7 @@ export default class SizeAwareImage extends React.PureComponent {
 
         if (dimensions && dimensions.width && !this.state.loaded) {
             placeHolder = (
-                <div className={`image-loading__container ${this.props.className}`}>
+                <div className={`image-loading__container ${this.props.className}`} style={{maxWidth: dimensions.width, maxHeight: dimensions.height}}>
                     <svg
                         xmlns='http://www.w3.org/2000/svg'
                         viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}

--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -58,8 +58,10 @@ h6 {
         max-height: 500px;
     }
     div.markdown-inline-img {
-        display: inline;
+        display: inline-block;
         width: 100%;
+        max-width: 960px;
+        vertical-align: middle;
     }
 }
 


### PR DESCRIPTION
#### Summary
   * Display inline causes issues with the space that an svg should occupy
     as it does not respect dimensions
   * Changing to inline-image and add max dimensions from images
Before:
<img width="1616" alt="Screenshot 2019-07-23 at 5 05 14 PM" src="https://user-images.githubusercontent.com/4973621/61710225-bc611e80-ad6e-11e9-98ba-ee888bcc50cc.png">
After:
<img width="1617" alt="Screenshot 2019-07-23 at 5 05 26 PM" src="https://user-images.githubusercontent.com/4973621/61710247-cbe06780-ad6e-11e9-97ee-e37db0914e86.png">


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16458
