### PR TITLE
[MM-18388] Added check for ALT key on a11y controller for Ctrl+~ function to avoid misidentification

### DIFF
--- a/utils/a11y_controller.js
+++ b/utils/a11y_controller.js
@@ -682,7 +682,9 @@ export default class A11yController {
             if (!this.regions || !this.regions.length) {
                 return;
             }
-            if (modifierKeys.ctrlIsPressed) {
+
+            // Check to make sure both aren't pressed because some older webkit browsers set CTRL and ALT when AltGr is pressed
+            if (modifierKeys.ctrlIsPressed && !modifierKeys.altIsPressed) {
                 this.tildeKeyIsPressed = true;
                 event.preventDefault();
                 if (modifierKeys.shiftIsPressed) {


### PR DESCRIPTION
#### Summary
On Italian keyboards, the AltGr+ó key combination was being identified as Ctrl+~ due to an issue that older browsers set the `event.ctrlKey` and `event.altKey` properties for AltGr. This PR forces a check to ensure that only Ctrl is pressed for this case.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/12096
https://mattermost.atlassian.net/browse/MM-18388
