### PR TITLE
MM-17400 - Repeated clicking of View These Users on team management page does not display the expected modal

### DIFF
--- a/components/admin_console/team_channel_settings/users_to_be_removed_modal.jsx
+++ b/components/admin_console/team_channel_settings/users_to_be_removed_modal.jsx
@@ -22,6 +22,8 @@ export default class UsersToBeRemovedModal extends React.PureComponent {
          * users to be removed
          */
         users: PropTypes.arrayOf(PropTypes.object).isRequired,
+
+        onHide: PropTypes.func,
     }
 
     constructor(props) {
@@ -35,6 +37,12 @@ export default class UsersToBeRemovedModal extends React.PureComponent {
 
     handleHide = () => {
         this.setState({show: false});
+    }
+
+    handleExit = () => {
+        if (this.props.onHide) {
+            this.props.onHide();
+        }
     }
 
     render() {
@@ -66,6 +74,7 @@ export default class UsersToBeRemovedModal extends React.PureComponent {
                 dialogClassName='a11y__modal settings-modal'
                 show={this.state.show}
                 onHide={this.handleHide}
+                onExited={this.handleExit}
                 id='confirmModal'
                 role='dialog'
                 aria-labelledby='confirmModalLabel'


### PR DESCRIPTION
#### Summary
When I enable sync/constraint on a team, and that will remove users, the messaging at the bottom has a link to open a modal with a list of users who will be removed, as expected. However, if I close that modal and click the link to open it again, nothing happens.

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-17400

