### PR TITLE
add user id to be show in the user page in the system console

### DIFF
--- a/components/admin_console/system_users/list/__snapshots__/system_users_list.test.jsx.snap
+++ b/components/admin_console/system_users/list/__snapshots__/system_users_list.test.jsx.snap
@@ -102,11 +102,31 @@ exports[`components/admin_console/system_users/list should match default snapsho
             defaultMessage="**Sign-in Method:** Email"
             id="admin.user_item.authServiceEmail"
           />,
+          ", ",
+          <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="**User ID:** {userID}"
+            id="admin.user_item.user_id"
+            values={
+              Object {
+                "userID": "id1",
+              }
+            }
+          />,
         ],
         "id2": Array [
           <InjectIntl(FormattedMarkdownMessage)
             defaultMessage="**Sign-in Method:** Email"
             id="admin.user_item.authServiceEmail"
+          />,
+          ", ",
+          <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="**User ID:** {userID}"
+            id="admin.user_item.user_id"
+            values={
+              Object {
+                "userID": "id2",
+              }
+            }
           />,
         ],
         "id3": Array [
@@ -116,6 +136,16 @@ exports[`components/admin_console/system_users/list should match default snapsho
             values={
               Object {
                 "service": "LDAP",
+              }
+            }
+          />,
+          ", ",
+          <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="**User ID:** {userID}"
+            id="admin.user_item.user_id"
+            values={
+              Object {
+                "userID": "id3",
               }
             }
           />,
@@ -130,6 +160,16 @@ exports[`components/admin_console/system_users/list should match default snapsho
               }
             }
           />,
+          ", ",
+          <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="**User ID:** {userID}"
+            id="admin.user_item.user_id"
+            values={
+              Object {
+                "userID": "id4",
+              }
+            }
+          />,
         ],
         "id5": Array [
           <InjectIntl(FormattedMarkdownMessage)
@@ -138,6 +178,16 @@ exports[`components/admin_console/system_users/list should match default snapsho
             values={
               Object {
                 "service": "Other Service",
+              }
+            }
+          />,
+          ", ",
+          <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="**User ID:** {userID}"
+            id="admin.user_item.user_id"
+            values={
+              Object {
+                "userID": "id5",
               }
             }
           />,
@@ -245,6 +295,16 @@ exports[`components/admin_console/system_users/list should match default snapsho
           />,
           ", ",
           <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="**User ID:** {userID}"
+            id="admin.user_item.user_id"
+            values={
+              Object {
+                "userID": "id1",
+              }
+            }
+          />,
+          ", ",
+          <InjectIntl(FormattedMarkdownMessage)
             defaultMessage="**MFA**: No"
             id="admin.user_item.mfaNo"
           />,
@@ -253,6 +313,16 @@ exports[`components/admin_console/system_users/list should match default snapsho
           <InjectIntl(FormattedMarkdownMessage)
             defaultMessage="**Sign-in Method:** Email"
             id="admin.user_item.authServiceEmail"
+          />,
+          ", ",
+          <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="**User ID:** {userID}"
+            id="admin.user_item.user_id"
+            values={
+              Object {
+                "userID": "id2",
+              }
+            }
           />,
           ", ",
           <InjectIntl(FormattedMarkdownMessage)
@@ -267,6 +337,16 @@ exports[`components/admin_console/system_users/list should match default snapsho
             values={
               Object {
                 "service": "LDAP",
+              }
+            }
+          />,
+          ", ",
+          <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="**User ID:** {userID}"
+            id="admin.user_item.user_id"
+            values={
+              Object {
+                "userID": "id3",
               }
             }
           />,
@@ -288,6 +368,16 @@ exports[`components/admin_console/system_users/list should match default snapsho
           />,
           ", ",
           <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="**User ID:** {userID}"
+            id="admin.user_item.user_id"
+            values={
+              Object {
+                "userID": "id4",
+              }
+            }
+          />,
+          ", ",
+          <InjectIntl(FormattedMarkdownMessage)
             defaultMessage="**MFA**: No"
             id="admin.user_item.mfaNo"
           />,
@@ -299,6 +389,16 @@ exports[`components/admin_console/system_users/list should match default snapsho
             values={
               Object {
                 "service": "Other Service",
+              }
+            }
+          />,
+          ", ",
+          <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="**User ID:** {userID}"
+            id="admin.user_item.user_id"
+            values={
+              Object {
+                "userID": "id5",
               }
             }
           />,

--- a/components/admin_console/system_users/list/system_users_list.jsx
+++ b/components/admin_console/system_users/list/system_users_list.jsx
@@ -211,6 +211,19 @@ export default class SystemUsersList extends React.Component {
             );
         }
 
+        info.push(', ');
+        const userID = user.id;
+        info.push(
+            <FormattedMarkdownMessage
+                key='admin.user_item.user_id'
+                id='admin.user_item.user_id'
+                defaultMessage='**User ID:** {userID}'
+                values={{
+                    userID,
+                }}
+            />
+        );
+
         if (this.props.mfaEnabled) {
             info.push(', ');
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1581,6 +1581,7 @@
   "admin.user_item.sysAdmin": "System Admin",
   "admin.user_item.teamAdmin": "Team Admin",
   "admin.user_item.teamMember": "Team Member",
+  "admin.user_item.user_id": "**User ID:** {userID}",
   "admin.user_item.userAccessTokenPostAll": "(can create post:all personal access tokens)",
   "admin.user_item.userAccessTokenPostAllPublic": "(can create post:channels personal access tokens)",
   "admin.user_item.userAccessTokenYes": "(can create personal access tokens)",


### PR DESCRIPTION
#### Summary
Adds the user id information in the system console -> user page

As a mattermost system administrator some tasks i need to know the userid, either to fill this info in some plugin config or to do any other task
And the only way to get that is using the dev tools (too hacky) or using the CLI which I need to have access to the server (too bad)

![Screenshot 2019-08-30 at 16 56 23](https://user-images.githubusercontent.com/4115580/64031956-ca624600-cb49-11e9-85c0-f50a4fc96e2f.png)



#### Ticket Link
jira:  https://mattermost.atlassian.net/browse/MM-18153