### PR TITLE
MM-17354 Fix for date line being cutoff when entering a channel with unreads

### DIFF
--- a/components/post_view/post_list/post_list_virtualized.jsx
+++ b/components/post_view/post_list/post_list_virtualized.jsx
@@ -418,6 +418,13 @@ export default class PostList extends React.PureComponent {
         );
 
         if (newMessagesSeparatorIndex > 0) {
+            // if there is a dateLine above START_OF_NEW_MESSAGES then scroll to date line
+            if (isDateLine(this.state.postListIds[newMessagesSeparatorIndex + 1])) {
+                return {
+                    index: newMessagesSeparatorIndex + 1,
+                    position: 'start',
+                };
+            }
             return {
                 index: newMessagesSeparatorIndex,
                 position: 'start',

--- a/components/post_view/post_list/post_list_virtualized.test.jsx
+++ b/components/post_view/post_list/post_list_virtualized.test.jsx
@@ -461,4 +461,49 @@ describe('PostList', () => {
             expect(postListIdsState[postListIdsState.length - 1]).toBe(PostListRowListIds.LOAD_OLDER_MESSAGES_TRIGGER);
         });
     });
+
+    describe('initScrollToIndex', () => {
+        test('return date index if it is just above new message line', () => {
+            const postListIds = [
+                'post1',
+                'post2',
+                'post3',
+                'post4',
+                PostListRowListIds.START_OF_NEW_MESSAGES,
+                DATE_LINE + 1551711600000,
+                'post5',
+            ];
+
+            const props = {
+                ...baseProps,
+                postListIds,
+            };
+
+            const wrapper = shallow(<PostList {...props}/>);
+            const instance = wrapper.instance();
+            const initScrollToIndex = instance.initScrollToIndex();
+            expect(initScrollToIndex).toEqual({index: 6, position: 'start'});
+        });
+    });
+
+    test('return new message line index if there is no date just above it', () => {
+        const postListIds = [
+            'post1',
+            'post2',
+            'post3',
+            'post4',
+            PostListRowListIds.START_OF_NEW_MESSAGES,
+            'post5',
+        ];
+
+        const props = {
+            ...baseProps,
+            postListIds,
+        };
+
+        const wrapper = shallow(<PostList {...props}/>);
+        const instance = wrapper.instance();
+        const initScrollToIndex = instance.initScrollToIndex();
+        expect(initScrollToIndex).toEqual({index: 5, position: 'start'});
+    });
 });


### PR DESCRIPTION
#### Summary
  * Previous logic was to scroll to new message line if there is one but if date line is above that then it gets cutoff or is partially above the fold

  * Adding a specific exception of scrolling to date line if it is just above the new message line so it is clearly visible.

Before:
<img width="1621" alt="Screenshot 2019-07-31 at 9 57 40 PM" src="https://user-images.githubusercontent.com/4973621/62231072-e6ef4f00-b3e0-11e9-9c77-33344bbb757f.png">

After:
<img width="1620" alt="Screenshot 2019-07-31 at 10 01 26 PM" src="https://user-images.githubusercontent.com/4973621/62231085-ee165d00-b3e0-11e9-9bc5-2ef717b997b7.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17354

