### PR TITLE
MM-16458 Fix for large markdown images causing a scroll pop

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -20,7 +20,6 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
     className="image-loading__container undefined"
     style={
       Object {
-        "maxHeight": 200,
         "maxWidth": 300,
       }
     }

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -116,7 +116,7 @@ export default class SizeAwareImage extends React.PureComponent {
             placeHolder = (
                 <div
                     className={`image-loading__container ${this.props.className}`}
-                    style={{maxWidth: dimensions.width, maxHeight: dimensions.height}}
+                    style={{maxWidth: dimensions.width}}
                 >
                     <svg
                         xmlns='http://www.w3.org/2000/svg'


### PR DESCRIPTION
#### Summary
Having max-height overrides css in some cases causing a scroll pop. This wasn't needed as `max-height: inherit` does the trick and `max-width` is what is needed from this https://github.com/mattermost/mattermost-webapp/pull/3212.

<img width="816" alt="Screenshot 2019-07-25 at 1 53 49 AM" src="https://user-images.githubusercontent.com/4973621/61826553-42b95580-ae80-11e9-9326-9da03d807b29.png">

![Jul-25-2019 02-17-04](https://user-images.githubusercontent.com/4973621/61827543-6b424f00-ae82-11e9-9ed8-2745df008a3c.gif)


#### Ticket Link
https://github.com/mattermost/mattermost-webapp/pull/3212
