### PR TITLE
MM-18570 - Hitting escape to close autocomplete also closes channel header modal

### DIFF
--- a/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.jsx.snap
+++ b/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`components/EditChannelHeaderModal edit dirrect message channel 1`] = `
   dialogClassName="a11y__modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
-  keyboard={true}
+  keyboard={false}
   manager={
     ModalManager {
       "add": [Function],
@@ -26,6 +26,7 @@ exports[`components/EditChannelHeaderModal edit dirrect message channel 1`] = `
   onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
+  onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"
@@ -131,7 +132,7 @@ exports[`components/EditChannelHeaderModal error with intl message 1`] = `
   dialogClassName="a11y__modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
-  keyboard={true}
+  keyboard={false}
   manager={
     ModalManager {
       "add": [Function],
@@ -147,6 +148,7 @@ exports[`components/EditChannelHeaderModal error with intl message 1`] = `
   onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
+  onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"
@@ -266,7 +268,7 @@ exports[`components/EditChannelHeaderModal error without intl message 1`] = `
   dialogClassName="a11y__modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
-  keyboard={true}
+  keyboard={false}
   manager={
     ModalManager {
       "add": [Function],
@@ -282,6 +284,7 @@ exports[`components/EditChannelHeaderModal error without intl message 1`] = `
   onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
+  onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"
@@ -401,7 +404,7 @@ exports[`components/EditChannelHeaderModal hide error message on new request 1`]
   dialogClassName="a11y__modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
-  keyboard={true}
+  keyboard={false}
   manager={
     ModalManager {
       "add": [Function],
@@ -417,6 +420,7 @@ exports[`components/EditChannelHeaderModal hide error message on new request 1`]
   onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
+  onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"
@@ -526,7 +530,7 @@ exports[`components/EditChannelHeaderModal should match snapshot, init 1`] = `
   dialogClassName="a11y__modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
-  keyboard={true}
+  keyboard={false}
   manager={
     ModalManager {
       "add": [Function],
@@ -542,6 +546,7 @@ exports[`components/EditChannelHeaderModal should match snapshot, init 1`] = `
   onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
+  onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"
@@ -651,7 +656,7 @@ exports[`components/EditChannelHeaderModal submitted 1`] = `
   dialogClassName="a11y__modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
-  keyboard={true}
+  keyboard={false}
   manager={
     ModalManager {
       "add": [Function],
@@ -667,6 +672,7 @@ exports[`components/EditChannelHeaderModal submitted 1`] = `
   onEntering={[Function]}
   onExited={[Function]}
   onHide={[Function]}
+  onKeyDown={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
   role="dialog"

--- a/components/edit_channel_header_modal/edit_channel_header_modal.jsx
+++ b/components/edit_channel_header_modal/edit_channel_header_modal.jsx
@@ -93,7 +93,7 @@ class EditChannelHeaderModal extends React.PureComponent {
     }
 
     handleModalKeyDown = (e) => {
-        if (isKeyPressed(e, KeyCodes.ESCAPE)){
+        if (isKeyPressed(e, KeyCodes.ESCAPE)) {
             this.onHide();
         }
     }

--- a/components/edit_channel_header_modal/edit_channel_header_modal.jsx
+++ b/components/edit_channel_header_modal/edit_channel_header_modal.jsx
@@ -92,6 +92,12 @@ class EditChannelHeaderModal extends React.PureComponent {
         }
     }
 
+    handleModalKeyDown = (e) => {
+        if (isKeyPressed(e, KeyCodes.ESCAPE)){
+            this.onHide();
+        }
+    }
+
     updatePreview = (newState) => {
         this.setState({preview: newState});
     }
@@ -190,6 +196,8 @@ class EditChannelHeaderModal extends React.PureComponent {
             <Modal
                 dialogClassName='a11y__modal'
                 show={this.state.show}
+                keyboard={false}
+                onKeyDown={this.handleModalKeyDown}
                 onHide={this.onHide}
                 onEntering={this.handleEntering}
                 onExited={this.props.onHide}


### PR DESCRIPTION
#### Summary
Fixed escape key handling in Edit Header modal

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-18570
