### PR TITLE
[MM-17316] Force emoji picker scrolling to category header

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -258,10 +258,11 @@ export default class EmojiPicker extends React.PureComponent {
     };
 
     handleCategoryClick(categoryName) {
-        this.emojiPickerContainer.scrollTop = this.state.categories[categoryName].offset;
         this.setState({
             cursor: [Object.keys(this.state.categories).indexOf(categoryName), 0],
+            divTopOffset: this.state.categories[categoryName].offset,
         });
+        this.emojiPickerContainer.scrollTop = this.state.categories[categoryName].offset;
         this.searchInput.focus();
     }
 


### PR DESCRIPTION
#### Summary
Upon changing the emoji picker to highlight the first emoji in a category, I stopped the window from scrolling to the actual category header. This fixes that issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17316
