### PR TITLE
Change order of components (post_reaction.jsx) to enable hovering for e2e test

### DIFF
--- a/components/post_view/post_reaction/__snapshots__/post_reaction.test.jsx.snap
+++ b/components/post_view/post_reaction/__snapshots__/post_reaction.test.jsx.snap
@@ -13,6 +13,7 @@ exports[`components/post_view/PostReaction should match snapshot 1`] = `
   <div>
     <EmojiPickerOverlay
       enableGifPicker={false}
+      n={true}
       onEmojiClick={[Function]}
       onEmojiClose={[MockFunction]}
       onHide={[MockFunction]}
@@ -22,43 +23,43 @@ exports[`components/post_view/PostReaction should match snapshot 1`] = `
       target={[MockFunction]}
       topOffset={-7}
     />
-    <button
-      aria-label="add reaction"
-      className="reacticon__container color--link style--none"
-      id="CENTER_reaction_post_id_1"
-      onClick={[MockFunction]}
+    <OverlayTrigger
+      className="hidden-xs"
+      defaultOverlayShown={false}
+      delayShow={500}
+      overlay={
+        <Tooltip
+          bsClass="tooltip"
+          className="hidden-xs"
+          id="reaction-icon-tooltip"
+          placement="right"
+        >
+          <FormattedMessage
+            defaultMessage="Add Reaction"
+            id="post_info.tooltip.add_reactions"
+            values={Object {}}
+          />
+        </Tooltip>
+      }
+      placement="top"
+      trigger={
+        Array [
+          "hover",
+          "focus",
+        ]
+      }
     >
-      <OverlayTrigger
-        className="hidden-xs"
-        defaultOverlayShown={false}
-        delayShow={500}
-        overlay={
-          <Tooltip
-            bsClass="tooltip"
-            className="hidden-xs"
-            id="reaction-icon-tooltip"
-            placement="right"
-          >
-            <FormattedMessage
-              defaultMessage="Add Reaction"
-              id="post_info.tooltip.add_reactions"
-              values={Object {}}
-            />
-          </Tooltip>
-        }
-        placement="top"
-        trigger={
-          Array [
-            "hover",
-            "focus",
-          ]
-        }
+      <button
+        aria-label="add reaction"
+        className="reacticon__container color--link style--none"
+        id="CENTER_reaction_post_id_1"
+        onClick={[MockFunction]}
       >
         <EmojiIcon
           className="icon icon--emoji"
         />
-      </OverlayTrigger>
-    </button>
+      </button>
+    </OverlayTrigger>
   </div>
 </Connect(ChannelPermissionGate)>
 `;

--- a/components/post_view/post_reaction/post_reaction.jsx
+++ b/components/post_view/post_reaction/post_reaction.jsx
@@ -74,33 +74,34 @@ export default class PostReaction extends React.PureComponent {
                         onEmojiClick={this.handleAddEmoji}
                         topOffset={TOP_OFFSET}
                         spaceRequiredAbove={spaceRequiredAbove}
+                        n={true}
                         spaceRequiredBelow={spaceRequiredBelow}
                     />
-                    <button
-                        id={`${location}_reaction_${postId}`}
-                        aria-label={localizeMessage('post_info.tooltip.add_reactions', 'Add Reaction').toLowerCase()}
-                        className='reacticon__container color--link style--none'
-                        onClick={this.props.toggleEmojiPicker}
+                    <OverlayTrigger
+                        className='hidden-xs'
+                        delayShow={500}
+                        placement='top'
+                        overlay={
+                            <Tooltip
+                                id='reaction-icon-tooltip'
+                                className='hidden-xs'
+                            >
+                                <FormattedMessage
+                                    id='post_info.tooltip.add_reactions'
+                                    defaultMessage='Add Reaction'
+                                />
+                            </Tooltip>
+                        }
                     >
-                        <OverlayTrigger
-                            className='hidden-xs'
-                            delayShow={500}
-                            placement='top'
-                            overlay={
-                                <Tooltip
-                                    id='reaction-icon-tooltip'
-                                    className='hidden-xs'
-                                >
-                                    <FormattedMessage
-                                        id='post_info.tooltip.add_reactions'
-                                        defaultMessage='Add Reaction'
-                                    />
-                                </Tooltip>
-                            }
+                        <button
+                            id={`${location}_reaction_${postId}`}
+                            aria-label={localizeMessage('post_info.tooltip.add_reactions', 'Add Reaction').toLowerCase()}
+                            className='reacticon__container color--link style--none'
+                            onClick={this.props.toggleEmojiPicker}
                         >
                             <EmojiIcon className='icon icon--emoji'/>
-                        </OverlayTrigger>
-                    </button>
+                        </button>
+                    </OverlayTrigger>
                 </div>
             </ChannelPermissionGate>
         );


### PR DESCRIPTION
#### Summary
While working on https://github.com/mattermost/mattermost-server/issues/12299 , I was not able to configure Cypress so that it would hover on 2 of 3 of the post menu icons (post reaction icon & comment icon). After reviewing the code, it turned out to be a problem with how the ```<button>``` element was not nested within the ```<OverlayTrigger>``` component, but was instead the parent of said component, which in turn resulted in Cypress not being able to hover over the post reaction icon.

I changed the nesting order by putting the ```<button>``` element inside the ```<OverlayTrigger>``` component.

#### Ticket Link
This PR was not a listed issue.

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/3894
https://github.com/mattermost/mattermost-webapp/pull/3893