### PR TITLE
MM-17752/MM-17890 Properly dispatch handleChannelUpdatedEvent

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -248,7 +248,7 @@ function handleClose(failCount) {
     ]));
 }
 
-function handleEvent(msg) {
+export function handleEvent(msg) {
     switch (msg.event) {
     case SocketEvents.POSTED:
     case SocketEvents.EPHEMERAL_MESSAGE:
@@ -320,7 +320,7 @@ function handleEvent(msg) {
         break;
 
     case SocketEvents.CHANNEL_UPDATED:
-        handleChannelUpdatedEvent(msg);
+        dispatch(handleChannelUpdatedEvent(msg));
         break;
 
     case SocketEvents.CHANNEL_MEMBER_UPDATED:

--- a/actions/websocket_actions.test.jsx
+++ b/actions/websocket_actions.test.jsx
@@ -21,10 +21,11 @@ import store from 'stores/redux_store.jsx';
 import configureStore from 'tests/test_store';
 
 import {browserHistory} from 'utils/browser_history';
-import Constants, {UserStatuses} from 'utils/constants';
+import Constants, {SocketEvents, UserStatuses} from 'utils/constants';
 
 import {
     handleChannelUpdatedEvent,
+    handleEvent,
     handleNewPostEvent,
     handleNewPostEvents,
     handlePostEditEvent,
@@ -117,6 +118,16 @@ jest.mock('actions/views/rhs', () => ({
         return {type: ''};
     }),
 }));
+
+describe('handleEvent', () => {
+    test('should dispatch channel updated event properly', () => {
+        const msg = {event: SocketEvents.CHANNEL_UPDATED};
+
+        handleEvent(msg);
+
+        expect(store.dispatch).toHaveBeenCalled();
+    });
+});
 
 describe('handlePostEditEvent', () => {
     test('post edited', async () => {


### PR DESCRIPTION
While fixing MM-16060, I switched `handleChannelUpdatedEvent` to be a redux action, but I forgot to actually dispatch it outside of the test code.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17890
https://mattermost.atlassian.net/browse/MM-17752

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/3077