### PR TITLE
[MM-17291] Show username for consecutive RHS comments, on mobile-browser view

### DIFF
--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -12,7 +12,6 @@ import {
 } from 'mattermost-redux/utils/post_utils';
 
 import Constants, {Locations, A11yCustomEventTypes} from 'utils/constants.jsx';
-import {isMobile} from 'utils/user_agent.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import DotMenu from 'components/dot_menu';
 import FileAttachmentListContainer from 'components/file_attachment_list';

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -12,6 +12,7 @@ import {
 } from 'mattermost-redux/utils/post_utils';
 
 import Constants, {Locations, A11yCustomEventTypes} from 'utils/constants.jsx';
+import {isMobile} from 'utils/user_agent.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 import DotMenu from 'components/dot_menu';
 import FileAttachmentListContainer from 'components/file_attachment_list';
@@ -196,7 +197,7 @@ export default class RhsComment extends React.PureComponent {
         let visibleMessage;
 
         let userProfile = null;
-        if (this.props.compactDisplay) {
+        if (this.props.compactDisplay || isMobile()) {
             userProfile = (
                 <UserProfile
                     userId={post.user_id}

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -196,8 +196,18 @@ export default class RhsComment extends React.PureComponent {
         let profilePicture;
         let visibleMessage;
 
-        let userProfile = null;
-        if (this.props.compactDisplay || isMobile()) {
+        let userProfile = (
+            <div className='hidden-sm'>
+                <UserProfile
+                    userId={post.user_id}
+                    isBusy={this.props.isBusy}
+                    isRHS={true}
+                    hasMention={true}
+                />
+            </div>
+        );
+
+        if (this.props.compactDisplay) {
             userProfile = (
                 <UserProfile
                     userId={post.user_id}

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -13,6 +13,7 @@ import {
 
 import Constants, {Locations, A11yCustomEventTypes} from 'utils/constants.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
+import {isMobile} from 'utils/utils.jsx';
 import DotMenu from 'components/dot_menu';
 import FileAttachmentListContainer from 'components/file_attachment_list';
 import PostProfilePicture from 'components/post_profile_picture';
@@ -195,18 +196,8 @@ export default class RhsComment extends React.PureComponent {
         let profilePicture;
         let visibleMessage;
 
-        let userProfile = (
-            <div className='hidden-sm'>
-                <UserProfile
-                    userId={post.user_id}
-                    isBusy={this.props.isBusy}
-                    isRHS={true}
-                    hasMention={true}
-                />
-            </div>
-        );
-
-        if (this.props.compactDisplay) {
+        let userProfile = null;
+        if (this.props.compactDisplay || isMobile()) {
             userProfile = (
                 <UserProfile
                     userId={post.user_id}


### PR DESCRIPTION
#### Summary

This PR fixes an issue where the username is not shown next to the timestamp in consecutive RHS comments, in mobile-browser view. Relevant screenshots are in the [Jira ticket](https://mattermost.atlassian.net/browse/MM-17291).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17291