### PR TITLE
[MM-18918] Migrate 'utils/server_version.jsx' and associated tests to TypeScript

### DIFF
--- a/components/announcement_bar/version_bar/version_bar.jsx
+++ b/components/announcement_bar/version_bar/version_bar.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 import {FormattedMessage} from 'react-intl';
 
-import {equalServerVersions} from 'utils/server_version.jsx';
+import {equalServerVersions} from 'utils/server_version';
 import {AnnouncementBarTypes} from 'utils/constants.jsx';
 
 import AnnouncementBar from '../announcement_bar.jsx';

--- a/components/system_notice/notices.jsx
+++ b/components/system_notice/notices.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
-import * as ServerVersion from 'utils/server_version.jsx';
+import * as ServerVersion from 'utils/server_version';
 import * as UserAgent from 'utils/user_agent.jsx';
 
 import mattermostIcon from 'images/icon50x50.png';

--- a/utils/server_version.test.tsx
+++ b/utils/server_version.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {equalServerVersions, isServerVersionGreaterThanOrEqualTo} from 'utils/server_version.jsx';
+import {equalServerVersions, isServerVersionGreaterThanOrEqualTo} from 'utils/server_version';
 
 describe('utils/server_version/equalServerVersions', () => {
     test('should handle undefined values', () => {

--- a/utils/server_version.test.tsx
+++ b/utils/server_version.test.tsx
@@ -4,12 +4,6 @@
 import {equalServerVersions, isServerVersionGreaterThanOrEqualTo} from 'utils/server_version';
 
 describe('utils/server_version/equalServerVersions', () => {
-    test('should handle undefined values', () => {
-        const a = undefined; // eslint-disable-line no-undefined
-        const b = null;
-        expect(equalServerVersions(a, b)).toEqual(true);
-    });
-
     test('should consider two empty versions as equal', () => {
         const a = '';
         const b = '';
@@ -66,12 +60,6 @@ describe('utils/server_version/equalServerVersions', () => {
 });
 
 describe('utils/server_version/isServerVersionGreaterThanOrEqualTo', () => {
-    test('should handle undefined values', () => {
-        const a = undefined; // eslint-disable-line no-undefined
-        const b = null;
-        expect(isServerVersionGreaterThanOrEqualTo(a, b)).toEqual(true);
-    });
-
     test('should consider two empty versions as equal', () => {
         const a = '';
         const b = '';

--- a/utils/server_version.tsx
+++ b/utils/server_version.tsx
@@ -12,7 +12,7 @@
  *     4.7.0.dev.3034fbc5fd566195d1b53e03890e35ff.true
  *     4.7.1.dev.d131dd02c5e6eec4693d9a0698aff95c.true
  */
-export function equalServerVersions(a, b) {
+export function equalServerVersions(a: string, b: string): boolean {
     if (a === b) {
         return true;
     }
@@ -36,7 +36,7 @@ export function equalServerVersions(a, b) {
  * eg.  currentVersion = 4.16.0, compareVersion = 4.17.0 returns false
  *      currentVersion = 4.16.1, compareVersion = 4.16.1 returns true
  */
-export function isServerVersionGreaterThanOrEqualTo(currentVersion, compareVersion) {
+export function isServerVersionGreaterThanOrEqualTo(currentVersion: string, compareVersion: string): boolean {
     if (currentVersion === compareVersion) {
         return true;
     }


### PR DESCRIPTION
 

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Migrate 'utils/server_version.jsx' and associated tests to Typescript
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-18918

Fixes mattermost/mattermost-server/issues/12485
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->

