### PR TITLE
[MM-17360] Reset post preview mode to false when switching channels

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -309,6 +309,7 @@ export default class CreatePost extends React.Component {
                 message: draft.message,
                 submitting: false,
                 serverError: null,
+                preview: false,
             });
         }
     }


### PR DESCRIPTION
#### Summary
This changes the default state of the create post "Preview Mode" to false after switching channels. Previously, this mode would persist, locking the post creation text input on the next opened channel.
![M7L1f9xvDO](https://user-images.githubusercontent.com/44858354/62081370-4560d580-b207-11e9-9f07-bb46b55a9a9e.gif)

Note that the pre-release feature "Show markdown preview..." must be enabled in order to use the "Preview" link:
<img width="810" alt="Screen Shot 2019-07-29 at 1 42 45 PM" src="https://user-images.githubusercontent.com/44858354/62081445-85c05380-b207-11e9-9930-7770c41a9858.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17360

#### Related Pull Requests
N/A

