### PR TITLE
MM-18629 - Remove default value for radio elements in interactive dialogs

### DIFF
--- a/components/interactive_dialog/dialog_element/dialog_element.jsx
+++ b/components/interactive_dialog/dialog_element/dialog_element.jsx
@@ -178,7 +178,7 @@ export default class DialogElement extends React.PureComponent {
                     label={displayNameContent}
                     helpText={helpTextContent}
                     options={options}
-                    value={value || (options && options[0].value)}
+                    value={value}
                     onChange={onChange}
                 />
             );

--- a/components/interactive_dialog/dialog_element/dialog_element.test.jsx
+++ b/components/interactive_dialog/dialog_element/dialog_element.test.jsx
@@ -165,7 +165,7 @@ describe('components/interactive_dialog/DialogElement', () => {
             expect(wrapper.find(RadioSetting).exists()).toBe(true);
         });
 
-        test('The default value is the first element of the list', () => {
+        test('No default value is selected from the radio button list', () => {
             const wrapper = shallow(
                 <DialogElement
                     {...baseDialogProps}
@@ -174,7 +174,7 @@ describe('components/interactive_dialog/DialogElement', () => {
                     onChange={jest.fn()}
                 />
             );
-            expect(wrapper.find({options: radioOptions, value: radioOptions[0].value}).exists()).toBe(true);
+            expect(wrapper.find({options: radioOptions}).props.value).toBeUndefined();
         });
 
         test('The default value can be specified from the list', () => {


### PR DESCRIPTION
#### Summary
Remove default value for radio elements in interactive dialogs so no option is selected initially. 

#### Ticket Link
[MM-18629](https://mattermost.atlassian.net/browse/MM-18629)
