### PR TITLE
Updating redux hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6242,23 +6242,6 @@
       "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
       "dev": true
     },
-    "focus-trap": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-4.0.2.tgz",
-      "integrity": "sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==",
-      "requires": {
-        "tabbable": "^3.1.2",
-        "xtend": "^4.0.1"
-      }
-    },
-    "focus-trap-react": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-6.0.0.tgz",
-      "integrity": "sha512-mvEYxmP75PMx0vOqoIAmJHO/qUEvdTAdz6gLlEZyxxODnuKQdnKea2RWTYxghAPrV+ibiIq2o/GTSgQycnAjcw==",
-      "requires": {
-        "focus-trap": "^4.0.2"
-      }
-    },
     "font-awesome": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
@@ -7679,23 +7662,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "httpplease": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/httpplease/-/httpplease-0.16.4.tgz",
-      "integrity": "sha1-04Lr4jDvUHkIC06f/r8xap51wNo=",
-      "requires": {
-        "urllite": "~0.5.0",
-        "xmlhttprequest": "*",
-        "xtend": "~3.0.0"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-        }
       }
     },
     "https-browserify": {
@@ -9878,8 +9844,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#3c2455d59299de4645a7296eb9c11b2c65917cb5",
-      "from": "github:mattermost/mattermost-redux#3c2455d59299de4645a7296eb9c11b2c65917cb5",
+      "version": "github:mattermost/mattermost-redux#4b33a54f75b5d2db14f400ef47fde24e74f68e3d",
+      "from": "github:mattermost/mattermost-redux#4b33a54f75b5d2db14f400ef47fde24e74f68e3d",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",
@@ -14421,11 +14387,6 @@
       "integrity": "sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg==",
       "dev": true
     },
-    "tabbable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
-      "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ=="
-    },
     "table": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
@@ -15231,14 +15192,6 @@
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "dev": true
     },
-    "urllite": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/urllite/-/urllite-0.5.0.tgz",
-      "integrity": "sha1-G3u5yj+w25Ug3hE0ZrvPfMNBRRo=",
-      "requires": {
-        "xtend": "~4.0.0"
-      }
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -15796,11 +15749,6 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
-    },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xregexp": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#3c10e2109527cd14a76e1f8edd9d317d8b8988b0",
-    "mattermost-redux": "github:mattermost/mattermost-redux#3c2455d59299de4645a7296eb9c11b2c65917cb5",
+    "mattermost-redux": "github:mattermost/mattermost-redux#4b33a54f75b5d2db14f400ef47fde24e74f68e3d",
     "moment-timezone": "0.5.25",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
Because of: https://github.com/mattermost/mattermost-redux/commit/4b33a54f75b5d2db14f400ef47fde24e74f68e3d

Timeline: this https://github.com/mattermost/mattermost-webapp/pull/3449 was cherry-picked to 5.15, which needed this https://github.com/mattermost/mattermost-redux/pull/898 to be cherry-picked to redux's 5.15, which changed the hash, which the present PR is updating.