### PR TITLE
E2E Cypress: leverage wait until in the system_console_spec for elastic search

### DIFF
--- a/e2e/cypress/integration/enterprise/elasticsearch/system_console_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch/system_console_spec.js
@@ -43,7 +43,7 @@ describe('Elasticsearch system console', () => {
     });
 
     it('can perform bulk index', () => {
-        // # Click the Index Now butto to start the index
+        // # Click the Index Now button to start the index
         cy.contains('button', 'Index Now').click();
 
         // # Small wait to ensure new row is added
@@ -65,8 +65,19 @@ describe('Elasticsearch system console', () => {
             and('have.text', 'In Progress');
 
         // * First row update to say Success
+        cy.waitUntil(() => {
+            return cy.get('@firstRow').then((el) => {
+                return el.find('.status-icon-success').length > 0;
+            });
+        }
+        , {
+            timeout: TIMEOUTS.FOUR_MINS,
+            interval: 2000,
+            errorMsg: 'Reindex did not succeed in time',
+        });
+
         cy.get('@firstRow').
-            find('.status-icon-success', {timeout: TIMEOUTS.GIGANTIC}).
+            find('.status-icon-success').
             should('be.visible').
             and('have.text', 'Success');
     });


### PR DESCRIPTION
#### Summary
Should fix failing/flaky test when reindexing elastic searched. Leveraged the same mechanism we use in the other elastic search tests.

#### Ticket Link
N/A
