### PR TITLE
MM-19844 - Disallow plugin upload when PluginSettings.RequirePluginSignature is true

### DIFF
--- a/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
+++ b/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
@@ -61,6 +61,40 @@ exports[`components/PluginManagement should match snapshot 1`] = `
             }
             value={true}
           />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
+          />
           <div
             className="form-group"
           >
@@ -273,6 +307,40 @@ exports[`components/PluginManagement should match snapshot when \`Enable Plugins
           id="PluginSettings"
           show={true}
         >
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
+          />
           <div
             className="form-group"
           >
@@ -304,6 +372,286 @@ exports[`components/PluginManagement should match snapshot when \`Enable Plugins
                 <input
                   accept=".gz"
                   disabled={false}
+                  onChange={[Function]}
+                  type="file"
+                />
+              </div>
+              <button
+                className="btn"
+                disabled={true}
+                onClick={[Function]}
+              >
+                <FormattedMessage
+                  defaultMessage="Upload"
+                  id="admin.plugin.upload"
+                  values={Object {}}
+                />
+              </button>
+              <div
+                className="help-text no-margin"
+              />
+              <p
+                className="help-text"
+              >
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="Upload a plugin for your Mattermost server. See [documentation](!https://about.mattermost.com/default-plugin-uploads) to learn more."
+                  id="admin.plugin.uploadDesc"
+                />
+              </p>
+            </div>
+          </div>
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, enables System Administrators to install plugins from the [marketplace](!https://mattermost.com/pl/default-mattermost-marketplace.html)."
+                id="admin.plugins.settings.enableMarketplaceDesc"
+              />
+            }
+            id="enableMarketplace"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Marketplace:"
+                id="admin.plugins.settings.enableMarketplace"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <AdminTextSetting
+            disabled={false}
+            helpText={
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
+            }
+            id="marketplaceUrl"
+            label={
+              <FormattedMessage
+                defaultMessage="Marketplace URL:"
+                id="admin.plugins.settings.marketplaceUrl"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            type="input"
+            value="marketplace.example.com"
+          />
+          <div
+            className="form-group"
+          >
+            <label
+              className="control-label col-sm-4"
+            >
+              <FormattedMessage
+                defaultMessage="Installed Plugins: "
+                id="admin.plugin.installedTitle"
+                values={Object {}}
+              />
+            </label>
+            <div
+              className="col-sm-8"
+            >
+              <p
+                className="help-text"
+              >
+                <FormattedHTMLMessage
+                  defaultMessage="Installed plugins on your Mattermost server. Pre-packaged plugins are installed by default, and can be disabled but not removed."
+                  id="admin.plugin.installedDesc"
+                  values={Object {}}
+                />
+              </p>
+              <br />
+            </div>
+          </div>
+        </SettingsGroup>
+      </div>
+    </div>
+    <div
+      className="admin-console-save"
+    >
+      <SaveButton
+        btnClass="btn-primary"
+        disabled={true}
+        extraClasses=""
+        onClick={[Function]}
+        saving={false}
+        savingMessage="Saving Config..."
+      />
+      <div
+        className="error-message"
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <FormError
+          error={null}
+          errors={Array []}
+        />
+      </div>
+      <Overlay
+        animation={[Function]}
+        delayShow={400}
+        placement="top"
+        rootClose={false}
+        show={false}
+      >
+        <Tooltip
+          bsClass="tooltip"
+          id="error-tooltip"
+          placement="right"
+        />
+      </Overlay>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`components/PluginManagement should match snapshot when \`Require Signature Plugin\` is true 1`] = `
+<form
+  className="form-horizontal"
+  onSubmit={[Function]}
+  role="form"
+>
+  <div
+    className="wrapper--fixed"
+  >
+    <AdminHeader>
+      <FormattedMessage
+        defaultMessage="Management"
+        id="admin.plugin.management.title"
+        values={Object {}}
+      />
+    </AdminHeader>
+    <div
+      className="admin-console__wrapper"
+    >
+      <div
+        className="admin-console__content"
+      >
+        <SettingsGroup
+          container={false}
+          id="PluginSettings"
+          show={true}
+        >
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, enables plugins on your Mattermost server. Use plugins to integrate with third-party systems, extend functionality, or customize the user interface of your Mattermost server. See [documentation](https://about.mattermost.com/default-plugin-uploads) to learn more."
+                id="admin.plugins.settings.enableDesc"
+              />
+            }
+            id="enable"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Plugins: "
+                id="admin.plugins.settings.enable"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <div
+            className="form-group"
+          >
+            <label
+              className="control-label col-sm-4"
+            >
+              <FormattedMessage
+                defaultMessage="Upload Plugin: "
+                id="admin.plugin.uploadTitle"
+                values={Object {}}
+              />
+            </label>
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="file__upload"
+              >
+                <button
+                  className="btn btn-primary"
+                  disabled={true}
+                >
+                  <FormattedMessage
+                    defaultMessage="Choose File"
+                    id="admin.plugin.choose"
+                    values={Object {}}
+                  />
+                </button>
+                <input
+                  accept=".gz"
+                  disabled={true}
                   onChange={[Function]}
                   type="file"
                 />
@@ -518,6 +866,40 @@ exports[`components/PluginManagement should match snapshot, No installed plugins
               />
             }
             value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
           />
           <div
             className="form-group"
@@ -770,6 +1152,40 @@ exports[`components/PluginManagement should match snapshot, allow insecure URL e
             }
             value={true}
           />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
+          />
           <div
             className="form-group"
           >
@@ -1016,6 +1432,40 @@ exports[`components/PluginManagement should match snapshot, disabled 1`] = `
             }
             value={false}
           />
+          <BooleanSetting
+            disabled={true}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
+          />
           <div
             className="form-group"
           >
@@ -1234,6 +1684,40 @@ exports[`components/PluginManagement should match snapshot, text entered into th
               />
             }
             value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
           />
           <div
             className="form-group"
@@ -1481,6 +1965,40 @@ exports[`components/PluginManagement should match snapshot, upload disabled 1`] 
             }
             value={true}
           />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
+          />
           <div
             className="form-group"
           >
@@ -1726,6 +2244,40 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
               />
             }
             value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
           />
           <div
             className="form-group"
@@ -2036,6 +2588,40 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             value={true}
           />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
+          />
           <div
             className="form-group"
           >
@@ -2312,6 +2898,40 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
               />
             }
             value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
           />
           <div
             className="form-group"
@@ -2590,6 +3210,40 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             value={true}
           />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
+          />
           <div
             className="form-group"
           >
@@ -2866,6 +3520,40 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
               />
             }
             value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
           />
           <div
             className="form-group"

--- a/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
+++ b/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
@@ -72,7 +72,7 @@ exports[`components/PluginManagement should match snapshot 1`] = `
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -318,7 +318,7 @@ exports[`components/PluginManagement should match snapshot when \`Enable Plugins
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -598,7 +598,7 @@ exports[`components/PluginManagement should match snapshot when \`Require Signat
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -878,7 +878,7 @@ exports[`components/PluginManagement should match snapshot, No installed plugins
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -1163,7 +1163,7 @@ exports[`components/PluginManagement should match snapshot, allow insecure URL e
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -1443,7 +1443,7 @@ exports[`components/PluginManagement should match snapshot, disabled 1`] = `
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -1696,7 +1696,7 @@ exports[`components/PluginManagement should match snapshot, text entered into th
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -1976,7 +1976,7 @@ exports[`components/PluginManagement should match snapshot, upload disabled 1`] 
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -2256,7 +2256,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -2599,7 +2599,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -2910,7 +2910,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -3221,7 +3221,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }
@@ -3532,7 +3532,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization."
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more."
                 id="admin.plugins.settings.requirePluginSignatureDesc"
               />
             }

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -968,7 +968,7 @@ export default class PluginManagement extends AdminSettings {
                             helpText={
                                 <FormattedMarkdownMessage
                                     id='admin.plugins.settings.requirePluginSignatureDesc'
-                                    defaultMessage='When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization.'
+                                    defaultMessage='When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more.'
                                 />
                             }
                             value={this.state.requirePluginSignature}

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
+import classNames from 'classnames';
+
 import PluginState from 'mattermost-redux/constants/plugins';
 
 import * as Utils from 'utils/utils.jsx';
@@ -435,6 +437,7 @@ export default class PluginManagement extends AdminSettings {
         config.PluginSettings.AllowInsecureDownloadUrl = this.state.allowInsecureDownloadUrl;
         config.PluginSettings.EnableMarketplace = this.state.enableMarketplace;
         config.PluginSettings.MarketplaceUrl = this.state.marketplaceUrl;
+        config.PluginSettings.RequirePluginSignature = this.state.requirePluginSignature;
 
         return config;
     }
@@ -446,6 +449,7 @@ export default class PluginManagement extends AdminSettings {
             allowInsecureDownloadUrl: config.PluginSettings.AllowInsecureDownloadUrl,
             enableMarketplace: config.PluginSettings.EnableMarketplace,
             marketplaceUrl: config.PluginSettings.MarketplaceUrl,
+            requirePluginSignature: config.PluginSettings.RequirePluginSignature,
         };
 
         return state;
@@ -916,7 +920,7 @@ export default class PluginManagement extends AdminSettings {
                     defaultMessage='Upload a plugin for your Mattermost server. See [documentation](!https://about.mattermost.com/default-plugin-uploads) to learn more.'
                 />
             );
-        } else if (enable === true && enableUploads === false) {
+        } else if (enable && !enableUploads) {
             uploadHelpText = (
                 <FormattedMarkdownMessage
                     id='admin.plugin.uploadDisabledDesc'
@@ -931,8 +935,6 @@ export default class PluginManagement extends AdminSettings {
                 />
             );
         }
-
-        const uploadBtnClass = enableUploads ? 'btn btn-primary' : 'btn';
 
         const overwriteUploadPluginModal = this.state.confirmOverwriteUploadModal && this.renderOverwritePluginModal({
             show: this.state.confirmOverwriteUploadModal,
@@ -955,6 +957,26 @@ export default class PluginManagement extends AdminSettings {
                     >
                         {this.renderEnablePluginsSetting()}
 
+                        <BooleanSetting
+                            id='requirePluginSignature'
+                            label={
+                                <FormattedMessage
+                                    id='admin.plugins.settings.requirePluginSignature'
+                                    defaultMessage='Require Plugin Signature:'
+                                />
+                            }
+                            helpText={
+                                <FormattedMarkdownMessage
+                                    id='admin.plugins.settings.requirePluginSignatureDesc'
+                                    defaultMessage='When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization.'
+                                />
+                            }
+                            value={this.state.requirePluginSignature}
+                            disabled={!this.state.enable}
+                            onChange={this.handleChange}
+                            setByEnv={this.isSetByEnv('PluginSettings.RequirePluginSignature')}
+                        />
+
                         <div className='form-group'>
                             <label
                                 className='control-label col-sm-4'
@@ -967,8 +989,8 @@ export default class PluginManagement extends AdminSettings {
                             <div className='col-sm-8'>
                                 <div className='file__upload'>
                                     <button
-                                        className={uploadBtnClass}
-                                        disabled={!enableUploads || !enable}
+                                        className={classNames(['btn', {'btn-primary': enableUploads}])}
+                                        disabled={!enableUploads || !this.state.enable || this.state.requirePluginSignature}
                                     >
                                         <FormattedMessage
                                             id='admin.plugin.choose'
@@ -980,7 +1002,7 @@ export default class PluginManagement extends AdminSettings {
                                         type='file'
                                         accept='.gz'
                                         onChange={this.handleUpload}
-                                        disabled={!enableUploads || !enable}
+                                        disabled={!enableUploads || !this.state.enable || this.state.requirePluginSignature}
                                     />
                                 </div>
                                 <button

--- a/components/admin_console/plugin_management/plugin_management.test.jsx
+++ b/components/admin_console/plugin_management/plugin_management.test.jsx
@@ -17,6 +17,7 @@ describe('components/PluginManagement', () => {
                 AllowInsecureDownloadUrl: false,
                 EnableMarketplace: true,
                 MarketplaceUrl: 'marketplace.example.com',
+                RequirePluginSignature: false,
             },
             ExperimentalSettings: {
                 RestrictSystemAdmin: false,
@@ -128,6 +129,21 @@ describe('components/PluginManagement', () => {
                 ...defaultProps.config,
                 ExperimentalSettings: {
                     RestrictSystemAdmin: true,
+                },
+            },
+        };
+        const wrapper = shallow(<PluginManagement {...props}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should match snapshot when `Require Signature Plugin` is true', () => {
+        const props = {
+            ...defaultProps,
+            config: {
+                ...defaultProps.config,
+                PluginSettings: {
+                    ...defaultProps.config.PluginSettings,
+                    RequirePluginSignature: true,
                 },
             },
         };

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1141,7 +1141,7 @@
   "admin.plugins.settings.marketplaceUrlDesc": "URL of the marketplace server.",
   "admin.plugins.settings.marketplaceUrlDesc.empty": " Marketplace URL is a required field.",
   "admin.plugins.settings.requirePluginSignature": "Require Plugin Signature:",
-  "admin.plugins.settings.requirePluginSignatureDesc": "When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization.",
+  "admin.plugins.settings.requirePluginSignatureDesc": "When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](https://about.mattermost.com/) to learn more.",
   "admin.privacy.showEmailDescription": "When false, hides the email address of members from everyone except System Administrators.",
   "admin.privacy.showEmailTitle": "Show Email Address: ",
   "admin.privacy.showFullNameDescription": "When false, hides the full name of members from everyone except System Administrators. Username is shown in place of full name.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1140,6 +1140,8 @@
   "admin.plugins.settings.marketplaceUrl": "Marketplace URL:",
   "admin.plugins.settings.marketplaceUrlDesc": "URL of the marketplace server.",
   "admin.plugins.settings.marketplaceUrlDesc.empty": " Marketplace URL is a required field.",
+  "admin.plugins.settings.requirePluginSignature": "Require Plugin Signature:",
+  "admin.plugins.settings.requirePluginSignatureDesc": "When true, uploading plugins is disabled and plugins are always verified during Mattermost server startup and initialization.",
   "admin.privacy.showEmailDescription": "When false, hides the email address of members from everyone except System Administrators.",
   "admin.privacy.showEmailTitle": "Show Email Address: ",
   "admin.privacy.showFullNameDescription": "When false, hides the full name of members from everyone except System Administrators. Username is shown in place of full name.",


### PR DESCRIPTION
#### Summary
Add `RequirePluginSignature` setting to plugin configuration page.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-19844

#### Screenshots

##### When `RequirePluginSignature` is `true`
![image](https://user-images.githubusercontent.com/25732808/68060922-d2b93780-fcd8-11e9-9586-3aafadeecbaa.png)




##### When `RequirePluginSignature` is `false`
![image](https://user-images.githubusercontent.com/25732808/68033354-e7281080-fc95-11e9-9803-9230b257b10d.png)

