### PR TITLE
Remove redundant package from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@types/chart.js": "^2.8.5",
     "@types/enzyme": "3.10.3",
     "@types/history": "^4.7.3",
     "@types/jest": "24.0.17",


### PR DESCRIPTION
#### Summary

The package `@types/chart.js` was added as a dependency in `package.json`, when it already exists in the `devDependencies`. My console shows a warning for this when running tests.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18925

#### Related Pull Requests

https://github.com/mattermost/mattermost-webapp/pull/3855 introduced the duplication

If I understand correctly, the only reason we would want to have types in the `dependencies` section is if another repo imports `mattermost-webapp` and wants to know about those types. With that in mind, should all `@types` dependencies go into `devDependencies`?