### PR TITLE
migrated status_icon to typescript

### DIFF
--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link_icon.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link_icon.jsx
@@ -10,7 +10,7 @@ import ArchiveIcon from 'components/widgets/icons/archive_icon';
 import DraftIcon from 'components/widgets/icons/draft_icon';
 import GlobeIcon from 'components/widgets/icons/globe_icon';
 import LockIcon from 'components/widgets/icons/lock_icon';
-import StatusIcon from 'components/status_icon.jsx';
+import StatusIcon from 'components/status_icon';
 import BotIcon from 'components/widgets/icons/bot_icon.jsx';
 
 export default class SidebarChannelButtonOrLinkIcon extends React.PureComponent {

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -8,7 +8,7 @@ import {FormattedMessage} from 'react-intl';
 import {UserStatuses, ModalIdentifiers} from 'utils/constants.jsx';
 import {localizeMessage} from 'utils/utils.jsx';
 import ResetStatusModal from 'components/reset_status_modal';
-import StatusIcon from 'components/status_icon.jsx';
+import StatusIcon from 'components/status_icon';
 
 import Avatar from 'components/widgets/users/avatar';
 import Menu from 'components/widgets/menu/menu';

--- a/components/status_icon.tsx
+++ b/components/status_icon.tsx
@@ -13,13 +13,14 @@ import StatusOfflineIcon from 'components/widgets/icons/status_offline_icon';
 import StatusOnlineAvatarIcon from 'components/widgets/icons/status_online_avatar_icon';
 import StatusOnlineIcon from 'components/widgets/icons/status_online_icon';
 
+type Props = {
+    button: boolean;
+    status: string;
+    className: string;
+    type: string;
+};
+
 export default class StatusIcon extends React.PureComponent {
-    static propTypes = {
-        button: PropTypes.bool,
-        status: PropTypes.string,
-        className: PropTypes.string,
-        type: PropTypes.string,
-    };
 
     static defaultProps = {
         className: '',


### PR DESCRIPTION
#### Summary
Migrate status_icon.jsx to typeScript

#### Ticket Link
 Fixes https://github.com/mattermost/mattermost-server/issues/12437

#### Related Pull Requests

- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)
