### PR TITLE
MM-15219 Added support for optional introduction text in interactive dialogs

### DIFF
--- a/components/interactive_dialog/__snapshots__/dialog_introduction_text.test.jsx.snap
+++ b/components/interactive_dialog/__snapshots__/dialog_introduction_text.test.jsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/DialogIntroductionText should not fail on empty value 1`] = `
+<DialogIntroductionText
+  id="testblankvalue"
+  value=""
+>
+  <span
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "",
+      }
+    }
+    id="testblankvalue"
+  />
+</DialogIntroductionText>
+`;
+
+exports[`components/DialogIntroductionText should render message with supported values 1`] = `
+<DialogIntroductionText
+  id="testsupported"
+  value="**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)"
+>
+  <span
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<p><strong>bold</strong> <em>italic</em> <a class=\\"theme markdown__link\\" href=\\"https://mattermost.com/\\" rel=\\"noreferrer\\" target=\\"_blank\\">link</a> &lt;br/&gt; <a class=\\"theme markdown__link\\" href=\\"!https://mattermost.com/\\" rel=\\"noreferrer\\" target=\\"_blank\\">link target blank</a></p>",
+      }
+    }
+    id="testsupported"
+  />
+</DialogIntroductionText>
+`;

--- a/components/interactive_dialog/dialog_introduction_text.jsx
+++ b/components/interactive_dialog/dialog_introduction_text.jsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import * as Markdown from 'utils/markdown'
+
+export default class DialogIntroductionText extends React.PureComponent {
+    static propTypes = {
+        id: PropTypes.string,
+        value: PropTypes.string.isRequired,
+    };
+
+    render() {
+        const formattedMessage = Markdown.format(this.props.value, {
+            breaks: true,
+            sanitize: true,
+            gfm: true
+        });
+
+        return (
+            <span
+                id={this.props.id}
+                dangerouslySetInnerHTML={{ __html: formattedMessage}}
+            />
+        );
+    }
+}

--- a/components/interactive_dialog/dialog_introduction_text.jsx
+++ b/components/interactive_dialog/dialog_introduction_text.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import * as Markdown from 'utils/markdown'
+import * as Markdown from 'utils/markdown';
 
 export default class DialogIntroductionText extends React.PureComponent {
     static propTypes = {
@@ -16,13 +16,13 @@ export default class DialogIntroductionText extends React.PureComponent {
         const formattedMessage = Markdown.format(this.props.value, {
             breaks: true,
             sanitize: true,
-            gfm: true
+            gfm: true,
         });
 
         return (
             <span
                 id={this.props.id}
-                dangerouslySetInnerHTML={{ __html: formattedMessage}}
+                dangerouslySetInnerHTML={{__html: formattedMessage}}
             />
         );
     }

--- a/components/interactive_dialog/dialog_introduction_text.test.jsx
+++ b/components/interactive_dialog/dialog_introduction_text.test.jsx
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {mount} from 'enzyme';
+
+import DialogIntroductionText from './dialog_introduction_text.jsx';
+
+describe('components/DialogIntroductionText', () => {
+    test('should render message with supported values', () => {
+        const descriptor = {
+            id: 'testsupported',
+            value: '**bold** *italic* [link](https://mattermost.com/) <br/> [link target blank](!https://mattermost.com/)',
+        };
+        const wrapper = mount(<DialogIntroductionText {...descriptor}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should not fail on empty value', () => {
+        const descriptor = {
+            id: 'testblankvalue',
+            value: '',
+        };
+        const wrapper = mount(<DialogIntroductionText {...descriptor}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/interactive_dialog/index.js
+++ b/components/interactive_dialog/index.js
@@ -19,6 +19,7 @@ function mapStateToProps(state) {
         callbackId: data.dialog.callback_id,
         elements: data.dialog.elements,
         title: data.dialog.title,
+        introductionText: data.dialog.introduction_text,
         iconUrl: data.dialog.icon_url,
         submitLabel: data.dialog.submit_label,
         notifyOnCancel: data.dialog.notify_on_cancel,

--- a/components/interactive_dialog/interactive_dialog.jsx
+++ b/components/interactive_dialog/interactive_dialog.jsx
@@ -8,12 +8,11 @@ import {FormattedMessage} from 'react-intl';
 import {checkDialogElementForError, checkIfErrorsMatchElements} from 'mattermost-redux/utils/integration_utils';
 
 import SpinnerButton from 'components/spinner_button';
-import {CustomRenderer} from 'components/formatted_markdown_message';
 
 import {localizeMessage} from 'utils/utils.jsx';
-import {formatWithRenderer} from 'utils/markdown';
 
 import DialogElement from './dialog_element';
+import DialogIntroductionText from './dialog_introduction_text';
 
 export default class InteractiveDialog extends React.Component {
     static propTypes = {
@@ -182,12 +181,10 @@ export default class InteractiveDialog extends React.Component {
                 </Modal.Header>
                 {(elements || introductionText) && <Modal.Body>
                     {introductionText &&
-                        <p>
-                            <span
-                                id='interactiveDialogModalIntroductionText'
-                                dangerouslySetInnerHTML={{__html: formatWithRenderer(introductionText, new CustomRenderer())}}
-                            />
-                        </p>
+                        <DialogIntroductionText
+                            id='interactiveDialogModalIntroductionText'
+                            value={introductionText}
+                        />
                     }
                     {elements && elements.map((e) => {
                         return (

--- a/components/interactive_dialog/interactive_dialog.jsx
+++ b/components/interactive_dialog/interactive_dialog.jsx
@@ -8,8 +8,10 @@ import {FormattedMessage} from 'react-intl';
 import {checkDialogElementForError, checkIfErrorsMatchElements} from 'mattermost-redux/utils/integration_utils';
 
 import SpinnerButton from 'components/spinner_button';
+import {CustomRenderer} from 'components/formatted_markdown_message';
 
 import {localizeMessage} from 'utils/utils.jsx';
+import {formatWithRenderer} from 'utils/markdown';
 
 import DialogElement from './dialog_element';
 
@@ -19,6 +21,7 @@ export default class InteractiveDialog extends React.Component {
         callbackId: PropTypes.string,
         elements: PropTypes.arrayOf(PropTypes.object),
         title: PropTypes.string.isRequired,
+        introductionText: PropTypes.string,
         iconUrl: PropTypes.string,
         submitLabel: PropTypes.string,
         notifyOnCancel: PropTypes.bool,
@@ -129,7 +132,7 @@ export default class InteractiveDialog extends React.Component {
     }
 
     render() {
-        const {title, iconUrl, submitLabel, elements} = this.props;
+        const {title, introductionText, iconUrl, submitLabel, elements} = this.props;
 
         let submitText = (
             <FormattedMessage
@@ -177,8 +180,16 @@ export default class InteractiveDialog extends React.Component {
                         {icon}{title}
                     </Modal.Title>
                 </Modal.Header>
-                {elements && <Modal.Body>
-                    {elements.map((e) => {
+                {(elements || introductionText) && <Modal.Body>
+                    {introductionText &&
+                        <p>
+                            <span
+                                id='interactiveDialogModalIntroductionText'
+                                dangerouslySetInnerHTML={{__html: formatWithRenderer(introductionText, new CustomRenderer())}}
+                            />
+                        </p>
+                    }
+                    {elements && elements.map((e) => {
                         return (
                             <DialogElement
                                 key={'dialogelement' + e.name}


### PR DESCRIPTION
#### Summary
Adds support for rendering optional markdown formatted introduction text in interactive dialogs.

![Screen Shot 2019-09-04 at 11 43 05 PM](https://user-images.githubusercontent.com/968043/64310579-9edac380-cf6e-11e9-813c-c885c25cfc6b.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15219

#### Related Pull Requests
- Has server changes (https://github.com/mattermost/mattermost-server/pull/12029)
- Has mobile changes (https://github.com/mattermost/mattermost-mobile/pull/3222)