### PR TITLE
MM-19517 Allow styling of slack attachment interactive elements.

### DIFF
--- a/components/post_view/message_attachments/__snapshots__/action_button.test.jsx.snap
+++ b/components/post_view/message_attachments/__snapshots__/action_button.test.jsx.snap
@@ -6,11 +6,6 @@ exports[`components/post_view/message_attachments/action_button.jsx should match
   data-action-id="action_id_1"
   key="action_id_1"
   onClick={[MockFunction]}
-  style={
-    Object {
-      "border": "none",
-    }
-  }
 >
   <Connect(Markdown)
     message="action_name_1"

--- a/components/post_view/message_attachments/__snapshots__/action_button.test.jsx.snap
+++ b/components/post_view/message_attachments/__snapshots__/action_button.test.jsx.snap
@@ -6,6 +6,36 @@ exports[`components/post_view/message_attachments/action_button.jsx should match
   data-action-id="action_id_1"
   key="action_id_1"
   onClick={[MockFunction]}
+  style={
+    Object {
+      "border": "none",
+    }
+  }
+>
+  <Connect(Markdown)
+    message="action_name_1"
+    options={
+      Object {
+        "autolinkedUrlSchemes": Array [],
+        "markdown": false,
+        "mentionHighlight": false,
+      }
+    }
+  />
+</button>
+`;
+
+exports[`components/post_view/message_attachments/action_button.jsx styles should work 1`] = `
+<button
+  data-action-cookie="cookie-contents"
+  data-action-id="action_id_1"
+  key="action_id_1"
+  onClick={[MockFunction]}
+  style={
+    Object {
+      "border": "none",
+    }
+  }
 >
   <Connect(Markdown)
     message="action_name_1"

--- a/components/post_view/message_attachments/action_button.jsx
+++ b/components/post_view/message_attachments/action_button.jsx
@@ -20,6 +20,7 @@ export default class ActionButton extends React.PureComponent {
                 data-action-cookie={action.cookie}
                 key={action.id}
                 onClick={handleAction}
+                style={action.style}
             >
                 <Markdown
                     message={action.name}

--- a/components/post_view/message_attachments/action_button.test.jsx
+++ b/components/post_view/message_attachments/action_button.test.jsx
@@ -18,9 +18,12 @@ describe('components/post_view/message_attachments/action_button.jsx', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    baseProps.action.style = {border: 'none'};
     test('styles should work', () => {
-        const wrapper = shallow(<ActionButton {...baseProps}/>);
+        const props = {
+            ...baseProps,
+            action: {...baseProps.action, style: {border: 'none'}},
+        };
+        const wrapper = shallow(<ActionButton {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 

--- a/components/post_view/message_attachments/action_button.test.jsx
+++ b/components/post_view/message_attachments/action_button.test.jsx
@@ -18,6 +18,12 @@ describe('components/post_view/message_attachments/action_button.jsx', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    baseProps.action.style = {border: 'none'};
+    test('styles should work', () => {
+        const wrapper = shallow(<ActionButton {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should call handleAction on click', () => {
         const wrapper = shallow(<ActionButton {...baseProps}/>);
 

--- a/components/post_view/message_attachments/action_menu/action_menu.jsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.jsx
@@ -93,7 +93,8 @@ export default class ActionMenu extends React.PureComponent {
                 providers={this.providers}
                 onSelected={this.handleSelected}
                 placeholder={action.name}
-                inputClassName='post-attachment-dropdown'
+                inputClassName={'post-attachment-dropdown'}
+                style={action.style}
                 value={this.state.value}
             />
         );

--- a/components/post_view/message_attachments/action_menu/action_menu.test.jsx
+++ b/components/post_view/message_attachments/action_menu/action_menu.test.jsx
@@ -21,6 +21,9 @@ describe('components/post_view/message_attachments/ActionMenu', () => {
                     value: '2',
                 },
             ],
+            style: {
+                border: 'none',
+            },
         },
         actions: {
             autocompleteChannels: jest.fn(),


### PR DESCRIPTION
Allows the styling of slack attachment interactive elements (buttons and dropdown menus).

Related server PR: https://github.com/mattermost/mattermost-server/compare/mm-19517-2 