### PR TITLE
MM-18366 Load team for channel details page if not loaded

### DIFF
--- a/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_details.test.jsx.snap
+++ b/components/admin_console/team_channel_settings/channel/details/__snapshots__/channel_details.test.jsx.snap
@@ -90,3 +90,90 @@ exports[`admin_console/team_channel_settings/channel/ChannelDetails should match
   />
 </div>
 `;
+
+exports[`admin_console/team_channel_settings/channel/ChannelDetails should match snapshot 2`] = `
+<div
+  className="wrapper--fixed"
+>
+  <div
+    className="admin-console__header with-back"
+  >
+    <div>
+      <Connect(BlockableLink)
+        className="fa fa-angle-left back"
+        to="/admin_console/user_management/channels"
+      />
+      <FormattedMessage
+        defaultMessage="Channel Configuration"
+        id="admin.channel_settings.channel_detail.channel_configuration"
+        values={Object {}}
+      />
+    </div>
+  </div>
+  <div
+    className="admin-console__wrapper"
+  >
+    <div
+      className="admin-console__content"
+    >
+      <RemoveConfirmModal
+        amount={0}
+        inChannel={false}
+        onCancel={[Function]}
+        onConfirm={[Function]}
+        show={false}
+      />
+      <ChannelProfile
+        channel={
+          Object {
+            "group_constrained": false,
+            "id": "123",
+            "name": "DN",
+            "team_name": "team",
+            "type": "O",
+          }
+        }
+        team={Object {}}
+      />
+      <ChannelModes
+        isOriginallyPrivate={false}
+        isPublic={true}
+        isSynced={false}
+        onToggle={[Function]}
+      />
+      <ChannelGroups
+        channel={
+          Object {
+            "group_constrained": false,
+            "id": "123",
+            "name": "DN",
+            "team_name": "team",
+            "type": "O",
+          }
+        }
+        groups={
+          Array [
+            Object {
+              "display_name": "DN",
+              "id": "123",
+              "member_count": 3,
+            },
+          ]
+        }
+        onAddCallback={[Function]}
+        onGroupRemoved={[Function]}
+        removedGroups={Array []}
+        synced={false}
+        totalGroups={1}
+      />
+    </div>
+  </div>
+  <SaveChangesPanel
+    cancelLink="/admin_console/user_management/channels"
+    onClick={[Function]}
+    saveNeeded={false}
+    saving={false}
+    serverError={null}
+  />
+</div>
+`;

--- a/components/admin_console/team_channel_settings/channel/details/channel_details.jsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_details.jsx
@@ -35,6 +35,7 @@ export default class ChannelDetails extends React.Component {
             membersMinusGroupMembers: PropTypes.func.isRequired,
             setNavigationBlocked: PropTypes.func.isRequired,
             getChannel: PropTypes.func.isRequired,
+            getTeam: PropTypes.func.isRequired,
             patchChannel: PropTypes.func.isRequired,
         }).isRequired,
     };
@@ -59,21 +60,31 @@ export default class ChannelDetails extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.channel.id !== prevProps.channel.id) {
+        const {channel, totalGroups} = this.props;
+        if (channel.id !== prevProps.channel.id) {
             // eslint-disable-next-line react/no-did-update-set-state
             this.setState({
-                totalGroups: this.props.totalGroups,
-                isSynced: Boolean(this.props.channel.group_constrained),
-                isPublic: this.props.channel.type === Constants.OPEN_CHANNEL,
+                totalGroups,
+                isSynced: Boolean(channel.group_constrained),
+                isPublic: channel.type === Constants.OPEN_CHANNEL,
             });
+        }
+
+        // If we don't have the team and channel on mount, we need to request the team after we load the channel
+        if (!prevProps.team.id && !prevProps.channel.team_id && channel.team_id) {
+            this.props.actions.getTeam(channel.team_id);
         }
     }
 
     async componentDidMount() {
-        const {channelID, actions} = this.props;
+        const {channelID, channel, team, actions} = this.props;
         actions.getGroups(channelID).
             then(() => actions.getChannel(channelID)).
             then(() => this.setState({groups: this.props.groups}));
+
+        if (!team.id && channel.team_id) {
+            actions.getTeam(channel.team_id);
+        }
     }
 
     setToggles = (isSynced, isPublic) => {

--- a/components/admin_console/team_channel_settings/channel/details/channel_details.test.jsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_details.test.jsx
@@ -27,22 +27,38 @@ describe('admin_console/team_channel_settings/channel/ChannelDetails', () => {
             display_name: 'test',
         };
 
-        const wrapper = shallow(
+        const actions = {
+            getChannel: jest.fn().mockResolvedValue([]),
+            getTeam: jest.fn().mockResolvedValue([]),
+            convertChannelToPrivate: jest.fn(),
+            linkGroupSyncable: jest.fn(),
+            conver: jest.fn(),
+            patchChannel: jest.fn(),
+            setNavigationBlocked: jest.fn(),
+            unlinkGroupSyncable: jest.fn(),
+            getGroups: jest.fn().mockResolvedValue([]),
+            membersMinusGroupMembers: jest.fn(),
+        };
+
+        let wrapper = shallow(
             <ChannelDetails
                 groups={groups}
                 team={team}
                 totalGroups={groups.length}
-                actions={{
-                    getChannel: jest.fn().mockResolvedValue([]),
-                    convertChannelToPrivate: jest.fn(),
-                    linkGroupSyncable: jest.fn(),
-                    conver: jest.fn(),
-                    patchChannel: jest.fn(),
-                    setNavigationBlocked: jest.fn(),
-                    unlinkGroupSyncable: jest.fn(),
-                    getGroups: jest.fn().mockResolvedValue([]),
-                    membersMinusGroupMembers: jest.fn(),
-                }}
+                actions={actions}
+                channel={testChannel}
+                channelID={testChannel.id}
+                allGroups={allGroups}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+
+        wrapper = shallow(
+            <ChannelDetails
+                groups={groups}
+                team={{}}
+                totalGroups={groups.length}
+                actions={actions}
                 channel={testChannel}
                 channelID={testChannel.id}
                 allGroups={allGroups}

--- a/components/admin_console/team_channel_settings/channel/details/index.js
+++ b/components/admin_console/team_channel_settings/channel/details/index.js
@@ -6,6 +6,7 @@ import {bindActionCreators} from 'redux';
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getAllGroups, getGroupsAssociatedToChannel} from 'mattermost-redux/selectors/entities/groups';
 import {convertChannelToPrivate, getChannel as fetchChannel, membersMinusGroupMembers, patchChannel} from 'mattermost-redux/actions/channels';
+import {getTeam as fetchTeam} from 'mattermost-redux/actions/teams';
 
 import {
     getGroupsAssociatedToChannel as fetchAssociatedGroups,
@@ -24,7 +25,7 @@ import ChannelDetails from './channel_details';
 function mapStateToProps(state, props) {
     const channelID = props.match.params.channel_id;
     const channel = getChannel(state, channelID) || {};
-    const team = channel.team_id ? getTeam(state, channel.team_id) : {};
+    const team = getTeam(state, channel.team_id) || {};
     const groups = getGroupsAssociatedToChannel(state, channelID);
     const associatedGroups = state.entities.channels.groupsAssociatedToChannel;
     const allGroups = getAllGroups(state, channel.team_id);
@@ -43,6 +44,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             getChannel: fetchChannel,
+            getTeam: fetchTeam,
             getGroups: fetchAssociatedGroups,
             convertChannelToPrivate,
             linkGroupSyncable,


### PR DESCRIPTION
#### Summary
If the team wasn't loaded then we weren't loading it and it could cause a JS error as we were passing `undefined` for the team prop.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18366