### PR TITLE
MM-17485 Fix for missing messages on socket reconn for channels visited only once preiously

### DIFF
--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -146,6 +146,7 @@ export function autocompleteUsersInChannel(prefix, channelId) {
 
 export function loadUnreads(channelId) {
     return async (dispatch) => {
+        const time = Date.now();
         const {data, error} = await dispatch(PostActions.getPostsUnread(channelId));
         if (error) {
             return {
@@ -160,6 +161,14 @@ export function loadUnreads(channelId) {
             data: channelId,
             amount: data.order.length,
         });
+
+        if (data.next_post_id === '') {
+            dispatch({
+                type: ActionTypes.RECEIVED_POSTS_FOR_CHANNEL_AT_TIME,
+                channelId,
+                time,
+            });
+        }
 
         return {
             atLatestMessage: data.next_post_id === '',

--- a/actions/views/channel.test.js
+++ b/actions/views/channel.test.js
@@ -226,6 +226,23 @@ describe('channel view actions', () => {
             expect(result).toEqual({atLatestMessage: false, atOldestmessage: false});
             expect(PostActions.getPostsUnread).toHaveBeenCalledWith('channel');
         });
+
+        test('when there are no posts after RECEIVED_POSTS_FOR_CHANNEL_AT_TIME should be dispatched', async () => {
+            const posts = {posts: {}, order: [], next_post_id: '', prev_post_id: ''};
+            Date.now = jest.fn().mockReturnValue(12344);
+
+            PostActions.getPostsUnread.mockReturnValue(() => ({data: posts}));
+
+            await store.dispatch(Actions.loadUnreads('channel', 'post'));
+
+            expect(store.getActions()).toEqual([
+                {amount: 0, data: 'channel', type: 'INCREASE_POST_VISIBILITY'},
+                {
+                    channelId: 'channel',
+                    time: 12344,
+                    type: 'RECEIVED_POSTS_FOR_CHANNEL_AT_TIME'},
+            ]);
+        });
     });
 
     describe('loadPostsAround', () => {


### PR DESCRIPTION
#### Summary
1. If last time since API is called is today and socket disconnected was yesterday then we use the last post in the channel to get any missing posts(Should not even have any missing posts but it is a failsafe measure).

2. If socket disconnected today and the last time we called since API is yesterday we use socket disconnected timestamp to get any new messages missed during that time.

  * Issue: if we never called since API i.e the second visit to a channel then lastGetPosts state in redux state will not exist, so we basically are calling since API after reconnect with the last post in channel which can be wrong as on reconnect we add new posts to the postsInChannel state

  * Solution: Dispatch RECEIVED_POSTS_FOR_CHANNEL_AT_TIME for unreads if we are at the latest
    so this way we will have a timestamp in the state of lastGetPosts.
    If posts are not recent then we don't need to worry because the subsequent visit to the channel
    will be making a call to load last 30 posts

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17485
