### PR TITLE
MM-17281: Adds default empty array for postListIds prop.

### DIFF
--- a/components/post_view/post_list/post_list.jsx
+++ b/components/post_view/post_list/post_list.jsx
@@ -85,6 +85,10 @@ export default class PostList extends React.PureComponent {
         }).isRequired,
     }
 
+    static defaultProps = {
+        postListIds: [],
+    };
+
     constructor(props) {
         super(props);
         this.state = {


### PR DESCRIPTION
#### Summary

Fixes JS error from undefined prop when leaving a public channel.

JS error occurs at https://github.com/mattermost/mattermost-webapp/blob/master/components/post_view/post_list/post_list_virtualized.jsx#L208, `...postListIds` is `undefined is not iterable`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17281