### PR TITLE
MM-19151 - Plugin Marketplace: Typing fast on search box does not ret…

### DIFF
--- a/components/plugin_marketplace/marketplace_modal.jsx
+++ b/components/plugin_marketplace/marketplace_modal.jsx
@@ -28,7 +28,7 @@ const MarketplaceTabs = {
     INSTALLED_PLUGINS: 'installed',
 };
 
-const TRACK_SEARCH_WAIT = 1000;
+const SEARCH_TIMEOUT_MILLISECONDS = 200;
 
 export default class MarketplaceModal extends React.Component {
     static propTypes = {
@@ -82,8 +82,7 @@ export default class MarketplaceModal extends React.Component {
     }
 
     doSearch = () => {
-        debounce(this.trackSearch, TRACK_SEARCH_WAIT);
-
+        this.trackSearch();
         this.getMarketplacePlugins();
     }
 
@@ -160,7 +159,7 @@ export default class MarketplaceModal extends React.Component {
                         className='form-control filter-textbox search_input'
                         placeholder={{id: t('marketplace_modal.search'), defaultMessage: 'Search Plugins'}}
                         inputComponent={LocalizedInput}
-                        onInput={this.doSearch}
+                        onInput={debounce(this.doSearch, SEARCH_TIMEOUT_MILLISECONDS)}
                     />
                 </div>
             </div>


### PR DESCRIPTION
#### Summary
When making multiple API calls at the same time, the last request that comes back with the result updates the store and overwrites any previous result. Due to this you sometimes see inaccurate result when searching in the Marketplace, as each key stroke results in an API call. Debouncing the search function reduces the chance of the issue occurring, however it still doesn't fix the underlying issue. The real fix would be to cancel the previous API request before making the new one. However this issue is widespread in the webapp and has to be addressed holistically. Fixing the issue by adding debouncing for now.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-19151
