### PR TITLE
Automated cherry pick of #3239

### DIFF
--- a/components/post_view/post_list/post_list.jsx
+++ b/components/post_view/post_list/post_list.jsx
@@ -85,6 +85,10 @@ export default class PostList extends React.PureComponent {
         }).isRequired,
     }
 
+    static defaultProps = {
+        postListIds: [],
+    };
+
     constructor(props) {
         super(props);
         this.state = {


### PR DESCRIPTION
Cherry pick of #3239 on release-5.14.

- #3239: MM-17281: Adds default empty array for postListIds prop.

/cc  @mkraft