### PR TITLE
[MM-17603] Added null check to label generator on suggestion list

### DIFF
--- a/components/suggestion/search_suggestion_list.jsx
+++ b/components/suggestion/search_suggestion_list.jsx
@@ -37,7 +37,10 @@ export default class SearchSuggestionList extends SuggestionList {
             this.currentLabel = item.name;
         }
 
-        this.currentLabel = this.currentLabel.toLowerCase();
+        if (this.currentLabel) {
+            this.currentLabel = this.currentLabel.toLowerCase();
+        }
+
         this.announceLabel();
     }
 


### PR DESCRIPTION
#### Summary
This PR fixes a possible null on the current label for the suggestion list, causing a JS error. It stops the `toLowerCase()` call if the object is null.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17603
