### PR TITLE
MM-17652 - Very long email addresses overlap with Role column on LDAP group sync warning modal

### DIFF
--- a/components/admin_console/team_channel_settings/group/__snapshots__/group_users.test.jsx.snap
+++ b/components/admin_console/team_channel_settings/group/__snapshots__/group_users.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsers should match snaps
       />
     </div>
     <div
-      className="group-description"
+      className="group-description group-users--header-padded"
     >
       <FormattedMessage
         defaultMessage="Role"
@@ -26,7 +26,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsers should match snaps
       />
     </div>
     <div
-      className="group-description"
+      className="group-description group-users--header-padded"
     >
       <FormattedMessage
         defaultMessage="Groups"
@@ -396,7 +396,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsers should match snaps
       />
     </div>
     <div
-      className="group-description"
+      className="group-description group-users--header-padded"
     >
       <FormattedMessage
         defaultMessage="Role"
@@ -405,7 +405,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsers should match snaps
       />
     </div>
     <div
-      className="group-description"
+      className="group-description group-users--header-padded"
     >
       <FormattedMessage
         defaultMessage="Groups"
@@ -775,7 +775,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsers should match snaps
       />
     </div>
     <div
-      className="group-description"
+      className="group-description group-users--header-padded"
     >
       <FormattedMessage
         defaultMessage="Role"
@@ -784,7 +784,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsers should match snaps
       />
     </div>
     <div
-      className="group-description"
+      className="group-description group-users--header-padded"
     >
       <FormattedMessage
         defaultMessage="Groups"
@@ -1154,7 +1154,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsers should match snaps
       />
     </div>
     <div
-      className="group-description"
+      className="group-description group-users--header-padded"
     >
       <FormattedMessage
         defaultMessage="Role"
@@ -1163,7 +1163,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsers should match snaps
       />
     </div>
     <div
-      className="group-description"
+      className="group-description group-users--header-padded"
     >
       <FormattedMessage
         defaultMessage="Groups"
@@ -1533,7 +1533,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsers should match snaps
       />
     </div>
     <div
-      className="group-description"
+      className="group-description group-users--header-padded"
     >
       <FormattedMessage
         defaultMessage="Role"
@@ -1542,7 +1542,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsers should match snaps
       />
     </div>
     <div
-      className="group-description"
+      className="group-description group-users--header-padded"
     >
       <FormattedMessage
         defaultMessage="Groups"

--- a/components/admin_console/team_channel_settings/group/__snapshots__/group_users_row.test.jsx.snap
+++ b/components/admin_console/team_channel_settings/group/__snapshots__/group_users_row.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsersRow should match sn
   className="group "
 >
   <div
-    className="group-row"
+    className="group-row roc"
     style={
       Object {
         "padding": "30px 0px",
@@ -13,7 +13,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsersRow should match sn
     }
   >
     <div
-      className="group-name"
+      className="group-name col-sm-8"
     >
       <div
         className="row"
@@ -42,7 +42,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsersRow should match sn
             Test display name
           </div>
           <div
-            className="row"
+            className="row email-group-row"
           >
             test@test.com
           </div>
@@ -50,12 +50,12 @@ exports[`admin_console/team_channel_settings/group/GroupUsersRow should match sn
       </div>
     </div>
     <span
-      className="group-user-removal-column group-description"
+      className="col-sm-2 group-user-removal-column group-description"
     >
       system_user
     </span>
     <span
-      className="group-user-removal-column group-description group-description-link"
+      className="col-sm-2 group-user-removal-column group-description group-description-link"
     >
       test group
     </span>
@@ -68,7 +68,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsersRow should match sn
   className="group "
 >
   <div
-    className="group-row"
+    className="group-row roc"
     style={
       Object {
         "padding": "30px 0px",
@@ -76,7 +76,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsersRow should match sn
     }
   >
     <div
-      className="group-name"
+      className="group-name col-sm-8"
     >
       <div
         className="row"
@@ -105,7 +105,7 @@ exports[`admin_console/team_channel_settings/group/GroupUsersRow should match sn
             Test display name
           </div>
           <div
-            className="row"
+            className="row email-group-row"
           >
             test@test.com
           </div>
@@ -113,12 +113,12 @@ exports[`admin_console/team_channel_settings/group/GroupUsersRow should match sn
       </div>
     </div>
     <span
-      className="group-user-removal-column group-description"
+      className="col-sm-2 group-user-removal-column group-description"
     >
       system_user
     </span>
     <span
-      className="group-user-removal-column group-description group-description-link"
+      className="col-sm-2 group-user-removal-column group-description group-description-link"
     >
       <OverlayTrigger
         defaultOverlayShown={false}

--- a/components/admin_console/team_channel_settings/group/group_users.jsx
+++ b/components/admin_console/team_channel_settings/group/group_users.jsx
@@ -98,13 +98,13 @@ export default class AdminGroupUsers extends React.PureComponent {
                             defaultMessage='Name'
                         />
                     </div>
-                    <div className='group-description'>
+                    <div className='group-description group-users--header-padded'>
                         <FormattedMessage
                             id='admin.team_channel_settings.user_list.roleHeader'
                             defaultMessage='Role'
                         />
                     </div>
-                    <div className='group-description'>
+                    <div className='group-description group-users--header-padded'>
                         <FormattedMessage
                             id='admin.team_channel_settings.user_list.groupsHeader'
                             defaultMessage='Groups'

--- a/components/admin_console/team_channel_settings/group/group_users_row.jsx
+++ b/components/admin_console/team_channel_settings/group/group_users_row.jsx
@@ -52,10 +52,10 @@ export default class AdminGroupUsersRow extends React.PureComponent {
                 className={'group '}
             >
                 <div
-                    className='group-row'
+                    className='group-row roc'
                     style={{padding: '30px 0px'}}
                 >
-                    <div className='group-name'>
+                    <div className='group-name col-sm-8'>
                         <div className='row'>
                             <div className='col-sm-2'>
                                 <img
@@ -70,7 +70,7 @@ export default class AdminGroupUsersRow extends React.PureComponent {
                                     {'-'}&nbsp;
                                     {displayName}
                                 </div>
-                                <div className='row'>
+                                <div className='row email-group-row'>
                                     {user.email}
                                 </div>
 
@@ -79,10 +79,10 @@ export default class AdminGroupUsersRow extends React.PureComponent {
 
                     </div>
                     <span
-                        className='group-user-removal-column group-description'
+                        className='col-sm-2 group-user-removal-column group-description'
                     >{this.renderRolesColumn(user)}</span>
                     <span
-                        className='group-user-removal-column group-description group-description-link'
+                        className='col-sm-2 group-user-removal-column group-description group-description-link'
                     >{this.renderGroupsColumn(user)}</span>
                 </div>
             </div>

--- a/sass/components/_groups.scss
+++ b/sass/components/_groups.scss
@@ -508,3 +508,13 @@
         z-index: 5;
     }
 }
+
+.email-group-row {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    width: 90%;
+}
+
+.group-users--header-padded {
+    padding-left: 24px;
+}


### PR DESCRIPTION

#### Summary
in the warning modal that appears when users will be removed from a team or channel on LDAP sync, very long email addresses overlap with the Role column.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-17652
