### PR TITLE
MM-17361 - Send messages on preview mode

### DIFF
--- a/components/create_comment/__snapshots__/create_comment.test.jsx.snap
+++ b/components/create_comment/__snapshots__/create_comment.test.jsx.snap
@@ -58,7 +58,7 @@ exports[`components/CreateComment should match snapshot read only channel 1`] = 
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -205,7 +205,7 @@ exports[`components/CreateComment should match snapshot, comment with message 1`
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -328,7 +328,7 @@ exports[`components/CreateComment should match snapshot, emoji picker disabled 1
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -487,7 +487,7 @@ exports[`components/CreateComment should match snapshot, empty comment 1`] = `
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -634,7 +634,7 @@ exports[`components/CreateComment should match snapshot, non-empty message and u
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
       </div>

--- a/components/create_comment/__snapshots__/create_comment.test.jsx.snap
+++ b/components/create_comment/__snapshots__/create_comment.test.jsx.snap
@@ -37,6 +37,7 @@ exports[`components/CreateComment should match snapshot read only channel 1`] = 
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           popoverMentionKeyClick={true}
+          preview={false}
           value=""
         />
         <span
@@ -57,6 +58,7 @@ exports[`components/CreateComment should match snapshot read only channel 1`] = 
         <TextboxLinks
           characterLimit={4000}
           message=""
+          preview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -146,6 +148,7 @@ exports[`components/CreateComment should match snapshot, comment with message 1`
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           popoverMentionKeyClick={true}
+          preview={false}
           value="Test message"
         />
         <span
@@ -202,6 +205,7 @@ exports[`components/CreateComment should match snapshot, comment with message 1`
         <TextboxLinks
           characterLimit={4000}
           message=""
+          preview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -291,6 +295,7 @@ exports[`components/CreateComment should match snapshot, emoji picker disabled 1
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           popoverMentionKeyClick={true}
+          preview={false}
           value="Test message"
         />
         <span
@@ -323,6 +328,7 @@ exports[`components/CreateComment should match snapshot, emoji picker disabled 1
         <TextboxLinks
           characterLimit={4000}
           message=""
+          preview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -424,6 +430,7 @@ exports[`components/CreateComment should match snapshot, empty comment 1`] = `
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           popoverMentionKeyClick={true}
+          preview={false}
           value=""
         />
         <span
@@ -480,6 +487,7 @@ exports[`components/CreateComment should match snapshot, empty comment 1`] = `
         <TextboxLinks
           characterLimit={4000}
           message=""
+          preview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -569,6 +577,7 @@ exports[`components/CreateComment should match snapshot, non-empty message and u
           onKeyDown={[Function]}
           onKeyPress={[Function]}
           popoverMentionKeyClick={true}
+          preview={false}
           value="Test message"
         />
         <span
@@ -625,6 +634,7 @@ exports[`components/CreateComment should match snapshot, non-empty message and u
         <TextboxLinks
           characterLimit={4000}
           message=""
+          preview={false}
           updatePreview={[Function]}
         />
       </div>

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -201,6 +201,7 @@ export default class CreateComment extends React.PureComponent {
             showPostDeletedModal: false,
             showConfirmModal: false,
             showEmojiPicker: false,
+            showPreview: false,
             draft: {
                 message: '',
                 uploadsInProgress: [],
@@ -270,7 +271,7 @@ export default class CreateComment extends React.PureComponent {
     }
 
     updatePreview = (newState) => {
-        this.setState({preview: newState});
+        this.setState({showPreview: newState});
     }
 
     focusTextboxIfNecessary = (e) => {
@@ -507,6 +508,11 @@ export default class CreateComment extends React.PureComponent {
             } else {
                 this.handleSubmit(e);
             }
+
+            this.updatePreview(false);
+            setTimeout(() => {
+                this.focusTextbox();
+            });
         }
 
         this.emitTypingEvent();
@@ -864,7 +870,7 @@ export default class CreateComment extends React.PureComponent {
         }
 
         let fileUpload;
-        if (!readOnlyChannel && !this.state.preview) {
+        if (!readOnlyChannel && !this.state.showPreview) {
             fileUpload = (
                 <FileUpload
                     ref='fileUpload'
@@ -884,7 +890,7 @@ export default class CreateComment extends React.PureComponent {
         let emojiPicker = null;
         const emojiButtonAriaLabel = formatMessage({id: 'emoji_picker.emojiPicker', defaultMessage: 'Emoji Picker'}).toLowerCase();
 
-        if (this.props.enableEmojiPicker && !readOnlyChannel && !this.state.preview) {
+        if (this.props.enableEmojiPicker && !readOnlyChannel && !this.state.showPreview) {
             emojiPicker = (
                 <div>
                     <EmojiPickerOverlay
@@ -954,7 +960,7 @@ export default class CreateComment extends React.PureComponent {
                                 ref='textbox'
                                 disabled={readOnlyChannel}
                                 characterLimit={this.props.maxPostSize}
-                                preview={this.state.preview}
+                                preview={this.state.showPreview}
                                 badConnection={this.props.badConnection}
                                 listenForMentionKeyClick={true}
                             />
@@ -977,7 +983,7 @@ export default class CreateComment extends React.PureComponent {
                             />
                             <TextboxLinks
                                 characterLimit={this.props.maxPostSize}
-                                preview={this.state.preview}
+                                preview={this.state.showPreview}
                                 updatePreview={this.updatePreview}
                                 message={readOnlyChannel ? '' : this.state.message}
                             />

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -547,7 +547,7 @@ export default class CreateComment extends React.PureComponent {
             Utils.isKeyPressed(e, Constants.KeyCodes.ENTER) &&
             (e.ctrlKey || e.metaKey)
         ) {
-            this.updatePreview();
+            this.updatePreview(false);
             this.commentMsgKeyPress(e);
             return;
         }
@@ -864,7 +864,7 @@ export default class CreateComment extends React.PureComponent {
         }
 
         let fileUpload;
-        if (!readOnlyChannel) {
+        if (!readOnlyChannel && !this.state.preview) {
             fileUpload = (
                 <FileUpload
                     ref='fileUpload'
@@ -884,7 +884,7 @@ export default class CreateComment extends React.PureComponent {
         let emojiPicker = null;
         const emojiButtonAriaLabel = formatMessage({id: 'emoji_picker.emojiPicker', defaultMessage: 'Emoji Picker'}).toLowerCase();
 
-        if (this.props.enableEmojiPicker && !readOnlyChannel) {
+        if (this.props.enableEmojiPicker && !readOnlyChannel && !this.state.preview) {
             emojiPicker = (
                 <div>
                     <EmojiPickerOverlay

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -983,7 +983,7 @@ export default class CreateComment extends React.PureComponent {
                             />
                             <TextboxLinks
                                 characterLimit={this.props.maxPostSize}
-                                preview={this.state.showPreview}
+                                showPreview={this.state.showPreview}
                                 updatePreview={this.updatePreview}
                                 message={readOnlyChannel ? '' : this.state.message}
                             />

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -547,6 +547,7 @@ export default class CreateComment extends React.PureComponent {
             Utils.isKeyPressed(e, Constants.KeyCodes.ENTER) &&
             (e.ctrlKey || e.metaKey)
         ) {
+            this.updatePreview();
             this.commentMsgKeyPress(e);
             return;
         }

--- a/components/create_post/__snapshots__/create_post.test.jsx.snap
+++ b/components/create_post/__snapshots__/create_post.test.jsx.snap
@@ -136,7 +136,7 @@ exports[`components/create_post Show tutorial 1`] = `
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -287,7 +287,7 @@ exports[`components/create_post should match snapshot for center textbox 1`] = `
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -403,7 +403,7 @@ exports[`components/create_post should match snapshot for read only channel 1`] 
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -554,7 +554,7 @@ exports[`components/create_post should match snapshot when file upload disabled 
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
       </div>
@@ -705,7 +705,7 @@ exports[`components/create_post should match snapshot, init 1`] = `
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
       </div>

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -328,7 +328,6 @@ export default class CreatePost extends React.Component {
     }
 
     updatePreview = (newState) => {
-        console.log(newState);
         this.setState({preview: newState});
     }
 

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -1317,7 +1317,7 @@ export default class CreatePost extends React.Component {
                             />
                             <TextboxLinks
                                 characterLimit={this.props.maxPostSize}
-                                preview={this.state.showPreview}
+                                showPreview={this.state.showPreview}
                                 updatePreview={this.updatePreview}
                                 message={readOnlyChannel ? '' : this.state.message}
                             />

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -268,7 +268,7 @@ export default class CreatePost extends React.Component {
             showEmojiPicker: false,
             showConfirmModal: false,
             channelTimezoneCount: 0,
-            preview: false,
+            showPreview: false,
             uploadsProgressPercent: {},
             renderScrollbar: false,
             orientation: null,
@@ -309,7 +309,7 @@ export default class CreatePost extends React.Component {
                 message: draft.message,
                 submitting: false,
                 serverError: null,
-                preview: false,
+                showPreview: false,
             });
         }
     }
@@ -328,7 +328,7 @@ export default class CreatePost extends React.Component {
     }
 
     updatePreview = (newState) => {
-        this.setState({preview: newState});
+        this.setState({showPreview: newState});
     }
 
     setOrientationListeners = () => {
@@ -671,12 +671,12 @@ export default class CreatePost extends React.Component {
             }
 
             if (withClosedCodeBlock && message) {
-                this.updatePreview(false);
                 this.setState({message}, () => this.handleSubmit(e));
             } else {
-                this.updatePreview(false);
                 this.handleSubmit(e);
             }
+
+            this.updatePreview(false);
         }
 
         this.emitTypingEvent();
@@ -1180,7 +1180,7 @@ export default class CreatePost extends React.Component {
         }
 
         let fileUpload;
-        if (!readOnlyChannel && !this.state.preview) {
+        if (!readOnlyChannel && !this.state.showPreview) {
             fileUpload = (
                 <FileUpload
                     ref='fileUpload'
@@ -1199,7 +1199,7 @@ export default class CreatePost extends React.Component {
         let emojiPicker = null;
         const emojiButtonAriaLabel = formatMessage({id: 'emoji_picker.emojiPicker', defaultMessage: 'Emoji Picker'}).toLowerCase();
 
-        if (this.props.enableEmojiPicker && !readOnlyChannel && !this.state.preview) {
+        if (this.props.enableEmojiPicker && !readOnlyChannel && !this.state.showPreview) {
             emojiPicker = (
                 <div>
                     <EmojiPickerOverlay
@@ -1274,7 +1274,7 @@ export default class CreatePost extends React.Component {
                                 ref='textbox'
                                 disabled={readOnlyChannel}
                                 characterLimit={this.props.maxPostSize}
-                                preview={this.state.preview}
+                                preview={this.state.showPreview}
                                 badConnection={this.props.badConnection}
                                 listenForMentionKeyClick={true}
                             />
@@ -1317,7 +1317,7 @@ export default class CreatePost extends React.Component {
                             />
                             <TextboxLinks
                                 characterLimit={this.props.maxPostSize}
-                                preview={this.state.preview}
+                                preview={this.state.showPreview}
                                 updatePreview={this.updatePreview}
                                 message={readOnlyChannel ? '' : this.state.message}
                             />

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -671,8 +671,10 @@ export default class CreatePost extends React.Component {
             }
 
             if (withClosedCodeBlock && message) {
+                this.updatePreview();
                 this.setState({message}, () => this.handleSubmit(e));
             } else {
+                this.updatePreview();
                 this.handleSubmit(e);
             }
         }
@@ -1178,7 +1180,7 @@ export default class CreatePost extends React.Component {
         }
 
         let fileUpload;
-        if (!readOnlyChannel) {
+        if (!readOnlyChannel && !this.state.preview) {
             fileUpload = (
                 <FileUpload
                     ref='fileUpload'
@@ -1197,7 +1199,7 @@ export default class CreatePost extends React.Component {
         let emojiPicker = null;
         const emojiButtonAriaLabel = formatMessage({id: 'emoji_picker.emojiPicker', defaultMessage: 'Emoji Picker'}).toLowerCase();
 
-        if (this.props.enableEmojiPicker && !readOnlyChannel) {
+        if (this.props.enableEmojiPicker && !readOnlyChannel && !this.state.preview) {
             emojiPicker = (
                 <div>
                     <EmojiPickerOverlay

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -328,6 +328,7 @@ export default class CreatePost extends React.Component {
     }
 
     updatePreview = (newState) => {
+        console.log(newState);
         this.setState({preview: newState});
     }
 
@@ -671,10 +672,10 @@ export default class CreatePost extends React.Component {
             }
 
             if (withClosedCodeBlock && message) {
-                this.updatePreview();
+                this.updatePreview(false);
                 this.setState({message}, () => this.handleSubmit(e));
             } else {
-                this.updatePreview();
+                this.updatePreview(false);
                 this.handleSubmit(e);
             }
         }

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -245,7 +245,7 @@ describe('components/create_post', () => {
         wrapper.instance().refs = {textbox: {getWrappedInstance: () => ({blur: jest.fn()})}};
 
         wrapper.setState({
-            preview: false,
+            showPreview: false,
         });
 
         const postTextbox = wrapper.find('#post_textbox');

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -244,6 +244,10 @@ describe('components/create_post', () => {
         const wrapper = shallowWithIntl(createPost());
         wrapper.instance().refs = {textbox: {getWrappedInstance: () => ({blur: jest.fn()})}};
 
+        wrapper.setState({
+            preview: false,
+        });
+
         const postTextbox = wrapper.find('#post_textbox');
         postTextbox.simulate('KeyPress', {key: KeyCodes.ENTER[0], preventDefault: jest.fn(), persist: jest.fn()});
         expect(GlobalActions.emitLocalUserTypingEvent).toHaveBeenCalledWith(currentChannelProp.id, '');

--- a/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
+++ b/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
@@ -78,6 +78,7 @@ exports[`components/EditPostModal should disable the button on not canDeletePost
           preview={false}
           suggestionListStyle="bottom"
           supportsCommands={false}
+          tabIndex="0"
           value=""
         />
         <div
@@ -234,6 +235,7 @@ exports[`components/EditPostModal should disable the button on not canEditPost a
           preview={false}
           suggestionListStyle="bottom"
           supportsCommands={false}
+          tabIndex="0"
           value="new message"
         />
         <div
@@ -390,6 +392,7 @@ exports[`components/EditPostModal should match with default config 1`] = `
           preview={false}
           suggestionListStyle="bottom"
           supportsCommands={false}
+          tabIndex="0"
           value=""
         />
         <div
@@ -546,6 +549,7 @@ exports[`components/EditPostModal should match without emoji picker 1`] = `
           preview={false}
           suggestionListStyle="bottom"
           supportsCommands={false}
+          tabIndex="0"
           value=""
         />
         <div
@@ -677,6 +681,7 @@ exports[`components/EditPostModal should not disable the button on not canDelete
           preview={false}
           suggestionListStyle="bottom"
           supportsCommands={false}
+          tabIndex="0"
           value="new message"
         />
         <div
@@ -833,6 +838,7 @@ exports[`components/EditPostModal should not disable the button on not canEditPo
           preview={false}
           suggestionListStyle="bottom"
           supportsCommands={false}
+          tabIndex="0"
           value=""
         />
         <div
@@ -989,6 +995,7 @@ exports[`components/EditPostModal should not disable the save button on not canD
           preview={false}
           suggestionListStyle="bottom"
           supportsCommands={false}
+          tabIndex="0"
           value=""
         />
         <div
@@ -1145,6 +1152,7 @@ exports[`components/EditPostModal should show emojis on emojis click 1`] = `
           preview={false}
           suggestionListStyle="bottom"
           supportsCommands={false}
+          tabIndex="0"
           value=""
         />
         <div
@@ -1301,6 +1309,7 @@ exports[`components/EditPostModal should show errors when it is set in the state
           preview={false}
           suggestionListStyle="bottom"
           supportsCommands={false}
+          tabIndex="0"
           value=""
         />
         <div

--- a/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
+++ b/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
@@ -116,7 +116,7 @@ exports[`components/EditPostModal should disable the button on not canDeletePost
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
         <div
@@ -273,7 +273,7 @@ exports[`components/EditPostModal should disable the button on not canEditPost a
         <TextboxLinks
           characterLimit={4000}
           message="new message"
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
         <div
@@ -430,7 +430,7 @@ exports[`components/EditPostModal should match with default config 1`] = `
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
         <div
@@ -562,7 +562,7 @@ exports[`components/EditPostModal should match without emoji picker 1`] = `
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
         <div
@@ -719,7 +719,7 @@ exports[`components/EditPostModal should not disable the button on not canDelete
         <TextboxLinks
           characterLimit={4000}
           message="new message"
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
         <div
@@ -876,7 +876,7 @@ exports[`components/EditPostModal should not disable the button on not canEditPo
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
         <div
@@ -1033,7 +1033,7 @@ exports[`components/EditPostModal should not disable the save button on not canD
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
         <div
@@ -1190,7 +1190,7 @@ exports[`components/EditPostModal should show emojis on emojis click 1`] = `
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
         <div
@@ -1347,7 +1347,7 @@ exports[`components/EditPostModal should show errors when it is set in the state
         <TextboxLinks
           characterLimit={4000}
           message=""
-          preview={false}
+          showPreview={false}
           updatePreview={[Function]}
         />
         <div

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -368,7 +368,7 @@ export default class EditPostModal extends React.PureComponent {
                         <div className='post-create-footer'>
                             <TextboxLinks
                                 characterLimit={this.props.maxPostSize}
-                                preview={this.state.preview}
+                                showPreview={this.state.preview}
                                 ref={this.setTextboxLinksRef}
                                 updatePreview={this.updatePreview}
                                 message={this.state.editText}

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -281,7 +281,7 @@ export default class EditPostModal extends React.PureComponent {
 
         let emojiPicker = null;
         const emojiButtonAriaLabel = formatMessage({id: 'emoji_picker.emojiPicker', defaultMessage: 'Emoji Picker'}).toLowerCase();
-        if (this.props.config.EnableEmojiPicker === 'true') {
+        if (this.props.config.EnableEmojiPicker === 'true' && !this.state.preview) {
             emojiPicker = (
                 <div>
                     <EmojiPickerOverlay
@@ -345,6 +345,7 @@ export default class EditPostModal extends React.PureComponent {
                     <div className='post-create__container'>
                         <div className='textarea-wrapper'>
                             <Textbox
+                                tabIndex='0'
                                 onChange={this.handleChange}
                                 onKeyPress={this.handleEditKeyPress}
                                 onKeyDown={this.handleKeyDown}

--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -78,7 +78,7 @@ export default class Textbox extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.preview === false && this.props.preview === true) {
+        if (!prevProps.preview && this.props.preview) {
             this.refs.preview.focus();
         }
     }

--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -78,8 +78,6 @@ export default class Textbox extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        console.log('Prev: ' + prevProps.preview);
-        console.log('Current: ' + this.props.preview);
         if (prevProps.preview === false && this.props.preview === true) {
             this.refs.preview.focus();
         }

--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -78,6 +78,8 @@ export default class Textbox extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        console.log('Prev: ' + prevProps.preview);
+        console.log('Current: ' + this.props.preview);
         if (prevProps.preview === false && this.props.preview === true) {
             this.refs.preview.focus();
         }

--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -77,8 +77,8 @@ export default class Textbox extends React.Component {
         this.props.onChange(e);
     }
 
-    componentDidUpdate() {
-        if (this.props.preview) {
+    componentDidUpdate(prevProps) {
+        if (prevProps.preview === false && this.props.preview === true) {
             this.refs.preview.focus();
         }
     }

--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -186,6 +186,8 @@ export default class Textbox extends React.Component {
                     ref='preview'
                     className='form-control custom-textarea textbox-preview-area'
                     onKeyPress={this.props.onKeyPress}
+                    onKeyDown={this.handleKeyDown}
+                    onBlur={this.handleBlur}
                 >
                     <PostMarkdown
                         isRHS={this.props.isRHS}

--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -77,6 +77,12 @@ export default class Textbox extends React.Component {
         this.props.onChange(e);
     }
 
+    componentDidUpdate() {
+        if (this.props.preview) {
+            this.refs.preview.focus();
+        }
+    }
+
     checkMessageLength = (message) => {
         if (this.props.handlePostError) {
             if (message.length > this.props.characterLimit) {
@@ -176,8 +182,10 @@ export default class Textbox extends React.Component {
 
             preview = (
                 <div
+                    tabIndex='0'
                     ref='preview'
                     className='form-control custom-textarea textbox-preview-area'
+                    onKeyPress={this.props.onKeyPress}
                 >
                     <PostMarkdown
                         isRHS={this.props.isRHS}

--- a/components/textbox/textbox_links.jsx
+++ b/components/textbox/textbox_links.jsx
@@ -13,7 +13,7 @@ const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
 export default class TextboxLinks extends React.Component {
     static propTypes = {
-        preview: PropTypes.bool,
+        showPreview: PropTypes.bool,
         characterLimit: PropTypes.number.isRequired,
         previewMessageLink: PropTypes.string,
         updatePreview: PropTypes.func,
@@ -26,7 +26,7 @@ export default class TextboxLinks extends React.Component {
 
     togglePreview = (e) => {
         e.preventDefault();
-        this.props.updatePreview(!this.props.preview);
+        this.props.updatePreview(!this.props.showPreview);
     }
 
     render() {
@@ -62,7 +62,7 @@ export default class TextboxLinks extends React.Component {
                     onClick={this.togglePreview}
                     className='style--none textbox-preview-link color--link'
                 >
-                    {this.props.preview ? (
+                    {this.props.showPreview ? (
                         editHeader
                     ) : (
                         <FormattedMessage

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -125,14 +125,7 @@
     }
 
     .custom-textarea {
-        border-color: $light-gray;
-        color: inherit;
         padding: 12px 30px 12px 15px;
-
-        &:focus {
-            border-color: $light-gray;
-            box-shadow: none;
-        }
     }
 
     .btn {

--- a/sass/layout/_forms.scss
+++ b/sass/layout/_forms.scss
@@ -160,6 +160,12 @@
 }
 
 .form-control {
+    border-color: v(center-channel-color-20);
+
+    &:focus {
+        border-color: v(center-channel-color-30);
+    }
+
     &.inline {
         display: inline-block;
         width: auto;

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -2,7 +2,7 @@
 
 .custom-textarea {
     background: transparent;
-    border: 1px solid #cccccc;
+    border: 1px solid v(center-channel-color-20);
     height: 100%;
     line-height: 20px;
     min-height: 36px;
@@ -12,7 +12,7 @@
     word-wrap: break-word;
 
     &:focus {
-        border-color: #cccccc;
+        border-color: v(center-channel-color-30);
         box-shadow: none;
     }
 
@@ -41,6 +41,10 @@
         position: relative;
         top: 0;
         z-index: 2;
+
+        &:focus {
+            border-color: v(center-channel-color-40);
+        }
 
         p {
             margin: 0;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -671,7 +671,7 @@ export function applyTheme(theme) {
         changeCss('.app__body .user-popover__role', 'background:' + changeOpacity(theme.centerChannelColor, 0.3));
         changeCss('.app__body .svg-text-color', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .mentions__name .status.status--group, .app__body .multi-select__note', 'background:' + changeOpacity(theme.centerChannelColor, 0.12));
-        changeCss('.app__body .modal-tabs .nav-tabs > li, .app__body .form-control, .app__body .system-notice, .app__body .file-view--single .file__image .image-loaded, .app__body .post .MenuWrapper .dropdown-menu button, .app__body .member-list__popover .more-modal__body, .app__body .alert.alert-transparent, .app__body .channel-header .channel-header__icon, .app__body .search-bar__container .search__form, .app__body .table > thead > tr > th, .app__body .table > tbody > tr > td', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.12));
+        changeCss('.app__body .modal-tabs .nav-tabs > li, .app__body .system-notice, .app__body .file-view--single .file__image .image-loaded, .app__body .post .MenuWrapper .dropdown-menu button, .app__body .member-list__popover .more-modal__body, .app__body .alert.alert-transparent, .app__body .channel-header .channel-header__icon, .app__body .search-bar__container .search__form, .app__body .table > thead > tr > th, .app__body .table > tbody > tr > td', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.12));
         changeCss('.app__body .post-list__arrows, .app__body .post .flag-icon__container', 'fill:' + changeOpacity(theme.centerChannelColor, 0.3));
         changeCss('.app__body .post .card-icon__container', 'color:' + changeOpacity(theme.centerChannelColor, 0.3));
         changeCss('@media(min-width: 768px){.app__body .search__icon svg', 'stroke:' + changeOpacity(theme.centerChannelColor, 0.4));
@@ -704,7 +704,7 @@ export function applyTheme(theme) {
         changeCss('.app__body .post-create__container .post-create-body .send-button.disabled i, .app__body .channel-header .channel-header__icon', 'color:' + changeOpacity(theme.centerChannelColor, 0.4));
         changeCss('.app__body .channel-header .pinned-posts-button svg', 'fill:' + changeOpacity(theme.centerChannelColor, 0.6));
         changeCss('.app__body .channel-header .channel-header_plugin-dropdown svg', 'fill:' + changeOpacity(theme.centerChannelColor, 0.6));
-        changeCss('.app__body .custom-textarea, .app__body .custom-textarea:focus, .app__body .file-preview, .app__body .post-image__details, .app__body .sidebar--right .sidebar-right__body, .app__body .markdown__table th, .app__body .markdown__table td, .app__body .suggestion-list__content, .app__body .modal .modal-content, .app__body .modal .settings-modal .settings-table .settings-content .divider-light, .app__body .webhooks__container, .app__body .dropdown-menu, .app__body .modal .modal-header', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
+        changeCss('.app__body .file-preview, .app__body .post-image__details, .app__body .sidebar--right .sidebar-right__body, .app__body .markdown__table th, .app__body .markdown__table td, .app__body .suggestion-list__content, .app__body .modal .modal-content, .app__body .modal .settings-modal .settings-table .settings-content .divider-light, .app__body .webhooks__container, .app__body .dropdown-menu, .app__body .modal .modal-header', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.emoji-picker .emoji-picker__header', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .popover.bottom>.arrow', 'border-bottom-color:' + changeOpacity(theme.centerChannelColor, 0.25));
         changeCss('.app__body .btn.btn-transparent, .app__body .search-help-popover .search-autocomplete__divider span, .app__body .suggestion-list__divider > span', 'color:' + changeOpacity(theme.centerChannelColor, 0.7));
@@ -758,7 +758,7 @@ export function applyTheme(theme) {
         changeCss('.app__body .post.post--comment.current--user .post__body', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .channel-header__info .status .offline--icon', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .navbar .status .offline--icon', 'fill:' + theme.centerChannelColor);
-        changeCss('.app__body .form-control:focus, .app__body .form-control:hover, .app__body .post-reaction:not(.post-reaction--current-user)', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.25));
+        changeCss('.app__body .post-reaction:not(.post-reaction--current-user)', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.25));
         changeCss('.app__body .post-reaction:not(.post-reaction--current-user)', 'color:' + changeOpacity(theme.centerChannelColor, 0.7));
         changeCss('.app__body .emoji-picker', 'color:' + theme.centerChannelColor);
         changeCss('.app__body .emoji-picker', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));


### PR DESCRIPTION
#### Summary
MM-17361 - Send messages on preview mode
Allows users to send messages on the preview mode, for the center channel textbox, and the edit post modal textbox.
This also disables the emoji picker and file picker if the preview mode is enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17361