### PR TITLE
MM-19195 - Clear search results before opening RHS for mobile view

### DIFF
--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -5,6 +5,7 @@ import {batchActions} from 'redux-batched-actions';
 
 import {SearchTypes} from 'mattermost-redux/action_types';
 import {
+    clearSearch,
     getFlaggedPosts,
     getPinnedPosts,
     searchPostsWithParams,
@@ -281,4 +282,13 @@ export function selectPost(post) {
 
 export function selectPostCard(post) {
     return {type: ActionTypes.SELECT_POST_CARD, postId: post.id, channelId: post.channel_id};
+}
+
+export function openRHSSearch() {
+    return (dispatch) => {
+        dispatch(clearSearch());
+        dispatch(updateSearchTerms(''));
+
+        dispatch(updateRhsState(RHSStates.SEARCH));
+    };
 }

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -68,7 +68,6 @@ export default class ChannelHeader extends React.PureComponent {
             showMentions: PropTypes.func.isRequired,
             openRHSSearch: PropTypes.func.isRequired,
             closeRightHandSide: PropTypes.func.isRequired,
-            updateRhsState: PropTypes.func.isRequired,
             getCustomEmojisInText: PropTypes.func.isRequired,
             updateChannelNotifyProps: PropTypes.func.isRequired,
             goToLastViewedChannel: PropTypes.func.isRequired,

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -66,6 +66,7 @@ export default class ChannelHeader extends React.PureComponent {
             showFlaggedPosts: PropTypes.func.isRequired,
             showPinnedPosts: PropTypes.func.isRequired,
             showMentions: PropTypes.func.isRequired,
+            openRHSSearch: PropTypes.func.isRequired,
             closeRightHandSide: PropTypes.func.isRequired,
             updateRhsState: PropTypes.func.isRequired,
             getCustomEmojisInText: PropTypes.func.isRequired,
@@ -188,7 +189,8 @@ export default class ChannelHeader extends React.PureComponent {
 
     searchButtonClick = (e) => {
         e.preventDefault();
-        this.props.actions.updateRhsState(RHSStates.SEARCH);
+
+        this.props.actions.openRHSSearch();
     };
 
     handleShortcut = (e) => {

--- a/components/channel_header/channel_header.test.jsx
+++ b/components/channel_header/channel_header.test.jsx
@@ -17,6 +17,7 @@ describe('components/ChannelHeader', () => {
             showFlaggedPosts: jest.fn(),
             showPinnedPosts: jest.fn(),
             showMentions: jest.fn(),
+            openRHSSearch: jest.fn(),
             closeRightHandSide: jest.fn(),
             updateRhsState: jest.fn(),
             openModal: jest.fn(),

--- a/components/channel_header/channel_header.test.jsx
+++ b/components/channel_header/channel_header.test.jsx
@@ -19,7 +19,6 @@ describe('components/ChannelHeader', () => {
             showMentions: jest.fn(),
             openRHSSearch: jest.fn(),
             closeRightHandSide: jest.fn(),
-            updateRhsState: jest.fn(),
             openModal: jest.fn(),
             closeModal: jest.fn(),
             getCustomEmojisInText: jest.fn(),

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -35,7 +35,6 @@ import {
     showMentions,
     openRHSSearch,
     closeRightHandSide,
-    updateRhsState,
 } from 'actions/views/rhs';
 import {getRhsState} from 'selectors/rhs';
 import {isModalOpen} from 'selectors/views/modals';

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -86,7 +86,6 @@ const mapDispatchToProps = (dispatch) => ({
         showMentions,
         openRHSSearch,
         closeRightHandSide,
-        updateRhsState,
         getCustomEmojisInText,
         updateChannelNotifyProps,
         goToLastViewedChannel,

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -33,6 +33,7 @@ import {
     showFlaggedPosts,
     showPinnedPosts,
     showMentions,
+    openRHSSearch,
     closeRightHandSide,
     updateRhsState,
 } from 'actions/views/rhs';
@@ -83,6 +84,7 @@ const mapDispatchToProps = (dispatch) => ({
         showFlaggedPosts,
         showPinnedPosts,
         showMentions,
+        openRHSSearch,
         closeRightHandSide,
         updateRhsState,
         getCustomEmojisInText,

--- a/components/channel_header_mobile/show_search_button/index.js
+++ b/components/channel_header_mobile/show_search_button/index.js
@@ -4,15 +4,12 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {clearSearch} from 'mattermost-redux/actions/search';
-
 import {openRHSSearch} from 'actions/views/rhs';
 
 import ShowSearchButton from './show_search_button';
 
 const mapDispatchToProps = (dispatch) => ({
     actions: bindActionCreators({
-        clearSearch,
         openRHSSearch,
     }, dispatch),
 });

--- a/components/channel_header_mobile/show_search_button/index.js
+++ b/components/channel_header_mobile/show_search_button/index.js
@@ -4,13 +4,16 @@
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
-import {updateRhsState} from 'actions/views/rhs';
+import {clearSearch} from 'mattermost-redux/actions/search';
+
+import {openRHSSearch} from 'actions/views/rhs';
 
 import ShowSearchButton from './show_search_button';
 
 const mapDispatchToProps = (dispatch) => ({
     actions: bindActionCreators({
-        updateRhsState,
+        clearSearch,
+        openRHSSearch,
     }, dispatch),
 });
 

--- a/components/channel_header_mobile/show_search_button/show_search_button.js
+++ b/components/channel_header_mobile/show_search_button/show_search_button.js
@@ -5,17 +5,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import SearchIcon from 'components/widgets/icons/search_icon';
-import {RHSStates} from 'utils/constants';
 
 export default class ShowSearchButton extends React.PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
+            openRHSSearch: PropTypes.func.isRequired,
             updateRhsState: PropTypes.func.isRequired,
         }).isRequired,
     }
 
     handleClick = () => {
-        this.props.actions.updateRhsState(RHSStates.SEARCH);
+        this.props.actions.openRHSSearch();
     }
 
     render() {

--- a/components/channel_header_mobile/show_search_button/show_search_button.js
+++ b/components/channel_header_mobile/show_search_button/show_search_button.js
@@ -10,7 +10,6 @@ export default class ShowSearchButton extends React.PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
             openRHSSearch: PropTypes.func.isRequired,
-            updateRhsState: PropTypes.func.isRequired,
         }).isRequired,
     }
 

--- a/components/search_results/index.jsx
+++ b/components/search_results/index.jsx
@@ -13,13 +13,13 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentSearchForCurrentTeam} from 'mattermost-redux/selectors/entities/search';
 
 import {
-    getSearchResultsTerms,
+    getSearchTerms,
     getIsSearchingTerm,
     getIsSearchingFlaggedPost,
     getIsSearchingPinnedPost,
     getIsSearchGettingMore,
 } from 'selectors/rhs';
-import {Preferences} from 'utils/constants';
+import {Preferences} from 'utils/constants.jsx';
 
 import SearchResults from './search_results.jsx';
 
@@ -61,7 +61,7 @@ function makeMapStateToProps() {
             results: posts,
             matches: getSearchMatches(state),
             currentUser: getCurrentUser(state),
-            searchTerms: getSearchResultsTerms(state),
+            searchTerms: getSearchTerms(state),
             isSearchingTerm: getIsSearchingTerm(state),
             isSearchingFlaggedPost: getIsSearchingFlaggedPost(state),
             isSearchingPinnedPost: getIsSearchingPinnedPost(state),


### PR DESCRIPTION
#### Summary
When the screen is small enough the search bar in the channel header turns into a button that when clicked opens the RHS and the user can type the search terms there. 

In this case, it was not cleaning out any previous results or search terms causing issues as the attached one. 

To fix these, I've included a new RHS action `openRHSSearch` that will clear out any current results and search terms before opening the RHS for the search button in the channel header in both smaller screen and mobile view cases.

#### Mobile View Search Button:
<img width="448" alt="Screen Shot 2019-10-23 at 2 10 06 PM" src="https://user-images.githubusercontent.com/936315/67421647-f379e280-f59e-11e9-9d6b-353109bbcab7.png">

#### Smaller Screen Search Button:
<img width="361" alt="Screen Shot 2019-10-23 at 2 09 56 PM" src="https://user-images.githubusercontent.com/936315/67421648-f379e280-f59e-11e9-9f85-286ee3da897f.png">

This was not a problem when the search has the input bar to type given that the RHS would only open when the search has been performed and will replace any old results from previous search actions.

#### Ticket Link
Fixes [MM-19195](https://mattermost.atlassian.net/browse/MM-19195)