### PR TITLE
Mm 18093 system console plugin enable

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -4,6 +4,11 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
 <component
   config={
     Object {
+      "EscapedSettings": Object {
+        "com.example.setting": Object {
+          "a": true,
+        },
+      },
       "FirstSettings": Object {
         "settinga": "fsdsdg",
         "settingb": false,
@@ -616,6 +621,36 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
               />
             }
             value={false}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <SchemaText
+                isTranslated={true}
+                text="escaped-help-text-a"
+                textDefault="This is some help text for the first escaped field."
+              />
+            }
+            id="EscapedSettings.com+example+setting.a"
+            key="Config_bool_EscapedSettings.com+example+setting.a"
+            label="Escaped Setting A"
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
           />
         </SettingsGroup>
       </form>

--- a/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.jsx.snap
+++ b/components/admin_console/custom_plugin_settings/__snapshots__/custom_plugin_settings.test.jsx.snap
@@ -27,7 +27,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
           >
             <SchemaText
               isMarkdown={true}
-              isTranslated={true}
+              isTranslated={false}
               text="# Header
 *This* is the **header**"
             />
@@ -36,7 +36,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             disabled={false}
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the text field."
               />
             }
@@ -60,7 +60,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             }
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the bool field."
               />
             }
@@ -82,7 +82,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             disabled={false}
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the dropdown field."
               />
             }
@@ -114,7 +114,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             disabled={false}
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the radio field."
               />
             }
@@ -145,7 +145,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             disabled={false}
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the generated field."
               />
             }
@@ -169,7 +169,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             disabled={false}
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the user autocomplete field."
               />
             }
@@ -185,7 +185,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
           >
             <SchemaText
               isMarkdown={true}
-              isTranslated={true}
+              isTranslated={false}
               text="# Footer
 *This* is the **footer**"
             />
@@ -322,7 +322,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
           >
             <SchemaText
               isMarkdown={true}
-              isTranslated={true}
+              isTranslated={false}
               text="# Header
 *This* is the **header**"
             />
@@ -331,12 +331,12 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             disabled={false}
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the text field."
               />
             }
-            id="settinga"
-            key="testplugin_text_settinga"
+            id="PluginSettings.Plugins.testplugin.settinga"
+            key="testplugin_text_PluginSettings.Plugins.testplugin.settinga"
             label="Setting One"
             onChange={[Function]}
             placeholder="e.g. some setting"
@@ -355,12 +355,12 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             }
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the bool field."
               />
             }
-            id="settingb"
-            key="testplugin_bool_settingb"
+            id="PluginSettings.Plugins.testplugin.settingb"
+            key="testplugin_bool_PluginSettings.Plugins.testplugin.settingb"
             label="Setting Two"
             onChange={[Function]}
             setByEnv={false}
@@ -377,13 +377,13 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             disabled={false}
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the dropdown field."
               />
             }
-            id="settingc"
+            id="PluginSettings.Plugins.testplugin.settingc"
             isDisabled={false}
-            key="testplugin_dropdown_settingc"
+            key="testplugin_dropdown_PluginSettings.Plugins.testplugin.settingc"
             label="Setting Three"
             onChange={[Function]}
             setByEnv={false}
@@ -409,12 +409,12 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             disabled={false}
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the radio field."
               />
             }
-            id="settingd"
-            key="testplugin_radio_settingd"
+            id="PluginSettings.Plugins.testplugin.settingd"
+            key="testplugin_radio_PluginSettings.Plugins.testplugin.settingd"
             label="Setting Four"
             onChange={[Function]}
             setByEnv={false}
@@ -440,12 +440,12 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             disabled={false}
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the generated field."
               />
             }
-            id="settinge"
-            key="testplugin_generated_settinge"
+            id="PluginSettings.Plugins.testplugin.settinge"
+            key="testplugin_generated_PluginSettings.Plugins.testplugin.settinge"
             label="Setting Five"
             onChange={[Function]}
             placeholder="e.g. 47KyfOxtk5+ovi1MDHFyzMDHIA6esMWb"
@@ -464,12 +464,12 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
             disabled={false}
             helpText={
               <SchemaText
-                isTranslated={false}
+                isTranslated={true}
                 text="This is some help text for the user autocomplete field."
               />
             }
-            id="settingf"
-            key="testplugin_userautocomplete_settingf"
+            id="PluginSettings.Plugins.testplugin.settingf"
+            key="testplugin_userautocomplete_PluginSettings.Plugins.testplugin.settingf"
             label="Setting Six"
             onChange={[Function]}
             placeholder="Type a username here"
@@ -480,7 +480,7 @@ exports[`components/admin_console/CustomPluginSettings should match snapshot wit
           >
             <SchemaText
               isMarkdown={true}
-              isTranslated={true}
+              isTranslated={false}
               text="# Footer
 *This* is the **footer**"
             />

--- a/components/admin_console/custom_plugin_settings/custom_plugin_settings.jsx
+++ b/components/admin_console/custom_plugin_settings/custom_plugin_settings.jsx
@@ -3,67 +3,7 @@
 
 import SchemaAdminSettings from 'components/admin_console/schema_admin_settings.jsx';
 
-export default class CustomPluginSettings extends SchemaAdminSettings {
-    constructor(props) {
-        super(props);
-        this.isPlugin = true;
-        this.getStateFromConfig = CustomPluginSettings.getStateFromConfig;
-    }
+// No changes required to the base SchemaAdminSettings, except to inject custom props.
+const CustomPluginSettings = SchemaAdminSettings;
 
-    static getDerivedStateFromProps(props, state) {
-        if (props.schema && props.schema.id !== state.prevSchemaId) {
-            return {
-                prevSchemaId: props.schema.id,
-                saveNeeded: false,
-                saving: false,
-                serverError: null,
-                errorTooltip: false,
-                ...CustomPluginSettings.getStateFromConfig(props.config, props.schema, props.roles),
-            };
-        }
-        return null;
-    }
-
-    getConfigFromState(config) {
-        const schema = this.props.schema;
-
-        if (schema) {
-            if (!config.PluginSettings.Plugins[schema.id]) {
-                config.PluginSettings.Plugins[schema.id] = {};
-            }
-
-            const configSettings = config.PluginSettings.Plugins[schema.id];
-
-            const settings = schema.settings || [];
-            settings.forEach((setting) => {
-                const lowerKey = setting.key.toLowerCase();
-                const value = this.state[lowerKey];
-                if (value == null && setting.default == null) {
-                    Reflect.deleteProperty(configSettings, lowerKey);
-                } else if (value == null) {
-                    configSettings[lowerKey] = setting.default;
-                } else {
-                    configSettings[lowerKey] = value;
-                }
-            });
-        }
-
-        return config;
-    }
-
-    static getStateFromConfig(config, schema) {
-        const state = {};
-
-        if (schema) {
-            const configSettings = config.PluginSettings.Plugins[schema.id] || {};
-
-            const settings = schema.settings || [];
-            settings.forEach((setting) => {
-                const lowerKey = setting.key.toLowerCase();
-                state[lowerKey] = configSettings[lowerKey] == null ? setting.default : configSettings[lowerKey];
-            });
-        }
-
-        return state;
-    }
-}
+export default CustomPluginSettings;

--- a/components/admin_console/custom_plugin_settings/custom_plugin_settings.test.jsx
+++ b/components/admin_console/custom_plugin_settings/custom_plugin_settings.test.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import CustomPluginSettings from 'components/admin_console/custom_plugin_settings/custom_plugin_settings.jsx';
+import SchemaAdminSettings from 'components/admin_console/schema_admin_settings';
 
 describe('components/admin_console/CustomPluginSettings', () => {
     let plugin = null;
@@ -103,7 +104,12 @@ describe('components/admin_console/CustomPluginSettings', () => {
 
     test('should match snapshot with settings and plugin', () => {
         const settings = plugin && plugin.settings_schema && plugin.settings_schema.settings && plugin.settings_schema.settings.map((setting) => {
-            return {...setting, label: setting.display_name};
+            const escapedPluginId = SchemaAdminSettings.escapePathPart(plugin.id);
+            return {
+                ...setting,
+                key: 'PluginSettings.Plugins.' + escapedPluginId + '.' + setting.key.toLowerCase(),
+                label: setting.display_name,
+            };
         });
         const wrapper = shallow(
             <CustomPluginSettings

--- a/components/admin_console/custom_plugin_settings/index.js
+++ b/components/admin_console/custom_plugin_settings/index.js
@@ -6,6 +6,10 @@ import {createSelector} from 'reselect';
 
 import {getRoles} from 'mattermost-redux/selectors/entities/roles';
 
+import {Constants} from 'utils/constants';
+import {t} from 'utils/i18n';
+import SchemaAdminSettings from '../schema_admin_settings';
+
 import CustomPluginSettings from './custom_plugin_settings.jsx';
 
 function makeGetPluginSchema() {
@@ -16,16 +20,29 @@ function makeGetPluginSchema() {
                 return null;
             }
 
+            const escapedPluginId = SchemaAdminSettings.escapePathPart(plugin.id);
+
             let settings;
             if (plugin.settings_schema && plugin.settings_schema.settings) {
                 settings = plugin.settings_schema.settings.map((setting) => {
                     return {
                         ...setting,
+                        key: 'PluginSettings.Plugins.' + escapedPluginId + '.' + setting.key.toLowerCase(),
                         help_text_markdown: true,
                         label: setting.display_name,
+                        translate: Boolean(plugin.translate),
                     };
                 });
             }
+
+            settings.unshift({
+                type: Constants.SettingsTypes.TYPE_BOOL,
+                key: 'PluginSettings.PluginStates.' + escapedPluginId + '.Enable',
+                label: t('admin.plugin.enable_plugin'),
+                label_default: 'Enable plugin: ',
+                help_text: t('admin.plugin.enable_plugin.help'),
+                help_text_default: 'When true, this plugin is enabled.',
+            });
 
             return {
                 ...plugin.settings_schema,

--- a/components/admin_console/custom_plugin_settings/index.js
+++ b/components/admin_console/custom_plugin_settings/index.js
@@ -42,7 +42,7 @@ function makeGetPluginSchema() {
                 type: Constants.SettingsTypes.TYPE_BOOL,
                 key: pluginEnabledConfigKey,
                 label: t('admin.plugin.enable_plugin'),
-                label_default: 'Enable plugin: ',
+                label_default: 'Enable Plugin: ',
                 help_text: t('admin.plugin.enable_plugin.help'),
                 help_text_default: 'When true, this plugin is enabled.',
             });

--- a/components/admin_console/custom_plugin_settings/index.js
+++ b/components/admin_console/custom_plugin_settings/index.js
@@ -9,6 +9,7 @@ import {getRoles} from 'mattermost-redux/selectors/entities/roles';
 import {Constants} from 'utils/constants';
 import {t} from 'utils/i18n';
 import SchemaAdminSettings from '../schema_admin_settings';
+import {it} from '../admin_definition';
 
 import CustomPluginSettings from './custom_plugin_settings.jsx';
 
@@ -21,6 +22,7 @@ function makeGetPluginSchema() {
             }
 
             const escapedPluginId = SchemaAdminSettings.escapePathPart(plugin.id);
+            const pluginEnabledConfigKey = 'PluginSettings.PluginStates.' + escapedPluginId + '.Enable';
 
             let settings;
             if (plugin.settings_schema && plugin.settings_schema.settings) {
@@ -31,13 +33,14 @@ function makeGetPluginSchema() {
                         help_text_markdown: true,
                         label: setting.display_name,
                         translate: Boolean(plugin.translate),
+                        isDisabled: it.stateIsFalse(pluginEnabledConfigKey),
                     };
                 });
             }
 
             settings.unshift({
                 type: Constants.SettingsTypes.TYPE_BOOL,
-                key: 'PluginSettings.PluginStates.' + escapedPluginId + '.Enable',
+                key: pluginEnabledConfigKey,
                 label: t('admin.plugin.enable_plugin'),
                 label_default: 'Enable plugin: ',
                 help_text: t('admin.plugin.enable_plugin.help'),

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -259,7 +259,7 @@ export default class SchemaAdminSettings extends React.Component {
             return <span>{''}</span>;
         }
 
-        if (this.props.schema.translate === false) {
+        if (setting.label.translate === false) {
             return <span>{setting.label}</span>;
         }
 
@@ -312,7 +312,7 @@ export default class SchemaAdminSettings extends React.Component {
         return (
             <SchemaText
                 isMarkdown={isMarkdown}
-                isTranslated={this.props.schema.translate}
+                isTranslated={setting.translate}
                 text={helpText}
                 textDefault={helpTextDefault}
                 textValues={helpTextValues}
@@ -325,7 +325,7 @@ export default class SchemaAdminSettings extends React.Component {
             return '';
         }
 
-        if (this.props.schema.translate === false) {
+        if (setting.translate === false) {
             return setting.label;
         }
         return Utils.localizeMessage(setting.label, setting.label_default);
@@ -753,12 +753,7 @@ export default class SchemaAdminSettings extends React.Component {
         if (schema.settings) {
             schema.settings.forEach((setting) => {
                 if (this.buildSettingFunctions[setting.type] && !this.isHidden(setting)) {
-                    // This is a hack required as plugin settings are case insensitive
-                    let s = setting;
-                    if (this.isPlugin) {
-                        s = {...setting, key: setting.key.toLowerCase()};
-                    }
-                    settingsList.push(this.buildSettingFunctions[setting.type](s));
+                    settingsList.push(this.buildSettingFunctions[setting.type](setting));
                 }
             });
         }
@@ -770,6 +765,7 @@ export default class SchemaAdminSettings extends React.Component {
                     <SchemaText
                         text={schema.header}
                         isMarkdown={true}
+                        isTranslated={this.props.schema.translate}
                     />
                 </div>
             );
@@ -782,6 +778,7 @@ export default class SchemaAdminSettings extends React.Component {
                     <SchemaText
                         text={schema.footer}
                         isMarkdown={true}
+                        isTranslated={this.props.schema.translate}
                     />
                 </div>
             );
@@ -861,6 +858,18 @@ export default class SchemaAdminSettings extends React.Component {
         }
     };
 
+    // Some path parts may contain periods (e.g. plugin ids), but path walking the configuration
+    // relies on splitting by periods. Use this pair of functions to allow such path parts.
+    //
+    // It is assumed that no path contains the symbol '+'.
+    static escapePathPart(pathPart) {
+        return pathPart.replace(/\./g, '+');
+    }
+
+    static unescapePathPart(pathPart) {
+        return pathPart.replace(/\+/g, '.');
+    }
+
     static getConfigValue(config, path) {
         const pathParts = path.split('.');
 
@@ -869,13 +878,13 @@ export default class SchemaAdminSettings extends React.Component {
                 return null;
             }
 
-            return obj[pathPart];
+            return obj[SchemaAdminSettings.unescapePathPart(pathPart)];
         }, config);
     }
 
     setConfigValue(config, path, value) {
         function setValue(obj, pathParts) {
-            const part = pathParts[0];
+            const part = SchemaAdminSettings.unescapePathPart(pathParts[0]);
 
             if (pathParts.length === 1) {
                 obj[part] = value;

--- a/components/admin_console/schema_admin_settings.test.jsx
+++ b/components/admin_console/schema_admin_settings.test.jsx
@@ -200,6 +200,15 @@ describe('components/admin_console/SchemaAdminSettings', () => {
                     help_text_default: 'This is some help text for the permissions field.',
                     permissions_mapping_name: 'enableOnlyAdminIntegrations',
                 },
+                {
+                    key: 'EscapedSettings.com+example+setting.a',
+                    label: 'escaped-label-a',
+                    label_default: 'Escaped Setting A',
+                    type: 'bool',
+                    default: false,
+                    help_text: 'escaped-help-text-a',
+                    help_text_default: 'This is some help text for the first escaped field.',
+                },
             ],
         };
 
@@ -216,6 +225,11 @@ describe('components/admin_console/SchemaAdminSettings', () => {
                 settingf: '3xz3r6n7dtbbmgref3yw4zg7sr',
                 settingg: 7,
                 settingh: 100,
+            },
+            EscapedSettings: {
+                'com.example.setting': {
+                    a: true,
+                },
             },
         };
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1086,6 +1086,8 @@
   "admin.plugin.disable": "Disable",
   "admin.plugin.disabling": "Disabling...",
   "admin.plugin.enable": "Enable",
+  "admin.plugin.enable_plugin": "Enable plugin: ",
+  "admin.plugin.enable_plugin.help": "When true, this plugin is enabled.",
   "admin.plugin.enabling": "Enabling...",
   "admin.plugin.error.activate": "Unable to upload the plugin. It may conflict with another plugin on your server.",
   "admin.plugin.error.extract": "Encountered an error when extracting the plugin. Review your plugin file content and try again.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1086,7 +1086,7 @@
   "admin.plugin.disable": "Disable",
   "admin.plugin.disabling": "Disabling...",
   "admin.plugin.enable": "Enable",
-  "admin.plugin.enable_plugin": "Enable plugin: ",
+  "admin.plugin.enable_plugin": "Enable Plugin: ",
   "admin.plugin.enable_plugin.help": "When true, this plugin is enabled.",
   "admin.plugin.enabling": "Enabling...",
   "admin.plugin.error.activate": "Unable to upload the plugin. It may conflict with another plugin on your server.",


### PR DESCRIPTION
#### Summary
Largely eliminate the `CustomPluginSettings` class by instead carefully encoding the paths to the plugin settings. Prepend a boolean setting that points at the plugin being enabled, allowing the plugin to be enabled and disabled from its own configuration page (in addition to the top level plugin management page).

![image](https://user-images.githubusercontent.com/1023171/64049362-f16d4780-cb4a-11e9-8f8e-d6d6b44f353b.png)

This also fixes a minor issue with the header and footers of plugins potentially clashing with an id (admittedly incredibly unlikely).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18093