### PR TITLE
[MM-18649] Fixed race condition for /leave action

### DIFF
--- a/actions/command.js
+++ b/actions/command.js
@@ -8,6 +8,7 @@ import {getCurrentChannel, getRedirectChannelNameForTeam} from 'mattermost-redux
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentRelativeTeamUrl, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {IntegrationTypes} from 'mattermost-redux/action_types';
+import {isFavoriteChannel} from 'mattermost-redux/utils/channel_utils';
 
 import {openModal} from 'actions/views/modals';
 import * as GlobalActions from 'actions/global_actions.jsx';
@@ -17,7 +18,6 @@ import {isUrlSafe, getSiteURL} from 'utils/url.jsx';
 import {localizeMessage, getUserIdFromChannelName} from 'utils/utils.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import {Constants, ModalIdentifiers} from 'utils/constants.jsx';
-import {isFavoriteChannel} from 'utils/channel_utils.jsx';
 import {browserHistory} from 'utils/browser_history';
 
 import UserSettingsModal from 'components/user_settings/modal';
@@ -71,13 +71,16 @@ export function executeCommand(message, args) {
                     category = Constants.Preferences.CATEGORY_GROUP_CHANNEL_SHOW;
                 }
                 const currentUserId = getCurrentUserId(state);
+                const currentTeamId = getCurrentTeamId(state);
+                const redirectChannel = getRedirectChannelNameForTeam(state, currentTeamId);
+                const teamUrl = getCurrentRelativeTeamUrl(state);
+                browserHistory.push(`${teamUrl}/channels/${redirectChannel}`);
+
                 dispatch(savePreferences(currentUserId, [{category, name, user_id: currentUserId, value: 'false'}]));
                 if (isFavoriteChannel(channel)) {
                     dispatch(unfavoriteChannel(channel.id));
                 }
-                const currentTeamId = getCurrentTeamId(state);
-                const redirectChannel = getRedirectChannelNameForTeam(state, currentTeamId);
-                browserHistory.push(`${getCurrentRelativeTeamUrl(state)}/channels/${redirectChannel}`);
+
                 return {data: true};
             }
             break;


### PR DESCRIPTION
#### Summary
When using the `/leave` command on a DM, the user would be immediately put back into the channel they just removed from their sidebar. 
This was caused by an improper ordering of the preferences, where the `savePreferences()` dispatch would not have the information of the redirect to town-square before trying to update the sidebar, thus redirecting you back to the channel it thinks you're already in. 
This PR re-orders the actions such that the removal has happened after the navigation to town-square, and the redirect executes properly.
Also, we were using the wrong import of `isFavoriteChannel()` causing a JS error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18649