### PR TITLE
MM-19586 Fix various accessibility issues

### DIFF
--- a/components/__snapshots__/autosize_textarea.test.jsx.snap
+++ b/components/__snapshots__/autosize_textarea.test.jsx.snap
@@ -30,6 +30,7 @@ exports[`components/AutosizeTextarea should match snapshot, init 1`] = `
     }
   >
     <textarea
+      aria-hidden={true}
       disabled={true}
       id="undefined-reference"
       rows="1"

--- a/components/autosize_textarea.jsx
+++ b/components/autosize_textarea.jsx
@@ -165,6 +165,7 @@ export default class AutosizeTextarea extends React.Component {
                         rows='1'
                         {...otherProps}
                         value={value || defaultValue}
+                        aria-hidden={true}
                     />
                 </div>
             </div>

--- a/components/channel_header/__snapshots__/channel_header.test.jsx.snap
+++ b/components/channel_header/__snapshots__/channel_header.test.jsx.snap
@@ -109,6 +109,7 @@ exports[`components/ChannelHeader should render archived view 1`] = `
       tooltipKey="pinnedPosts"
     />
     <HeaderIconWrapper
+      ariaLabel={true}
       buttonId="channelHeaderSearchButton"
       iconComponent={
         <SearchIcon
@@ -343,6 +344,7 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
       tooltipKey="pinnedPosts"
     />
     <HeaderIconWrapper
+      ariaLabel={true}
       buttonId="channelHeaderSearchButton"
       iconComponent={
         <SearchIcon
@@ -548,6 +550,7 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
       tooltipKey="pinnedPosts"
     />
     <HeaderIconWrapper
+      ariaLabel={true}
       buttonId="channelHeaderSearchButton"
       iconComponent={
         <SearchIcon
@@ -764,6 +767,7 @@ exports[`components/ChannelHeader should render properly when populated with cha
       tooltipKey="pinnedPosts"
     />
     <HeaderIconWrapper
+      ariaLabel={true}
       buttonId="channelHeaderSearchButton"
       iconComponent={
         <SearchIcon

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -682,6 +682,7 @@ export default class ChannelHeader extends React.PureComponent {
                                     aria-hidden='true'
                                 />
                             }
+                            ariaLabel={true}
                             buttonId={'channelHeaderSearchButton'}
                             onClick={this.searchButtonClick}
                             tooltipKey={'search'}

--- a/components/sidebar/__snapshots__/sidebar.test.jsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.jsx.snap
@@ -87,7 +87,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="publicChannelList"
           key="public"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -140,7 +139,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="privateChannelList"
           key="private"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -193,7 +191,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="directChannelList"
           key="direct"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -358,7 +355,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="publicChannelList"
           key="public"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -411,7 +407,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="privateChannelList"
           key="private"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -464,7 +459,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="directChannelList"
           key="direct"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -629,7 +623,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="publicChannelList"
           key="public"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -682,7 +675,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="privateChannelList"
           key="private"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -735,7 +727,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="directChannelList"
           key="direct"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -900,7 +891,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="publicChannelList"
           key="public"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -953,7 +943,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="privateChannelList"
           key="private"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1006,7 +995,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
           className="nav nav-pills nav-stacked a11y__section"
           id="directChannelList"
           key="direct"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1179,7 +1167,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="publicChannelList"
           key="public"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1232,7 +1219,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="privateChannelList"
           key="private"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1285,7 +1271,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="directChannelList"
           key="direct"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1450,7 +1435,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="publicChannelList"
           key="public"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1503,7 +1487,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="privateChannelList"
           key="private"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1556,7 +1539,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="directChannelList"
           key="direct"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1725,7 +1707,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="publicChannelList"
           key="public"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1778,7 +1759,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="privateChannelList"
           key="private"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1831,7 +1811,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="directChannelList"
           key="direct"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -1996,7 +1975,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="publicChannelList"
           key="public"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -2049,7 +2027,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="privateChannelList"
           key="private"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -2102,7 +2079,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="directChannelList"
           key="direct"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -2267,7 +2243,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="publicChannelList"
           key="public"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -2320,7 +2295,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="privateChannelList"
           key="private"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -2373,7 +2347,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="directChannelList"
           key="direct"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -2538,7 +2511,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="publicChannelList"
           key="public"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -2591,7 +2563,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="privateChannelList"
           key="private"
-          role="presentation"
           tabIndex="-1"
         >
           <li
@@ -2644,7 +2615,6 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
           className="nav nav-pills nav-stacked a11y__section"
           id="directChannelList"
           key="direct"
-          role="presentation"
           tabIndex="-1"
         >
           <li

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -589,7 +589,6 @@ export default class Sidebar extends React.PureComponent {
                             <ul
                                 key={section.type}
                                 aria-label={ariaLabel}
-                                role='presentation'
                                 className='nav nav-pills nav-stacked a11y__section'
                                 id={sectionId + 'List'}
                                 tabIndex='-1'

--- a/components/user_settings/notifications/__snapshots__/manage_auto_responder.test.jsx.snap
+++ b/components/user_settings/notifications/__snapshots__/manage_auto_responder.test.jsx.snap
@@ -412,6 +412,7 @@ exports[`components/user_settings/notifications/ManageAutoResponder should match
                       }
                     >
                       <textarea
+                        aria-hidden={true}
                         className="form-control"
                         disabled={true}
                         id="autoResponderMessageInput-reference"


### PR DESCRIPTION
This adds a missing aria-label to the channel header search button (only visible in tablet view), adds aria-hidden to the reference textarea for the AutosizeTextarea, and removes the incorrect `role="presentation"` from the lists that make up each section of the LHS channel list.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19586