### PR TITLE
MM-18786 - Restored setSelected in MultiSelectList component

### DIFF
--- a/components/multiselect/multiselect_list.jsx
+++ b/components/multiselect/multiselect_list.jsx
@@ -50,6 +50,10 @@ export default class MultiSelectList extends React.Component {
         }
     }
 
+    setSelected = (selected) => {
+        this.setState({selected});
+    }
+
     handleArrowPress = (e) => {
         if (cmdOrCtrlPressed(e) && e.shiftKey) {
             return;


### PR DESCRIPTION
#### Summary
Restored `setSelected` function in `MultiSelectList` component that was removed in this cleanup PR https://github.com/mattermost/mattermost-webapp/pull/3969 but is still [referenced](https://github.com/mattermost/mattermost-webapp/blob/517d37a22220d22b95d22dcf2a4910c8588d862e/components/multiselect/multiselect.jsx#L148) by `MultiSelect` component causing the related bug. 

#### Ticket Link
Fixes [MM-19678](https://mattermost.atlassian.net/browse/MM-19678)
