### PR TITLE
Fixing guest being removed from other not-visible user from a channel

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -33,6 +33,7 @@ import {
     receivedPost,
 } from 'mattermost-redux/actions/posts';
 import {clearErrors, logError} from 'mattermost-redux/actions/errors';
+import {getUser as loadUser} from 'mattermost-redux/actions/users';
 
 import * as TeamActions from 'mattermost-redux/actions/teams';
 import {
@@ -660,7 +661,7 @@ function handleUserAddedEvent(msg) {
     }
 }
 
-export function handleUserRemovedEvent(msg) {
+export async function handleUserRemovedEvent(msg) {
     const state = getState();
     const currentChannel = getCurrentChannel(state) || {};
     const currentUserId = getCurrentUserId(state);
@@ -677,6 +678,10 @@ export function handleUserRemovedEvent(msg) {
             if (msg.data.remover_id === msg.broadcast.user_id) {
                 browserHistory.push(getCurrentRelativeTeamUrl(state));
             } else {
+                if (!getUser(state, msg.data.remover_id)) {
+                    await dispatch(loadUser(msg.data.remover_id))
+                }
+
                 const user = getUser(state, msg.data.remover_id) || {};
 
                 dispatch(openModal({

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -33,7 +33,6 @@ import {
     receivedPost,
 } from 'mattermost-redux/actions/posts';
 import {clearErrors, logError} from 'mattermost-redux/actions/errors';
-import {getUser as loadUser} from 'mattermost-redux/actions/users';
 
 import * as TeamActions from 'mattermost-redux/actions/teams';
 import {
@@ -41,6 +40,7 @@ import {
     getMe,
     getMissingProfilesByIds,
     getStatusesByIds,
+    getUser as loadUser,
 } from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {getCurrentUser, getCurrentUserId, getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
@@ -679,7 +679,7 @@ export async function handleUserRemovedEvent(msg) {
                 browserHistory.push(getCurrentRelativeTeamUrl(state));
             } else {
                 if (!getUser(state, msg.data.remover_id)) {
-                    await dispatch(loadUser(msg.data.remover_id))
+                    await dispatch(loadUser(msg.data.remover_id));
                 }
 
                 const user = getUser(state, msg.data.remover_id) || {};

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -678,11 +678,11 @@ export async function handleUserRemovedEvent(msg) {
             if (msg.data.remover_id === msg.broadcast.user_id) {
                 browserHistory.push(getCurrentRelativeTeamUrl(state));
             } else {
-                if (!getUser(state, msg.data.remover_id)) {
+                let user = getUser(state, msg.data.remover_id)
+                if (!user) {
                     await dispatch(loadUser(msg.data.remover_id));
+                    user = getUser(state, msg.data.remover_id) || {};
                 }
-
-                const user = getUser(state, msg.data.remover_id) || {};
 
                 dispatch(openModal({
                     modalId: ModalIdentifiers.REMOVED_FROM_CHANNEL,

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -678,7 +678,7 @@ export async function handleUserRemovedEvent(msg) {
             if (msg.data.remover_id === msg.broadcast.user_id) {
                 browserHistory.push(getCurrentRelativeTeamUrl(state));
             } else {
-                let user = getUser(state, msg.data.remover_id)
+                let user = getUser(state, msg.data.remover_id);
                 if (!user) {
                     await dispatch(loadUser(msg.data.remover_id));
                     user = getUser(state, msg.data.remover_id) || {};

--- a/actions/websocket_actions.test.jsx
+++ b/actions/websocket_actions.test.jsx
@@ -10,6 +10,7 @@ import {ChannelTypes, UserTypes} from 'mattermost-redux/action_types';
 import {
     getMissingProfilesByIds,
     getStatusesByIds,
+    getUser,
 } from 'mattermost-redux/actions/users';
 import {General, WebsocketEvents} from 'mattermost-redux/constants';
 
@@ -47,6 +48,7 @@ jest.mock('mattermost-redux/actions/posts', () => ({
 jest.mock('mattermost-redux/actions/users', () => ({
     getMissingProfilesByIds: jest.fn(() => ({type: 'GET_MISSING_PROFILES_BY_IDS'})),
     getStatusesByIds: jest.fn(() => ({type: 'GET_STATUSES_BY_IDS'})),
+    getUser: jest.fn(() => ({type: 'GET_STATUSES_BY_IDS'})),
 }));
 
 jest.mock('actions/post_actions', () => ({
@@ -228,6 +230,36 @@ describe('handleUserRemovedEvent', () => {
         handleUserRemovedEvent(msg);
         mockState.entities.roles.roles = {system_guest: {permissions: ['view_members']}};
         expect(store.dispatch).toHaveBeenCalledWith(expectedAction);
+    });
+
+    test('should load the remover_id user if is not available in the store', async () => {
+        const msg = {
+            data: {
+                channel_id: 'otherChannel',
+                remover_id: 'otherUser',
+            },
+            broadcast: {
+                user_id: 'currentUserId',
+            },
+        };
+
+        handleUserRemovedEvent(msg);
+        expect(getUser).toHaveBeenCalledWith('otherUser');
+    });
+
+    test('should not load the remover_id user if is available in the store', async () => {
+        const msg = {
+            data: {
+                channel_id: 'otherChannel',
+                remover_id: 'user',
+            },
+            broadcast: {
+                user_id: 'currentUserId',
+            },
+        };
+
+        handleUserRemovedEvent(msg);
+        expect(getUser).not.toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
#### Summary
When a guest was removed from a channel and the user wasn't visible, it needs
to ask for the user information to confirm that the other user is no longer
visible.

#### Ticket Link
[MM-19169](https://mattermost.atlassian.net/browse/MM-19169)