### PR TITLE
Fix an issue where we may not have a parent when reporting cypress results

### DIFF
--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -36,7 +36,7 @@ Cypress.on('test:after:run', (test, runnable) => {
             // has the same hook id, or until we get to a tile of ''
             // (which means we are at the top level)
             if (parent.id !== `r${hookId}`) {
-                while (parent.parent.id !== `r${hookId}`) {
+                while (parent.parent && parent.parent.id !== `r${hookId}`) {
                     if (parent.title === '') {
                         // If we have a title of '' we have reached the top parent
                         break;


### PR DESCRIPTION
#### Summary
Depending on the test structure (e.g. before/after hooks, nesting, etc...), there can be times where the parent will not have a parent. This would then error, but "outside" of Cypress proper, so the error only is visible in the dev tools console.

#### Ticket Link
N/A