### PR TITLE
MM-17602 Load statuses when opening channel member list from header

### DIFF
--- a/actions/user_actions.jsx
+++ b/actions/user_actions.jsx
@@ -5,7 +5,7 @@ import {getChannelAndMyMember, getChannelMembersByIds} from 'mattermost-redux/ac
 import {savePreferences as savePreferencesRedux} from 'mattermost-redux/actions/preferences';
 import {getTeamMembersByIds} from 'mattermost-redux/actions/teams';
 import * as UserActions from 'mattermost-redux/actions/users';
-import {Preferences as PreferencesRedux} from 'mattermost-redux/constants';
+import {Preferences as PreferencesRedux, General} from 'mattermost-redux/constants';
 import {
     getChannel,
     getCurrentChannelId,
@@ -24,6 +24,16 @@ import {Constants, Preferences, UserStatuses} from 'utils/constants.jsx';
 
 const dispatch = store.dispatch;
 const getState = store.getState;
+
+export function loadProfilesAndStatusesInChannel(channelId, page = 0, perPage = General.PROFILE_CHUNK_SIZE, sort = '') {
+    return async (doDispatch) => {
+        const {data} = await doDispatch(UserActions.getProfilesInChannel(channelId, page, perPage, sort));
+        if (data) {
+            doDispatch(loadStatusesForProfilesList(data));
+        }
+        return {data: true};
+    };
+}
 
 export function loadProfilesAndTeamMembers(page, perPage, teamId) {
     return async (doDispatch, doGetState) => {

--- a/actions/user_actions.test.js
+++ b/actions/user_actions.test.js
@@ -15,8 +15,9 @@ jest.mock('mattermost-redux/actions/users', () => {
     return {
         ...original,
         getProfilesInTeam: (...args) => ({type: 'MOCK_GET_PROFILES_IN_TEAM', args}),
-        getProfilesInChannel: (...args) => ({type: 'MOCK_GET_PROFILES_IN_CHANNEL', args}),
+        getProfilesInChannel: (...args) => ({type: 'MOCK_GET_PROFILES_IN_CHANNEL', args, data: [{id: 'user_1'}]}),
         getProfilesInGroupChannels: (...args) => ({type: 'MOCK_GET_PROFILES_IN_GROUP_CHANNELS', args}),
+        getStatusesByIds: (...args) => ({type: 'MOCK_GET_STATUSES_BY_ID', args}),
     };
 });
 
@@ -120,6 +121,16 @@ describe('Actions.User', () => {
         },
     };
 
+    test('loadProfilesAndStatusesInChannel', async () => {
+        const testStore = await mockStore(initialState);
+        await testStore.dispatch(UserActions.loadProfilesAndStatusesInChannel('channel_1', 0, 60, 'status'));
+        const actualActions = testStore.getActions();
+        expect(actualActions[0].args).toEqual(['channel_1', 0, 60, 'status']);
+        expect(actualActions[0].type).toEqual('MOCK_GET_PROFILES_IN_CHANNEL');
+        expect(actualActions[1].args).toEqual([['user_1']]);
+        expect(actualActions[1].type).toEqual('MOCK_GET_STATUSES_BY_ID');
+    });
+
     test('loadProfilesAndTeamMembers', async () => {
         const expectedActions = [{type: 'MOCK_GET_PROFILES_IN_TEAM', args: ['team_1', 0, 60]}];
 
@@ -139,7 +150,7 @@ describe('Actions.User', () => {
     test('loadProfilesAndTeamMembersAndChannelMembers', async () => {
         const expectedActions = [{type: 'MOCK_GET_PROFILES_IN_CHANNEL', args: ['current_channel_id', 0, 60]}];
 
-        let testStore = await mockStore({});
+        let testStore = await mockStore(initialState);
         await testStore.dispatch(UserActions.loadProfilesAndTeamMembersAndChannelMembers(0, 60, 'team_1', 'current_channel_id'));
         let actualActions = testStore.getActions();
         expect(actualActions[0].args).toEqual(expectedActions[0].args);

--- a/components/popover_list_members/index.js
+++ b/components/popover_list_members/index.js
@@ -3,12 +3,12 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {getProfilesInChannel} from 'mattermost-redux/actions/users';
 import {getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getUserStatuses, makeGetProfilesInChannel} from 'mattermost-redux/selectors/entities/users';
 
 import {openDirectChannelToUserId} from 'actions/channel_actions.jsx';
+import {loadProfilesAndStatusesInChannel} from 'actions/user_actions.jsx';
 import {openModal} from 'actions/views/modals';
 
 import PopoverListMembers from './popover_list_members.jsx';
@@ -34,7 +34,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             openModal,
-            getProfilesInChannel,
+            loadProfilesAndStatusesInChannel,
             openDirectChannelToUserId,
         }, dispatch),
     };

--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -28,7 +28,7 @@ export default class PopoverListMembers extends React.Component {
         teamUrl: PropTypes.string,
         actions: PropTypes.shape({
             openModal: PropTypes.func.isRequired,
-            getProfilesInChannel: PropTypes.func.isRequired,
+            loadProfilesAndStatusesInChannel: PropTypes.func.isRequired,
             openDirectChannelToUserId: PropTypes.func.isRequired,
         }).isRequired,
     };
@@ -106,7 +106,7 @@ export default class PopoverListMembers extends React.Component {
 
     handleGetProfilesInChannel = (e) => {
         this.setState({popoverTarget: e.target, showPopover: !this.state.showPopover});
-        this.props.actions.getProfilesInChannel(this.props.channel.id, 0, undefined, 'status'); // eslint-disable-line no-undefined
+        this.props.actions.loadProfilesAndStatusesInChannel(this.props.channel.id, 0, undefined, 'status'); // eslint-disable-line no-undefined
     };
 
     getTargetPopover = () => {

--- a/components/popover_list_members/popover_list_members.test.jsx
+++ b/components/popover_list_members/popover_list_members.test.jsx
@@ -34,7 +34,7 @@ describe('components/PopoverListMembers', () => {
     };
 
     const actions = {
-        getProfilesInChannel: jest.fn(),
+        loadProfilesAndStatusesInChannel: jest.fn(),
         openDirectChannelToUserId: jest.fn().mockResolvedValue({data: {name: 'channelname'}}),
         openModal: jest.fn(),
     };


### PR DESCRIPTION
#### Summary
When opening the popover we were not pulling statuses and since we sorted by status it looked super confusing because we'd show everyone offline unless we had pulled their status in a different place previously.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17602