### PR TITLE
Fix storybook for master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           at: .
       - aws-s3/sync:
           from: storybook-static
-          to: s3://alpha-storybook.mattermost.com/$(echo "${CIRCLE_BRANCH}" | sed 's/pull\//PR-/g' | sed 's/^master$//g')/
+          to: s3://alpha-storybook.mattermost.com/$(echo "${CIRCLE_BRANCH}" | sed 's/pull\//PR-/g')/
           arguments: --cache-control no-cache
       - aws-s3/sync:
           from: storybook-static


### PR DESCRIPTION
#### Summary
Before this PR the master branch was generating it in a weird way so wasn't
able to be visible, with this at least is visibile in the path with "/master",
probably we would need a redirect somehow at root directory.