### PR TITLE
[MM-20160] Option to make team admin should not be provided to a guest user

### DIFF
--- a/components/admin_console/manage_teams_modal/__snapshots__/manage_teams_dropdown.test.jsx.snap
+++ b/components/admin_console/manage_teams_modal/__snapshots__/manage_teams_dropdown.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`ManageTeamsDropdown should match snapshot for guest 1`] = `
   >
     <MenuItemAction
       onClick={[Function]}
-      show={true}
+      show={false}
       text="Make Team Admin"
     />
     <MenuItemAction

--- a/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
+++ b/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
@@ -70,7 +70,7 @@ export default class ManageTeamsDropdown extends React.Component {
                     ariaLabel={Utils.localizeMessage('team_members_dropdown.menuAriaLabel', 'Team member role change')}
                 >
                     <Menu.ItemAction
-                        show={!isTeamAdmin}
+                        show={!isTeamAdmin && !isGuest}
                         onClick={this.makeTeamAdmin}
                         text={Utils.localizeMessage('admin.user_item.makeTeamAdmin', 'Make Team Admin')}
                     />


### PR DESCRIPTION
#### Summary
- Check that the user isn't a Guest before offering to make them a team admin.

#### Ticket Link
- Fixes: [MM-20160](https://mattermost.atlassian.net/browse/MM-20160)
