### PR TITLE
[MM-19042] Plugins settings page won't load in 5.16

### DIFF
--- a/components/admin_console/custom_plugin_settings/index.js
+++ b/components/admin_console/custom_plugin_settings/index.js
@@ -24,7 +24,7 @@ function makeGetPluginSchema() {
             const escapedPluginId = SchemaAdminSettings.escapePathPart(plugin.id);
             const pluginEnabledConfigKey = 'PluginSettings.PluginStates.' + escapedPluginId + '.Enable';
 
-            let settings;
+            let settings = [];
             if (plugin.settings_schema && plugin.settings_schema.settings) {
                 settings = plugin.settings_schema.settings.map((setting) => {
                     return {


### PR DESCRIPTION
#### Summary
- There was a small bug in a change made in the marketplace PR. The quality-of-life improvement of having the "enable plugin" setting on the plugin's setting page was unshifting a potentially empty array.

#### Ticket Link
- Fixes [MM-19042](https://mattermost.atlassian.net/browse/MM-19042)
