### PR TITLE
[MM-13547] Refactor webapp routes

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -323,7 +323,9 @@ export async function completeUserData() {
             }
         }
 
-        await dispatch(fetchMyChannelsAndMembers(team.id));
+        if (team) {
+            await dispatch(fetchMyChannelsAndMembers(team.id));
+        }
     }
 }
 

--- a/actions/global_actions.test.js
+++ b/actions/global_actions.test.js
@@ -3,13 +3,12 @@
 
 import configureStore from 'redux-mock-store';
 
-import {browserHistory} from 'utils/browser_history';
 import {closeRightHandSide, closeMenu as closeRhsMenu} from 'actions/views/rhs';
 import {close as closeLhs} from 'actions/views/lhs';
 import LocalStorageStore from 'stores/local_storage_store';
-import {getState} from 'stores/redux_store';
+import {dispatch, getState} from 'stores/redux_store';
 
-import {redirectUserToDefaultTeam, toggleSideBarRightMenuAction} from 'actions/global_actions.jsx';
+import {completeUserData, defaultRoute, toggleSideBarRightMenuAction} from 'actions/global_actions.jsx';
 
 jest.mock('actions/views/rhs', () => ({
     closeMenu: jest.fn(),
@@ -24,6 +23,14 @@ jest.mock('mattermost-redux/actions/users', () => ({
     loadMe: () => ({type: 'MOCK_RECEIVED_ME'}),
 }));
 
+jest.mock('mattermost-redux/actions/channels', () => ({
+    fetchMyChannelsAndMembers: (teamId) => ({type: 'MOCK_RECEIVED_CHANNELS_AND_MEMBERS', payload: teamId}),
+}));
+
+jest.mock('utils/channel_utils', () => ({
+    getRedirectChannelNameForTeam: () => 'channel-in-team-1',
+}));
+
 jest.mock('stores/redux_store', () => {
     return {
         dispatch: jest.fn(),
@@ -32,8 +39,8 @@ jest.mock('stores/redux_store', () => {
 });
 
 describe('actions/global_actions', () => {
-    describe('redirectUserToDefaultTeam', () => {
-        it('should redirect to /select_team when no team is available', async () => {
+    describe('completeUserData', () => {
+        it('should load the user if it has no memberships', async () => {
             const mockStore = configureStore();
             const store = mockStore({
                 entities: {
@@ -60,18 +67,51 @@ describe('actions/global_actions', () => {
             });
 
             getState.mockImplementation(store.getState);
-
-            browserHistory.push = jest.fn();
-            await redirectUserToDefaultTeam();
-            expect(browserHistory.push).toHaveBeenCalledWith('/select_team');
+            await completeUserData();
+            expect(dispatch).toHaveBeenCalledWith({type: 'MOCK_RECEIVED_ME'});
         });
 
-        it('should redirect to last channel on first team when current team is no longer available', async () => {
-            const userId = 'user1';
-            LocalStorageStore.setPreviousTeamId('non-existent');
-            LocalStorageStore.setPreviousChannelName(userId, 'team1', 'channel-in-team-1');
-            LocalStorageStore.setPreviousChannelName(userId, 'team2', 'channel-in-team-2');
+        it('should fetch channels and members for guest users', async () => {
+            LocalStorageStore.setPreviousTeamId('user1', 'team1');
+            const mockStore = configureStore();
+            const store = mockStore({
+                entities: {
+                    general: {
+                        config: {
+                            DefaultClientLocale: 'en',
+                        },
+                    },
+                    teams: {
+                        teams: {
+                            team1: {id: 'team1', display_name: 'Team 1', name: 'team1', delete_at: 0},
+                        },
+                        myMembers: {
+                            team1: {},
+                        },
+                    },
+                    channels: {
+                        myMembers: {},
+                        channels: {},
+                    },
+                    users: {
+                        currentUserId: 'user1',
+                        profiles: {
+                            user1: {
+                                id: 'user1',
+                                roles: 'system_guest',
+                            },
+                        },
+                    },
+                },
+            });
 
+            getState.mockImplementation(store.getState);
+            await completeUserData();
+            expect(dispatch).toHaveBeenCalledWith({type: 'MOCK_RECEIVED_CHANNELS_AND_MEMBERS', payload: 'team1'});
+        });
+
+        it('should fetch channels and members for guest users when last team is no longer available', async () => {
+            LocalStorageStore.setPreviousTeamId('user1', 'nonexistent');
             const mockStore = configureStore();
             const store = mockStore({
                 entities: {
@@ -88,6 +128,127 @@ describe('actions/global_actions', () => {
                         myMembers: {
                             team1: {},
                             team2: {},
+                        },
+                    },
+                    channels: {
+                        myMembers: {},
+                        channels: {},
+                    },
+                    users: {
+                        currentUserId: 'user1',
+                        profiles: {
+                            user1: {
+                                id: 'user1',
+                                roles: 'system_guest',
+                            },
+                        },
+                    },
+                },
+            });
+
+            getState.mockImplementation(store.getState);
+            await completeUserData();
+            expect(dispatch).toHaveBeenCalledWith({type: 'MOCK_RECEIVED_CHANNELS_AND_MEMBERS', payload: 'team1'});
+        });
+    });
+
+    describe('defaultRoute', () => {
+        it('should redirect to the login if there is no user loaded', () => {
+            const state = {
+                entities: {
+                    general: {
+                        config: {
+                            DefaultClientLocale: 'en',
+                        },
+                    },
+                    teams: {},
+                    channels: {},
+                    users: {
+                        currentUserId: '',
+                        profiles: {},
+                    },
+                },
+            };
+
+            expect(defaultRoute(state)).toBe('/login');
+        });
+
+        it("should redirect to root if we haven't received the user teams yet", () => {
+            const state = {
+                entities: {
+                    general: {
+                        config: {
+                            DefaultClientLocale: 'en',
+                        },
+                    },
+                    teams: {},
+                    channels: {},
+                    users: {
+                        currentUserId: 'user1',
+                        profiles: {
+                            user1: {id: 'user1'},
+                        },
+                    },
+                },
+                requests: {
+                    teams: {
+                        getMyTeams: {},
+                    },
+                },
+            };
+
+            expect(defaultRoute(state)).toBe('/');
+        });
+
+        it("should redirect to root if the user is a guest and they don't have channel memberships", () => {
+            const state = {
+                entities: {
+                    general: {
+                        config: {
+                            DefaultClientLocale: 'en',
+                        },
+                    },
+                    teams: {},
+                    channels: {},
+                    users: {
+                        currentUserId: 'user1',
+                        profiles: {
+                            user1: {
+                                id: 'user1',
+                                roles: 'system_guest',
+                            },
+                        },
+                    },
+                },
+                requests: {
+                    teams: {
+                        getMyTeams: {status: 'success'},
+                    },
+                },
+            };
+
+            expect(defaultRoute(state)).toBe('/');
+        });
+
+        it('should redirect to last team and channel if they are available', () => {
+            LocalStorageStore.setPreviousTeamId('user1', 'team2');
+            LocalStorageStore.setPreviousChannelName('user1', 'team2', 'channel-in-team-2');
+
+            const state = {
+                entities: {
+                    general: {
+                        config: {
+                            DefaultClientLocale: 'en',
+                        },
+                    },
+                    teams: {
+                        teams: {
+                            team1: {id: 'team1', display_name: 'Team 1', name: 'team1', delete_at: 0},
+                            team2: {id: 'team2', display_name: 'Team 2', name: 'team2', delete_at: 0},
+                        },
+                        myMembers: {
+                            team1: {team_id: 'team1'},
+                            team2: {team_id: 'team2'},
                         },
                     },
                     channels: {
@@ -109,19 +270,108 @@ describe('actions/global_actions', () => {
                         },
                     },
                     users: {
-                        currentUserId: userId,
+                        currentUserId: 'user1',
                         profiles: {
-                            [userId]: {id: userId},
+                            user1: {id: 'user1'},
                         },
                     },
                 },
-            });
+                requests: {
+                    teams: {
+                        getMyTeams: {status: 'success'},
+                    },
+                },
+            };
 
-            getState.mockImplementation(store.getState);
+            expect(defaultRoute(state)).toBe('/team2/channels/channel-in-team-2');
+        });
 
-            browserHistory.push = jest.fn();
-            await redirectUserToDefaultTeam();
-            expect(browserHistory.push).toHaveBeenCalledWith('/team1/channels/channel-in-team-1');
+        it('should redirect to last channel on first team when current team is no longer available', () => {
+            LocalStorageStore.setPreviousTeamId('user1', 'nonexistent');
+
+            const state = {
+                entities: {
+                    general: {
+                        config: {
+                            DefaultClientLocale: 'en',
+                        },
+                    },
+                    teams: {
+                        teams: {
+                            team1: {id: 'team1', display_name: 'Team 1', name: 'team1', delete_at: 0},
+                            team2: {id: 'team2', display_name: 'Team 2', name: 'team2', delete_at: 0},
+                        },
+                        myMembers: {
+                            team1: {team_id: 'team1'},
+                            team2: {team_id: 'team2'},
+                        },
+                    },
+                    channels: {
+                        myMembers: {
+                            'channel-in-team-1': {},
+                            'channel-in-team-2': {},
+                        },
+                        channels: {
+                            'channel-in-team-1': {
+                                id: 'channel-in-team-1',
+                                team_id: 'team1',
+                                name: 'channel-in-team-1',
+                            },
+                            'channel-in-team-2': {
+                                id: 'channel-in-team-2',
+                                team_id: 'team2',
+                                name: 'channel-in-team-2',
+                            },
+                        },
+                    },
+                    users: {
+                        currentUserId: 'user1',
+                        profiles: {
+                            user1: {id: 'user1'},
+                        },
+                    },
+                },
+                requests: {
+                    teams: {
+                        getMyTeams: {status: 'success'},
+                    },
+                },
+            };
+
+            expect(defaultRoute(state)).toBe('/team1/channels/channel-in-team-1');
+        });
+
+        it('should redirect to /select_team when no team is available', () => {
+            const state = {
+                entities: {
+                    general: {
+                        config: {
+                            DefaultClientLocale: 'en',
+                        },
+                    },
+                    teams: {
+                        teams: {},
+                        myMembers: {},
+                    },
+                    channels: {
+                        myMembers: {},
+                        channels: {},
+                    },
+                    users: {
+                        currentUserId: 'user1',
+                        profiles: {
+                            user1: {id: 'user1'},
+                        },
+                    },
+                },
+                requests: {
+                    teams: {
+                        getMyTeams: {status: 'success'},
+                    },
+                },
+            };
+
+            expect(defaultRoute(state)).toBe('/select_team');
         });
     });
 

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -59,7 +59,6 @@ import {syncPostsInChannel} from 'actions/views/channel';
 
 import {browserHistory} from 'utils/browser_history';
 import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
-import * as GlobalActions from 'actions/global_actions.jsx';
 import {handleNewPost} from 'actions/post_actions.jsx';
 import * as StatusActions from 'actions/status_actions.jsx';
 import {loadProfilesForSidebar} from 'actions/user_actions.jsx';
@@ -567,7 +566,7 @@ function handleLeaveTeamEvent(msg) {
         // if they are on the team being removed redirect them to default team
         if (getCurrentTeamId(state) === msg.data.team_id) {
             if (!global.location.pathname.startsWith('/admin_console')) {
-                GlobalActions.redirectUserToDefaultTeam();
+                browserHistory.push('/');
             }
         }
     }
@@ -926,7 +925,7 @@ function handleUserRoleUpdated(msg) {
         store.dispatch({type: UserTypes.RECEIVED_PROFILE, data: {...user, roles}});
 
         if (demoted && global.location.pathname.startsWith('/admin_console')) {
-            GlobalActions.redirectUserToDefaultTeam();
+            browserHistory.push('/');
         }
     }
 }

--- a/components/__snapshots__/complete_user_data.test.jsx.snap
+++ b/components/__snapshots__/complete_user_data.test.jsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/CompleteUserData should match snapshot 1`] = `
+<LoadingScreen
+  position="relative"
+  style={Object {}}
+/>
+`;

--- a/components/channel_layout/channel_identifier_router/actions.js
+++ b/components/channel_layout/channel_identifier_router/actions.js
@@ -74,6 +74,7 @@ export function goToChannelByChannelId(match, history) {
         let channel = getChannel(state, channelId);
         const member = state.entities.channels.myMembers[channelId];
         const teamObj = getTeamByName(state, team);
+
         if (!channel || !member) {
             const {data, error} = await dispatch(joinChannel(getCurrentUserId(state), teamObj.id, channelId, null));
             if (error) {

--- a/components/complete_user_data.jsx
+++ b/components/complete_user_data.jsx
@@ -1,0 +1,20 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {completeUserData} from 'actions/global_actions.jsx';
+
+import LoadingScreen from 'components/loading_screen.tsx';
+
+export default class CompleteUserData extends React.Component {
+    componentDidMount() {
+        completeUserData();
+    }
+
+    render() {
+        return (
+            <LoadingScreen/>
+        );
+    }
+}

--- a/components/complete_user_data.test.jsx
+++ b/components/complete_user_data.test.jsx
@@ -1,0 +1,17 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import CompleteUserData from 'components/complete_user_data.jsx';
+
+describe('components/CompleteUserData', () => {
+    it('should match snapshot', () => {
+        const wrapper = shallow(
+            <CompleteUserData/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/components/do_verify_email/do_verify_email.jsx
+++ b/components/do_verify_email/do_verify_email.jsx
@@ -12,8 +12,6 @@ import logoImage from 'images/logo.png';
 import BackButton from 'components/common/back_button.jsx';
 import LoadingScreen from 'components/loading_screen';
 
-import * as GlobalActions from 'actions/global_actions.jsx';
-
 export default class DoVerifyEmail extends React.PureComponent {
     static propTypes = {
 
@@ -70,7 +68,7 @@ export default class DoVerifyEmail extends React.PureComponent {
 
     handleRedirect() {
         if (this.props.isLoggedIn) {
-            GlobalActions.redirectUserToDefaultTeam();
+            browserHistory.push('/');
         } else {
             browserHistory.push('/login?extra=verified&email=' + encodeURIComponent((new URLSearchParams(this.props.location.search)).get('email')));
         }

--- a/components/logged_in/index.js
+++ b/components/logged_in/index.js
@@ -5,24 +5,18 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
-import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getCurrentUser, shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
-
-import {checkIfMFARequired} from 'utils/route';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import LoggedIn from './logged_in.jsx';
 
-function mapStateToProps(state, ownProps) {
-    const license = getLicense(state);
+function mapStateToProps(state) {
     const config = getConfig(state);
-    const showTermsOfService = shouldShowTermsOfService(state);
 
     return {
         currentUser: getCurrentUser(state),
         currentChannelId: getCurrentChannelId(state),
-        mfaRequired: checkIfMFARequired(getCurrentUser(state), license, config, ownProps.match.url),
         enableTimezone: config.ExperimentalTimezone === 'true',
-        showTermsOfService,
     };
 }
 

--- a/components/logged_in/logged_in.jsx
+++ b/components/logged_in/logged_in.jsx
@@ -4,7 +4,6 @@
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Redirect} from 'react-router';
 import {viewChannel} from 'mattermost-redux/actions/channels';
 import semver from 'semver';
 
@@ -28,12 +27,10 @@ export default class LoggedIn extends React.PureComponent {
         currentUser: PropTypes.object,
         currentChannelId: PropTypes.string,
         children: PropTypes.object,
-        mfaRequired: PropTypes.bool.isRequired,
         enableTimezone: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             autoUpdateTimezone: PropTypes.func.isRequired,
         }).isRequired,
-        showTermsOfService: PropTypes.bool.isRequired,
     }
 
     constructor(props) {
@@ -155,18 +152,6 @@ export default class LoggedIn extends React.PureComponent {
     render() {
         if (!this.isValidState()) {
             return <LoadingScreen/>;
-        }
-
-        if (this.props.mfaRequired) {
-            if (this.props.location.pathname !== '/mfa/setup') {
-                return <Redirect to={'/mfa/setup'}/>;
-            }
-        } else if (this.props.location.pathname === '/mfa/confirm') {
-            // Nothing to do. Wait for MFA flow to complete before prompting TOS.
-        } else if (this.props.showTermsOfService) {
-            if (this.props.location.pathname !== '/terms_of_service') {
-                return <Redirect to={'/terms_of_service?redirect_to=' + encodeURIComponent(this.props.location.pathname)}/>;
-            }
         }
 
         return this.props.children;

--- a/components/logged_in/logged_in.test.jsx
+++ b/components/logged_in/logged_in.test.jsx
@@ -14,12 +14,10 @@ describe('components/logged_in/LoggedIn', () => {
     const children = <span>{'Test'}</span>;
     const baseProps = {
         currentUser: {},
-        mfaRequired: false,
         enableTimezone: false,
         actions: {
             autoUpdateTimezone: jest.fn(),
         },
-        showTermsOfService: false,
         location: {
             pathname: '/',
         },
@@ -38,114 +36,6 @@ describe('components/logged_in/LoggedIn', () => {
   position="relative"
   style={Object {}}
 />
-`
-        );
-    });
-
-    it('should redirect to mfa when required and not on /mfa/setup', () => {
-        const props = {
-            ...baseProps,
-            mfaRequired: true,
-        };
-
-        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-
-        expect(wrapper).toMatchInlineSnapshot(`
-<Redirect
-  to="/mfa/setup"
-/>
-`
-        );
-    });
-
-    it('should render children when mfa required and already on /mfa/setup', () => {
-        const props = {
-            ...baseProps,
-            mfaRequired: true,
-            location: {
-                pathname: '/mfa/setup',
-            },
-        };
-
-        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-
-        expect(wrapper).toMatchInlineSnapshot(`
-<span>
-  Test
-</span>
-`
-        );
-    });
-
-    it('should render children when mfa is not required and on /mfa/confirm', () => {
-        const props = {
-            ...baseProps,
-            mfaRequired: false,
-            location: {
-                pathname: '/mfa/confirm',
-            },
-        };
-
-        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-
-        expect(wrapper).toMatchInlineSnapshot(`
-<span>
-  Test
-</span>
-`
-        );
-    });
-
-    it('should redirect to terms of service when mfa not required and terms of service required but not on /terms_of_service', () => {
-        const props = {
-            ...baseProps,
-            mfaRequired: false,
-            showTermsOfService: true,
-        };
-
-        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-
-        expect(wrapper).toMatchInlineSnapshot(`
-<Redirect
-  to="/terms_of_service?redirect_to=%2F"
-/>
-`
-        );
-    });
-
-    it('should render children when mfa is not required and terms of service required and on /terms_of_service', () => {
-        const props = {
-            ...baseProps,
-            mfaRequired: false,
-            showTermsOfService: true,
-            location: {
-                pathname: '/terms_of_service',
-            },
-        };
-
-        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-
-        expect(wrapper).toMatchInlineSnapshot(`
-<span>
-  Test
-</span>
-`
-        );
-    });
-
-    it('should render children when neither mfa nor terms of service required', () => {
-        const props = {
-            ...baseProps,
-            mfaRequired: false,
-            showTermsOfService: false,
-        };
-
-        const wrapper = shallow(<LoggedIn {...props}>{children}</LoggedIn>);
-
-        expect(wrapper).toMatchInlineSnapshot(`
-<span>
-  Test
-</span>
 `
         );
     });

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -8,7 +8,6 @@ import {Link} from 'react-router-dom';
 
 import {Client4} from 'mattermost-redux/client';
 
-import * as GlobalActions from 'actions/global_actions.jsx';
 import LocalStorageStore from 'stores/local_storage_store';
 
 import {browserHistory} from 'utils/browser_history';
@@ -90,7 +89,7 @@ class LoginController extends React.Component {
         this.configureTitle();
 
         if (this.props.currentUser) {
-            GlobalActions.redirectUserToDefaultTeam();
+            browserHistory.push('/');
             return;
         }
 
@@ -333,7 +332,7 @@ class LoginController extends React.Component {
         } else if (experimentalPrimaryTeam) {
             browserHistory.push(`/${experimentalPrimaryTeam}`);
         } else {
-            GlobalActions.redirectUserToDefaultTeam();
+            browserHistory.push('/');
         }
     }
 

--- a/components/mfa/confirm.jsx
+++ b/components/mfa/confirm.jsx
@@ -7,7 +7,7 @@ import {FormattedMessage} from 'react-intl';
 import Constants from 'utils/constants.jsx';
 import {isKeyPressed} from 'utils/utils.jsx';
 
-import {redirectUserToDefaultTeam} from 'actions/global_actions.jsx';
+import {browserHistory} from 'utils/browser_history.jsx';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
@@ -24,7 +24,7 @@ export default class Confirm extends React.Component {
 
     submit = (e) => {
         e.preventDefault();
-        redirectUserToDefaultTeam();
+        browserHistory.push('/');
     }
 
     onKeyPress = (e) => {

--- a/components/mfa/confirm.test.jsx
+++ b/components/mfa/confirm.test.jsx
@@ -4,14 +4,16 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import {redirectUserToDefaultTeam} from 'actions/global_actions.jsx';
+import {browserHistory} from 'utils/browser_history.jsx';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 import Confirm from 'components/mfa/confirm.jsx';
 import Constants from 'utils/constants.jsx';
 
-jest.mock('actions/global_actions.jsx', () => ({
-    redirectUserToDefaultTeam: jest.fn(),
+jest.mock('utils/browser_history.jsx', () => ({
+    browserHistory: {
+        push: jest.fn(),
+    },
 }));
 
 describe('components/mfa/components/Confirm', () => {
@@ -29,7 +31,7 @@ describe('components/mfa/components/Confirm', () => {
         const wrapper = mountWithIntl(<Confirm/>);
         wrapper.find('form').simulate('submit');
 
-        expect(redirectUserToDefaultTeam).toHaveBeenCalled();
+        expect(browserHistory.push).toHaveBeenCalledWith('/');
     });
 
     test('should submit on enter', () => {
@@ -46,6 +48,6 @@ describe('components/mfa/components/Confirm', () => {
         };
         map.keydown(event);
 
-        expect(redirectUserToDefaultTeam).toHaveBeenCalled();
+        expect(browserHistory.push).toHaveBeenCalledWith('/');
     });
 });

--- a/components/mfa/mfa_controller/mfa_controller.jsx
+++ b/components/mfa/mfa_controller/mfa_controller.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {Route, Switch} from 'react-router-dom';
 
 import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 import logoImage from 'images/logo.png';
@@ -15,6 +14,12 @@ import Setup from '../setup';
 import Confirm from '../confirm';
 
 export default class MFAController extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {setupCompleted: false};
+    }
+
     componentDidMount() {
         document.body.classList.add('sticky');
         document.getElementById('root').classList.add('container-fluid');
@@ -33,6 +38,10 @@ export default class MFAController extends React.Component {
         e.preventDefault();
         emitUserLoggedOutEvent('/login');
     }
+
+    completeSetup = () => {
+        this.setState({setupCompleted: true});
+    };
 
     render() {
         let backButton;
@@ -55,6 +64,18 @@ export default class MFAController extends React.Component {
             backButton = (<BackButton/>);
         }
 
+        let step;
+        if (this.state.setupCompleted) {
+            step = (<Confirm state={this.state}/>);
+        } else {
+            step = (
+                <Setup
+                    state={this.state}
+                    completeSetup={this.completeSetup}
+                />
+            );
+        }
+
         return (
             <div className='inner-wrap'>
                 <div className='row content'>
@@ -74,28 +95,7 @@ export default class MFAController extends React.Component {
                                     src={logoImage}
                                 />
                                 <div id='mfa'>
-                                    <Switch>
-                                        <Route
-                                            path={`${this.props.match.url}/setup`}
-                                            render={(props) => (
-                                                <Setup
-                                                    state={this.state}
-                                                    updateParent={this.updateParent}
-                                                    {...props}
-                                                />
-                                            )}
-                                        />
-                                        <Route
-                                            path={`${this.props.match.url}/confirm`}
-                                            render={(props) => (
-                                                <Confirm
-                                                    state={this.state}
-                                                    updateParent={this.updateParent}
-                                                    {...props}
-                                                />
-                                            )}
-                                        />
-                                    </Switch>
+                                    {step}
                                 </div>
                             </div>
                         </div>

--- a/components/mfa/setup/setup.jsx
+++ b/components/mfa/setup/setup.jsx
@@ -14,6 +14,7 @@ import LocalizedInput from 'components/localized_input/localized_input';
 export default class Setup extends React.Component {
     static propTypes = {
         currentUser: PropTypes.object,
+        completeSetup: PropTypes.func.isRequired,
         siteName: PropTypes.string,
         enforceMultifactorAuthentication: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
@@ -75,7 +76,7 @@ export default class Setup extends React.Component {
                 return;
             }
 
-            this.props.history.push('/mfa/confirm');
+            this.props.completeSetup();
         });
     }
 

--- a/components/needs_team/index.js
+++ b/components/needs_team/index.js
@@ -9,7 +9,6 @@ import {loadProfilesForDirect} from 'mattermost-redux/actions/users';
 import {fetchMyChannelsAndMembers, markChannelAsRead, viewChannel} from 'mattermost-redux/actions/channels';
 import {getMyTeamUnreads, getTeamByName, selectTeam} from 'mattermost-redux/actions/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
-import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
@@ -17,18 +16,14 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 import {loadStatusesForChannelAndSidebar} from 'actions/status_actions';
 import {setPreviousTeamId} from 'actions/local_storage';
 import {addUserToTeam} from 'actions/team_actions';
-import {checkIfMFARequired} from 'utils/route';
 
 import NeedsTeam from './needs_team.jsx';
 
-function mapStateToProps(state, ownProps) {
-    const license = getLicense(state);
-    const config = getConfig(state);
+function mapStateToProps(state) {
     const currentUser = getCurrentUser(state);
 
     return {
         theme: getTheme(state),
-        mfaRequired: checkIfMFARequired(currentUser, license, config, ownProps.match.url),
         currentUser,
         currentTeamId: getCurrentTeamId(state),
         teamsList: getMyTeams(state),

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -43,7 +43,6 @@ export default class NeedsTeam extends React.Component {
             loadProfilesForDirect: PropTypes.func.isRequired,
         }).isRequired,
         theme: PropTypes.object.isRequired,
-        mfaRequired: PropTypes.bool.isRequired,
 
         /*
          * Object from react-router
@@ -59,11 +58,6 @@ export default class NeedsTeam extends React.Component {
     constructor(params) {
         super(params);
         this.blurTime = new Date().getTime();
-
-        if (this.props.mfaRequired) {
-            this.props.history.push('/mfa/setup');
-            return;
-        }
 
         clearInterval(wakeUpInterval);
 

--- a/components/root/index.js
+++ b/components/root/index.js
@@ -5,7 +5,6 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
 
 import {loadMeAndConfig} from 'actions/views/root';
 
@@ -13,13 +12,10 @@ import Root from './root.jsx';
 
 function mapStateToProps(state) {
     const config = getConfig(state);
-    const showTermsOfService = shouldShowTermsOfService(state);
 
     return {
         diagnosticsEnabled: config.DiagnosticsEnabled === 'true',
-        noAccounts: config.NoAccounts === 'true',
         diagnosticId: config.DiagnosticId,
-        showTermsOfService,
     };
 }
 

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -7,10 +7,8 @@ require('perfect-scrollbar/jquery')($);
 import PropTypes from 'prop-types';
 import React from 'react';
 import FastClick from 'fastclick';
-import {Route, Switch, Redirect} from 'react-router-dom';
 import {setUrl} from 'mattermost-redux/actions/general';
 import {setSystemEmojis} from 'mattermost-redux/actions/emojis';
-import {getConfig} from 'mattermost-redux/selectors/entities/general';
 
 import * as UserAgent from 'utils/user_agent.jsx';
 import {EmojiIndicesByAlias} from 'utils/emoji.jsx';
@@ -22,72 +20,18 @@ import * as I18n from 'i18n/i18n.jsx';
 import {initializePlugins} from 'plugins';
 import 'plugins/export.js';
 import Constants, {StoragePrefixes} from 'utils/constants.jsx';
-import {HFTRoute, LoggedInHFTRoute} from 'components/header_footer_template_route';
 import IntlProvider from 'components/intl_provider';
-import NeedsTeam from 'components/needs_team';
-import PermalinkRedirector from 'components/permalink_redirector';
-import {makeAsyncComponent} from 'components/async_load';
-import loadErrorPage from 'bundle-loader?lazy!components/error_page';
-import loadLoginController from 'bundle-loader?lazy!components/login/login_controller';
-import loadAdminConsole from 'bundle-loader?lazy!components/admin_console';
-import loadLoggedIn from 'bundle-loader?lazy!components/logged_in';
-import loadPasswordResetSendLink from 'bundle-loader?lazy!components/password_reset_send_link';
-import loadPasswordResetForm from 'bundle-loader?lazy!components/password_reset_form';
-import loadSignupController from 'bundle-loader?lazy!components/signup/signup_controller';
-import loadSignupEmail from 'bundle-loader?lazy!components/signup/signup_email';
-import loadTermsOfService from 'bundle-loader?lazy!components/terms_of_service';
-import loadShouldVerifyEmail from 'bundle-loader?lazy!components/should_verify_email';
-import loadDoVerifyEmail from 'bundle-loader?lazy!components/do_verify_email';
-import loadClaimController from 'bundle-loader?lazy!components/claim';
-import loadHelpController from 'bundle-loader?lazy!components/help/help_controller';
-import loadGetIosApp from 'bundle-loader?lazy!components/get_ios_app';
-import loadGetAndroidApp from 'bundle-loader?lazy!components/get_android_app';
-import loadSelectTeam from 'bundle-loader?lazy!components/select_team';
-import loadAuthorize from 'bundle-loader?lazy!components/authorize';
-import loadCreateTeam from 'bundle-loader?lazy!components/create_team';
-import loadMfa from 'bundle-loader?lazy!components/mfa/mfa_controller';
 import store from 'stores/redux_store.jsx';
 import {getSiteURL} from 'utils/url.jsx';
 import {enableDevModeFeatures, isDevMode} from 'utils/utils';
 import A11yController from 'utils/a11y_controller';
 
-const CreateTeam = makeAsyncComponent(loadCreateTeam);
-const ErrorPage = makeAsyncComponent(loadErrorPage);
-const TermsOfService = makeAsyncComponent(loadTermsOfService);
-const LoginController = makeAsyncComponent(loadLoginController);
-const AdminConsole = makeAsyncComponent(loadAdminConsole);
-const LoggedIn = makeAsyncComponent(loadLoggedIn);
-const PasswordResetSendLink = makeAsyncComponent(loadPasswordResetSendLink);
-const PasswordResetForm = makeAsyncComponent(loadPasswordResetForm);
-const SignupController = makeAsyncComponent(loadSignupController);
-const SignupEmail = makeAsyncComponent(loadSignupEmail);
-const ShouldVerifyEmail = makeAsyncComponent(loadShouldVerifyEmail);
-const DoVerifyEmail = makeAsyncComponent(loadDoVerifyEmail);
-const ClaimController = makeAsyncComponent(loadClaimController);
-const HelpController = makeAsyncComponent(loadHelpController);
-const GetIosApp = makeAsyncComponent(loadGetIosApp);
-const GetAndroidApp = makeAsyncComponent(loadGetAndroidApp);
-const SelectTeam = makeAsyncComponent(loadSelectTeam);
-const Authorize = makeAsyncComponent(loadAuthorize);
-const Mfa = makeAsyncComponent(loadMfa);
-
-const LoggedInRoute = ({component: Component, ...rest}) => (
-    <Route
-        {...rest}
-        render={(props) => (
-            <LoggedIn {...props}>
-                <Component {...props}/>
-            </LoggedIn>
-        )}
-    />
-);
+import RootSwitch from './switch';
 
 export default class Root extends React.Component {
     static propTypes = {
         diagnosticsEnabled: PropTypes.bool,
         diagnosticId: PropTypes.string,
-        noAccounts: PropTypes.bool,
-        showTermsOfService: PropTypes.bool,
         actions: PropTypes.shape({
             loadMeAndConfig: PropTypes.func.isRequired,
         }).isRequired,
@@ -143,6 +87,7 @@ export default class Root extends React.Component {
 
         this.state = {
             configLoaded: false,
+            completingUserData: false,
         };
 
         // Keyboard navigation for accessibility
@@ -196,10 +141,6 @@ export default class Root extends React.Component {
         /*eslint-enable */
 
         const afterIntl = () => {
-            if (this.props.location.pathname === '/' && this.props.noAccounts) {
-                this.props.history.push('/signup_user_complete');
-            }
-
             initializePlugins().then(() => {
                 this.setState({configLoaded: true});
             });
@@ -211,43 +152,10 @@ export default class Root extends React.Component {
         }
 
         loadRecentlyUsedCustomEmojis()(store.dispatch, store.getState);
-
-        const iosDownloadLink = getConfig(store.getState()).IosAppDownloadLink;
-        const androidDownloadLink = getConfig(store.getState()).AndroidAppDownloadLink;
-
-        const toResetPasswordScreen = this.props.location.pathname === '/reset_password_complete';
-
-        // redirect to the mobile landing page if the user hasn't seen it before
-        if (iosDownloadLink && UserAgent.isIosWeb() && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen) {
-            this.props.history.push('/get_ios_app?redirect_to=' + encodeURIComponent(this.props.location.pathname) + encodeURIComponent(this.props.location.search));
-            BrowserStore.setLandingPageSeen(true);
-        } else if (androidDownloadLink && UserAgent.isAndroidWeb() && !BrowserStore.hasSeenLandingPage() && !toResetPasswordScreen) {
-            this.props.history.push('/get_android_app?redirect_to=' + encodeURIComponent(this.props.location.pathname) + encodeURIComponent(this.props.location.search));
-            BrowserStore.setLandingPageSeen(true);
-        }
-    }
-
-    redirectIfNecessary = (props) => {
-        if (props.location.pathname === '/') {
-            if (this.props.noAccounts) {
-                this.props.history.push('/signup_user_complete');
-            } else if (props.showTermsOfService) {
-                this.props.history.push('/terms_of_service');
-            }
-        }
-    }
-
-    UNSAFE_componentWillReceiveProps(newProps) { // eslint-disable-line camelcase
-        this.redirectIfNecessary(newProps);
     }
 
     componentDidMount() {
-        this.props.actions.loadMeAndConfig().then((response) => {
-            if (this.props.location.pathname === '/' && response[2] && response[2].data) {
-                GlobalActions.redirectUserToDefaultTeam();
-            }
-            this.onConfigLoaded();
-        });
+        this.props.actions.loadMeAndConfig().then(() => this.onConfigLoaded());
         trackLoadTime();
     }
 
@@ -262,94 +170,7 @@ export default class Root extends React.Component {
 
         return (
             <IntlProvider>
-                <Switch>
-                    <Route
-                        path={'/error'}
-                        component={ErrorPage}
-                    />
-                    <HFTRoute
-                        path={'/login'}
-                        component={LoginController}
-                    />
-                    <HFTRoute
-                        path={'/reset_password'}
-                        component={PasswordResetSendLink}
-                    />
-                    <HFTRoute
-                        path={'/reset_password_complete'}
-                        component={PasswordResetForm}
-                    />
-                    <HFTRoute
-                        path={'/signup_user_complete'}
-                        component={SignupController}
-                    />
-                    <HFTRoute
-                        path={'/signup_email'}
-                        component={SignupEmail}
-                    />
-                    <HFTRoute
-                        path={'/should_verify_email'}
-                        component={ShouldVerifyEmail}
-                    />
-                    <HFTRoute
-                        path={'/do_verify_email'}
-                        component={DoVerifyEmail}
-                    />
-                    <HFTRoute
-                        path={'/claim'}
-                        component={ClaimController}
-                    />
-                    <HFTRoute
-                        path={'/help'}
-                        component={HelpController}
-                    />
-                    <LoggedInRoute
-                        path={'/terms_of_service'}
-                        component={TermsOfService}
-                    />
-                    <Route
-                        path={'/get_ios_app'}
-                        component={GetIosApp}
-                    />
-                    <Route
-                        path={'/get_android_app'}
-                        component={GetAndroidApp}
-                    />
-                    <LoggedInRoute
-                        path={'/admin_console'}
-                        component={AdminConsole}
-                    />
-                    <LoggedInHFTRoute
-                        path={'/select_team'}
-                        component={SelectTeam}
-                    />
-                    <LoggedInHFTRoute
-                        path={'/oauth/authorize'}
-                        component={Authorize}
-                    />
-                    <LoggedInHFTRoute
-                        path={'/create_team'}
-                        component={CreateTeam}
-                    />
-                    <LoggedInRoute
-                        path={'/mfa'}
-                        component={Mfa}
-                    />
-                    <LoggedInRoute
-                        path={['/_redirect/integrations*', '/_redirect/pl/:postid']}
-                        component={PermalinkRedirector}
-                    />
-                    <LoggedInRoute
-                        path={'/:team'}
-                        component={NeedsTeam}
-                    />
-                    <Redirect
-                        to={{
-                            ...this.props.location,
-                            pathname: '/login',
-                        }}
-                    />
-                </Switch>
+                <RootSwitch/>
             </IntlProvider>
         );
     }

--- a/components/root/root.test.jsx
+++ b/components/root/root.test.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import Root from 'components/root/root';
-import * as GlobalActions from 'actions/global_actions.jsx';
 import * as Utils from 'utils/utils';
 
 jest.mock('fastclick', () => ({
@@ -14,10 +13,6 @@ jest.mock('fastclick', () => ({
 
 jest.mock('actions/diagnostics_actions', () => ({
     trackLoadTime: () => {}, // eslint-disable-line no-empty-function
-}));
-
-jest.mock('actions/global_actions', () => ({
-    redirectUserToDefaultTeam: jest.fn(),
 }));
 
 jest.mock('utils/utils', () => ({
@@ -58,10 +53,9 @@ describe('components/Root', () => {
         expect(props.actions.loadMeAndConfig).toHaveBeenCalledTimes(1);
 
         wrapper.instance().onConfigLoaded();
-        expect(props.history.push).toHaveBeenCalledWith('/signup_user_complete');
     });
 
-    test('should load user, config, and license on mount and redirect to defaultTeam on success', (done) => {
+    test('should load user, config and license on mount', (done) => {
         const props = {
             ...baseProps,
             actions: {
@@ -74,7 +68,6 @@ describe('components/Root', () => {
         class MockedRoot extends Root {
             onConfigLoaded = jest.fn(() => {
                 expect(this.onConfigLoaded).toHaveBeenCalledTimes(1);
-                expect(GlobalActions.redirectUserToDefaultTeam).toHaveBeenCalledTimes(1);
                 done();
             });
         }
@@ -82,26 +75,6 @@ describe('components/Root', () => {
         shallow(<MockedRoot {...props}/>);
 
         expect(props.actions.loadMeAndConfig).toHaveBeenCalledTimes(1);
-    });
-
-    test('should load user, config, and license on mount and should not redirect to defaultTeam id pathname is not root', (done) => {
-        const props = {
-            ...baseProps,
-            location: {
-                pathname: '/admin_console',
-            },
-        };
-
-        // Mock the method by extending the class because we don't have a chance to do it before shallow mounts the component
-        class MockedRoot extends Root {
-            onConfigLoaded = jest.fn(() => {
-                expect(this.onConfigLoaded).toHaveBeenCalledTimes(1);
-                expect(GlobalActions.redirectUserToDefaultTeam).not.toHaveBeenCalled();
-                done();
-            });
-        }
-
-        shallow(<MockedRoot {...props}/>);
     });
 
     test('should load config and enable dev mode features', () => {

--- a/components/root/switch/index.js
+++ b/components/root/switch/index.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {withRouter} from 'react-router-dom';
+import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getCurrentUserId, getCurrentUser, shouldShowTermsOfService} from 'mattermost-redux/selectors/entities/users';
+
+import {checkIfMFARequired} from 'utils/route';
+
+import {defaultRoute} from 'actions/global_actions.jsx';
+
+import Switch from './switch.jsx';
+
+function mapStateToProps(state) {
+    const license = getLicense(state);
+    const config = getConfig(state);
+
+    return {
+        currentUserId: getCurrentUserId(state),
+        defaultRoute: defaultRoute(state),
+        noAccounts: config.NoAccounts === 'true',
+        mfaRequired: checkIfMFARequired(getCurrentUser(state), license, config),
+        showTermsOfService: shouldShowTermsOfService(state),
+        iosDownloadLink: config.IosAppDownloadLink,
+        androidDownloadLink: config.AndroidAppDownloadLink,
+    };
+}
+
+export default withRouter(connect(mapStateToProps)(Switch));

--- a/components/root/switch/switch.jsx
+++ b/components/root/switch/switch.jsx
@@ -1,0 +1,321 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Route, Switch, Redirect} from 'react-router-dom';
+
+import {HFTRoute, LoggedInHFTRoute} from 'components/header_footer_template_route';
+import NeedsTeam from 'components/needs_team';
+import PermalinkRedirector from 'components/permalink_redirector';
+import {makeAsyncComponent} from 'components/async_load';
+import BrowserStore from 'stores/browser_store.jsx';
+import * as UserAgent from 'utils/user_agent.jsx';
+import CompleteUserData from 'components/complete_user_data.jsx';
+
+import loadErrorPage from 'bundle-loader?lazy!components/error_page';
+import loadLoginController from 'bundle-loader?lazy!components/login/login_controller';
+import loadAdminConsole from 'bundle-loader?lazy!components/admin_console';
+import loadLoggedIn from 'bundle-loader?lazy!components/logged_in';
+import loadPasswordResetSendLink from 'bundle-loader?lazy!components/password_reset_send_link';
+import loadPasswordResetForm from 'bundle-loader?lazy!components/password_reset_form';
+import loadSignupController from 'bundle-loader?lazy!components/signup/signup_controller';
+import loadSignupEmail from 'bundle-loader?lazy!components/signup/signup_email';
+import loadTermsOfService from 'bundle-loader?lazy!components/terms_of_service';
+import loadShouldVerifyEmail from 'bundle-loader?lazy!components/should_verify_email';
+import loadDoVerifyEmail from 'bundle-loader?lazy!components/do_verify_email';
+import loadClaimController from 'bundle-loader?lazy!components/claim';
+import loadHelpController from 'bundle-loader?lazy!components/help/help_controller';
+import loadGetIosApp from 'bundle-loader?lazy!components/get_ios_app';
+import loadGetAndroidApp from 'bundle-loader?lazy!components/get_android_app';
+import loadSelectTeam from 'bundle-loader?lazy!components/select_team';
+import loadAuthorize from 'bundle-loader?lazy!components/authorize';
+import loadCreateTeam from 'bundle-loader?lazy!components/create_team';
+import loadMfa from 'bundle-loader?lazy!components/mfa/mfa_controller';
+
+const CreateTeam = makeAsyncComponent(loadCreateTeam);
+const ErrorPage = makeAsyncComponent(loadErrorPage);
+const TermsOfService = makeAsyncComponent(loadTermsOfService);
+const LoginController = makeAsyncComponent(loadLoginController);
+const AdminConsole = makeAsyncComponent(loadAdminConsole);
+const LoggedIn = makeAsyncComponent(loadLoggedIn);
+const PasswordResetSendLink = makeAsyncComponent(loadPasswordResetSendLink);
+const PasswordResetForm = makeAsyncComponent(loadPasswordResetForm);
+const SignupController = makeAsyncComponent(loadSignupController);
+const SignupEmail = makeAsyncComponent(loadSignupEmail);
+const ShouldVerifyEmail = makeAsyncComponent(loadShouldVerifyEmail);
+const DoVerifyEmail = makeAsyncComponent(loadDoVerifyEmail);
+const ClaimController = makeAsyncComponent(loadClaimController);
+const HelpController = makeAsyncComponent(loadHelpController);
+const GetIosApp = makeAsyncComponent(loadGetIosApp);
+const GetAndroidApp = makeAsyncComponent(loadGetAndroidApp);
+const SelectTeam = makeAsyncComponent(loadSelectTeam);
+const Authorize = makeAsyncComponent(loadAuthorize);
+const Mfa = makeAsyncComponent(loadMfa);
+
+const LoggedInRoute = ({component: Component, ...rest}) => (
+    <Route
+        {...rest}
+        render={(props) => (
+            <LoggedIn {...props}>
+                <Component {...props}/>
+            </LoggedIn>
+        )}
+    />
+);
+
+export default class RootSwitch extends React.PureComponent {
+    static propTypes = {
+        currentUserId: PropTypes.string,
+        defaultRoute: PropTypes.string.isRequired,
+        noAccounts: PropTypes.bool.isRequired,
+        mfaRequired: PropTypes.bool.isRequired,
+        showTermsOfService: PropTypes.bool.isRequired,
+        iosDownloadLink: PropTypes.string,
+        androidDownloadLink: PropTypes.string,
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            currentUserIdSet: 0,
+            showTermsOfServiceSet: 0,
+        };
+    }
+
+    componentDidUpdate(prevProps) {
+        /* eslint-disable react/no-did-update-set-state */
+
+        // Record the time when the currentUserId is first set.
+        if (!prevProps.currentUserId && this.props.currentUserId) {
+            this.setState({
+                currentUserIdSet: Date.now(),
+            });
+        }
+
+        // Record the time when showTermsOfService is first set.
+        if (!prevProps.showTermsOfService && this.props.showTermsOfService) {
+            this.setState({
+                showTermsOfServiceSet: Date.now(),
+            });
+        }
+    }
+
+    shouldShowTermsOfService() {
+        // Honour a request to show terms of service only within 15 seconds of transitioning to
+        // the logged in state with the showTermsOfService bit set. This prevents forcing all users
+        // through the terms of service flow when enabled until they next login or refresh the
+        // page.
+        return this.props.showTermsOfService &&
+            this.state.showTermsOfServiceSet > 0 &&
+            Math.abs(this.state.showTermsOfServiceSet - this.state.currentUserIdSet) < 15 * 1000;
+    }
+
+    render() {
+        let routes = [];
+
+        routes = routes.concat([
+            <Route
+                key={'/error'}
+                path={'/error'}
+                component={ErrorPage}
+            />,
+            <HFTRoute
+                key={'/login'}
+                path={'/login'}
+                component={LoginController}
+            />,
+            <HFTRoute
+                key={'/reset_password'}
+                path={'/reset_password'}
+                component={PasswordResetSendLink}
+            />,
+            <HFTRoute
+                key={'/reset_password_complete'}
+                path={'/reset_password_complete'}
+                component={PasswordResetForm}
+            />,
+            <HFTRoute
+                key={'/signup_email'}
+                path={'/signup_email'}
+                component={SignupEmail}
+            />,
+            <HFTRoute
+                key={'/should_verify_email'}
+                path={'/should_verify_email'}
+                component={ShouldVerifyEmail}
+            />,
+            <HFTRoute
+                key={'/do_verify_email'}
+                path={'/do_verify_email'}
+                component={DoVerifyEmail}
+            />,
+            <HFTRoute
+                key={'/claim'}
+                path={'/claim'}
+                component={ClaimController}
+            />,
+            <HFTRoute
+                key={'/help'}
+                path={'/help'}
+                component={HelpController}
+            />,
+        ]);
+
+        // Setup handling for the sign up controller. If there are no accounts, force creation.
+        routes.push(
+            <HFTRoute
+                key={'/signup_user_complete'}
+                path={'/signup_user_complete'}
+                component={SignupController}
+            />
+        );
+        if (this.props.noAccounts) {
+            routes.push(
+                <Redirect
+                    key={'/signup_user_complete'}
+                    to={'/signup_user_complete'}
+                />
+            );
+        }
+
+        // Setup the MFA route. If MFA setup is required, force the user through the flow.
+        routes.push(
+            <LoggedInRoute
+                key={'/mfa'}
+                path={'/mfa'}
+                component={Mfa}
+            />
+        );
+
+        if (this.props.mfaRequired) {
+            routes.push(
+                <Redirect
+                    key={'/mfa?redirect'}
+                    to={'/mfa?redirect_to=' + encodeURIComponent(this.props.location.pathname)}
+                />
+            );
+        }
+
+        // Setup the TOS route. If the TOS flow is required, force the user through it.
+        routes.push(
+            <LoggedInRoute
+                key={'/terms_of_service'}
+                path={'/terms_of_service'}
+                component={TermsOfService}
+            />
+        );
+
+        if (this.shouldShowTermsOfService()) {
+            routes.push(
+                <Redirect
+                    key='/terms_of_service?redirect_to'
+                    to={'/terms_of_service?redirect_to=' + encodeURIComponent(this.props.location.pathname)}
+                />
+            );
+        }
+
+        const seenLandingPage = BrowserStore.hasSeenLandingPage();
+        const promptIosDownload = this.props.iosDownloadLink && UserAgent.isIosWeb() && !seenLandingPage;
+        const promptAndroidDownload = this.props.androidDownloadLink && UserAgent.isAndroidWeb() && !seenLandingPage;
+
+        // Prompt an iOS customer to try the app, unless already seen.
+        routes.push(
+            <Route
+                key={'/get_ios_app'}
+                path={'/get_ios_app'}
+                component={GetIosApp}
+            />
+        );
+        if (promptIosDownload) {
+            BrowserStore.setLandingPageSeen(true);
+            routes.push(
+                <Redirect
+                    key='/get_ios_app?redirect_to'
+                    to={'/get_ios_app?redirect_to=' + encodeURIComponent(this.props.location.pathname)}
+                />
+            );
+        }
+
+        // Prompt an Android customer to try the app, unless already seen.
+        routes.push(
+            <Route
+                key={'/get_android_app'}
+                path={'/get_android_app'}
+                component={GetAndroidApp}
+            />
+        );
+        if (promptAndroidDownload) {
+            BrowserStore.setLandingPageSeen(true);
+            routes.push(
+                <Redirect
+                    key='/get_android_app?redirect_to'
+                    to={'/get_android_app?redirect_to=' + encodeURIComponent(this.props.location.pathname)}
+                />
+            );
+        }
+
+        routes = routes.concat([
+            <LoggedInRoute
+                key={'/admin_console'}
+                path={'/admin_console'}
+                component={AdminConsole}
+            />,
+            <LoggedInHFTRoute
+                key={'/select_team'}
+                path={'/select_team'}
+                component={SelectTeam}
+            />,
+            <LoggedInHFTRoute
+                key={'/oauth/authorize'}
+                path={'/oauth/authorize'}
+                component={Authorize}
+            />,
+            <LoggedInHFTRoute
+                key={'/create_team'}
+                path={'/create_team'}
+                component={CreateTeam}
+            />,
+            <LoggedInRoute
+                key={'/_redirect'}
+                path={['/_redirect/integrations*', '/_redirect/pl/:postid']}
+                component={PermalinkRedirector}
+            />,
+            <LoggedInRoute
+                key={'/:team'}
+                path={'/:team'}
+                component={NeedsTeam}
+            />,
+        ]);
+
+        // If the defaultRoute is '/`, there is insufficient data to
+        // determine where to route the user. Render a loading screen
+        // while fetching new data until the defaultRoute changes.
+        if (this.props.defaultRoute === '/') {
+            routes.push(
+                <Route
+                    key={'/'}
+                    path={'/'}
+                    component={CompleteUserData}
+                />
+            );
+        }
+
+        routes.push(
+            <Redirect
+                key={'/default'}
+                to={{
+                    ...this.props.location,
+                    pathname: this.props.defaultRoute,
+                }}
+            />
+        );
+
+        return (
+            <Switch>
+                {routes}
+            </Switch>
+        );
+    }
+}

--- a/components/root/switch/switch.jsx
+++ b/components/root/switch/switch.jsx
@@ -279,7 +279,7 @@ export default class RootSwitch extends React.PureComponent {
             />,
             <LoggedInRoute
                 key={'/_redirect'}
-                path={['/_redirect/integrations*', '/_redirect/pl/:postid']}
+                path={['/_redirect/integrations*', '/_redirect/pl/:postid', '/_redirect/messages/@:username']}
                 component={PermalinkRedirector}
             />,
             <LoggedInRoute

--- a/components/root/switch/switch.test.jsx
+++ b/components/root/switch/switch.test.jsx
@@ -1,0 +1,138 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import {Redirect} from 'react-router-dom';
+
+import Switch from 'components/root/switch/switch.jsx';
+
+describe('components/root/switch/switch', () => {
+    const baseProps = {
+        location: {
+            pathname: '/',
+        },
+        defaultRoute: '/',
+        noAccounts: false,
+        mfaRequired: false,
+        showTermsOfService: false,
+    };
+
+    it('should redirect to mfa when required', () => {
+        const props = {
+            ...baseProps,
+            mfaRequired: true,
+        };
+
+        const wrapper = shallow(<Switch {...props}/>);
+        const redirectComponents = wrapper.find(Redirect);
+
+        expect(redirectComponents).toHaveLength(2);
+        expect(redirectComponents.first()).toMatchInlineSnapshot(`
+<Redirect
+  key="/mfa?redirect"
+  to="/mfa?redirect_to=%2F"
+/>
+`);
+    });
+
+    it('should not redirect to mfa if not required', () => {
+        const props = {
+            ...baseProps,
+            mfaRequired: false,
+        };
+
+        const wrapper = shallow(<Switch {...props}/>);
+
+        expect(wrapper.find(Redirect)).toHaveLength(1);
+    });
+
+    it('should redirect to mfa if both mfa and terms of service are required', () => {
+        const props = {
+            ...baseProps,
+            mfaRequired: true,
+            showTermsOfService: true,
+        };
+
+        const wrapper = shallow(<Switch {...props}/>);
+        wrapper.setState({
+            showTermsOfServiceSet: 1,
+            currentUserIdSet: 1,
+        });
+        const redirectComponents = wrapper.find(Redirect);
+
+        expect(redirectComponents).toHaveLength(3);
+        expect(redirectComponents.first()).toMatchInlineSnapshot(`
+<Redirect
+  key="/mfa?redirect"
+  to="/mfa?redirect_to=%2F"
+/>
+`);
+    });
+
+    it('should redirect terms of service when required', () => {
+        const props = {
+            ...baseProps,
+            showTermsOfService: true,
+        };
+
+        const wrapper = shallow(<Switch {...props}/>);
+        wrapper.setState({
+            showTermsOfServiceSet: 1,
+            currentUserIdSet: 1,
+        });
+        const redirectComponents = wrapper.find(Redirect);
+
+        expect(redirectComponents).toHaveLength(2);
+        expect(redirectComponents.first()).toMatchInlineSnapshot(`
+<Redirect
+  key="/terms_of_service?redirect_to"
+  to="/terms_of_service?redirect_to=%2F"
+/>
+`);
+    });
+
+    it('should not redirect terms of service if not required', () => {
+        const props = {
+            ...baseProps,
+            showTermsOfService: false,
+        };
+
+        const wrapper = shallow(<Switch {...props}/>);
+        wrapper.setState({
+            showTermsOfServiceSet: 1,
+            currentUserIdSet: 1,
+        });
+
+        expect(wrapper.find(Redirect)).toHaveLength(1);
+    });
+
+    it('should redirect to signup when there are no accounts', () => {
+        const props = {
+            ...baseProps,
+            noAccounts: true,
+        };
+
+        const wrapper = shallow(<Switch {...props}/>);
+        const redirectComponents = wrapper.find(Redirect);
+
+        expect(redirectComponents).toHaveLength(2);
+        expect(redirectComponents.first()).toMatchInlineSnapshot(`
+<Redirect
+  key="/signup_user_complete"
+  to="/signup_user_complete"
+/>
+`);
+    });
+
+    it('should not redirect to signup if there are accounts already', () => {
+        const props = {
+            ...baseProps,
+            noAccounts: false,
+        };
+
+        const wrapper = shallow(<Switch {...props}/>);
+
+        expect(wrapper.find(Redirect)).toHaveLength(1);
+    });
+});

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -11,8 +11,8 @@ import classNames from 'classnames';
 import Scrollbars from 'react-custom-scrollbars';
 import {SpringSystem, MathUtil} from 'rebound';
 
+import {browserHistory} from 'utils/browser_history.jsx';
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
-import {redirectUserToDefaultTeam} from 'actions/global_actions';
 import * as ChannelUtils from 'utils/channel_utils.jsx';
 import {Constants, ModalIdentifiers, SidebarChannelGroups} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -204,7 +204,7 @@ export default class Sidebar extends React.PureComponent {
             this.channelIdIsDisplayedForProps(prevProps.orderedChannelIds, this.props.currentChannel.id)
         ) {
             this.closedDirectChannel = true;
-            redirectUserToDefaultTeam();
+            browserHistory.push('/');
             return;
         }
 

--- a/components/signup/signup_controller/signup_controller.jsx
+++ b/components/signup/signup_controller/signup_controller.jsx
@@ -8,7 +8,6 @@ import {Link} from 'react-router-dom';
 import {Client4} from 'mattermost-redux/client';
 
 import {browserHistory} from 'utils/browser_history';
-import * as GlobalActions from 'actions/global_actions.jsx';
 import logoImage from 'images/logo.png';
 import AnnouncementBar from 'components/announcement_bar';
 import BackButton from 'components/common/back_button.jsx';
@@ -100,7 +99,7 @@ export default class SignupController extends React.Component {
             } else if (inviteId) {
                 this.getInviteInfo(inviteId);
             } else if (userLoggedIn) {
-                GlobalActions.redirectUserToDefaultTeam();
+                browserHistory.push('/');
             }
         }
     }

--- a/components/signup/signup_controller/signup_controller.test.jsx
+++ b/components/signup/signup_controller/signup_controller.test.jsx
@@ -4,15 +4,10 @@
 import React from 'react';
 
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper.jsx';
-import * as GlobalActions from 'actions/global_actions.jsx';
 import {browserHistory} from 'utils/browser_history';
 import {Constants} from 'utils/constants.jsx';
 
 import SignupController from './signup_controller.jsx';
-
-jest.mock('actions/global_actions', () => ({
-    redirectUserToDefaultTeam: jest.fn(),
-}));
 
 jest.mock('utils/browser_history', () => ({
     browserHistory: {
@@ -90,7 +85,6 @@ describe('components/SignupController', () => {
         expect(wrapper).toMatchSnapshot();
         expect(addUserToTeamFromInvite).toHaveBeenCalled();
         expect(getInviteInfo).not.toHaveBeenCalled();
-        expect(GlobalActions.redirectUserToDefaultTeam).not.toHaveBeenCalled();
 
         await addUserToTeamFromInvite();
         expect(browserHistory.push).toHaveBeenCalledWith(`/defaultTeam/channels/${Constants.DEFAULT_CHANNEL}`);

--- a/components/signup/signup_email/signup_email.jsx
+++ b/components/signup/signup_email/signup_email.jsx
@@ -9,7 +9,6 @@ import {Link} from 'react-router-dom';
 import {isEmail} from 'mattermost-redux/utils/helpers';
 
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
-import * as GlobalActions from 'actions/global_actions.jsx';
 import {browserHistory} from 'utils/browser_history';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -136,7 +135,7 @@ export default class SignupEmail extends React.Component {
             if (redirectTo) {
                 browserHistory.push(redirectTo);
             } else {
-                GlobalActions.redirectUserToDefaultTeam();
+                browserHistory.push('/');
             }
         });
     }

--- a/components/terms_of_service/terms_of_service.jsx
+++ b/components/terms_of_service/terms_of_service.jsx
@@ -49,7 +49,7 @@ export default class TermsOfService extends React.PureComponent {
         if (this.props.termsEnabled) {
             this.getTermsOfService();
         } else {
-            GlobalActions.redirectUserToDefaultTeam();
+            browserHistory.push('/');
         }
     }
 
@@ -89,7 +89,7 @@ export default class TermsOfService extends React.PureComponent {
                 if (redirectTo && redirectTo.match(/^\/([^/]|$)/)) {
                     browserHistory.push(redirectTo);
                 } else {
-                    GlobalActions.redirectUserToDefaultTeam();
+                    browserHistory.push('/');
                 }
             }
         );

--- a/components/terms_of_service/terms_of_service.test.jsx
+++ b/components/terms_of_service/terms_of_service.test.jsx
@@ -10,7 +10,6 @@ import {emitUserLoggedOutEvent} from 'actions/global_actions.jsx';
 
 jest.mock('actions/global_actions.jsx', () => ({
     emitUserLoggedOutEvent: jest.fn(),
-    redirectUserToDefaultTeam: jest.fn(),
 }));
 
 describe('components/terms_of_service/TermsOfService', () => {

--- a/components/user_settings/security/mfa_section/mfa_section.jsx
+++ b/components/user_settings/security/mfa_section/mfa_section.jsx
@@ -37,7 +37,7 @@ export default class MfaSection extends React.PureComponent {
     setupMfa = (e) => {
         e.preventDefault();
 
-        browserHistory.push('/mfa/setup');
+        browserHistory.push('/mfa');
     };
 
     removeMfa = async (e) => {
@@ -53,7 +53,7 @@ export default class MfaSection extends React.PureComponent {
         }
 
         if (this.props.mfaEnforced) {
-            browserHistory.push('/mfa/setup');
+            browserHistory.push('/mfa');
             return;
         }
 

--- a/components/user_settings/security/mfa_section/mfa_section.test.jsx
+++ b/components/user_settings/security/mfa_section/mfa_section.test.jsx
@@ -104,7 +104,7 @@ describe('MfaSection', () => {
 
             wrapper.instance().setupMfa({preventDefault: jest.fn()});
 
-            expect(browserHistory.push).toHaveBeenCalledWith('/mfa/setup');
+            expect(browserHistory.push).toHaveBeenCalledWith('/mfa');
         });
     });
 
@@ -132,7 +132,7 @@ describe('MfaSection', () => {
             await wrapper.instance().removeMfa({preventDefault: jest.fn()});
 
             expect(baseProps.updateSection).not.toHaveBeenCalled();
-            expect(browserHistory.push).toHaveBeenCalledWith('/mfa/setup');
+            expect(browserHistory.push).toHaveBeenCalledWith('/mfa');
         });
 
         it('on error, should show error', async () => {

--- a/utils/route.jsx
+++ b/utils/route.jsx
@@ -16,22 +16,16 @@ export const notFoundParams = {
     type: ErrorPageTypes.PAGE_NOT_FOUND,
 };
 
-const mfaPaths = [
-    '/mfa/setup',
-    '/mfa/confirm',
-];
-
 const mfaAuthServices = [
     '',
     'email',
     'ldap',
 ];
 
-export function checkIfMFARequired(user, license, config, path) {
+export function checkIfMFARequired(user, license, config) {
     if (license.MFA === 'true' &&
             config.EnableMultifactorAuthentication === 'true' &&
-            config.EnforceMultifactorAuthentication === 'true' &&
-            mfaPaths.indexOf(path) === -1) {
+            config.EnforceMultifactorAuthentication === 'true') {
         if (isGuest(user) && config.GuestAccountsEnforceMultifactorAuthentication !== 'true') {
             return false;
         }
@@ -44,4 +38,3 @@ export function checkIfMFARequired(user, license, config, path) {
 
     return false;
 }
-

--- a/utils/route.test.js
+++ b/utils/route.test.js
@@ -11,37 +11,35 @@ describe('Utils.Route', () => {
             const config = {EnableMultifactorAuthentication: 'true', EnforceMultifactorAuthentication: 'true'};
             const license = {MFA: 'true'};
 
-            assert.ok(checkIfMFARequired(user, license, config, ''));
-            assert.ok(!checkIfMFARequired(user, license, config, '/mfa/setup'));
-            assert.ok(!checkIfMFARequired(user, license, config, '/mfa/confirm'));
+            assert.ok(checkIfMFARequired(user, license, config));
 
             user.auth_service = 'email';
-            assert.ok(checkIfMFARequired(user, license, config, ''));
+            assert.ok(checkIfMFARequired(user, license, config));
 
             user.auth_service = 'ldap';
-            assert.ok(checkIfMFARequired(user, license, config, ''));
+            assert.ok(checkIfMFARequired(user, license, config));
 
             user.auth_service = 'saml';
-            assert.ok(!checkIfMFARequired(user, license, config, ''));
+            assert.ok(!checkIfMFARequired(user, license, config));
 
             user.auth_service = '';
             user.mfa_active = true;
-            assert.ok(!checkIfMFARequired(user, license, config, ''));
+            assert.ok(!checkIfMFARequired(user, license, config));
         });
 
         test('mfa is not enforced or enabled', () => {
             const user = {mfa_active: false, auth_service: ''};
             const config = {EnableMultifactorAuthentication: 'true', EnforceMultifactorAuthentication: 'false'};
             const license = {MFA: 'true'};
-            assert.ok(!checkIfMFARequired(user, license, config, ''));
+            assert.ok(!checkIfMFARequired(user, license, config));
 
             config.EnforceMultifactorAuthentication = 'true';
             config.EnableMultifactorAuthentication = 'false';
-            assert.ok(!checkIfMFARequired(user, license, config, ''));
+            assert.ok(!checkIfMFARequired(user, license, config));
 
             license.MFA = 'false';
             config.EnableMultifactorAuthentication = 'true';
-            assert.ok(!checkIfMFARequired(user, license, config, ''));
+            assert.ok(!checkIfMFARequired(user, license, config));
         });
     });
 });


### PR DESCRIPTION
#### Summary
This PR refactors the webapp routes and makes the switch component the arbiter of the dispatching. Switch handles all the logic related to conditional routes, MFA and ToS redirections and so on. It has a final root route that will render a loading screen while it fetches more information, to then do another pass on the routes and make an informed decision on where to point the user to.

As part of this PR the MFA component has been refactored as well, and now instead of having two routes (`/mfa/setup` and `/mfa/confirm`) it has only one, and manages the two steps of the MFA configuration inside of the component itself instead of using routes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13547