### PR TITLE
MM-19995 Fix usage of React.forwardRef for LocalizedInput

### DIFF
--- a/components/__snapshots__/searchable_channel_list.test.jsx.snap
+++ b/components/__snapshots__/searchable_channel_list.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`components/SearchableChannelList should match init snapshot 1`] = `
         inputComponent={
           Object {
             "$$typeof": Symbol(react.forward_ref),
-            "displayName": "forwardRef(injectIntl(input))",
+            "displayName": "LocalizedInput",
             "render": [Function],
           }
         }

--- a/components/admin_console/__snapshots__/custom_url_schemes_setting.test.jsx.snap
+++ b/components/admin_console/__snapshots__/custom_url_schemes_setting.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`components/AdminConsole/CustomUrlSchemeSetting initial state with multi
   label="Custom URL Schemes:"
   setByEnv={false}
 >
-  <forwardRef(injectIntl(input))
+  <LocalizedInput
     className="form-control"
     disabled={false}
     id="MySetting"
@@ -31,7 +31,7 @@ exports[`components/AdminConsole/CustomUrlSchemeSetting initial state with no it
   label="Custom URL Schemes:"
   setByEnv={false}
 >
-  <forwardRef(injectIntl(input))
+  <LocalizedInput
     className="form-control"
     disabled={false}
     id="MySetting"
@@ -55,7 +55,7 @@ exports[`components/AdminConsole/CustomUrlSchemeSetting initial state with one i
   label="Custom URL Schemes:"
   setByEnv={false}
 >
-  <forwardRef(injectIntl(input))
+  <LocalizedInput
     className="form-control"
     disabled={false}
     id="MySetting"
@@ -79,7 +79,7 @@ exports[`components/AdminConsole/CustomUrlSchemeSetting renders properly when di
   label="Custom URL Schemes:"
   setByEnv={false}
 >
-  <forwardRef(injectIntl(input))
+  <LocalizedInput
     className="form-control"
     disabled={true}
     id="MySetting"
@@ -103,7 +103,7 @@ exports[`components/AdminConsole/CustomUrlSchemeSetting renders properly when se
   label="Custom URL Schemes:"
   setByEnv={true}
 >
-  <forwardRef(injectIntl(input))
+  <LocalizedInput
     className="form-control"
     disabled={true}
     id="MySetting"

--- a/components/admin_console/compliance_reports/compliance_reports.jsx
+++ b/components/admin_console/compliance_reports/compliance_reports.jsx
@@ -55,6 +55,12 @@ export default class ComplianceReports extends React.PureComponent {
         this.state = {
             loadingReports: true,
         };
+
+        this.descInput = React.createRef();
+        this.emailsInput = React.createRef();
+        this.fromInput = React.createRef();
+        this.keywordsInput = React.createRef();
+        this.toInput = React.createRef();
     }
 
     componentDidMount() {
@@ -81,20 +87,20 @@ export default class ComplianceReports extends React.PureComponent {
         this.setState({runningReport: true});
 
         const job = {};
-        job.desc = this.refs.desc.value;
-        job.emails = this.refs.emails.value;
-        job.keywords = this.refs.keywords.value;
-        job.start_at = Date.parse(this.refs.from.value);
-        job.end_at = Date.parse(this.refs.to.value);
+        job.desc = this.descInput.current.value;
+        job.emails = this.emailsInput.current.value;
+        job.keywords = this.keywordsInput.current.value;
+        job.start_at = Date.parse(this.fromInput.current.value);
+        job.end_at = Date.parse(this.toInput.current.value);
 
         this.props.actions.createComplianceReport(job).then(
             ({data}) => {
                 if (data) {
-                    this.refs.emails.value = '';
-                    this.refs.keywords.value = '';
-                    this.refs.desc.value = '';
-                    this.refs.from.value = '';
-                    this.refs.to.value = '';
+                    this.emailsInput.current.value = '';
+                    this.keywordsInput.current.value = '';
+                    this.descInput.current.value = '';
+                    this.fromInput.current.value = '';
+                    this.toInput.current.value = '';
                 }
                 this.setState({runningReport: false});
             }
@@ -292,7 +298,7 @@ export default class ComplianceReports extends React.PureComponent {
                             type='text'
                             className='form-control'
                             id='desc'
-                            ref='desc'
+                            ref={this.descInput}
                             placeholder={{id: t('admin.compliance_reports.desc_placeholder'), defaultMessage: 'E.g. "Audit 445 for HR"'}}
                         />
                     </div>
@@ -307,7 +313,7 @@ export default class ComplianceReports extends React.PureComponent {
                             type='text'
                             className='form-control'
                             id='from'
-                            ref='from'
+                            ref={this.fromInput}
                             placeholder={{id: t('admin.compliance_reports.from_placeholder'), defaultMessage: 'E.g. "2016-03-11"'}}
                         />
                     </div>
@@ -322,7 +328,7 @@ export default class ComplianceReports extends React.PureComponent {
                             type='text'
                             className='form-control'
                             id='to'
-                            ref='to'
+                            ref={this.toInput}
                             placeholder={{id: t('admin.compliance_reports.to_placeholder'), defaultMessage: 'E.g. "2016-03-15"'}}
                         />
                     </div>
@@ -339,7 +345,7 @@ export default class ComplianceReports extends React.PureComponent {
                             type='text'
                             className='form-control'
                             id='emails'
-                            ref='emails'
+                            ref={this.emailsInput}
                             placeholder={{id: t('admin.compliance_reports.emails_placeholder'), defaultMessage: 'E.g. "bill@example.com, bob@example.com"'}}
                         />
                     </div>
@@ -354,7 +360,7 @@ export default class ComplianceReports extends React.PureComponent {
                             type='text'
                             className='form-control'
                             id='keywords'
-                            ref='keywords'
+                            ref={this.keywordsInput}
                             placeholder={{id: t('admin.compliance_reports.keywords_placeholder'), defaultMessage: 'E.g. "shorting stock"'}}
                         />
                     </div>

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/__snapshots__/permission_team_scheme_settings.test.jsx.snap
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/__snapshots__/permission_team_scheme_settings.test.jsx.snap
@@ -62,7 +62,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
                 values={Object {}}
               />
             </label>
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               className="form-control"
               id="scheme-name"
               onChange={[Function]}
@@ -333,7 +333,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
                 values={Object {}}
               />
             </label>
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               className="form-control"
               id="scheme-name"
               onChange={[Function]}
@@ -584,7 +584,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
                 values={Object {}}
               />
             </label>
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               className="form-control"
               id="scheme-name"
               onChange={[Function]}
@@ -865,7 +865,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_team_sc
                 values={Object {}}
               />
             </label>
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               className="form-control"
               id="scheme-name"
               onChange={[Function]}

--- a/components/admin_console/system_users/system_users.jsx
+++ b/components/admin_console/system_users/system_users.jsx
@@ -301,7 +301,6 @@ export default class SystemUsers extends React.Component {
                 <div className='system-users__filter'>
                     <LocalizedInput
                         id='searchUsers'
-                        ref='filter'
                         className='form-control filter-textbox'
                         placeholder={{id: t('filtered_user_list.search'), defaultMessage: 'Search users'}}
                         onInput={doSearch}

--- a/components/claim/components/email_to_ldap.jsx
+++ b/components/claim/components/email_to_ldap.jsx
@@ -28,6 +28,10 @@ export default class EmailToLDAP extends React.Component {
             serverError: '',
             showMfa: false,
         };
+
+        this.emailPasswordInput = React.createRef();
+        this.ldapIdInput = React.createRef();
+        this.ldapPassword = React.createRef();
     }
 
     preSubmit = (e) => {
@@ -40,21 +44,21 @@ export default class EmailToLDAP extends React.Component {
             serverError: '',
         };
 
-        const password = this.refs.emailpassword.value;
+        const password = this.emailPasswordInput.current.value;
         if (!password) {
             state.passwordError = Utils.localizeMessage('claim.email_to_ldap.pwdError', 'Please enter your password.');
             this.setState(state);
             return;
         }
 
-        const ldapId = this.refs.ldapid.value.trim();
+        const ldapId = this.ldapIdInput.current.value.trim();
         if (!ldapId) {
             state.ldapError = Utils.localizeMessage('claim.email_to_ldap.ldapIdError', 'Please enter your AD/LDAP ID.');
             this.setState(state);
             return;
         }
 
-        const ldapPassword = this.refs.ldappassword.value;
+        const ldapPassword = this.ldapPassword.current.value;
         if (!ldapPassword) {
             state.ldapPasswordError = Utils.localizeMessage('claim.email_to_ldap.ldapPasswordError', 'Please enter your AD/LDAP password.');
             this.setState(state);
@@ -187,7 +191,7 @@ export default class EmailToLDAP extends React.Component {
                             type='password'
                             className='form-control'
                             name='emailPassword'
-                            ref='emailpassword'
+                            ref={this.emailPasswordInput}
                             autoComplete='off'
                             placeholder={{id: t('claim.email_to_ldap.pwd'), defaultMessage: 'Password'}}
                             spellCheck='false'
@@ -205,7 +209,7 @@ export default class EmailToLDAP extends React.Component {
                             type='text'
                             className='form-control'
                             name='ldapId'
-                            ref='ldapid'
+                            ref={this.ldapIdInput}
                             autoComplete='off'
                             placeholder={loginPlaceholder}
                             spellCheck='false'
@@ -217,7 +221,7 @@ export default class EmailToLDAP extends React.Component {
                             type='password'
                             className='form-control'
                             name='ldapPassword'
-                            ref='ldappassword'
+                            ref={this.ldapPasswordInput}
                             autoComplete='off'
                             placeholder={{id: t('claim.email_to_ldap.ldapPwd'), defaultMessage: 'AD/LDAP Password'}}
                             spellCheck='false'

--- a/components/claim/components/email_to_oauth.jsx
+++ b/components/claim/components/email_to_oauth.jsx
@@ -3,7 +3,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
 import {emailToOAuth} from 'actions/admin_actions.jsx';
@@ -24,13 +23,15 @@ export default class EmailToOAuth extends React.PureComponent {
         super(props);
 
         this.state = {showMfa: false, password: ''};
+
+        this.passwordInput = React.createRef();
     }
 
     preSubmit = (e) => {
         e.preventDefault();
         var state = {};
 
-        var password = ReactDOM.findDOMNode(this.refs.password).value;
+        var password = this.passwordInput.current.value;
         if (!password) {
             state.error = Utils.localizeMessage('claim.email_to_oauth.pwdError', 'Please enter your password.');
             this.setState(state);
@@ -124,7 +125,7 @@ export default class EmailToOAuth extends React.PureComponent {
                             type='password'
                             className='form-control'
                             name='password'
-                            ref='password'
+                            ref={this.passwordInput}
                             placeholder={{id: t('claim.email_to_oauth.pwd'), defaultMessage: 'Password'}}
                             spellCheck='false'
                         />

--- a/components/claim/components/ldap_to_email.jsx
+++ b/components/claim/components/ldap_to_email.jsx
@@ -26,6 +26,10 @@ export default class LDAPToEmail extends React.Component {
             ldapPasswordError: '',
             serverError: '',
         };
+
+        this.ldapPasswordInput = React.createRef();
+        this.passwordInput = React.createRef();
+        this.passwordConfirmInput = React.createRef();
     }
 
     preSubmit = (e) => {
@@ -38,14 +42,14 @@ export default class LDAPToEmail extends React.Component {
             serverError: '',
         };
 
-        const ldapPassword = this.refs.ldappassword.value;
+        const ldapPassword = this.ldapPasswordInput.current.value;
         if (!ldapPassword) {
             state.ldapPasswordError = Utils.localizeMessage('claim.ldap_to_email.ldapPasswordError', 'Please enter your AD/LDAP password.');
             this.setState(state);
             return;
         }
 
-        const password = this.refs.password.value;
+        const password = this.passwordInput.current.value;
         if (!password) {
             state.passwordError = Utils.localizeMessage('claim.ldap_to_email.pwdError', 'Please enter your password.');
             this.setState(state);
@@ -60,7 +64,7 @@ export default class LDAPToEmail extends React.Component {
             return;
         }
 
-        const confirmPassword = this.refs.passwordconfirm.value;
+        const confirmPassword = this.passwordConfirmInput.current.value;
         if (!confirmPassword || password !== confirmPassword) {
             state.confirmError = Utils.localizeMessage('claim.ldap_to_email.pwdNotMatch', 'Passwords do not match.');
             this.setState(state);
@@ -161,7 +165,7 @@ export default class LDAPToEmail extends React.Component {
                             type='password'
                             className='form-control'
                             name='ldapPassword'
-                            ref='ldappassword'
+                            ref={this.ldapPasswordInput}
                             placeholder={passwordPlaceholder}
                             spellCheck='false'
                         />
@@ -178,7 +182,7 @@ export default class LDAPToEmail extends React.Component {
                             type='password'
                             className='form-control'
                             name='password'
-                            ref='password'
+                            ref={this.passwordInput}
                             placeholder={{id: t('claim.ldap_to_email.pwd'), defaultMessage: 'Password'}}
                             spellCheck='false'
                         />
@@ -189,7 +193,7 @@ export default class LDAPToEmail extends React.Component {
                             type='password'
                             className='form-control'
                             name='passwordconfirm'
-                            ref='passwordconfirm'
+                            ref={this.passwordConfirmInput}
                             placeholder={{id: t('claim.ldap_to_email.confirm'), defaultMessage: 'Confirm Password'}}
                             spellCheck='false'
                         />

--- a/components/claim/components/oauth_to_email.jsx
+++ b/components/claim/components/oauth_to_email.jsx
@@ -3,7 +3,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
 import {oauthToEmail} from 'actions/admin_actions.jsx';
@@ -24,13 +23,16 @@ export default class OAuthToEmail extends React.PureComponent {
         super(props);
 
         this.state = {};
+
+        this.passwordInput = React.createRef();
+        this.passwordConfirmInput = React.createRef();
     }
 
     submit = (e) => {
         e.preventDefault();
         const state = {};
 
-        const password = ReactDOM.findDOMNode(this.refs.password).value;
+        const password = this.passwordInput.current.value;
         if (!password) {
             state.error = Utils.localizeMessage('claim.oauth_to_email.enterPwd', 'Please enter a password.');
             this.setState(state);
@@ -43,7 +45,7 @@ export default class OAuthToEmail extends React.PureComponent {
             return;
         }
 
-        const confirmPassword = ReactDOM.findDOMNode(this.refs.passwordconfirm).value;
+        const confirmPassword = this.passwordConfirmInput.current.value;
         if (!confirmPassword || password !== confirmPassword) {
             state.error = Utils.localizeMessage('claim.oauth_to_email.pwdNotMatch', 'Passwords do not match.');
             this.setState(state);
@@ -112,7 +114,7 @@ export default class OAuthToEmail extends React.PureComponent {
                             type='password'
                             className='form-control'
                             name='password'
-                            ref='password'
+                            ref={this.passwordInput}
                             placeholder={{id: t('claim.oauth_to_email.newPwd'), defaultMessage: 'New Password'}}
                             spellCheck='false'
                         />
@@ -122,7 +124,7 @@ export default class OAuthToEmail extends React.PureComponent {
                             type='password'
                             className='form-control'
                             name='passwordconfirm'
-                            ref='passwordconfirm'
+                            ref={this.passwordConfirmInput}
                             placeholder={{id: t('claim.oauth_to_email.confirm'), defaultMessage: 'Confirm Password'}}
                             spellCheck='false'
                         />

--- a/components/integrations/__snapshots__/abstract_command.test.jsx.snap
+++ b/components/integrations/__snapshots__/abstract_command.test.jsx.snap
@@ -113,7 +113,7 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="trigger"
             maxLength={128}
@@ -186,7 +186,7 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="url"
             maxLength="1024"
@@ -271,7 +271,7 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="username"
             maxLength="64"
@@ -312,7 +312,7 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="iconUrl"
             maxLength="1024"
@@ -386,7 +386,7 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="autocompleteHint"
             maxLength="1024"
@@ -427,7 +427,7 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="description"
             maxLength="128"
@@ -609,7 +609,7 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="trigger"
             maxLength={128}
@@ -682,7 +682,7 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="url"
             maxLength="1024"
@@ -767,7 +767,7 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="username"
             maxLength="64"
@@ -808,7 +808,7 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="iconUrl"
             maxLength="1024"
@@ -882,7 +882,7 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="autocompleteHint"
             maxLength="1024"
@@ -923,7 +923,7 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
         <div
           className="col-md-5 col-sm-8"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="description"
             maxLength="128"

--- a/components/localized_input/__snapshots__/localized_input.test.tsx.snap
+++ b/components/localized_input/__snapshots__/localized_input.test.tsx.snap
@@ -1,38 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/localized_input/localized_input should match snapshot 1`] = `
-<input
+<LocalizedInput
   className="test-class"
-  intl={
+  onChange={[MockFunction]}
+  placeholder={
     Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatDateToParts": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatNumberToParts": [Function],
-      "formatPlural": [Function],
-      "formatRelativeTime": [Function],
-      "formatTime": [Function],
-      "formatTimeToParts": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralRules": [Function],
-        "getRelativeTimeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
+      "defaultMessage": "placeholder to test",
+      "id": "test.placeholder",
     }
   }
-  placeholder="placeholder to test"
   value="test value"
-/>
+>
+  <FormattedMessage
+    defaultMessage="placeholder to test"
+    id="test.placeholder"
+    values={Object {}}
+  >
+    <input
+      className="test-class"
+      onChange={[MockFunction]}
+      placeholder="placeholder to test"
+      value="test value"
+    />
+  </FormattedMessage>
+</LocalizedInput>
 `;

--- a/components/localized_input/localized_input.test.tsx
+++ b/components/localized_input/localized_input.test.tsx
@@ -1,30 +1,55 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {mount} from 'enzyme';
 import React from 'react';
+import {IntlProvider} from 'react-intl';
 
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
+import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 
-import LocalizedInput from 'components/localized_input/localized_input';
+import LocalizedInput from './localized_input';
 
 describe('components/localized_input/localized_input', () => {
     const baseProps = {
         className: 'test-class',
+        onChange: jest.fn(),
+        placeholder: {id: 'test.placeholder', defaultMessage: 'placeholder to test'},
         value: 'test value',
     };
 
     test('should match snapshot', () => {
-        const wrapper = shallowWithIntl(
-            <LocalizedInput
-                {...baseProps}
-                placeholder={{id: 'test.placeholder', defaultMessage: 'placeholder to test'}}
-            />
-        );
+        const wrapper = mount(
+            <IntlProvider
+                locale='en'
+                messages={{}}
+            >
+                <LocalizedInput {...baseProps}/>
+            </IntlProvider>
+        ).childAt(0);
 
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find('input').length).toBe(1);
         expect(wrapper.find('input').get(0).props.value).toBe('test value');
         expect(wrapper.find('input').get(0).props.className).toBe('test-class');
         expect(wrapper.find('input').get(0).props.placeholder).toBe('placeholder to test');
+    });
+
+    it('ref should properly be forwarded', () => {
+        const ref = React.createRef<HTMLInputElement>();
+        const props = {
+            ...baseProps,
+            ref,
+        };
+
+        const wrapper = mountWithIntl(
+            <IntlProvider
+                locale='en'
+                messages={{}}
+            >
+                <LocalizedInput {...props}/>
+            </IntlProvider>
+        );
+
+        expect(ref.current).toBe(wrapper.find('input').instance());
     });
 });

--- a/components/localized_input/localized_input.tsx
+++ b/components/localized_input/localized_input.tsx
@@ -2,41 +2,36 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {injectIntl, IntlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 type Props = {
     placeholder: {
         id: string;
         defaultMessage: string;
+        values?: {string: any};
     };
     value?: string;
-    intl: IntlShape;
-    forwardedRef?: React.RefObject<HTMLInputElement>;
 };
 
-class LocalizedInput extends React.Component<Props> {
-    public shouldComponentUpdate(nextProps: Props): boolean {
-        return nextProps.value !== this.props.value ||
-            nextProps.placeholder.id !== this.props.placeholder.id ||
-            nextProps.placeholder.defaultMessage !== this.props.placeholder.defaultMessage;
-    }
+const LocalizedInput = React.forwardRef((props: Props, ref?: React.Ref<HTMLInputElement>) => {
+    const {placeholder, ...otherProps} = props;
 
-    public render(): JSX.Element {
-        const {formatMessage} = this.props.intl;
-        const {placeholder, forwardedRef, ...otherProps} = this.props;
-        const placeholderString: string = formatMessage(placeholder);
+    return (
+        <FormattedMessage
+            id={placeholder.id}
+            defaultMessage={placeholder.defaultMessage}
+            values={placeholder.values}
+        >
+            {(localizedPlaceholder: string) => (
+                <input
+                    {...otherProps}
+                    ref={ref}
+                    placeholder={localizedPlaceholder}
+                />
+            )}
+        </FormattedMessage>
+    );
+});
+LocalizedInput.displayName = 'LocalizedInput';
 
-        return (
-            <input
-                {...otherProps}
-                ref={forwardedRef}
-                placeholder={placeholderString}
-            />
-        );
-    }
-}
-
-const Component = injectIntl(LocalizedInput, {forwardRef: true});
-Component.displayName = 'forwardRef(injectIntl(input))';
-
-export default Component;
+export default LocalizedInput;

--- a/components/login/__snapshots__/login_mfa.test.jsx.snap
+++ b/components/login/__snapshots__/login_mfa.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`components/login/LoginMfa should match snapshot 1`] = `
     <div
       className="form-group"
     >
-      <forwardRef(injectIntl(input))
+      <LocalizedInput
         autoComplete="off"
         autoFocus={true}
         className="form-control"

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -84,6 +84,9 @@ class LoginController extends React.Component {
             sessionExpired: false,
             brandImageError: false,
         };
+
+        this.loginIdInput = React.createRef();
+        this.passwordInput = React.createRef();
     }
 
     componentDidMount() {
@@ -99,7 +102,7 @@ class LoginController extends React.Component {
         const email = search.get('email');
 
         if (extra === Constants.SIGNIN_VERIFIED && email) {
-            this.refs.password.focus();
+            this.passwordInput.current.focus();
         }
 
         // Determine if the user was unexpectedly logged out.
@@ -191,16 +194,16 @@ class LoginController extends React.Component {
         // password managers don't always call onInput handlers for form fields so it's possible
         // for the state to get out of sync with what the user sees in the browser
         let loginId = this.state.loginId;
-        if (this.refs.loginId) {
-            loginId = this.refs.loginId.value;
+        if (this.loginIdInput.current) {
+            loginId = this.loginIdInput.current.value;
             if (loginId !== this.state.loginId) {
                 this.setState({loginId});
             }
         }
 
         let password = this.state.password;
-        if (this.refs.password) {
-            password = this.refs.password.value;
+        if (this.passwordInput.current) {
+            password = this.passwordInput.current.value;
             if (password !== this.state.password) {
                 this.setState({password});
             }
@@ -553,7 +556,7 @@ class LoginController extends React.Component {
                             <input
                                 id='loginId'
                                 className='form-control'
-                                ref='loginId'
+                                ref={this.loginIdInput}
                                 name='loginId'
                                 value={this.state.loginId}
                                 onChange={this.handleLoginIdChange}
@@ -568,7 +571,7 @@ class LoginController extends React.Component {
                                 id='loginPassword'
                                 type='password'
                                 className='form-control'
-                                ref='password'
+                                ref={this.passwordInput}
                                 name='password'
                                 value={this.state.password}
                                 onChange={this.handlePasswordChange}

--- a/components/mfa/setup/setup.jsx
+++ b/components/mfa/setup/setup.jsx
@@ -26,6 +26,8 @@ export default class Setup extends React.Component {
         super(props);
 
         this.state = {secret: '', qrCode: ''};
+
+        this.input = React.createRef();
     }
 
     componentDidMount() {
@@ -52,7 +54,7 @@ export default class Setup extends React.Component {
 
     submit = (e) => {
         e.preventDefault();
-        const code = this.refs.code.value.replace(/\s/g, '');
+        const code = this.input.current.value.replace(/\s/g, '');
         if (!code || code.length === 0) {
             this.setState({error: Utils.localizeMessage('mfa.setup.codeError', 'Please enter the code from Google Authenticator.')});
             return;
@@ -150,7 +152,7 @@ export default class Setup extends React.Component {
                     </p>
                     <p>
                         <LocalizedInput
-                            ref='code'
+                            ref={this.input}
                             className='form-control'
                             placeholder={{id: t('mfa.setup.code'), defaultMessage: 'MFA Code'}}
                             autoFocus={true}

--- a/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
+++ b/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
@@ -131,7 +131,7 @@ exports[`components/NewChannelModal should match snapshot, display only private 
           <div
             className="col-sm-9"
           >
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newChannelName"
@@ -430,7 +430,7 @@ exports[`components/NewChannelModal should match snapshot, display only public c
           <div
             className="col-sm-9"
           >
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newChannelName"
@@ -771,7 +771,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
           <div
             className="col-sm-9"
           >
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newChannelName"
@@ -1112,7 +1112,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
           <div
             className="col-sm-9"
           >
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newChannelName"
@@ -1453,7 +1453,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
           <div
             className="col-sm-9"
           >
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newChannelName"
@@ -1804,7 +1804,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
           <div
             className="col-sm-9"
           >
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newChannelName"
@@ -2159,7 +2159,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
           <div
             className="col-sm-9"
           >
-            <forwardRef(injectIntl(input))
+            <LocalizedInput
               autoFocus={true}
               className="form-control"
               id="newChannelName"

--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -5,7 +5,6 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
-import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
 import GlobeIcon from 'components/widgets/icons/globe_icon';
@@ -105,6 +104,10 @@ export default class NewChannelModal extends React.PureComponent {
         this.state = {
             displayNameError: '',
         };
+
+        this.channelHeaderInput = React.createRef();
+        this.channelPurposeInput = React.createRef();
+        this.displayNameInput = React.createRef();
     }
 
     componentDidMount() {
@@ -129,7 +132,7 @@ export default class NewChannelModal extends React.PureComponent {
     handleSubmit = (e) => {
         e.preventDefault();
 
-        const displayName = ReactDOM.findDOMNode(this.refs.display_name).value.trim();
+        const displayName = this.displayNameInput.current.value.trim();
         if (displayName.length < Constants.MIN_CHANNELNAME_LENGTH) {
             this.setState({displayNameError: true});
             return;
@@ -140,9 +143,9 @@ export default class NewChannelModal extends React.PureComponent {
 
     handleChange = () => {
         const newData = {
-            displayName: this.refs.display_name.value,
-            header: this.refs.channel_header.value,
-            purpose: this.refs.channel_purpose.value,
+            displayName: this.displayNameInput.current.value,
+            header: this.channelHeaderInput.current.value,
+            purpose: this.channelPurposeInput.current.value,
         };
         this.props.onDataChanged(newData);
     }
@@ -340,7 +343,7 @@ export default class NewChannelModal extends React.PureComponent {
                                         id='newChannelName'
                                         onChange={this.handleChange}
                                         type='text'
-                                        ref='display_name'
+                                        ref={this.displayNameInput}
                                         className='form-control'
                                         placeholder={{id: t('channel_modal.nameEx'), defaultMessage: 'E.g.: "Bugs", "Marketing", "客户支持"'}}
                                         maxLength={Constants.MAX_CHANNELNAME_LENGTH}
@@ -386,7 +389,7 @@ export default class NewChannelModal extends React.PureComponent {
                                     <textarea
                                         id='newChannelPurpose'
                                         className='form-control no-resize'
-                                        ref='channel_purpose'
+                                        ref={this.channelPurposeInput}
                                         rows='4'
                                         placeholder={Utils.localizeMessage('channel_modal.purposeEx', 'E.g.: "A channel to file bugs and improvements"')}
                                         maxLength='250'
@@ -423,7 +426,7 @@ export default class NewChannelModal extends React.PureComponent {
                                     <textarea
                                         id='newChannelHeader'
                                         className='form-control no-resize'
-                                        ref='channel_header'
+                                        ref={this.channelHeaderInput}
                                         rows='4'
                                         placeholder={Utils.localizeMessage('channel_modal.headerEx', 'E.g.: "[Link Title](http://example.com)"')}
                                         maxLength='1024'

--- a/components/new_channel_modal/new_channel_modal.test.jsx
+++ b/components/new_channel_modal/new_channel_modal.test.jsx
@@ -91,9 +91,6 @@ describe('components/NewChannelModal', () => {
     });
 
     test('should match when handleChange is called', () => {
-        const newOnDataChanged = jest.fn();
-        const props = {...baseProps, onDataChanged: newOnDataChanged};
-
         const state = {
             entities: {
                 channels: {
@@ -127,30 +124,22 @@ describe('components/NewChannelModal', () => {
 
         const wrapper = mountWithIntl(
             <Provider store={store}>
-                <NewChannelModal {...props}/>
+                <NewChannelModal {...baseProps}/>
             </Provider>
         );
         const modal = wrapper.find(NewChannelModal).instance();
 
-        const refDisplayName = modal.refs.display_name;
-        refDisplayName.value = 'new display_name';
-
-        const refChannelHeader = modal.refs.channel_header;
-        refChannelHeader.value = 'new channel_header';
-
-        const refChannelPurpose = modal.refs.channel_purpose;
-        refChannelPurpose.value = 'new channel_purpose';
+        wrapper.find('input#newChannelName').instance().value = 'new display_name';
+        wrapper.find('textarea#newChannelHeader').instance().value = 'new channel_header';
+        wrapper.find('textarea#newChannelPurpose').instance().value = 'new channel_purpose';
 
         modal.handleChange();
 
-        expect(newOnDataChanged).toHaveBeenCalledTimes(1);
-        expect(newOnDataChanged).toHaveBeenCalledWith({displayName: 'new display_name', header: 'new channel_header', purpose: 'new channel_purpose'});
+        expect(baseProps.onDataChanged).toHaveBeenCalledTimes(1);
+        expect(baseProps.onDataChanged).toHaveBeenCalledWith({displayName: 'new display_name', header: 'new channel_header', purpose: 'new channel_purpose'});
     });
 
     test('should match when handleSubmit is called', () => {
-        const newOnSubmitChannel = jest.fn();
-        const props = {...baseProps, onSubmitChannel: newOnSubmitChannel};
-
         const state = {
             entities: {
                 channels: {
@@ -178,13 +167,13 @@ describe('components/NewChannelModal', () => {
 
         const wrapper = mountWithIntl(
             <Provider store={store}>
-                <NewChannelModal {...props}/>
+                <NewChannelModal {...baseProps}/>
             </Provider>
         );
         const modal = wrapper.find(NewChannelModal).instance();
         modal.handleSubmit({preventDefault: jest.fn()});
 
-        expect(newOnSubmitChannel).toHaveBeenCalledTimes(1);
+        expect(baseProps.onSubmitChannel).toHaveBeenCalledTimes(1);
         expect(modal.state.displayNameError).toEqual('');
     });
 

--- a/components/password_reset_form/__snapshots__/password_reset_form.test.js.snap
+++ b/components/password_reset_form/__snapshots__/password_reset_form.test.js.snap
@@ -31,7 +31,7 @@ exports[`components/PasswordResetForm should match snapshot 1`] = `
       <div
         className="form-group"
       >
-        <forwardRef(injectIntl(input))
+        <LocalizedInput
           autoFocus={true}
           className="form-control"
           id="resetPasswordInput"

--- a/components/password_reset_send_link/__snapshots__/password_reset_send_link.test.js.snap
+++ b/components/password_reset_send_link/__snapshots__/password_reset_send_link.test.js.snap
@@ -31,7 +31,7 @@ exports[`components/PasswordResetSendLink should match snapshot 1`] = `
         <div
           className="form-group"
         >
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             autoFocus={true}
             className="form-control"
             id="passwordResetEmailInput"

--- a/components/plugin_marketplace/__snapshots__/marketplace_modal.test.jsx.snap
+++ b/components/plugin_marketplace/__snapshots__/marketplace_modal.test.jsx.snap
@@ -46,7 +46,7 @@ exports[`components/MarketplaceModal should match the snapshot, error banner is 
             inputComponent={
               Object {
                 "$$typeof": Symbol(react.forward_ref),
-                "displayName": "forwardRef(injectIntl(input))",
+                "displayName": "LocalizedInput",
                 "render": [Function],
               }
             }
@@ -138,7 +138,7 @@ exports[`components/MarketplaceModal should match the snapshot, no plugins insta
             inputComponent={
               Object {
                 "$$typeof": Symbol(react.forward_ref),
-                "displayName": "forwardRef(injectIntl(input))",
+                "displayName": "LocalizedInput",
                 "render": [Function],
               }
             }
@@ -240,7 +240,7 @@ exports[`components/MarketplaceModal should match the snapshot, with plugins ins
             inputComponent={
               Object {
                 "$$typeof": Symbol(react.forward_ref),
-                "displayName": "forwardRef(injectIntl(input))",
+                "displayName": "LocalizedInput",
                 "render": [Function],
               }
             }

--- a/components/rename_channel_modal/__snapshots__/rename_channel_modal.test.jsx.snap
+++ b/components/rename_channel_modal/__snapshots__/rename_channel_modal.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`components/RenameChannelModal should match snapshot 1`] = `
             values={Object {}}
           />
         </label>
-        <forwardRef(injectIntl(input))
+        <LocalizedInput
           className="form-control"
           id="display_name"
           maxLength={64}
@@ -119,7 +119,7 @@ exports[`components/RenameChannelModal should match snapshot 1`] = `
               fake-channel/channels/
             </span>
           </OverlayTrigger>
-          <forwardRef(injectIntl(input))
+          <LocalizedInput
             className="form-control"
             id="channel_name"
             maxLength={64}


### PR DESCRIPTION
The login screen is currently broken because `LocalizedInput` was updated to use `React.forwardRef`, but that doesn't work with string refs that are used throughout the app. This updates them all to ref objects.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19995