### PR TITLE
MM-19491 Only mark channel as read on focus when channel isn't manually unread

### DIFF
--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -3,13 +3,26 @@
 
 import {batchActions} from 'redux-batched-actions';
 
-import {leaveChannel as leaveChannelRedux, joinChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
+import {
+    leaveChannel as leaveChannelRedux,
+    joinChannel,
+    markChannelAsRead,
+    unfavoriteChannel,
+} from 'mattermost-redux/actions/channels';
 import * as PostActions from 'mattermost-redux/actions/posts';
 import {TeamTypes} from 'mattermost-redux/action_types';
 import {autocompleteUsers} from 'mattermost-redux/actions/users';
 import {selectTeam} from 'mattermost-redux/actions/teams';
 import {Posts} from 'mattermost-redux/constants';
-import {getChannel, getChannelsNameMapInCurrentTeam, getCurrentChannel, getRedirectChannelNameForTeam, getMyChannels, getMyChannelMemberships} from 'mattermost-redux/selectors/entities/channels';
+import {
+    getChannel,
+    getChannelsNameMapInCurrentTeam,
+    getCurrentChannel,
+    getRedirectChannelNameForTeam,
+    getMyChannels,
+    getMyChannelMemberships,
+    isManuallyUnread,
+} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentRelativeTeamUrl, getCurrentTeam, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getUserByUsername} from 'mattermost-redux/selectors/entities/users';
 import {getMyPreferences} from 'mattermost-redux/selectors/entities/preferences';
@@ -301,5 +314,15 @@ export function syncPostsInChannel(channelId, since, fetchThreads = true) {
 export function scrollPostListToBottom() {
     return () => {
         EventEmitter.emit(EventTypes.POST_LIST_SCROLL_TO_BOTTOM);
+    };
+}
+
+export function markChannelAsReadOnFocus(channelId) {
+    return (dispatch, getState) => {
+        if (isManuallyUnread(getState(), channelId)) {
+            return;
+        }
+
+        dispatch(markChannelAsRead(channelId));
     };
 }

--- a/actions/views/channel.test.js
+++ b/actions/views/channel.test.js
@@ -5,7 +5,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import {General, Posts} from 'mattermost-redux/constants';
-import {leaveChannel} from 'mattermost-redux/actions/channels';
+import {leaveChannel, markChannelAsRead} from 'mattermost-redux/actions/channels';
 import * as PostActions from 'mattermost-redux/actions/posts';
 
 import {browserHistory} from 'utils/browser_history';
@@ -26,15 +26,13 @@ jest.mock('utils/channel_utils.jsx', () => ({
 }));
 
 jest.mock('actions/channel_actions.jsx', () => ({
-    openDirectChannelToUserId: jest.fn(() => {
-        return {type: ''};
-    }),
+    openDirectChannelToUserId: jest.fn(() => ({type: ''})),
 }));
 
 jest.mock('mattermost-redux/actions/channels', () => ({
-    leaveChannel: jest.fn(() => {
-        return {type: ''};
-    }),
+    ...jest.requireActual('mattermost-redux/actions/channels'),
+    markChannelAsRead: jest.fn(() => ({type: ''})),
+    leaveChannel: jest.fn(() => ({type: ''})),
 }));
 
 jest.mock('mattermost-redux/actions/posts');
@@ -64,6 +62,7 @@ describe('channel view actions', () => {
             channels: {
                 currentChannelId: 'channelid1',
                 channels: {channelid1: channel1, channelid2: townsquare, gmchannelid: gmChannel},
+                manuallyUnread: {},
                 myMembers: {
                     gmchannelid: {channel_id: 'gmchannelid', user_id: 'userid1'},
                     channelid1: {channel_id: 'channelid1', user_id: 'userid1'},
@@ -488,6 +487,35 @@ describe('channel view actions', () => {
 
             await store.dispatch(Actions.syncPostsInChannel(channelId, 12355, false));
             expect(PostActions.getPostsSince).toHaveBeenCalledWith(channelId, 12343, false);
+        });
+    });
+
+    describe('markChannelAsReadOnFocus', () => {
+        test('should mark channel as read when channel is not manually unread', async () => {
+            test = mockStore(initialState);
+
+            await store.dispatch(Actions.markChannelAsReadOnFocus(channel1.id));
+
+            expect(markChannelAsRead).toHaveBeenCalledWith(channel1.id);
+        });
+
+        test('should not mark channel as read when channel is manually unread', async () => {
+            store = mockStore({
+                ...initialState,
+                entities: {
+                    ...initialState.entities,
+                    channels: {
+                        ...initialState.entities.channels,
+                        manuallyUnread: {
+                            [channel1.id]: true,
+                        },
+                    },
+                },
+            });
+
+            await store.dispatch(Actions.markChannelAsReadOnFocus(channel1.id));
+
+            expect(markChannelAsRead).not.toHaveBeenCalled();
         });
     });
 });

--- a/components/needs_team/index.js
+++ b/components/needs_team/index.js
@@ -6,7 +6,7 @@ import {bindActionCreators} from 'redux';
 import {withRouter} from 'react-router-dom';
 
 import {loadProfilesForDirect} from 'mattermost-redux/actions/users';
-import {fetchMyChannelsAndMembers, markChannelAsRead, viewChannel} from 'mattermost-redux/actions/channels';
+import {fetchMyChannelsAndMembers, viewChannel} from 'mattermost-redux/actions/channels';
 import {getMyTeamUnreads, getTeamByName, selectTeam} from 'mattermost-redux/actions/teams';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getLicense, getConfig} from 'mattermost-redux/selectors/entities/general';
@@ -14,9 +14,10 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeamId, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels';
 
-import {loadStatusesForChannelAndSidebar} from 'actions/status_actions';
 import {setPreviousTeamId} from 'actions/local_storage';
+import {loadStatusesForChannelAndSidebar} from 'actions/status_actions';
 import {addUserToTeam} from 'actions/team_actions';
+import {markChannelAsReadOnFocus} from 'actions/views/channel';
 import {checkIfMFARequired} from 'utils/route';
 
 import NeedsTeam from './needs_team.jsx';
@@ -42,7 +43,7 @@ function mapDispatchToProps(dispatch) {
             fetchMyChannelsAndMembers,
             getMyTeamUnreads,
             viewChannel,
-            markChannelAsRead,
+            markChannelAsReadOnFocus,
             getTeamByName,
             addUserToTeam,
             setPreviousTeamId,

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -34,7 +34,7 @@ export default class NeedsTeam extends React.Component {
             fetchMyChannelsAndMembers: PropTypes.func.isRequired,
             getMyTeamUnreads: PropTypes.func.isRequired,
             viewChannel: PropTypes.func.isRequired,
-            markChannelAsRead: PropTypes.func.isRequired,
+            markChannelAsReadOnFocus: PropTypes.func.isRequired,
             getTeamByName: PropTypes.func.isRequired,
             addUserToTeam: PropTypes.func.isRequired,
             selectTeam: PropTypes.func.isRequired,
@@ -148,7 +148,7 @@ export default class NeedsTeam extends React.Component {
     }
 
     handleFocus = () => {
-        this.props.actions.markChannelAsRead(this.props.currentChannelId);
+        this.props.actions.markChannelAsReadOnFocus(this.props.currentChannelId);
         window.isActive = true;
 
         if (Date.now() - this.blurTime > UNREAD_CHECK_TIME_MILLISECONDS) {

--- a/components/needs_team/needs_team.test.jsx
+++ b/components/needs_team/needs_team.test.jsx
@@ -56,7 +56,7 @@ describe('components/needs_team', () => {
         fetchMyChannelsAndMembers: jest.fn().mockResolvedValue({data: true}),
         getMyTeamUnreads: jest.fn(),
         viewChannel: jest.fn(),
-        markChannelAsRead: jest.fn(),
+        markChannelAsReadOnFocus: jest.fn(),
         getTeamByName: jest.fn().mockResolvedValue({data: teamData}),
         addUserToTeam: jest.fn().mockResolvedValue({data: true}),
         selectTeam: jest.fn(),


### PR DESCRIPTION
Currently, if you select another window and then switch back to Mattermost, it marks the channel as read, even if you previously marked it as unread. This fixes that

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19491