### PR TITLE
Fix failing E2E due to pending post

### DIFF
--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -299,6 +299,7 @@ export default class Post extends React.PureComponent {
             <div
                 ref={this.postRef}
                 id={'post_' + post.id}
+                data-testid='postView'
                 role='listitem'
                 className={`a11y__section ${this.getClassName(post, isSystemMessage, isMeMessage, fromWebhook, fromAutoResponder, fromBot)}`}
                 tabIndex='0'

--- a/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
@@ -22,6 +22,7 @@ describe('Account Settings > Display > Message Display', () => {
     it('M14283 Compact view: Line breaks remain intact after editing', () => {
         // # Enter in text
         cy.get('#post_textbox').
+            clear().
             type('First line').
             type('{shift}{enter}{enter}').
             type('Text after{enter}');

--- a/e2e/cypress/integration/interactive_menu/basic_options_spec.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options_spec.js
@@ -200,7 +200,7 @@ function verifyMessageAttachmentList(postId, isRhs, text) {
         } else {
             // # Select an option (long) in center view
             cy.get('.select-suggestion-container > input').should('be.visible').click();
-            cy.get('#suggestionList').should('be.visible').children().first().click();
+            cy.get('#suggestionList').should('be.visible').children().first().click({force: true});
         }
 
         // * Verify exact height, width and padding of suggestion container and its input

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -12,6 +12,7 @@ import './api_commands';
 import './task_commands';
 import '@testing-library/cypress/add-commands';
 import 'cypress-file-upload';
+import 'cypress-wait-until';
 import addContext from 'mochawesome/addContext';
 
 Cypress.on('test:after:run', (test, runnable) => {

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -133,20 +133,21 @@ Cypress.Commands.add('postMessageReplyInRHS', (message) => {
     cy.wait(TIMEOUTS.TINY);
 });
 
+function waitUntilPermanentPost() {
+    cy.waitUntil(() => cy.getAllByTestId('postView').last().then((el) => !(el[0].id.includes(':'))));
+}
+
 Cypress.Commands.add('getLastPost', () => {
-    cy.get('#post-list', {timeout: TIMEOUTS.HUGE}).should('be.visible');
-    return cy.getAllByTestId('postContent', {timeout: TIMEOUTS.HUGE}).last().scrollIntoView().should('be.visible');
+    waitUntilPermanentPost();
+
+    cy.getAllByTestId('postView').last();
 });
 
-Cypress.Commands.add('getLastPostId', (opts = {force: false}) => {
-    cy.getLastPost().parent().as('parent');
+Cypress.Commands.add('getLastPostId', () => {
+    waitUntilPermanentPost();
 
-    if (opts.force) {
-        cy.get('@parent').should('have.attr', 'id').invoke('replace', 'post_', '');
-    } else {
-        cy.get('@parent').should('have.attr', 'id').and('not.include', ':').
-            invoke('replace', 'post_', '');
-    }
+    cy.getAllByTestId('postView').last().should('have.attr', 'id').and('not.include', ':').
+        invoke('replace', 'post_', '');
 });
 
 /**

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -715,6 +715,12 @@
         }
       }
     },
+    "cypress-wait-until": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.4.1.tgz",
+      "integrity": "sha512-VNaVsJX48OCz/989GwhofTBCKHf4LHFxQXSHDBN+a0Z03HEiF36l+pvHnK9ZiuZYWA6zZGJwRdDGQ7lWXVHwBQ==",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1836,9 +1842,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.isempty": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,16 +6,17 @@
     "cypress": "3.4.1",
     "cypress-file-upload": "3.1.2",
     "cypress-multi-reporters": "1.1.23",
+    "cypress-wait-until": "1.4.1",
     "express": "4.17.1",
+    "lodash": "4.17.15",
     "merge-deep": "3.0.2",
-    "start-server-and-test": "1.9.1",
     "mocha": "6.1.4",
     "mocha-junit-reporters": "1.23.6",
     "mocha-multi-reporters": "1.1.7",
     "mochawesome": "4.0.1",
     "mochawesome-merge": "2.0.1",
     "mochawesome-report-generator": "4.0.1",
-    "lodash": ">=4.17.13"
+    "start-server-and-test": "1.9.1"
   },
   "scripts": {
     "cypress:run": "cypress run --config ignoreTestFiles='**/enterprise/**/*.js'",


### PR DESCRIPTION
#### Summary
-  fixed `f.apply` error by introducing `cypress-wait-until` to wait for permanent post before proceeding to next step.
- updated E2E dependencies
- fixed failing test on interactive menu

#### Ticket Link
none
