### PR TITLE
MM-19439 - Fixed dot menu to open up 

### DIFF
--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -214,10 +214,12 @@ export default class DotMenu extends Component {
             const y = rect.y || rect.top;
             const height = rect.height;
             const windowHeight = window.innerHeight;
-            this.setState({
-                openUp: (y + height) > (windowHeight - MENU_BOTTOM_MARGIN),
-                width: rect.width,
-            });
+
+            if ((y + height) > (windowHeight - MENU_BOTTOM_MARGIN)) {
+                this.setState({openUp: true});
+            }
+
+            this.setState({width: rect.width});
         }
     }
 


### PR DESCRIPTION
#### Summary
The dot menu was not always opening up at the top of the post when needed and causing the related bug. This was a regression from PR https://github.com/mattermost/mattermost-webapp/pull/3357

The `openUp` flag was always being set with the condition that checks the menu boundaries and there was a border case where the boundaries changed causing the menu to open incorrectly in the bottom. Reverting to only enable the `openUp` flag if the condition is met and not overriding if it is false.

#### Ticket Link
Fixes [MM-19493](https://mattermost.atlassian.net/browse/MM-19439)
