### PR TITLE
[MM-19687] Refresh icon is not displayed for the Github Integration on the LHS when alert banner is visible

### DIFF
--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -8,6 +8,10 @@
     width: 65px;
     z-index: 13;
 
+    body.announcement-bar--fixed & {
+        height: calc(100% - #{$announcement-bar-height});
+    }
+
     .fa {
         @include single-transition(all, .15s, ease);
         @include opacity(.6);


### PR DESCRIPTION
#### Summary
- Set the correct height for the team sidebar when the announcement banner is visible.
- This was pushing the github plugin's icons off the visible window.

#### Ticket Link
[MM-19687](https://mattermost.atlassian.net/browse/MM-19687) 
