### PR TITLE
MM-18340: restore dialog's store.subscribe

### DIFF
--- a/actions/integration_actions.jsx
+++ b/actions/integration_actions.jsx
@@ -6,11 +6,6 @@ import * as IntegrationActions from 'mattermost-redux/actions/integrations';
 import {getProfilesByIds} from 'mattermost-redux/actions/users';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
 
-import {ModalIdentifiers} from 'utils/constants';
-import {openModal} from 'actions/views/modals';
-import InteractiveDialog from 'components/interactive_dialog';
-import store from 'stores/redux_store.jsx';
-
 const DEFAULT_PAGE_SIZE = 100;
 
 export function loadIncomingHooksAndProfilesForTeam(teamId, page = 0, perPage = DEFAULT_PAGE_SIZE) {
@@ -144,22 +139,3 @@ export function getYoutubeVideoInfo(googleKey, videoId, success, error) {
             return success(res.body);
         });
 }
-
-let previousTriggerId = '';
-store.subscribe(() => {
-    const state = store.getState();
-    const currentTriggerId = state.entities.integrations.dialogTriggerId;
-
-    if (currentTriggerId === previousTriggerId) {
-        return;
-    }
-
-    previousTriggerId = currentTriggerId;
-
-    const dialog = state.entities.integrations.dialog || {};
-    if (dialog.trigger_id !== currentTriggerId) {
-        return;
-    }
-
-    store.dispatch(openModal({modalId: ModalIdentifiers.INTERACTIVE_DIALOG, dialogType: InteractiveDialog}));
-});

--- a/plugins/export.js
+++ b/plugins/export.js
@@ -4,6 +4,7 @@
 import messageHtmlToComponent from 'utils/message_html_to_component';
 import {formatText} from 'utils/text_formatting.jsx';
 
+// The following import has intentional side effects. Do not remove without research.
 import {openInteractiveDialog} from './interactive_dialog';
 
 // Common libraries exposed on window for plugins to use as Webpack externals.

--- a/plugins/interactive_dialog.js
+++ b/plugins/interactive_dialog.js
@@ -17,3 +17,28 @@ export function openInteractiveDialog(dialog) {
     store.dispatch(openModal({modalId: ModalIdentifiers.INTERACTIVE_DIALOG, dialogType: InteractiveDialog}));
 }
 
+// This code is problematic for a couple of different reasons:
+// * it monitors the store to modify the store: this is perhaps better handled by a saga
+// * it makes importing this file impure by triggering a side-effect which may not be obvious
+// * it's not really located in the "right place": dialogs are applicable to non-modals too
+// * it's nigh impossible to test as written
+//
+// It's worth fixing all of this, but I think this requires some refactoring.
+let previousTriggerId = '';
+store.subscribe(() => {
+    const state = store.getState();
+    const currentTriggerId = state.entities.integrations.dialogTriggerId;
+
+    if (currentTriggerId === previousTriggerId) {
+        return;
+    }
+
+    previousTriggerId = currentTriggerId;
+
+    const dialog = state.entities.integrations.dialog || {};
+    if (dialog.trigger_id !== currentTriggerId) {
+        return;
+    }
+
+    store.dispatch(openModal({modalId: ModalIdentifiers.INTERACTIVE_DIALOG, dialogType: InteractiveDialog}));
+});

--- a/plugins/interactive_dialog.js
+++ b/plugins/interactive_dialog.js
@@ -20,7 +20,7 @@ export function openInteractiveDialog(dialog) {
 // This code is problematic for a couple of different reasons:
 // * it monitors the store to modify the store: this is perhaps better handled by a saga
 // * it makes importing this file impure by triggering a side-effect which may not be obvious
-// * it's not really located in the "right place": dialogs are applicable to non-modals too
+// * it's not really located in the "right place": dialogs are applicable to non-plugins too
 // * it's nigh impossible to test as written
 //
 // It's worth fixing all of this, but I think this requires some refactoring.


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-webapp/pull/3493 unintentionally removed the import of `actions/integration_actions`, which defined a side effect necessary to the correct functioning of interactive dialogs.

I've relocated this somewhere that is more intentionally imported, and commented details as to the issues with this code block. I'm not explicitly fixing the issues right now, and I'm not sure if I can unit test this, so I'm just restoring the import for now.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18340