### PR TITLE
[MM-18897] Fix paragraphs in post markdown preview

### DIFF
--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -35,7 +35,9 @@
     }
 
     .textbox-preview-area {
-        white-space: normal;
+        ul {
+            white-space: normal;
+        }
         box-shadow: none;
         left: 0;
         position: relative;


### PR DESCRIPTION
#### Summary

This PR fixes the issue with the markdown preview feature, where new paragraphs are rendered with no newline between them. 

This was fixed before, during a fix for whitespace in ul elements [Ticket](https://mattermost.atlassian.net/browse/MM-14714) and [PR](https://github.com/mattermost/mattermost-webapp/pull/2612). This PR scopes that fix to only apply to ul elements.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18897