### PR TITLE
Change order of components (comment_icon.jsx) to enable hovering

### DIFF
--- a/components/common/comment_icon.jsx
+++ b/components/common/comment_icon.jsx
@@ -55,24 +55,25 @@ export default class CommentIcon extends React.PureComponent {
         );
 
         return (
-            <button
-                id={`${this.props.location}_commentIcon_${this.props.postId}`}
-                aria-label={localizeMessage('post_info.comment_icon.tooltip.reply', 'Reply').toLowerCase()}
-                className={iconStyle + ' color--link style--none ' + this.props.extraClass}
-                onClick={this.props.handleCommentClick}
+            <OverlayTrigger
+                className='hidden-xs'
+                delayShow={500}
+                placement='top'
+                overlay={tooltip}
             >
-                <OverlayTrigger
-                    className='hidden-xs'
-                    delayShow={500}
-                    placement='top'
-                    overlay={tooltip}
+                <button
+                    id={`${this.props.location}_commentIcon_${this.props.postId}`}
+                    aria-label={localizeMessage('post_info.comment_icon.tooltip.reply', 'Reply').toLowerCase()}
+                    className={iconStyle + ' color--link style--none ' + this.props.extraClass}
+                    onClick={this.props.handleCommentClick}
                 >
                     <span className='d-flex'>
                         <ReplyIcon className='comment-icon'/>
                         {commentCountSpan}
                     </span>
-                </OverlayTrigger>
-            </button>
+                </button>
+            </OverlayTrigger>
         );
     }
 }
+

--- a/components/post_view/post_reaction/__snapshots__/post_reaction.test.jsx.snap
+++ b/components/post_view/post_reaction/__snapshots__/post_reaction.test.jsx.snap
@@ -13,6 +13,7 @@ exports[`components/post_view/PostReaction should match snapshot 1`] = `
   <div>
     <EmojiPickerOverlay
       enableGifPicker={false}
+      n={true}
       onEmojiClick={[Function]}
       onEmojiClose={[MockFunction]}
       onHide={[MockFunction]}
@@ -22,43 +23,43 @@ exports[`components/post_view/PostReaction should match snapshot 1`] = `
       target={[MockFunction]}
       topOffset={-7}
     />
-    <button
-      aria-label="add reaction"
-      className="reacticon__container color--link style--none"
-      id="CENTER_reaction_post_id_1"
-      onClick={[MockFunction]}
+    <OverlayTrigger
+      className="hidden-xs"
+      defaultOverlayShown={false}
+      delayShow={500}
+      overlay={
+        <Tooltip
+          bsClass="tooltip"
+          className="hidden-xs"
+          id="reaction-icon-tooltip"
+          placement="right"
+        >
+          <FormattedMessage
+            defaultMessage="Add Reaction"
+            id="post_info.tooltip.add_reactions"
+            values={Object {}}
+          />
+        </Tooltip>
+      }
+      placement="top"
+      trigger={
+        Array [
+          "hover",
+          "focus",
+        ]
+      }
     >
-      <OverlayTrigger
-        className="hidden-xs"
-        defaultOverlayShown={false}
-        delayShow={500}
-        overlay={
-          <Tooltip
-            bsClass="tooltip"
-            className="hidden-xs"
-            id="reaction-icon-tooltip"
-            placement="right"
-          >
-            <FormattedMessage
-              defaultMessage="Add Reaction"
-              id="post_info.tooltip.add_reactions"
-              values={Object {}}
-            />
-          </Tooltip>
-        }
-        placement="top"
-        trigger={
-          Array [
-            "hover",
-            "focus",
-          ]
-        }
+      <button
+        aria-label="add reaction"
+        className="reacticon__container color--link style--none"
+        id="CENTER_reaction_post_id_1"
+        onClick={[MockFunction]}
       >
         <EmojiIcon
           className="icon icon--emoji"
         />
-      </OverlayTrigger>
-    </button>
+      </button>
+    </OverlayTrigger>
   </div>
 </Connect(ChannelPermissionGate)>
 `;

--- a/components/post_view/post_reaction/post_reaction.jsx
+++ b/components/post_view/post_reaction/post_reaction.jsx
@@ -74,33 +74,34 @@ export default class PostReaction extends React.PureComponent {
                         onEmojiClick={this.handleAddEmoji}
                         topOffset={TOP_OFFSET}
                         spaceRequiredAbove={spaceRequiredAbove}
+                        n={true}
                         spaceRequiredBelow={spaceRequiredBelow}
                     />
-                    <button
-                        id={`${location}_reaction_${postId}`}
-                        aria-label={localizeMessage('post_info.tooltip.add_reactions', 'Add Reaction').toLowerCase()}
-                        className='reacticon__container color--link style--none'
-                        onClick={this.props.toggleEmojiPicker}
+                    <OverlayTrigger
+                        className='hidden-xs'
+                        delayShow={500}
+                        placement='top'
+                        overlay={
+                            <Tooltip
+                                id='reaction-icon-tooltip'
+                                className='hidden-xs'
+                            >
+                                <FormattedMessage
+                                    id='post_info.tooltip.add_reactions'
+                                    defaultMessage='Add Reaction'
+                                />
+                            </Tooltip>
+                        }
                     >
-                        <OverlayTrigger
-                            className='hidden-xs'
-                            delayShow={500}
-                            placement='top'
-                            overlay={
-                                <Tooltip
-                                    id='reaction-icon-tooltip'
-                                    className='hidden-xs'
-                                >
-                                    <FormattedMessage
-                                        id='post_info.tooltip.add_reactions'
-                                        defaultMessage='Add Reaction'
-                                    />
-                                </Tooltip>
-                            }
+                        <button
+                            id={`${location}_reaction_${postId}`}
+                            aria-label={localizeMessage('post_info.tooltip.add_reactions', 'Add Reaction').toLowerCase()}
+                            className='reacticon__container color--link style--none'
+                            onClick={this.props.toggleEmojiPicker}
                         >
                             <EmojiIcon className='icon icon--emoji'/>
-                        </OverlayTrigger>
-                    </button>
+                        </button>
+                    </OverlayTrigger>
                 </div>
             </ChannelPermissionGate>
         );

--- a/e2e/cypress/integration/messaging/tooltip_visual_verification_spec.js
+++ b/e2e/cypress/integration/messaging/tooltip_visual_verification_spec.js
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+// Username of a test user that you want to start a DM with
+let username = '';
+
+// Function to hover over individual items
+function hoverOverItem(postId, iconName, tooltipName, location = 'CENTER') {
+    // # Get the latest post and hover over it
+    cy.get(`#post_${postId}`).trigger('mouseover');
+
+    // # Hover on the icon that you want to test
+    cy.get(`#${location}_${iconName}_${postId}`).trigger('mouseover', {
+        force: true,
+    });
+
+    // # Check that after hovering on the icon you would like to test, the relevant tooltip appears
+    cy.get(`${tooltipName}`).should('be.visible');
+}
+
+describe('M18697 - Visual verification of tooltips on post hover menu', () => {
+    before(() => {
+        // # Login as user-1
+        cy.apiLogin('user-1');
+
+        // # Use the API to create a new user
+        cy.createNewUser().then((res) => {
+            username = res.username;
+
+            // # Start DM with new user
+            cy.visit(`/ad-1/messages/@${username}`);
+        });
+
+        // # Wait a few ms for the user to be created before sending the test message
+        cy.wait(TIMEOUTS.SMALL);
+
+        // # Post test message
+        cy.postMessage('Test');
+    });
+
+    it('Check dotmenu icon tooltip', () => {
+        cy.getLastPostId().then((postId) => {
+            hoverOverItem(postId, 'button', '#dotmenu-icon-tooltip');
+        });
+    });
+
+    it('Check reaction icon tooltip', () => {
+        cy.getLastPostId().then((postId) => {
+            hoverOverItem(postId, 'reaction', '#reaction-icon-tooltip');
+        });
+    });
+
+    it('Check comment icon tooltip', () => {
+        cy.getLastPostId().then((postId) => {
+            hoverOverItem(postId, 'commentIcon', '#comment-icon-tooltip');
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
This PR fixed a similar issue to the link I have attached below. I changed the order of the ```<button>``` element and the ```OverlayTrigger``` component within the ```comment_icon.jsx``` file so that the Cypress e2e test I wrote would be able to hover on the comment icon.

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/3889
https://github.com/mattermost/mattermost-webapp/pull/3893