### PR TITLE
[MM-18600] Reset SuggestionBox pretext on post submit

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -188,6 +188,14 @@ export default class SuggestionBox extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        const {value} = this.props;
+
+        // Post was just submitted, update pretext property.
+        if (value === '' && this.pretext !== value) {
+            this.handlePretextChanged(value);
+            return;
+        }
+
         if (prevProps.contextId !== this.props.contextId) {
             const textbox = this.getTextbox();
             const pretext = textbox.value.substring(0, textbox.selectionEnd).toLowerCase();

--- a/components/suggestion/suggestion_box.test.jsx
+++ b/components/suggestion/suggestion_box.test.jsx
@@ -94,6 +94,23 @@ describe('components/SuggestionBox', () => {
         expect(instance.handlePretextChanged.mock.calls.length).toBe(1);
     });
 
+    test('should force pretext change after text has been cleared by parent', async () => {
+        const wrapper = shallow(
+            <SuggestionBox
+                {...baseProps}
+            />
+        );
+        const instance = wrapper.instance();
+        instance.handlePretextChanged = jest.fn();
+        instance.pretext = 'value';
+
+        wrapper.setProps({...baseProps});
+        expect(instance.handlePretextChanged).not.toBeCalled();
+
+        wrapper.setProps({...baseProps, value: ''});
+        expect(instance.handlePretextChanged).toBeCalledWith('');
+    });
+
     test('should force pretext change on composition update', () => {
         const wrapper = shallow(
             <SuggestionBox


### PR DESCRIPTION
#### Summary

This PR solves the issue with trying to use the channel autocomplete `~` after submitting a post with just a channel mention.

The issue is that the `SuggestionBox` component's reference to `this.pretext` is stale after submitting the post. If we check that the current post text is empty, and the pretext is out of sync, we can update the pretext to empty string to reset the component. This added block does not run when the user clears the post text themselves, as that is handled in `this.handleChange()`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18600

#### Reproduction Steps

- In a new post, type `~` and press tab to select the first channel.
- Submit the post (at the time before submitting, `this.pretext` is set to `~`)
- Type `~`. The channel autocomplete does not come up, because the stale value of `this.pretext` is still `~`, and because those values match, the `~` character does not trigger the channel mention dropdown.
