### PR TITLE
[MM-20341] Add E2E test to verify customizable system config "About Link"

### DIFF
--- a/components/widgets/settings/setting.tsx
+++ b/components/widgets/settings/setting.tsx
@@ -34,10 +34,7 @@ const Setting: React.FC<Props> = ({
             >
                 {label}
             </label>
-            <div
-                data-testid={inputId + 'help-text'}
-                className={inputClassName}
-            >
+            <div className={inputClassName}>
                 {children}
                 <div
                     data-testid={inputId + 'help-text'}

--- a/components/widgets/settings/setting.tsx
+++ b/components/widgets/settings/setting.tsx
@@ -39,7 +39,10 @@ const Setting: React.FC<Props> = ({
                 className={inputClassName}
             >
                 {children}
-                <div className='help-text'>
+                <div
+                    data-testid={inputId + 'help-text'}
+                    className='help-text'
+                >
                     {helpText}
                 </div>
                 {footer}

--- a/components/widgets/settings/text_setting.tsx
+++ b/components/widgets/settings/text_setting.tsx
@@ -75,7 +75,7 @@ export default class TextSetting extends React.Component<WidgetTextSettingProps>
 
             input = (
                 <input
-                    data-testid={this.props.id + 'input'}
+                    data-testId={this.props.id + type}
                     id={this.props.id}
                     className='form-control'
                     type={type}

--- a/components/widgets/settings/text_setting.tsx
+++ b/components/widgets/settings/text_setting.tsx
@@ -75,7 +75,7 @@ export default class TextSetting extends React.Component<WidgetTextSettingProps>
 
             input = (
                 <input
-                    data-testId={this.props.id + type}
+                    data-testid={this.props.id + type}
                     id={this.props.id}
                     className='form-control'
                     type={type}

--- a/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
+++ b/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
@@ -20,7 +20,7 @@ describe('Customization', () => {
                     HelpLink: config.SupportSettings.HelpLink,
                 },
                 TeamSettings: {
-                    SiteName: config.TeamSettings.SiteName
+                    SiteName: config.TeamSettings.SiteName,
                 },
             };
         });
@@ -36,7 +36,7 @@ describe('Customization', () => {
 
     it('SC20335 - Can change Site Name setting', () => {
         // * Verify site name's setting name for is visible and matches the text
-        cy.findByTestId('TeamSettings.SiteNamelabel').should('be.visible').and('have.text', 'Site Name:');
+        cy.findByTestId('TeamSettings.SiteNamelabel').scrollIntoView().should('be.visible').and('have.text', 'Site Name:');
 
         // * Verify the site name input box has default value. The default value depends on the setup before running the test.
         cy.findByTestId('TeamSettings.SiteNameinput').should('have.value', origConfig.TeamSettings.SiteName);
@@ -58,17 +58,13 @@ describe('Customization', () => {
             // * Verify the site name is saved, directly via REST API
             expect(config.TeamSettings.SiteName).to.eq(siteName);
         });
-
-        // # Login as sysadmin and visit customization system console page
-        cy.apiLogin('sysadmin');
-        cy.visit('/admin_console/site_config/customization');
     });
 
     it('SC20341 Can change About Link setting', () => {
         const newAboutLink = 'https://about.mattermost.com/new-about-page/';
 
         // * Verify that setting is visible and has the correct label text
-        cy.findByTestId('SupportSettings.AboutLinklabel').should('be.visible').and('have.text', 'About Link:');
+        cy.findByTestId('SupportSettings.AboutLinklabel').scrollIntoView().should('be.visible').and('have.text', 'About Link:');
 
         // * Verify that the help text is visible and matches text content
         cy.findByTestId('SupportSettings.AboutLinkhelp-text').

--- a/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
+++ b/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
@@ -15,8 +15,13 @@ describe('Customization', () => {
         cy.apiGetConfig().then((response) => {
             const config = response.body;
             origConfig = {
-                SupportSettings: {HelpLink: config.SupportSettings.HelpLink},
-                TeamSettings: {SiteName: config.TeamSettings.SiteName},
+                SupportSettings: {
+                    AboutLink: config.SupportSettings.AboutLink,
+                    HelpLink: config.SupportSettings.HelpLink,
+                },
+                TeamSettings: {
+                    SiteName: config.TeamSettings.SiteName
+                },
             };
         });
 
@@ -52,6 +57,43 @@ describe('Customization', () => {
 
             // * Verify the site name is saved, directly via REST API
             expect(config.TeamSettings.SiteName).to.eq(siteName);
+        });
+    });
+
+    it('SC20341 Can change About Link setting', () => {
+        const newAboutLink = 'https://about.mattermost.com/new-about-page/';
+
+        // # Login as a system admin member
+        cy.apiLogin('sysadmin');
+
+        // # Visit the site config customization page
+        cy.visit('/admin_console/site_config/customization');
+
+        // * URL should be the customization page
+        cy.url().should('include', 'customization');
+
+        // * Verify that setting is visible and has the correct label text
+        cy.findByTestId('SupportSettings.AboutLink').
+            scrollIntoView().should('be.visible').
+            find('label').should('be.visible').and('have.text', 'About Link:');
+
+        // * Verify that the help text is visible and matches text content
+        cy.findByTestId('SupportSettings.AboutLinkhelp-text').
+            should('be.visible').and('have.text', 'The URL for the About link on the Mattermost login and sign-up pages. If this field is empty, the About link is hidden from users.');
+
+        // * Verify that the existing is visible and has default value
+        cy.findByTestId('SupportSettings.AboutLinkinput').
+            should('be.visible').
+            and('have.value', origConfig.SupportSettings.AboutLink);
+
+        // # Clear existing about link and type the new about link
+        cy.findByTestId('SupportSettings.AboutLinkinput').clear().type(newAboutLink);
+
+        // # Click the save button
+        cy.get('#saveSetting').click();
+
+        cy.apiGetConfig().then((response) => {
+            expect(response.body.SupportSettings.AboutLink).to.equal(newAboutLink);
         });
     });
 });

--- a/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
+++ b/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
@@ -58,19 +58,18 @@ describe('Customization', () => {
             // * Verify the site name is saved, directly via REST API
             expect(config.TeamSettings.SiteName).to.eq(siteName);
         });
+
+        // # Login as sysadmin and visit customization system console page
+        cy.apiLogin('sysadmin');
+        cy.visit('/admin_console/site_config/customization');
+    });
+
+    after(() => {
+        cy.apiUpdateConfig(originalConfig);
     });
 
     it('SC20341 Can change About Link setting', () => {
         const newAboutLink = 'https://about.mattermost.com/new-about-page/';
-
-        // # Login as a system admin member
-        cy.apiLogin('sysadmin');
-
-        // # Visit the site config customization page
-        cy.visit('/admin_console/site_config/customization');
-
-        // * URL should be the customization page
-        cy.url().should('include', 'customization');
 
         // * Verify that setting is visible and has the correct label text
         cy.findByTestId('SupportSettings.AboutLink').

--- a/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
+++ b/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
@@ -42,7 +42,7 @@ describe('Customization', () => {
         cy.findByTestId('TeamSettings.SiteNameinput').should('have.value', origConfig.TeamSettings.SiteName);
 
         // * Verify the site name's help text is visible and matches the text
-        cy.findByTestId('TeamSettings.SiteNamehelp-text').find('span').should('be.visible').and('have.text', 'Name of service shown in login screens and UI. When not specified, it defaults to "Mattermost".');
+        cy.findByTestId('TeamSettings.SiteNamehelp-text').should('be.visible').and('have.text', 'Name of service shown in login screens and UI. When not specified, it defaults to "Mattermost".');
 
         // # Generate and enter a random site name
         const siteName = 'New site name';
@@ -64,25 +64,18 @@ describe('Customization', () => {
         cy.visit('/admin_console/site_config/customization');
     });
 
-    after(() => {
-        cy.apiUpdateConfig(originalConfig);
-    });
-
     it('SC20341 Can change About Link setting', () => {
         const newAboutLink = 'https://about.mattermost.com/new-about-page/';
 
         // * Verify that setting is visible and has the correct label text
-        cy.findByTestId('SupportSettings.AboutLink').
-            scrollIntoView().should('be.visible').
-            find('label').should('be.visible').and('have.text', 'About Link:');
+        cy.findByTestId('SupportSettings.AboutLinklabel').should('be.visible').and('have.text', 'About Link:');
 
         // * Verify that the help text is visible and matches text content
         cy.findByTestId('SupportSettings.AboutLinkhelp-text').
             should('be.visible').and('have.text', 'The URL for the About link on the Mattermost login and sign-up pages. If this field is empty, the About link is hidden from users.');
 
         // * Verify that the existing is visible and has default value
-        cy.findByTestId('SupportSettings.AboutLinkinput').
-            should('be.visible').
+        cy.findByTestId('SupportSettings.AboutLinkinput').should('be.visible').
             and('have.value', origConfig.SupportSettings.AboutLink);
 
         // # Clear existing about link and type the new about link


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
- Adds an E2E test to verify that the system config `About Link` exists and can be modified

Test steps:
- Reset config to defaults
- Login as sysadmin & visit the page `/admin_console/site_config/customization`
- Verify the text in the label for the setting
- Verify that the help text exists and is correct
- Verify that the input exists and that it has the default about link
- Clear, modify and save the new about link
- Check that the config was saved by hitting the API

#### Ticket Link
- Fixes https://github.com/mattermost/mattermost-server/issues/13177
- JIRA: https://mattermost.atlassian.net/browse/MM-20341
