### PR TITLE
Automated cherry pick of #3983

### DIFF
--- a/components/plugin_marketplace/marketplace_item/__snapshots__/marketplace_item.test.jsx.snap
+++ b/components/plugin_marketplace/marketplace_item/__snapshots__/marketplace_item.test.jsx.snap
@@ -332,3 +332,86 @@ exports[`components/MarketplaceItem should match snapshot, with plugin icon 1`] 
   />
 </div>
 `;
+
+exports[`components/MarketplaceItem should match snapshot, with server error 1`] = `
+<div
+  className="more-modal__row more-modal__row--link item_error"
+  key="id"
+>
+  <PluginIcon
+    className="icon__plugin icon__plugin--background"
+  />
+  <div
+    className="more-modal__details"
+  >
+    <a
+      aria-label="name, test plugin"
+      className="style--none more-modal__row--link"
+      href="http://example.com"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      name
+       
+      <span
+        className="light subtitle"
+      >
+        (1.0.0)
+      </span>
+      <p
+        className="more-modal__description error_text"
+      >
+        <Component />
+      </p>
+    </a>
+  </div>
+  <div
+    className="more-modal__actions"
+  >
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <LoadingWrapper
+        loading={false}
+        text="Installing..."
+      >
+        <FormattedMessage
+          defaultMessage="Try Again"
+          id="marketplace_modal.list.try_again"
+          values={Object {}}
+        />
+      </LoadingWrapper>
+    </button>
+  </div>
+  <ConfirmModal
+    confirmButtonClass="btn btn-danger"
+    confirmButtonText={
+      <FormattedMessage
+        defaultMessage="Overwrite"
+        id="admin.plugin.upload.overwrite_modal.overwrite"
+        values={Object {}}
+      />
+    }
+    message={
+      <FormattedMessage
+        defaultMessage="A plugin with this ID already exists. Would you like to overwrite it?"
+        id="admin.plugin.upload.overwrite_modal.desc"
+        values={Object {}}
+      />
+    }
+    modalClass=""
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    show={false}
+    title={
+      <FormattedMessage
+        defaultMessage="Overwrite existing plugin?"
+        id="admin.plugin.upload.overwrite_modal.title"
+        values={Object {}}
+      />
+    }
+  />
+</div>
+`;

--- a/components/plugin_marketplace/marketplace_item/__snapshots__/marketplace_item.test.jsx.snap
+++ b/components/plugin_marketplace/marketplace_item/__snapshots__/marketplace_item.test.jsx.snap
@@ -1,6 +1,169 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/MarketplaceItem should match snapshot, no homepage url 1`] = `
+<div
+  className="more-modal__row more-modal__row--link"
+  key="id"
+>
+  <PluginIcon
+    className="icon__plugin icon__plugin--background"
+  />
+  <div
+    className="more-modal__details"
+  >
+    <span
+      aria-label="name, test plugin"
+      className="style--none"
+    >
+      name
+       
+      <span
+        className="light subtitle"
+      >
+        (1.0.0)
+      </span>
+      <p
+        className="more-modal__description"
+      >
+        test plugin
+      </p>
+    </span>
+  </div>
+  <div
+    className="more-modal__actions"
+  >
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <LoadingWrapper
+        loading={false}
+        text="Installing..."
+      >
+        <FormattedMessage
+          defaultMessage="Install"
+          id="marketplace_modal.list.Install"
+          values={Object {}}
+        />
+      </LoadingWrapper>
+    </button>
+  </div>
+  <ConfirmModal
+    confirmButtonClass="btn btn-danger"
+    confirmButtonText={
+      <FormattedMessage
+        defaultMessage="Overwrite"
+        id="admin.plugin.upload.overwrite_modal.overwrite"
+        values={Object {}}
+      />
+    }
+    message={
+      <FormattedMessage
+        defaultMessage="A plugin with this ID already exists. Would you like to overwrite it?"
+        id="admin.plugin.upload.overwrite_modal.desc"
+        values={Object {}}
+      />
+    }
+    modalClass=""
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    show={false}
+    title={
+      <FormattedMessage
+        defaultMessage="Overwrite existing plugin?"
+        id="admin.plugin.upload.overwrite_modal.title"
+        values={Object {}}
+      />
+    }
+  />
+</div>
+`;
+
 exports[`components/MarketplaceItem should match snapshot, no plugin icon 1`] = `
+<div
+  className="more-modal__row more-modal__row--link"
+  key="id"
+>
+  <PluginIcon
+    className="icon__plugin icon__plugin--background"
+  />
+  <div
+    className="more-modal__details"
+  >
+    <a
+      aria-label="name, test plugin"
+      className="style--none more-modal__row--link"
+      href="http://example.com"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      name
+       
+      <span
+        className="light subtitle"
+      >
+        (1.0.0)
+      </span>
+      <p
+        className="more-modal__description"
+      >
+        test plugin
+      </p>
+    </a>
+  </div>
+  <div
+    className="more-modal__actions"
+  >
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <LoadingWrapper
+        loading={false}
+        text="Installing..."
+      >
+        <FormattedMessage
+          defaultMessage="Install"
+          id="marketplace_modal.list.Install"
+          values={Object {}}
+        />
+      </LoadingWrapper>
+    </button>
+  </div>
+  <ConfirmModal
+    confirmButtonClass="btn btn-danger"
+    confirmButtonText={
+      <FormattedMessage
+        defaultMessage="Overwrite"
+        id="admin.plugin.upload.overwrite_modal.overwrite"
+        values={Object {}}
+      />
+    }
+    message={
+      <FormattedMessage
+        defaultMessage="A plugin with this ID already exists. Would you like to overwrite it?"
+        id="admin.plugin.upload.overwrite_modal.desc"
+        values={Object {}}
+      />
+    }
+    modalClass=""
+    onCancel={[Function]}
+    onConfirm={[Function]}
+    show={false}
+    title={
+      <FormattedMessage
+        defaultMessage="Overwrite existing plugin?"
+        id="admin.plugin.upload.overwrite_modal.title"
+        values={Object {}}
+      />
+    }
+  />
+</div>
+`;
+
+exports[`components/MarketplaceItem should match snapshot, with homepage url 1`] = `
 <div
   className="more-modal__row more-modal__row--link"
   key="id"

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.jsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import {FormattedMessage} from 'react-intl';
 
@@ -160,8 +161,8 @@ export default class MarketplaceItem extends React.Component {
             let pluginDetails = (
                 <>
                     {this.props.name} <span className='light subtitle'>{versionLabel}</span>
-                    <p className={'more-modal__description' + (this.state.serverError ? ' error_text' : '')}>
-                        { this.state.serverError ? this.state.serverError : this.props.description}
+                    <p className={classNames('more-modal__description', {error_text: this.state.serverError})}>
+                        {this.state.serverError ? this.state.serverError : this.props.description}
                     </p>
                 </>
             );
@@ -191,7 +192,7 @@ export default class MarketplaceItem extends React.Component {
 
             return (
                 <div
-                    className={'more-modal__row more-modal__row--link' + (this.state.serverError ? ' item_error' : '')}
+                    className={classNames('more-modal__row', 'more-modal__row--link', {item_error: this.state.serverError})}
                     key={this.props.id}
                 >
                     {pluginIcon}

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.jsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.jsx
@@ -157,6 +157,38 @@ export default class MarketplaceItem extends React.Component {
                 pluginIcon = <PluginIcon className='icon__plugin icon__plugin--background'/>;
             }
 
+            let pluginDetails = (
+                <>
+                    {this.props.name} <span className='light subtitle'>{versionLabel}</span>
+                    <p className={'more-modal__description' + (this.state.serverError ? ' error_text' : '')}>
+                        { this.state.serverError ? this.state.serverError : this.props.description}
+                    </p>
+                </>
+            );
+
+            if (this.props.homepageUrl) {
+                pluginDetails = (
+                    <a
+                        aria-label={ariaLabel}
+                        className='style--none more-modal__row--link'
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        href={this.props.homepageUrl}
+                    >
+                        {pluginDetails}
+                    </a>
+                );
+            } else {
+                pluginDetails = (
+                    <span
+                        aria-label={ariaLabel}
+                        className='style--none'
+                    >
+                        {pluginDetails}
+                    </span>
+                );
+            }
+
             return (
                 <div
                     className={'more-modal__row more-modal__row--link' + (this.state.serverError ? ' item_error' : '')}
@@ -164,18 +196,7 @@ export default class MarketplaceItem extends React.Component {
                 >
                     {pluginIcon}
                     <div className='more-modal__details'>
-                        <a
-                            aria-label={ariaLabel}
-                            className='style--none more-modal__row--link'
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            href={this.props.homepageUrl}
-                        >
-                            {this.props.name} <span className='light subtitle'>{versionLabel}</span>
-                            <p className={'more-modal__description' + (this.state.serverError ? ' error_text' : '')}>
-                                { this.state.serverError ? this.state.serverError : this.props.description}
-                            </p>
-                        </a>
+                        {pluginDetails}
                     </div>
                     <div className='more-modal__actions'>
                         {this.getItemButton()}

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.test.jsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.test.jsx
@@ -43,4 +43,25 @@ describe('components/MarketplaceItem', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should match snapshot, with homepage url', () => {
+        const wrapper = shallow(
+            <MarketplaceItem {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot, no homepage url', () => {
+        const props = {
+            ...baseProps,
+        }
+        delete props['homepageUrl'];
+
+        const wrapper = shallow(
+            <MarketplaceItem {...props}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.test.jsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.test.jsx
@@ -64,4 +64,19 @@ describe('components/MarketplaceItem', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should match snapshot, with server error', () => {
+        const props = {
+            ...baseProps,
+        };
+
+        const wrapper = shallow(
+            <MarketplaceItem {...props}/>
+        );
+        wrapper.setState({
+            serverError: true,
+        });
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.test.jsx
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.test.jsx
@@ -55,8 +55,8 @@ describe('components/MarketplaceItem', () => {
     test('should match snapshot, no homepage url', () => {
         const props = {
             ...baseProps,
-        }
-        delete props['homepageUrl'];
+        };
+        delete props.homepageUrl;
 
         const wrapper = shallow(
             <MarketplaceItem {...props}/>


### PR DESCRIPTION
Cherry pick of #3983 on release-5.17.

- #3983: MM-19183: handle plugins without homepage

/cc  @lieut-data