### PR TITLE
[MM-17539] User is unable to send messages again if the user flags a deleted post on RHS

### DIFF
--- a/components/rhs_root_post/__snapshots__/rhs_root_post.test.jsx.snap
+++ b/components/rhs_root_post/__snapshots__/rhs_root_post.test.jsx.snap
@@ -71,7 +71,7 @@ exports[`components/RhsRootPost should match snapshot 1`] = `
             postId="id"
           />
           <Connect(PostFlagIcon)
-            isFlagged={true}
+            isFlagged={false}
             location="RHS_ROOT"
             postId="id"
           />
@@ -84,7 +84,7 @@ exports[`components/RhsRootPost should match snapshot 1`] = `
             enableEmojiPicker={true}
             handleAddReactionClick={[Function]}
             handleDropdownOpened={[Function]}
-            isFlagged={true}
+            isFlagged={false}
             isReadOnly={false}
             location="RHS_ROOT"
             post={
@@ -249,11 +249,6 @@ exports[`components/RhsRootPost should match snapshot on deleted post 1`] = `
             location="RHS_ROOT"
             postId="id"
           />
-          <Connect(PostFlagIcon)
-            isFlagged={true}
-            location="RHS_ROOT"
-            postId="id"
-          />
         </div>
       </div>
       <div
@@ -306,6 +301,322 @@ exports[`components/RhsRootPost should match snapshot on deleted post 1`] = `
               "props": Object {},
               "root_id": "",
               "state": "DELETED",
+              "type": "",
+              "update_at": 1502715372443,
+              "user_id": "user_id",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/RhsRootPost should match snapshot on flagged, deleted post 1`] = `
+<div
+  aria-label=""
+  className="thread__root a11y__section post post--root post--thread current--user post--compact"
+  id="rhsPost_id"
+  onFocus={[Function]}
+  role="listitem"
+  tabIndex="-1"
+>
+  <div
+    className="post-right-channel__name"
+  >
+    Test
+  </div>
+  <div
+    className="post__content"
+  >
+    <div
+      className="post__img"
+    >
+      <Connect(PostProfilePicture)
+        compactDisplay={true}
+        isBusy={false}
+        isRHS={true}
+        post={
+          Object {
+            "channel_id": "channel_id",
+            "create_at": 1502715365009,
+            "delete_at": 0,
+            "edit_at": 1502715372443,
+            "id": "id",
+            "isFlagged": true,
+            "is_pinned": false,
+            "message": "post message",
+            "original_id": "",
+            "parent_id": "",
+            "pending_post_id": "",
+            "props": Object {},
+            "root_id": "",
+            "state": "DELETED",
+            "type": "",
+            "update_at": 1502715372443,
+            "user_id": "user_id",
+          }
+        }
+        userId="user_id"
+      />
+    </div>
+    <div>
+      <div
+        className="post__header"
+      >
+        <div
+          className="col__name"
+        >
+          <Connect(UserProfile)
+            hasMention={true}
+            isBusy={false}
+            isRHS={true}
+            key="user_id"
+            userId="user_id"
+          />
+        </div>
+        <div
+          className="col"
+        >
+          <Connect(PostTime)
+            eventTime={1502715365009}
+            isPermalink={false}
+            location="RHS_ROOT"
+            postId="id"
+          />
+        </div>
+      </div>
+      <div
+        className="post__body"
+      >
+        <div
+          className=" post--edited"
+        >
+          <MessageWithAdditionalContent
+            isEmbedVisible={false}
+            pluginPostTypes={Object {}}
+            post={
+              Object {
+                "channel_id": "channel_id",
+                "create_at": 1502715365009,
+                "delete_at": 0,
+                "edit_at": 1502715372443,
+                "id": "id",
+                "isFlagged": true,
+                "is_pinned": false,
+                "message": "post message",
+                "original_id": "",
+                "parent_id": "",
+                "pending_post_id": "",
+                "props": Object {},
+                "root_id": "",
+                "state": "DELETED",
+                "type": "",
+                "update_at": 1502715372443,
+                "user_id": "user_id",
+              }
+            }
+            previewCollapsed=""
+            previewEnabled={false}
+          />
+        </div>
+        <Connect(ReactionList)
+          isReadOnly={false}
+          post={
+            Object {
+              "channel_id": "channel_id",
+              "create_at": 1502715365009,
+              "delete_at": 0,
+              "edit_at": 1502715372443,
+              "id": "id",
+              "isFlagged": true,
+              "is_pinned": false,
+              "message": "post message",
+              "original_id": "",
+              "parent_id": "",
+              "pending_post_id": "",
+              "props": Object {},
+              "root_id": "",
+              "state": "DELETED",
+              "type": "",
+              "update_at": 1502715372443,
+              "user_id": "user_id",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/RhsRootPost should match snapshot when flagged 1`] = `
+<div
+  aria-label=""
+  className="thread__root a11y__section post post--root post--thread current--user post--compact"
+  id="rhsPost_id"
+  onFocus={[Function]}
+  role="listitem"
+  tabIndex="-1"
+>
+  <div
+    className="post-right-channel__name"
+  >
+    Test
+  </div>
+  <div
+    className="post__content"
+  >
+    <div
+      className="post__img"
+    >
+      <Connect(PostProfilePicture)
+        compactDisplay={true}
+        isBusy={false}
+        isRHS={true}
+        post={
+          Object {
+            "channel_id": "channel_id",
+            "create_at": 1502715365009,
+            "delete_at": 0,
+            "edit_at": 1502715372443,
+            "id": "id",
+            "is_pinned": false,
+            "message": "post message",
+            "original_id": "",
+            "parent_id": "",
+            "pending_post_id": "",
+            "props": Object {},
+            "root_id": "",
+            "type": "",
+            "update_at": 1502715372443,
+            "user_id": "user_id",
+          }
+        }
+        userId="user_id"
+      />
+    </div>
+    <div>
+      <div
+        className="post__header"
+      >
+        <div
+          className="col__name"
+        >
+          <Connect(UserProfile)
+            hasMention={true}
+            isBusy={false}
+            isRHS={true}
+            key="user_id"
+            userId="user_id"
+          />
+        </div>
+        <div
+          className="col"
+        >
+          <Connect(PostTime)
+            eventTime={1502715365009}
+            isPermalink={true}
+            location="RHS_ROOT"
+            postId="id"
+          />
+          <Connect(PostFlagIcon)
+            isFlagged={true}
+            location="RHS_ROOT"
+            postId="id"
+          />
+        </div>
+        <div
+          className="col col__reply"
+        >
+          <Connect(DotMenu)
+            commentCount={0}
+            enableEmojiPicker={true}
+            handleAddReactionClick={[Function]}
+            handleDropdownOpened={[Function]}
+            isFlagged={true}
+            isReadOnly={false}
+            location="RHS_ROOT"
+            post={
+              Object {
+                "channel_id": "channel_id",
+                "create_at": 1502715365009,
+                "delete_at": 0,
+                "edit_at": 1502715372443,
+                "id": "id",
+                "is_pinned": false,
+                "message": "post message",
+                "original_id": "",
+                "parent_id": "",
+                "pending_post_id": "",
+                "props": Object {},
+                "root_id": "",
+                "type": "",
+                "update_at": 1502715372443,
+                "user_id": "user_id",
+              }
+            }
+          />
+          <Connect(PostReaction)
+            channelId="channel_id"
+            getDotMenuRef={[Function]}
+            location="RHS_ROOT"
+            postId="id"
+            showEmojiPicker={false}
+            teamId="team_id"
+            toggleEmojiPicker={[Function]}
+          />
+        </div>
+      </div>
+      <div
+        className="post__body"
+      >
+        <div
+          className=" post--edited"
+        >
+          <MessageWithAdditionalContent
+            isEmbedVisible={false}
+            pluginPostTypes={Object {}}
+            post={
+              Object {
+                "channel_id": "channel_id",
+                "create_at": 1502715365009,
+                "delete_at": 0,
+                "edit_at": 1502715372443,
+                "id": "id",
+                "is_pinned": false,
+                "message": "post message",
+                "original_id": "",
+                "parent_id": "",
+                "pending_post_id": "",
+                "props": Object {},
+                "root_id": "",
+                "type": "",
+                "update_at": 1502715372443,
+                "user_id": "user_id",
+              }
+            }
+            previewCollapsed=""
+            previewEnabled={false}
+          />
+        </div>
+        <Connect(ReactionList)
+          isReadOnly={false}
+          post={
+            Object {
+              "channel_id": "channel_id",
+              "create_at": 1502715365009,
+              "delete_at": 0,
+              "edit_at": 1502715372443,
+              "id": "id",
+              "is_pinned": false,
+              "message": "post message",
+              "original_id": "",
+              "parent_id": "",
+              "pending_post_id": "",
+              "props": Object {},
+              "root_id": "",
               "type": "",
               "update_at": 1502715372443,
               "user_id": "user_id",

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -274,7 +274,8 @@ export default class RhsRootPost extends React.PureComponent {
         }
 
         let postFlagIcon;
-        if (this.props.post.type !== Constants.PostTypes.FAKE_PARENT_DELETED) {
+        const showFlagIcon = !isEphemeral && !post.failed && !isSystemMessage;
+        if (showFlagIcon) {
             postFlagIcon = (
                 <PostFlagIcon
                     location={Locations.RHS_ROOT}

--- a/components/rhs_root_post/rhs_root_post.test.jsx
+++ b/components/rhs_root_post/rhs_root_post.test.jsx
@@ -45,7 +45,7 @@ describe('components/RhsRootPost', () => {
             commentCount: 0,
             author: 'Author',
             reactions: {},
-            isFlagged: true,
+            isFlagged: false,
             isBusy: false,
             previewCollapsed: '',
             previewEnabled: false,
@@ -69,12 +69,40 @@ describe('components/RhsRootPost', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should match snapshot when flagged', () => {
+        const props = {
+            ...defaultProps,
+            isFlagged: true,
+        };
+        const wrapper = shallowWithIntl(
+            <RhsRootPost {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should match snapshot on deleted post', () => {
         const props = {
             ...defaultProps,
             post: {
                 ...defaultProps.post,
                 state: Posts.POST_DELETED,
+            },
+        };
+        const wrapper = shallowWithIntl(
+            <RhsRootPost {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot on flagged, deleted post', () => {
+        const props = {
+            ...defaultProps,
+            post: {
+                ...defaultProps.post,
+                state: Posts.POST_DELETED,
+                isFlagged: true,
             },
         };
         const wrapper = shallowWithIntl(


### PR DESCRIPTION
#### Summary
Prevents the flag icon from displaying on the root post in a thread in the RHS if the post has been deleted. Borrows [similar logic](https://github.com/mattermost/mattermost-webapp/blob/master/components/post_view/post_info/post_info.jsx#L223) from the `<PostInfo/>` component in the center channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17539

#### Related Pull Requests
N/A
