### PR TITLE
[MM-17198] Fetch channels and memberships if guest on redirect

### DIFF
--- a/actions/global_actions.test.js
+++ b/actions/global_actions.test.js
@@ -52,7 +52,9 @@ describe('actions/global_actions', () => {
                     },
                     users: {
                         currentUserId: 'user1',
-                        profiles: {},
+                        profiles: {
+                            user1: {id: 'user1'},
+                        },
                     },
                 },
             });
@@ -108,7 +110,9 @@ describe('actions/global_actions', () => {
                     },
                     users: {
                         currentUserId: userId,
-                        profiles: {},
+                        profiles: {
+                            [userId]: {id: userId},
+                        },
                     },
                 },
             });


### PR DESCRIPTION
#### Summary
When trying to decide which is the adequate channel to redirect a guest, we cannot default to `town-square` as it is possible that the guest is not a member of it. Instead, we need to fetch the guest channels and members from the server and then decide to which channel we want to redirect them to.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17198

#### Related Pull Requests
- [Has redux changes](https://github.com/mattermost/mattermost-redux/pull/900)