### PR TITLE
Automated cherry pick of #3784

### DIFF
--- a/components/invitation_modal/invitation_modal_confirm_step_row.scss
+++ b/components/invitation_modal/invitation_modal_confirm_step_row.scss
@@ -9,6 +9,7 @@
         .email {
             margin: 0 4px 0 8px;
             overflow-wrap: anywhere;
+            word-break: break-word;
         }
         .name {
             margin: 0 4px 0 8px;


### PR DESCRIPTION
Cherry pick of #3784 on release-5.16.

- #3784: Fixing line breaks in invite email success page (chrome and

/cc  @jespino