### PR TITLE
MM-16683: redirect integrations*, not just integrations

### DIFF
--- a/components/permalink_redirector/permalink_redirector.test.jsx
+++ b/components/permalink_redirector/permalink_redirector.test.jsx
@@ -71,6 +71,19 @@ describe('components/PermalinkRedirector', () => {
         expect(baseProps.actions.redirect).toHaveBeenCalledTimes(1);
     });
 
+    test('calls redirect for integrations/bots', async () => {
+        const props = {
+            ...baseProps,
+            url: '/_redirect/integrations/bots',
+        };
+        shallowWithIntl(
+            <PermalinkRedirector {...props}/>
+        );
+
+        expect(baseProps.actions.redirect).toHaveBeenCalledWith(props.url, props.params);
+        expect(baseProps.actions.redirect).toHaveBeenCalledTimes(1);
+    });
+
     describe('actions', () => {
         const initialState = {
             entities: {

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -336,7 +336,7 @@ export default class Root extends React.Component {
                         component={Mfa}
                     />
                     <LoggedInRoute
-                        path={['/_redirect/integrations', '/_redirect/pl/:postid']}
+                        path={['/_redirect/integrations*', '/_redirect/pl/:postid']}
                         component={PermalinkRedirector}
                     />
                     <LoggedInRoute


### PR DESCRIPTION
#### Summary
Route `integrations*` to the permalink redirector, not just `integrations`, allowing the match to include the entire URL and thus send `/_redirect/integrations/bots` to `/<team>/integrations/bots` instead of just `/<team>/integrations`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16683