### PR TITLE
MM-20151 Fix for svg console error about width property

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -32,7 +32,6 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
         }
       }
       viewBox="0 0 300 200"
-      width="inherit"
       xmlns="http://www.w3.org/2000/svg"
     />
   </div>

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -134,7 +134,6 @@ export default class SizeAwareImage extends React.PureComponent {
                         xmlns='http://www.w3.org/2000/svg'
                         viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
                         style={{maxHeight: dimensions.height, maxWidth: dimensions.width}}
-                        width='inherit'
                     />
                 </div>
             );

--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -62,7 +62,7 @@ h6 {
     div.markdown-inline-img {
         min-width: 50px;
         display: inline-block;
-        width: auto;
+        width: 100%;
         vertical-align: middle;
     }
 


### PR DESCRIPTION
#### Summary
The issue of svg happens becuase of a change in https://github.com/mattermost/mattermost-webapp/pull/4164 which was added because of 

> Changing the width of svg to inherit to occupy the space as needed. This wasnt needed earlier but some of the recent changes made this a requirement.

The recent changes as it turns out was https://github.com/mattermost/mattermost-webapp/pull/4047 which was caused because of the https://github.com/mattermost/mattermost-webapp/pull/3639

So in total 
We don't need the width prop on svg added in https://github.com/mattermost/mattermost-webapp/pull/4164 if we revert the width change from https://github.com/mattermost/mattermost-webapp/pull/4047. 

https://github.com/mattermost/mattermost-webapp/pull/4047 was made for fixing an issue with aspect ratio images being wrong

i.e
<img width="1375" alt="Screenshot 2019-11-13 at 6 34 02 PM" src="https://user-images.githubusercontent.com/4973621/68767816-624ed680-0647-11ea-83bf-124830c5dfe3.png">
Instead of 
![Screenshot 2019-10-24 at 9 27 43 PM](https://user-images.githubusercontent.com/11034289/67505690-29a18a00-f6a5-11e9-92e3-e5a11530258d.png)

Which works now with this PR even along with the other tocket of scroll pop https://mattermost.atlassian.net/browse/MM-19909 which added a `width` prop on svg causing the error

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20151