### PR TITLE
[MM-18118] Check locale is valid before sending to intl_provider

### DIFF
--- a/selectors/i18n.js
+++ b/selectors/i18n.js
@@ -3,9 +3,9 @@
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserLocale} from 'mattermost-redux/selectors/entities/i18n';
+import {General} from 'mattermost-redux/constants';
 
 import * as I18n from 'i18n/i18n';
-import { General } from 'mattermost-redux/constants';
 
 // This is a placeholder for if we ever implement browser-locale detection
 export function getCurrentLocale(state) {

--- a/selectors/i18n.js
+++ b/selectors/i18n.js
@@ -5,10 +5,15 @@ import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserLocale} from 'mattermost-redux/selectors/entities/i18n';
 
 import * as I18n from 'i18n/i18n';
+import { General } from 'mattermost-redux/constants';
 
 // This is a placeholder for if we ever implement browser-locale detection
 export function getCurrentLocale(state) {
-    return getCurrentUserLocale(state, getConfig(state).DefaultClientLocale);
+    const currentLocale = getCurrentUserLocale(state, getConfig(state).DefaultClientLocale);
+    if (I18n.isLanguageAvailable(currentLocale)) {
+        return currentLocale;
+    }
+    return General.DEFAULT_LOCALE;
 }
 
 export function getTranslations(state, locale) {

--- a/selectors/i18n.test.js
+++ b/selectors/i18n.test.js
@@ -1,8 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {getCurrentLocale, getTranslations} from 'selectors/i18n';
 import {General} from 'mattermost-redux/constants';
+
+import {getCurrentLocale, getTranslations} from 'selectors/i18n';
 
 describe('selectors/i18n', () => {
     describe('getCurrentLocale', () => {
@@ -45,6 +46,28 @@ describe('selectors/i18n', () => {
 
             expect(getCurrentLocale(state)).toEqual('de');
         });
+
+        test('returns default locale when invalid user locale specified', () => {
+            const state = {
+                entities: {
+                    general: {
+                        config: {
+                            DefaultClientLocale: 'en',
+                        },
+                    },
+                    users: {
+                        currentUserId: 'abcd',
+                        profiles: {
+                            abcd: {
+                                locale: 'not_valid',
+                            },
+                        },
+                    },
+                },
+            };
+
+            expect(getCurrentLocale(state)).toEqual(General.DEFAULT_LOCALE);
+        });
     });
 
     describe('getTranslations', () => {
@@ -71,28 +94,6 @@ describe('selectors/i18n', () => {
         test('returns English translations for unsupported locale', () => {
             // This test will have to be changed if we add support for Gaelic
             expect(getTranslations(state, 'gd')).toBe(state.views.i18n.translations.en);
-        });
-
-        test('returns default locale when invalid user locale specified', () => {
-            const state = {
-                entities: {
-                    general: {
-                        config: {
-                            DefaultClientLocale: 'en',
-                        },
-                    },
-                    users: {
-                        currentUserId: 'abcd',
-                        profiles: {
-                            abcd: {
-                                locale: 'not_valid',
-                            },
-                        },
-                    },
-                },
-            };
-
-            expect(getCurrentLocale(state)).toEqual(General.DEFAULT_LOCALE);
         });
     });
 });

--- a/selectors/i18n.test.js
+++ b/selectors/i18n.test.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {getCurrentLocale, getTranslations} from 'selectors/i18n';
+import {General} from 'mattermost-redux/constants';
 
 describe('selectors/i18n', () => {
     describe('getCurrentLocale', () => {
@@ -70,6 +71,28 @@ describe('selectors/i18n', () => {
         test('returns English translations for unsupported locale', () => {
             // This test will have to be changed if we add support for Gaelic
             expect(getTranslations(state, 'gd')).toBe(state.views.i18n.translations.en);
+        });
+
+        test('returns default locale when invalid user locale specified', () => {
+            const state = {
+                entities: {
+                    general: {
+                        config: {
+                            DefaultClientLocale: 'en',
+                        },
+                    },
+                    users: {
+                        currentUserId: 'abcd',
+                        profiles: {
+                            abcd: {
+                                locale: 'not_valid',
+                            },
+                        },
+                    },
+                },
+            };
+
+            expect(getCurrentLocale(state)).toEqual(General.DEFAULT_LOCALE);
         });
     });
 });


### PR DESCRIPTION
#### Summary
If an invalid locale is specified in the database, upon refreshing the app a logged in user will experience a blank screen. This PR forces the locale to the default in this case, such that `intl_provider` is never fed an invalid locale.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18118
