### PR TITLE
[MM-19190] Include deactivated users in gm channel header channel name

### DIFF
--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -55,7 +55,7 @@ function makeMapStateToProps() {
             const dmUserId = getUserIdFromChannelName(user.id, channel.name);
             dmUser = getUser(state, dmUserId);
         } else if (channel && channel.type === General.GM_CHANNEL) {
-            gmMembers = doGetProfilesInChannel(state, channel.id, true);
+            gmMembers = doGetProfilesInChannel(state, channel.id, false);
         }
         const stats = getCurrentChannelStats(state) || {member_count: 0, guest_count: 0};
 


### PR DESCRIPTION
#### Summary

The PR fixes an issue with the GM channel header not displaying deactivated users in the channel name. It is a regression introduced in https://github.com/mattermost/mattermost-webapp/pull/3832

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19190
