### PR TITLE
MM-18717

### DIFF
--- a/e2e/cypress/integration/messaging/permalink_message_edit_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_message_edit_spec.js
@@ -7,55 +7,53 @@
 // Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-
 describe('Permalink message edit', () => {
-	it('M18717 - Edit a message in permalink view', () => {
-		// # Login as "user-1" and go to /
-		cy.apiLogin('user-1');
-		cy.visit('/');
+    it('M18717 - Edit a message in permalink view', () => {
+        // # Login as "user-1" and go to /
+        cy.apiLogin('user-1');
+        cy.visit('/');
 
-		const searchWord = 'searchtest';
-		
-		// # Post message
-		cy.postMessage(searchWord)
-		
-		// # Search for searchWord
-		cy.get('#searchBox').type(searchWord).type('{enter}').then(() => {
-		
-			// # Jump to permalink view	
-			cy.get('.search-item__jump').first().click()
-			
-			cy.getLastPostId().then((postId) => {
-				// # Click on ... button of last post matching the searchWord
-				cy.clickPostDotMenu(postId);
-				
-				// # Click on edit post
-				cy.get(`#edit_post_${postId}`).click();
-				
-				// # Add new text in edit box
-				cy.get('#edit_textbox').clear().type('edited searchtest');
-				
-				// # Click edit button
-				cy.get('#editButton').click();
-				
-				// # Check edited post
-				cy.get(`#postMessageText_${postId}`).should('contain', 'edited searchtest')
-				cy.get(`#postEdited_${postId}`).should('contain', '(edited)')
-				
-				// # Logout as "user-1"
-				cy.apiLogout('user-1');
-				
-				// # Login as "user-2" and go to /
-				cy.apiLogin('user-2');
-				cy.visit('/');
-				
-				// # Find searchWord and verify edited post
-				cy.get('#searchBox').type(searchWord).type('{enter}').then(() => {
-					cy.get('.search-item__jump').first().click()
-					cy.get(`#postMessageText_${postId}`).should('contain', 'edited searchtest')
-					cy.get(`#postEdited_${postId}`).should('contain', '(edited)')
-				});
-			});
-		});
-	});
+        const searchWord = 'searchtest';
+
+        // # Post message
+        cy.postMessage(searchWord);
+
+        // # Search for searchWord
+        cy.get('#searchBox').type(searchWord).type('{enter}').then(() => {
+            // # Jump to permalink view
+            cy.get('.search-item__jump').first().click();
+
+            cy.getLastPostId().then((postId) => {
+                // # Click on ... button of last post matching the searchWord
+                cy.clickPostDotMenu(postId);
+
+                // # Click on edit post
+                cy.get(`#edit_post_${postId}`).click();
+
+                // # Add new text in edit box
+                cy.get('#edit_textbox').clear().type('edited searchtest');
+
+                // # Click edit button
+                cy.get('#editButton').click();
+
+                // # Check edited post
+                cy.get(`#postMessageText_${postId}`).should('contain', 'edited searchtest');
+                cy.get(`#postEdited_${postId}`).should('contain', '(edited)');
+
+                // # Logout as "user-1"
+                cy.apiLogout('user-1');
+
+                // # Login as "user-2" and go to /
+                cy.apiLogin('user-2');
+                cy.visit('/');
+
+                // # Find searchWord and verify edited post
+                cy.get('#searchBox').type(searchWord).type('{enter}').then(() => {
+                    cy.get('.search-item__jump').first().click();
+                    cy.get(`#postMessageText_${postId}`).should('contain', 'edited searchtest');
+                    cy.get(`#postEdited_${postId}`).should('contain', '(edited)');
+                });
+            });
+        });
+    });
 });

--- a/e2e/cypress/integration/messaging/permalink_message_edit_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_message_edit_spec.js
@@ -1,0 +1,61 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// [number] indicates a test step (e.g. # Go to a page)
+// [*] indicates an assertion (e.g. * Check the title)
+// Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+
+describe('Permalink message edit', () => {
+	it('M18717 - Edit a message in permalink view', () => {
+		// # Login as "user-1" and go to /
+		cy.apiLogin('user-1');
+		cy.visit('/');
+
+		const searchWord = 'searchtest';
+		
+		// # Post message
+		cy.postMessage(searchWord)
+		
+		// # Search for searchWord
+		cy.get('#searchBox').type(searchWord).type('{enter}').then(() => {
+		
+			// # Jump to permalink view	
+			cy.get('.search-item__jump').first().click()
+			
+			cy.getLastPostId().then((postId) => {
+				// # Click on ... button of last post matching the searchWord
+				cy.clickPostDotMenu(postId);
+				
+				// # Click on edit post
+				cy.get(`#edit_post_${postId}`).click();
+				
+				// # Add new text in edit box
+				cy.get('#edit_textbox').clear().type('edited searchtest');
+				
+				// # Click edit button
+				cy.get('#editButton').click();
+				
+				// # Check edited post
+				cy.get(`#postMessageText_${postId}`).should('contain', 'edited searchtest')
+				cy.get(`#postEdited_${postId}`).should('contain', '(edited)')
+				
+				// # Logout as "user-1"
+				cy.apiLogout('user-1');
+				
+				// # Login as "user-2" and go to /
+				cy.apiLogin('user-2');
+				cy.visit('/');
+				
+				// # Find searchWord and verify edited post
+				cy.get('#searchBox').type(searchWord).type('{enter}').then(() => {
+					cy.get('.search-item__jump').first().click()
+					cy.get(`#postMessageText_${postId}`).should('contain', 'edited searchtest')
+					cy.get(`#postEdited_${postId}`).should('contain', '(edited)')
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
#### Summary

This PR adds a Cypress integration test for viewing edited messages in permalink mode.  Integration test behavior is listed below:

**Steps**
---
1.  Log in as User_1 and visit root path
2.  Post a message
3.  Search for the message
4.  Click the jump link to view message in permalink mode
5.  Select the `...` button, edit the message, and submit changes
6.  Verify changes
7.  Log out

**User_2**
---
8.  Log in as User_2 and visit root path
9.  Search for edited message
10.  Click the jump link to view message in permalink mode
11.  Verify changes

**Issues that Need Addressing**

This is my first time ever using cypress, and my first time contributing to Mattermost, so getting a feel for the new environment took some time.  In the assigned [issue](https://github.com/mattermost/mattermost-server/issues/12305), it specifies to test one user with a different browser/device.  Currently, I am unsure of how to implement this in to the test.  I researched the [browser launch API](https://docs.cypress.io/api/plugins/browser-launch-api.html#Usage) a bit, but would appreciate the input of someone more experienced.


#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/12305