### PR TITLE
[MM-18598] Group settings add team modal doesn't show team name

### DIFF
--- a/components/team_selector_modal/team_selector_modal.jsx
+++ b/components/team_selector_modal/team_selector_modal.jsx
@@ -155,10 +155,15 @@ export default class TeamSelectorModal extends React.Component {
                 <div
                     className='more-modal__details'
                 >
-                    <TeamIcon
-                        name={option.display_name}
-                        url={imageURLForTeam(option)}
-                    />
+                    <div className='team-info-block'>
+                        <TeamIcon
+                            name={option.display_name}
+                            url={imageURLForTeam(option)}
+                        />
+                        <div className='team-data'>
+                            <div className='title'>{option.display_name}</div>
+                        </div>
+                    </div>
                 </div>
                 <div className='more-modal__actions'>
                     <div className='more-modal__actions--round'>

--- a/sass/components/_permissions.scss
+++ b/sass/components/_permissions.scss
@@ -341,3 +341,16 @@
         }
     }
 }
+
+.team-info-block {	
+    display: flex;	
+    flex-grow: 1;	
+    align-items: center;		
+    .team-data {	
+        flex-grow: 1;	
+        padding: 0 0 0 10px;	
+        .title {	
+            font-weight: bold;	
+        }	
+    }	
+}


### PR DESCRIPTION
#### Summary
Fixes missing 'Team Name' from 'Add Teams To Team Selection List' modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18598

#### Related Pull Requests
N/A
