### PR TITLE
MM-17221 Fix status positions on posts in compact view

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1424,8 +1424,6 @@
             @include border-radius(50px);
             display: inline-flex;
             overflow: hidden;
-            height: 32px;
-            width: 32px;
             justify-content: center;
             align-items: center;
 


### PR DESCRIPTION
#### Summary
The width and height were being set twice after the recent CSS changes, causing compact view to be offset.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17221