### PR TITLE
MM-17324 - Updating dropdown focus trap

### DIFF
--- a/components/widgets/menu/menu.jsx
+++ b/components/widgets/menu/menu.jsx
@@ -37,11 +37,11 @@ export default class Menu extends React.PureComponent {
         this.setState({focusTrapped: false});
     }
 
-    focusContainer = () => {
+    setInitialFocus = () => {
         return this.node.current;
     }
 
-    focus = () => {
+    focusContainer = () => {
         this.node.current.focus();
     }
 
@@ -66,7 +66,7 @@ export default class Menu extends React.PureComponent {
                 active={this.state.focusTrapped}
                 focusTrapOptions={{
                     clickOutsideDeactivates: true,
-                    initialFocus: this.focusContainer,
+                    initialFocus: this.setInitialFocus,
                 }}
             >
                 <div>
@@ -79,7 +79,7 @@ export default class Menu extends React.PureComponent {
                         style={styles}
                         role='menu'
                         aria-label={ariaLabel}
-                        onMouseOver={this.focus}
+                        onMouseOver={this.focusContainer}
                     >
                         {children}
                     </ul>

--- a/components/widgets/menu/menu.jsx
+++ b/components/widgets/menu/menu.jsx
@@ -37,6 +37,14 @@ export default class Menu extends React.PureComponent {
         this.setState({focusTrapped: false});
     }
 
+    focusContainer = () => {
+        return this.node.current;
+    }
+
+    removeFocus = () => {
+        this.node.current.focus();
+    }
+
     render() {
         const {children, openUp, openLeft, id, ariaLabel, customStyles} = this.props;
         let styles = {};
@@ -58,17 +66,20 @@ export default class Menu extends React.PureComponent {
                 active={this.state.focusTrapped}
                 focusTrapOptions={{
                     clickOutsideDeactivates: true,
+                    initialFocus: this.focusContainer,
                 }}
             >
                 <div>
                     <ul
                         id={id}
+                        tabIndex='-1'
                         onClick={this.removeFocusTrap}
                         className='a11y__popup Menu dropdown-menu'
                         ref={this.node}
                         style={styles}
                         role='menu'
                         aria-label={ariaLabel}
+                        onMouseOver={this.removeFocus}
                     >
                         {children}
                     </ul>

--- a/components/widgets/menu/menu.jsx
+++ b/components/widgets/menu/menu.jsx
@@ -41,7 +41,7 @@ export default class Menu extends React.PureComponent {
         return this.node.current;
     }
 
-    removeFocus = () => {
+    focus = () => {
         this.node.current.focus();
     }
 
@@ -79,7 +79,7 @@ export default class Menu extends React.PureComponent {
                         style={styles}
                         role='menu'
                         aria-label={ariaLabel}
-                        onMouseOver={this.removeFocus}
+                        onMouseOver={this.focus}
                     >
                         {children}
                     </ul>

--- a/components/widgets/menu/menu.test.jsx
+++ b/components/widgets/menu/menu.test.jsx
@@ -25,6 +25,7 @@ describe('components/Menu', () => {
   focusTrapOptions={
     Object {
       "clickOutsideDeactivates": true,
+      "initialFocus": [Function],
     }
   }
   paused={false}
@@ -34,8 +35,10 @@ describe('components/Menu', () => {
       aria-label="test-label"
       className="a11y__popup Menu dropdown-menu"
       onClick={[Function]}
+      onMouseOver={[Function]}
       role="menu"
       style={Object {}}
+      tabIndex="-1"
     >
       text
     </ul>
@@ -61,6 +64,7 @@ describe('components/Menu', () => {
   focusTrapOptions={
     Object {
       "clickOutsideDeactivates": true,
+      "initialFocus": [Function],
     }
   }
   paused={false}
@@ -71,8 +75,10 @@ describe('components/Menu', () => {
       className="a11y__popup Menu dropdown-menu"
       id="test-id"
       onClick={[Function]}
+      onMouseOver={[Function]}
       role="menu"
       style={Object {}}
+      tabIndex="-1"
     >
       text
     </ul>
@@ -102,6 +108,7 @@ describe('components/Menu', () => {
   focusTrapOptions={
     Object {
       "clickOutsideDeactivates": true,
+      "initialFocus": [Function],
     }
   }
   paused={false}
@@ -111,8 +118,10 @@ describe('components/Menu', () => {
       aria-label="test-label"
       className="a11y__popup Menu dropdown-menu"
       onClick={[Function]}
+      onMouseOver={[Function]}
       role="menu"
       style={Object {}}
+      tabIndex="-1"
     >
       text
     </ul>
@@ -142,6 +151,7 @@ describe('components/Menu', () => {
   focusTrapOptions={
     Object {
       "clickOutsideDeactivates": true,
+      "initialFocus": [Function],
     }
   }
   paused={false}
@@ -151,6 +161,7 @@ describe('components/Menu', () => {
       aria-label="test-label"
       className="a11y__popup Menu dropdown-menu"
       onClick={[Function]}
+      onMouseOver={[Function]}
       role="menu"
       style={
         Object {
@@ -160,6 +171,7 @@ describe('components/Menu', () => {
           "top": "auto",
         }
       }
+      tabIndex="-1"
     >
       text
     </ul>


### PR DESCRIPTION
#### Summary
MM-17324 - Updating dropdown focus trap

Now dropdown menus will not have the first item focused. You can still select different menu options if you press tab. However, if you stop using your keyboard, and use your mouse instead the highlight will shift based on your mobile position.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17324