### PR TITLE
MM-18239 Refactor actions/views/root.js::loadTranslations to have a single point of return.

### DIFF
--- a/actions/views/root.js
+++ b/actions/views/root.js
@@ -57,11 +57,11 @@ export function loadTranslations(locale, url) {
         // No need to go to the server for EN
         if (locale === 'en') {
             copyAndDispatchTranslations(dispatch, translations, en, locale);
-            return;
         }
         Client4.getTranslations(url).then((serverTranslations) => {
             copyAndDispatchTranslations(dispatch, translations, serverTranslations, locale);
         }).catch(() => {}); // eslint-disable-line no-empty-function
+	copyAndDispatchTranslations(dispatch, translations, en, locale);
     };
 }
 


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Refactor actions/views/root.js::loadTranslations to have a single point of return.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/12515
