### PR TITLE
[GH-12186] Order tooltip for reactions on web by who recently reacted with those emoji

### DIFF
--- a/components/post_view/reaction/reaction.jsx
+++ b/components/post_view/reaction/reaction.jsx
@@ -96,28 +96,37 @@ export default class Reaction extends React.PureComponent {
         this.props.actions.getMissingProfilesByIds(ids);
     }
 
+    getSortedUsers = (getDisplayName) => {
+        // Sort users by recency order with "you" being first if the current user reacted
+        let currentUserReacted = false;
+        const sortedReactions = this.props.reactions.sort((a, b) => b.create_at - a.create_at);
+        const users = sortedReactions.reduce((accumulator, current) => {
+            if (current.user_id === this.props.currentUserId) {
+                currentUserReacted = true;
+            } else {
+                const user = this.props.profiles.find((u) => u.id === current.user_id);
+                if (user) {
+                    accumulator.push(getDisplayName(user));
+                }
+            }
+            return accumulator;
+        }, []);
+
+        if (currentUserReacted) {
+            users.unshift(Utils.localizeMessage('reaction.you', 'You'));
+        }
+
+        return {currentUserReacted, users};
+    }
+
     render() {
         if (!this.props.emojiImageUrl) {
             return null;
         }
 
-        let currentUserReacted = false;
-        const users = [];
+        const {currentUserReacted, users} = this.getSortedUsers(Utils.getDisplayNameByUser);
+
         const otherUsersCount = this.props.otherUsersCount;
-        for (const user of this.props.profiles) {
-            if (user.id === this.props.currentUserId) {
-                currentUserReacted = true;
-            } else {
-                users.push(Utils.getDisplayNameByUser(user));
-            }
-        }
-
-        // Sort users in alphabetical order with "you" being first if the current user reacted
-        users.sort();
-        if (currentUserReacted) {
-            users.unshift(Utils.localizeMessage('reaction.you', 'You'));
-        }
-
         let names;
         if (otherUsersCount > 0) {
             if (users.length > 0) {

--- a/components/post_view/reaction/reaction.test.jsx
+++ b/components/post_view/reaction/reaction.test.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import {shallow} from 'enzyme';
+import assert from 'assert';
 
 import Reaction from 'components/post_view/reaction/reaction.jsx';
 
@@ -98,5 +99,42 @@ describe('components/post_view/Reaction', () => {
 
         expect(newActions.getMissingProfilesByIds).toHaveBeenCalledTimes(1);
         expect(newActions.getMissingProfilesByIds).toHaveBeenCalledWith([reactions[0].user_id, reactions[1].user_id]);
+    });
+
+    test('should sort users by recency', () => {
+        const baseDate = Date.now();
+        const newReactions = [
+            {user_id: 'user_id_2', create_at: baseDate},
+            {user_id: 'user_id_1', create_at: baseDate + 8000},
+            {user_id: 'user_id_3', create_at: baseDate + 5000},
+        ];
+        const newProfiles = [{id: 'user_id_1'}, {id: 'user_id_2'}, {id: 'user_id_3'}];
+        const props = {
+            ...baseProps,
+            reactions: newReactions,
+            profiles: newProfiles,
+            otherUsersCount: 1,
+        };
+        const getDisplayNameMock = (user) => {
+            switch (user.id) {
+            case 'user_id_1':
+                return 'username_1';
+            case 'user_id_2':
+                return 'username_2';
+            case 'user_id_3':
+                return 'username_3';
+            default:
+                return '';
+            }
+        };
+
+        const wrapper = shallow(<Reaction {...props}/>);
+
+        const {currentUserReacted, users} = wrapper.instance().getSortedUsers(getDisplayNameMock);
+        expect(currentUserReacted).toEqual(true);
+        assert.deepEqual(
+            users,
+            ['You', 'username_3', 'username_2']
+        );
     });
 });


### PR DESCRIPTION
#### Summary
In the tooltip of an emoji reaction to a post, the users are ordered by recency (who reacted most recently), not alphabetically. And if the logged-in user has reacted, "You" - or its localized equivalent - will precede the other users in the tooltip (even if they reacted after the logged-in user).

Here is a screenshot illustrating this behavior.

![image](https://user-images.githubusercontent.com/25670682/64919720-8c525c80-d7ae-11e9-9c57-9b8b22914a07.png)

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/12186

