### PR TITLE
Fix release-5.17 tests

### DIFF
--- a/utils/markdown/index.test.js
+++ b/utils/markdown/index.test.js
@@ -11,7 +11,6 @@ describe('format', () => {
 ~~~`);
 
         expect(output).toContain('<span class="post-code__language">Diff</span>');
-        expect(output).toContain('<code class="hljs hljs-ln">');
     });
 
     test('should highlight code with space before language', () => {
@@ -21,7 +20,6 @@ describe('format', () => {
 ~~~`);
 
         expect(output).toContain('<span class="post-code__language">Diff</span>');
-        expect(output).toContain('<code class="hljs hljs-ln">');
     });
 
     test('should not highlight code with an invalid language', () => {


### PR DESCRIPTION
The lines of the test that I removed were about testing line numbers in code blocks which don't exist in 5.17