### PR TITLE
Automated cherry pick of #4159

### DIFF
--- a/actions/views/rhs.js
+++ b/actions/views/rhs.js
@@ -81,6 +81,13 @@ export function updateSearchTerms(terms) {
     };
 }
 
+function updateSearchResultsTerms(terms) {
+    return {
+        type: ActionTypes.UPDATE_RHS_SEARCH_RESULTS_TERMS,
+        terms,
+    };
+}
+
 export function performSearch(terms, isMentionSearch) {
     return (dispatch, getState) => {
         const teamId = getCurrentTeamId(getState());
@@ -101,10 +108,7 @@ export function showSearchResults() {
         const searchTerms = getSearchTerms(getState());
 
         dispatch(updateRhsState(RHSStates.SEARCH));
-        dispatch({
-            type: ActionTypes.UPDATE_RHS_SEARCH_RESULTS_TERMS,
-            terms: searchTerms,
-        });
+        dispatch(updateSearchResultsTerms(searchTerms));
 
         return dispatch(performSearch(searchTerms));
     };
@@ -284,6 +288,7 @@ export function openRHSSearch() {
     return (dispatch) => {
         dispatch(clearSearch());
         dispatch(updateSearchTerms(''));
+        dispatch(updateSearchResultsTerms(''));
 
         dispatch(updateRhsState(RHSStates.SEARCH));
     };

--- a/components/search_results/index.jsx
+++ b/components/search_results/index.jsx
@@ -13,7 +13,7 @@ import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentSearchForCurrentTeam} from 'mattermost-redux/selectors/entities/search';
 
 import {
-    getSearchTerms,
+    getSearchResultsTerms,
     getIsSearchingTerm,
     getIsSearchingFlaggedPost,
     getIsSearchingPinnedPost,
@@ -61,7 +61,7 @@ function makeMapStateToProps() {
             results: posts,
             matches: getSearchMatches(state),
             currentUser: getCurrentUser(state),
-            searchTerms: getSearchTerms(state),
+            searchTerms: getSearchResultsTerms(state),
             isSearchingTerm: getIsSearchingTerm(state),
             isSearchingFlaggedPost: getIsSearchingFlaggedPost(state),
             isSearchingPinnedPost: getIsSearchingPinnedPost(state),


### PR DESCRIPTION
Cherry pick of #4159 on release-5.17.

- #4159: Revert the search results component to not bind directly to

/cc  @marianunez