### PR TITLE
[MM-15270] Request team from API if invite_id is empty

### DIFF
--- a/components/invitation_modal/index.js
+++ b/components/invitation_modal/index.js
@@ -9,6 +9,7 @@ import {getMyChannels} from 'mattermost-redux/selectors/entities/channels';
 import {haveIChannelPermission, haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getProfiles, searchProfiles as reduxSearchProfiles} from 'mattermost-redux/actions/users';
+import {getTeam} from 'mattermost-redux/actions/teams';
 import {Permissions} from 'mattermost-redux/constants';
 
 import {closeModal} from 'actions/views/modals';
@@ -61,6 +62,7 @@ function mapDispatchToProps(dispatch) {
             sendGuestsInvites,
             sendMembersInvites,
             searchProfiles,
+            getTeam,
         }, dispatch),
     };
 }

--- a/components/invitation_modal/invitation_modal.jsx
+++ b/components/invitation_modal/invitation_modal.jsx
@@ -35,6 +35,7 @@ export default class InvitationModal extends React.Component {
             sendGuestsInvites: PropTypes.func.isRequired,
             sendMembersInvites: PropTypes.func.isRequired,
             searchProfiles: PropTypes.func.isRequired,
+            getTeam: PropTypes.func.isRequired,
         }).isRequired,
     }
 
@@ -65,6 +66,12 @@ export default class InvitationModal extends React.Component {
             invitesSent: [],
             invitesNotSent: [],
         };
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (this.state.step === STEPS_INVITE_MEMBERS && prevState.step !== STEPS_INVITE_MEMBERS && !this.props.currentTeam.invite_id) {
+            this.props.actions.getTeam(this.props.currentTeam.id);
+        }
     }
 
     goToInitialStep = () => {

--- a/components/invitation_modal/invitation_modal.test.jsx
+++ b/components/invitation_modal/invitation_modal.test.jsx
@@ -27,6 +27,7 @@ describe('components/invitation_modal/InvitationModal', () => {
             sendGuestsInvites: jest.fn(),
             sendMembersInvites: jest.fn(),
             searchProfiles: jest.fn(),
+            getTeam: jest.fn(),
         },
     };
 
@@ -69,5 +70,18 @@ describe('components/invitation_modal/InvitationModal', () => {
             {context}
         );
         expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should call actions.getTeam if invite_id is empty', () => {
+        const props = {...defaultProps};
+        props.currentTeam.invite_id = '';
+        const wrapper = shallow(
+            <InvitationModal {...props}/>,
+            {context}
+        );
+        wrapper.instance().goToMembers();
+
+        expect(props.actions.getTeam).toHaveBeenCalledTimes(1);
+        expect(props.actions.getTeam).toHaveBeenCalledWith(props.currentTeam.id);
     });
 });

--- a/components/team_general_tab/index.js
+++ b/components/team_general_tab/index.js
@@ -5,7 +5,7 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {patchTeam, removeTeamIcon, setTeamIcon, regenerateTeamInviteId} from 'mattermost-redux/actions/teams';
+import {getTeam, patchTeam, removeTeamIcon, setTeamIcon, regenerateTeamInviteId} from 'mattermost-redux/actions/teams';
 import {Permissions} from 'mattermost-redux/constants';
 import {haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 
@@ -26,6 +26,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            getTeam,
             patchTeam,
             regenerateTeamInviteId,
             removeTeamIcon,

--- a/components/team_general_tab/team_general_tab.jsx
+++ b/components/team_general_tab/team_general_tab.jsx
@@ -28,6 +28,7 @@ export default class GeneralTab extends React.Component {
         collapseModal: PropTypes.func.isRequired,
         maxFileSize: PropTypes.number.isRequired,
         actions: PropTypes.shape({
+            getTeam: PropTypes.func.isRequired,
             patchTeam: PropTypes.func.isRequired,
             regenerateTeamInviteId: PropTypes.func.isRequired,
             removeTeamIcon: PropTypes.func.isRequired,
@@ -38,7 +39,6 @@ export default class GeneralTab extends React.Component {
 
     constructor(props) {
         super(props);
-
         this.state = this.setupInitialState(props);
     }
 
@@ -74,6 +74,27 @@ export default class GeneralTab extends React.Component {
             allowed_domains: nextProps.team.allowed_domains,
             invite_id: nextProps.team.invite_id,
             allow_open_invite: nextProps.team.allow_open_invite,
+        });
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (!prevState.shouldFetchTeam && this.state.shouldFetchTeam) {
+            this.fetchTeam();
+        }
+    }
+
+    fetchTeam() {
+        if (this.state.serverError) {
+            return;
+        }
+        this.props.actions.getTeam(this.props.team.id).then(({error}) => {
+            const state = {
+                shouldFetchTeam: false,
+            };
+            if (error) {
+                state.serverError = error.message;
+            }
+            this.setState(state);
         });
     }
 
@@ -270,6 +291,13 @@ export default class GeneralTab extends React.Component {
     }
 
     handleUpdateSection = (section) => {
+        if (section === 'invite_id' && this.props.activeSection !== section && !this.props.team.invite_id) {
+            this.setState({shouldFetchTeam: true}, () => {
+                this.updateSection(section);
+            });
+            return;
+        }
+
         this.updateSection(section);
     }
 

--- a/components/team_general_tab/team_general_tab.test.jsx
+++ b/components/team_general_tab/team_general_tab.test.jsx
@@ -6,12 +6,14 @@ import {shallow} from 'enzyme';
 import GeneralTab from 'components/team_general_tab/team_general_tab.jsx';
 
 describe('components/TeamSettings', () => {
+    const getTeam = jest.fn().mockResolvedValue({data: true});
     const patchTeam = jest.fn().mockReturnValue({data: true});
     const regenerateTeamInviteId = jest.fn().mockReturnValue({data: true});
     const removeTeamIcon = jest.fn().mockReturnValue({data: true});
     const setTeamIcon = jest.fn().mockReturnValue({data: true});
 
     const baseActions = {
+        getTeam,
         patchTeam,
         regenerateTeamInviteId,
         removeTeamIcon,
@@ -178,5 +180,18 @@ describe('components/TeamSettings', () => {
         const wrapper = shallow(<GeneralTab {...props}/>);
 
         expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should call actions.getTeam on handleUpdateSection if invite_id is empty', () => {
+        const actions = {...baseActions};
+        const props = {...defaultProps, actions};
+        props.team.invite_id = '';
+
+        const wrapper = shallow(<GeneralTab {...props}/>);
+
+        wrapper.instance().handleUpdateSection('invite_id');
+
+        expect(actions.getTeam).toHaveBeenCalledTimes(1);
+        expect(actions.getTeam).toHaveBeenCalledWith(props.team.id);
     });
 });


### PR DESCRIPTION
#### Summary

PR adds a `getTeam` request in team settings/invitation modal if `team.invite_id` is empty since we'll soon be removing `invite_id` from the related websocket broadcasted event for security reasons.  

This PR is backward compatible and can be merged.

#### Ticket

https://mattermost.atlassian.net/browse/MM-15270

#### Related PRs

https://github.com/mattermost/mattermost-server/pull/12952