### PR TITLE
MM-17671 Permalink does not render posts in IE11

### DIFF
--- a/components/post_view/post_list_ie/index.js
+++ b/components/post_view/post_list_ie/index.js
@@ -16,10 +16,12 @@ function makeMapStateToProps() {
     const combineUserActivityPosts = makeCombineUserActivityFromPosts();
     return function mapStateToProps(state, ownProps) {
         let posts;
+        const postVisibility = state.views.channel.postVisibility[ownProps.channelId];
+
         if (ownProps.focusedPostId) {
             posts = getPostsAroundPost(state, ownProps.focusedPostId, ownProps.channelId);
         } else {
-            posts = getPostsInChannel(state, ownProps.channelId, ownProps.postVisibility);
+            posts = getPostsInChannel(state, ownProps.channelId, postVisibility);
         }
 
         return {
@@ -27,6 +29,7 @@ function makeMapStateToProps() {
             currentUserId: getCurrentUserId(state),
             lastViewedAt: state.views.channel.lastChannelViewTime[ownProps.channelId],
             channel: getCurrentChannel(state),
+            postVisibility,
         };
     };
 }

--- a/components/post_view/post_list_ie/post_list_ie.jsx
+++ b/components/post_view/post_list_ie/post_list_ie.jsx
@@ -77,6 +77,11 @@ export default class PostList extends React.PureComponent {
              * Function to check and set if app is in mobile view
              */
             checkAndSetMobileView: PropTypes.func.isRequired,
+
+            /**
+             * Function to load permalink posts
+             */
+            loadPostsAround: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -386,7 +391,12 @@ export default class PostList extends React.PureComponent {
         }
 
         let posts;
-        const {atOldestmessage} = await this.props.actions.loadLatestPosts(channelId, focusedPostId);
+        let atOldestmessage;
+        if (focusedPostId) {
+            ({atOldestmessage} = await this.props.actions.loadPostsAround(channelId, focusedPostId));
+        } else {
+            ({atOldestmessage} = await this.props.actions.loadLatestPosts(channelId));
+        }
 
         if (this.mounted) {
             this.setState({


### PR DESCRIPTION
#### Summary
  * Use loadPostsAround for loading posts in permalink view.

In the recent refactor of post actions we changed initial posts load action to be two loadLatestPosts and loadPostsAround and IE had it missing.

Also postVisibility which was being passed from parent does not exist anymore so this causes issues as posts are spliced in IE based on that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17671

Note: Not adding any tests as this file does not have any and it will be removed from master really soon