### PR TITLE
MM-19495 Render unicode emojis the same as text emojis and emoticons

### DIFF
--- a/utils/emoticons.jsx
+++ b/utils/emoticons.jsx
@@ -53,7 +53,7 @@ export function handleEmoticons(text, tokens) {
         const alias = `$MM_EMOTICON${index}$`;
 
         tokens.set(alias, {
-            value: `<span data-emoticon="${name}">${matchText}</span>`,
+            value: renderEmoji(name, matchText),
             originalText: fullMatch,
         });
 
@@ -73,4 +73,8 @@ export function handleEmoticons(text, tokens) {
     }
 
     return output;
+}
+
+export function renderEmoji(name, matchText) {
+    return `<span data-emoticon="${name}">${matchText}</span>`;
 }

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import XRegExp from 'xregexp';
-import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
 import emojiRegex from 'emoji-regex';
 
 import {formatWithRenderer} from 'utils/markdown';
@@ -562,22 +561,23 @@ function replaceNewlines(text) {
     return text.replace(/\n/g, ' ');
 }
 
-export function handleUnicodeEmoji(text, supportedEmoji, searchPattern) {
+export function handleUnicodeEmoji(text, emojiMap, searchPattern) {
     let output = text;
 
     // replace all occurances of unicode emoji with additional markup
-    output = output.replace(searchPattern, (emoji) => {
+    output = output.replace(searchPattern, (emojiMatch) => {
         // convert unicode character to hex string
-        const emojiCode = emoji.codePointAt(0).toString(16);
+        const emojiCode = emojiMatch.codePointAt(0).toString(16);
 
         // convert emoji to image if supported, or wrap in span to apply appropriate formatting
-        if (supportedEmoji.hasUnicode(emojiCode)) {
-            // build image tag to replace supported unicode emoji
-            return `<img class="emoticon" draggable="false" alt="${emoji}" src="${getEmojiImageUrl(supportedEmoji.getUnicode(emojiCode))}">`;
+        if (emojiMap.hasUnicode(emojiCode)) {
+            const emoji = emojiMap.getUnicode(emojiCode);
+
+            return Emoticons.renderEmoji(emoji.aliases[0], emojiMatch);
         }
 
         // wrap unsupported unicode emoji in span to style as needed
-        return `<span class="emoticon emoticon--unicode">${emoji}</span>`;
+        return `<span class="emoticon emoticon--unicode">${emojiMatch}</span>`;
     });
     return output;
 }

--- a/utils/text_formatting.test.jsx
+++ b/utils/text_formatting.test.jsx
@@ -119,7 +119,7 @@ describe('handleUnicodeEmoji', () => {
         const UNICODE_EMOJI_REGEX = emojiRegex();
 
         const output = handleUnicodeEmoji(text, emojiMap, UNICODE_EMOJI_REGEX);
-        expect(output).toBe('<img class="emoticon" draggable="false" alt="👍" src="/static/emoji/1f44d.png">');
+        expect(output).toBe('<span data-emoticon="+1">👍</span>');
     });
     test('unicode emoji without image support should get wrapped in a span tag', () => {
         const text = '🤟'; // note, this test will fail as soon as this emoji gets a corresponding image


### PR DESCRIPTION
Unicode emojis have been rendered slightly differently from text-based emojis and emoticons for some time now, and the way that they were being rendered caused them to get picked up as inline markdown images. This caused some CSS issues for them in the past and still causes them to be clickable like markdown images.

This changes so that they're rendered by spans in this step of the process (the same as other emojis) which are later transformed into the correct `PostEmoji` component later on

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19495