### PR TITLE
Automated cherry pick of #4266

### DIFF
--- a/components/analytics/format.test.tsx
+++ b/components/analytics/format.test.tsx
@@ -7,21 +7,20 @@ describe('components/analytics/format.tsx', () => {
     test('should syncronize chart date ranges', () => {
         const data1 = {
             datasets: [
-                {data: [1,2]}
+                {data: [1, 2]}
             ],
-            labels: ["date1", "date2"],
+            labels: ['date1', 'date2'],
         };
         const data2 = {
             datasets: [],
             labels: [],
         };
         const data3 = {
-            datasets: [{data:[3]}],
-            labels: ["date1"],
+            datasets: [{data: [3]}],
+            labels: ['date1'],
         };
         synchronizeChartData(data1, data2, data3);
         expect(data2.labels.length).toBe(0);
         expect(data3.labels).toEqual(data1.labels);
     });
-
 });

--- a/components/analytics/format.test.tsx
+++ b/components/analytics/format.test.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {synchronizeChartData} from './format';
+
+describe('components/analytics/format.tsx', () => {
+    test('should syncronize chart date ranges', () => {
+        const data1 = {
+            datasets: [
+                {data: [1,2]}
+            ],
+            labels: ["date1", "date2"],
+        };
+        const data2 = {
+            datasets: [],
+            labels: [],
+        };
+        const data3 = {
+            datasets: [{data:[3]}],
+            labels: ["date1"],
+        };
+        synchronizeChartData(data1, data2, data3);
+        expect(data2.labels.length).toBe(0);
+        expect(data3.labels).toEqual(data1.labels);
+    });
+
+});

--- a/components/analytics/format.tsx
+++ b/components/analytics/format.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+import {Dictionary} from 'mattermost-redux/types/utilities';
+
 import * as Utils from 'utils/utils.jsx';
-import { Dictionary } from 'mattermost-redux/types/utilities';
 
 export function formatChannelDoughtnutData(totalPublic: any, totalPrivate: any) {
     const channelTypeData = {
@@ -65,25 +66,25 @@ export function formatPostsPerDayData(data: any) {
 //
 // For date-labelled charts, this ensures that each charts starts and ends on the same interval, even if data for part of that interval was never collected.
 export function synchronizeChartData(...chartDatas: any[]) {
-    const labels: Dictionary<boolean> = {};
+    const labels: Set<string> = new Set();
+
     // collect all labels
-    chartDatas.forEach(chartData => {
-        chartData.labels.forEach((label: string) => labels[label] = true);        
+    chartDatas.forEach((chartData) => {
+        chartData.labels.forEach((label: string) => labels.add(label));
     });
+
     // fill in missing
-    const allLabels = Object.keys(labels);
-    chartDatas.forEach(chartData => {
+    chartDatas.forEach((chartData) => {
         if (chartData.labels.length > 0) { // don't add to empty graphs
-            allLabels.forEach((label: string) => {
+            labels.forEach((label: string) => {
                 if (chartData.labels.indexOf(label) === -1) {
                     chartData.labels.push(label);
                     chartData.datasets[0].data.push(0);
                 }
-            });        
-        }        
+            });
+        }
     });
 }
-
 
 export function formatUsersWithPostsPerDayData(data: any) {
     const chartData = {

--- a/components/analytics/format.tsx
+++ b/components/analytics/format.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import * as Utils from 'utils/utils.jsx';
+import { Dictionary } from 'mattermost-redux/types/utilities';
 
 export function formatChannelDoughtnutData(totalPublic: any, totalPrivate: any) {
     const channelTypeData = {
@@ -59,6 +60,27 @@ export function formatPostsPerDayData(data: any) {
 
     return chartData;
 }
+
+export function syncronizeChartData(...chartDatas: any[]) {
+    const labels: Dictionary<boolean> = {};
+    // collect all labels
+    chartDatas.forEach(chartData => {
+        chartData.labels.forEach((label: string) => labels[label] = true);        
+    });
+    // fill in missing
+    const allLabels = Object.keys(labels);
+    chartDatas.forEach(chartData => {
+        if (chartData.labels.length > 0) { // don't add to empty graphs
+            allLabels.forEach((label: string) => {
+                if (chartData.labels.indexOf(label) === -1) {
+                    chartData.labels.push(label);
+                    chartData.datasets[0].data.push(0);
+                }
+            });        
+        }        
+    });
+}
+
 
 export function formatUsersWithPostsPerDayData(data: any) {
     const chartData = {

--- a/components/analytics/format.tsx
+++ b/components/analytics/format.tsx
@@ -61,7 +61,10 @@ export function formatPostsPerDayData(data: any) {
     return chartData;
 }
 
-export function syncronizeChartData(...chartDatas: any[]) {
+// synchronizeChartData converges on a uniform set of labels for all entries in the given chart data. If a given label wasn't already present in the chart data, a 0-valued data point at that label is added.
+//
+// For date-labelled charts, this ensures that each charts starts and ends on the same interval, even if data for part of that interval was never collected.
+export function synchronizeChartData(...chartDatas: any[]) {
     const labels: Dictionary<boolean> = {};
     // collect all labels
     chartDatas.forEach(chartData => {

--- a/components/analytics/system_analytics/system_analytics.jsx
+++ b/components/analytics/system_analytics/system_analytics.jsx
@@ -21,7 +21,7 @@ import {
     formatUsersWithPostsPerDayData,
     formatChannelDoughtnutData,
     formatPostDoughtnutData,
-    syncronizeChartData,
+    synchronizeChartData,
 } from '../format';
 
 const StatTypes = Constants.StatTypes;
@@ -50,7 +50,7 @@ export default class SystemAnalytics extends React.PureComponent {
         const postCountsDay = formatPostsPerDayData(stats[StatTypes.POST_PER_DAY]);
         const botPostCountsDay = formatPostsPerDayData(stats[StatTypes.BOT_POST_PER_DAY]);
         const userCountsWithPostsDay = formatUsersWithPostsPerDayData(stats[StatTypes.USERS_WITH_POSTS_PER_DAY]);
-        syncronizeChartData(postCountsDay, botPostCountsDay, userCountsWithPostsDay);
+        synchronizeChartData(postCountsDay, botPostCountsDay, userCountsWithPostsDay);
 
         let banner;
         let postCount;

--- a/components/analytics/system_analytics/system_analytics.jsx
+++ b/components/analytics/system_analytics/system_analytics.jsx
@@ -21,6 +21,7 @@ import {
     formatUsersWithPostsPerDayData,
     formatChannelDoughtnutData,
     formatPostDoughtnutData,
+    syncronizeChartData,
 } from '../format';
 
 const StatTypes = Constants.StatTypes;
@@ -49,6 +50,7 @@ export default class SystemAnalytics extends React.PureComponent {
         const postCountsDay = formatPostsPerDayData(stats[StatTypes.POST_PER_DAY]);
         const botPostCountsDay = formatPostsPerDayData(stats[StatTypes.BOT_POST_PER_DAY]);
         const userCountsWithPostsDay = formatUsersWithPostsPerDayData(stats[StatTypes.USERS_WITH_POSTS_PER_DAY]);
+        syncronizeChartData(postCountsDay, botPostCountsDay, userCountsWithPostsDay);
 
         let banner;
         let postCount;


### PR DESCRIPTION
Cherry pick of #4266 on release-5.18.

- #4266: synchronize date ranges on graphs

/cc  @reflog