### PR TITLE
MM-17305 - Fixed channel/teams list sort order

### DIFF
--- a/components/admin_console/team_channel_settings/channel/list/__snapshots__/channel_row.test.jsx.snap
+++ b/components/admin_console/team_channel_settings/channel/list/__snapshots__/channel_row.test.jsx.snap
@@ -14,7 +14,6 @@ exports[`admin_console/team_channel_settings/channel/ChannelRow should match sna
       <GlobeIcon
         className="channel-icon channel-icon__globe"
       />
-      DN
     </span>
     <span
       className="group-description row-content"

--- a/components/admin_console/team_channel_settings/channel/list/channel_row.jsx
+++ b/components/admin_console/team_channel_settings/channel/list/channel_row.jsx
@@ -30,7 +30,7 @@ export default class ChannelRow extends React.Component {
                 <div className='group-row'>
                     <span className='group-name overflow--ellipsis row-content'>
                         {channel.type === Constants.PRIVATE_CHANNEL ? <LockIcon className='channel-icon channel-icon__lock'/> : <GlobeIcon className='channel-icon channel-icon__globe'/>}
-                        {channel.name}
+                        {channel.display_name}
                     </span>
                     <span className='group-description row-content'>
                         {channel.team_name}

--- a/components/admin_console/team_channel_settings/channel/list/index.js
+++ b/components/admin_console/team_channel_settings/channel/list/index.js
@@ -14,13 +14,13 @@ import {Constants} from 'utils/constants';
 
 import List from './channel_list.jsx';
 
-const compareByName = (a, b) => a.display_name.localeCompare(b.display_name);
+const compareByDisplayName = (a, b) => a.display_name.localeCompare(b.display_name);
 
 const getSortedListOfChannels = createSelector(
     getAllChannels,
     (teams) => Object.values(teams).
         filter((c) => c.type === Constants.OPEN_CHANNEL || c.type === Constants.PRIVATE_CHANNEL).
-        sort(compareByName)
+        sort(compareByDisplayName)
 );
 
 function mapStateToProps(state) {

--- a/components/admin_console/team_channel_settings/channel/list/index.js
+++ b/components/admin_console/team_channel_settings/channel/list/index.js
@@ -14,7 +14,7 @@ import {Constants} from 'utils/constants';
 
 import List from './channel_list.jsx';
 
-const compareByName = (a, b) => a.name.localeCompare(b.name);
+const compareByName = (a, b) => a.display_name.localeCompare(b.display_name);
 
 const getSortedListOfChannels = createSelector(
     getAllChannels,

--- a/components/admin_console/team_channel_settings/team/list/index.js
+++ b/components/admin_console/team_channel_settings/team/list/index.js
@@ -14,7 +14,7 @@ import TeamList from './team_list.jsx';
 
 const getSortedListOfTeams = createSelector(
     getTeams,
-    (teams) => Object.values(teams).sort((a, b) => a.name.localeCompare(b.name))
+    (teams) => Object.values(teams).sort((a, b) => a.display_name.localeCompare(b.display_name))
 );
 
 function mapStateToProps(state) {


### PR DESCRIPTION
#### Summary

Channels and Teams were ordered by name instead of display_name 

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-17305
