### PR TITLE
MM-18139 - Add signature_url param when invoking install_from_url api

### DIFF
--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -555,7 +555,7 @@ export default class PluginManagement extends AdminSettings {
             serverError: null,
             lastMessage: null,
         });
-        const {error} = await this.props.actions.installPluginFromUrl(pluginDownloadUrl, null, force);
+        const {error} = await this.props.actions.installPluginFromUrl(pluginDownloadUrl, force);
 
         if (error) {
             if (error.server_error_id === 'app.plugin.install_id.app_error' && !force) {

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -555,7 +555,7 @@ export default class PluginManagement extends AdminSettings {
             serverError: null,
             lastMessage: null,
         });
-        const {error} = await this.props.actions.installPluginFromUrl(pluginDownloadUrl, force);
+        const {error} = await this.props.actions.installPluginFromUrl(pluginDownloadUrl, null, force);
 
         if (error) {
             if (error.server_error_id === 'app.plugin.install_id.app_error' && !force) {

--- a/components/integrations_marketplace/marketplace_item/marketplace_item.jsx
+++ b/components/integrations_marketplace/marketplace_item/marketplace_item.jsx
@@ -56,7 +56,7 @@ export default class MarketplaceItem extends React.Component {
         }
 
         installPlugin = async (force) => {
-            const {error} = await this.props.actions.installPluginFromUrl(this.props.downloadUrl, this.props.signatureUrl, force);
+            const {error} = await this.props.actions.installPluginFromUrl(this.props.downloadUrl, force, this.props.signatureUrl);
 
             if (error) {
                 if (error.server_error_id === 'app.plugin.install_id.app_error' && !force) {

--- a/components/integrations_marketplace/marketplace_item/marketplace_item.jsx
+++ b/components/integrations_marketplace/marketplace_item/marketplace_item.jsx
@@ -21,6 +21,7 @@ export default class MarketplaceItem extends React.Component {
             description: PropTypes.string.isRequired,
             version: PropTypes.string.isRequired,
             downloadUrl: PropTypes.string,
+            signatureUrl: PropTypes.string,
             homepageUrl: PropTypes.string,
             installed: PropTypes.bool.isRequired,
             onConfigure: PropTypes.func.isRequired,
@@ -55,7 +56,7 @@ export default class MarketplaceItem extends React.Component {
         }
 
         installPlugin = async (force) => {
-            const {error} = await this.props.actions.installPluginFromUrl(this.props.downloadUrl, force);
+            const {error} = await this.props.actions.installPluginFromUrl(this.props.downloadUrl, this.props.signatureUrl, force);
 
             if (error) {
                 if (error.server_error_id === 'app.plugin.install_id.app_error' && !force) {

--- a/components/integrations_marketplace/marketplace_modal.jsx
+++ b/components/integrations_marketplace/marketplace_modal.jsx
@@ -116,6 +116,7 @@ export default class MarketplaceModal extends React.Component {
                             version={p.Manifest.version}
                             isPrepackaged={false}
                             downloadUrl={p.DownloadURL}
+                            signatureUrl={p.SignatureURL}
                             homepageUrl={p.HomepageURL}
                             installed={p.InstalledVersion !== ''}
                             onConfigure={this.close}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10873,8 +10873,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#1f1fb1d05bcfef3eac070e6115fe28c3bf7e2e2e",
-      "from": "github:mattermost/mattermost-redux#1f1fb1d05bcfef3eac070e6115fe28c3bf7e2e2e",
+      "version": "github:mattermost/mattermost-redux#96e562dc699d0feac9d7581c420d0689679f1dfc",
+      "from": "github:mattermost/mattermost-redux#96e562dc699d0feac9d7581c420d0689679f1dfc",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10873,8 +10873,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#96e562dc699d0feac9d7581c420d0689679f1dfc",
-      "from": "github:mattermost/mattermost-redux#96e562dc699d0feac9d7581c420d0689679f1dfc",
+      "version": "github:mattermost/mattermost-redux#7e611167208c9a87a35d13a590a48107537d0a15",
+      "from": "github:mattermost/mattermost-redux#7e611167208c9a87a35d13a590a48107537d0a15",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#96e562dc699d0feac9d7581c420d0689679f1dfc",
+    "mattermost-redux": "github:mattermost/mattermost-redux#7e611167208c9a87a35d13a590a48107537d0a15",
     "moment-timezone": "0.5.26",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#1f1fb1d05bcfef3eac070e6115fe28c3bf7e2e2e",
+    "mattermost-redux": "github:mattermost/mattermost-redux#96e562dc699d0feac9d7581c420d0689679f1dfc",
     "moment-timezone": "0.5.26",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
Pipe `SignatureUrl` param through when invoking `installPluginFromUrl` api.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-18139

#### Related Pull Requests
- Has server changes https://github.com/mattermost/mattermost-server/pull/12036/files
- Has redux changes https://github.com/mattermost/mattermost-redux/pull/917
