### PR TITLE
MM-19909 Fix for scroll pop with markdown images

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -29,10 +29,10 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
         Object {
           "maxHeight": 200,
           "maxWidth": 300,
-          "verticalAlign": "middle",
         }
       }
       viewBox="0 0 300 200"
+      width="inherit"
       xmlns="http://www.w3.org/2000/svg"
     />
   </div>

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -133,7 +133,8 @@ export default class SizeAwareImage extends React.PureComponent {
                     <svg
                         xmlns='http://www.w3.org/2000/svg'
                         viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
-                        style={{verticalAlign: 'middle', maxHeight: dimensions.height, maxWidth: dimensions.width}}
+                        style={{maxHeight: dimensions.height, maxWidth: dimensions.width}}
+                        width='inherit'
                     />
                 </div>
             );

--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -59,7 +59,7 @@ h6 {
         max-height: 500px;
     }
 
-    div .markdown-inline-img {
+    div.markdown-inline-img {
         min-width: 50px;
         display: inline-block;
         width: auto;


### PR DESCRIPTION
#### Summary
  * There was a change with inherited classes https://github.com/mattermost/mattermost-webapp/pull/3639 on . markdown-inline-img causing this issue
The change of .markdown-inline-img was added to div intentionally to apply for div wrapper to match the styles of img which is going to be replaced when it loads. Reverted the change  

 * Changing the width of svg to inherit to occupy the space as needed. This wasnt needed earlier but some of the recent changes made this a requirement.
![Nov-08-2019 16-00-31](https://user-images.githubusercontent.com/4973621/68470456-20d2bb80-0242-11ea-92a5-e82f81ab54a2.gif)
 
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19909
