### PR TITLE
MM-20655: Replacing link to homepage with link to trial page, adding UTM tags, modifying some text

### DIFF
--- a/components/admin_console/license_settings/license_settings.jsx
+++ b/components/admin_console/license_settings/license_settings.jsx
@@ -175,13 +175,13 @@ export default class LicenseSettings extends React.Component {
             // Note: DO NOT LOCALISE THESE STRINGS. Legally we can not since the license is in English.
             edition = (
                 <p>
-                    {'Mattermost Enterprise Edition. Unlock enterprise features in this software through the purchase of a subscription from '}
+                    {'Mattermost Enterprise Edition. Unlock enterprise features in this software by starting a trial subscription at '}
                     <a
                         target='_blank'
                         rel='noopener noreferrer'
-                        href='https://mattermost.com/'
+                        href='https://mattermost.com/trial/?utm_medium=product&utm_source=product-trial'
                     >
-                        {'https://mattermost.com/'}
+                        {'https://mattermost.com/trial/'}
                     </a>
                 </p>
             );

--- a/components/admin_console/license_settings/license_settings.jsx
+++ b/components/admin_console/license_settings/license_settings.jsx
@@ -175,7 +175,7 @@ export default class LicenseSettings extends React.Component {
             // Note: DO NOT LOCALISE THESE STRINGS. Legally we can not since the license is in English.
             edition = (
                 <p>
-                    {'Mattermost Enterprise Edition. Unlock enterprise features in this software by starting a trial subscription at '}
+                    {'Mattermost Enterprise Edition. A license is required to unlock enterprise features. Start a trial subscription at '}
                     <a
                         target='_blank'
                         rel='noopener noreferrer'


### PR DESCRIPTION
Replacing link to homepage with link to trial page, adding UTM tags, modifying some text

#### Summary
We want to generate Product Qualified Leads, or PQLs, that represent people who are using the product and have demonstrated interest in enterprise features. We want to include a link to the trial page from within the Edition and License page to make it easy to try out enterprise features. With UTM tags, we can better ascertain interest in the more advanced features.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20655

#### Related Pull Requests
N/A

#### Screenshots
<img width="1075" alt="Screen Shot 2019-11-21 at 12 09 28 PM" src="https://user-images.githubusercontent.com/57730300/69373058-d137bb00-0c57-11ea-8521-f9266a854086.png">
