### PR TITLE
Leverage cy.waitUntil to wait better for elastic search reindex

### DIFF
--- a/e2e/cypress/fixtures/timeouts.js
+++ b/e2e/cypress/fixtures/timeouts.js
@@ -8,4 +8,5 @@ module.exports = {
     LARGE: 30000,
     HUGE: 60000,
     GIGANTIC: 120000,
+    FOUR_MINS: 240000,
 };

--- a/e2e/cypress/integration/enterprise/elasticsearch/helpers/index.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch/helpers/index.js
@@ -36,9 +36,19 @@ module.exports = {
         // Small wait to ensure new row is added
         cy.wait(TIMEOUTS.TINY);
 
-        // Newest row should eventuall result in Success
-        cy.get('.job-table__table').find('tbody > tr').eq(0).as('firstRow').find('.status-icon-warning', {timeout: TIMEOUTS.LARGE}).should('be.visible');
-        cy.get('@firstRow').find('.status-icon-success', {timeout: TIMEOUTS.GIGANTIC}).should('be.visible');
+        cy.get('.job-table__table').find('tbody > tr').eq(0).as('firstRow').find('.status-icon-warning', {timeout: TIMEOUTS.GIGANTIC}).should('be.visible');
+
+        // Newest row should eventually result in Success
+        cy.waitUntil(() => {
+            return cy.get('@firstRow').then((el) => {
+                return el.find('.status-icon-success').length > 0;
+            });
+        }
+        , {
+            timeout: TIMEOUTS.FOUR_MINS,
+            interval: 2000,
+            errorMsg: 'Reindex did not succeed in time',
+        });
     },
     disableElasticSearch: () => {
         // Disable elastic search via API


### PR DESCRIPTION
#### Summary
This should make reindexing a bit more stable. Timeout is fairly long and should be more than sufficient when running on CI, locally it CAN take awhile if you have a large enough data set (or maybe not enough computing power?).

Note that there may be another issue afoot around when we enable/disable elastic search, but it has been intermittent and still need to dig into that more. 

#### Ticket Link
n/a
