### PR TITLE
MM-19759 - Added TOS and Privacy Policy default links in About Screen

### DIFF
--- a/components/about_build_modal/__snapshots__/about_build_modal.test.jsx.snap
+++ b/components/about_build_modal/__snapshots__/about_build_modal.test.jsx.snap
@@ -171,6 +171,7 @@ exports[`components/AboutBuildModal should match snapshot for enterprise edition
         >
           <a
             href="https://about.mattermost.com/default-terms/"
+            id="tosLink"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -184,7 +185,8 @@ exports[`components/AboutBuildModal should match snapshot for enterprise edition
              - 
           </span>
           <a
-            href="https://mattermost.com/privacy-policy/"
+            href="https://about.mattermost.com/default-privacy-policy/"
+            id="privacyLink"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -409,6 +411,7 @@ exports[`components/AboutBuildModal should match snapshot for team edition 1`] =
         >
           <a
             href="https://about.mattermost.com/default-terms/"
+            id="tosLink"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -422,7 +425,8 @@ exports[`components/AboutBuildModal should match snapshot for team edition 1`] =
              - 
           </span>
           <a
-            href="https://mattermost.com/privacy-policy/"
+            href="https://about.mattermost.com/default-privacy-policy/"
+            id="privacyLink"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -658,6 +662,7 @@ exports[`components/AboutBuildModal should show ci if a ci build 1`] = `
         >
           <a
             href="https://about.mattermost.com/default-terms/"
+            id="tosLink"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -671,7 +676,8 @@ exports[`components/AboutBuildModal should show ci if a ci build 1`] = `
              - 
           </span>
           <a
-            href="https://mattermost.com/privacy-policy/"
+            href="https://about.mattermost.com/default-privacy-policy/"
+            id="privacyLink"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -895,6 +901,7 @@ exports[`components/AboutBuildModal should show dev if this is a dev build 1`] =
         >
           <a
             href="https://about.mattermost.com/default-terms/"
+            id="tosLink"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -908,7 +915,8 @@ exports[`components/AboutBuildModal should show dev if this is a dev build 1`] =
              - 
           </span>
           <a
-            href="https://mattermost.com/privacy-policy/"
+            href="https://about.mattermost.com/default-privacy-policy/"
+            id="privacyLink"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/components/about_build_modal/about_build_modal.jsx
+++ b/components/about_build_modal/about_build_modal.jsx
@@ -9,6 +9,8 @@ import {FormattedMessage} from 'react-intl';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 import MattermostLogo from 'components/widgets/icons/mattermost_logo';
 
+import {AboutLinks} from 'utils/constants';
+
 export default class AboutBuildModal extends React.PureComponent {
     static defaultProps = {
         show: false,
@@ -138,37 +140,33 @@ export default class AboutBuildModal extends React.PureComponent {
             }
         }
 
-        let termsOfService;
-        if (config.TermsOfServiceLink) {
-            termsOfService = (
-                <a
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    href={config.TermsOfServiceLink}
-                >
-                    <FormattedMessage
-                        id='about.tos'
-                        defaultMessage='Terms of Service'
-                    />
-                </a>
-            );
-        }
+        const termsOfService = (
+            <a
+                target='_blank'
+                id='tosLink'
+                rel='noopener noreferrer'
+                href={AboutLinks.TERMS_OF_SERVICE}
+            >
+                <FormattedMessage
+                    id='about.tos'
+                    defaultMessage='Terms of Service'
+                />
+            </a>
+        );
 
-        let privacyPolicy;
-        if (config.PrivacyPolicyLink) {
-            privacyPolicy = (
-                <a
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    href={config.PrivacyPolicyLink}
-                >
-                    <FormattedMessage
-                        id='about.privacy'
-                        defaultMessage='Privacy Policy'
-                    />
-                </a>
-            );
-        }
+        const privacyPolicy = (
+            <a
+                target='_blank'
+                id='privacyLink'
+                rel='noopener noreferrer'
+                href={AboutLinks.PRIVACY_POLICY}
+            >
+                <FormattedMessage
+                    id='about.privacy'
+                    defaultMessage='Privacy Policy'
+                />
+            </a>
+        );
 
         let tosPrivacyHyphen;
         if (config.TermsOfServiceLink && config.PrivacyPolicyLink) {

--- a/components/about_build_modal/about_build_modal.test.jsx
+++ b/components/about_build_modal/about_build_modal.test.jsx
@@ -7,6 +7,7 @@ import {shallow} from 'enzyme';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper.jsx';
 import AboutBuildModal from 'components/about_build_modal/about_build_modal.jsx';
+import {AboutLinks} from 'utils/constants';
 
 describe('components/AboutBuildModal', () => {
     const RealDate = Date;
@@ -40,8 +41,8 @@ describe('components/AboutBuildModal', () => {
             BuildHash: 'abcdef1234567890',
             BuildHashEnterprise: '0123456789abcdef',
             BuildDate: '21 January 2017',
-            TermsOfServiceLink: 'https://about.mattermost.com/default-terms/',
-            PrivacyPolicyLink: 'https://mattermost.com/privacy-policy/',
+            TermsOfServiceLink: 'https://about.custom.com/default-terms/',
+            PrivacyPolicyLink: 'https://about.custom.com/privacy-policy/',
         };
         license = {
             IsLicensed: 'true',
@@ -115,6 +116,23 @@ describe('components/AboutBuildModal', () => {
 
         wrapper.find(Modal).first().props().onExited();
         expect(onHide).toHaveBeenCalledTimes(1);
+    });
+
+    test('should show default tos and privacy policy links and not the config links', () => {
+        const wrapper = mountWithIntl(
+            <AboutBuildModal
+                config={config}
+                license={license}
+                show={true}
+                onHide={jest.fn()}
+            />
+        );
+
+        expect(wrapper.find('#tosLink').props().href).toBe(AboutLinks.TERMS_OF_SERVICE);
+        expect(wrapper.find('#privacyLink').props().href).toBe(AboutLinks.PRIVACY_POLICY);
+
+        expect(wrapper.find('#tosLink').props().href).not.toBe(config.TermsOfServiceLink);
+        expect(wrapper.find('#privacyLink').props().href).not.toBe(config.PrivacyPolicyLink);
     });
 
     function shallowAboutBuildModal(props = {}) {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -542,6 +542,11 @@ export const SidebarChannelGroups = {
     FAVORITE: 'favorite',
 };
 
+export const AboutLinks = {
+    TERMS_OF_SERVICE: 'https://about.mattermost.com/default-terms/',
+    PRIVACY_POLICY: 'https://about.mattermost.com/default-privacy-policy/',
+};
+
 export const PermissionsScope = {
     [Permissions.INVITE_USER]: 'team_scope',
     [Permissions.INVITE_GUEST]: 'team_scope',


### PR DESCRIPTION
#### Summary
Changed Terms of Service and Privacy Policy links in the About modal to always point to MM default links and not rely on the customizable links in the config.

The default links are currently defined in a constant here in the webApp for 5.17 quality release but should be retrieved from the API. This is captured in [this ticket](https://mattermost.atlassian.net/browse/MM-19788) for future release.

#### Ticket Link
[MM-19759](https://mattermost.atlassian.net/browse/MM-19759)

#### Related Pull Requests
- Has mobile changes (WIP)
