### PR TITLE
Remove ESLint rule for typescript non null assertion operator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -77,6 +77,7 @@
         "plugin:cypress/recommended"
       ],
       "rules": {
+        "@typescript-eslint/no-non-null-assertion": 0,
         "@typescript-eslint/no-var-requires": 0,
         "@typescript-eslint/prefer-interface": 0,
         "@typescript-eslint/explicit-function-return-type": 0,


### PR DESCRIPTION
#### Summary
With the TypeScript conversion, we are allowing the non-null assertion operator to get around strict null checks when it's not necessary. I propose we leave strict null checks on such that it's always caught and thought about before a developer commits.