### PR TITLE
[MM-17261] Load team roles when receiving a member role update

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -22,6 +22,7 @@ import {
     viewChannel,
     markChannelAsRead,
 } from 'mattermost-redux/actions/channels';
+import {loadRolesIfNeeded} from 'mattermost-redux/actions/roles';
 import {setServerVersion} from 'mattermost-redux/actions/general';
 import {
     getCustomEmojiForReaction,
@@ -665,9 +666,14 @@ function handleDeleteTeamEvent(msg) {
 }
 
 function handleUpdateMemberRoleEvent(msg) {
+    const memberData = JSON.parse(msg.data.member);
+    const newRoles = memberData.roles.split(' ');
+
+    dispatch(loadRolesIfNeeded(newRoles));
+
     dispatch({
         type: TeamTypes.RECEIVED_MY_TEAM_MEMBER,
-        data: JSON.parse(msg.data.member),
+        data: memberData,
     });
 }
 


### PR DESCRIPTION
#### Summary
This PR loads the necessary user roles when receiving a member role update.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17261