### PR TITLE
GH-10166 - Show an error message when the plugin is not compatible

### DIFF
--- a/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
+++ b/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
@@ -2092,6 +2092,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                   handleEnable={[Function]}
                   handleRemove={[Function]}
                   hasSettings={true}
+                  isCompatible={true}
                   key="plugin_0"
                   pluginStatus={
                     Object {
@@ -2105,6 +2106,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                           "version": "0.1.0",
                         },
                       ],
+                      "is_compatible": true,
                       "is_prepackaged": false,
                       "name": "Plugin 0",
                       "state": 0,
@@ -2119,6 +2121,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                   handleEnable={[Function]}
                   handleRemove={[Function]}
                   hasSettings={true}
+                  isCompatible={true}
                   key="plugin_1"
                   pluginStatus={
                     Object {
@@ -2137,6 +2140,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                           "version": "0.0.2",
                         },
                       ],
+                      "is_compatible": true,
                       "is_prepackaged": false,
                       "name": "Plugin 1",
                       "state": 5,
@@ -2428,6 +2432,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                   handleEnable={[Function]}
                   handleRemove={[Function]}
                   hasSettings={true}
+                  isCompatible={true}
                   key="plugin_0"
                   pluginStatus={
                     Object {
@@ -2441,6 +2446,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                           "version": "0.1.0",
                         },
                       ],
+                      "is_compatible": true,
                       "is_prepackaged": false,
                       "name": "Plugin 0",
                       "state": 0,
@@ -2732,6 +2738,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                   handleEnable={[Function]}
                   handleRemove={[Function]}
                   hasSettings={true}
+                  isCompatible={true}
                   key="plugin_0"
                   pluginStatus={
                     Object {
@@ -2745,6 +2752,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                           "version": "0.1.0",
                         },
                       ],
+                      "is_compatible": true,
                       "is_prepackaged": false,
                       "name": "Plugin 0",
                       "state": 0,
@@ -3036,6 +3044,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                   handleEnable={[Function]}
                   handleRemove={[Function]}
                   hasSettings={true}
+                  isCompatible={true}
                   key="plugin_0"
                   pluginStatus={
                     Object {
@@ -3049,6 +3058,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                           "version": "0.1.0",
                         },
                       ],
+                      "is_compatible": true,
                       "is_prepackaged": false,
                       "name": "Plugin 0",
                       "state": 0,
@@ -3340,6 +3350,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                   handleEnable={[Function]}
                   handleRemove={[Function]}
                   hasSettings={false}
+                  isCompatible={true}
                   key="plugin_0"
                   pluginStatus={
                     Object {
@@ -3353,6 +3364,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                           "version": "0.1.0",
                         },
                       ],
+                      "is_compatible": true,
                       "is_prepackaged": false,
                       "name": "Plugin 0",
                       "state": 0,
@@ -3367,6 +3379,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                   handleEnable={[Function]}
                   handleRemove={[Function]}
                   hasSettings={false}
+                  isCompatible={true}
                   key="plugin_1"
                   pluginStatus={
                     Object {
@@ -3385,6 +3398,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                           "version": "0.0.2",
                         },
                       ],
+                      "is_compatible": true,
                       "is_prepackaged": false,
                       "name": "Plugin 1",
                       "state": 5,

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -74,7 +74,18 @@ PluginItemState.propTypes = {
     state: PropTypes.number.isRequired,
 };
 
-const PluginItemStateDescription = ({state}) => {
+const PluginItemStateDescription = ({state, isCompatible}) => {
+    if (!isCompatible) {
+        return (
+            <div className='alert alert-info'>
+                <i className='fa fa-ban'/>
+                <FormattedMessage
+                    id='admin.plugin.not_compatible.description'
+                    defaultMessage='This plugin is not compatible with your system configuration.'
+                />
+            </div>
+        );
+    }
     switch (state) {
     case PluginState.PLUGIN_STATE_NOT_RUNNING:
         return (
@@ -143,6 +154,7 @@ const PluginItemStateDescription = ({state}) => {
 
 PluginItemStateDescription.propTypes = {
     state: PropTypes.number.isRequired,
+    isCompatible: PropTypes.bool.isRequired,
 };
 
 const PluginItem = ({
@@ -153,12 +165,15 @@ const PluginItem = ({
     handleRemove,
     showInstances,
     hasSettings,
+    isCompatible,
 }) => {
     let activateButton;
     const activating = pluginStatus.state === PluginState.PLUGIN_STATE_STARTING;
     const deactivating = pluginStatus.state === PluginState.PLUGIN_STATE_STOPPING;
 
-    if (pluginStatus.active) {
+    if (!isCompatible) {
+        // don't show an activate button
+    } else if (pluginStatus.active) {
         activateButton = (
             <a
                 data-plugin-id={pluginStatus.id}
@@ -235,7 +250,7 @@ const PluginItem = ({
         }
         removeButton = (
             <span>
-                {' - '}
+                { activateButton ? ' - ' : '' }
                 <a
                     data-plugin-id={pluginStatus.id}
                     disabled={removing}
@@ -289,6 +304,7 @@ const PluginItem = ({
         <PluginItemStateDescription
             key='state-description'
             state={pluginStatus.state}
+            isCompatible={isCompatible}
         />
     );
 
@@ -389,6 +405,7 @@ PluginItem.propTypes = {
     handleRemove: PropTypes.func.isRequired,
     showInstances: PropTypes.bool.isRequired,
     hasSettings: PropTypes.bool.isRequired,
+    isCompatible: PropTypes.bool.isRequired,
 };
 
 export default class PluginManagement extends AdminSettings {
@@ -810,6 +827,7 @@ export default class PluginManagement extends AdminSettings {
                         handleRemove={this.handleRemove}
                         showInstances={showInstances}
                         hasSettings={hasSettings}
+                        isCompatible={!p || p.is_compatible}
                     />
                 );
             });

--- a/components/admin_console/plugin_management/plugin_management.test.jsx
+++ b/components/admin_console/plugin_management/plugin_management.test.jsx
@@ -27,6 +27,7 @@ describe('components/PluginManagement', () => {
                 state: PluginState.PLUGIN_STATE_NOT_RUNNING,
                 name: 'Plugin 0',
                 description: 'The plugin 0.',
+                is_compatible: true,
                 is_prepackaged: false,
                 active: false,
                 instances: [
@@ -43,6 +44,7 @@ describe('components/PluginManagement', () => {
                 state: PluginState.PLUGIN_STATE_STOPPING,
                 name: 'Plugin 1',
                 description: 'The plugin.',
+                is_compatible: true,
                 is_prepackaged: false,
                 active: true,
                 instances: [
@@ -66,6 +68,7 @@ describe('components/PluginManagement', () => {
                 id: 'plugin_0',
                 name: 'Plugin 0',
                 version: '0.1.0',
+                is_compatible: true,
                 settings_schema: {
                     footer: 'This is a footer',
                     header: 'This is a header',
@@ -79,6 +82,7 @@ describe('components/PluginManagement', () => {
                 id: 'plugin_1',
                 name: 'Plugin 1',
                 version: '0.1.0',
+                is_compatible: true,
                 settings_schema: {
                     footer: 'This is a footer',
                     header: 'This is a header',
@@ -218,6 +222,7 @@ describe('components/PluginManagement', () => {
                 plugin_0: {
                     id: 'plugin_0',
                     version: '0.1.0',
+                    is_compatible: true,
                     state: PluginState.PLUGIN_STATE_NOT_RUNNING,
                     name: 'Plugin 0',
                     description: 'The plugin 0.',
@@ -234,6 +239,7 @@ describe('components/PluginManagement', () => {
                 plugin_1: {
                     id: 'plugin_1',
                     version: '0.0.1',
+                    is_compatible: true,
                     state: PluginState.PLUGIN_STATE_STOPPING,
                     name: 'Plugin 1',
                     description: 'The plugin.',
@@ -260,6 +266,7 @@ describe('components/PluginManagement', () => {
                     id: 'plugin_0',
                     name: 'Plugin 0',
                     version: '0.1.0',
+                    is_compatible: true,
                     settings_schema: {},
                     webapp: {},
                 },
@@ -269,6 +276,7 @@ describe('components/PluginManagement', () => {
                     id: 'plugin_1',
                     name: 'Plugin 1',
                     version: '0.1.0',
+                    is_compatible: true,
                     settings_schema: {},
                     webapp: {},
                 },
@@ -302,6 +310,7 @@ describe('components/PluginManagement', () => {
                 plugin_0: {
                     id: 'plugin_0',
                     version: '0.1.0',
+                    is_compatible: true,
                     state: PluginState.PLUGIN_STATE_NOT_RUNNING,
                     name: 'Plugin 0',
                     description: 'The plugin 0.',
@@ -323,6 +332,7 @@ describe('components/PluginManagement', () => {
                     id: 'plugin_0',
                     name: 'Plugin 0',
                     version: '0.1.0',
+                    is_compatible: true,
                     settings_schema: {
                         header: 'This is a header',
                     },
@@ -358,6 +368,7 @@ describe('components/PluginManagement', () => {
                 plugin_0: {
                     id: 'plugin_0',
                     version: '0.1.0',
+                    is_compatible: true,
                     state: PluginState.PLUGIN_STATE_NOT_RUNNING,
                     name: 'Plugin 0',
                     description: 'The plugin 0.',
@@ -379,6 +390,7 @@ describe('components/PluginManagement', () => {
                     id: 'plugin_0',
                     name: 'Plugin 0',
                     version: '0.1.0',
+                    is_compatible: true,
                     settings_schema: {
                         footer: 'This is a footer',
                     },
@@ -414,6 +426,7 @@ describe('components/PluginManagement', () => {
                 plugin_0: {
                     id: 'plugin_0',
                     version: '0.1.0',
+                    is_compatible: true,
                     state: PluginState.PLUGIN_STATE_NOT_RUNNING,
                     name: 'Plugin 0',
                     description: 'The plugin 0.',
@@ -435,6 +448,7 @@ describe('components/PluginManagement', () => {
                     id: 'plugin_0',
                     name: 'Plugin 0',
                     version: '0.1.0',
+                    is_compatible: true,
                     settings_schema: {
                         settings: [
                             {bla: 'test', xoxo: 'test2'},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1093,6 +1093,7 @@
   "admin.plugin.management.title": "Plugin Management",
   "admin.plugin.multiple_versions_warning": "There are multiple versions of this plugin installed across your cluster. Re-install this plugin to ensure it works consistently.",
   "admin.plugin.no_plugins": "No installed plugins.",
+  "admin.plugin.not_compatible.description": "This plugin is not compatible with your system configuration.",
   "admin.plugin.prepackaged": "pre-packaged",
   "admin.plugin.remove": "Remove",
   "admin.plugin.removing": "Removing...",


### PR DESCRIPTION
#### Summary
Displays an error message on the plugins that can't be used because the system does not meet their requirements. It also removes the `Enable` link when they can't be enabled.

Needs the PR on the server to be merged before this can be merged (otherwise, all the plugins would be deemed "not compatible").

#### Ticket Link
[#10166 - Plugin framework: Show that a plugin requires a certain Mattermost config setting](https://github.com/mattermost/mattermost-server/issues/10166)

#### Related PRs
Server change: [Plugin framework: Show that a plugin requires a certain Mattermost config setting ](https://github.com/mattermost/mattermost-server/pull/11832)
Plugin starter change: [Call to CheckRequiredConfig when OnActivate is hit](https://github.com/mattermost/mattermost-plugin-starter-template/pull/56)
