### PR TITLE
[MM-17490] Moved defaultAriaLabelRenderer up to multiselect.jsx

### DIFF
--- a/components/add_groups_to_channel_modal/__snapshots__/add_groups_to_channel_modal.test.jsx.snap
+++ b/components/add_groups_to_channel_modal/__snapshots__/add_groups_to_channel_modal.test.jsx.snap
@@ -56,6 +56,7 @@ exports[`components/AddGroupsToChannelModal should match snapshot 1`] = `
     componentClass="div"
   >
     <MultiSelect
+      ariaLabelRenderer={[Function]}
       buttonSubmitLoadingText="Adding..."
       buttonSubmitText="Add"
       handleAdd={[Function]}

--- a/components/add_groups_to_team_modal/__snapshots__/add_groups_to_team_modal.test.jsx.snap
+++ b/components/add_groups_to_team_modal/__snapshots__/add_groups_to_team_modal.test.jsx.snap
@@ -56,6 +56,7 @@ exports[`components/AddGroupsToTeamModal should match snapshot 1`] = `
     componentClass="div"
   >
     <MultiSelect
+      ariaLabelRenderer={[Function]}
       buttonSubmitLoadingText="Adding..."
       buttonSubmitText="Add"
       handleAdd={[Function]}

--- a/components/channel_selector_modal/__snapshots__/channel_selector_modal.test.jsx.snap
+++ b/components/channel_selector_modal/__snapshots__/channel_selector_modal.test.jsx.snap
@@ -51,6 +51,7 @@ exports[`components/ChannelSelectorModal should match snapshot 1`] = `
     componentClass="div"
   >
     <MultiSelect
+      ariaLabelRenderer={[Function]}
       buttonSubmitText="Add"
       handleAdd={[Function]}
       handleDelete={[Function]}

--- a/components/multiselect/__snapshots__/multiselect.test.jsx.snap
+++ b/components/multiselect/__snapshots__/multiselect.test.jsx.snap
@@ -114,6 +114,7 @@ exports[`components/multiselect/multiselect should match snapshot 1`] = `
     />
   </div>
   <MultiSelectList
+    ariaLabelRenderer={[Function]}
     onAction={[Function]}
     onAdd={[Function]}
     onSelect={[Function]}
@@ -275,6 +276,7 @@ exports[`components/multiselect/multiselect should match snapshot for page 2 1`]
     />
   </div>
   <MultiSelectList
+    ariaLabelRenderer={[Function]}
     onAction={[Function]}
     onAdd={[Function]}
     onSelect={[Function]}

--- a/components/multiselect/multiselect.jsx
+++ b/components/multiselect/multiselect.jsx
@@ -21,7 +21,7 @@ export default class MultiSelect extends React.Component {
         optionRenderer: PropTypes.func,
         values: PropTypes.arrayOf(PropTypes.object),
         valueRenderer: PropTypes.func,
-        ariaLabelRenderer: PropTypes.func,
+        ariaLabelRenderer: PropTypes.func.isRequired,
         handleInput: PropTypes.func,
         handleDelete: PropTypes.func,
         perPage: PropTypes.number,
@@ -37,6 +37,10 @@ export default class MultiSelect extends React.Component {
         saving: PropTypes.bool,
         loading: PropTypes.bool,
         placeholderText: PropTypes.string,
+    }
+
+    static defaultProps = {
+        ariaLabelRenderer: defaultAriaLabelRenderer,
     }
 
     constructor(props) {
@@ -191,23 +195,9 @@ export default class MultiSelect extends React.Component {
         this.props.handleDelete(values);
     }
 
-    defaultAriaLabelRenderer(option) {
-        if (!option) {
-            return null;
-        }
-        return option.label;
-    }
-
     render() {
         const options = Object.assign([], this.props.options);
         const {totalCount, users, values} = this.props;
-
-        let renderer;
-        if (this.props.ariaLabelRenderer) {
-            renderer = this.props.ariaLabelRenderer;
-        } else {
-            renderer = this.defaultAriaLabelRenderer;
-        }
 
         let numRemainingText;
         if (this.props.numRemainingText) {
@@ -349,7 +339,7 @@ export default class MultiSelect extends React.Component {
                             placeholder={this.props.placeholderText}
                             inputValue={this.state.input}
                             getOptionValue={(option) => option.id}
-                            getOptionLabel={(option) => renderer(option)}
+                            getOptionLabel={(option) => this.props.ariaLabelRenderer(option)}
                             aria-label={this.props.placeholderText}
                             className={this.state.a11yActive ? 'multi-select__focused' : ''}
                         />
@@ -374,7 +364,7 @@ export default class MultiSelect extends React.Component {
                     ref='list'
                     options={optionsToDisplay}
                     optionRenderer={this.props.optionRenderer}
-                    ariaLabelRenderer={renderer}
+                    ariaLabelRenderer={this.props.ariaLabelRenderer}
                     page={this.state.page}
                     perPage={this.props.perPage}
                     onPageChange={this.props.handlePageChange}
@@ -389,6 +379,13 @@ export default class MultiSelect extends React.Component {
             </div>
         );
     }
+}
+
+function defaultAriaLabelRenderer(option) {
+    if (!option) {
+        return null;
+    }
+    return option.label;
 }
 
 const nullComponent = () => null;

--- a/components/multiselect/multiselect.jsx
+++ b/components/multiselect/multiselect.jsx
@@ -191,9 +191,23 @@ export default class MultiSelect extends React.Component {
         this.props.handleDelete(values);
     }
 
+    defaultAriaLabelRenderer(option) {
+        if (!option) {
+            return null;
+        }
+        return option.label;
+    }
+
     render() {
         const options = Object.assign([], this.props.options);
         const {totalCount, users, values} = this.props;
+
+        let renderer;
+        if (this.props.ariaLabelRenderer) {
+            renderer = this.props.ariaLabelRenderer;
+        } else {
+            renderer = this.defaultAriaLabelRenderer;
+        }
 
         let numRemainingText;
         if (this.props.numRemainingText) {
@@ -335,7 +349,7 @@ export default class MultiSelect extends React.Component {
                             placeholder={this.props.placeholderText}
                             inputValue={this.state.input}
                             getOptionValue={(option) => option.id}
-                            getOptionLabel={(option) => this.props.ariaLabelRenderer(option)}
+                            getOptionLabel={(option) => renderer(option)}
                             aria-label={this.props.placeholderText}
                             className={this.state.a11yActive ? 'multi-select__focused' : ''}
                         />
@@ -360,7 +374,7 @@ export default class MultiSelect extends React.Component {
                     ref='list'
                     options={optionsToDisplay}
                     optionRenderer={this.props.optionRenderer}
-                    ariaLabelRenderer={this.props.ariaLabelRenderer}
+                    ariaLabelRenderer={renderer}
                     page={this.state.page}
                     perPage={this.props.perPage}
                     onPageChange={this.props.handlePageChange}

--- a/components/multiselect/multiselect_list.jsx
+++ b/components/multiselect/multiselect_list.jsx
@@ -119,13 +119,6 @@ export default class MultiSelectList extends React.Component {
         );
     }
 
-    defaultAriaLabelRenderer(option) {
-        if (!option) {
-            return null;
-        }
-        return option.label;
-    }
-
     render() {
         const options = this.props.options;
         let renderOutput;
@@ -163,13 +156,8 @@ export default class MultiSelectList extends React.Component {
 
             const optionControls = options.map((o, i) => renderer(o, this.state.selected === i, this.props.onAdd));
 
-            if (this.props.ariaLabelRenderer) {
-                renderer = this.props.ariaLabelRenderer;
-            } else {
-                renderer = this.defaultAriaLabelRenderer;
-            }
             const selectedOption = options[this.state.selected];
-            const ariaLabel = renderer(selectedOption);
+            const ariaLabel = this.props.ariaLabelRenderer(selectedOption);
 
             renderOutput = (
                 <div className='more-modal__list'>

--- a/components/team_selector_modal/__snapshots__/team_selector_modal.test.jsx.snap
+++ b/components/team_selector_modal/__snapshots__/team_selector_modal.test.jsx.snap
@@ -79,6 +79,7 @@ exports[`components/TeamSelectorModal should match snapshot 1`] = `
       }
     />
     <MultiSelect
+      ariaLabelRenderer={[Function]}
       buttonSubmitText="Add"
       handleAdd={[Function]}
       handleDelete={[Function]}


### PR DESCRIPTION
#### Summary
Multiselect was crashing the app when an `ariaLabelRenderer` wasn't specified. This PR moves the default renderer up to the multiselect component so there's always a renderer.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17490
