### PR TITLE
[MM-18385] Force screen reader to read whole aria-live section on multiselect option change

### DIFF
--- a/components/multiselect/multiselect_list.jsx
+++ b/components/multiselect/multiselect_list.jsx
@@ -164,6 +164,7 @@ export default class MultiSelectList extends React.Component {
                     <div
                         className='sr-only'
                         aria-live='polite'
+                        aria-atomic='true'
                     >
                         {ariaLabel}
                     </div>


### PR DESCRIPTION
#### Summary
Firefox was not correctly reading the `aria-live` region of the `multiselect` component, instead it was reading bits and pieces as the text field was updated. This PR adds the `aria-atomic` label, which ensures the entire option is read correctly.

NOTE: Microsoft Edge continues to have issues with JAWS and NVDA. See: https://github.com/FreedomScientific/VFO-standards-support/issues/266
Hopefully this will be fixed soon.

Tested on Firefox 69.0 and JAWS 2019.1907.42

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18385
