### PR TITLE
Fixing main menu color in mobile

### DIFF
--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -46,6 +46,7 @@
                 button,
                 a,
                 a:hover {
+                    color: $white;
                     opacity: .8;
                 }
 

--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -42,11 +42,11 @@
                 border: 0px;
                 padding-top: 0px;
                 box-shadow: none;
+                color: inherit;
 
                 button,
                 a,
                 a:hover {
-                    color: $white;
                     opacity: .8;
                 }
 


### PR DESCRIPTION
#### Summary
Fixing main menu color in mobile

This bug was introduced in this commit 2009444241757fc7eb62da8a1c707f2fea3a91ca. I'm not 100% sure if I'm not breaking anything else with this change, and I don't know the original reason to remove the "color" from the CSS, so maybe Assad knows if this is breaking anything else.

#### Ticket Link
[MM-17306](https://mattermost.atlassian.net/browse/MM-17306)