### PR TITLE
MM-17526 Fix for overflow in compact view for long posts

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -741,6 +741,7 @@
     padding: 8px .5em 0 1.5em; // If this needs to be changed then .post-row__padding needs to be adjusted accordingly
     position: relative;
     word-wrap: break-word;
+    overflow: hidden;
 
     .browser--ie & {
         .post__header {


### PR DESCRIPTION
#### Summary
Compact view causes a overlap with next posts because of an overflow override which is responsible for wrapping posts
![Aug-20-2019 01-41-35](https://user-images.githubusercontent.com/4973621/63295988-ab62e900-c2eb-11e9-9cf0-9cd48a5eeaa3.gif)

The css of overflow state hides the content and normally this takes few frames showing the overflowed content for a brief period of time.
![Aug-20-2019 01-34-34](https://user-images.githubusercontent.com/4973621/63296100-e82ee000-c2eb-11e9-81d4-b96c4140efaf.gif)

Adding overflow to .post class instead

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17526
