### PR TITLE
force click for profile popover e2e test

### DIFF
--- a/e2e/cypress/integration/messaging/mobile_profile_popover_spec.js
+++ b/e2e/cypress/integration/messaging/mobile_profile_popover_spec.js
@@ -26,10 +26,11 @@ describe('Profile popover', () => {
             cy.wait(TIMEOUTS.TINY);
 
             // # Click on user profile image
-            cy.get(`#post_${postId}`).find('.profile-icon > img').click();
+            cy.get(`#post_${postId}`).find('.profile-icon > img').click({force: true});
 
             // * Popover should have rendered to screen
             cy.get('#user-profile-popover').should('be.visible');
+            cy.get('body').type('{esc}');
         });
     });
 
@@ -38,7 +39,7 @@ describe('Profile popover', () => {
         cy.apiSaveMessageDisplayPreference('compact');
         cy.getLastPostId().then((postId) => {
             // # Click on username
-            cy.get(`#post_${postId}`).find('.user-popover').click();
+            cy.get(`#post_${postId}`).find('.user-popover').click({force: true});
 
             // * Popover should have rendered to screen
             cy.get('#user-profile-popover').should('be.visible');


### PR DESCRIPTION
#### Summary
This test was acting up in a CI build.

Force clicking the profile icon image should address any issues if it is somehow not visible. Additionally, typing escape after the first test to dismiss the popover so it is not already there for the next test.

#### Ticket Link
N/A
