### PR TITLE
MM-17475: restore regeneratorRuntime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1444,6 +1444,11 @@
           "version": "2.6.5",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
           "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
       }
     },
@@ -13813,9 +13818,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "redux": "4.0.4",
     "redux-batched-actions": "0.4.1",
     "redux-persist": "4.10.2",
+    "regenerator-runtime": "^0.13.3",
     "reselect": "4.0.0",
     "superagent": "5.1.0",
     "xregexp": "4.2.4",

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import regeneratorRuntime from 'regenerator-runtime';
+
 import {Client4} from 'mattermost-redux/client';
 
 import store from 'stores/redux_store.jsx';
@@ -8,6 +10,10 @@ import {ActionTypes} from 'utils/constants.jsx';
 import {getSiteURL} from 'utils/url.jsx';
 import PluginRegistry from 'plugins/registry';
 import {unregisterAllPluginWebSocketEvents, unregisterPluginReconnectHandler} from 'actions/websocket_actions.jsx';
+
+// Plugins may have been compiled with the regenerator runtime. Ensure this remains available
+// as a global export even though the webapp does not depend on same.
+window.regeneratorRuntime = regeneratorRuntime;
 
 // plugins records all active web app plugins by id.
 window.plugins = {};


### PR DESCRIPTION
#### Summary
This dependency was removed as part of a recent Babel upgrade, but
plugins compiled without that same upgrade may fail to start. Restore
the dependency to ensure plugins don't break on upgrade to 5.16.

We may revisit this dependency on the next major version bump.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17475