### PR TITLE
MM-17752 Fix channel_updated WS event not dispatching

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -249,7 +249,7 @@ function handleClose(failCount) {
     ]));
 }
 
-function handleEvent(msg) {
+export function handleEvent(msg) {
     switch (msg.event) {
     case SocketEvents.POSTED:
     case SocketEvents.EPHEMERAL_MESSAGE:
@@ -321,7 +321,7 @@ function handleEvent(msg) {
         break;
 
     case SocketEvents.CHANNEL_UPDATED:
-        handleChannelUpdatedEvent(msg);
+        dispatch(handleChannelUpdatedEvent(msg));
         break;
 
     case SocketEvents.CHANNEL_MEMBER_UPDATED:

--- a/actions/websocket_actions.test.jsx
+++ b/actions/websocket_actions.test.jsx
@@ -22,7 +22,7 @@ import store from 'stores/redux_store.jsx';
 import configureStore from 'tests/test_store';
 
 import {browserHistory} from 'utils/browser_history';
-import Constants, {UserStatuses} from 'utils/constants';
+import Constants, {UserStatuses, SocketEvents} from 'utils/constants';
 
 import {
     handleChannelUpdatedEvent,
@@ -32,6 +32,7 @@ import {
     handleUserRemovedEvent,
     handleUserTypingEvent,
     reconnect,
+    handleEvent,
 } from './websocket_actions';
 
 jest.mock('mattermost-redux/actions/posts', () => ({
@@ -382,6 +383,13 @@ describe('handleChannelUpdatedEvent', () => {
             },
         },
     };
+
+    test('called from handleEvent', () => {
+        const channel = {id: 'channel'};
+        const msg = {event: SocketEvents.CHANNEL_UPDATED, data: {channel: JSON.stringify(channel)}};
+        handleEvent(msg);
+        expect(store.dispatch).toHaveBeenCalled();
+    });
 
     test('when a channel is updated', () => {
         const testStore = configureStore(initialState);


### PR DESCRIPTION
#### Summary
The function was updated to be a redux action but we were still calling it normally.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17752