### PR TITLE
Fixing JS error on channel leave or being removed from the channel

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -400,9 +400,11 @@ export default class Sidebar extends React.PureComponent {
     }
 
     updateScrollbarOnChannelChange = (channelId) => {
-        const curChannel = this.refs[channelId].getWrappedInstance().refs.channel.getBoundingClientRect();
-        if ((curChannel.top - Constants.CHANNEL_SCROLL_ADJUSTMENT < 0) || (curChannel.top + curChannel.height > this.refs.scrollbar.view.getBoundingClientRect().height)) {
-            this.refs.scrollbar.scrollTop(this.refs.scrollbar.view.scrollTop + (curChannel.top - Constants.CHANNEL_SCROLL_ADJUSTMENT));
+        if (this.refs[channelId]) {
+            const curChannel = this.refs[channelId].getWrappedInstance().refs.channel.getBoundingClientRect();
+            if ((curChannel.top - Constants.CHANNEL_SCROLL_ADJUSTMENT < 0) || (curChannel.top + curChannel.height > this.refs.scrollbar.view.getBoundingClientRect().height)) {
+                this.refs.scrollbar.scrollTop(this.refs.scrollbar.view.scrollTop + (curChannel.top - Constants.CHANNEL_SCROLL_ADJUSTMENT));
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Fixing JS error on channel leave or being removed from the channel. If the
channelId was undefined or the channelId is not longer rendered there is no
ref, we need to check that before we try to use the ref.

#### Ticket Link
[MM-20929](https://mattermost.atlassian.net/browse/MM-20929)
[MM-20920](https://mattermost.atlassian.net/browse/MM-20920)