### PR TITLE
Fix failing E2E tests

### DIFF
--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -313,6 +313,7 @@ export default class Post extends React.PureComponent {
                 <div
                     role='application'
                     id='postContent'
+                    data-testid='postContent'
                     className={'post__content ' + centerClass}
                     aria-hidden={this.state.ariaHidden}
                 >

--- a/e2e/cypress/integration/channel/message_spec.js
+++ b/e2e/cypress/integration/channel/message_spec.js
@@ -56,7 +56,7 @@ describe('Message', () => {
 
         // # Post a message to force next user message to display a message
         cy.getCurrentChannelId().then((channelId) => {
-            cy.postMessageAs({sender: sysadmin, message: 'Hello', channelId, baseUrl: Cypress.config('baseUrl')});
+            cy.postMessageAs({sender: sysadmin, message: 'Hello', channelId});
         });
 
         // # Post message "One"

--- a/e2e/cypress/integration/interactive_menu/basic_options_spec.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options_spec.js
@@ -42,7 +42,7 @@ describe('MM-15887 Interactive menus - basic options', () => {
         cy.apiSaveTeammateNameDisplayPreference('username');
 
         // # Visit '/' and create incoming webhook
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
         cy.getCurrentChannelId().then((id) => {
             channelId = id;
 
@@ -124,10 +124,8 @@ describe('MM-15887 Interactive menus - basic options', () => {
 
         // # Get last post
         cy.getLastPostId().then((parentMessageId) => {
-            const baseUrl = Cypress.config('baseUrl');
-
             // # Post another message
-            cy.postMessageAs({sender: user1, message: 'Just another message', channelId, baseUrl});
+            cy.postMessageAs({sender: user1, message: 'Just another message', channelId});
 
             // # Click comment icon to open RHS
             cy.clickPostCommentIcon(parentMessageId);
@@ -136,7 +134,7 @@ describe('MM-15887 Interactive menus - basic options', () => {
             cy.get('#rhsContainer').should('be.visible');
 
             // # Have another user reply to the webhook message
-            cy.postMessageAs({sender: user1, message: 'Reply to webhook', channelId, rootId: parentMessageId, baseUrl});
+            cy.postMessageAs({sender: user1, message: 'Reply to webhook', channelId, rootId: parentMessageId});
 
             // # Get the latest post
             cy.getLastPostId().then((replyMessageId) => {

--- a/e2e/cypress/integration/messaging/focus_move_spec.js
+++ b/e2e/cypress/integration/messaging/focus_move_spec.js
@@ -109,7 +109,7 @@ describe('Messaging', () => {
                 channel = res.body;
 
                 // # Select the channel on the left hand side
-                cy.get(`#sidebarItem_${channel.name}`).click();
+                cy.get(`#sidebarItem_${channel.name}`).click({force: true});
 
                 // * Channel's display name should be visible at the top of the center pane
                 cy.get('#channelHeaderTitle').should('contain', channel.display_name);

--- a/e2e/cypress/integration/search/date_filter_spec.js
+++ b/e2e/cypress/integration/search/date_filter_spec.js
@@ -122,11 +122,11 @@ describe('SF15699 Search Date Filter', () => {
         cy.getCurrentChannelId().then((channelId) => {
             // Post message as new admin to Town Square
             cy.get('@newAdmin').then((user) => {
-                cy.postMessageAs({sender: user, message: firstMessage, channelId, createAt: firstDateEarly.ms, baseUrl});
+                cy.postMessageAs({sender: user, message: firstMessage, channelId, createAt: firstDateEarly.ms});
             });
 
             // Post message as sysadmin to Town Square
-            cy.postMessageAs({sender: users.sysadmin, message: secondMessage, channelId, createAt: secondDateEarly.ms, baseUrl});
+            cy.postMessageAs({sender: users.sysadmin, message: secondMessage, channelId, createAt: secondDateEarly.ms});
         });
 
         // # Create messages at same dates in Off Topic channel
@@ -136,11 +136,11 @@ describe('SF15699 Search Date Filter', () => {
 
         cy.getCurrentChannelId().then((channelId) => {
             // Post message as sysadmin to off topic
-            cy.postMessageAs({sender: users.sysadmin, message: firstOffTopicMessage, channelId, createAt: firstDateLater.ms, baseUrl});
+            cy.postMessageAs({sender: users.sysadmin, message: firstOffTopicMessage, channelId, createAt: firstDateLater.ms});
 
             // Post message as new admin to off topic
             cy.get('@newAdmin').then((user) => {
-                cy.postMessageAs({sender: user, message: secondOffTopicMessage, channelId, createAt: secondDateLater.ms, baseUrl});
+                cy.postMessageAs({sender: user, message: secondOffTopicMessage, channelId, createAt: secondDateLater.ms});
             });
         });
     });
@@ -316,10 +316,10 @@ describe('SF15699 Search Date Filter', () => {
 
             // Post same message at different times
             cy.getCurrentChannelId().then((channelId) => {
-                cy.postMessageAs({sender: users.sysadmin, message: 'pretarget ' + identifier, channelId, createAt: preTarget.ms, baseUrl});
-                cy.postMessageAs({sender: users.sysadmin, message: targetAMMessage, channelId, createAt: targetAM.ms, baseUrl});
-                cy.postMessageAs({sender: users.sysadmin, message: targetPMMessage, channelId, createAt: targetPM.ms, baseUrl});
-                cy.postMessageAs({sender: users.sysadmin, message: 'postTarget' + identifier, channelId, createAt: postTarget.ms, baseUrl});
+                cy.postMessageAs({sender: users.sysadmin, message: 'pretarget ' + identifier, channelId, createAt: preTarget.ms});
+                cy.postMessageAs({sender: users.sysadmin, message: targetAMMessage, channelId, createAt: targetAM.ms});
+                cy.postMessageAs({sender: users.sysadmin, message: targetPMMessage, channelId, createAt: targetPM.ms});
+                cy.postMessageAs({sender: users.sysadmin, message: 'postTarget' + identifier, channelId, createAt: postTarget.ms});
             });
 
             // * Verify we only see messages from the expected date, and not outside of it
@@ -367,7 +367,7 @@ describe('SF15699 Search Date Filter', () => {
 
             // # Post message with unique text
             cy.getCurrentChannelId().then((channelId) => {
-                cy.postMessageAs({sender: users.sysadmin, message: targetMessage, channelId, createAt: targetDate.ms, baseUrl});
+                cy.postMessageAs({sender: users.sysadmin, message: targetMessage, channelId, createAt: targetDate.ms});
             });
 
             // # Set clock to custom date, reload page for it to take effect
@@ -441,7 +441,7 @@ describe('SF15699 Search Date Filter', () => {
 
             // # Post message with unique text
             cy.getCurrentChannelId().then((channelId) => {
-                cy.postMessageAs({sender: users.sysadmin, message: targetMessage, channelId, createAt: target.ms, baseUrl});
+                cy.postMessageAs({sender: users.sysadmin, message: targetMessage, channelId, createAt: target.ms});
             });
 
             // * Verify result appears in current timezone

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -135,7 +135,7 @@ Cypress.Commands.add('postMessageReplyInRHS', (message) => {
 
 Cypress.Commands.add('getLastPost', () => {
     cy.get('#post-list', {timeout: TIMEOUTS.HUGE}).should('be.visible');
-    return cy.get('#postListContent #postContent', {timeout: TIMEOUTS.HUGE}).last().scrollIntoView().should('be.visible');
+    return cy.getAllByTestId('postContent', {timeout: TIMEOUTS.HUGE}).last().scrollIntoView().should('be.visible');
 });
 
 Cypress.Commands.add('getLastPostId', (opts = {force: false}) => {


### PR DESCRIPTION
#### Summary
Daily report - https://community.mattermost.com/core/pl/yrt4wogua7d5mdcgzye13ajx7e

Fix failing tests on:
1. System Message MM-14636 - Validate that system message is wrapping properly
  - might be flaky when initiating ``getLastPost``.  Make use of `data-testid` and get the last post by using ``getAllByTestId``
2. MM-15887 Interactive menus - basic options displays reply in center channel with commented on [users] message [text]
  - failed when `user-1` try to post a message in a team where it's not member of.
3. Messaging M17452 Focus does not move when it has already been set elsewhere
  - failed when channel name is not viewable in the sidebar, either scroll into view or force click into it.

While here, I did clean up the use of `cy.postMessageAs` where baseUrl is actually not necessary to pass into it.