### PR TITLE
MM-17420 Fix width of AutosizeTextarea reference

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -25,6 +25,9 @@
         height: auto;
         max-height: 60vh;
         min-height: 8em;
+        -ms-overflow-style: auto;
+        -webkit-overflow-scrolling: touch;
+        overflow-y: auto;
 
         &.custom-textarea--preview {
             display: none;

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -6,7 +6,7 @@
     height: 100%;
     line-height: 20px;
     min-height: 36px;
-    overflow-x: hidden;
+    overflow: hidden;
     resize: none;
     white-space: pre-wrap;
     word-wrap: break-word;
@@ -440,12 +440,8 @@
     .custom-textarea {
         bottom: 0;
         max-height: calc(50vh - 40px);
-        overflow: hidden;
         padding: 12px 0 12px 15px;
         resize: none;
-        -ms-overflow-style: auto;
-        -webkit-overflow-scrolling: touch;
-        overflow-y: auto;
 
         &:not(.custom-textarea--emoji-picker) {
             padding-right: 40px;


### PR DESCRIPTION
The invisible textarea used to calculate the height of the AutosizeTextarea was calculating the height incorrectly because it had `overflow-y:auto` set which was causing it to render a scrollbar when it shouldn't have been. This messed up the height calculation on browsers where the scrollbar takes up space in the textarea (like Firefox) because the reference textarea was slightly skinnier than the actual one.

That `overflow-y` was added in [this PR](https://github.com/mattermost/mattermost-webapp/pull/3247) to fix scrolling being disabled in the EditPostModal which happened because [this earlier PR](https://github.com/mattermost/mattermost-webapp/pull/3136/files#diff-1428328d7327589043eb01c9848a1a7bR344) added a div with the `post-create-container` class to that modal which caused [these other CSS rules](https://github.com/mattermost/mattermost-webapp/blob/master/sass/layout/_post.scss#L440) to apply including one that set `overflow: hidden`. Next time we're doing some CSS cleanup, we should probably look at the `custom-textarea` class since it now only ever exists inside of a `post-create-container` element.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17420