### PR TITLE
[MM-17551] Fixed so that team icon settings displays removal tooltip properly

### DIFF
--- a/sass/routes/_settings.scss
+++ b/sass/routes/_settings.scss
@@ -178,11 +178,12 @@
             text-decoration: none;
             top: -8px;
             width: 24px;
+            border: none;
+            padding: 0;
 
             span {
                 font-size: 22px;
-                left: .5px;
-                position: relative;
+                margin-top: -3px;
             }
         }
 


### PR DESCRIPTION
#### Summary
When I changed the `setting_picture` component to have a readable remove button, I missed fixing the styling for the Team Icon use of that component. This PR does that fix.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17551
