### PR TITLE
MM-18706 Add E2E on reply input box expansion

### DIFF
--- a/e2e/cypress/integration/messaging/message_reply_input_box_expand_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_input_box_expand_spec.js
@@ -1,0 +1,103 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+describe('Message Reply', () => {
+    before(() => {
+        // # Login and navigate to town-square
+        cy.toMainChannelView('user-1');
+
+        // # Post a new message to ensure there will be a post to click on
+        cy.postMessage('Hello ' + Date.now());
+    });
+
+    it('M18706-Input box on reply thread can expand', () => {
+        const maxReplyCount = 15;
+        const halfViewportHeight = Cypress.config('viewportHeight') / 2;
+        const padding = 4;
+        const postCreateContainerDefaultHeight = 184 - padding;
+        const replyTextBoxDefaultHeight = 100;
+        const postCreateContainerClassName = 'post-create__container';
+        const replyTextBoxId = 'reply_textbox';
+        let newLinesCount;
+        let newLines;
+
+        // # Click "Reply"
+        cy.getLastPostId().then((postId) => {
+            cy.clickPostCommentIcon(postId);
+        });
+
+        // # Post several replies and verify last reply
+        cy.get(`#${replyTextBoxId}`).clear().should('be.visible').as('replyTextBox');
+        for (let i = 1; i <= maxReplyCount; i++) {
+            cy.get('@replyTextBox').type(`post ${i}`).type('{enter}');
+        }
+        verifyLastReply(maxReplyCount);
+
+        // # Get post create container and reply text box
+        cy.document().then((doc) => {
+            const postCreateContainer = doc.getElementsByClassName(postCreateContainerClassName)[0];
+            const replyTextBox = doc.getElementById(replyTextBoxId);
+
+            // * Check if post create container has default offset height and less than 50% of viewport height
+            expect(postCreateContainer.offsetHeight - padding).to.eq(postCreateContainerDefaultHeight).and.lessThan(halfViewportHeight);
+
+            // * Check if reply text box has default offset height and less than post create container default offset height
+            expect(replyTextBox.offsetHeight).to.eq(replyTextBoxDefaultHeight).and.lessThan(postCreateContainerDefaultHeight);
+        });
+
+        // # Enter new lines into RHS so that box should reach max height, verify last reply, and verify heights
+        newLinesCount = 25;
+        newLines = '{shift}{enter}'.repeat(newLinesCount);
+        cy.get('@replyTextBox').type(newLines);
+        verifyLastReply(maxReplyCount);
+        verifyHeights(postCreateContainerClassName, replyTextBoxId, padding, halfViewportHeight, postCreateContainerDefaultHeight);
+
+        // # Enter more new lines into RHS, verify last reply, and verify heights
+        newLinesCount *= 2;
+        newLines = '{shift}{enter}'.repeat(newLinesCount);
+        cy.get('@replyTextBox').type(newLines);
+        verifyLastReply(maxReplyCount);
+        verifyHeights(postCreateContainerClassName, replyTextBoxId, padding, halfViewportHeight, postCreateContainerDefaultHeight);
+
+        // # Get first reply and scroll into view
+        cy.getNthPostId(-maxReplyCount).then((replyId) => {
+            cy.get(`#postMessageText_${replyId}`).scrollIntoView();
+            cy.wait(TIMEOUTS.TINY);
+        });
+
+        // # Type new message to reply text box and verify last reply
+        cy.get('@replyTextBox').type('new message');
+        verifyLastReply(maxReplyCount);
+    });
+
+    function verifyLastReply(maxReplyCount) {
+        // * Check last reply is visible
+        cy.getLastPostId().then((replyId) => {
+            cy.get(`#postMessageText_${replyId}`).should('be.visible').and('have.text', `post ${maxReplyCount}`);
+        });
+    }
+
+    function verifyHeights(postCreateContainerClassName, replyTextBoxId, padding, halfViewportHeight, postCreateContainerDefaultHeight) {
+        // # Get post create container and reply text box
+        cy.document().then((doc) => {
+            const postCreateContainer = doc.getElementsByClassName(postCreateContainerClassName)[0];
+            const replyTextBox = doc.getElementById(replyTextBoxId);
+
+            // * Check if post create container offset height is 50% of viewport height
+            expect(postCreateContainer.offsetHeight - padding).to.eq(halfViewportHeight);
+
+            // * Check if reply text box offset height is greater than post create container default height
+            expect(replyTextBox.offsetHeight).to.be.greaterThan(postCreateContainerDefaultHeight);
+
+            // * Check if reply text box height attribute is greater than reply text box offset height
+            cy.get(`#${replyTextBoxId}`).should('have.attr', 'height').and('greaterThan', replyTextBox.offsetHeight);
+        });
+    }
+});

--- a/e2e/cypress/integration/messaging/message_reply_input_box_expand_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_input_box_expand_spec.js
@@ -26,7 +26,6 @@ describe('Messaging', () => {
         const postCreateContainerClassName = 'post-create__container';
         const replyTextBoxId = 'reply_textbox';
         let newLinesCount;
-        let newLines;
 
         // # Click "Reply"
         cy.getLastPostId().then((postId) => {
@@ -54,17 +53,11 @@ describe('Messaging', () => {
 
         // # Enter new lines into RHS so that box should reach max height, verify last reply, and verify heights
         newLinesCount = 25;
-        newLines = '{shift}{enter}'.repeat(newLinesCount);
-        cy.get('@replyTextBox').type(newLines);
-        verifyLastReply(maxReplyCount);
-        verifyHeights(postCreateContainerClassName, replyTextBoxId, padding, halfViewportHeight, postCreateContainerDefaultHeight);
+        enterNewLinesAndVerifyLastReplyAndHeights(newLinesCount, maxReplyCount, postCreateContainerClassName, replyTextBoxId, padding, halfViewportHeight, postCreateContainerDefaultHeight);
 
         // # Enter more new lines into RHS, verify last reply, and verify heights
         newLinesCount *= 2;
-        newLines = '{shift}{enter}'.repeat(newLinesCount);
-        cy.get('@replyTextBox').type(newLines);
-        verifyLastReply(maxReplyCount);
-        verifyHeights(postCreateContainerClassName, replyTextBoxId, padding, halfViewportHeight, postCreateContainerDefaultHeight);
+        enterNewLinesAndVerifyLastReplyAndHeights(newLinesCount, maxReplyCount, postCreateContainerClassName, replyTextBoxId, padding, halfViewportHeight, postCreateContainerDefaultHeight);
 
         // # Get first reply and scroll into view
         cy.getNthPostId(-maxReplyCount).then((replyId) => {
@@ -76,6 +69,13 @@ describe('Messaging', () => {
         cy.get('@replyTextBox').type('new message');
         verifyLastReply(maxReplyCount);
     });
+
+    function enterNewLinesAndVerifyLastReplyAndHeights(newLinesCount, maxReplyCount, postCreateContainerClassName, replyTextBoxId, padding, halfViewportHeight, postCreateContainerDefaultHeight) {
+        const newLines = '{shift}{enter}'.repeat(newLinesCount);
+        cy.get('@replyTextBox').type(newLines);
+        verifyLastReply(maxReplyCount);
+        verifyHeights(postCreateContainerClassName, replyTextBoxId, padding, halfViewportHeight, postCreateContainerDefaultHeight);
+    }
 
     function verifyLastReply(maxReplyCount) {
         // * Check last reply is visible

--- a/e2e/cypress/integration/messaging/message_reply_input_box_expand_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_input_box_expand_spec.js
@@ -8,7 +8,7 @@
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
-describe('Message Reply', () => {
+describe('Messaging', () => {
     before(() => {
         // # Login and navigate to town-square
         cy.toMainChannelView('user-1');


### PR DESCRIPTION
* add E2E on reply input box expansion
* post several replies so that reply box goes to the bottom
* verify default heights
* type new lines so that reply input box reach max height, then verify last reply is not covered and the corresponding heights are correct
* add more new lines to reply to make sure box only expands up to 50% of viewport
* scroll up to first reply then start typing again on the reply box and verify replies are pushed up

Ticket Link:
Github - https://github.com/mattermost/mattermost-server/issues/12295
Jira - https://mattermost.atlassian.net/browse/MM-18706