### PR TITLE
Fixed make check-types by excluding cypress folder

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-	"experimentalDecorators": true,
+    "experimentalDecorators": true,
     "jsx": "react",
     "baseUrl": "."
   },
@@ -27,6 +27,7 @@
   ],
   "exclude": [
     "dist",
+    "e2e",
     "!node_modules/@types"
   ]
 }


### PR DESCRIPTION
#### Summary
Cypress was included in TS checking and confused the typings of Chai and Jest

