### PR TITLE
[MM-17687] User detail page: Profile image square instead of round

### DIFF
--- a/components/__snapshots__/profile_picture.test.jsx.snap
+++ b/components/__snapshots__/profile_picture.test.jsx.snap
@@ -64,14 +64,14 @@ exports[`components/ProfilePicture should match snapshot, profile and src, defau
   trigger="click"
 >
   <span
-    className="status-wrapper "
+    className="status-wrapper"
   >
     <span
       className="profile-icon "
     >
       <img
         alt="user profile image"
-        className="more-modal__image"
+        className="ProfilePicture more-modal__image"
         height="36"
         src="http://example.com/emoji.png"
         width="36"

--- a/components/more_direct_channels/__snapshots__/more_direct_channels.test.jsx.snap
+++ b/components/more_direct_channels/__snapshots__/more_direct_channels.test.jsx.snap
@@ -13,7 +13,6 @@ exports[`components/MoreDirectChannels should match renderOption snapshot 1`] = 
     src="/api/v4/users/user_id_1/image"
     status="online"
     width="32"
-    wrapperClass=""
   />
   <div
     className="more-modal__details"

--- a/components/profile_picture.jsx
+++ b/components/profile_picture.jsx
@@ -8,6 +8,8 @@ import {OverlayTrigger} from 'react-bootstrap';
 import ProfilePopover from 'components/profile_popover';
 import StatusIcon from 'components/status_icon';
 
+import './profile_picture.scss';
+
 export default class ProfilePicture extends React.PureComponent {
     static defaultProps = {
         width: '36',
@@ -15,7 +17,6 @@ export default class ProfilePicture extends React.PureComponent {
         isRHS: false,
         isEmoji: false,
         hasMention: false,
-        wrapperClass: '',
     };
 
     static propTypes = {
@@ -64,10 +65,10 @@ export default class ProfilePicture extends React.PureComponent {
                         />
                     }
                 >
-                    <span className={`status-wrapper ${this.props.wrapperClass}`}>
+                    <span className='status-wrapper'>
                         <span className={profileIconClass}>
                             <img
-                                className='more-modal__image'
+                                className='ProfilePicture more-modal__image'
                                 alt={`${this.props.username || 'user'} profile image`}
                                 width={this.props.width}
                                 height={this.props.width}

--- a/components/profile_picture.scss
+++ b/components/profile_picture.scss
@@ -1,0 +1,3 @@
+.ProfilePicture {
+    border-radius: 50%;
+}


### PR DESCRIPTION
#### Summary
Fixes profile image border radius.
<img width="398" alt="Screen Shot 2019-08-23 at 12 05 00 AM" src="https://user-images.githubusercontent.com/44858354/63573252-b317cd00-c539-11e9-9ee6-185521c8f8c4.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17687

#### Related Pull Requests
N/A
