### PR TITLE
[MM-19470] Fix role name for guests and admins in system console team list

### DIFF
--- a/components/admin_console/system_user_detail/__snapshots__/system_user_detail.test.jsx.snap
+++ b/components/admin_console/system_user_detail/__snapshots__/system_user_detail.test.jsx.snap
@@ -144,8 +144,17 @@ exports[`components/admin_console/system_user_detail should match default snapsh
       >
         <Connect(TeamList)
           refreshTeams={true}
+          user={
+            Object {
+              "first_name": "Jim",
+              "id": "1234",
+              "last_name": "Halpert",
+              "nickname": "Big Tuna",
+              "roles": "system_user",
+              "username": "jim.halpert",
+            }
+          }
           userDetailCallback={[Function]}
-          userId="1234"
         />
       </AdminPanel>
     </div>
@@ -399,8 +408,18 @@ exports[`components/admin_console/system_user_detail should match snapshot if MF
       >
         <Connect(TeamList)
           refreshTeams={true}
+          user={
+            Object {
+              "first_name": "Jim",
+              "id": "1234",
+              "last_name": "Halpert",
+              "mfa_active": "MFA",
+              "nickname": "Big Tuna",
+              "roles": "system_user",
+              "username": "jim.halpert",
+            }
+          }
           userDetailCallback={[Function]}
-          userId="1234"
         />
       </AdminPanel>
     </div>
@@ -648,8 +667,17 @@ exports[`components/admin_console/system_user_detail should match snapshot if no
       >
         <Connect(TeamList)
           refreshTeams={true}
+          user={
+            Object {
+              "first_name": "Jim",
+              "id": "1234",
+              "last_name": "Halpert",
+              "nickname": null,
+              "roles": "system_user",
+              "username": "jim.halpert",
+            }
+          }
           userDetailCallback={[Function]}
-          userId="1234"
         />
       </AdminPanel>
     </div>
@@ -897,8 +925,18 @@ exports[`components/admin_console/system_user_detail should match snapshot if us
       >
         <Connect(TeamList)
           refreshTeams={true}
+          user={
+            Object {
+              "delete_at": 1561683854166,
+              "first_name": "Jim",
+              "id": "1234",
+              "last_name": "Halpert",
+              "nickname": "Big Tuna",
+              "roles": "system_user",
+              "username": "jim.halpert",
+            }
+          }
           userDetailCallback={[Function]}
-          userId="1234"
         />
       </AdminPanel>
     </div>

--- a/components/admin_console/system_user_detail/system_user_detail.jsx
+++ b/components/admin_console/system_user_detail/system_user_detail.jsx
@@ -406,7 +406,7 @@ export default class SystemUserDetail extends React.PureComponent {
                             )}
                         >
                             <TeamList
-                                userId={this.props.user.id}
+                                user={this.props.user}
                                 userDetailCallback={this.setTeamsData}
                                 refreshTeams={this.state.refreshTeams}
                             />

--- a/components/admin_console/system_user_detail/team_list/__snapshots__/abstract_list.test.jsx.snap
+++ b/components/admin_console/system_user_detail/team_list/__snapshots__/abstract_list.test.jsx.snap
@@ -246,6 +246,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id11",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id12"
@@ -255,6 +265,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "Team 12 description",
           "display_name": "Team 12",
           "id": "id12",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />
@@ -268,6 +288,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id13",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id14"
@@ -277,6 +307,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "Team 14 description",
           "display_name": "Team 14",
           "id": "id14",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />
@@ -290,6 +330,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id15",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id16"
@@ -299,6 +349,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "Team 16 description",
           "display_name": "Team 16",
           "id": "id16",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />
@@ -312,6 +372,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id17",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id18"
@@ -321,6 +391,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "Team 18 description",
           "display_name": "Team 18",
           "id": "id18",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />
@@ -334,6 +414,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id19",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id20"
@@ -343,6 +433,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "Team 20 description",
           "display_name": "Team 20",
           "id": "id20",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />
@@ -443,6 +543,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id1",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id2"
@@ -452,6 +562,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "The 2 description",
           "display_name": "Team 2",
           "id": "id2",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />
@@ -465,6 +585,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id3",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id4"
@@ -474,6 +604,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "Team 4 description",
           "display_name": "Team 4",
           "id": "id4",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />
@@ -487,6 +627,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id5",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id6"
@@ -496,6 +646,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "Team 6 description",
           "display_name": "Team 6",
           "id": "id6",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />
@@ -509,6 +669,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id7",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id8"
@@ -518,6 +688,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "Team 8 description",
           "display_name": "Team 8",
           "id": "id8",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />
@@ -531,6 +711,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id9",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id10"
@@ -540,6 +730,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "Team 10 description",
           "display_name": "Team 10",
           "id": "id10",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />
@@ -640,6 +840,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "id": "id1",
         }
       }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
+        }
+      }
     />
     <TeamRow
       key="id2"
@@ -649,6 +859,16 @@ exports[`admin_console/system_user_detail/team_list/AbstractList should match sn
           "description": "The 2 description",
           "display_name": "Team 2",
           "id": "id2",
+        }
+      }
+      user={
+        Object {
+          "first_name": "Jim",
+          "id": "1234",
+          "last_name": "Halpert",
+          "nickname": "Big Tuna",
+          "roles": "system_user",
+          "username": "jim.halpert",
         }
       }
     />

--- a/components/admin_console/system_user_detail/team_list/abstract_list.test.jsx
+++ b/components/admin_console/system_user_detail/team_list/abstract_list.test.jsx
@@ -8,11 +8,21 @@ import AbstractList from './abstract_list.jsx';
 import TeamRow from './team_row.jsx';
 
 describe('admin_console/system_user_detail/team_list/AbstractList', () => {
+    const user = {
+        username: 'jim.halpert',
+        first_name: 'Jim',
+        last_name: 'Halpert',
+        nickname: 'Big Tuna',
+        id: '1234',
+        roles: 'system_user',
+    };
+
     const renderRow = jest.fn((item) => {
         return (
             <TeamRow
                 key={item.id}
                 team={item}
+                user={user}
                 onRowClick={jest.fn()}
             />
         );

--- a/components/admin_console/system_user_detail/team_list/team_list.jsx
+++ b/components/admin_console/system_user_detail/team_list/team_list.jsx
@@ -38,7 +38,7 @@ const headerLabels = [
 
 export default class TeamList extends React.Component {
     static propTypes = {
-        userId: PropTypes.string.isRequired,
+        user: PropTypes.object.isRequired,
         locale: PropTypes.string.isRequired,
         emptyListTextId: PropTypes.string.isRequired,
         emptyListTextDefaultMessage: PropTypes.string.isRequired,
@@ -73,7 +73,7 @@ export default class TeamList extends React.Component {
         }
     }
 
-    getTeamsAndMemberships = async (userId = this.props.userId) => {
+    getTeamsAndMemberships = async (userId = this.props.user.id) => {
         const teams = await this.props.actions.getTeamsData(userId);
         const memberships = await this.props.actions.getTeamMembersForUser(userId);
         return Promise.all([teams, memberships]).
@@ -106,7 +106,7 @@ export default class TeamList extends React.Component {
                 actions={this.props.actions}
                 emptyListTextId={this.props.emptyListTextId}
                 emptyListTextDefaultMessage={this.props.emptyListTextDefaultMessage}
-                userId={this.props.userId}
+                userId={this.props.user.id}
             />
         );
     }
@@ -116,6 +116,7 @@ export default class TeamList extends React.Component {
             <TeamRow
                 key={item.id}
                 team={item}
+                user={this.props.user}
                 onRowClick={this.onTeamClick}
             />
         );

--- a/components/admin_console/system_user_detail/team_list/team_list.test.jsx
+++ b/components/admin_console/system_user_detail/team_list/team_list.test.jsx
@@ -8,7 +8,14 @@ import TeamList from './team_list.jsx';
 
 describe('admin_console/system_user_detail/team_list/TeamList', () => {
     const defaultProps = {
-        userId: '1234',
+        user: {
+            username: 'jim.halpert',
+            first_name: 'Jim',
+            last_name: 'Halpert',
+            nickname: 'Big Tuna',
+            id: '1234',
+            roles: 'system_user',
+        },
         locale: 'en',
         emptyListTextId: 'emptyListTextId',
         emptyListTextDefaultMessage: 'No teams found',

--- a/components/admin_console/system_user_detail/team_list/team_row.jsx
+++ b/components/admin_console/system_user_detail/team_list/team_row.jsx
@@ -13,6 +13,7 @@ import './team_row.scss';
 export default class TeamRow extends React.Component {
     static propTypes = {
         team: PropTypes.object.isRequired,
+        user: PropTypes.object.isRequired,
     };
     renderTeamType = (team) => {
         if (team.group_constrained) {
@@ -38,8 +39,25 @@ export default class TeamRow extends React.Component {
             />
         );
     }
-    renderTeamRole = (team) => {
-        if (team.scheme_admin) {
+    renderTeamRole = (team, user) => {
+        const isSysAdmin = Utils.isSystemAdmin(user.roles);
+        const isAdmin = team.scheme_admin && !isSysAdmin;
+        const isGuest = Utils.isGuest(user);
+        if (isGuest) {
+            return (
+                <FormattedMessage
+                    id={'admin.system_users.guest'}
+                    defaultMessage={'Guest'}
+                />
+            );
+        } else if (isSysAdmin) {
+            return (
+                <FormattedMessage
+                    id={'admin.system_users.system_admin'}
+                    defaultMessage={'System Admin'}
+                />
+            );
+        } else if (isAdmin) {
             return (
                 <FormattedMessage
                     id={'admin.systemUserDetail.teamList.teamRole.admin'}
@@ -55,7 +73,7 @@ export default class TeamRow extends React.Component {
         );
     }
     render = () => {
-        const {team} = this.props;
+        const {team, user} = this.props;
         const teamIconUrl = Utils.imageURLForTeam(team);
         return (
             <div className={'TeamRow'}>
@@ -83,7 +101,7 @@ export default class TeamRow extends React.Component {
                     </span>
 
                     <span className='TeamRow__description'>
-                        {this.renderTeamRole(team)}
+                        {this.renderTeamRole(team, user)}
                     </span>
                 </div>
             </div>


### PR DESCRIPTION
#### Summary

Fixes a problem with roles in `TeamRow` not showing the correct label for Guests and System Admins.

This is a PR **only** aimed at **5.17** since same components have been heavily updated by #3766.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19470