### PR TITLE
MM-18701 Add E2E on permalink loading indicator

### DIFF
--- a/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
@@ -24,7 +24,8 @@ describe('Messaging', () => {
         const privateChannelDisplayName = titleCase(privateChannelName.replace(/-/g, ' '));
         const publicChannelName = 'test-public-channel-' + dateNow;
         const publicChannelDisplayName = titleCase(publicChannelName.replace(/-/g, ' '));
-        var testPrivateChannel, testPublicChannel;
+        let testPrivateChannel;
+        let testPublicChannel;
 
         // # Get current team id
         cy.getCurrentTeamId().then((teamId) => {
@@ -36,12 +37,12 @@ describe('Messaging', () => {
                 cy.get('#sidebarItem_' + testPrivateChannel.name).click({force: true});
 
                 // # Post several messages
-                for (var i = 1; i <= maxMessageCount; i++) { 
+                for (let i = 1; i <= maxMessageCount; i++) {
                     cy.postMessage(`${message}-${i}`);
                 }
 
-                // # Get last post id from that postlist area
-                cy.getLastPostId().then((postId) => {
+                // # Get first post id from that postlist area
+                cy.getNthPostId(-maxMessageCount).then((postId) => {
                     // # Click on ... button of last post
                     cy.clickPostDotMenu(postId);
 
@@ -86,9 +87,9 @@ describe('Messaging', () => {
                     });
 
                     // # Get last post id from open channel
-                    cy.getLastPostId().then((clickedpostid) => {
+                    cy.getLastPostId().then((clickedPostId) => {
                         // * Check the sent message
-                        cy.get(`#postMessageText_${clickedpostid}`).should('be.visible').and('have.text', `${message}-${maxMessageCount}`);
+                        cy.get(`#postMessageText_${clickedPostId}`).should('be.visible').and('have.text', `${message}-${maxMessageCount}`);
 
                         // * Check if the loading indicator is not visible
                         cy.get('.loading-screen').should('not.be.visible');

--- a/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
@@ -1,0 +1,89 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [number] indicates a test step (e.g. 1. Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+describe('Permalink loading indicator', () => {
+    before(() => {
+        // # Login and go to /
+        cy.apiLogin('user-1');
+        cy.visit('/');
+    });
+
+    it('M18701-Permalink to first post in channel shows endless loading indicator above', () => {
+        const dateNow = Date.now();
+        const message = 'Hello' + dateNow;
+        const privateChannelName = 'test-private-channel-' + dateNow;
+        const publicChannelName = 'test-public-channel-' + dateNow;
+
+        // # Get current team id
+        cy.getCurrentTeamId().then((teamId) => {
+            // # Create private channel to post message
+            cy.apiCreateChannel(teamId, privateChannelName, privateChannelName, 'P', 'Test private channel').then((response) => {
+                const testPrivateChannel = response.body;
+
+                // # Click on test private channel
+                cy.get('#sidebarItem_' + testPrivateChannel.name).click({force: true});
+
+                // # Post message to use
+                cy.postMessage(message);
+
+                // # Get last post id from that postlist area
+                cy.getLastPostId().then((postId) => {
+                    // # Click on ... button of last post
+                    cy.clickPostDotMenu(postId);
+
+                    // # Click on permalink option
+                    cy.get(`#permalink_${postId}`).click();
+
+                    // # Copy permalink from button
+                    cy.get('#linkModalCopyLink').click();
+
+                    // # Copy link url from text area
+                    cy.get('#linkModalTextArea').invoke('val').as('linkText');
+
+                    // # Close modal dialog
+                    cy.get('#linkModalCloseButton').click();
+                });
+            });
+        });
+
+        // # Get current team id
+        cy.getCurrentTeamId().then((teamId) => {
+            // # Create public channel to post permalink
+            cy.apiCreateChannel(teamId, publicChannelName, publicChannelName, 'O', 'Test public channel').then((response) => {
+                const testPublicChannel = response.body;
+
+                // # Click on test public channel
+                cy.get('#sidebarItem_' + testPublicChannel.name).click({force: true});
+
+                // # Paste link on postlist area
+                cy.get('@linkText').then((linkText) => {
+                    cy.postMessage(linkText);
+
+                    // # Get last post id from that postlist area
+                    cy.getLastPostId().then((postId) => {
+                        // # Click on permalink
+                        cy.get(`#postMessageText_${postId} > p > .markdown__link`).scrollIntoView().click();
+
+                        // # Check if url include the permalink
+                        cy.url().should('include', linkText);
+                    });
+
+                    // # Get last post id from open channel
+                    cy.getLastPostId().then((clickedpostid) => {
+                        // # Check the sent message
+                        cy.get(`#postMessageText_${clickedpostid}`).should('be.visible').and('have.text', message);
+
+                        // # Check the loading spinner does not appear
+                        cy.get('#loadingSpinner').should('not.be.visible');
+                    });
+                });
+            });
+        });
+    });
+});

--- a/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
@@ -70,16 +70,16 @@ describe('Permalink loading indicator', () => {
                         // # Click on permalink
                         cy.get(`#postMessageText_${postId} > p > .markdown__link`).scrollIntoView().click();
 
-                        // # Check if url include the permalink
+                        // * Check if url include the permalink
                         cy.url().should('include', linkText);
                     });
 
                     // # Get last post id from open channel
                     cy.getLastPostId().then((clickedpostid) => {
-                        // # Check the sent message
+                        // * Check the sent message
                         cy.get(`#postMessageText_${clickedpostid}`).should('be.visible').and('have.text', message);
 
-                        // # Check the loading spinner does not appear
+                        // * Check the loading spinner does not appear
                         cy.get('#loadingSpinner').should('not.be.visible');
                     });
                 });

--- a/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
@@ -7,7 +7,9 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-describe('Permalink loading indicator', () => {
+import {titleCase} from '../../utils';
+
+describe('Messaging', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
@@ -17,20 +19,26 @@ describe('Permalink loading indicator', () => {
     it('M18701-Permalink to first post in channel shows endless loading indicator above', () => {
         const dateNow = Date.now();
         const message = 'Hello' + dateNow;
+        const maxMessageCount = 10;
         const privateChannelName = 'test-private-channel-' + dateNow;
+        const privateChannelDisplayName = titleCase(privateChannelName.replace(/-/g, ' '));
         const publicChannelName = 'test-public-channel-' + dateNow;
+        const publicChannelDisplayName = titleCase(publicChannelName.replace(/-/g, ' '));
+        var testPrivateChannel, testPublicChannel;
 
         // # Get current team id
         cy.getCurrentTeamId().then((teamId) => {
             // # Create private channel to post message
-            cy.apiCreateChannel(teamId, privateChannelName, privateChannelName, 'P', 'Test private channel').then((response) => {
-                const testPrivateChannel = response.body;
+            cy.apiCreateChannel(teamId, privateChannelName, privateChannelDisplayName, 'P', 'Test private channel').then((response) => {
+                testPrivateChannel = response.body;
 
                 // # Click on test private channel
                 cy.get('#sidebarItem_' + testPrivateChannel.name).click({force: true});
 
-                // # Post message to use
-                cy.postMessage(message);
+                // # Post several messages
+                for (var i = 1; i <= maxMessageCount; i++) { 
+                    cy.postMessage(`${message}-${i}`);
+                }
 
                 // # Get last post id from that postlist area
                 cy.getLastPostId().then((postId) => {
@@ -55,8 +63,8 @@ describe('Permalink loading indicator', () => {
         // # Get current team id
         cy.getCurrentTeamId().then((teamId) => {
             // # Create public channel to post permalink
-            cy.apiCreateChannel(teamId, publicChannelName, publicChannelName, 'O', 'Test public channel').then((response) => {
-                const testPublicChannel = response.body;
+            cy.apiCreateChannel(teamId, publicChannelName, publicChannelDisplayName, 'O', 'Test public channel').then((response) => {
+                testPublicChannel = response.body;
 
                 // # Click on test public channel
                 cy.get('#sidebarItem_' + testPublicChannel.name).click({force: true});
@@ -72,15 +80,21 @@ describe('Permalink loading indicator', () => {
 
                         // * Check if url include the permalink
                         cy.url().should('include', linkText);
+
+                        // * Check if the matching channel intro title is visible
+                        cy.get('#channelIntro').contains('.channel-intro__title', `Beginning of ${testPrivateChannel.display_name}`).should('be.visible');
                     });
 
                     // # Get last post id from open channel
                     cy.getLastPostId().then((clickedpostid) => {
                         // * Check the sent message
-                        cy.get(`#postMessageText_${clickedpostid}`).should('be.visible').and('have.text', message);
+                        cy.get(`#postMessageText_${clickedpostid}`).should('be.visible').and('have.text', `${message}-${maxMessageCount}`);
 
-                        // * Check the loading spinner does not appear
-                        cy.get('#loadingSpinner').should('not.be.visible');
+                        // * Check if the loading indicator is not visible
+                        cy.get('.loading-screen').should('not.be.visible');
+
+                        // * Check if the more messages text is not visible
+                        cy.get('.more-messages-text').should('not.be.visible');
                     });
                 });
             });

--- a/e2e/cypress/utils/index.js
+++ b/e2e/cypress/utils/index.js
@@ -47,5 +47,15 @@ export function getMessageMenusPayload({dataSource, options} = {}) {
     return data;
 }
 
+export function titleCase(str) {
+    var splitStr = str.toLowerCase().split(' ');
+    
+    for (var i = 0; i < splitStr.length; i++) {
+        splitStr[i] = splitStr[i].charAt(0).toUpperCase() + splitStr[i].substring(1);     
+    }
+
+    return splitStr.join(' '); 
+ }
+
 export const reUrl = /(https?:\/\/[^ ]*)/;
 

--- a/e2e/cypress/utils/index.js
+++ b/e2e/cypress/utils/index.js
@@ -48,14 +48,14 @@ export function getMessageMenusPayload({dataSource, options} = {}) {
 }
 
 export function titleCase(str) {
-    var splitStr = str.toLowerCase().split(' ');
-    
-    for (var i = 0; i < splitStr.length; i++) {
-        splitStr[i] = splitStr[i].charAt(0).toUpperCase() + splitStr[i].substring(1);     
+    const splitStr = str.toLowerCase().split(' ');
+
+    for (let i = 0; i < splitStr.length; i++) {
+        splitStr[i] = splitStr[i].charAt(0).toUpperCase() + splitStr[i].substring(1);
     }
 
-    return splitStr.join(' '); 
- }
+    return splitStr.join(' ');
+}
 
 export const reUrl = /(https?:\/\/[^ ]*)/;
 


### PR DESCRIPTION
* add E2E on permalink loading indicator
* create private channel, post multiple messages, and copy permalink from first post
* create public channel, post permalink, click on permalink
* verify url include permalink, channel intro is correct, messages are displayed, loading indicator is not visible, and more messages text is not visible

Ticket Link:
Github - https://github.com/mattermost/mattermost-server/issues/12294
Jira - https://mattermost.atlassian.net/browse/MM-18701