### PR TITLE
MM-17326 Fix for svg not rendering in posts

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -38,7 +38,7 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
   </div>
   <button
     aria-label="file thumbnail"
-    className="style--none"
+    className="style--none file-preview__button"
     style={
       Object {
         "height": 1,

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -142,7 +142,7 @@ export default class SizeAwareImage extends React.PureComponent {
                 <button
                     {...props}
                     aria-label={ariaLabelImage}
-                    className='style--none'
+                    className='style--none file-preview__button'
                     style={imageStyleChangesOnLoad}
                 >
                     <img

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -227,6 +227,10 @@
                     }
                }
             }
+            > .file-preview__button {
+               width: 100%;
+               text-align: left;
+            }
         }
 
         .image-fade-in {


### PR DESCRIPTION
#### Summary
The nesting of svg element changed with recent changes of adding buttons causing the parent button to not occupy space as it is an inline-block element. Adding a width and text align to have the image aligned to left

Before:
<img width="417" alt="Screenshot 2019-07-26 at 7 10 32 PM" src="https://user-images.githubusercontent.com/4973621/61958737-8676a100-afdf-11e9-9e48-fe29540ac35a.png">

After:
![Jul-26-2019 20-08-57](https://user-images.githubusercontent.com/4973621/61959799-cf2f5980-afe1-11e9-8cb4-1ebfd5dd4c4c.gif)

### Ticket
https://mattermost.atlassian.net/browse/MM-17326
