### PR TITLE
MM-20006 - Fixed Display Name order in Channel Header

### DIFF
--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -331,21 +331,27 @@ class ChannelHeader extends React.PureComponent {
         }
 
         if (isGroup) {
-            const nodes = [];
+            // map the displayname to the gm member users
+            const membersMap = {};
             for (const user of gmMembers) {
                 if (user.id === currentUser.id) {
                     continue;
                 }
                 const userDisplayName = Utils.getDisplayNameByUserId(user.id);
-                nodes.push((
-                    <React.Fragment key={userDisplayName}>
-                        {nodes.length !== 0 && ', '}
-                        {userDisplayName}
-                        <GuestBadge show={Utils.isGuest(user)}/>
-                    </React.Fragment>
-                ));
+                membersMap[userDisplayName] = user;
             }
-            channelTitle = nodes;
+
+            const displayNames = channel.display_name.split(', ');
+            channelTitle = displayNames.map((displayName, index) => {
+                return (
+                    <React.Fragment key={displayName}>
+                        {index > 0 && ', '}
+                        {displayName}
+                        <GuestBadge show={Utils.isGuest(membersMap[displayName])}/>
+                    </React.Fragment>
+                );
+            });
+
             if (hasGuests) {
                 hasGuestsText = (
                     <span className='has-guest-header'>

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -338,16 +338,28 @@ class ChannelHeader extends React.PureComponent {
                     continue;
                 }
                 const userDisplayName = Utils.getDisplayNameByUserId(user.id);
-                membersMap[userDisplayName] = user;
+
+                if (!membersMap[userDisplayName]) {
+                    membersMap[userDisplayName] = []; //Create an array for cases with same display name
+                }
+
+                membersMap[userDisplayName].push(user);
             }
 
             const displayNames = channel.display_name.split(', ');
+
             channelTitle = displayNames.map((displayName, index) => {
+                if (!membersMap[displayName]) {
+                    return displayName;
+                }
+
+                const user = membersMap[displayName].shift();
+
                 return (
-                    <React.Fragment key={displayName}>
+                    <React.Fragment key={user.id}>
                         {index > 0 && ', '}
                         {displayName}
-                        <GuestBadge show={Utils.isGuest(membersMap[displayName])}/>
+                        <GuestBadge show={Utils.isGuest(user)}/>
                     </React.Fragment>
                 );
             });


### PR DESCRIPTION
#### Summary

Fixed the channel display name order in the channel header that was only ordered by username and not honoring the user preferences for user display name. This was regression from https://github.com/mattermost/mattermost-webapp/pull/3832

The fix navigates the display names as ordered by `channel.display_name` and then maps to the necessary components to include guest label if needed. This replaces the previous implementation that navigated the users list in `gmMembers` that is not sorted properly. 

#### Ticket Link
Fixes [MM-20006](https://mattermost.atlassian.net/browse/MM-20006)
