### PR TITLE
Added Cypress Test to verify behavior when Guest User is removed from channel

### DIFF
--- a/components/removed_from_channel_modal/__snapshots__/removed_from_channel_modal.test.jsx.snap
+++ b/components/removed_from_channel_modal/__snapshots__/removed_from_channel_modal.test.jsx.snap
@@ -75,6 +75,7 @@ exports[`components/RemoveFromChannelModal should match snapshot 1`] = `
   >
     <button
       className="btn btn-primary"
+      id="removedChannelBtn"
       onClick={[Function]}
       type="button"
     >

--- a/components/removed_from_channel_modal/removed_from_channel_modal.jsx
+++ b/components/removed_from_channel_modal/removed_from_channel_modal.jsx
@@ -96,6 +96,7 @@ export default class RemovedFromChannelModal extends React.PureComponent {
                         type='button'
                         className='btn btn-primary'
                         onClick={this.onHide}
+                        id='removedChannelBtn'
                     >
                         <FormattedMessage
                             id='removed_channel.okay'

--- a/components/team_sidebar/team_sidebar_controller.jsx
+++ b/components/team_sidebar/team_sidebar_controller.jsx
@@ -136,7 +136,10 @@ export default class TeamSidebar extends React.PureComponent {
 
         return (
             <div className={classNames('team-sidebar', {'move--right': this.props.isOpen})}>
-                <div className='team-wrapper'>
+                <div
+                    className='team-wrapper'
+                    id='teamSidebarWrapper'
+                >
                     <Scrollbars
                         autoHide={true}
                         autoHideTimeout={500}

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
@@ -26,7 +26,7 @@ function removeUserFromAllChannels(verifyAlert) {
         });
 
         // * Verify if guest user gets a message when the channel is removed. Does not appears when removed from last channel of the last team
-        if (channel === 'Town Square'  || verifyAlert) {
+        if (channel === 'Town Square' || verifyAlert) {
             cy.get('#removeFromChannelModalLabel').should('be.visible').and('have.text', `Removed from ${channel}`);
             cy.get('.modal-body').should('be.visible').and('have.text', `Someone removed you from ${channel}`);
             cy.get('#removedChannelBtn').should('be.visible').and('have.text', 'Okay').click().wait(TIMEOUTS.TINY);

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
@@ -1,0 +1,99 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. #. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/**
+ * Note: This test requires Enterprise license to be uploaded
+ */
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+
+let guest;
+let team1;
+let team2;
+
+function removeUserFromAllChannels(verifyAlert) {
+    // # Remove the Guest user from all channels of a team as a sysadmin
+    const channels = ['Town Square', 'Off-Topic'];
+    channels.forEach((channel, index) => {
+        // # Remove the Guest User from channel
+        cy.getCurrentChannelId().then((channelId) => {
+            cy.removeUserFromChannel(channelId, guest.id);
+        });
+
+        // * Verify if guest user gets a message when the channel is removed
+        if (index < channels.length - 1 || verifyAlert) {
+            cy.get('#removeFromChannelModalLabel').should('be.visible').and('have.text', `Removed from ${channel}`);
+            cy.get('.modal-body').should('be.visible').and('have.text', `Someone removed you from ${channel}`);
+            cy.get('#removedChannelBtn').should('be.visible').and('have.text', 'Okay').click().wait(TIMEOUTS.TINY);
+        }
+    });
+}
+
+describe('Guest Account - Guest User Removal Experience', () => {
+    before(() => {
+        // # Enable Guest Account Settings
+        cy.apiUpdateConfig({
+            GuestAccountsSettings: {
+                Enable: true,
+            },
+        });
+
+        // # Login as new user
+        cy.loginAsNewUser().then((userResponse) => {
+            guest = userResponse;
+            cy.visit('/');
+
+            // # Get the Current Team Id
+            cy.getCurrentTeamId().then((teamId) => {
+                cy.apiGetTeam(teamId).then((response) => {
+                    team1 = {id: teamId, name: response.body.name};
+                });
+            });
+
+            // # Create new team and visit its URL
+            cy.apiCreateTeam('test-team2', 'Test Team2').then((response) => {
+                team2 = {id: response.body.id, name: response.body.name};
+                cy.visit(`/${team2.name}`);
+            });
+        });
+    });
+
+    it('MM-18044 Verify behavior when Guest User is removed from channel', () => {
+        // # Demote the current member to a guest user
+        cy.demoteUser(guest.id);
+
+        // * Verify team Sidebar is visible
+        cy.get('#teamSidebarWrapper').should('be.visible');
+
+        // # Remove User from all the channels of the team as a sysadmin
+        removeUserFromAllChannels(true);
+
+        // * Verify if user is automatically redirected to the other team
+        cy.url().should('include', team1.name);
+
+        // * Verify team Sidebar is not present
+        cy.get('#teamSidebarWrapper').should('not.exist');
+
+        // # Remove User from all the channels of the team as a sysadmin
+        removeUserFromAllChannels(false);
+
+        // * Verify if the user is redirected to the Select Team page
+        cy.url().should('include', '/select_team');
+        cy.get('.signup__content').should('be.visible').and('have.text', 'Your guest account has no channels assigned. Please contact an administrator.');
+
+        // # Login as sysadmin and navigate to channel
+        cy.apiLogin('sysadmin');
+        cy.visit(`/${team2.name}/channels/town-square`);
+
+        // * Verify if status is displayed indicating guest user is removed from the channel
+        cy.getLastPost().
+            should('contain', 'System').
+            and('contain', `You and @${guest.username} joined the team.`).
+            and('contain', `@${guest.username} was removed from the channel.`);
+    });
+});

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
@@ -19,14 +19,14 @@ let team2;
 function removeUserFromAllChannels(verifyAlert) {
     // # Remove the Guest user from all channels of a team as a sysadmin
     const channels = ['Town Square', 'Off-Topic'];
-    channels.forEach((channel, index) => {
+    channels.forEach((channel) => {
         // # Remove the Guest User from channel
         cy.getCurrentChannelId().then((channelId) => {
             cy.removeUserFromChannel(channelId, guest.id);
         });
 
-        // * Verify if guest user gets a message when the channel is removed
-        if (index < channels.length - 1 || verifyAlert) {
+        // * Verify if guest user gets a message when the channel is removed. Does not appears when removed from last channel of the last team
+        if (channel === 'Town Square'  || verifyAlert) {
             cy.get('#removeFromChannelModalLabel').should('be.visible').and('have.text', `Removed from ${channel}`);
             cy.get('.modal-body').should('be.visible').and('have.text', `Someone removed you from ${channel}`);
             cy.get('#removedChannelBtn').should('be.visible').and('have.text', 'Okay').click().wait(TIMEOUTS.TINY);

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -724,3 +724,15 @@ Cypress.Commands.add('demoteUser', (userId) => {
     const baseUrl = Cypress.config('baseUrl');
     cy.externalRequest({user: users.sysadmin, method: 'post', baseUrl, path: `users/${userId}/demote`});
 });
+
+/**
+ * Remove a User from a Channel directly via API
+ * @param {String} channelId - The channel ID
+ * @param {String} userId - The user ID
+ * All parameter required
+ */
+Cypress.Commands.add('removeUserFromChannel', (channelId, userId) => {
+    //Demote Regular Member to Guest User
+    const baseUrl = Cypress.config('baseUrl');
+    cy.externalRequest({user: users.sysadmin, method: 'delete', baseUrl, path: `channels/${channelId}/members/${userId}`});
+});


### PR DESCRIPTION
#### Summary
1. Verify if a Guest user is automatically redirected to another team when removed from all the channels of a team. 
2. Verify if a Guest user is automatically redirected to select team page with a message 'Your guest account has no channels assigned. Please contact an administrator.' when removed from all the teams and channels.
3. Verify if System message is displayed when Guest User leaves the channel. 

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-18044