### PR TITLE
Fixed few flaky tests

### DIFF
--- a/e2e/cypress/integration/channel/add_users_to_channel_spec.js
+++ b/e2e/cypress/integration/channel/add_users_to_channel_spec.js
@@ -31,7 +31,7 @@ function addNumberOfUsersToChannel(num = 1) {
     cy.get('#channelHeaderTitle').click();
 
     // * The dropdown menu of the channel header should be visible;
-    cy.get('#channelHeaderDropdownMenu').should('be.visible');
+    cy.get('#channelLeaveChannel').should('be.visible');
 
     // # Click 'Add Members'
     cy.get('#channelAddMembers').click();

--- a/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
+++ b/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
@@ -7,10 +7,16 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+
 const timestamp = Date.now();
 
 function verifyChannel(res, verifyExistence = true) {
     const channel = res.body;
+
+    // # Wait for Channel to be c
+    cy.wait(TIMEOUTS.TINY);
 
     // # Hover on the channel name
     cy.get(`#sidebarItem_${channel.name}`).should('be.visible').trigger('mouseover');

--- a/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
+++ b/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
@@ -9,7 +9,6 @@
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
-
 const timestamp = Date.now();
 
 function verifyChannel(res, verifyExistence = true) {

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
@@ -28,7 +28,7 @@ function removeUserFromAllChannels(verifyAlert) {
         // * Verify if guest user gets a message when the channel is removed. Does not appears when removed from last channel of the last team
         if (channel === 'Town Square' || verifyAlert) {
             cy.get('#removeFromChannelModalLabel').should('be.visible').and('have.text', `Removed from ${channel}`);
-            cy.get('.modal-body').should('be.visible').and('have.text', `Someone removed you from ${channel}`);
+            cy.get('.modal-body').should('be.visible').and('have.text', `sysadmin removed you from ${channel}`);
             cy.get('#removedChannelBtn').should('be.visible').and('have.text', 'Okay').click().wait(TIMEOUTS.TINY);
         }
     });

--- a/e2e/cypress/integration/messaging/focus_move_spec.js
+++ b/e2e/cypress/integration/messaging/focus_move_spec.js
@@ -14,7 +14,7 @@ function verifyFocusInAddChannelMemberModal() {
     cy.get('#channelHeaderTitle').click();
 
     // * The dropdown menu of the channel header should be visible;
-    cy.get('#channelHeaderDropdownMenu').should('be.visible');
+    cy.get('#channelLeaveChannel').should('be.visible');
 
     // # Click 'Add Members'
     cy.get('#channelAddMembers').click();


### PR DESCRIPTION
## Summary
Fixes few Flaky E2E Tests. 
- For some reasons, Cypress was not able to detect the id channelHeaderDropdownMenu even though it was present. I changed it to verify if one of the child elements of the Channel Header Dropdown Menu is present. 
- Instead of `Someone removed you`, it is expected now to display which user removed. So updated it to `sysadmin removed you`. 
- Added a small timeout to wait before the channel is created and is displayed. 

#### Ticket Link
NA