### PR TITLE
MM-18976 - Migrate `components/copy_text.jsx` to TypeScript

### DIFF
--- a/components/copy_text.tsx
+++ b/components/copy_text.tsx
@@ -1,37 +1,31 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes from 'prop-types';
 import React from 'react';
-
 import {FormattedMessage} from 'react-intl';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 import Constants from 'utils/constants.jsx';
 import {copyToClipboard} from 'utils/utils.jsx';
 
-export default class CopyText extends React.PureComponent {
-    static propTypes = {
-        value: PropTypes.string.isRequired,
+type Props = {
+    value: string;
+    defaultMessage?: string;
+    idMessage: string;
+};
 
-        defaultMessage: PropTypes.string,
-
-        idMessage: PropTypes.string,
+export default class CopyText extends React.PureComponent<Props, {}> {
+    public static defaultProps = {
+        defaultMessage: 'Copy',
+        idMessage: 'integrations.copy',
     };
 
-    static get defaultProps() {
-        return {
-            idMessage: 'integrations.copy',
-            defaultMessage: 'Copy',
-        };
-    }
-
-    copyText = (e) => {
+    private copyText = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
         e.preventDefault();
         copyToClipboard(this.props.value);
     };
 
-    render() {
+    public render() {
         if (!document.queryCommandSupported('copy')) {
             return null;
         }

--- a/components/integrations/confirm_integration/confirm_integration.jsx
+++ b/components/integrations/confirm_integration/confirm_integration.jsx
@@ -8,7 +8,7 @@ import {Link} from 'react-router-dom';
 
 import {browserHistory} from 'utils/browser_history';
 import {Constants, ErrorPageTypes} from 'utils/constants.jsx';
-import CopyText from 'components/copy_text.jsx';
+import CopyText from 'components/copy_text';
 import BackstageHeader from 'components/backstage/components/backstage_header.jsx';
 import {getSiteURL} from 'utils/url.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';

--- a/components/integrations/installed_command.jsx
+++ b/components/integrations/installed_command.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
 import {t} from 'utils/i18n';
-import CopyText from '../copy_text.jsx';
+import CopyText from '../copy_text';
 
 import DeleteIntegration from './delete_integration.jsx';
 

--- a/components/integrations/installed_incoming_webhook.jsx
+++ b/components/integrations/installed_incoming_webhook.jsx
@@ -9,7 +9,7 @@ import {Link} from 'react-router-dom';
 import {getSiteURL} from 'utils/url.jsx';
 import {t} from 'utils/i18n';
 
-import CopyText from 'components/copy_text.jsx';
+import CopyText from 'components/copy_text';
 
 import DeleteIntegration from './delete_integration.jsx';
 

--- a/components/integrations/installed_oauth_app/installed_oauth_app.jsx
+++ b/components/integrations/installed_oauth_app/installed_oauth_app.jsx
@@ -10,7 +10,7 @@ import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
 import FormError from 'components/form_error';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
-import CopyText from 'components/copy_text.jsx';
+import CopyText from 'components/copy_text';
 
 import DeleteIntegration from '../delete_integration.jsx';
 

--- a/components/integrations/installed_outgoing_webhook.jsx
+++ b/components/integrations/installed_outgoing_webhook.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
 import {t} from 'utils/i18n';
-import CopyText from 'components/copy_text.jsx';
+import CopyText from 'components/copy_text';
 
 import DeleteIntegration from './delete_integration.jsx';
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/jest": "24.0.17",
     "@types/node": "12.7.0",
     "@types/react": "16.8.24",
+    "@types/react-bootstrap": "0.32.20",
     "@types/react-dom": "16.8.5",
     "@types/react-router-dom": "4.3.4",
     "@types/react-transition-group": "4.2.2",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Migrate `components/copy_text.jsx` to TypeScript

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-server/issues/12452
Fixes https://mattermost.atlassian.net/browse/MM-18976