### PR TITLE
Cypress E2E - Add additional waits when searching search date filter

### DIFF
--- a/e2e/cypress/integration/search/date_filter_spec.js
+++ b/e2e/cypress/integration/search/date_filter_spec.js
@@ -12,10 +12,10 @@ import TIMEOUTS from '../../fixtures/timeouts';
 
 function searchAndValidate(query, expectedResults = []) {
     // # Enter in search query, and hit enter
-    cy.get('#searchBox').clear().type(query).type('{enter}');
+    cy.get('#searchBox').clear().wait(500).type(query).wait(500).type('{enter}');
 
     cy.get('#loadingSpinner').should('not.be.visible');
-    cy.get('#search-items-container', {timeout: TIMEOUTS.LARGE}).should('be.visible');
+    cy.get('#search-items-container', {timeout: TIMEOUTS.HUGE}).should('be.visible');
 
     // * Verify the amount of results matches the amount of our expected results
     cy.queryAllByTestId('search-item-container').should('have.length', expectedResults.length).then((results) => {
@@ -212,12 +212,16 @@ describe('SF15699 Search Date Filter', () => {
             const queryString = `on:${Cypress.moment().format('YYYY-MM-DD')} ${timestamp}`;
 
             it('with keyboard', () => {
-                searchAndValidate(queryString, [todayMessage]);
-                cy.get('#searchBox').focus().type('{backspace}'.repeat(queryString.length)).should('have.value', '');
+                cy.get('#searchBox').
+                    clear().
+                    wait(500).
+                    type(queryString).
+                    type('{backspace}'.repeat(queryString.length)).
+                    should('have.value', '');
             });
 
             it('with "x"', () => {
-                searchAndValidate(queryString, [todayMessage]);
+                cy.get('#searchBox').clear().wait(500).type(queryString);
                 cy.get('#searchClearButton').click();
                 cy.get('#searchBox').should('have.value', '');
             });


### PR DESCRIPTION
#### Summary
This should address some of the flakiness around when we search in the search date filter tests. Additionally sometimes the "remove query string" tests flaked out a bit, so refactored them.

#### Ticket Link
N/A
