### PR TITLE
getting the branch name if is from upstream or fixing if come from PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           at: .
       - run:
           command: |
-            curl -f -o server.tar.gz https://releases.mattermost.com/mattermost-platform-pr/${CHANGE_BRANCH}/mattermost-enterprise-linux-amd64.tar.gz || curl -f -o server.tar.gz https://releases.mattermost.com/mattermost-platform/master/mattermost-enterprise-linux-amd64.tar.gz
+            curl -f -o server.tar.gz https://releases.mattermost.com/mattermost-platform-pr/$(echo "${CIRCLE_BRANCH}" | sed 's/pull\//PR-/g')/mattermost-enterprise-linux-amd64.tar.gz || curl -f -o server.tar.gz https://releases.mattermost.com/mattermost-platform/master/mattermost-enterprise-linux-amd64.tar.gz
 
             tar xf server.tar.gz
             rm -rf mattermost/client


### PR DESCRIPTION
the previous env var does not exist anymore and that was failing when
need to build server/webapp from upstream with same branch names
