### PR TITLE
[MM-18332] Ignore trailing and leading whitespace in Username Field during bot creation

### DIFF
--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -243,7 +243,7 @@ export default class AddBot extends React.Component {
         });
 
         const bot = {
-            username: this.state.username.toLowerCase(),
+            username: this.state.username.toLowerCase().trim(),
             display_name: this.state.displayName,
             description: this.state.description,
         };


### PR DESCRIPTION
#### Summary
During bot creation, remove the leading and trailing username white space before submission.  Without the automatic removal, the user would receive a notice of invalid username, although the trailing space is not "visible"

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18332