### PR TITLE
MM-17294 - Revert "MM-15452 - Add ability to override LHS icon for bot accounts (#3026)

### DIFF
--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -4,7 +4,6 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {Client4} from 'mattermost-redux/client';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 
 import {
@@ -79,7 +78,6 @@ function makeMapStateToProps() {
         let channelTeammateUsername = '';
         let channelTeammateIsBot = false;
         let channelDisplayName = channel.display_name;
-        let botIconUrl = null;
         if (channel.type === Constants.DM_CHANNEL) {
             teammate = getUser(state, channel.teammate_id);
             if (teammate) {
@@ -87,9 +85,6 @@ function makeMapStateToProps() {
                 channelTeammateDeletedAt = teammate.delete_at;
                 channelTeammateUsername = teammate.username;
                 channelTeammateIsBot = teammate.is_bot;
-            }
-            if (channelTeammateIsBot) {
-                botIconUrl = botIconImageUrl(teammate);
             }
 
             channelDisplayName = displayUsername(teammate, teammateNameDisplay, false);
@@ -110,7 +105,6 @@ function makeMapStateToProps() {
             channelId,
             channelName: channel.name,
             channelDisplayName,
-            botIconUrl,
             channelType: channel.type,
             channelStatus: channel.status,
             channelFake: channel.fake,
@@ -143,13 +137,6 @@ function mapDispatchToProps(dispatch) {
             openLhs,
         }, dispatch),
     };
-}
-
-/**
- * Gets the LHS bot icon url for a given botUser.
- */
-function botIconImageUrl(botUser) {
-    return `${Client4.getBotRoute(botUser.id)}/icon?_=${(botUser.last_picture_update || 0)}`;
 }
 
 export default connect(makeMapStateToProps, mapDispatchToProps, null, {withRef: true})(SidebarChannel);

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -36,11 +36,6 @@ export default class SidebarChannel extends React.PureComponent {
         channelDisplayName: PropTypes.string.isRequired,
 
         /**
-         * LHS bot icon image url
-         */
-        botIconUrl: PropTypes.string,
-
-        /**
          * Channel is muted
          */
         channelMuted: PropTypes.bool,
@@ -299,7 +294,6 @@ export default class SidebarChannel extends React.PureComponent {
                     rowClass={rowClass}
                     channelId={this.props.channelId}
                     channelName={this.props.channelName}
-                    botIconUrl={this.props.botIconUrl}
                     channelStatus={this.props.channelStatus}
                     channelType={this.props.channelType}
                     displayName={displayName}

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
@@ -23,7 +23,6 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
         channelType: PropTypes.string.isRequired,
         channelId: PropTypes.string.isRequired,
         channelName: PropTypes.string.isRequired,
-        botIconUrl: PropTypes.string,
         displayName: PropTypes.string.isRequired,
         channelStatus: PropTypes.string,
         handleClose: PropTypes.func,
@@ -77,7 +76,6 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
                 <SidebarChannelButtonOrLinkIcon
                     channelStatus={this.props.channelStatus}
                     channelType={this.props.channelType}
-                    botIconUrl={this.props.botIconUrl}
                     channelIsArchived={this.props.channelIsArchived}
                     hasDraft={this.props.hasDraft}
                     membersCount={this.props.membersCount}

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link_icon.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link_icon.jsx
@@ -4,8 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Svg from 'react-inlinesvg';
-
 import {Constants} from 'utils/constants.jsx';
 
 import ArchiveIcon from 'components/svg/archive_icon';
@@ -17,7 +15,6 @@ import BotIcon from 'components/svg/bot_icon.jsx';
 
 export default class SidebarChannelButtonOrLinkIcon extends React.PureComponent {
     static propTypes = {
-        botIconUrl: PropTypes.string,
         channelIsArchived: PropTypes.bool.isRequired,
         channelType: PropTypes.string.isRequired,
         channelStatus: PropTypes.string,
@@ -27,21 +24,6 @@ export default class SidebarChannelButtonOrLinkIcon extends React.PureComponent 
         teammateDeletedAt: PropTypes.number,
         teammateIsBot: PropTypes.bool,
     };
-
-    constructor(props) {
-        super(props);
-        this.state = {
-            svgError: false,
-            botIconUrl: null,
-        };
-    }
-
-    onSvgLoadError = () => {
-        this.setState({
-            svgError: true,
-            botIconUrl: this.props.botIconUrl,
-        });
-    }
 
     render() {
         let icon = null;
@@ -69,21 +51,9 @@ export default class SidebarChannelButtonOrLinkIcon extends React.PureComponent 
                     <ArchiveIcon className='icon icon__archive'/>
                 );
             } else if (this.props.teammateId && this.props.teammateIsBot) {
-                // Use default bot icon
-                icon = (<BotIcon className='icon icon__bot'/>);
-
-                // Attempt to display custom icon if botIconUrl has changed
-                // or if there was no error when loading custom svg
-                if ((this.props.botIconUrl && !this.state.svgError) ||
-                    this.props.botIconUrl !== this.state.botIconUrl) {
-                    icon = (
-                        <Svg
-                            className='icon icon__bot'
-                            src={this.props.botIconUrl}
-                            onError={this.onSvgLoadError}
-                        />
-                    );
-                }
+                icon = (
+                    <BotIcon className='icon icon__bot'/>
+                );
             } else {
                 icon = (
                     <StatusIcon

--- a/package-lock.json
+++ b/package-lock.json
@@ -12035,6 +12035,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -13343,16 +13344,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
-      }
-    },
-    "react-inlinesvg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/react-inlinesvg/-/react-inlinesvg-1.0.0.tgz",
-      "integrity": "sha512-S1Wt5RNg12cUJD+RI6UV+pwrMorSMFuW20VKwGDsngXUDTiBgeniUGL0Cu4hVfwBI+8va2jZx3xeQcaKEI+hRw==",
-      "requires": {
-        "dom-to-react": "^1.0.0",
-        "exenv": "^1.2.2",
-        "once": "^1.4.0"
       }
     },
     "react-input-autosize": {
@@ -17464,7 +17455,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",
@@ -17552,7 +17544,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "react-day-picker": "7.3.0",
     "react-dom": "16.8.6",
     "react-hot-loader": "4.12.8",
-    "react-inlinesvg": "1.0.0",
     "react-intl": "2.9.0",
     "react-overlays": "1.2.0",
     "react-redux": "5.1.1",

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -275,14 +275,6 @@
                     &.icon__bot {
                         @include opacity(.5);
                     }
-
-                    &.icon__bot {
-                        // Restrict icon size for user customized bot icons
-                        svg {
-                            max-width: 16px;
-                            max-height: 15px;
-                        }
-                    }
                 }
 
                 &.has-close {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -511,7 +511,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .sidebar--left .sidebar__switcher span', 'color:' + theme.sidebarText);
         changeCss('.app__body .sidebar--left .sidebar__switcher button svg', 'fill:' + theme.sidebarText);
         changeCss('.channel-header .channel-header_plugin-dropdown a, .app__body .sidebar__switcher button', 'background:' + changeOpacity(theme.sidebarText, 0.08));
-        changeCss('.app__body .icon__bot', 'fill:' + theme.sidebarText);
     }
 
     if (theme.sidebarUnreadText) {


### PR DESCRIPTION
#### Summary
Disable displaying LHS bot-icon. Will re-enable as part of https://mattermost.atlassian.net/browse/MM-17422

This reverts commit c74f4caba2cbe496683d16a9b57d92c9a8618c7f.
https://github.com/mattermost/mattermost-webapp/pull/3026

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-17294

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/3026
