### PR TITLE
Disable ESLint rule for JSX file extensions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,12 +51,7 @@
         "detectObjects": true
       }
     ],
-    "react/jsx-filename-extension": [
-      1,
-      {
-        "extensions": [".js"]
-      }
-    ],
+    "react/jsx-filename-extension": 0,
     "react/prop-types": [
       2,
       {


### PR DESCRIPTION
We've had this set to warn people about using `.jsx` for ages since we wanted to switch everything to `.js`, but we haven't actually done anything about it, so it just causes a ton of warnings that we're not doing anything about. This makes the style checker's output noisy and confuses contributors. TypeScript actually requires the `.tsx` extension for JSX files as well, so we won't be able to enforce this anyway.