### PR TITLE
Add vim temporary files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ e2e/node_modules
 e2e/cypress/videos
 e2e/results
 storybook-static
+
+# Vim temporary files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~


### PR DESCRIPTION
#### Summary

I've noticed that this repo does not ignore vim files and I was almost going to involuntarily commit some.
I've copied the related section from [mattermost-server](https://github.com/mattermost/mattermost-server/blob/46c624f4f8707d8d45344ad5fc9b9019dd992d2c/.gitignore#L62-L68) to ignore files related to the [vim](https://en.wikipedia.org/wiki/Vim_(text_editor)) editor.

