### PR TITLE
MM-20765: Client4.ts no longer throwing Error

### DIFF
--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -843,7 +843,10 @@ export default class SchemaAdminSettings extends React.Component {
         config = this.getConfigFromState(config);
 
         try {
-            await this.props.updateConfig(config);
+            let response = await this.props.updateConfig(config);
+            if (typeof response.error !== 'undefined'){
+                throw response.error
+            }
             this.setState(getStateFromConfig(config));
         } catch (err) {
             this.setState({


### PR DESCRIPTION
#### Summary
The call to Client4.ts  updateConfig is no longer throwing an error, but rather it is returning an object containing an error.
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20765

#### Screenshots
<img width="1441" alt="Screen Shot 2019-11-30 at 5 22 03 PM" src="https://user-images.githubusercontent.com/12704875/69907672-05b52080-1396-11ea-8a60-52161d12d308.png">
