### PR TITLE
MM-19005 - Adjusting suggestion list sizing

### DIFF
--- a/sass/components/_suggestion-list.scss
+++ b/sass/components/_suggestion-list.scss
@@ -43,6 +43,10 @@
     padding-bottom: 5px;
     width: 100%;
 
+    .modal & {
+        max-height: 205px;
+    }
+
     .command {
         border-bottom: 1px solid $light-gray;
         font-size: .95em;


### PR DESCRIPTION
#### Summary
MM-19005 - Adjusting suggestion list sizing
This basically just reduces the size of the suggestion list to cater to the height for the remind plugin. Obviously a better solution would be to have the suggestion list render on the root level and then have check the amount of space available from the top/bottom of the screen and adjust its height based on that, but since we're not going too far with that now, this would do as a quick fix.

![Screenshot 2019-10-30 at 5 28 18 PM](https://user-images.githubusercontent.com/11034289/67858462-08c0b500-fb3b-11e9-993c-99414a775690.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19005