### PR TITLE
MM-19493 For manually unread channel, don't mark as read on new message

### DIFF
--- a/actions/post_utils.js
+++ b/actions/post_utils.js
@@ -10,7 +10,7 @@ import {
 import * as PostActions from 'mattermost-redux/actions/posts';
 import {WebsocketEvents} from 'mattermost-redux/constants';
 import * as PostSelectors from 'mattermost-redux/selectors/entities/posts';
-import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannelId, isManuallyUnread} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {
     isFromWebhook,
@@ -85,19 +85,21 @@ export function setChannelReadAndView(post, websocketMessageProps) {
 
         let markAsRead = false;
         let markAsReadOnServer = false;
-        if (
-            post.user_id === getCurrentUserId(state) &&
-            !isSystemMessage(post) &&
-            !isFromWebhook(post)
-        ) {
-            markAsRead = true;
-            markAsReadOnServer = false;
-        } else if (
-            post.channel_id === getCurrentChannelId(state) &&
-            window.isActive
-        ) {
-            markAsRead = true;
-            markAsReadOnServer = true;
+        if (!isManuallyUnread(getState(), post.channel_id)) {
+            if (
+                post.user_id === getCurrentUserId(state) &&
+                !isSystemMessage(post) &&
+                !isFromWebhook(post)
+            ) {
+                markAsRead = true;
+                markAsReadOnServer = false;
+            } else if (
+                post.channel_id === getCurrentChannelId(state) &&
+                window.isActive
+            ) {
+                markAsRead = true;
+                markAsReadOnServer = true;
+            }
         }
 
         if (markAsRead) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14295,8 +14295,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#6e1510f0ced2ac1a63360cb9e000d5b3d3c34d30",
-      "from": "github:mattermost/mattermost-redux#6e1510f0ced2ac1a63360cb9e000d5b3d3c34d30",
+      "version": "github:mattermost/mattermost-redux#fcdcfe0a7b9aaad38cc9f301b68fb1877c0b4960",
+      "from": "github:mattermost/mattermost-redux#fcdcfe0a7b9aaad38cc9f301b68fb1877c0b4960",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#09e4643601bc620c682d16410ddc4a4115815a12",
-    "mattermost-redux": "github:mattermost/mattermost-redux#6e1510f0ced2ac1a63360cb9e000d5b3d3c34d30",
+    "mattermost-redux": "github:mattermost/mattermost-redux#fcdcfe0a7b9aaad38cc9f301b68fb1877c0b4960",
     "moment-timezone": "0.5.26",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
Skip the step of `setChannelReadAndView` that marks a channel as read when the user is viewing a channel if they manually marked it as unread.

Mobile/Redux PR: https://github.com/mattermost/mattermost-redux/pull/950

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19493