### PR TITLE
[MM 18159] Fix multiple hover post menus appearing after escaping from image preview.

### DIFF
--- a/utils/a11y_controller.js
+++ b/utils/a11y_controller.js
@@ -296,6 +296,12 @@ export default class A11yController {
      * @param {array or boolean} elementPath - array of element's dom branch or boolean to find section/region of element
      */
     nextElement(element, elementPath = false) {
+        if (
+            this.modalIsOpen ||
+            this.popupIsOpen
+        ) {
+            return;
+        }
         let region;
         let section;
         if (elementPath && elementPath.length) {


### PR DESCRIPTION
#### Summary
When clicking on image previews in posts, the post hover menu on the right of the post was getting stuck visible once closing the menus. This PR corrects that by preventing element focusing by the a11yController while modals are open.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18159