### PR TITLE
MM-18624: revert fetch threads support

### DIFF
--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -274,7 +274,7 @@ export function loadPosts({channelId, postId, type}) {
     };
 }
 
-export function syncPostsInChannel(channelId, since, fetchThreads = true) {
+export function syncPostsInChannel(channelId, since) {
     return async (dispatch, getState) => {
         const time = Date.now();
         const state = getState();
@@ -286,7 +286,7 @@ export function syncPostsInChannel(channelId, since, fetchThreads = true) {
             sinceTimeToGetPosts = lastPostsApiCallForChannel;
         }
 
-        const {data, error} = await dispatch(PostActions.getPostsSince(channelId, sinceTimeToGetPosts, fetchThreads));
+        const {data, error} = await dispatch(PostActions.getPostsSince(channelId, sinceTimeToGetPosts, false));
         if (data) {
             dispatch({
                 type: ActionTypes.RECEIVED_POSTS_FOR_CHANNEL_AT_TIME,

--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -147,7 +147,7 @@ export function autocompleteUsersInChannel(prefix, channelId) {
 export function loadUnreads(channelId) {
     return async (dispatch) => {
         const time = Date.now();
-        const {data, error} = await dispatch(PostActions.getPostsUnread(channelId, false));
+        const {data, error} = await dispatch(PostActions.getPostsUnread(channelId));
         if (error) {
             return {
                 error,
@@ -179,7 +179,7 @@ export function loadUnreads(channelId) {
 
 export function loadPostsAround(channelId, focusedPostId) {
     return async (dispatch) => {
-        const {data, error} = await dispatch(PostActions.getPostsAround(channelId, focusedPostId, Posts.POST_CHUNK_SIZE / 2, false));
+        const {data, error} = await dispatch(PostActions.getPostsAround(channelId, focusedPostId, Posts.POST_CHUNK_SIZE / 2));
         if (error) {
             return {
                 error,
@@ -203,7 +203,7 @@ export function loadPostsAround(channelId, focusedPostId) {
 export function loadLatestPosts(channelId) {
     return async (dispatch) => {
         const time = Date.now();
-        const {data, error} = await dispatch(PostActions.getPosts(channelId, 0, Posts.POST_CHUNK_SIZE / 2, false));
+        const {data, error} = await dispatch(PostActions.getPosts(channelId, 0, Posts.POST_CHUNK_SIZE / 2));
 
         if (error) {
             return {
@@ -241,9 +241,9 @@ export function loadPosts({channelId, postId, type}) {
         const page = 0;
         let result;
         if (type === PostRequestTypes.BEFORE_ID) {
-            result = await dispatch(PostActions.getPostsBefore(channelId, postId, page, POST_INCREASE_AMOUNT, false));
+            result = await dispatch(PostActions.getPostsBefore(channelId, postId, page, POST_INCREASE_AMOUNT));
         } else {
-            result = await dispatch(PostActions.getPostsAfter(channelId, postId, page, POST_INCREASE_AMOUNT, false));
+            result = await dispatch(PostActions.getPostsAfter(channelId, postId, page, POST_INCREASE_AMOUNT));
         }
 
         const {data} = result;
@@ -286,7 +286,7 @@ export function syncPostsInChannel(channelId, since) {
             sinceTimeToGetPosts = lastPostsApiCallForChannel;
         }
 
-        const {data, error} = await dispatch(PostActions.getPostsSince(channelId, sinceTimeToGetPosts, false));
+        const {data, error} = await dispatch(PostActions.getPostsSince(channelId, sinceTimeToGetPosts));
         if (data) {
             dispatch({
                 type: ActionTypes.RECEIVED_POSTS_FOR_CHANNEL_AT_TIME,

--- a/actions/views/channel.test.js
+++ b/actions/views/channel.test.js
@@ -160,7 +160,7 @@ describe('channel view actions', () => {
 
             expect(result.data).toBe(posts);
 
-            expect(PostActions.getPosts).toHaveBeenCalledWith('channel', 0, Posts.POST_CHUNK_SIZE / 2, false);
+            expect(PostActions.getPosts).toHaveBeenCalledWith('channel', 0, Posts.POST_CHUNK_SIZE / 2);
         });
 
         test('when oldest posts are recived', async () => {
@@ -205,7 +205,7 @@ describe('channel view actions', () => {
             const result = await store.dispatch(Actions.loadUnreads('channel', 'post'));
 
             expect(result).toEqual({atLatestMessage: true, atOldestmessage: true});
-            expect(PostActions.getPostsUnread).toHaveBeenCalledWith('channel', false);
+            expect(PostActions.getPostsUnread).toHaveBeenCalledWith('channel');
         });
 
         test('when there are posts before and after the response', async () => {
@@ -224,7 +224,7 @@ describe('channel view actions', () => {
 
             const result = await store.dispatch(Actions.loadUnreads('channel', 'post'));
             expect(result).toEqual({atLatestMessage: false, atOldestmessage: false});
-            expect(PostActions.getPostsUnread).toHaveBeenCalledWith('channel', false);
+            expect(PostActions.getPostsUnread).toHaveBeenCalledWith('channel');
         });
 
         test('when there are no posts after RECEIVED_POSTS_FOR_CHANNEL_AT_TIME should be dispatched', async () => {
@@ -255,7 +255,7 @@ describe('channel view actions', () => {
 
             expect(result).toEqual({atLatestMessage: true, atOldestmessage: true});
 
-            expect(PostActions.getPostsAround).toHaveBeenCalledWith('channel', 'post', Posts.POST_CHUNK_SIZE / 2, false);
+            expect(PostActions.getPostsAround).toHaveBeenCalledWith('channel', 'post', Posts.POST_CHUNK_SIZE / 2);
         });
 
         test('when there are posts before and after reponse posts chunk', async () => {
@@ -463,7 +463,7 @@ describe('channel view actions', () => {
             });
 
             await store.dispatch(Actions.syncPostsInChannel(channelId, 12350));
-            expect(PostActions.getPostsSince).toHaveBeenCalledWith(channelId, 12350, false);
+            expect(PostActions.getPostsSince).toHaveBeenCalledWith(channelId, 12350);
         });
 
         test('should call getPostsSince with lastDisconnect time as last discconet was later than lastGetPosts', async () => {
@@ -487,7 +487,7 @@ describe('channel view actions', () => {
             });
 
             await store.dispatch(Actions.syncPostsInChannel(channelId, 12355));
-            expect(PostActions.getPostsSince).toHaveBeenCalledWith(channelId, 12343, false);
+            expect(PostActions.getPostsSince).toHaveBeenCalledWith(channelId, 12343);
         });
     });
 });

--- a/actions/views/channel.test.js
+++ b/actions/views/channel.test.js
@@ -462,7 +462,7 @@ describe('channel view actions', () => {
                 },
             });
 
-            await store.dispatch(Actions.syncPostsInChannel(channelId, 12350, false));
+            await store.dispatch(Actions.syncPostsInChannel(channelId, 12350));
             expect(PostActions.getPostsSince).toHaveBeenCalledWith(channelId, 12350, false);
         });
 
@@ -486,7 +486,7 @@ describe('channel view actions', () => {
                 },
             });
 
-            await store.dispatch(Actions.syncPostsInChannel(channelId, 12355, false));
+            await store.dispatch(Actions.syncPostsInChannel(channelId, 12355));
             expect(PostActions.getPostsSince).toHaveBeenCalledWith(channelId, 12343, false);
         });
     });

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -170,7 +170,7 @@ export function reconnect(includeWebSocket = true) {
         const mostRecentPost = getPost(state, mostRecentId);
         dispatch(loadChannelsForCurrentUser());
         if (mostRecentPost) {
-            dispatch(syncPostsInChannel(currentChannelId, mostRecentPost.create_at, false));
+            dispatch(syncPostsInChannel(currentChannelId, mostRecentPost.create_at));
         } else {
             // if network timed-out the first time when loading a channel
             // we can request for getPosts again when socket is connected

--- a/actions/websocket_actions.test.jsx
+++ b/actions/websocket_actions.test.jsx
@@ -318,7 +318,7 @@ describe('handleNewPostEvents', () => {
 describe('reconnect', () => {
     test('should call syncPostsInChannel when socket reconnects', () => {
         reconnect(false);
-        expect(syncPostsInChannel).toHaveBeenCalledWith('otherChannel', '12345', false);
+        expect(syncPostsInChannel).toHaveBeenCalledWith('otherChannel', '12345');
     });
 });
 

--- a/components/permalink_view/actions.js
+++ b/components/permalink_view/actions.js
@@ -13,7 +13,7 @@ import {ActionTypes, Constants, ErrorPageTypes} from 'utils/constants.jsx';
 
 export function focusPost(postId, returnTo = '') {
     return async (dispatch, getState) => {
-        const {data} = await dispatch(getPostThread(postId, false));
+        const {data} = await dispatch(getPostThread(postId));
 
         if (!data) {
             browserHistory.replace(`/error?type=${ErrorPageTypes.PERMALINK_NOT_FOUND}&returnTo=${returnTo}`);

--- a/components/permalink_view/permalink_view.test.jsx
+++ b/components/permalink_view/permalink_view.test.jsx
@@ -134,7 +134,7 @@ describe('components/PermalinkView', () => {
                 const testStore = await mockStore(initialState);
                 await testStore.dispatch(focusPost('postid1'));
 
-                expect(getPostThread).toHaveBeenCalledWith('postid1', false);
+                expect(getPostThread).toHaveBeenCalledWith('postid1');
                 expect(testStore.getActions()).toEqual([
                     {type: 'MOCK_GET_POST_THREAD', data: {posts: {postid1: {id: 'postid1', message: 'some message', channel_id: 'channelid1'}}, order: ['postid1']}},
                     {type: 'MOCK_SELECT_CHANNEL', args: ['channelid1']},
@@ -149,7 +149,7 @@ describe('components/PermalinkView', () => {
 
                 await testStore.dispatch(focusPost('postid2'));
 
-                expect(getPostThread).toHaveBeenCalledWith('postid2', false);
+                expect(getPostThread).toHaveBeenCalledWith('postid2');
                 expect(testStore.getActions()).toEqual([
                     {type: 'MOCK_GET_POST_THREAD', data: {posts: {postid2: {id: 'postid2', message: 'some message', channel_id: 'channelid2'}}, order: ['postid2']}},
                     {type: 'MOCK_GET_CHANNEL', data: {id: 'channelid2', type: 'O', team_id: 'current_team_id'}},
@@ -165,7 +165,7 @@ describe('components/PermalinkView', () => {
                 const testStore = await mockStore(initialState);
                 await testStore.dispatch(focusPost('dmpostid1'));
 
-                expect(getPostThread).toHaveBeenCalledWith('dmpostid1', false);
+                expect(getPostThread).toHaveBeenCalledWith('dmpostid1');
                 expect(testStore.getActions()).toEqual([
                     {type: 'MOCK_GET_POST_THREAD', data: {posts: {dmpostid1: {id: 'dmpostid1', message: 'some message', channel_id: 'dmchannelid'}}, order: ['dmpostid1']}},
                 ]);
@@ -176,7 +176,7 @@ describe('components/PermalinkView', () => {
                 const testStore = await mockStore(initialState);
                 await testStore.dispatch(focusPost('gmpostid1'));
 
-                expect(getPostThread).toHaveBeenCalledWith('gmpostid1', false);
+                expect(getPostThread).toHaveBeenCalledWith('gmpostid1');
                 expect(testStore.getActions()).toEqual([
                     {type: 'MOCK_GET_POST_THREAD', data: {posts: {gmpostid1: {id: 'gmpostid1', message: 'some message', channel_id: 'gmchannelid'}}, order: ['gmpostid1']}},
                 ]);

--- a/components/post_view/post/index.js
+++ b/components/post_view/post/index.js
@@ -3,12 +3,13 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {createSelector} from 'reselect';
 
 import {Posts} from 'mattermost-redux/constants';
 import {getPost, makeIsPostCommentMention} from 'mattermost-redux/selectors/entities/posts';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
+import {isPostEphemeral, isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {selectPost, selectPostCard} from 'actions/views/rhs';
 import {Preferences} from 'utils/constants.jsx';
@@ -32,17 +33,29 @@ export function isFirstReply(post, previousPost) {
     return false;
 }
 
+export function makeGetReplyCount() {
+    return createSelector(
+        (state) => state.entities.posts.posts,
+        (state, post) => state.entities.posts.postsInThread[post.root_id || post.id],
+        (allPosts, postIds) => {
+            if (!postIds) {
+                return 0;
+            }
+
+            // Count the number of non-ephemeral posts in the thread
+            return postIds.map((id) => allPosts[id]).filter((post) => post && !isPostEphemeral(post)).length;
+        }
+    );
+}
+
 function makeMapStateToProps() {
+    const getReplyCount = makeGetReplyCount();
     const isPostCommentMention = makeIsPostCommentMention();
     const createAriaLabelForPost = makeCreateAriaLabelForPost();
 
     return (state, ownProps) => {
         const post = ownProps.post || getPost(state, ownProps.postId);
-        let replyCount = post.reply_count;
-        if (post.root_id !== '') {
-            const rootPost = getPost(state, post.root_id);
-            replyCount = rootPost ? rootPost.reply_count : 0;
-        }
+
         let previousPost = null;
         if (ownProps.previousPostId) {
             previousPost = getPost(state, ownProps.previousPostId);
@@ -67,7 +80,7 @@ function makeMapStateToProps() {
             isFirstReply: isFirstReply(post, previousPost),
             consecutivePostByUser,
             previousPostIsComment,
-            replyCount,
+            replyCount: getReplyCount(state, post),
             isCommentMention: isPostCommentMention(state, post.id),
             center: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_CENTERED,
             compactDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.MESSAGE_DISPLAY, Preferences.MESSAGE_DISPLAY_DEFAULT) === Preferences.MESSAGE_DISPLAY_COMPACT,

--- a/components/post_view/post/index.test.js
+++ b/components/post_view/post/index.test.js
@@ -1,7 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {isFirstReply} from './index';
+import {Posts} from 'mattermost-redux/constants';
+
+import {isFirstReply, makeGetReplyCount} from './index';
 
 describe('isFirstReply', () => {
     for (const testCase of [
@@ -58,4 +60,90 @@ describe('isFirstReply', () => {
             expect(isFirstReply(testCase.post, testCase.previousPost)).toBe(testCase.expected);
         });
     }
+});
+
+describe('makeGetReplyCount', () => {
+    test('should return the number of comments when called on a root post', () => {
+        const getReplyCount = makeGetReplyCount();
+
+        const state = {
+            entities: {
+                posts: {
+                    posts: {
+                        post1: {id: 'post1'},
+                        post2: {id: 'post2', root_id: 'post1'},
+                        post3: {id: 'post3', root_id: 'post1'},
+                    },
+                    postsInThread: {
+                        post1: ['post2', 'post3'],
+                    },
+                },
+            },
+        };
+        const post = state.entities.posts.posts.post1;
+
+        expect(getReplyCount(state, post)).toBe(2);
+    });
+
+    test('should return the number of comments when called on a comment', () => {
+        const getReplyCount = makeGetReplyCount();
+
+        const state = {
+            entities: {
+                posts: {
+                    posts: {
+                        post1: {id: 'post1'},
+                        post2: {id: 'post2', root_id: 'post1'},
+                        post3: {id: 'post3', root_id: 'post1'},
+                    },
+                    postsInThread: {
+                        post1: ['post2', 'post3'],
+                    },
+                },
+            },
+        };
+        const post = state.entities.posts.posts.post3;
+
+        expect(getReplyCount(state, post)).toBe(2);
+    });
+
+    test('should return 0 when called on a post without comments', () => {
+        const getReplyCount = makeGetReplyCount();
+
+        const state = {
+            entities: {
+                posts: {
+                    posts: {
+                        post1: {id: 'post1'},
+                    },
+                    postsInThread: {},
+                },
+            },
+        };
+        const post = state.entities.posts.posts.post1;
+
+        expect(getReplyCount(state, post)).toBe(0);
+    });
+
+    test('should not count ephemeral comments', () => {
+        const getReplyCount = makeGetReplyCount();
+
+        const state = {
+            entities: {
+                posts: {
+                    posts: {
+                        post1: {id: 'post1'},
+                        post2: {id: 'post2', root_id: 'post1', type: Posts.POST_TYPES.EPHEMERAL},
+                        post3: {id: 'post3', root_id: 'post1'},
+                    },
+                    postsInThread: {
+                        post1: ['post2', 'post3'],
+                    },
+                },
+            },
+        };
+        const post = state.entities.posts.posts.post1;
+
+        expect(getReplyCount(state, post)).toBe(1);
+    });
 });

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -103,7 +103,7 @@ export default class RhsThread extends React.Component {
         const curPostsArray = this.props.posts || [];
 
         if (this.props.socketConnectionStatus && !prevProps.socketConnectionStatus) {
-            this.props.actions.getPostThread(this.props.selected.id, false);
+            this.props.actions.getPostThread(this.props.selected.id);
         }
 
         if (prevPostsArray.length >= curPostsArray.length) {

--- a/components/rhs_thread/rhs_thread.test.jsx
+++ b/components/rhs_thread/rhs_thread.test.jsx
@@ -67,6 +67,6 @@ describe('components/RhsThread', () => {
         wrapper.setProps({socketConnectionStatus: false});
         wrapper.setProps({socketConnectionStatus: true});
 
-        expect(actions.getPostThread).toHaveBeenCalledWith(post.id, false);
+        expect(actions.getPostThread).toHaveBeenCalledWith(post.id);
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13822,8 +13822,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#a7efaf1f476572e6f7ff5bd515cc8ab1cf88e90d",
-      "from": "github:mattermost/mattermost-redux#a7efaf1f476572e6f7ff5bd515cc8ab1cf88e90d",
+      "version": "github:mattermost/mattermost-redux#d67a3c644bfe89a615631a3bf41079cfe663a05d",
+      "from": "github:mattermost/mattermost-redux#d67a3c644bfe89a615631a3bf41079cfe663a05d",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13822,8 +13822,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#0567a7736f0bfc792d29461432d474ce8daeca37",
-      "from": "github:mattermost/mattermost-redux#0567a7736f0bfc792d29461432d474ce8daeca37",
+      "version": "github:mattermost/mattermost-redux#a7efaf1f476572e6f7ff5bd515cc8ab1cf88e90d",
+      "from": "github:mattermost/mattermost-redux#a7efaf1f476572e6f7ff5bd515cc8ab1cf88e90d",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#0567a7736f0bfc792d29461432d474ce8daeca37",
+    "mattermost-redux": "github:mattermost/mattermost-redux#a7efaf1f476572e6f7ff5bd515cc8ab1cf88e90d",
     "moment-timezone": "0.5.26",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
-    "mattermost-redux": "github:mattermost/mattermost-redux#a7efaf1f476572e6f7ff5bd515cc8ab1cf88e90d",
+    "mattermost-redux": "github:mattermost/mattermost-redux#d67a3c644bfe89a615631a3bf41079cfe663a05d",
     "moment-timezone": "0.5.26",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
This reverts commits 647eba0053b334ba3967e86bb291ea2c61c98103 and c0f9cb84b0675865931e3a191ecf9646b2633dbc.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18624

#### PR Set
https://github.com/mattermost/mattermost-server/pull/12387
https://github.com/mattermost/mattermost-webapp/pull/3789
https://github.com/mattermost/mattermost-redux/pull/935