### PR TITLE
Migrate 'components/message_submit_error.jsx' and associated tests to TypeScript

### DIFF
--- a/components/message_submit_error.test.tsx
+++ b/components/message_submit_error.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import MessageSubmitError from 'components/message_submit_error.jsx';
+import MessageSubmitError from 'components/message_submit_error';
 
 describe('components/MessageSubmitError', () => {
     const baseProps = {

--- a/components/message_submit_error.tsx
+++ b/components/message_submit_error.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import PropTypes from 'prop-types';
 import React, {ReactFragment} from 'react';
 import {FormattedMessage} from 'react-intl';
 
@@ -14,16 +13,10 @@ interface ErrorMessage {
 interface MessageSubmitErrorProps {
     error: ErrorMessage;
     handleSubmit: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
-    submittedMessage: string;
+    submittedMessage?: string;
 }
 
 class MessageSubmitError extends React.PureComponent<MessageSubmitErrorProps, {}> {
-    public static propTypes = {
-        error: PropTypes.object.isRequired,
-        handleSubmit: PropTypes.func.isRequired,
-        submittedMessage: PropTypes.string,
-    }
-
     public renderSlashCommandError = (): string | ReactFragment => {
         if (!this.props.submittedMessage) {
             return this.props.error.message;

--- a/components/message_submit_error.tsx
+++ b/components/message_submit_error.tsx
@@ -24,7 +24,7 @@ class MessageSubmitError extends React.PureComponent<MessageSubmitErrorProps, {}
         submittedMessage: PropTypes.string,
     }
 
-    _renderSlashCommandError = () : string | ReactFragment => {
+    public renderSlashCommandError = (): string | ReactFragment => {
         if (!this.props.submittedMessage) {
             return this.props.error.message;
         }
@@ -61,7 +61,7 @@ class MessageSubmitError extends React.PureComponent<MessageSubmitErrorProps, {}
 
         let errorContent = error.message;
         if (isErrorInvalidSlashCommand(error)) {
-            errorContent = this._renderSlashCommandError();
+            errorContent = this.renderSlashCommandError();
         }
 
         return (

--- a/components/message_submit_error.tsx
+++ b/components/message_submit_error.tsx
@@ -2,19 +2,29 @@
 // See LICENSE.txt for license information.
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {ReactFragment} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {isErrorInvalidSlashCommand} from 'utils/post_utils.jsx';
 
-class MessageSubmitError extends React.PureComponent {
-    static propTypes = {
+interface ErrorMessage {
+    message: string | ReactFragment;
+}
+
+interface MessageSubmitErrorProps {
+    error: ErrorMessage;
+    handleSubmit: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
+    submittedMessage: string;
+}
+
+class MessageSubmitError extends React.PureComponent<MessageSubmitErrorProps, {}> {
+    public static propTypes = {
         error: PropTypes.object.isRequired,
         handleSubmit: PropTypes.func.isRequired,
         submittedMessage: PropTypes.string,
     }
 
-    renderSlashCommandError = () => {
+    _renderSlashCommandError = () : string | ReactFragment => {
         if (!this.props.submittedMessage) {
             return this.props.error.message;
         }
@@ -42,7 +52,7 @@ class MessageSubmitError extends React.PureComponent {
         );
     }
 
-    render() {
+    public render(): JSX.Element | null {
         const error = this.props.error;
 
         if (!error) {
@@ -51,7 +61,7 @@ class MessageSubmitError extends React.PureComponent {
 
         let errorContent = error.message;
         if (isErrorInvalidSlashCommand(error)) {
-            errorContent = this.renderSlashCommandError();
+            errorContent = this._renderSlashCommandError();
         }
 
         return (


### PR DESCRIPTION
**Summary**

MM-18985-Migrate 'components/message_submit_error.jsx' and associated tests to TypeScript

**Ticket Link**
[https://mattermost.atlassian.net/browse/MM-18985](https://mattermost.atlassian.net/browse/MM-18985)
Fixes https://github.com/mattermost/mattermost-server/issues/12444