### PR TITLE
Automated cherry pick of #3822

### DIFF
--- a/components/emoji_picker/emoji_picker.jsx
+++ b/components/emoji_picker/emoji_picker.jsx
@@ -162,7 +162,7 @@ export default class EmojiPicker extends React.PureComponent {
             allEmojis: {},
             categories,
             filter: '',
-            cursor: [0, 0], // categoryIndex, emojiIndex
+            cursor: [-1, -1], // categoryIndex, emojiIndex
             divTopOffset: 0,
             emojisToShow: SYSTEM_EMOJIS_COUNT,
             renderAllCategories: false,

--- a/components/emoji_picker/emoji_picker.test.jsx
+++ b/components/emoji_picker/emoji_picker.test.jsx
@@ -79,10 +79,7 @@ describe('components/emoji_picker/EmojiPicker', () => {
 
         // Nine categories as there is no recent caterogry
         expect(wrapper.find(EmojiPickerCategory).length).toBe(9);
-        expect(wrapper.find(EmojiPickerCategory).find({selected: true}).length).toBe(1);
-
-        // People EmojiPickerCategory should have prop selected true
-        expect(wrapper.find(EmojiPickerCategory).find({selected: true}).find({category: 'people'}).length).toBe(1);
+        expect(wrapper.find(EmojiPickerCategory).find({selected: true}).length).toBe(0);
 
         expect(wrapper.find(EmojiPickerCategorySection).length).toBe(1);
         expect(wrapper.find(EmojiPickerCategorySection).find({categoryName: 'people'}).length).toBe(1);
@@ -104,10 +101,10 @@ describe('components/emoji_picker/EmojiPicker', () => {
             offsetHeight: 200,
         };
 
-        // 10 categories as there is recent caterogry and prop selected should be true on EmojiPickerCategory for recent category
+        // 10 categories as there is recent caterogry
         expect(wrapper.find(EmojiPickerCategory).length).toBe(10);
-        expect(wrapper.find(EmojiPickerCategory).find({selected: true}).length).toBe(1);
-        expect(wrapper.find(EmojiPickerCategory).find({selected: true}).find({category: 'recent'}).length).toBe(1);
+        expect(wrapper.find(EmojiPickerCategory).find({selected: true}).length).toBe(0);
+        expect(wrapper.find(EmojiPickerCategory).find({category: 'recent'}).length).toBe(1);
 
         expect(wrapper.find(EmojiPickerCategorySection).length).toBe(2);
         expect(wrapper.find(EmojiPickerCategorySection).find({categoryName: 'recent'}).length).toBe(1);

--- a/components/emoji_picker/emoji_picker.test.jsx
+++ b/components/emoji_picker/emoji_picker.test.jsx
@@ -79,7 +79,7 @@ describe('components/emoji_picker/EmojiPicker', () => {
 
         // Nine categories as there is no recent caterogry
         expect(wrapper.find(EmojiPickerCategory).length).toBe(9);
-        expect(wrapper.find(EmojiPickerCategory).find({selected: true}).length).toBe(0);
+        expect(wrapper.find(EmojiPickerCategory).find({selected: true}).length).toBe(1);
 
         expect(wrapper.find(EmojiPickerCategorySection).length).toBe(1);
         expect(wrapper.find(EmojiPickerCategorySection).find({categoryName: 'people'}).length).toBe(1);
@@ -103,7 +103,7 @@ describe('components/emoji_picker/EmojiPicker', () => {
 
         // 10 categories as there is recent caterogry
         expect(wrapper.find(EmojiPickerCategory).length).toBe(10);
-        expect(wrapper.find(EmojiPickerCategory).find({selected: true}).length).toBe(0);
+        expect(wrapper.find(EmojiPickerCategory).find({selected: true}).length).toBe(1);
         expect(wrapper.find(EmojiPickerCategory).find({category: 'recent'}).length).toBe(1);
 
         expect(wrapper.find(EmojiPickerCategorySection).length).toBe(2);


### PR DESCRIPTION
Cherry pick of #3822 on release-5.16.

- #3822: remove default selection of the first emoji

/cc  @reflog