### PR TITLE
MM-20621 - Updating z-index for fullscreen modals

### DIFF
--- a/components/widgets/modals/full_screen_modal.scss
+++ b/components/widgets/modals/full_screen_modal.scss
@@ -5,7 +5,7 @@
     width: 100%;
     height: 100%;
     background: var(--center-channel-bg);
-    z-index: 1030;
+    z-index: 1030 !important;
     overflow: auto;
 
     .close-x, .back {


### PR DESCRIPTION
#### Summary
MM-20621 - Updating z-index for fullscreen modals
Incorrect z-index is being applied to the fullscreen modal css that is added to the plugins. Instead of fixing that in different plugins, we should remove all fullscreen css from plugins as that is already available in the webapp.
Here's a ticket for that:
https://mattermost.atlassian.net/browse/MM-20744

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20621