### PR TITLE
MM-20027 - Reporting > Statistics showing 'Loading...' when value is zero

### DIFF
--- a/components/analytics/__snapshots__/statistic_count.test.tsx.snap
+++ b/components/analytics/__snapshots__/statistic_count.test.tsx.snap
@@ -24,6 +24,30 @@ exports[`components/analytics/statistic_count.tsx should match snapshot, loaded 
 </div>
 `;
 
+exports[`components/analytics/statistic_count.tsx should match snapshot, loaded with zero value 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6"
+>
+  <div
+    className="total-count"
+  >
+    <div
+      className="title"
+    >
+      Test Zero
+      <i
+        className="fa test-icon"
+      />
+    </div>
+    <div
+      className="content"
+    >
+      0
+    </div>
+  </div>
+</div>
+`;
+
 exports[`components/analytics/statistic_count.tsx should match snapshot, on loading 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6"

--- a/components/analytics/statistic_count.test.tsx
+++ b/components/analytics/statistic_count.test.tsx
@@ -39,5 +39,5 @@ describe('components/analytics/statistic_count.tsx', () => {
         );
 
         expect(wrapper).toMatchSnapshot();
-    });    
+    });
 });

--- a/components/analytics/statistic_count.test.tsx
+++ b/components/analytics/statistic_count.test.tsx
@@ -28,4 +28,16 @@ describe('components/analytics/statistic_count.tsx', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should match snapshot, loaded with zero value', () => {
+        const wrapper = shallow(
+            <StatisticCount
+                title='Test Zero'
+                icon='test-icon'
+                count={0}
+            />
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });    
 });

--- a/components/analytics/statistic_count.tsx
+++ b/components/analytics/statistic_count.tsx
@@ -26,7 +26,7 @@ export default class StatisticCount extends React.PureComponent<Props> {
                         {this.props.title}
                         <i className={'fa ' + this.props.icon}/>
                     </div>
-                    <div className='content'>{!this.props.count || isNaN(this.props.count) ? loading : this.props.count}</div>
+                    <div className='content'>{typeof this.props.count === 'undefined' || isNaN(this.props.count) ? loading : this.props.count}</div>
                 </div>
             </div>
         );


### PR DESCRIPTION
#### Summary
Statistics widget checked for 'loading/undefined' state by using `!count` instead of actually checking if it's undefined

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-20027
