### PR TITLE
[MM-18875] Blur file attachment link on click

### DIFF
--- a/components/file_attachment/__snapshots__/filename_overlay.test.jsx.snap
+++ b/components/file_attachment/__snapshots__/filename_overlay.test.jsx.snap
@@ -24,6 +24,7 @@ exports[`components/file_attachment/FilenameOverlay should match snapshot, compa
   <a
     className="post-image__name"
     href="#"
+    id="file-attachment-link"
     onClick={[MockFunction]}
     rel="noopener noreferrer"
   >

--- a/components/file_attachment/file_attachment.jsx
+++ b/components/file_attachment/file_attachment.jsx
@@ -104,6 +104,7 @@ export default class FileAttachment extends React.PureComponent {
 
     onAttachmentClick = (e) => {
         e.preventDefault();
+        e.target.blur();
         if (this.props.handleImageClick) {
             this.props.handleImageClick(this.props.index);
         }

--- a/components/file_attachment/file_attachment.test.jsx
+++ b/components/file_attachment/file_attachment.test.jsx
@@ -4,6 +4,8 @@
 import {shallow} from 'enzyme';
 import React from 'react';
 
+import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
+
 import FileAttachment from './file_attachment';
 
 jest.mock('utils/utils.jsx', () => {
@@ -122,13 +124,14 @@ describe('FileAttachment', () => {
     });
 
     test('should blur file attachment link after click', () => {
-        const wrapper = shallow(createComponent({compactDisplay: true}));
+        const wrapper = mountWithIntl(createComponent({compactDisplay: true}));
         const e = {
             preventDefault: jest.fn(),
             target: {blur: jest.fn()},
         };
 
-        wrapper.instance().onAttachmentClick(e);
+        const a = wrapper.find('#file-attachment-link');
+        a.simulate('click', e);
         expect(e.target.blur).toHaveBeenCalled();
     });
 });

--- a/components/file_attachment/file_attachment.test.jsx
+++ b/components/file_attachment/file_attachment.test.jsx
@@ -120,4 +120,15 @@ describe('FileAttachment', () => {
         wrapper.setState({loaded: false});
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should blur file attachment link after click', () => {
+        const wrapper = shallow(createComponent({compactDisplay: true}));
+        const e = {
+            preventDefault: jest.fn(),
+            target: {blur: jest.fn()},
+        };
+
+        wrapper.instance().onAttachmentClick(e);
+        expect(e.target.blur).toHaveBeenCalled();
+    });
 });

--- a/components/file_attachment/filename_overlay.jsx
+++ b/components/file_attachment/filename_overlay.jsx
@@ -66,7 +66,7 @@ export default class FilenameOverlay extends React.PureComponent {
                     overlay={<Tooltip id='file-name__tooltip'>{fileName}</Tooltip>}
                 >
                     <a
-                    id='file-attachment-link'
+                        id='file-attachment-link'
                         href='#'
                         onClick={handleImageClick}
                         className='post-image__name'

--- a/components/file_attachment/filename_overlay.jsx
+++ b/components/file_attachment/filename_overlay.jsx
@@ -66,6 +66,7 @@ export default class FilenameOverlay extends React.PureComponent {
                     overlay={<Tooltip id='file-name__tooltip'>{fileName}</Tooltip>}
                 >
                     <a
+                    id='file-attachment-link'
                         href='#'
                         onClick={handleImageClick}
                         className='post-image__name'


### PR DESCRIPTION
#### Summary

This PR fixes the issue where the tooltip for a file attachment link would appear after closing the image popup. The link is now forced to blur after click so the tooltip is not applied.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18875