### PR TITLE
Fix module not found error when running and building storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -34,18 +34,20 @@ module.exports = async ({config, mode}) => {
       ],
     });
 
+    config.resolve.alias.actions = path.join(path.resolve(__dirname), '..', 'actions')
+    config.resolve.alias.client = path.join(path.resolve(__dirname), '..', 'client')
     config.resolve.alias.components = path.join(path.resolve(__dirname), '..', 'components')
-    config.resolve.alias.actions = path.join(path.resolve(__dirname), '..', 'actions')
+    config.resolve.alias.dispatcher = path.join(path.resolve(__dirname), '..', 'dispatcher')
     config.resolve.alias.i18n = path.join(path.resolve(__dirname), '..', 'i18n')
-    config.resolve.alias.utils = path.join(path.resolve(__dirname), '..', 'utils')
-    config.resolve.alias.stores = path.join(path.resolve(__dirname), '..', 'stores')
-    config.resolve.alias.actions = path.join(path.resolve(__dirname), '..', 'actions')
-    config.resolve.alias.selectors = path.join(path.resolve(__dirname), '..', 'selectors')
     config.resolve.alias.images = path.join(path.resolve(__dirname), '..', 'images')
-    config.resolve.alias.store = path.join(path.resolve(__dirname), '..', 'store')
+    config.resolve.alias.plugins = path.join(path.resolve(__dirname), '..', 'plugins')
     config.resolve.alias.reducers = path.join(path.resolve(__dirname), '..', 'reducers')
     config.resolve.alias.sass = path.join(path.resolve(__dirname), '..', 'sass')
+    config.resolve.alias.selectors = path.join(path.resolve(__dirname), '..', 'selectors')
+    config.resolve.alias.store = path.join(path.resolve(__dirname), '..', 'store')
+    config.resolve.alias.stores = path.join(path.resolve(__dirname), '..', 'stores')
     config.resolve.alias.storybook = path.join(path.resolve(__dirname), '..', 'storybook')
+    config.resolve.alias.utils = path.join(path.resolve(__dirname), '..', 'utils')
 
     return config;
 };


### PR DESCRIPTION
#### Summary
This fixes error of module not found when running and building storybook by updating webpack config to resolve alias for client, dispatcher and plugins.

(I rearranged the order of those `config.resolve.alias` to easily check duplicates/missing.)

QA test:
Run either `make storybook` or `make build-storybook` and verify that no error found in the command line.

#### Ticket Link
none
