### PR TITLE
MM-18708 Fix state of embed visibility for users logging in on same browser/client

### DIFF
--- a/actions/post_actions.jsx
+++ b/actions/post_actions.jsx
@@ -263,9 +263,11 @@ export function deleteAndRemovePost(post) {
 
 export function toggleEmbedVisibility(postId) {
     return (dispatch, getState) => {
-        const visible = isEmbedVisible(getState(), postId);
+        const state = getState();
+        const currentUserId = getCurrentUserId(state);
+        const visible = isEmbedVisible(state, postId);
 
-        dispatch(StorageActions.setGlobalItem(StoragePrefixes.EMBED_VISIBLE + postId, !visible));
+        dispatch(StorageActions.setGlobalItem(StoragePrefixes.EMBED_VISIBLE + currentUserId + '_' + postId, !visible));
     };
 }
 

--- a/selectors/posts.js
+++ b/selectors/posts.js
@@ -3,6 +3,7 @@
 
 import {createSelector} from 'reselect';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getBool as getBoolPreference} from 'mattermost-redux/selectors/entities/preferences';
 
 import {getGlobalItem} from 'selectors/storage';
@@ -26,6 +27,7 @@ export const getEditingPost = createSelector(
 );
 
 export function isEmbedVisible(state, postId) {
+    const currentUserId = getCurrentUserId(state);
     const previewCollapsed = getBoolPreference(
         state,
         Preferences.CATEGORY_DISPLAY_SETTINGS,
@@ -33,7 +35,7 @@ export function isEmbedVisible(state, postId) {
         Preferences.COLLAPSE_DISPLAY_DEFAULT !== 'false'
     );
 
-    return getGlobalItem(state, StoragePrefixes.EMBED_VISIBLE + postId, !previewCollapsed);
+    return getGlobalItem(state, StoragePrefixes.EMBED_VISIBLE + currentUserId + '_' + postId, !previewCollapsed);
 }
 
 export function shouldShowJoinLeaveMessages(state) {


### PR DESCRIPTION
#### Summary
Found this bug by @larkox while submitting E2E for link preview which includes tests for:
...
4. Have the user who posted it click the collapse arrows to collapse the preview
5. Verify preview did not collapse for other user
...

This can probably affect those users who shares logging in to a common workstation.

Before, the storage key is `...:isVisible_[postId]`:
<img width="1039" alt="Screen Shot 2019-11-11 at 10 25 27 PM" src="https://user-images.githubusercontent.com/5334504/68594295-34945100-04d2-11ea-907e-22a262baf457.png">

After, `...:isVisible_[userId]_[postId]`:
<img width="1043" alt="Screen Shot 2019-11-11 at 10 03 09 PM" src="https://user-images.githubusercontent.com/5334504/68594116-d4051400-04d1-11ea-8b6b-0b0fe708b5a4.png">

Note: I didn't bother to add backwards compatibility since this don't have noticeable change (where user mostly cared on embed visibility of recent post/s).

#### Ticket Link
Jira ticket: [MM-18708](https://mattermost.atlassian.net/browse/MM-18708)
