### PR TITLE
MM-18582 Remove utils.displayTime in favour of FormattedTime component

### DIFF
--- a/components/admin_console/license_settings/license_settings.jsx
+++ b/components/admin_console/license_settings/license_settings.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import {formatTime, formatDate, FormattedMessage} from 'react-intl';
 
 import * as Utils from 'utils/utils.jsx';
 
@@ -99,9 +99,9 @@ export default class LicenseSettings extends React.Component {
         let licenseType;
         let licenseKey;
 
-        const issued = Utils.displayDate(parseInt(license.IssuedAt, 10)) + ' ' + Utils.displayTime(parseInt(license.IssuedAt, 10), true);
-        const startsAt = Utils.displayDate(parseInt(license.StartsAt, 10));
-        const expiresAt = Utils.displayDate(parseInt(license.ExpiresAt, 10));
+        const issued = formatDate(parseInt(license.IssuedAt, 10)) + ' ' + formatTime(parseInt(license.IssuedAt, 10));
+        const startsAt = formatDate(parseInt(license.StartsAt, 10));
+        const expiresAt = formatDate(parseInt(license.ExpiresAt, 10));
 
         if (license.IsLicensed === 'true' && !uploading) {
             // Note: DO NOT LOCALISE THESE STRINGS. Legally we can not since the license is in English.

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -194,42 +194,6 @@ export function displayDate(ticks) {
     return monthNames[d.getMonth()] + ' ' + d.getDate() + ', ' + d.getFullYear();
 }
 
-export function displayTime(ticks, utc) {
-    const d = new Date(ticks);
-    let hours;
-    let minutes;
-    let ampm = '';
-    let timezone = '';
-
-    if (utc) {
-        hours = d.getUTCHours();
-        minutes = d.getUTCMinutes();
-        timezone = ' UTC';
-    } else {
-        hours = d.getHours();
-        minutes = d.getMinutes();
-    }
-
-    if (minutes <= 9) {
-        minutes = '0' + minutes;
-    }
-
-    const useMilitaryTime = getBool(store.getState(), Constants.Preferences.CATEGORY_DISPLAY_SETTINGS, 'use_military_time');
-    if (!useMilitaryTime) {
-        ampm = ' AM';
-        if (hours >= 12) {
-            ampm = ' PM';
-        }
-
-        hours %= 12;
-        if (!hours) {
-            hours = '12';
-        }
-    }
-
-    return hours + ':' + minutes + ampm + timezone;
-}
-
 // returns Unix timestamp in milliseconds
 export function getTimestamp() {
     return Date.now();


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Remove utils.displayTime in favour of FormattedTime component
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://github.com/mattermost/mattermost-server/issues/12242