### PR TITLE
Fix code preview on attachments

### DIFF
--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -51,7 +51,7 @@ export default class Renderer extends marked.Renderer {
         // if we have to apply syntax highlighting AND highlighting of search terms, create two copies
         // of the code block, one with syntax highlighting applied and another with invisible text, but
         // search term highlighting and overlap them
-        const content = SyntaxHighlighting.highlight(usedLanguage, code);
+        const content = SyntaxHighlighting.highlight(usedLanguage, code, true);
         let searchedContent = '';
 
         if (this.formattingOptions.searchPatterns) {

--- a/utils/syntax_highlighting.tsx
+++ b/utils/syntax_highlighting.tsx
@@ -157,13 +157,16 @@ function formatHighLight(code: string) {
     return code;
 }
 
-export function highlight(lang: string, code: string) {
+export function highlight(lang: string, code: string, addLineNumbers = false) {
     const language = getLanguageFromNameOrAlias(lang);
 
     if (language) {
         try {
             const codeValue = hlJS.highlight(language, code).value;
-            return formatHighLight(codeValue);
+            if (addLineNumbers) {
+                return formatHighLight(codeValue);
+            }
+            return codeValue;
         } catch (e) {
             // fall through if highlighting fails and handle below
         }


### PR DESCRIPTION
#### Summary
Fix code preview on attachments. This was broken because this PR (mattermost/mattermost-webapp#3578) only took in consideration the code blocks not the file code previews.

#### Ticket Link
[MM-20250](https://mattermost.atlassian.net/browse/MM-20250)