### PR TITLE
Fixing store out-of-sync for guest accounts

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -14,12 +14,13 @@ import {
     IntegrationTypes,
     PreferenceTypes,
 } from 'mattermost-redux/action_types';
-import {WebsocketEvents, General} from 'mattermost-redux/constants';
+import {WebsocketEvents, General, Permissions} from 'mattermost-redux/constants';
 import {
     getChannelAndMyMember,
     getChannelStats,
     viewChannel,
     markChannelAsRead,
+
 } from 'mattermost-redux/actions/channels';
 import {setServerVersion} from 'mattermost-redux/actions/general';
 import {
@@ -46,6 +47,7 @@ import {getMyTeams, getCurrentRelativeTeamUrl, getCurrentTeamId, getCurrentTeamU
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getChannel, getCurrentChannel, getCurrentChannelId, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getPost, getMostRecentPostIdInChannel} from 'mattermost-redux/selectors/entities/posts';
+import {haveISystemPermission, haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 
 import {getSelectedChannelId} from 'selectors/rhs';
 
@@ -698,6 +700,22 @@ export function handleUserRemovedEvent(msg) {
             type: UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL,
             data: {id: msg.broadcast.channel_id, user_id: msg.data.user_id},
         });
+    }
+
+    const channelId = msg.broadcast.channel_id || msg.data.channel_id;
+    const userId = msg.broadcast.user_id || msg.data.user_id;
+    const channel = getChannel(state, channelId);
+    if (channel && !haveISystemPermission(state, {permission: Permissions.VIEW_MEMBERS}) && !haveITeamPermission(state, {permission: Permissions.VIEW_MEMBERS, team: channel.team_id})) {
+        dispatch(batchActions([
+            {
+                type: UserTypes.RECEIVED_PROFILE_NOT_IN_TEAM,
+                data: {id: channel.team_id, user_id: userId},
+            },
+            {
+                type: TeamTypes.REMOVE_MEMBER_FROM_TEAM,
+                data: {team_id: channel.team_id, user_id: userId},
+            },
+        ]));
     }
 }
 

--- a/actions/websocket_actions.test.jsx
+++ b/actions/websocket_actions.test.jsx
@@ -66,12 +66,24 @@ const mockState = {
         users: {
             currentUserId: 'currentUserId',
             profiles: {
+                currentUserId: {
+                    id: 'currentUserId',
+                    roles: 'system_guest',
+                },
                 user: {
                     id: 'user',
+                    roles: 'system_guest',
                 },
             },
             statuses: {
                 user: 'away',
+            },
+        },
+        roles: {
+            roles: {
+                system_guest: {
+                    permissions: ['view_members'],
+                },
             },
         },
         general: {
@@ -79,7 +91,12 @@ const mockState = {
         },
         channels: {
             currentChannelId: 'otherChannel',
-            channels: {},
+            channels: {
+                otherChannel: {
+                    id: 'otherChannel',
+                    team_id: 'otherTeam',
+                },
+            },
         },
         preferences: {
             myPreferences: {},
@@ -165,6 +182,52 @@ describe('handleUserRemovedEvent', () => {
 
         handleUserRemovedEvent(msg);
         expect(closeRightHandSide).toHaveBeenCalled();
+    });
+
+    test('shouldn\'t remove the team user if the user have view members permissions', async () => {
+        const expectedAction = {
+            meta: {batch: true},
+            payload: [
+                {type: 'RECEIVED_PROFILE_NOT_IN_TEAM', data: {id: 'otherTeam', user_id: 'guestId'}},
+                {type: 'REMOVE_MEMBER_FROM_TEAM', data: {team_id: 'otherTeam', user_id: 'guestId'}},
+            ],
+            type: 'BATCHING_REDUCER.BATCH',
+        };
+        const msg = {
+            data: {
+                channel_id: 'otherChannel',
+            },
+            broadcast: {
+                user_id: 'guestId',
+            },
+        };
+
+        handleUserRemovedEvent(msg);
+        expect(store.dispatch).not.toHaveBeenCalledWith(expectedAction);
+    });
+
+    test('should remove the team user if the user doesn\'t have view members permissions', async () => {
+        const expectedAction = {
+            meta: {batch: true},
+            payload: [
+                {type: 'RECEIVED_PROFILE_NOT_IN_TEAM', data: {id: 'otherTeam', user_id: 'guestId'}},
+                {type: 'REMOVE_MEMBER_FROM_TEAM', data: {team_id: 'otherTeam', user_id: 'guestId'}},
+            ],
+            type: 'BATCHING_REDUCER.BATCH',
+        };
+        const msg = {
+            data: {
+                channel_id: 'otherChannel',
+            },
+            broadcast: {
+                user_id: 'guestId',
+            },
+        };
+
+        mockState.entities.roles.roles = {system_guest: {permissions: []}};
+        handleUserRemovedEvent(msg);
+        mockState.entities.roles.roles = {system_guest: {permissions: ['view_members']}};
+        expect(store.dispatch).toHaveBeenCalledWith(expectedAction);
     });
 });
 


### PR DESCRIPTION
#### Summary
When a guest (a users without the `VIEW_MEMBERS` permission available) is in a
channel a user gets out of the channel and is no longer visible the store
wasn't updated. Now every time a user leave the channel the team membership is
removed from the store (so it can be reloaded if needed when the user visits a
page that needs it).

#### Ticket Link
[MM-17216](https://mattermost.atlassian.net/browse/MM-17216)