### PR TITLE
More robust menu animation for safari

### DIFF
--- a/components/widgets/menu/menu_wrapper_animation.jsx
+++ b/components/widgets/menu/menu_wrapper_animation.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {tween, styler} from 'popmotion';
+import {chain, tween, styler, action} from 'popmotion';
 import {CSSTransition} from 'react-transition-group';
 
 import {isMobile} from 'utils/utils.jsx';
@@ -18,12 +18,24 @@ export default class MenuWrapperAnimation extends React.PureComponent {
 
     onEntering = (node) => {
         const nodeStyler = styler(node);
-        tween({from: {opacity: 0}, to: {opacity: 1}, duration: ANIMATION_DURATION}).start(nodeStyler.set);
+        chain(
+            action(({update, complete}) => {
+                update({display: 'block'});
+                complete();
+            }),
+            tween({from: {opacity: 0}, to: {opacity: 1}, duration: ANIMATION_DURATION}),
+        ).start(nodeStyler.set);
     }
 
     onExiting = (node) => {
         const nodeStyler = styler(node);
-        tween({from: {opacity: 1}, to: {opacity: 0}, duration: ANIMATION_DURATION}).start(nodeStyler.set);
+        chain(
+            tween({from: {opacity: 1}, to: {opacity: 0}, duration: ANIMATION_DURATION}),
+            action(({update, complete}) => {
+                update({display: 'none'});
+                complete();
+            }),
+        ).start(nodeStyler.set);
     }
 
     render() {

--- a/sass/widgets/menu/_menu.scss
+++ b/sass/widgets/menu/_menu.scss
@@ -21,7 +21,7 @@
         &.dropdown-menu {
             opacity: 0;
 
-            @media screen and (min-width: 641px) {
+            @media screen and (min-width: 768px) {
                 max-height: 0;
                 overflow: hidden;
                 overflow-y: hidden;
@@ -32,7 +32,7 @@
     &.Menu-enter-active {
         &.dropdown-menu {
             opacity: 1;
-            @media screen and (min-width: 641px) {
+            @media screen and (min-width: 768px) {
                 max-height: 80vh;
                 transition: max-height 1000ms ease-in, opacity 250ms linear;
                 overflow-y: hidden;
@@ -46,7 +46,7 @@
     &.Menu-enter-done {
         &.dropdown-menu {
             opacity: 1;
-            @media screen and (min-width: 641px) {
+            @media screen and (min-width: 768px) {
                 max-height: 80vh;
                 overflow-y: auto;
             }
@@ -56,12 +56,12 @@
     &.Menu-exit {
         &.dropdown-menu {
             opacity: 0;
-            @media screen and (min-width: 641px) {
+            @media screen and (min-width: 768px) {
                 max-height: 0;
                 transition: max-height 1000ms ease-in 0ms, opacity 250ms linear 750ms;
                 overflow-y: hidden;
             }
-            @media screen and (max-width: 640px) {
+            @media screen and (max-width: 768px) {
                 transition: opacity 1000ms linear;
             }
         }

--- a/sass/widgets/menu/_menu_wrapper.scss
+++ b/sass/widgets/menu/_menu_wrapper.scss
@@ -2,7 +2,12 @@
     position: relative;
 
     .Menu {
-        display: block;
+        display: none;
+        opacity: 0;
+        @media screen and (max-width: 768px) {
+            display: block;
+            opacity: 1;
+        }
     }
     *:first-child {
         @include unselectable;


### PR DESCRIPTION
#### Summary
The menu animation was flikering on safari some times, that was because certain
delay between the rendering plus the initial javascript animation, this is now
fixed moving the "display" change responsability to the animation itself. By
the way I change the breakpoint for mobile animations to the 768px limit, where
is the mobile view triggered.

#### Ticket Link
[MM-17579](https://mattermost.atlassian.net/browse/MM-17579)