### PR TITLE
Fix cypress report by escaping characters on title

### DIFF
--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -27,7 +27,7 @@ function generateStatsFieldValue(stats, failedFullTitles) {
     let statsFieldValue = `
 | Key | Value |
 |:---|:---|
-| Passing Rate | ${stats.passPercent.toFixed(2)}%25 |
+| Passing Rate | ${stats.passPercent.toFixed(2)}% |
 | Duration | ${(stats.duration / (60 * 1000)).toFixed(2)} mins |
 | Suites | ${stats.suites} |
 | Tests | ${stats.tests} |
@@ -42,7 +42,7 @@ function generateStatsFieldValue(stats, failedFullTitles) {
     if (failedFullTitles && failedFullTitles.length > 0) {
         const failed = failedFullTitles;
         if (failed.length > MAX_FAILED_TITLES) {
-            failedTests = failed.slice(0, MAX_FAILED_TITLES - 1).map((f) => `- ${f}`).join('\n');
+            failedTests = failed.slice(0, MAX_FAILED_TITLES - 1).map((f) => `- ${f.replace(/[:'"\\]/gi, '')}`).join('\n');
             failedTests += '\n- more...';
         } else {
             failedTests = failed.map((f) => `- ${f}`).join('\n');

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -40,12 +40,13 @@ function generateStatsFieldValue(stats, failedFullTitles) {
     // Only show per maximum number of failed titles with the last item as "more..." if failing tests are more than that.
     let failedTests;
     if (failedFullTitles && failedFullTitles.length > 0) {
+        const re = /[:'"\\]/gi;
         const failed = failedFullTitles;
         if (failed.length > MAX_FAILED_TITLES) {
-            failedTests = failed.slice(0, MAX_FAILED_TITLES - 1).map((f) => `- ${f.replace(/[:'"\\]/gi, '')}`).join('\n');
+            failedTests = failed.slice(0, MAX_FAILED_TITLES - 1).map((f) => `- ${f.replace(re, '')}`).join('\n');
             failedTests += '\n- more...';
         } else {
-            failedTests = failed.map((f) => `- ${f}`).join('\n');
+            failedTests = failed.map((f) => `- ${f.replace(re, '')}`).join('\n');
         }
     }
 


### PR DESCRIPTION
#### Summary
Fix cypress report by escaping characters on title

#### Ticket Link
none