### PR TITLE
Update eslint-config for typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8626,8 +8626,8 @@
       }
     },
     "eslint-config-mattermost": {
-      "version": "github:mattermost/eslint-config-mattermost#6fe27a2bd1f9df4d4eb96fac6fcdcc0fee0ecbd7",
-      "from": "github:mattermost/eslint-config-mattermost#6fe27a2bd1f9df4d4eb96fac6fcdcc0fee0ecbd7",
+      "version": "github:mattermost/eslint-config-mattermost#8f9eb1414bf9ebfb509359bddddfad9788ca3c3c",
+      "from": "github:mattermost/eslint-config-mattermost#8f9eb1414bf9ebfb509359bddddfad9788ca3c3c",
       "dev": true
     },
     "eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "enzyme-adapter-react-16": "1.14.0",
     "enzyme-to-json": "3.3.5",
     "eslint": "6.0.1",
-    "eslint-config-mattermost": "github:mattermost/eslint-config-mattermost#6fe27a2bd1f9df4d4eb96fac6fcdcc0fee0ecbd7",
+    "eslint-config-mattermost": "github:mattermost/eslint-config-mattermost#8f9eb1414bf9ebfb509359bddddfad9788ca3c3c",
     "eslint-import-resolver-webpack": "0.11.1",
     "eslint-plugin-cypress": "2.6.0",
     "eslint-plugin-header": "3.0.0",


### PR DESCRIPTION
## Summary
Update to our eslint config to support TypeScript tests (see https://github.com/mattermost/eslint-config-mattermost/pull/1)
