### PR TITLE
Fix broken build due to utils/url.jsx

### DIFF
--- a/components/announcement_bar/configuration_bar/index.js
+++ b/components/announcement_bar/configuration_bar/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 
 import {AnnouncementBarMessages} from 'utils/constants.jsx';
 import {dismissNotice} from 'actions/views/notice';
-import {getSiteURL} from 'utils/url.jsx';
+import {getSiteURL} from 'utils/url';
 
 import ConfigurationBar from './configuration_bar.jsx';
 

--- a/components/plugin_marketplace/index.js
+++ b/components/plugin_marketplace/index.js
@@ -9,7 +9,7 @@ import {getMarketplaceInstalledPlugins} from 'mattermost-redux/selectors/entitie
 
 import {isModalOpen} from 'selectors/views/modals';
 import {ModalIdentifiers} from 'utils/constants';
-import {getSiteURL} from 'utils/url.jsx';
+import {getSiteURL} from 'utils/url';
 
 import {closeModal} from 'actions/views/modals';
 


### PR DESCRIPTION
Fix broken build due to utils/url.jsx - missed from https://github.com/mattermost/mattermost-webapp/commit/63bcb51368cf8161663ad89c8107edd4653a9a7c