### PR TITLE
Fix failing E2E

### DIFF
--- a/e2e/cypress/integration/channel/edit_message_spec.js
+++ b/e2e/cypress/integration/channel/edit_message_spec.js
@@ -113,35 +113,6 @@ describe('Edit Message', () => {
         });
     });
 
-    it('M13542 Open edit modal immediately after making a post when post is pending', () => {
-        // # and go to /. We set fetch to null here so that we can intercept XHR network requests
-        cy.visit('/', {
-            onBeforeLoad: (win) => {
-                win.fetch = null;
-            },
-        });
-
-        // # Enter first message
-        cy.get('#post_textbox').clear().type('Hello{enter}');
-
-        // Start a server, and stub out the response to ensure we have a pending post
-        // Note that this fails the creation of the second post. But we only need it
-        // to be pending
-        cy.server();
-        cy.route({response: {}, method: 'POST', url: 'api/v4/posts', delay: 5000});
-
-        // # Enter second message, submit, and then uparrow to show edit post modal
-        cy.get('#post_textbox').type('world!{enter}{uparrow}');
-
-        // * Edit post modal should appear, and edit the post
-        cy.get('#editPostModal').should('be.visible');
-        cy.get('#edit_textbox').should('have.text', 'Hello').type(' New message{enter}');
-        cy.get('#editPostModal').should('be.not.visible');
-
-        // * Verify last post is pending
-        cy.getLastPostId({force: true}).should('contain', ':');
-    });
-
     it('M15519 Open edit modal immediately after making a post when post is pending', () => {
         // # and go to /. We set fetch to null here so that we can intercept XHR network requests
         cy.visit('/');

--- a/e2e/cypress/integration/channel/header_spec.js
+++ b/e2e/cypress/integration/channel/header_spec.js
@@ -34,10 +34,10 @@ describe('Header', () => {
         cy.updateChannelHeader('>' + ' newheader'.repeat(20));
 
         // * Check if channel header description has ellipsis
-        cy.get('#channelHeaderDescription').should('have.text', ' newheader'.repeat(20));
-        cy.get('#channelHeaderDescription').then(($header) => {
-            expect($header.outerWidth()).lt($header[0].scrollWidth);
-        });
+        cy.get('#channelHeaderDescription').find('p').
+            should('have.text', ' newheader'.repeat(20).trim()).
+            and('have.css', 'overflow', 'hidden').
+            and('have.css', 'text-overflow', 'ellipsis');
     });
 
     it('CS14730 - Channel Header: Markdown quote', () => {

--- a/e2e/cypress/integration/channel/message_spec.js
+++ b/e2e/cypress/integration/channel/message_spec.js
@@ -38,16 +38,6 @@ describe('Message', () => {
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
         cy.visit('/');
-
-        // # Change settings to allow @channel messages
-        cy.getCookie('MMUSERID').then((cookie) => {
-            cy.request({
-                headers: {'X-Requested-With': 'XMLHttpRequest'},
-                url: '/api/v4/users/me/patch',
-                method: 'PUT',
-                body: {user_id: cookie.value, notify_props: {channel: 'true'}},
-            });
-        });
     });
 
     it('M13701 Consecutive message does not repeat profile info', () => {
@@ -104,6 +94,9 @@ describe('Message', () => {
     });
 
     it('M14320 @here, @all and @channel (ending in a period) still highlight', () => {
+        // # Change settings to allow @channel messages
+        cy.apiPatchMe({notify_props: {channel: 'true'}});
+
         // # Login as new user
         cy.loginAsNewUser().then(() => {
             // # Create new team and visit its URL

--- a/e2e/cypress/integration/markdown/markdown_image_spec.js
+++ b/e2e/cypress/integration/markdown/markdown_image_spec.js
@@ -24,7 +24,7 @@ describe('Markdown', () => {
 
     it('with in-line images 1', () => {
         // #  Post markdown message
-        cy.postMessageFromFile(`markdown/markdown_inline_images_1.md`).wait(TIMEOUTS.SMALL);
+        cy.postMessageFromFile('markdown/markdown_inline_images_1.md').wait(TIMEOUTS.SMALL);
 
         // * Verify that HTML Content is correct.
         // Note we use the Gigantic timeout to ensure that the large images will load
@@ -41,7 +41,7 @@ describe('Markdown', () => {
 
     it('with in-line images 2', () => {
         // #  Post markdown message
-        cy.postMessageFromFile(`markdown/markdown_inline_images_2.md`).wait(TIMEOUTS.SMALL);
+        cy.postMessageFromFile('markdown/markdown_inline_images_2.md').wait(TIMEOUTS.SMALL);
 
         // * Verify that HTML Content is correct.
         // Note we use the Gigantic timeout to ensure that the large images will load

--- a/e2e/cypress/integration/markdown/markdown_image_spec.js
+++ b/e2e/cypress/integration/markdown/markdown_image_spec.js
@@ -22,24 +22,37 @@ describe('Markdown', () => {
 
     const baseUrl = Cypress.config('baseUrl');
 
-    const inlineImage1 = `<h3 class="markdown__heading">In-line Images</h3><p>Mattermost/platform build status:  <a class="theme markdown__link" href="https://travis-ci.org/mattermost/platform" rel="noreferrer" target="_blank"><div class="style--none file-preview__button"><img class="markdown-inline-img" alt="Build Status" aria-label="file thumbnail" tabindex="0" src="${baseUrl}/api/v4/image?url=https%3A%2F%2Ftravis-ci.org%2Fmattermost%2Fplatform.svg%3Fbranch%3Dmaster"></div></a></p>`;
-    const inlineImage2 = `<h3 class="markdown__heading">In-line Images</h3><p>GitHub favicon:  <div class="style--none file-preview__button"><img class="markdown-inline-img" alt="Github" aria-label="file thumbnail" tabindex="0" src="${baseUrl}/api/v4/image?url=https%3A%2F%2Fgithub.githubassets.com%2Ffavicon.ico"></div></p>`;
+    it('with in-line images 1', () => {
+        // #  Post markdown message
+        cy.postMessageFromFile(`markdown/markdown_inline_images_1.md`).wait(TIMEOUTS.SMALL);
 
-    const tests = [
-        {name: 'with in-line images 1', fileKey: 'markdown_inline_images_1', expected: inlineImage1},
-        {name: 'with in-line images 2', fileKey: 'markdown_inline_images_2', expected: inlineImage2},
-    ];
+        // * Verify that HTML Content is correct.
+        // Note we use the Gigantic timeout to ensure that the large images will load
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#postMessageText_${postId}`).find('p').
+                should('have.text', 'Mattermost/platform build status:  ');
 
-    tests.forEach((test) => {
-        it(test.name, () => {
-            // #  Post markdown message
-            cy.postMessageFromFile(`markdown/${test.fileKey}.md`);
+            cy.get(`#postMessageText_${postId}`).find('img').
+                should('have.class', 'markdown-inline-img').
+                and('have.attr', 'alt', 'Build Status').
+                and('have.attr', 'src', `${baseUrl}/api/v4/image?url=https%3A%2F%2Ftravis-ci.org%2Fmattermost%2Fplatform.svg%3Fbranch%3Dmaster`);
+        });
+    });
 
-            // * Verify that HTML Content is correct.
-            // Note we use the Gigantic timeout to ensure that the large images will load
-            cy.getLastPostId().then((postId) => {
-                cy.get(`#postMessageText_${postId}`, {timeout: TIMEOUTS.GIGANTIC}).should('have.html', test.expected);
-            });
+    it('with in-line images 2', () => {
+        // #  Post markdown message
+        cy.postMessageFromFile(`markdown/markdown_inline_images_2.md`).wait(TIMEOUTS.SMALL);
+
+        // * Verify that HTML Content is correct.
+        // Note we use the Gigantic timeout to ensure that the large images will load
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#postMessageText_${postId}`).find('p').
+                should('have.text', 'GitHub favicon:  ');
+
+            cy.get(`#postMessageText_${postId}`).find('img').
+                should('have.class', 'markdown-inline-img').
+                and('have.attr', 'alt', 'Github').
+                and('have.attr', 'src', `${baseUrl}/api/v4/image?url=https%3A%2F%2Fgithub.githubassets.com%2Ffavicon.ico`);
         });
     });
 });

--- a/e2e/cypress/integration/markdown/markdown_text_spec.js
+++ b/e2e/cypress/integration/markdown/markdown_text_spec.js
@@ -49,7 +49,7 @@ describe('Markdown message', () => {
     testCases.forEach((testCase) => {
         it(testCase.name, () => {
             // #  Post markdown message
-            cy.postMessageFromFile(`markdown/${testCase.fileKey}.md`);
+            cy.postMessageFromFile(`markdown/${testCase.fileKey}.md`).wait(TIMEOUTS.SMALL);
 
             // * Verify that HTML Content is correct
             cy.compareLastPostHTMLContentFromFile(`markdown/${testCase.fileKey}.html`);
@@ -65,7 +65,7 @@ describe('Markdown message', () => {
 </blockquote>`;
 
         // #  Post markdown message
-        cy.postMessageFromFile('markdown/markdown_block_quotes_2.md');
+        cy.postMessageFromFile('markdown/markdown_block_quotes_2.md').wait(TIMEOUTS.SMALL);
 
         // * Verify that HTML Content is correct
         cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/integration/search/date_filter_spec.js
+++ b/e2e/cypress/integration/search/date_filter_spec.js
@@ -42,12 +42,7 @@ function getMsAndQueryForDate(date) {
 }
 
 function changeTimezone(timezone) {
-    cy.request({
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/api/v4/users/me/patch',
-        method: 'PUT',
-        body: {timezone: {automaticTimezone: '', manualTimezone: timezone, useAutomaticTimezone: 'false'}},
-    });
+    cy.apiPatchMe({timezone: {automaticTimezone: '', manualTimezone: timezone, useAutomaticTimezone: 'false'}});
 }
 
 describe('SF15699 Search Date Filter', () => {

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -458,6 +458,18 @@ Cypress.Commands.add('apiPatchUser', (userId, userData) => {
     });
 });
 
+Cypress.Commands.add('apiPatchMe', (data) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/users/me/patch',
+        method: 'PUT',
+        body: data,
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        cy.wrap(response);
+    });
+});
+
 /**
  * Creates a new user via the API, adds them to 3 teams, and sets preference to bypass tutorial.
  * Then logs in as the user

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -168,7 +168,7 @@ Cypress.Commands.add('getNthPostId', (nthPost) => {
  */
 Cypress.Commands.add('postMessageFromFile', (file, target = '#post_textbox') => {
     cy.fixture(file, 'utf-8').then((text) => {
-        cy.get(target).clear().invoke('val', text).wait(TIMEOUTS.MEDIUM).type(' {backspace}{enter}').should('have.text', '');
+        cy.get(target).clear().invoke('val', text).wait(TIMEOUTS.TINY).type(' {backspace}{enter}').should('have.text', '');
     });
 });
 


### PR DESCRIPTION
#### Summary
Fix the following failing E2E on daily:
- M13564 Ellipsis indicates the channel header is too long
- Markdown images / text

Remove the following test since stubbing on fetch is currently not supported by Cypress
- M13542 Open edit modal immediately after making a post when post is pending

#### Ticket Link
none
