### PR TITLE
MM-18913: Migrate latinise.tsx and tests to Typescript

### DIFF
--- a/utils/latinise.test.tsx
+++ b/utils/latinise.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {latinise} from 'utils/latinise.jsx';
+import {latinise} from 'utils/latinise';
 
 describe('Latinise', () => {
     describe('handleNames', () => {

--- a/utils/latinise.test.tsx
+++ b/utils/latinise.test.tsx
@@ -4,20 +4,18 @@
 import {latinise} from 'utils/latinise';
 
 describe('Latinise', () => {
-    describe('handleNames', () => {
-        test('should return ascii version of Dév Spé', () => {
-            expect(latinise('Dév Spé')).
-                toEqual('Dev Spe');
-        });
+    test('should return ascii version of Dév Spé', () => {
+        expect(latinise('Dév Spé')).
+            toEqual('Dev Spe');
+    });
 
-        test('should not replace any characters', () => {
-            expect(latinise('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890')).
-                toEqual('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890');
-        });
+    test('should not replace any characters', () => {
+        expect(latinise('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890')).
+            toEqual('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890');
+    });
 
-        test('should replace characters with diacritics with ascii equivalents', () => {
-            expect(latinise('àáâãäåæçèéêëìíîïñòóôõöœùúûüýÿ')).
-                toEqual('aaaaaaaeceeeeiiiinooooooeuuuuyy');
-        });
+    test('should replace characters with diacritics with ascii equivalents', () => {
+        expect(latinise('àáâãäåæçèéêëìíîïñòóôõöœùúûüýÿ')).
+            toEqual('aaaaaaaeceeeeiiiinooooooeuuuuyy');
     });
 });

--- a/utils/latinise.tsx
+++ b/utils/latinise.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-var latinMap = {
+const latinMap: { [key: string]: string } = {
     Á: 'A', // LATIN CAPITAL LETTER A WITH ACUTE
     Ă: 'A', // LATIN CAPITAL LETTER A WITH BREVE
     Ắ: 'A', // LATIN CAPITAL LETTER A WITH BREVE AND ACUTE
@@ -993,10 +993,10 @@ var latinMap = {
     ₓ: 'x', // LATIN SUBSCRIPT SMALL LETTER X
 };
 
-export function map(x) {
+export function map(x: string) {
     return latinMap[x] || x;
 }
 
-export function latinise(input) {
+export function latinise(input: string) {
     return input.replace(/[^A-Za-z0-9]/g, map);
 }

--- a/utils/url.jsx
+++ b/utils/url.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {latinise} from 'utils/latinise.jsx';
+import {latinise} from 'utils/latinise';
 
 export function cleanUpUrlable(input) {
     var cleaned = latinise(input);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Migrate 'utils/latinise.jsx' and associated tests to TypeScript.
#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/12490
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->