### PR TITLE
Fixing badge positioning in @ suggestions and ctrl k switcher

### DIFF
--- a/components/suggestion/at_mention_provider/at_mention_suggestion.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_suggestion.jsx
@@ -120,14 +120,14 @@ export default class AtMentionSuggestion extends Suggestion {
                     show={Boolean(user.is_bot)}
                     className='badge-autocomplete'
                 />
-                <GuestBadge
-                    show={Utils.isGuest(user)}
-                    className='badge-autocomplete'
-                />
                 <span className='mention__fullname'>
                     {' '}
                     {description}
                 </span>
+                <GuestBadge
+                    show={Utils.isGuest(user)}
+                    className='badge-autocomplete'
+                />
             </div>
         );
     }

--- a/components/suggestion/generic_user_provider.jsx
+++ b/components/suggestion/generic_user_provider.jsx
@@ -47,12 +47,12 @@ class UserSuggestion extends Suggestion {
                 <span className='admin-setting-user--align'>
                     {'@' + username}
                 </span>
-                <BotBadge show={Boolean(item.is_bot)}/>
-                <GuestBadge show={Utils.isGuest(item)}/>
                 <span className='admin-setting-user__fullname'>
                     {' '}
                     {description}
                 </span>
+                <BotBadge show={Boolean(item.is_bot)}/>
+                <GuestBadge show={Utils.isGuest(item)}/>
             </div>
         );
     }


### PR DESCRIPTION
#### Summary
Badges are positioned at the end of the username/fullname text, instead of in between.

#### Ticket Link
[MM-17202](https://mattermost.atlassian.net/browse/MM-17202)