### PR TITLE
Migrate lazy loading to use React.lazy rather than bundle-loader

### DIFF
--- a/components/app.jsx
+++ b/components/app.jsx
@@ -10,7 +10,7 @@ import {browserHistory} from 'utils/browser_history';
 import store from 'stores/redux_store.jsx';
 
 import {makeAsyncComponent} from 'components/async_load';
-import loadRoot from 'bundle-loader?lazy!components/root';
+const loadRoot = React.lazy(() => import("components/root"));
 
 const Root = makeAsyncComponent(loadRoot);
 

--- a/components/header_footer_template_route.jsx
+++ b/components/header_footer_template_route.jsx
@@ -4,9 +4,10 @@
 import React from 'react';
 import {Route} from 'react-router-dom';
 
-import HeaderFooterTemplate from 'bundle-loader?lazy!components/header_footer_template';
-import loadLoggedIn from 'bundle-loader?lazy!components/logged_in';
 import {AsyncComponent} from 'components/async_load';
+
+const HeaderFooterTemplate = React.lazy(() => import("components/header_footer_template"))
+const loadLoggedIn = React.lazy(() => import("components/logged_in"));
 
 export const HFTRoute = ({component: Component, ...rest}) => (
     <Route

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -13,8 +13,9 @@ import Constants from 'utils/constants.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {makeAsyncComponent} from 'components/async_load';
-import loadBackstageController from 'bundle-loader?lazy!components/backstage';
 import ChannelController from 'components/channel_layout/channel_controller';
+
+const loadBackstageController = React.lazy(() => import("components/backstage"));
 
 const BackstageController = makeAsyncComponent(loadBackstageController);
 

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -27,29 +27,30 @@ import IntlProvider from 'components/intl_provider';
 import NeedsTeam from 'components/needs_team';
 import PermalinkRedirector from 'components/permalink_redirector';
 import {makeAsyncComponent} from 'components/async_load';
-import loadErrorPage from 'bundle-loader?lazy!components/error_page';
-import loadLoginController from 'bundle-loader?lazy!components/login/login_controller';
-import loadAdminConsole from 'bundle-loader?lazy!components/admin_console';
-import loadLoggedIn from 'bundle-loader?lazy!components/logged_in';
-import loadPasswordResetSendLink from 'bundle-loader?lazy!components/password_reset_send_link';
-import loadPasswordResetForm from 'bundle-loader?lazy!components/password_reset_form';
-import loadSignupController from 'bundle-loader?lazy!components/signup/signup_controller';
-import loadSignupEmail from 'bundle-loader?lazy!components/signup/signup_email';
-import loadTermsOfService from 'bundle-loader?lazy!components/terms_of_service';
-import loadShouldVerifyEmail from 'bundle-loader?lazy!components/should_verify_email';
-import loadDoVerifyEmail from 'bundle-loader?lazy!components/do_verify_email';
-import loadClaimController from 'bundle-loader?lazy!components/claim';
-import loadHelpController from 'bundle-loader?lazy!components/help/help_controller';
-import loadGetIosApp from 'bundle-loader?lazy!components/get_ios_app';
-import loadGetAndroidApp from 'bundle-loader?lazy!components/get_android_app';
-import loadSelectTeam from 'bundle-loader?lazy!components/select_team';
-import loadAuthorize from 'bundle-loader?lazy!components/authorize';
-import loadCreateTeam from 'bundle-loader?lazy!components/create_team';
-import loadMfa from 'bundle-loader?lazy!components/mfa/mfa_controller';
 import store from 'stores/redux_store.jsx';
 import {getSiteURL} from 'utils/url.jsx';
 import {enableDevModeFeatures, isDevMode} from 'utils/utils';
 import A11yController from 'utils/a11y_controller';
+
+const loadErrorPage = React.lazy(() => import("components/error_page"))
+const loadLoginController = React.lazy(() => import("components/login/login_controller"))
+const loadAdminConsole = React.lazy(() => import("components/admin_console"))
+const loadLoggedIn = React.lazy(() => import("components/logged_in"))
+const loadPasswordResetSendLink = React.lazy(() => import("components/password_reset_send_link"))
+const loadPasswordResetForm = React.lazy(() => import("components/password_reset_form"))
+const loadSignupController = React.lazy(() => import("components/signup/signup_controller"))
+const loadSignupEmail = React.lazy(() => import("components/signup/signup_email"))
+const loadTermsOfService = React.lazy(() => import("components/terms_of_service"))
+const loadShouldVerifyEmail = React.lazy(() => import("components/should_verify_email"))
+const loadDoVerifyEmail = React.lazy(() => import("components/do_verify_email"))
+const loadClaimController = React.lazy(() => import("components/claim"))
+const loadHelpController = React.lazy(() => import("components/help/help_controller"))
+const loadGetIosApp = React.lazy(() => import("components/get_ios_app"))
+const loadGetAndroidApp = React.lazy(() => import("components/get_android_app"))
+const loadSelectTeam = React.lazy(() => import("components/select_team"))
+const loadAuthorize = React.lazy(() => import("components/authorize"))
+const loadCreateTeam = React.lazy(() => import("components/create_team"))
+const loadMfa = React.lazy(() => import("components/mfa/mfa_controller"))
 
 const CreateTeam = makeAsyncComponent(loadCreateTeam);
 const ErrorPage = makeAsyncComponent(loadErrorPage);

--- a/components/team_settings_modal/team_settings_modal.jsx
+++ b/components/team_settings_modal/team_settings_modal.jsx
@@ -10,9 +10,10 @@ import {FormattedMessage} from 'react-intl';
 
 import * as Utils from 'utils/utils.jsx';
 import {AsyncComponent} from 'components/async_load';
-import loadSettingsSidebar from 'bundle-loader?lazy!components/settings_sidebar.jsx';
 
 import TeamSettings from 'components/team_settings';
+
+const loadSettingsSidebar = React.lazy(() => import("components/settings_sidebar.jsx"))
 
 export default class TeamSettingsModal extends React.Component {
     static propTypes = {

--- a/components/user_settings/modal/user_settings_modal.jsx
+++ b/components/user_settings/modal/user_settings_modal.jsx
@@ -14,8 +14,8 @@ import {t} from 'utils/i18n';
 import ConfirmModal from '../../confirm_modal.jsx';
 import {AsyncComponent} from 'components/async_load';
 
-import loadUserSettings from 'bundle-loader?lazy!components/user_settings';
-import loadSettingsSidebar from 'bundle-loader?lazy!../../settings_sidebar.jsx';
+const loadUserSettings = React.lazy(() => import("components/user_settings"))
+const loadSettingsSidebar = React.lazy(() => import("../../settings_sidebar.jsx"))
 
 const holders = defineMessages({
     general: {

--- a/components/view_image/view_image.jsx
+++ b/components/view_image/view_image.jsx
@@ -14,10 +14,10 @@ import CodePreview from 'components/code_preview';
 import FileInfoPreview from 'components/file_info_preview';
 import LoadingImagePreview from 'components/loading_image_preview';
 import {AsyncComponent} from 'components/async_load.jsx';
-import loadPDFPreview from 'bundle-loader?lazy!components/pdf_preview';
-
 import ImagePreview from './image_preview';
 import PopoverBar from './popover_bar';
+
+const loadPDFPreview = React.lazy(() => import("components/pdf_preview"));
 
 const KeyCodes = Constants.KeyCodes;
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "babel-jest": "24.8.0",
     "babel-loader": "8.0.6",
     "babel-plugin-typescript-to-proptypes": "0.17.1",
-    "bundle-loader": "0.5.6",
     "clone": "2.1.2",
     "copy-webpack-plugin": "5.0.3",
     "cross-env": "5.2.0",


### PR DESCRIPTION
#### Summary
Use the native React.lazy() to lazy load components rather than the third party bundle-loader.