### PR TITLE
[MM-17786] Handle window focus events (a11y_controller.js)

### DIFF
--- a/utils/a11y_controller.js
+++ b/utils/a11y_controller.js
@@ -30,6 +30,7 @@ export default class A11yController {
         this.downArrowKeyIsPressed = false;
         this.tabKeyIsPressed = false;
         this.tildeKeyIsPressed = false;
+        this.windowIsFocused = true;
 
         // used to reset navigation whenever navigation within a region occurs (section or element)
         this.resetNavigation = false;
@@ -40,6 +41,7 @@ export default class A11yController {
         document.addEventListener(EventTypes.MOUSE_DOWN, this.handleMouseDown, listenerOptions);
         document.addEventListener(EventTypes.MOUSE_UP, this.handleMouseUp, listenerOptions);
         document.addEventListener(EventTypes.FOCUS, this.handleFocus, listenerOptions);
+        window.addEventListener(EventTypes.BLUR, this.handleWindowBlur, listenerOptions);
     }
 
     destroy() {
@@ -52,6 +54,7 @@ export default class A11yController {
         document.removeEventListener(EventTypes.MOUSE_DOWN, this.handleMouseDown, listenerOptions);
         document.removeEventListener(EventTypes.MOUSE_UP, this.handleMouseUp, listenerOptions);
         document.removeEventListener(EventTypes.FOCUS, this.handleFocus, listenerOptions);
+        window.removeEventListener(EventTypes.BLUR, this.handleWindowBlur, listenerOptions);
     }
 
     // convenience getter/setters
@@ -425,7 +428,7 @@ export default class A11yController {
             return;
         }
 
-        // set focus on the element that should have focus if neede
+        // set focus on the element that should have focus if needed
         if (document.activeElement !== this.focusedElement) {
             this.focusedElement.focus();
         }
@@ -762,8 +765,19 @@ export default class A11yController {
     }
 
     handleFocus = (event) => {
-        if (!this.mouseIsPressed) {
+        if (!this.mouseIsPressed && this.windowIsFocused) {
             this.nextElement(event.target, event.path || true);
+        }
+
+        // focus just came back to the app
+        if (!this.windowIsFocused) {
+            this.windowIsFocused = true;
+        }
+    }
+
+    handleWindowBlur = (event) => {
+        if (event.target === window) {
+            this.windowIsFocused = false;
         }
     }
 


### PR DESCRIPTION
#### Summary
This PR updates the a11ycontroller.js to keep track of window focus so that it doesn't inadvertently make a11y visual updates when the windows comes back into focus again.

The problem was that once the window came back into focus, the element that last had focus received a focus event again and since that event wasn't triggered by a mouse click, the a11y_controller assumed it was a legit focus event and highlighted the element.

Test Steps:
1. Click on a post (not a button or link in a post)
2. Switch to a new tab and switch back
3. Move the mouse without clicking

Expected: There should be no visual updates to the post (i.e. the post should not receive an a11y focus outline.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17786