### PR TITLE
MM-19955 Remove divider from post menu on mobile

### DIFF
--- a/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
+++ b/components/dot_menu/__snapshots__/dot_menu.test.jsx.snap
@@ -101,7 +101,15 @@ exports[`components/dot_menu/DotMenu should match snapshot, canDelete 1`] = `
         text="Pin"
       />
     </MenuGroup>
-    <MenuGroup>
+    <MenuGroup
+      divider={
+        <li
+          className="MenuItem__divider"
+          id="divider_post_post_id_1_edit"
+          role="menuitem"
+        />
+      }
+    >
       <MenuItemAction
         id="edit_post_post_id_1"
         onClick={[Function]}
@@ -225,7 +233,15 @@ exports[`components/dot_menu/DotMenu should match snapshot, on Center 1`] = `
         text="Pin"
       />
     </MenuGroup>
-    <MenuGroup>
+    <MenuGroup
+      divider={
+        <li
+          className="MenuItem__divider"
+          id="divider_post_post_id_1_edit"
+          role="menuitem"
+        />
+      }
+    >
       <MenuItemAction
         id="edit_post_post_id_1"
         onClick={[Function]}

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -221,6 +221,16 @@ export default class DotMenu extends Component {
         }
     }
 
+    renderDivider = (suffix) => {
+        return (
+            <li
+                id={`divider_post_${this.props.post.id}_${suffix}`}
+                className='MenuItem__divider'
+                role='menuitem'
+            />
+        );
+    }
+
     render() {
         const isSystemMessage = PostUtils.isSystemMessage(this.props.post);
         const isMobile = Utils.isMobile();
@@ -337,7 +347,7 @@ export default class DotMenu extends Component {
                             onClick={this.handlePinMenuItemActivated}
                         />
                     </Menu.Group>
-                    <Menu.Group>
+                    <Menu.Group divider={this.renderDivider('edit')}>
                         <Menu.ItemAction
                             id={`edit_post_${this.props.post.id}`}
                             show={this.state.canEdit}
@@ -352,13 +362,7 @@ export default class DotMenu extends Component {
                             isDangerous={true}
                         />
                     </Menu.Group>
-                    {pluginItems.length > 0 &&
-                    <li
-                        id={`divider_post_${this.props.post.id}`}
-                        className='MenuItem__divider'
-                        role='menuitem'
-                    />
-                    }
+                    {pluginItems.length > 0 && this.renderDivider('plugins')}
                     {pluginItems}
                     <Pluggable
                         postId={this.props.post.id}

--- a/components/dot_menu/dot_menu.test.jsx
+++ b/components/dot_menu/dot_menu.test.jsx
@@ -73,9 +73,9 @@ describe('components/dot_menu/DotMenu', () => {
         const wrapper = shallow(
             <DotMenu {...baseProps}/>
         );
-        expect(wrapper.find('#divider_post_post_id_1').exists()).toBe(false);
+        expect(wrapper.find('#divider_post_post_id_1_plugins').exists()).toBe(false);
 
         wrapper.setProps({pluginMenuItems: [{id: 'test_plugin_menu_item_1', text: 'woof'}]});
-        expect(wrapper.find('#divider_post_post_id_1').length).toBe(1);
+        expect(wrapper.find('#divider_post_post_id_1_plugins').length).toBe(1);
     });
 });


### PR DESCRIPTION
The default divider is visible on mobile, but the one used above the plugin sections of the post menu has CSS that hides it on mobile. This switches the Edit/Delete section to use the same divider as the plugin section of the post menu.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19955

#### Screenshots
![Screen Shot 2019-11-11 at 1 55 53 PM](https://user-images.githubusercontent.com/3277310/68612673-0ccdca80-048b-11ea-943d-ee1c6ea3d599.png)
![Screen Shot 2019-11-11 at 1 56 06 PM](https://user-images.githubusercontent.com/3277310/68612675-0d666100-048b-11ea-87a9-104f0ec2b7e4.png)
