### PR TITLE
[MM-17085] Add more interactive dialog tests

### DIFF
--- a/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
@@ -15,6 +15,18 @@ const webhookUtils = require('../../../utils/webhook_utils');
 
 let createdCommand;
 let fullDialog;
+const inputTypes = {
+    realname: 'input',
+    someemail: 'email',
+    somenumber: 'number',
+    somepassword: 'password',
+};
+
+const optionsLength = {
+    someuserselector: 25, // default number of users in autocomplete
+    somechannelselector: 2, // town-square and off-topic for new team
+    someoptionselector: 3, // number of defined basic options
+};
 
 describe('ID15888 Interactive Dialog', () => {
     before(() => {
@@ -81,8 +93,19 @@ describe('ID15888 Interactive Dialog', () => {
 
                 if (['someuserselector', 'somechannelselector', 'someoptionselector'].includes(element.name)) {
                     cy.wrap($elForm).find('input').should('be.visible').and('have.attr', 'autocomplete', 'off').and('have.attr', 'placeholder', element.placeholder);
+
+                    // * Verify that the suggestion list or autocomplete open up on click of input element
+                    cy.wrap($elForm).find('#suggestionList').should('not.be.visible');
+                    cy.wrap($elForm).find('input').click();
+                    cy.wrap($elForm).find('#suggestionList').should('be.visible').children().should('have.length', optionsLength[element.name]);
                 } else {
                     cy.wrap($elForm).find(`#${element.name}`).should('be.visible').and('have.value', element.default).and('have.attr', 'placeholder', element.placeholder);
+                }
+
+                // * Verify that input element are given with the correct type of "input", "email", "number" and "password".
+                // * To take advantage of supported built-in validation.
+                if (inputTypes[element.name]) {
+                    cy.wrap($elForm).find(`#${element.name}`).should('have.attr', 'type', inputTypes[element.name]);
                 }
 
                 if (element.help_text) {

--- a/e2e/utils/webhook_utils.js
+++ b/e2e/utils/webhook_utils.js
@@ -56,6 +56,21 @@ function getFullDialog(triggerId, webhookBaseUrl) {
                     options: null,
                 },
                 {
+                    display_name: 'Password',
+                    name: 'somepassword',
+                    type: 'text',
+                    subtype: 'password',
+                    default: 'p@ssW0rd',
+                    placeholder: 'placeholder',
+                    help_text:
+                        'This a password input in an interactive dialog triggered by a test integration.',
+                    optional: true,
+                    min_length: 0,
+                    max_length: 0,
+                    data_source: '',
+                    options: null,
+                },
+                {
                     display_name: 'Display Name Long Text Area',
                     name: 'realnametextarea',
                     type: 'textarea',


### PR DESCRIPTION
#### Summary
Add more interactive dialog tests
- verify input types including support to `password` element
- verify if autocomplete/suggestion list is open on click to input with datasource

#### Ticket Link
Jira ticket: [MM-17085](https://mattermost.atlassian.net/browse/MM-17085)
