### PR TITLE
migrate 'utils/dragster' to typescript

### DIFF
--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -6,7 +6,7 @@ import React, {PureComponent} from 'react';
 import ReactDOM from 'react-dom';
 import {defineMessages, intlShape, FormattedMessage} from 'react-intl';
 
-import dragster from 'utils/dragster.js';
+import dragster from 'utils/dragster';
 import Constants from 'utils/constants.jsx';
 import DelayedAction from 'utils/delayed_action';
 import {t} from 'utils/i18n';

--- a/utils/dragster.test.ts
+++ b/utils/dragster.test.ts
@@ -4,28 +4,28 @@
 import dragster from './dragster';
 
 describe('utils.dragster', () => {
-    let div;
-    let unbind;
-    let enterEvent;
-    let leaveEvent;
-    let overEvent;
-    let dropEvent;
+    let div: HTMLElement;
+    let unbind: () => void;
+    let enterEvent: CustomEvent | null;
+    let leaveEvent: CustomEvent | null;
+    let overEvent: CustomEvent | null;
+    let dropEvent: CustomEvent | null;
     const id = 'utils_dragster_test';
     const dragenter = new CustomEvent('dragenter', {detail: 'dragenter_detail'});
     const dragleave = new CustomEvent('dragleave', {detail: 'dragleave_detail'});
     const dragover = new CustomEvent('dragover', {detail: 'dragover_detail'});
     const drop = new CustomEvent('drop', {detail: 'drop_detail'});
     const options = {
-        enter: (event) => {
+        enter: (event: CustomEvent) => {
             enterEvent = event;
         },
-        leave: (event) => {
+        leave: (event: CustomEvent) => {
             leaveEvent = event;
         },
-        over: (event) => {
+        over: (event: CustomEvent) => {
             overEvent = event;
         },
-        drop: (event) => {
+        drop: (event: CustomEvent) => {
             dropEvent = event;
         },
     };
@@ -52,36 +52,36 @@ describe('utils.dragster', () => {
     it('should dispatch dragenter event', () => {
         div.dispatchEvent(dragenter);
 
-        expect(enterEvent.detail.detail).toEqual('dragenter_detail');
+        expect(enterEvent!.detail.detail).toEqual('dragenter_detail');
     });
 
     it('should dispatch dragleave event', () => {
         div.dispatchEvent(dragleave);
 
-        expect(leaveEvent.detail.detail).toEqual('dragleave_detail');
+        expect(leaveEvent!.detail.detail).toEqual('dragleave_detail');
     });
 
     it('should dispatch dragover event', () => {
         div.dispatchEvent(dragover);
 
-        expect(overEvent.detail.detail).toEqual('dragover_detail');
+        expect(overEvent!.detail.detail).toEqual('dragover_detail');
     });
 
     it('should dispatch drop event', () => {
         div.dispatchEvent(drop);
 
-        expect(dropEvent.detail.detail).toEqual('drop_detail');
+        expect(dropEvent!.detail.detail).toEqual('drop_detail');
     });
 
     it('should dispatch dragenter event again', () => {
         div.dispatchEvent(dragenter);
 
-        expect(enterEvent.detail.detail).toEqual('dragenter_detail');
+        expect(enterEvent!.detail.detail).toEqual('dragenter_detail');
     });
 
     it('should dispatch dragenter event once if dispatched 2 times', () => {
         div.dispatchEvent(dragenter);
 
-        expect(enterEvent).toBe(null);
+        expect(enterEvent).toBeNull();
     });
 });

--- a/utils/dragster.ts
+++ b/utils/dragster.ts
@@ -1,7 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export default function dragster(query, options) {
+type Options = {
+    enter?: (event: CustomEvent) => void;
+    leave?: (event: CustomEvent) => void;
+    over?: (event: CustomEvent) => void;
+    drop?: (event: CustomEvent) => void;
+}
+
+export default function dragster(query: string, options: Options) {
     const noop = () => {}; // eslint-disable-line no-empty-function
 
     const defaults = {
@@ -21,7 +28,7 @@ export default function dragster(query, options) {
     let first = false;
     let second = false;
 
-    const dragenter = (event) => {
+    const dragenter = (event: Event) => {
         if (first) {
             second = true;
             return;
@@ -34,7 +41,7 @@ export default function dragster(query, options) {
         event.preventDefault();
     };
 
-    const dragleave = (event) => {
+    const dragleave = (event: Event) => {
         if (second) {
             second = false;
         } else if (first) {
@@ -47,13 +54,13 @@ export default function dragster(query, options) {
         event.preventDefault();
     };
 
-    const dragover = (event) => {
+    const dragover = (event: Event) => {
         const overEvent = new CustomEvent('dragster:over', {detail: event});
         node.dispatchEvent(overEvent);
         event.preventDefault();
     };
 
-    const drop = (event) => {
+    const drop = (event: Event) => {
         if (second) {
             second = false;
         } else if (first) {


### PR DESCRIPTION
#### Summary
Migrate the dragster utility to Typescript, update it's imports,
and migrate its tests to Typescript.

#### Ticket Link
Completes https://mattermost.atlassian.net/browse/MM-18909
#### Additional Comments

I'm not a fan of the null checks in the tests but was unsure what a better method to satisfy the compiler would be so I'm open to suggestions.
