### PR TITLE
Fixed Interactive Dialog E2E test

### DIFF
--- a/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
@@ -71,6 +71,11 @@ describe('ID15888 Interactive Dialog', () => {
         });
     });
 
+    afterEach(() => {
+        // # Reload current page after each test to close any dialogs left open
+        cy.reload();
+    });
+
     it('UI check', () => {
         // # Post a slash command
         cy.get('#postListContent').should('be.visible');
@@ -103,8 +108,10 @@ describe('ID15888 Interactive Dialog', () => {
                 } else if (element.name === 'someradiooptions') {
                     cy.wrap($elForm).find('input').should('be.visible').and('have.length', optionsLength[element.name]);
 
-                    // * Verify that the default value is the first element of the list
-                    cy.wrap($elForm).find('input').first().should('have.value', 'engineering').and('have.attr', 'checked');
+                    // * Verify that no option is selected by default
+                    cy.wrap($elForm).find('input').each(($elInput) => {
+                        cy.wrap($elInput).should('not.be.checked');
+                    });
                 } else if (element.name === 'boolean_input') {
                     cy.wrap($elForm).find('.checkbox').should('be.visible').within(() => {
                         cy.get('#boolean_input').
@@ -235,7 +242,7 @@ describe('ID15888 Interactive Dialog', () => {
             {valid: false, value: 'invalid-number'},
             {valid: true, value: 12},
         ].forEach((testCase) => {
-            cy.get('#somenumber').scrollIntoView().type(testCase.value);
+            cy.get('#somenumber').scrollIntoView().clear().type(testCase.value);
 
             cy.get('#interactiveDialogSubmit').click();
 


### PR DESCRIPTION
Summary
Fixed Interactive Dialog test

-  Changed the assertion to verify that by default no radio button is selected (This is based on the recent changes done in the ticket https://mattermost.atlassian.net/browse/MM-18629)  
- Added step to reload after each testcase to avoid having any dialogs left open (due to any failures)
- Added step to clear input before number validation

#### Screenshots
![Screenshot 2019-11-21 at 8 41 10 AM](https://user-images.githubusercontent.com/1429138/69301070-084ba380-0c3b-11ea-945c-afc46cfe8e68.png)
