### PR TITLE
[MM-18164] Turned on aria-labels for the RHS header buttons

### DIFF
--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -185,6 +185,7 @@ export default class SearchBar extends React.Component {
                             aria-hidden='true'
                         />
                     }
+                    ariaLabel={true}
                     buttonClass={'channel-header__icon style--none ' + mentionBtnClass}
                     buttonId={'channelHeaderMentionButton'}
                     onClick={this.searchMentions}
@@ -199,6 +200,7 @@ export default class SearchBar extends React.Component {
                     iconComponent={
                         <FlagIcon className='icon icon__flag'/>
                     }
+                    ariaLabel={true}
                     buttonClass={'channel-header__icon style--none ' + flagBtnClass}
                     buttonId={'channelHeaderFlagButton'}
                     onClick={this.getFlagged}


### PR DESCRIPTION
#### Summary
When `aria-label`s were added for the Recent Mentions and Flagged Posts buttons, we forgot to add them to the RHS implementations. This PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18164
