### PR TITLE
[MM-19247] Fix Invite Guests Permission in custom Team Scheme

### DIFF
--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -543,6 +543,7 @@ export const SidebarChannelGroups = {
 
 export const PermissionsScope = {
     [Permissions.INVITE_USER]: 'team_scope',
+    [Permissions.INVITE_GUEST]: 'team_scope',
     [Permissions.ADD_USER_TO_TEAM]: 'team_scope',
     [Permissions.USE_SLASH_COMMANDS]: 'channel_scope',
     [Permissions.MANAGE_SLASH_COMMANDS]: 'team_scope',


### PR DESCRIPTION
#### Summary

Fixes a bug where `invite_guest` permission was filtered out of the team scheme cause it was missing from `PermissionsScope`.

#### Ticket

https://mattermost.atlassian.net/browse/MM-19247