### PR TITLE
[MM-17019] Filter archived teams out of team membership selectors

### DIFF
--- a/actions/global_actions.test.js
+++ b/actions/global_actions.test.js
@@ -80,8 +80,8 @@ describe('actions/global_actions', () => {
                     },
                     teams: {
                         teams: {
-                            team1: {id: 'team1', display_name: 'Team 1', name: 'team1'},
-                            team2: {id: 'team2', display_name: 'Team 2', name: 'team2'},
+                            team1: {id: 'team1', display_name: 'Team 1', name: 'team1', delete_at: 0},
+                            team2: {id: 'team2', display_name: 'Team 2', name: 'team2', delete_at: 0},
                         },
                         myMembers: {
                             team1: {},

--- a/components/permissions_gates/any_team_permission_gate/any_team_permission_gate.test.jsx
+++ b/components/permissions_gates/any_team_permission_gate/any_team_permission_gate.test.jsx
@@ -19,8 +19,8 @@ describe('components/permissions_gates', () => {
             },
             teams: {
                 teams: {
-                    team_id: {id: 'team_id'},
-                    team_id2: {id: 'team_id2'},
+                    team_id: {id: 'team_id', delete_at: 0},
+                    team_id2: {id: 'team_id2', delete_at: 0},
                 },
                 myMembers: {
                     team_id: {team_id: 'team_id', roles: 'team_role'},

--- a/package-lock.json
+++ b/package-lock.json
@@ -10757,8 +10757,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#3e283f1d52cd70a9323e314b9d95757b9e216aea",
-      "from": "github:mattermost/mattermost-redux#3e283f1d52cd70a9323e314b9d95757b9e216aea",
+      "version": "github:mattermost/mattermost-redux#84748d22aebf07826c6938058e3da0f8d583d6f8",
+      "from": "github:mattermost/mattermost-redux#84748d22aebf07826c6938058e3da0f8d583d6f8",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#3c10e2109527cd14a76e1f8edd9d317d8b8988b0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#871d2d248a618c100d083dd95c3151de8be6f539",
+    "mattermost-redux": "github:mattermost/mattermost-redux#84748d22aebf07826c6938058e3da0f8d583d6f8",
     "moment-timezone": "0.5.26",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
This PR updates the mattermost-redux hash to fix the issue of treating archived teams as valid teams to browse.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17019
Fixes "On joining first team, team sidebar may flash open then closed, or may flash back and forth and then stay visible"

#### Related Pull Requests
- Has redux changes: https://github.com/mattermost/mattermost-redux/pull/888

Pulling from `mattermost-redux@master` to `mattermost-webapp@master`