### PR TITLE
Automated cherry pick of #4134

### DIFF
--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -50,6 +50,7 @@ export default class RhsComment extends React.PureComponent {
         channelIsArchived: PropTypes.bool.isRequired,
         isConsecutivePost: PropTypes.bool,
         handleCardClick: PropTypes.func,
+        a11yIndex: PropTypes.number,
     };
 
     static contextTypes = {
@@ -436,6 +437,7 @@ export default class RhsComment extends React.PureComponent {
                 onMouseLeave={this.unsetHover}
                 aria-label={this.state.currentAriaLabel}
                 onFocus={this.handlePostFocus}
+                data-a11y-sort-order={this.props.a11yIndex}
             >
                 <div
                     role='application'

--- a/components/rhs_root_post/__snapshots__/rhs_root_post.test.jsx.snap
+++ b/components/rhs_root_post/__snapshots__/rhs_root_post.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`components/RhsRootPost should match snapshot 1`] = `
 <div
   aria-label=""
   className="thread__root a11y__section post post--root post--thread current--user post--compact"
+  data-a11y-sort-order="0"
   id="rhsPost_id"
   onFocus={[Function]}
   role="listitem"
@@ -183,6 +184,7 @@ exports[`components/RhsRootPost should match snapshot on deleted post 1`] = `
 <div
   aria-label=""
   className="thread__root a11y__section post post--root post--thread current--user post--compact"
+  data-a11y-sort-order="0"
   id="rhsPost_id"
   onFocus={[Function]}
   role="listitem"
@@ -319,6 +321,7 @@ exports[`components/RhsRootPost should match snapshot on flagged, deleted post 1
 <div
   aria-label=""
   className="thread__root a11y__section post post--root post--thread current--user post--compact"
+  data-a11y-sort-order="0"
   id="rhsPost_id"
   onFocus={[Function]}
   role="listitem"
@@ -458,6 +461,7 @@ exports[`components/RhsRootPost should match snapshot when flagged 1`] = `
 <div
   aria-label=""
   className="thread__root a11y__section post post--root post--thread current--user post--compact"
+  data-a11y-sort-order="0"
   id="rhsPost_id"
   onFocus={[Function]}
   role="listitem"

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -324,6 +324,7 @@ export default class RhsRootPost extends React.PureComponent {
                 className={`thread__root a11y__section ${this.getClassName(post, isSystemMessage)}`}
                 aria-label={this.state.currentAriaLabel}
                 onFocus={this.handlePostFocus}
+                data-a11y-sort-order='0'
             >
                 <div className='post-right-channel__name'>{channelName}</div>
                 <div

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -268,6 +268,7 @@ export default class RhsThread extends React.Component {
 
         const commentsLists = [];
         const postsLength = postsArray.length;
+        let a11yIndex = 1;
         for (let i = 0; i < postsLength; i++) {
             const comPost = postsArray[i];
             const previousPostId = i > 0 ? postsArray[i - 1].id : '';
@@ -297,6 +298,7 @@ export default class RhsThread extends React.Component {
                     previewCollapsed={this.props.previewCollapsed}
                     previewEnabled={this.props.previewEnabled}
                     handleCardClick={this.handleCardClickPost}
+                    a11yIndex={a11yIndex++}
                 />
             );
         }

--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -234,7 +234,7 @@ class SearchResults extends React.Component {
                 sortedResults = results;
             }
 
-            ctls = sortedResults.map((post) => {
+            ctls = sortedResults.map((post, index) => {
                 return (
                     <SearchResultsItem
                         key={post.id}
@@ -243,6 +243,7 @@ class SearchResults extends React.Component {
                         matches={this.props.matches[post.id]}
                         term={(!this.props.isFlaggedPosts && !this.props.isPinnedPosts && !this.props.isMentionSearch) ? searchTerms : ''}
                         isMentionSearch={this.props.isMentionSearch}
+                        a11yIndex={index}
                     />
                 );
             }, this);

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -90,6 +90,8 @@ class SearchResultsItem extends React.PureComponent {
          */
         isBot: PropTypes.bool.isRequired,
 
+        a11yIndex: PropTypes.number,
+
         /**
         *  Function used for closing LHS
         */
@@ -362,6 +364,7 @@ class SearchResultsItem extends React.PureComponent {
                     className={`a11y__section ${this.getClassName()}`}
                     aria-label={this.state.currentAriaLabel}
                     onFocus={this.handleSearchItemFocus}
+                    data-a11y-sort-order={this.props.a11yIndex}
                 >
                     <div
                         className='search-channel__name'

--- a/utils/a11y_controller.js
+++ b/utils/a11y_controller.js
@@ -588,8 +588,19 @@ export default class A11yController {
             return [];
         }
         return Array.from(elements).sort((elementA, elementB) => {
-            const elementAOrder = elementA.getAttribute(A11yAttributeNames.SORT_ORDER);
-            const elementBOrder = elementB.getAttribute(A11yAttributeNames.SORT_ORDER);
+            const elementAOrder = parseInt(elementA.getAttribute(A11yAttributeNames.SORT_ORDER));
+            const elementBOrder = parseInt(elementB.getAttribute(A11yAttributeNames.SORT_ORDER));
+
+            if (isNaN(elementAOrder) && isNaN(elementBOrder)) {
+                return 0;
+            }
+            if (isNaN(elementBOrder)) {
+                return -1;
+            }
+            if (isNaN(elementAOrder)) {
+                return 1;
+            }
+
             return elementAOrder - elementBOrder;
         });
     }

--- a/utils/a11y_controller.js
+++ b/utils/a11y_controller.js
@@ -588,8 +588,8 @@ export default class A11yController {
             return [];
         }
         return Array.from(elements).sort((elementA, elementB) => {
-            const elementAOrder = parseInt(elementA.getAttribute(A11yAttributeNames.SORT_ORDER));
-            const elementBOrder = parseInt(elementB.getAttribute(A11yAttributeNames.SORT_ORDER));
+            const elementAOrder = parseInt(elementA.getAttribute(A11yAttributeNames.SORT_ORDER), 10);
+            const elementBOrder = parseInt(elementB.getAttribute(A11yAttributeNames.SORT_ORDER), 10);
 
             if (isNaN(elementAOrder) && isNaN(elementBOrder)) {
                 return 0;


### PR DESCRIPTION
Cherry pick of #4134 on release-5.17.

- #4134: explicitly set a11y navigation sort order in rhs

/cc  @deanwhillier