### PR TITLE
[MM-17338] Wrap save_button message in span to avoid "node not a child of this node" error

### DIFF
--- a/components/__snapshots__/save_button.test.jsx.snap
+++ b/components/__snapshots__/save_button.test.jsx.snap
@@ -38,7 +38,9 @@ exports[`components/SaveButton should match snapshot, extraClasses 1`] = `
     loading={false}
     text="Saving"
   >
-    Save
+    <span>
+      Save
+    </span>
   </LoadingWrapper>
 </button>
 `;
@@ -81,7 +83,9 @@ exports[`components/SaveButton should match snapshot, on defaultMessage 1`] = `
     loading={false}
     text="Saving"
   >
-    Save
+    <span>
+      Save
+    </span>
   </LoadingWrapper>
 </button>
 `;
@@ -124,7 +128,9 @@ exports[`components/SaveButton should match snapshot, on defaultMessage 2`] = `
     loading={false}
     text="Saving"
   >
-    Go
+    <span>
+      Go
+    </span>
   </LoadingWrapper>
 </button>
 `;
@@ -167,7 +173,9 @@ exports[`components/SaveButton should match snapshot, on savingMessage 1`] = `
     loading={true}
     text="Saving"
   >
-    Save
+    <span>
+      Save
+    </span>
   </LoadingWrapper>
 </button>
 `;
@@ -210,7 +218,9 @@ exports[`components/SaveButton should match snapshot, on savingMessage 2`] = `
     loading={true}
     text="Saving Config..."
   >
-    Save
+    <span>
+      Save
+    </span>
   </LoadingWrapper>
 </button>
 `;

--- a/components/save_button.jsx
+++ b/components/save_button.jsx
@@ -63,7 +63,7 @@ export default class SaveButton extends React.PureComponent {
                     loading={saving}
                     text={savingMessageComponent}
                 >
-                    {defaultMessageComponent}
+                    <span>{defaultMessageComponent}</span>
                 </LoadingWrapper>
             </button>
         );

--- a/components/user_settings/notifications/__snapshots__/manage_auto_responder.test.jsx.snap
+++ b/components/user_settings/notifications/__snapshots__/manage_auto_responder.test.jsx.snap
@@ -176,7 +176,9 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
                   loading={false}
                   text="Saving"
                 >
-                  Save
+                  <span>
+                    Save
+                  </span>
                 </LoadingWrapper>
               </button>
             </SaveButton>
@@ -465,7 +467,9 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
                   loading={false}
                   text="Saving"
                 >
-                  Save
+                  <span>
+                    Save
+                  </span>
                 </LoadingWrapper>
               </button>
             </SaveButton>

--- a/components/user_settings/notifications/email_notification_setting/__snapshots__/email_notification_setting.test.jsx.snap
+++ b/components/user_settings/notifications/email_notification_setting/__snapshots__/email_notification_setting.test.jsx.snap
@@ -252,7 +252,9 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
                   loading={false}
                   text="Saving"
                 >
-                  Save
+                  <span>
+                    Save
+                  </span>
                 </LoadingWrapper>
               </button>
             </SaveButton>
@@ -693,7 +695,9 @@ exports[`components/user_settings/notifications/EmailNotificationSetting should 
                   loading={false}
                   text="Saving"
                 >
-                  Save
+                  <span>
+                    Save
+                  </span>
                 </LoadingWrapper>
               </button>
             </SaveButton>


### PR DESCRIPTION
#### Summary
Under certain circumstances, the save button is failing when clicked with a node error. It seems to be caused due React trying to unmount a text-only component. This PR wraps the text sent to the component with a `span`, preventing the error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17338