### PR TITLE
[MM-18746] Fix channels autocomplete both for interactive dialog and menu

### DIFF
--- a/components/interactive_dialog/dialog_element/dialog_element.jsx
+++ b/components/interactive_dialog/dialog_element/dialog_element.jsx
@@ -33,6 +33,9 @@ export default class DialogElement extends React.PureComponent {
         options: PropTypes.arrayOf(PropTypes.object),
         value: PropTypes.any,
         onChange: PropTypes.func,
+        actions: PropTypes.shape({
+            autocompleteChannels: PropTypes.func.isRequired,
+        }).isRequired,
     }
 
     constructor(props) {
@@ -43,7 +46,7 @@ export default class DialogElement extends React.PureComponent {
             if (props.dataSource === 'users') {
                 this.providers = [new GenericUserProvider()];
             } else if (props.dataSource === 'channels') {
-                this.providers = [new GenericChannelProvider()];
+                this.providers = [new GenericChannelProvider(props.actions.autocompleteChannels)];
             } else if (props.options) {
                 this.providers = [new MenuActionProvider(props.options)];
             }

--- a/components/interactive_dialog/dialog_element/dialog_element.test.jsx
+++ b/components/interactive_dialog/dialog_element/dialog_element.test.jsx
@@ -15,6 +15,9 @@ describe('components/interactive_dialog/DialogElement', () => {
         name: 'testing',
         type: 'text',
         maxLength: 100,
+        actions: {
+            autocompleteChannels: jest.fn(),
+        },
     };
     const baseTextSettingProps = {
         id: baseDialogProps.name,

--- a/components/interactive_dialog/dialog_element/index.js
+++ b/components/interactive_dialog/dialog_element/index.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+
+import {autocompleteChannels} from 'actions/channel_actions';
+
+import DialogElement from './dialog_element';
+
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            autocompleteChannels,
+        }, dispatch),
+    };
+}
+
+export default connect(null, mapDispatchToProps)(DialogElement);

--- a/components/post_view/message_attachments/action_menu/action_menu.jsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.jsx
@@ -15,6 +15,7 @@ export default class ActionMenu extends React.PureComponent {
         action: PropTypes.object.isRequired,
         selected: PropTypes.object,
         actions: PropTypes.shape({
+            autocompleteChannels: PropTypes.func.isRequired,
             selectAttachmentMenuAction: PropTypes.func.isRequired,
         }).isRequired,
     }
@@ -28,7 +29,7 @@ export default class ActionMenu extends React.PureComponent {
             if (action.data_source === 'users') {
                 this.providers = [new GenericUserProvider()];
             } else if (action.data_source === 'channels') {
-                this.providers = [new GenericChannelProvider()];
+                this.providers = [new GenericChannelProvider(props.actions.autocompleteChannels)];
             } else if (action.options) {
                 this.providers = [new MenuActionProvider(action.options)];
             }

--- a/components/post_view/message_attachments/action_menu/action_menu.test.jsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.test.jsx
@@ -23,6 +23,7 @@ describe('components/post_view/message_attachments/ActionMenu', () => {
             ],
         },
         actions: {
+            autocompleteChannels: jest.fn(),
             selectAttachmentMenuAction: jest.fn(),
         },
     };

--- a/components/post_view/message_attachments/action_menu/index.js
+++ b/components/post_view/message_attachments/action_menu/index.js
@@ -4,6 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
+import {autocompleteChannels} from 'actions/channel_actions';
 import {selectAttachmentMenuAction} from 'actions/views/posts';
 
 import ActionMenu from './action_menu.jsx';
@@ -21,6 +22,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             selectAttachmentMenuAction,
+            autocompleteChannels,
         }, dispatch),
     };
 }

--- a/components/suggestion/generic_channel_provider.jsx
+++ b/components/suggestion/generic_channel_provider.jsx
@@ -3,8 +3,6 @@
 
 import React from 'react';
 
-import {autocompleteChannels} from 'actions/channel_actions.jsx';
-
 import Provider from './provider.jsx';
 import Suggestion from './suggestion.jsx';
 
@@ -47,11 +45,17 @@ class ChannelSuggestion extends Suggestion {
 }
 
 export default class ChannelProvider extends Provider {
+    constructor(channelSearchFunc) {
+        super();
+
+        this.autocompleteChannels = channelSearchFunc;
+    }
+
     handlePretextChanged(pretext, resultsCallback) {
         const normalizedPretext = pretext.toLowerCase();
         this.startNewRequest(normalizedPretext);
 
-        autocompleteChannels(
+        this.autocompleteChannels(
             normalizedPretext,
             (data) => {
                 if (this.shouldCancelDispatch(normalizedPretext)) {


### PR DESCRIPTION
#### Summary
Fix channels autocomplete both for interactive dialog and menu.  This was introduced by the [recent migration](https://github.com/mattermost/mattermost-webapp/pull/3453/files) which I missed to check during code review.

Can be tested using mattermost demo plugin (`/dialog`) or running Cypress tests with "/interactive_dialog" and "/interactive_menu" folders

#### Ticket Link
Jira ticket - [MM-18746](https://mattermost.atlassian.net/browse/MM-18746)

