### PR TITLE
Fix E2E on user status and toggling private/public channel

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/channel_modes_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_modes_spec.js
@@ -8,6 +8,22 @@
 // ***************************************************************
 
 describe('Test channel public/private toggle', () => {
+    before(() => {
+        // Enable LDAP and LDAP group sync
+        cy.apiUpdateConfig({
+            LdapSettings: {Enable: true},
+            ServiceSettings: {ExperimentalLdapGroupSync: true},
+        });
+    });
+
+    after(() => {
+        // Disable LDAP and LDAP group sync
+        cy.apiUpdateConfig({
+            LdapSettings: {Enable: false},
+            ServiceSettings: {ExperimentalLdapGroupSync: false},
+        });
+    });
+
     it('Verify that System Admin can change channel privacy using toggle', () => {
         cy.apiLogin('sysadmin');
         cy.visit('/');
@@ -54,6 +70,20 @@ describe('Test channel public/private toggle', () => {
             cy.get('#channel_manage .group-teams-and-channels--body').find('button').eq(0).click();
             cy.get('#channel_manage .group-teams-and-channels--body').find('button').eq(0).click();
             cy.get('#channel_manage .group-teams-and-channels--body').find('button').eq(1).contains('Private');
+        });
+    });
+
+    it('Verify that toggles are disabled for default channel', () => {
+        cy.apiLogin('sysadmin');
+        cy.visit('/');
+        cy.get('#sidebarItem_town-square').scrollIntoView().click({force: true});
+        cy.getCurrentChannelId().then((id) => {
+            cy.visit(`/admin_console/user_management/channels/${id}`);
+            cy.get('#channel_profile').contains('town-square');
+            cy.get('#channel_manage .group-teams-and-channels--body').find('button').eq(0).should('have.class', 'false');
+            cy.get('#channel_manage .group-teams-and-channels--body').find('button').eq(1).contains('Public');
+            cy.get('#channel_manage .group-teams-and-channels--body').find('button').eq(0).should('have.class', 'disabled');
+            cy.get('#channel_manage .group-teams-and-channels--body').find('button').eq(1).should('have.class', 'disabled');
         });
     });
 });

--- a/e2e/cypress/integration/enterprise/system_console/channel_modes_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_modes_spec.js
@@ -16,14 +16,6 @@ describe('Test channel public/private toggle', () => {
         });
     });
 
-    after(() => {
-        // Disable LDAP and LDAP group sync
-        cy.apiUpdateConfig({
-            LdapSettings: {Enable: false},
-            ServiceSettings: {ExperimentalLdapGroupSync: false},
-        });
-    });
-
     it('Verify that System Admin can change channel privacy using toggle', () => {
         cy.apiLogin('sysadmin');
         cy.visit('/');


### PR DESCRIPTION
#### Summary
For channel modes, I moved this into "/enterprise" folder since it requires license to test.  Also enable LDAP and LDAP group sync for those test cases.
For user status, it failed due to compact and standard display modes.  Those are now handled separately. 

#### Ticket Link
none
