### PR TITLE
MM-17868 Fix accessibilityLabel warning for ToggleModalButtonRedux

### DIFF
--- a/components/post_view/channel_intro_message/channel_intro_message.jsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.jsx
@@ -245,28 +245,33 @@ export function createDefaultIntroMessage(channel, centeredIntro, enableUserCrea
                     permissions={[Permissions.ADD_USER_TO_TEAM]}
                 >
                     {!teamIsGroupConstrained &&
-                    <ToggleModalButtonRedux
-                        id='introTextInvite'
-                        className='intro-links color--link cursor--pointer'
-                        modalId={ModalIdentifiers.INVITATION}
-                        dialogType={InvitationModal}
+                    <FormattedMessage
+                        id='intro_messages.inviteOthers'
+                        defaultMessage='Invite others to this team'
                     >
-                        <FormattedMessage
-                            id='generic_icons.add'
-                            defaultMessage='Add Icon'
-                        >
-                            {(title) => (
-                                <i
-                                    className='fa fa-user-plus'
-                                    title={title}
-                                />
-                            )}
-                        </FormattedMessage>
-                        <FormattedMessage
-                            id='intro_messages.inviteOthers'
-                            defaultMessage='Invite others to this team'
-                        />
-                    </ToggleModalButtonRedux>
+                        {(message) => (
+                            <ToggleModalButtonRedux
+                                accessibilityLabel={message}
+                                id='introTextInvite'
+                                className='intro-links color--link cursor--pointer'
+                                modalId={ModalIdentifiers.INVITATION}
+                                dialogType={InvitationModal}
+                            >
+                                <FormattedMessage
+                                    id='generic_icons.add'
+                                    defaultMessage='Add Icon'
+                                >
+                                    {(title) => (
+                                        <i
+                                            className='fa fa-user-plus'
+                                            title={title}
+                                        />
+                                    )}
+                                </FormattedMessage>
+                                {message}
+                            </ToggleModalButtonRedux>
+                        )}
+                    </FormattedMessage>
                     }
                     {teamIsGroupConstrained &&
                     <ToggleModalButton


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The `ToggleModalButtonRedux` component requires the prop `accessibilityLabel` to be set and the option to `Invite others to this team` was not setting the accessibility label

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-17868