### PR TITLE
[MM-19194] Clicking "Pinned" Icon removes text in the search box

### DIFF
--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -175,10 +175,6 @@ export function showPinnedPosts(channelId) {
 
         dispatch(batchActions([
             {
-                type: ActionTypes.UPDATE_RHS_SEARCH_TERMS,
-                terms: '',
-            },
-            {
                 type: ActionTypes.UPDATE_RHS_STATE,
                 channelId: channelId || currentChannelId,
                 state: RHSStates.PIN,

--- a/actions/views/rhs.test.js
+++ b/actions/views/rhs.test.js
@@ -283,10 +283,6 @@ describe('rhs view actions', () => {
                     },
                     payload: [
                         {
-                            type: ActionTypes.UPDATE_RHS_SEARCH_TERMS,
-                            terms: '',
-                        },
-                        {
                             type: ActionTypes.UPDATE_RHS_STATE,
                             channelId: currentChannelId,
                             state: RHSStates.PIN,
@@ -339,10 +335,6 @@ describe('rhs view actions', () => {
                         batch: true,
                     },
                     payload: [
-                        {
-                            type: ActionTypes.UPDATE_RHS_SEARCH_TERMS,
-                            terms: '',
-                        },
                         {
                             type: ActionTypes.UPDATE_RHS_STATE,
                             channelId,


### PR DESCRIPTION
#### Summary
- An earlier commit dispatched an action to remove the search terms when the pinned post button is clicked. Removed that.

#### Ticket Link
- Fixes [MM-19194](https://mattermost.atlassian.net/browse/MM-19194)