### PR TITLE
MM-18823 - Saving empty string on Marketplace URL resets the URL instead of showing error

### DIFF
--- a/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
+++ b/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
@@ -157,10 +157,12 @@ exports[`components/PluginManagement should match snapshot 1`] = `
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -367,10 +369,12 @@ exports[`components/PluginManagement should match snapshot when \`Enable Plugins
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -611,10 +615,12 @@ exports[`components/PluginManagement should match snapshot, No installed plugins
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -860,10 +866,12 @@ exports[`components/PluginManagement should match snapshot, allow insecure URL e
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -1104,10 +1112,12 @@ exports[`components/PluginManagement should match snapshot, disabled 1`] = `
           <AdminTextSetting
             disabled={true}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -1321,10 +1331,12 @@ exports[`components/PluginManagement should match snapshot, text entered into th
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -1565,10 +1577,12 @@ exports[`components/PluginManagement should match snapshot, upload disabled 1`] 
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -1809,10 +1823,12 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -2116,10 +2132,12 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -2391,10 +2409,12 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -2666,10 +2686,12 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={
@@ -2941,10 +2963,12 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
           <AdminTextSetting
             disabled={false}
             helpText={
-              <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="URL of the marketplace server."
-                id="admin.plugins.settings.marketplaceUrlDesc"
-              />
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
             }
             id="marketplaceUrl"
             label={

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -1035,7 +1035,6 @@ export default class PluginManagement extends AdminSettings {
                             onChange={this.handleChange}
                             setByEnv={this.isSetByEnv('PluginSettings.MarketplaceUrl')}
                         />
-
                         {pluginsContainer}
                     </SettingsGroup>
                     {overwriteUploadPluginModal}

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -596,7 +596,7 @@ export default class PluginManagement extends AdminSettings {
             <div>
                 {
                     url === '' &&
-                    <div>
+                    <div className='alert-warning'>
                         <i className='fa fa-warning'/>
                         <FormattedMarkdownMessage
                             id='admin.plugins.settings.marketplaceUrlDesc.empty'

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -591,6 +591,34 @@ export default class PluginManagement extends AdminSettings {
         });
     }
 
+    getMarketplaceUrlHelpText = (url) => {
+        return (
+            <div>
+                {
+                    url === '' &&
+                    <div>
+                        <i className='fa fa-warning'/>
+                        <FormattedMarkdownMessage
+                            id='admin.plugins.settings.marketplaceUrlDesc.empty'
+                            defaultMessage=' Marketplace URL is a required field.'
+                        />
+                    </div>
+                }
+                {
+                    url !== '' &&
+                    <FormattedMarkdownMessage
+                        id='admin.plugins.settings.marketplaceUrlDesc'
+                        defaultMessage='URL of the marketplace server.'
+                    />
+                }
+            </div>
+        );
+    }
+
+    canSave = () => {
+        return this.state.marketplaceUrl !== '';
+    }
+
     handleSubmitInstall = (e) => {
         e.preventDefault();
         return this.installFromUrl(false);
@@ -1001,17 +1029,13 @@ export default class PluginManagement extends AdminSettings {
                                     defaultMessage='Marketplace URL:'
                                 />
                             }
-                            helpText={
-                                <FormattedMarkdownMessage
-                                    id='admin.plugins.settings.marketplaceUrlDesc'
-                                    defaultMessage='URL of the marketplace server.'
-                                />
-                            }
+                            helpText={this.getMarketplaceUrlHelpText(this.state.marketplaceUrl)}
                             value={this.state.marketplaceUrl}
                             disabled={!this.state.enable || !this.state.enableMarketplace}
                             onChange={this.handleChange}
                             setByEnv={this.isSetByEnv('PluginSettings.MarketplaceUrl')}
                         />
+
                         {pluginsContainer}
                     </SettingsGroup>
                     {overwriteUploadPluginModal}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1133,6 +1133,7 @@
   "admin.plugins.settings.enableMarketplaceDesc": "When true, enables System Administrators to install plugins from the [marketplace](!https://mattermost.com/pl/default-mattermost-marketplace.html).",
   "admin.plugins.settings.marketplaceUrl": "Marketplace URL:",
   "admin.plugins.settings.marketplaceUrlDesc": "URL of the marketplace server.",
+  "admin.plugins.settings.marketplaceUrlDesc.empty": " Marketplace URL is a required field.",
   "admin.privacy.showEmailDescription": "When false, hides the email address of members from everyone except System Administrators.",
   "admin.privacy.showEmailTitle": "Show Email Address: ",
   "admin.privacy.showFullNameDescription": "When false, hides the full name of members from everyone except System Administrators. Username is shown in place of full name.",


### PR DESCRIPTION
#### Summary
Disable `save` button when URL is empty. Show a warning message when URL is empty.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-18823

#### Screenshot (When URL is empty)
![image](https://user-images.githubusercontent.com/25732808/66584654-89e7e600-eb53-11e9-9111-062f34bea5aa.png)


