### PR TITLE
GH-11994: Add support for footer and footer_icon in attachments

### DIFF
--- a/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
+++ b/components/post_view/message_attachments/message_attachment/__snapshots__/message_attachment.test.jsx.snap
@@ -87,6 +87,18 @@ exports[`components/post_view/MessageAttachment should call actions.doPostAction
             </Connect(ExternalImage)>
           </div>
           <div
+            className="attachment__footer-container"
+          >
+            <Connect(ExternalImage)
+              src="footer_icon"
+            >
+              <Component />
+            </Connect(ExternalImage)>
+            <span>
+              footer
+            </span>
+          </div>
+          <div
             className="attachment-actions"
           >
             <ActionButton
@@ -131,6 +143,133 @@ exports[`components/post_view/MessageAttachment should call actions.doPostAction
 `;
 
 exports[`components/post_view/MessageAttachment should match snapshot 1`] = `
+<div
+  className="attachment attachment--pretext"
+>
+  <div
+    className="attachment__thumb-pretext"
+  >
+    <Connect(Markdown)
+      message="pretext"
+    />
+  </div>
+  <div
+    className="attachment__content"
+  >
+    <div
+      className="clearfix attachment__container"
+      style={
+        Object {
+          "borderLeftColor": "#FFF",
+        }
+      }
+    >
+      <a
+        href="author_link"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <Connect(ExternalImage)
+          key="attachment__author-icon"
+          src="author_icon"
+        >
+          <Component />
+        </Connect(ExternalImage)>
+        <span
+          className="attachment__author-name"
+          key="attachment__author-name"
+        >
+          author_name
+        </span>
+      </a>
+      <h1
+        className="attachment__title"
+      >
+        <a
+          className="attachment__title-link"
+          href="title_link"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          title
+        </a>
+      </h1>
+      <div>
+        <div
+          className="attachment__body"
+          onClick={[Function]}
+        >
+          <Connect(ShowMore)
+            checkOverflow={0}
+            isAttachmentText={true}
+            text="short text"
+          >
+            <Connect(Markdown)
+              imageProps={
+                Object {
+                  "onImageLoaded": [Function],
+                }
+              }
+              message="short text"
+            />
+          </Connect(ShowMore)>
+          <div
+            className="attachment__image-container"
+          >
+            <Connect(ExternalImage)
+              imageMetadata={
+                Object {
+                  "height": 200,
+                  "width": 200,
+                }
+              }
+              src="image_url"
+            >
+              <Component />
+            </Connect(ExternalImage)>
+          </div>
+          <div
+            className="attachment__footer-container"
+          >
+            <Connect(ExternalImage)
+              src="footer_icon"
+            >
+              <Component />
+            </Connect(ExternalImage)>
+            <span>
+              footer
+            </span>
+          </div>
+        </div>
+        <div
+          className="attachment__thumb-container"
+        >
+          <Connect(ExternalImage)
+            imageMetadata={
+              Object {
+                "height": 200,
+                "width": 200,
+              }
+            }
+            src="thumb_url"
+          >
+            <Component />
+          </Connect(ExternalImage)>
+        </div>
+        <div
+          style={
+            Object {
+              "clear": "both",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/post_view/MessageAttachment should match snapshot when no footer is provided (even if footer_icon is provided) 1`] = `
 <div
   className="attachment attachment--pretext"
 >
@@ -364,6 +503,58 @@ exports[`components/post_view/MessageAttachment should match snapshot when the a
           className="attachment__body attachment__body--no_thumb"
           onClick={[Function]}
         />
+        <div
+          style={
+            Object {
+              "clear": "both",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/post_view/MessageAttachment should match snapshot when the footer is truncated 1`] = `
+<div
+  className="attachment "
+>
+  <div
+    className="attachment__content"
+  >
+    <div
+      className="clearfix attachment__container attachment__container--undefined"
+    >
+      <h1
+        className="attachment__title"
+      >
+        <Connect(Markdown)
+          message="footer"
+          options={
+            Object {
+              "autolinkedUrlSchemes": Array [],
+              "mentionHighlight": false,
+              "renderer": LinkOnlyRenderer {
+                "options": Object {},
+              },
+            }
+          }
+        />
+      </h1>
+      <div>
+        <div
+          className="attachment__body attachment__body--no_thumb"
+          onClick={[Function]}
+        >
+          <div
+            className="attachment__footer-container"
+          >
+            <span>
+              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
+            </span>
+          </div>
+        </div>
         <div
           style={
             Object {

--- a/components/post_view/message_attachments/message_attachment/message_attachment.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.jsx
@@ -3,9 +3,11 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import truncate from 'lodash/truncate';
 
 import {isUrlSafe} from 'utils/url';
 import {handleFormattedTextClick} from 'utils/utils';
+import {Constants} from 'utils/constants';
 
 import ExternalImage from 'components/external_image';
 import Markdown from 'components/markdown';
@@ -365,6 +367,38 @@ export default class MessageAttachment extends React.PureComponent {
             );
         }
 
+        let footer;
+        if (attachment.footer) {
+            let footerIcon;
+            if (attachment.footer_icon) {
+                const footerIconMetadata = this.props.imagesMetadata[attachment.footer_icon];
+
+                footerIcon = (
+                    <ExternalImage
+                        src={attachment.footer_icon}
+                        imageMetadata={footerIconMetadata}
+                    >
+                        {(footerIconUrl) => (
+                            <img
+                                alt={'attachment footer icon'}
+                                className='attachment__footer-icon'
+                                src={footerIconUrl}
+                                height='16'
+                                width='16'
+                            />
+                        )}
+                    </ExternalImage>
+                );
+            }
+
+            footer = (
+                <div className='attachment__footer-container'>
+                    {footerIcon}
+                    <span>{truncate(attachment.footer, {length: Constants.MAX_ATTACHMENT_FOOTER_LENGTH, omission: '…'})}</span>
+                </div>
+            );
+        }
+
         let thumb;
         if (attachment.thumb_url) {
             const thumbMetadata = this.props.imagesMetadata[attachment.thumb_url];
@@ -416,6 +450,7 @@ export default class MessageAttachment extends React.PureComponent {
                                 {attachmentText}
                                 {image}
                                 {fields}
+                                {footer}
                                 {actions}
                             </div>
                             {thumb}

--- a/components/post_view/message_attachments/message_attachment/message_attachment.test.jsx
+++ b/components/post_view/message_attachments/message_attachment/message_attachment.test.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
+import {Constants} from 'utils/constants';
+
 import ExternalImage from 'components/external_image';
 import MessageAttachment from 'components/post_view/message_attachments/message_attachment/message_attachment.jsx';
 
@@ -19,6 +21,8 @@ describe('components/post_view/MessageAttachment', () => {
         image_url: 'image_url',
         thumb_url: 'thumb_url',
         color: '#FFF',
+        footer: 'footer',
+        footer_icon: 'footer_icon',
     };
 
     const baseProps = {
@@ -120,14 +124,19 @@ describe('components/post_view/MessageAttachment', () => {
                 author_icon: 'http://example.com/author.png',
                 image_url: 'http://example.com/image.png',
                 thumb_url: 'http://example.com/thumb.png',
+
+                // footer_icon is only rendered if footer is provided
+                footer: attachment.footer,
+                footer_icon: 'http://example.com/footer.png',
             },
         };
 
         const wrapper = shallow(<MessageAttachment {...props}/>);
 
-        expect(wrapper.find(ExternalImage)).toHaveLength(3);
+        expect(wrapper.find(ExternalImage)).toHaveLength(4);
         expect(wrapper.find(ExternalImage).find({src: props.attachment.author_icon}).exists()).toBe(true);
         expect(wrapper.find(ExternalImage).find({src: props.attachment.image_url}).exists()).toBe(true);
+        expect(wrapper.find(ExternalImage).find({src: props.attachment.footer_icon}).exists()).toBe(true);
         expect(wrapper.find(ExternalImage).find({src: props.attachment.thumb_url}).exists()).toBe(true);
     });
 
@@ -162,6 +171,34 @@ describe('components/post_view/MessageAttachment', () => {
             ...baseProps,
             attachment: {
                 title: 'Do you like https://mattermost.com?',
+            },
+        };
+
+        const wrapper = shallow(<MessageAttachment {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot when no footer is provided (even if footer_icon is provided)', () => {
+        const props = {
+            ...baseProps,
+            attachment: {
+                ...attachment,
+                footer: undefined,
+            },
+        };
+
+        const wrapper = shallow(<MessageAttachment {...props}/>);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot when the footer is truncated', () => {
+        const props = {
+            ...baseProps,
+            attachment: {
+                title: 'footer',
+                footer: 'a'.repeat(Constants.MAX_ATTACHMENT_FOOTER_LENGTH + 1),
             },
         };
 

--- a/sass/layout/_webhooks.scss
+++ b/sass/layout/_webhooks.scss
@@ -301,6 +301,18 @@
             }
         }
 
+        .attachment__footer-container {
+            position: relative;
+            padding-top: .7em;
+            font-size: 12px;
+            color: #A3A3A3;
+
+            .attachment__footer-icon {
+                margin-top: -2px;
+                margin-right: 5px;
+            }
+        }
+
         .attachment-actions {
             position: relative;
             display: flex;

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1330,6 +1330,7 @@ export const Constants = {
     CHANNEL_ID_LENGTH: 26,
     TRANSPARENT_PIXEL: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
     TRIPLE_BACK_TICKS: /```/g,
+    MAX_ATTACHMENT_FOOTER_LENGTH: 300,
 };
 
 export const AcceptedProfileImageTypes = ['image/jpeg', 'image/png', 'image/bmp'];


### PR DESCRIPTION
## Summary
Adds support for the `footer` and `footer_icon` properties in message attachments.

#### Screenshots

No footer:

<img width="574" alt="no-footer" src="https://user-images.githubusercontent.com/1638631/64125757-95d8cf00-cd81-11e9-8633-9ddf797c4c6b.png">

Text-only footer:

<img width="574" alt="footer-no-icon" src="https://user-images.githubusercontent.com/1638631/64125768-9f623700-cd81-11e9-916f-f83724f67fe9.png">

Footer with icon:

<img width="573" alt="footer-with-icon" src="https://user-images.githubusercontent.com/1638631/64125772-a6894500-cd81-11e9-9a69-9363da6ee93e.png">

Footer with more than 300 characters:

<img width="572" alt="long-footer" src="https://user-images.githubusercontent.com/1638631/64125787-adb05300-cd81-11e9-8d8c-120508fec464.png">

#### Other details

The `footer_icon` is only rendered if `footer` is also provided.  

The `footer` text is truncated if it exceeds 300 characters.

#### Ticket Link

https://github.com/mattermost/mattermost-server/issues/11994
