### PR TITLE
Fix weird cursor behaviour when mousing off of post

### DIFF
--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -238,7 +238,7 @@ export default class Post extends React.PureComponent {
             className += ' post--pinned';
         }
 
-        if (this.state.alt && this.state.hover) {
+        if (this.state.alt) {
             className += ' cursor--pointer';
         }
 
@@ -250,11 +250,7 @@ export default class Post extends React.PureComponent {
     }
 
     unsetHover = () => {
-        this.setState({hover: false, alt: false});
-    }
-
-    handleAlt = (e) => {
-        this.setState({alt: e.altKey});
+        this.setState({hover: false});
     }
 
     handleAlt = (e) => {


### PR DESCRIPTION
@Willyfrog I changed the behaviour of the pointer cursor in the centre channel to not disappear when you mouse off the post (see the second commit) since it felt really weird in testing.

Basically, this makes it so that holding alt always makes posts show the pointer cursor instead of only having it happen sometimes.