### PR TITLE
MM-15887 E2E for interactive menu for long option

### DIFF
--- a/components/widgets/settings/autocomplete_selector.jsx
+++ b/components/widgets/settings/autocomplete_selector.jsx
@@ -109,7 +109,10 @@ export default class AutocompleteSelector extends React.PureComponent {
         }
 
         return (
-            <div className='form-group'>
+            <div
+                data-testid='autoCompleteSelector'
+                className='form-group'
+            >
                 {labelContent}
                 <div className={inputClassName}>
                     <SuggestionBox

--- a/components/widgets/settings/autocomplete_selector.test.jsx
+++ b/components/widgets/settings/autocomplete_selector.test.jsx
@@ -18,6 +18,7 @@ describe('components/widgets/settings/AutocompleteSelector', () => {
         expect(wrapper).toMatchInlineSnapshot(`
 <div
   className="form-group"
+  data-testid="autoCompleteSelector"
 >
   <label
     className="control-label "
@@ -67,6 +68,7 @@ describe('components/widgets/settings/AutocompleteSelector', () => {
         expect(wrapper).toMatchInlineSnapshot(`
 <div
   className="form-group"
+  data-testid="autoCompleteSelector"
 >
   <label
     className="control-label "
@@ -107,6 +109,7 @@ describe('components/widgets/settings/AutocompleteSelector', () => {
         expect(wrapper).toMatchInlineSnapshot(`
 <div
   className="form-group"
+  data-testid="autoCompleteSelector"
 >
   <label
     className="control-label "


### PR DESCRIPTION
#### Summary
E2E for interactive menu for long option
Ref - [Tab/test case](https://docs.google.com/spreadsheets/d/1hbJ0rf_YxhCo1oDw1wUzTQaM1BJPAxE5XNZb6PvZwbc/edit#gid=1272020211&range=9:9) from Release testing spreadsheet

Requirement:
- Selected options with long usernames are not cut off in the RHS

Expected:
- Option is displayed in the text box
- Ephemeral message posts (only visible to you) showing the selection you have made
- RHS opens
- Username selected displays properly (truncated) and is not just cut off

#### Ticket Link
Jira ticket - [MM-15887](https://mattermost.atlassian.net/browse/MM-15887)
