### PR TITLE
[MM-19497] Fixed focusing on search results/mentions RHS

### DIFF
--- a/components/search_results_item/__snapshots__/search_results_item.test.jsx.snap
+++ b/components/search_results_item/__snapshots__/search_results_item.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
     date={2017-12-14T18:15:28.290Z}
   />
   <div
-    className="post post--thread post--compact"
+    className="a11y__section post post--thread post--compact"
   >
     <div
       className="search-channel__name"
@@ -134,6 +134,7 @@ exports[`components/SearchResultsItem should match snapshot for DM 1`] = `
             />
             <a
               className="search-item__jump"
+              href="#"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -223,7 +224,7 @@ exports[`components/SearchResultsItem should match snapshot for archived channel
     date={2017-12-14T18:15:28.290Z}
   />
   <div
-    className="post post--thread post--compact"
+    className="a11y__section post post--thread post--compact"
   >
     <div
       className="search-channel__name"
@@ -343,6 +344,7 @@ exports[`components/SearchResultsItem should match snapshot for archived channel
             />
             <a
               className="search-item__jump"
+              href="#"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -432,7 +434,7 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
     date={2017-12-14T18:15:28.290Z}
   />
   <div
-    className="post post--thread post--compact"
+    className="a11y__section post post--thread post--compact"
   >
     <div
       className="search-channel__name"
@@ -540,6 +542,7 @@ exports[`components/SearchResultsItem should match snapshot for channel 1`] = `
             />
             <a
               className="search-item__jump"
+              href="#"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -629,7 +632,7 @@ exports[`components/SearchResultsItem should match snapshot for deleted message 
     date={2017-12-14T18:15:28.290Z}
   />
   <div
-    className="post post--thread post--compact"
+    className="a11y__section post post--thread post--compact"
   >
     <div
       className="search-channel__name"
@@ -764,7 +767,7 @@ exports[`components/SearchResultsItem should match snapshot for deleted message 
     date={2017-12-14T18:15:28.290Z}
   />
   <div
-    className="post post--thread post--compact"
+    className="a11y__section post post--thread post--compact"
   >
     <div
       className="search-channel__name"

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -287,6 +287,7 @@ export default class SearchResultsItem extends React.PureComponent {
                         searchStyle={'search-item__comment'}
                     />
                     <a
+                        href='#'
                         onClick={this.handleJumpClick}
                         className='search-item__jump'
                     >
@@ -338,7 +339,7 @@ export default class SearchResultsItem extends React.PureComponent {
                 className='search-item__container'
             >
                 <DateSeparator date={currentPostDay}/>
-                <div className={this.getClassName()}>
+                <div className={`a11y__section ${this.getClassName()}`}>
                     <div className='search-channel__name'>
                         {channelName}
                         {channelIsArchived &&

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -114,7 +114,8 @@ export default class SearchResultsItem extends React.PureComponent {
         this.props.actions.selectPost(this.props.post);
     };
 
-    handleJumpClick = () => {
+    handleJumpClick = (e) => {
+        e.preventDefault();
         if (Utils.isMobile()) {
             this.props.actions.closeRightHandSide();
         }

--- a/components/search_results_item/search_results_item.test.jsx
+++ b/components/search_results_item/search_results_item.test.jsx
@@ -198,7 +198,7 @@ describe('components/SearchResultsItem', () => {
             <SearchResultsItem {...props}/>
         );
 
-        wrapper.find('.search-item__jump').simulate('click');
+        wrapper.find('.search-item__jump').simulate('click', {preventDefault: jest.fn()});
         expect(setRhsExpanded).toHaveBeenCalledTimes(1);
         expect(setRhsExpanded).toHaveBeenLastCalledWith(false);
         expect(browserHistory.push).toHaveBeenLastCalledWith(`/${defaultProps.currentTeamName}/pl/${post.id}`);


### PR DESCRIPTION
#### Summary
When focusing a post in the RHS under Search/Recent Mentions/Flagged Posts, the post options were not focusable when tabbing through. This PR adds the `a11y__section` class to allow them to be focused with the `a11y-controller`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19497
