### PR TITLE
Automated cherry pick of #4162

### DIFF
--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -153,7 +153,7 @@ function autolinkEmails(text, tokens) {
         const alias = `$MM_EMAIL${index}$`;
 
         tokens.set(alias, {
-            value: `<a class="theme" href="mailto:${email}">${email}</a>`,
+            value: `<a class="theme" href="mailto:${email}" rel="noreferrer" target="_blank">${email}</a>`,
             originalText: email,
         });
 

--- a/utils/text_formatting_email.test.jsx
+++ b/utils/text_formatting_email.test.jsx
@@ -9,47 +9,47 @@ describe('TextFormatting.Emails', () => {
     it('Valid email addresses', () => {
         assert.equal(
             TextFormatting.formatText('email@domain.com').trim(),
-            '<p><a class="theme" href="mailto:email@domain.com">email@domain.com</a></p>',
+            '<p><a class="theme" href="mailto:email@domain.com" rel="noreferrer" target="_blank">email@domain.com</a></p>',
         );
 
         assert.equal(
             TextFormatting.formatText('firstname.lastname@domain.com').trim(),
-            '<p><a class="theme" href="mailto:firstname.lastname@domain.com">firstname.lastname@domain.com</a></p>',
+            '<p><a class="theme" href="mailto:firstname.lastname@domain.com" rel="noreferrer" target="_blank">firstname.lastname@domain.com</a></p>',
         );
 
         assert.equal(
             TextFormatting.formatText('email@subdomain.domain.com').trim(),
-            '<p><a class="theme" href="mailto:email@subdomain.domain.com">email@subdomain.domain.com</a></p>',
+            '<p><a class="theme" href="mailto:email@subdomain.domain.com" rel="noreferrer" target="_blank">email@subdomain.domain.com</a></p>',
         );
 
         assert.equal(
             TextFormatting.formatText('firstname+lastname@domain.com').trim(),
-            '<p><a class="theme" href="mailto:firstname+lastname@domain.com">firstname+lastname@domain.com</a></p>',
+            '<p><a class="theme" href="mailto:firstname+lastname@domain.com" rel="noreferrer" target="_blank">firstname+lastname@domain.com</a></p>',
         );
 
         assert.equal(
             TextFormatting.formatText('1234567890@domain.com').trim(),
-            '<p><a class="theme" href="mailto:1234567890@domain.com">1234567890@domain.com</a></p>',
+            '<p><a class="theme" href="mailto:1234567890@domain.com" rel="noreferrer" target="_blank">1234567890@domain.com</a></p>',
         );
 
         assert.equal(
             TextFormatting.formatText('email@domain-one.com').trim(),
-            '<p><a class="theme" href="mailto:email@domain-one.com">email@domain-one.com</a></p>',
+            '<p><a class="theme" href="mailto:email@domain-one.com" rel="noreferrer" target="_blank">email@domain-one.com</a></p>',
         );
 
         assert.equal(
             TextFormatting.formatText('email@domain.name').trim(),
-            '<p><a class="theme" href="mailto:email@domain.name">email@domain.name</a></p>',
+            '<p><a class="theme" href="mailto:email@domain.name" rel="noreferrer" target="_blank">email@domain.name</a></p>',
         );
 
         assert.equal(
             TextFormatting.formatText('email@domain.co.jp').trim(),
-            '<p><a class="theme" href="mailto:email@domain.co.jp">email@domain.co.jp</a></p>',
+            '<p><a class="theme" href="mailto:email@domain.co.jp" rel="noreferrer" target="_blank">email@domain.co.jp</a></p>',
         );
 
         assert.equal(
             TextFormatting.formatText('firstname-lastname@domain.com').trim(),
-            '<p><a class="theme" href="mailto:firstname-lastname@domain.com">firstname-lastname@domain.com</a></p>',
+            '<p><a class="theme" href="mailto:firstname-lastname@domain.com" rel="noreferrer" target="_blank">firstname-lastname@domain.com</a></p>',
         );
     });
 
@@ -112,14 +112,14 @@ describe('TextFormatting.Emails', () => {
     it('Should be invalid, but matching GitHub', () => {
         assert.equal(
             TextFormatting.formatText('email@domain@domain.com').trim(),
-            '<p>email@<a class="theme" href="mailto:domain@domain.com">domain@domain.com</a></p>',
+            '<p>email@<a class="theme" href="mailto:domain@domain.com" rel="noreferrer" target="_blank">domain@domain.com</a></p>',
         );
     });
 
     it('Should be invalid, but broken', () => {
         assert.equal(
             TextFormatting.formatText('email@domain@domain.com').trim(),
-            '<p>email@<a class="theme" href="mailto:domain@domain.com">domain@domain.com</a></p>',
+            '<p>email@<a class="theme" href="mailto:domain@domain.com" rel="noreferrer" target="_blank">domain@domain.com</a></p>',
         );
     });
 });

--- a/utils/text_formatting_links.test.jsx
+++ b/utils/text_formatting_links.test.jsx
@@ -230,11 +230,11 @@ describe('Markdown.Links', () => {
     it('Email addresses', () => {
         assert.equal(
             Markdown.format('test@example.com').trim(),
-            '<p><a class="theme" href="mailto:test@example.com">test@example.com</a></p>'
+            '<p><a class="theme" href="mailto:test@example.com" rel="noreferrer" target="_blank">test@example.com</a></p>'
         );
         assert.equal(
             Markdown.format('test_underscore@example.com').trim(),
-            '<p><a class="theme" href="mailto:test_underscore@example.com">test_underscore@example.com</a></p>'
+            '<p><a class="theme" href="mailto:test_underscore@example.com" rel="noreferrer" target="_blank">test_underscore@example.com</a></p>'
         );
 
         assert.equal(
@@ -429,17 +429,17 @@ describe('Markdown.Links', () => {
 
         assert.equal(
             Markdown.format('(test@example.com)').trim(),
-            '<p>(<a class="theme" href="mailto:test@example.com">test@example.com</a>)</p>'
+            '<p>(<a class="theme" href="mailto:test@example.com" rel="noreferrer" target="_blank">test@example.com</a>)</p>'
         );
 
         assert.equal(
             Markdown.format('(email test@example.com)').trim(),
-            '<p>(email <a class="theme" href="mailto:test@example.com">test@example.com</a>)</p>'
+            '<p>(email <a class="theme" href="mailto:test@example.com" rel="noreferrer" target="_blank">test@example.com</a>)</p>'
         );
 
         assert.equal(
             Markdown.format('(test@example.com email)').trim(),
-            '<p>(<a class="theme" href="mailto:test@example.com">test@example.com</a> email)</p>'
+            '<p>(<a class="theme" href="mailto:test@example.com" rel="noreferrer" target="_blank">test@example.com</a> email)</p>'
         );
 
         assert.equal(


### PR DESCRIPTION
Cherry pick of #4162 on release-5.17.

- #4162: include target="_blank" and rel="noreferrer" to email

/cc  @cpoile