### PR TITLE
MM-18531 Added Feature to Close Channel via Direct Message

### DIFF
--- a/components/channel_header_dropdown/channel_header_dropdown_items.js
+++ b/components/channel_header_dropdown/channel_header_dropdown_items.js
@@ -30,6 +30,7 @@ import Menu from 'components/widgets/menu/menu.jsx';
 
 import MenuItemLeaveChannel from './menu_items/leave_channel';
 import MenuItemCloseChannel from './menu_items/close_channel';
+import MenuItemDirectLevelChannel from './menu_items/close_direct_channel';
 import MenuItemToggleMuteChannel from './menu_items/toggle_mute_channel';
 import MenuItemToggleFavoriteChannel from './menu_items/toggle_favorite_channel';
 import MenuItemViewPinnedPosts from './menu_items/view_pinned_posts';
@@ -203,6 +204,13 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
                         dialogProps={{channel}}
                         text={localizeMessage('channel_header.setHeader', 'Edit Channel Header')}
                     />
+                    <Menu.Group divider={divider}>
+                        <MenuItemDirectLevelChannel
+                            id='channelDirectLevel'
+                            channel={channel}
+                            currentUser={user}
+                        />
+                    </Menu.Group>
                     <ChannelPermissionGate
                         channelId={channel.id}
                         teamId={channel.team_id}

--- a/components/channel_header_dropdown/menu_items/close_direct_channel/__snapshots__/close_direct_channel.test.js.snap
+++ b/components/channel_header_dropdown/menu_items/close_direct_channel/__snapshots__/close_direct_channel.test.js.snap
@@ -3,7 +3,7 @@
 exports[`components/ChannelHeaderDropdown/MenuItem.CloseDirectChannel shoud be hidden if the channel is not a DM 1`] = `
 <MenuItemAction
   onClick={[Function]}
-  show={true}
+  show={false}
   text="Close Channel"
 />
 `;

--- a/components/channel_header_dropdown/menu_items/close_direct_channel/__snapshots__/close_direct_channel.test.js.snap
+++ b/components/channel_header_dropdown/menu_items/close_direct_channel/__snapshots__/close_direct_channel.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/ChannelHeaderDropdown/MenuItem.CloseDirectChannel shoud be hidden if the channel is not a DM 1`] = `
+<MenuItemAction
+  onClick={[Function]}
+  show={true}
+  text="Close Channel"
+/>
+`;
+
+exports[`components/ChannelHeaderDropdown/MenuItem.CloseDirectChannel should match snapshot 1`] = `
+<MenuItemAction
+  onClick={[Function]}
+  show={true}
+  text="Close Channel"
+/>
+`;

--- a/components/channel_header_dropdown/menu_items/close_direct_channel/close_direct_channel.js
+++ b/components/channel_header_dropdown/menu_items/close_direct_channel/close_direct_channel.js
@@ -1,0 +1,81 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {localizeMessage} from 'utils/utils';
+import {Constants} from 'utils/constants';
+import {browserHistory} from 'utils/browser_history';
+import Menu from 'components/widgets/menu/menu';
+
+export default class CloseDirectChannel extends React.PureComponent {
+    static propTypes = {
+
+        /**
+         * Object with info about currentUser
+         */
+        currentUser: PropTypes.object.isRequired,
+
+        /**
+         * Object with info about currentTeam
+         */
+        currentTeam: PropTypes.object.isRequired,
+
+        /**
+         * String with info about redirect
+         */
+        redirectChannel: PropTypes.string.isRequired,
+
+        /**
+         * Object with info about channel
+         */
+        channel: PropTypes.object.isRequired,
+
+        /**
+         * Use for test selector
+         */
+        id: PropTypes.string,
+
+        /**
+         * Object with action creators
+         */
+        actions: PropTypes.shape({
+
+            /**
+             * Action creator to update user preferences
+             */
+            savePreferences: PropTypes.func.isRequired,
+        }).isRequired,
+    };
+
+    isLeaving = false;
+
+    handleClose = () => {
+        if (!this.isLeaving) {
+            const id = this.props.channel.teammate_id;
+            const category = Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;
+
+            const currentUserId = this.props.currentUser.id;
+            this.props.actions.savePreferences(currentUserId, [{user_id: currentUserId, category, name: id, value: 'false'}]).then(
+                () => {
+                    this.isLeaving = false;
+                }
+            );
+
+            browserHistory.push(`/${this.props.currentTeam.name}/channels/${this.props.redirectChannel}`);
+        }
+    }
+
+    render() {
+        const {id, channel} = this.props;
+        return (
+            <Menu.ItemAction
+                id={id}
+                show={channel.type === Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL}
+                onClick={this.handleClose}
+                text={localizeMessage('center_panel.direct.closeChannel', 'Close Channel')}
+            />
+        );
+    }
+}

--- a/components/channel_header_dropdown/menu_items/close_direct_channel/close_direct_channel.js
+++ b/components/channel_header_dropdown/menu_items/close_direct_channel/close_direct_channel.js
@@ -54,19 +54,21 @@ export default class CloseDirectChannel extends React.PureComponent {
     handleClose = (e) => {
         e.preventDefault();
 
-        if (!this.isLeaving) {
-            const id = this.props.channel.teammate_id;
-            const category = Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;
+        const {
+            channel,
+            currentUser,
+            currentTeam,
+            redirectChannel,
+            actions: {
+                savePreferences,
+            },
+        } = this.props;
 
-            const currentUserId = this.props.currentUser.id;
-            this.props.actions.savePreferences(currentUserId, [{user_id: currentUserId, category, name: id, value: 'false'}]).then(
-                () => {
-                    this.isLeaving = false;
-                }
-            );
+        const category = Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;
 
-            browserHistory.push(`/${this.props.currentTeam.name}/channels/${this.props.redirectChannel}`);
-        }
+        savePreferences(currentUser.id, [{user_id: currentUser.id, category, name: channel.teammate_id, value: 'false'}]);
+
+        browserHistory.push(`/${currentTeam.name}/channels/${redirectChannel}`);
     }
 
     render() {

--- a/components/channel_header_dropdown/menu_items/close_direct_channel/close_direct_channel.js
+++ b/components/channel_header_dropdown/menu_items/close_direct_channel/close_direct_channel.js
@@ -51,7 +51,9 @@ export default class CloseDirectChannel extends React.PureComponent {
 
     isLeaving = false;
 
-    handleClose = () => {
+    handleClose = (e) => {
+        e.preventDefault();
+
         if (!this.isLeaving) {
             const id = this.props.channel.teammate_id;
             const category = Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;

--- a/components/channel_header_dropdown/menu_items/close_direct_channel/close_direct_channel.test.js
+++ b/components/channel_header_dropdown/menu_items/close_direct_channel/close_direct_channel.test.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {Constants} from 'utils/constants';
+
+import Menu from 'components/widgets/menu/menu';
+
+import CloseDirectChannel from './close_direct_channel';
+
+describe('components/ChannelHeaderDropdown/MenuItem.CloseDirectChannel', () => {
+    const baseProps = {
+        currentUser: {
+            id: 'user_id',
+        },
+        channel: {
+            id: 'channel_id',
+            type: Constants.DM_CHANNEL,
+            teammate_id: 'teammate-id',
+        },
+        redirectChannel: 'test-default-channel',
+        currentTeam: {
+            id: 'team_id',
+            name: 'test-team',
+            display_name: 'Test team display name',
+            description: 'Test team description',
+            type: 'team-type',
+        },
+        actions: {
+            savePreferences: jest.fn(() => Promise.resolve()),
+        },
+    };
+
+    it('should match snapshot', () => {
+        const wrapper = shallow(<CloseDirectChannel {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('shoud be hidden if the channel is not a DM', () => {
+        const wrapper = shallow(<CloseDirectChannel {...baseProps}/>);
+        baseProps.channel.type = Constants.GM_CHANNEL;
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should run savePreferences function on click', () => {
+        const wrapper = shallow(<CloseDirectChannel {...baseProps}/>);
+        wrapper.find(Menu.ItemAction).simulate('click', {
+            preventDefault: jest.fn(),
+        });
+        expect(baseProps.actions.savePreferences).toBeCalledWith(baseProps.currentUser.id, [{user_id: baseProps.currentUser.id, category: Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: baseProps.channel.teammate_id, value: 'false'}]);
+    });
+});

--- a/components/channel_header_dropdown/menu_items/close_direct_channel/close_direct_channel.test.js
+++ b/components/channel_header_dropdown/menu_items/close_direct_channel/close_direct_channel.test.js
@@ -39,8 +39,16 @@ describe('components/ChannelHeaderDropdown/MenuItem.CloseDirectChannel', () => {
     });
 
     it('shoud be hidden if the channel is not a DM', () => {
-        const wrapper = shallow(<CloseDirectChannel {...baseProps}/>);
-        baseProps.channel.type = Constants.GM_CHANNEL;
+        const props = {
+            ...baseProps,
+            channel: {
+                id: 'channel_id',
+                type: Constants.GM_CHANNEL,
+                teammate_id: 'teammate-id',
+            },
+        };
+
+        const wrapper = shallow(<CloseDirectChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 

--- a/components/channel_header_dropdown/menu_items/close_direct_channel/index.js
+++ b/components/channel_header_dropdown/menu_items/close_direct_channel/index.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+
+import {savePreferences} from 'mattermost-redux/actions/preferences';
+import {getCurrentTeam, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
+
+import CloseDirectChannel from './close_direct_channel';
+
+const mapStateToProps = (state) => {
+    return {
+        currentTeam: getCurrentTeam(state),
+        redirectChannel: getRedirectChannelNameForTeam(state, getCurrentTeamId(state)),
+    };
+};
+
+const mapDispatchToProps = (dispatch) => ({
+    actions: bindActionCreators({savePreferences}, dispatch),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(CloseDirectChannel);

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1790,6 +1790,7 @@
   "bots.token.confirm_text": "Are you sure you want to delete the token?",
   "bots.token.delete": "Delete Token",
   "center_panel.archived.closeChannel": "Close Channel",
+  "center_panel.direct.closeChannel": "Close Channel",
   "center_panel.permalink.archivedChannel": "You are viewing an **archived channel**. ",
   "center_panel.recent": "Click here to jump to recent messages. ",
   "center_panel.recent.icon": "Jump to recent messages Icon",


### PR DESCRIPTION
### Summary
This PR gives support for Closing a Direct Message under the DM username. 

Decided to create a new component to handle this feature, instead of reworking the `CloseChannel` already in place due to the fact that the `CloseChannel` is based on `isArchived`.

Changes: 

- [X] UI
- [X] Added Unit Tests

#### Ticket Link
Fixes  [https://github.com/mattermost/mattermost-server/issues/12244](https://github.com/mattermost/mattermost-server/issues/12244)

Jira: [https://mattermost.atlassian.net/browse/MM-18531](https://mattermost.atlassian.net/browse/MM-18531)
