### PR TITLE
MM-16908 Fix for Image attachments display loading indicator when receiving a new message

### DIFF
--- a/components/post_view/post_list/post_list_virtualized.jsx
+++ b/components/post_view/post_list/post_list_virtualized.jsx
@@ -432,7 +432,7 @@ export default class PostList extends React.PureComponent {
     }
 
     scrollToLatestMessages = () => {
-        if (this.props.olderPosts.allLoaded) {
+        if (this.props.newerPosts.allLoaded) {
             this.scrollToBottom();
         } else {
             this.props.actions.changeUnreadChunkTimeStamp('');

--- a/components/post_view/post_list/post_list_virtualized.test.jsx
+++ b/components/post_view/post_list/post_list_virtualized.test.jsx
@@ -437,7 +437,7 @@ describe('PostList', () => {
     describe('scrollToLatestMessages', () => {
         test('should call scrollToBottom', () => {
             const wrapper = shallow(<PostList {...baseProps}/>);
-            wrapper.setProps({olderPosts: {allLoaded: true, loading: false}});
+            wrapper.setProps({newerPosts: {allLoaded: true, loading: false}});
             const instance = wrapper.instance();
             instance.scrollToBottom = jest.fn();
             instance.scrollToLatestMessages();


### PR DESCRIPTION
#### Summary
The state check for scrollToBottom should be based on newerPosts props rather than olderPosts props. This causes a rerender in the parent causing the image to mount again

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16908

