### PR TITLE
[MM-18369] Fixed issue where no transition on RHS broke searching on Firefox

### DIFF
--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -78,7 +78,7 @@ export default class SidebarRight extends React.PureComponent {
 
     determineTransition = () => {
         const transitionInfo = window.getComputedStyle(this.sidebarRight.current).getPropertyValue('transition');
-        const hasTransition = transitionInfo !== 'all 0s ease 0s';
+        const hasTransition = Boolean(transitionInfo) && transitionInfo !== 'all 0s ease 0s';
 
         if (this.sidebarRight.current && hasTransition) {
             this.setState({isOpened: this.props.isOpen});


### PR DESCRIPTION
#### Summary
My fix here #3594 caused an issue with Firefox, since Firefox does not provide a default computed value for transitions like Chrome does. This PR checks to make sure there is a transition and that it's not the default value. Tested with Chrome, Firefox, Safari and Edge.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18369
