### PR TITLE
Escape % key to prevent error passing such value into command line

### DIFF
--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -27,7 +27,7 @@ function generateStatsFieldValue(stats, failedFullTitles) {
     let statsFieldValue = `
 | Key | Value |
 |:---|:---|
-| Passing Rate | ${stats.passPercent.toFixed(2)} |
+| Passing Rate | ${stats.passPercent.toFixed(2)}%25 |
 | Duration | ${(stats.duration / (60 * 1000)).toFixed(2)} mins |
 | Suites | ${stats.suites} |
 | Tests | ${stats.tests} |

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -27,7 +27,7 @@ function generateStatsFieldValue(stats, failedFullTitles) {
     let statsFieldValue = `
 | Key | Value |
 |:---|:---|
-| Passing Rate | ${stats.passPercent.toFixed(2)}% |
+| Passing Rate | ${stats.passPercent.toFixed(2)} |
 | Duration | ${(stats.duration / (60 * 1000)).toFixed(2)} mins |
 | Suites | ${stats.suites} |
 | Tests | ${stats.tests} |


### PR DESCRIPTION
#### Ticket Link
This is a follow PR to https://github.com/mattermost/mattermost-webapp/pull/3194.

This fixes the issue of not properly sending the stats field value for Cypress reporting.
