### PR TITLE
[MM-20209] Update current channel header when a guest user is deactivated/promoted

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -17,10 +17,10 @@ import {
 import {WebsocketEvents, General, Permissions} from 'mattermost-redux/constants';
 import {
     getChannelAndMyMember,
+    getChannelMember,
     getChannelStats,
     viewChannel,
     markChannelAsRead,
-
 } from 'mattermost-redux/actions/channels';
 import {setServerVersion} from 'mattermost-redux/actions/general';
 import {
@@ -46,7 +46,7 @@ import {Client4} from 'mattermost-redux/client';
 import {getCurrentUser, getCurrentUserId, getStatusForUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 import {getMyTeams, getCurrentRelativeTeamUrl, getCurrentTeamId, getCurrentTeamUrl} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getChannelsInTeam, getChannel, getCurrentChannel, getCurrentChannelId, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
+import {getChannelsInTeam, getChannel, getCurrentChannel, getCurrentChannelId, getRedirectChannelNameForTeam, getMembersInCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getPost, getMostRecentPostIdInChannel} from 'mattermost-redux/selectors/entities/posts';
 import {haveISystemPermission, haveITeamPermission} from 'mattermost-redux/selectors/entities/roles';
 
@@ -69,6 +69,7 @@ import {loadPlugin, loadPluginsIfNecessary, removePlugin} from 'plugins';
 import {ActionTypes, Constants, AnnouncementBarMessages, SocketEvents, UserStatuses, ModalIdentifiers} from 'utils/constants';
 import {fromAutoResponder} from 'utils/post_utils';
 import {getSiteURL} from 'utils/url';
+import {isGuest} from 'utils/utils';
 import RemovedFromChannelModal from 'components/removed_from_channel_modal';
 import InteractiveDialog from 'components/interactive_dialog';
 
@@ -755,9 +756,24 @@ export async function handleUserRemovedEvent(msg) {
     }
 }
 
-function handleUserUpdatedEvent(msg) {
-    const currentUser = getCurrentUser(getState());
+export async function handleUserUpdatedEvent(msg) {
+    const state = getState();
+    const currentUser = getCurrentUser(state);
     const user = msg.data.user;
+
+    if (isGuest(user)) {
+        let members = getMembersInCurrentChannel(state);
+        const currentChannelId = getCurrentChannelId(state);
+        if (members && members[user.id]) {
+            dispatch(getChannelStats(currentChannelId));
+        } else {
+            await dispatch(getChannelMember(currentChannelId, user.id));
+            members = getMembersInCurrentChannel(getState());
+            if (members && members[user.id]) {
+                dispatch(getChannelStats(currentChannelId));
+            }
+        }
+    }
 
     if (currentUser.id === user.id) {
         if (user.update_at > currentUser.update_at) {

--- a/actions/websocket_actions.test.jsx
+++ b/actions/websocket_actions.test.jsx
@@ -12,6 +12,9 @@ import {
     getStatusesByIds,
     getUser,
 } from 'mattermost-redux/actions/users';
+import {
+    getChannelStats,
+} from 'mattermost-redux/actions/channels';
 import {General, WebsocketEvents} from 'mattermost-redux/constants';
 
 import {handleNewPost} from 'actions/post_actions';
@@ -36,6 +39,7 @@ import {
     handlePostUnreadEvent,
     handleUserRemovedEvent,
     handleUserTypingEvent,
+    handleUserUpdatedEvent,
     handleLeaveTeamEvent,
     reconnect,
 } from './websocket_actions';
@@ -50,6 +54,10 @@ jest.mock('mattermost-redux/actions/users', () => ({
     getMissingProfilesByIds: jest.fn(() => ({type: 'GET_MISSING_PROFILES_BY_IDS'})),
     getStatusesByIds: jest.fn(() => ({type: 'GET_STATUSES_BY_IDS'})),
     getUser: jest.fn(() => ({type: 'GET_STATUSES_BY_IDS'})),
+}));
+
+jest.mock('mattermost-redux/actions/channels', () => ({
+    getChannelStats: jest.fn(() => ({type: 'GET_CHANNEL_STATS'})),
 }));
 
 jest.mock('actions/post_actions', () => ({
@@ -107,6 +115,9 @@ const mockState = {
             },
             channelsInTeam: {
                 team: ['channel1', 'channel2'],
+            },
+            membersInChannel: {
+                otherChannel: {}
             },
         },
         preferences: {
@@ -200,6 +211,57 @@ describe('handlePostUnreadEvent', () => {
 
         handlePostUnreadEvent(msg);
         expect(store.dispatch).toHaveBeenCalledWith(expectedAction);
+    });
+});
+
+describe('handleUserUpdatedEvent', () => {
+    test('should not get channel stats if user is not guest', async () => {
+        const msg = {
+            data: {
+                user: {
+                    id: 'userid',
+                    roles: 'system_user',
+                },
+            },
+        };
+
+        await handleUserUpdatedEvent(msg);
+        expect(getChannelStats).not.toHaveBeenCalled();
+    });
+
+    test('should not get channel stats if user is not in current channel', async () => {
+        const msg = {
+            data: {
+                user: {
+                    id: 'userid',
+                    roles: 'system_user',
+                },
+            },
+        };
+
+        await handleUserUpdatedEvent(msg);
+        expect(getChannelStats).not.toHaveBeenCalled();
+    });
+
+    test('should get channel stats if user is guest and in current channel', async () => {
+        const msg = {
+            data: {
+                user: {
+                    id: 'guestid',
+                    roles: 'system_guest',
+                },
+            },
+        };
+
+        mockState.entities.channels.membersInChannel.otherChannel = {
+            guestid: {
+                id: 'guestid',
+            },
+        };
+
+        await handleUserUpdatedEvent(msg);
+        mockState.entities.channels.membersInChannel.otherChannel = {};
+        expect(getChannelStats).toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
#### Summary

PR fixes a problem with current channel header not getting updated (until channel reload) when a guest user is deactivated/activated/demoted/promoted.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-20209

#### Related Pull Requests

https://github.com/mattermost/mattermost-server/pull/13180