### PR TITLE
Moving divider hidding logic from css to javascript

### DIFF
--- a/components/widgets/menu/menu.jsx
+++ b/components/widgets/menu/menu.jsx
@@ -21,7 +21,11 @@ export default class Menu extends React.PureComponent {
         this.node = React.createRef();
     }
 
-    hideUnneededDividers() {
+    hideUnneededDividers = () => {
+        if (this.node.current === null) {
+            return;
+        }
+
         const children = Object.values(this.node.current.children).slice(0, this.node.current.children.length);
 
         // Hiding formers dividers and duplicated ones

--- a/components/widgets/menu/menu.jsx
+++ b/components/widgets/menu/menu.jsx
@@ -21,6 +21,44 @@ export default class Menu extends React.PureComponent {
         this.node = React.createRef();
     }
 
+    hideUnneededDividers() {
+        const children = Object.values(this.node.current.children).slice(0, this.node.current.children.length);
+
+        // Hiding formers dividers and duplicated ones
+        let prevWasDivider = false;
+        let isAtBeginning = true;
+        for (const child of children) {
+            if (child.classList.contains('menu-divider') || child.classList.contains('mobile-menu-divider')) {
+                if (isAtBeginning) {
+                    child.style.display = 'none';
+                } else if (prevWasDivider) {
+                    child.style.display = 'none';
+                }
+                prevWasDivider = true;
+            } else {
+                isAtBeginning = false;
+                prevWasDivider = false;
+            }
+        }
+
+        // Hiding trailing dividers
+        for (const child of children.reverse()) {
+            if (child.classList.contains('menu-divider') || child.classList.contains('mobile-menu-divider')) {
+                child.style.display = 'none';
+            } else {
+                break;
+            }
+        }
+    }
+
+    componentDidMount() {
+        this.hideUnneededDividers();
+    }
+
+    componentDidUpdate() {
+        this.hideUnneededDividers();
+    }
+
     // Used from DotMenu component to know in which direction show the menu
     rect() {
         if (this.node && this.node.current) {

--- a/components/widgets/menu/menu.jsx
+++ b/components/widgets/menu/menu.jsx
@@ -28,14 +28,12 @@ export default class Menu extends React.PureComponent {
 
         const children = Object.values(this.node.current.children).slice(0, this.node.current.children.length);
 
-        // Hiding formers dividers and duplicated ones
+        // Hiding dividers at beginning and duplicated ones
         let prevWasDivider = false;
         let isAtBeginning = true;
         for (const child of children) {
             if (child.classList.contains('menu-divider') || child.classList.contains('mobile-menu-divider')) {
-                if (isAtBeginning) {
-                    child.style.display = 'none';
-                } else if (prevWasDivider) {
+                if (isAtBeginning || prevWasDivider) {
                     child.style.display = 'none';
                 }
                 prevWasDivider = true;

--- a/components/widgets/menu/menu.test.jsx
+++ b/components/widgets/menu/menu.test.jsx
@@ -209,4 +209,102 @@ describe('components/Menu', () => {
         </div>
         `);
     });
+
+    test('should hide the correct dividers on mobile', () => {
+        const utils = require('utils/utils'); //eslint-disable-line global-require
+        utils.isMobile.mockReturnValue(false);
+        const pseudoMenu = document.createElement('div');
+        const listOfItems = [
+            'mobile-menu-divider', 'mobile-menu-divider', 'mobile-menu-divider', 'mobile-menu-divider',
+            'other', 'other',
+            'mobile-menu-divider', 'mobile-menu-divider',
+            'other',
+            'mobile-menu-divider', 'mobile-menu-divider', 'mobile-menu-divider',
+            'other', 'other', 'other',
+            'mobile-menu-divider', 'mobile-menu-divider', 'mobile-menu-divider', 'mobile-menu-divider',
+        ];
+        for (const className of listOfItems) {
+            const element = document.createElement('div');
+            element.classList.add(className);
+            pseudoMenu.append(element);
+        }
+
+        const wrapper = shallow(<Menu ariaLabel='test-label'>{'text'}</Menu>);
+        const instance = wrapper.instance();
+        instance.node.current = pseudoMenu;
+        instance.hideUnneededDividers();
+
+        expect(instance.node.current).toMatchInlineSnapshot(`
+        <div>
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="mobile-menu-divider"
+          />
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="mobile-menu-divider"
+          />
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="mobile-menu-divider"
+            style="display: none;"
+          />
+        </div>
+        `);
+    });
 });

--- a/components/widgets/menu/menu.test.jsx
+++ b/components/widgets/menu/menu.test.jsx
@@ -111,4 +111,102 @@ describe('components/Menu', () => {
 </ul>
 `);
     });
+
+    test('should hide the correct dividers', () => {
+        const utils = require('utils/utils'); //eslint-disable-line global-require
+        utils.isMobile.mockReturnValue(false);
+        const pseudoMenu = document.createElement('div');
+        const listOfItems = [
+            'menu-divider', 'menu-divider', 'menu-divider', 'menu-divider',
+            'other', 'other',
+            'menu-divider', 'menu-divider',
+            'other',
+            'menu-divider', 'menu-divider', 'menu-divider',
+            'other', 'other', 'other',
+            'menu-divider', 'menu-divider', 'menu-divider', 'menu-divider',
+        ];
+        for (const className of listOfItems) {
+            const element = document.createElement('div');
+            element.classList.add(className);
+            pseudoMenu.append(element);
+        }
+
+        const wrapper = shallow(<Menu ariaLabel='test-label'>{'text'}</Menu>);
+        const instance = wrapper.instance();
+        instance.node.current = pseudoMenu;
+        instance.hideUnneededDividers();
+
+        expect(instance.node.current).toMatchInlineSnapshot(`
+        <div>
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="menu-divider"
+          />
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="menu-divider"
+          />
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="other"
+          />
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+          <div
+            class="menu-divider"
+            style="display: none;"
+          />
+        </div>
+        `);
+    });
 });

--- a/sass/widgets/menu/_menu_group.scss
+++ b/sass/widgets/menu/_menu_group.scss
@@ -4,21 +4,5 @@
         background: $black;
         height: 1px;
         margin: 8px 0;
-
-        & + .menu-divider,
-        &:first-child,
-        &:last-child,
-        &:nth-last-of-type(3) {
-            display: none;
-        }
-    }
-
-    &.mobile-menu-divider {
-        & + .mobile-menu-divider,
-        &:first-child,
-        &:nth-last-child(2),
-        &:nth-last-of-type(3) {
-            display: none;
-        }
     }
 }


### PR DESCRIPTION
#### Summary
Because the divider visibility was done by css some cases were hard to solve
(maybe imposible to solve) so I moved that logic into javascript to be able to
express correctly the expected behavior for the menu dividers visibility.

#### Ticket Link
[MM-14490](https://mattermost.atlassian.net/browse/MM-14490)