### PR TITLE
MM-18705 Add E2E on center channel RHS overlap

### DIFF
--- a/components/create_comment/__snapshots__/create_comment.test.jsx.snap
+++ b/components/create_comment/__snapshots__/create_comment.test.jsx.snap
@@ -79,6 +79,7 @@ exports[`components/CreateComment should match snapshot read only channel 1`] = 
         <input
           className="btn btn-primary comment-btn"
           disabled={false}
+          id="addCommentButton"
           onClick={[Function]}
           type="button"
           value="Add Comment"
@@ -240,6 +241,7 @@ exports[`components/CreateComment should match snapshot, comment with message 1`
         <input
           className="btn btn-primary comment-btn"
           disabled={false}
+          id="addCommentButton"
           onClick={[Function]}
           type="button"
           value="Add Comment"
@@ -377,6 +379,7 @@ exports[`components/CreateComment should match snapshot, emoji picker disabled 1
         <input
           className="btn btn-primary comment-btn"
           disabled={false}
+          id="addCommentButton"
           onClick={[Function]}
           type="button"
           value="Add Comment"
@@ -550,6 +553,7 @@ exports[`components/CreateComment should match snapshot, empty comment 1`] = `
         <input
           className="btn btn-primary comment-btn disabled"
           disabled={true}
+          id="addCommentButton"
           onClick={[Function]}
           type="button"
           value="Add Comment"
@@ -711,6 +715,7 @@ exports[`components/CreateComment should match snapshot, non-empty message and u
         <input
           className="btn btn-primary comment-btn"
           disabled={false}
+          id="addCommentButton"
           onClick={[Function]}
           type="button"
           value="Add Comment"

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -1010,9 +1010,9 @@ class CreateComment extends React.PureComponent {
                         </div>
                         <div className='text-right margin-top'>
                             <input
-                                id='addCommentButton'
                                 type='button'
                                 disabled={!enableAddButton}
+                                id='addCommentButton'
                                 className={addButtonClass}
                                 value={formatMessage({id: 'create_comment.comment', defaultMessage: 'Add Comment'})}
                                 onClick={this.handleSubmit}

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -1010,6 +1010,7 @@ class CreateComment extends React.PureComponent {
                         </div>
                         <div className='text-right margin-top'>
                             <input
+                                id='addCommentButton'
                                 type='button'
                                 disabled={!enableAddButton}
                                 className={addButtonClass}

--- a/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
@@ -42,6 +42,6 @@ describe('Messaging', () => {
         }
 
         // * Check if "Add Comment" button is visible
-        cy.get('input[type=button]').scrollIntoView().should('be.visible').and('have.value', 'Add Comment');
+        cy.get('#addCommentButton').scrollIntoView().should('be.visible').and('have.value', 'Add Comment');
     });
 });

--- a/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
@@ -6,7 +6,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-describe('Message Reply', () => {
+describe('Messaging', () => {
     before(() => {
         // # Change viewport to tablet
         cy.viewport('ipad-2');

--- a/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
@@ -1,0 +1,47 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+describe('Message Reply', () => {
+    before(() => {
+        // # Change viewport to tablet
+        cy.viewport('ipad-2');
+
+        // # Login and navigate to town-square
+        cy.toMainChannelView('user-1');
+
+        // # Post a new message to ensure there will be a post to click on
+        cy.postMessage('Hello ' + Date.now());
+    });
+
+    it('M18705-Center channel input box does not overlap with RHS', () => {
+        const maxReplyCount = 15;
+
+        // * Check if center channel post text box is focused
+        cy.get('#post_textbox').should('be.focused');
+
+        // # Click "Reply"
+        cy.getLastPostId().then((postId) => {
+            cy.clickPostCommentIcon(postId);
+        });
+
+        // * Check if center channel post text box is not focused
+        // Although visually post text box is not visible to user,
+        // cypress still considers it visible so the assertion
+        // should('not.be.visible') will fail
+        cy.get('#post_textbox').should('not.be.focused');
+
+        // # Post several replies
+        cy.get('#reply_textbox').clear().should('be.visible').as('replyTextBox');
+        for (let i = 1; i <= maxReplyCount; i++) {
+            cy.get('@replyTextBox').type(`post ${i}`).type('{enter}');
+        }
+
+        // * Check if "Add Comment" button is visible
+        cy.get('input[type=button]').should('be.visible').and('have.value', 'Add Comment');
+    });
+});

--- a/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/center_channel_rhs_overlap_spec.js
@@ -42,6 +42,6 @@ describe('Message Reply', () => {
         }
 
         // * Check if "Add Comment" button is visible
-        cy.get('input[type=button]').should('be.visible').and('have.value', 'Add Comment');
+        cy.get('input[type=button]').scrollIntoView().should('be.visible').and('have.value', 'Add Comment');
     });
 });


### PR DESCRIPTION
* add E2E on center channel RHS overlap
* post message on center channel and verify post text box is focused
* reply to message and verify post text box is not focused
* post several replies, scroll into view ”Add Comment" button and verify it is visible

Note: Although visually post text box is not visible to user, cypress still considers it visible so the assertion should('not.be.visible') will fail. Instead, should('not.be.focused') is used

Ticket Link:
Github - https://github.com/mattermost/mattermost-server/issues/12290
Jira - https://mattermost.atlassian.net/browse/MM-18705