### PR TITLE
[MM-17923] Fix Guest Badge alignment when long username/fullname wraps

### DIFF
--- a/components/invitation_modal/invitation_modal_confirm_step_row.jsx
+++ b/components/invitation_modal/invitation_modal_confirm_step_row.jsx
@@ -51,8 +51,10 @@ export default class InvitationModalConfirmStepRow extends React.Component {
             <div className='InvitationModalConfirmStepRow'>
                 <div className='username-or-icon'>
                     {icon}
-                    <span className={className}>{username}</span>
-                    {guestBadge}
+                    <span className={className}>
+                        {username}
+                        {guestBadge}
+                    </span>
                 </div>
                 <div className='reason'>
                     {invitation.reason}

--- a/components/invitation_modal/invitation_modal_confirm_step_row.scss
+++ b/components/invitation_modal/invitation_modal_confirm_step_row.scss
@@ -48,6 +48,8 @@
         }
         .Badge {
             margin-top: 2px;
+            display: inline-block;
+            vertical-align: top;
         }
     }
     .reason {


### PR DESCRIPTION
#### Summary

Fixes an alignment issue of the Guest Badge in case of very long usernames/fullnames.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17923
