### PR TITLE
[MM-19339] Fix tabbing in modals and multi post-hover-menus

### DIFF
--- a/utils/a11y_controller.js
+++ b/utils/a11y_controller.js
@@ -296,12 +296,6 @@ export default class A11yController {
      * @param {array or boolean} elementPath - array of element's dom branch or boolean to find section/region of element
      */
     nextElement(element, elementPath = false) {
-        if (
-            this.modalIsOpen ||
-            this.popupIsOpen
-        ) {
-            return;
-        }
         let region;
         let section;
         if (elementPath && elementPath.length) {
@@ -419,7 +413,9 @@ export default class A11yController {
         // setup new active element
         this.activeElement = element;
         this.activeElement.addEventListener(A11yCustomEventTypes.UPDATE, this.handleActiveElementUpdate);
-        this.activeElement.dispatchEvent(new Event(A11yCustomEventTypes.ACTIVATE));
+        if (this.activeElement !== this.activeRegion && this.activeElement !== this.activeSection) {
+            this.activeElement.dispatchEvent(new Event(A11yCustomEventTypes.ACTIVATE));
+        }
 
         // apply visual updates to active element
         this.updateActiveElement();
@@ -556,6 +552,7 @@ export default class A11yController {
         this.tabKeyIsPressed = false;
         this.tildeKeyIsPressed = false;
         this.enterKeyIsPressed = false;
+        this.lastInputEventIsKeyboard = false;
     }
 
     // helper methods
@@ -676,15 +673,16 @@ export default class A11yController {
             altIsPressed: event.altKey,
             shiftIsPressed: event.shiftKey,
         };
-        this.lastInputEventIsKeyboard = true;
         switch (true) {
         case isKeyPressed(event, Constants.KeyCodes.TAB):
+            this.lastInputEventIsKeyboard = true;
             if ((!isMac() && modifierKeys.altIsPressed) || cmdOrCtrlPressed(event)) {
                 return;
             }
             this.tabKeyIsPressed = true;
             break;
         case isKeyPressed(event, Constants.KeyCodes.TILDE):
+            this.lastInputEventIsKeyboard = true;
             if (!this.regions || !this.regions.length) {
                 return;
             }
@@ -701,6 +699,7 @@ export default class A11yController {
             }
             break;
         case isKeyPressed(event, Constants.KeyCodes.F6):
+            this.lastInputEventIsKeyboard = true;
             if (!isDesktopApp() && !cmdOrCtrlPressed(event)) {
                 return;
             }
@@ -713,6 +712,7 @@ export default class A11yController {
             }
             break;
         case isKeyPressed(event, Constants.KeyCodes.UP):
+            this.lastInputEventIsKeyboard = true;
             if (!this.navigationInProgress || !this.sections || !this.sections.length) {
                 return;
             }
@@ -725,6 +725,7 @@ export default class A11yController {
             }
             break;
         case isKeyPressed(event, Constants.KeyCodes.DOWN):
+            this.lastInputEventIsKeyboard = true;
             if (!this.navigationInProgress || !this.sections || !this.sections.length) {
                 return;
             }
@@ -780,7 +781,7 @@ export default class A11yController {
     }
 
     handleFocus = (event) => {
-        if (!this.mouseIsPressed && this.windowIsFocused) {
+        if (this.lastInputEventIsKeyboard && this.windowIsFocused) {
             this.nextElement(event.target, event.path || true);
         }
 


### PR DESCRIPTION
#### Summary
The fix for [this ticket](https://mattermost.atlassian.net/browse/MM-18159) broke keyboard navigation in modals, specifically preventing focused elements in modals from visually indicating they have focus. This PR reverts the fix for the original ticket to fix the broken modal navigation and applies a new fix for the original ticket.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19339 (new ticket)
https://mattermost.atlassian.net/browse/MM-18159 (original ticket)