### PR TITLE
MM-19908 - Fixed ProfilePopover not closing on SendMessage

### DIFF
--- a/components/profile_picture.tsx
+++ b/components/profile_picture.tsx
@@ -38,7 +38,9 @@ export default class ProfilePicture extends React.PureComponent<Props> {
     };
 
     public hideProfilePopover = () => {
-        this.overlay.hide!();
+        if (this.overlay){
+            this.overlay.hide!();
+        }
     }
 
     setOverlayRef = (ref: OverlayTrigger) => {

--- a/components/profile_picture.tsx
+++ b/components/profile_picture.tsx
@@ -9,7 +9,7 @@ import StatusIcon from 'components/status_icon';
 import Avatar from 'components/widgets/users/avatar';
 
 interface MMOverlayTrigger extends OverlayTrigger {
-    hide: () => void;
+    hide?: () => void;
 }
 
 type Props = {
@@ -27,7 +27,7 @@ type Props = {
 }
 
 export default class ProfilePicture extends React.PureComponent<Props> {
-    public overlay = React.createRef<MMOverlayTrigger>();
+    public overlay!: MMOverlayTrigger;
 
     public static defaultProps = {
         size: 'md',
@@ -38,9 +38,11 @@ export default class ProfilePicture extends React.PureComponent<Props> {
     };
 
     public hideProfilePopover = () => {
-        if (this.overlay.current && typeof this.overlay.current.hide === 'function') {
-            this.overlay.current.hide();
-        }
+        this.overlay.hide!();
+    }
+
+    setOverlayRef = (ref: OverlayTrigger) => {
+        this.overlay = ref;
     }
 
     public render() {
@@ -55,7 +57,7 @@ export default class ProfilePicture extends React.PureComponent<Props> {
         if (this.props.userId) {
             return (
                 <OverlayTrigger
-                    ref={this.overlay}
+                    ref={this.setOverlayRef}
                     trigger='click'
                     placement='right'
                     rootClose={true}

--- a/components/profile_picture.tsx
+++ b/components/profile_picture.tsx
@@ -38,7 +38,7 @@ export default class ProfilePicture extends React.PureComponent<Props> {
     };
 
     public hideProfilePopover = () => {
-        if (this.overlay){
+        if (this.overlay) {
             this.overlay.hide!();
         }
     }

--- a/components/user_profile/user_profile.jsx
+++ b/components/user_profile/user_profile.jsx
@@ -34,7 +34,13 @@ export default class UserProfile extends PureComponent {
     };
 
     hideProfilePopover = () => {
-        this.refs.overlay.hide();
+        if (this.overlay) {
+            this.overlay.hide();
+        }
+    }
+
+    setOverlaynRef = (ref) => {
+        this.overlay = ref;
     }
 
     render() {
@@ -68,7 +74,7 @@ export default class UserProfile extends PureComponent {
         return (
             <React.Fragment>
                 <OverlayTrigger
-                    ref='overlay'
+                    ref={this.setOverlaynRef}
                     trigger='click'
                     placement={placement}
                     rootClose={true}


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->

Fixed issues where the `OverlayTrigger` `ref` were not being set properly for `ProfilePopover` and was causing the popover to not close when the user would click the "Send Message" button (and the associated bug when in web mobile mode).  

#### Ticket Link
Fixes [MM-19908](https://mattermost.atlassian.net/browse/MM-19908)