### PR TITLE
MM-20324 - Plugin upload should not be enabled before saving the Require Plugin Signature setting

### DIFF
--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -803,6 +803,9 @@ export default class PluginManagement extends AdminSettings {
         let serverError = '';
         let lastMessage = '';
 
+        // Using props values to make sure these are set on the server and not just locally
+        const enableUploadButton = enableUploads && enable && !this.props.config.PluginSettings.RequirePluginSignature;
+
         if (this.state.serverError) {
             serverError = <div className='col-sm-12'><div className='form-group has-error half'><label className='control-label'>{this.state.serverError}</label></div></div>;
         }
@@ -990,9 +993,7 @@ export default class PluginManagement extends AdminSettings {
                                 <div className='file__upload'>
                                     <button
                                         className={classNames(['btn', {'btn-primary': enableUploads}])}
-
-                                        // Using props values to make sure these are set on the server and not just locally
-                                        disabled={!enableUploads || !enable || this.props.config.PluginSettings.RequirePluginSignature}
+                                        disabled={!enableUploadButton}
                                     >
                                         <FormattedMessage
                                             id='admin.plugin.choose'
@@ -1004,9 +1005,7 @@ export default class PluginManagement extends AdminSettings {
                                         type='file'
                                         accept='.gz'
                                         onChange={this.handleUpload}
-
-                                        // Using props values to make sure these are set on the server and not just locally
-                                        disabled={!enableUploads || !enable || this.props.config.PluginSettings.RequirePluginSignature}
+                                        disabled={!enableUploadButton}
                                     />
                                 </div>
                                 <button

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -990,7 +990,9 @@ export default class PluginManagement extends AdminSettings {
                                 <div className='file__upload'>
                                     <button
                                         className={classNames(['btn', {'btn-primary': enableUploads}])}
-                                        disabled={!enableUploads || !this.state.enable || this.state.requirePluginSignature}
+
+                                        /* Using props values to make sure these are set on the server and not just locally */
+                                        disabled={!enableUploads || !enable || this.props.config.PluginSettings.RequirePluginSignature}
                                     >
                                         <FormattedMessage
                                             id='admin.plugin.choose'
@@ -1002,7 +1004,9 @@ export default class PluginManagement extends AdminSettings {
                                         type='file'
                                         accept='.gz'
                                         onChange={this.handleUpload}
-                                        disabled={!enableUploads || !this.state.enable || this.state.requirePluginSignature}
+
+                                        /* Using props values to make sure these are set on the server and not just locally */
+                                        disabled={!enableUploads || !enable || this.props.config.PluginSettings.RequirePluginSignature}
                                     />
                                 </div>
                                 <button

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -991,7 +991,7 @@ export default class PluginManagement extends AdminSettings {
                                     <button
                                         className={classNames(['btn', {'btn-primary': enableUploads}])}
 
-                                        /* Using props values to make sure these are set on the server and not just locally */
+                                        // Using props values to make sure these are set on the server and not just locally
                                         disabled={!enableUploads || !enable || this.props.config.PluginSettings.RequirePluginSignature}
                                     >
                                         <FormattedMessage
@@ -1005,7 +1005,7 @@ export default class PluginManagement extends AdminSettings {
                                         accept='.gz'
                                         onChange={this.handleUpload}
 
-                                        /* Using props values to make sure these are set on the server and not just locally */
+                                        // Using props values to make sure these are set on the server and not just locally
                                         disabled={!enableUploads || !enable || this.props.config.PluginSettings.RequirePluginSignature}
                                     />
                                 </div>


### PR DESCRIPTION
#### Summary
Using `props` over `state` for UploadButton to make sure settings are set on the server and not just locally.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-20324

