### PR TITLE
Fixing line breaks in invite email success page (chrome and safari)

### DIFF
--- a/components/invitation_modal/invitation_modal_confirm_step_row.scss
+++ b/components/invitation_modal/invitation_modal_confirm_step_row.scss
@@ -9,6 +9,7 @@
         .email {
             margin: 0 4px 0 8px;
             overflow-wrap: anywhere;
+            word-break: break-word;
         }
         .name {
             margin: 0 4px 0 8px;


### PR DESCRIPTION
#### Summary
Fixing line breaks in invite email success page (chrome and safari)

#### Ticket Link
[MM-17193](https://mattermost.atlassian.net/browse/MM-17193)