### PR TITLE
Adding enter inside blocks work properly on edit and take into consideration the position of the cursor

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -503,7 +503,7 @@ export default class CreateComment extends React.PureComponent {
             codeBlockOnCtrlEnter,
         } = this.props;
 
-        const {allowSending, withClosedCodeBlock, message} = postMessageOnKeyPress(e, this.state.draft.message, ctrlSend, codeBlockOnCtrlEnter);
+        const {allowSending, withClosedCodeBlock, message} = postMessageOnKeyPress(e, this.state.draft.message, ctrlSend, codeBlockOnCtrlEnter, 0, 0, this.state.caretPosition);
 
         if (allowSending) {
             e.persist();

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -655,7 +655,7 @@ export default class CreatePost extends React.Component {
     postMsgKeyPress = (e) => {
         const {ctrlSend, codeBlockOnCtrlEnter} = this.props;
 
-        const {allowSending, withClosedCodeBlock, ignoreKeyPress, message} = postMessageOnKeyPress(e, this.state.message, ctrlSend, codeBlockOnCtrlEnter, Date.now(), this.lastChannelSwitchAt);
+        const {allowSending, withClosedCodeBlock, ignoreKeyPress, message} = postMessageOnKeyPress(e, this.state.message, ctrlSend, codeBlockOnCtrlEnter, Date.now(), this.lastChannelSwitchAt, this.state.caretPosition);
 
         if (ignoreKeyPress) {
             e.preventDefault();

--- a/components/edit_post_modal/edit_post_modal.test.jsx
+++ b/components/edit_post_modal/edit_post_modal.test.jsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import ReactRouterEnzymeContext from 'react-router-enzyme-context';
 
+import {isMobile} from 'utils/user_agent';
+
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import {Constants, ModalIdentifiers} from 'utils/constants';
 import DeletePostModal from 'components/delete_post_modal';
@@ -10,6 +12,10 @@ import EditPostModal from 'components/edit_post_modal/edit_post_modal.jsx';
 
 jest.mock('actions/global_actions.jsx', () => ({
     emitClearSuggestions: jest.fn(),
+}));
+
+jest.mock('utils/user_agent', () => ({
+    isMobile: jest.fn().mockReturnValue(false),
 }));
 
 function createEditPost({canEditPost, canDeletePost, ctrlSend, config, license, editingPost, actions} = {canEditPost: true, canDeletePost: true}) { //eslint-disable-line react/prop-types
@@ -386,10 +392,11 @@ describe('components/EditPostModal', () => {
     });
 
     describe('should handle edition on key press enter depending on the conditions', () => {
-        it('for Android, ctrlSend true', () => {
-            global.navigator = {userAgent: 'Android'};
+        it('for Mobile, ctrlSend true', () => {
+            isMobile.mockReturnValue(true);
             const wrapper = shallowWithIntl(createEditPost({ctrlSend: true}));
             const instance = wrapper.instance();
+            instance.setState({caretPosition: 3});
             instance.editbox = {blur: jest.fn()};
 
             const preventDefault = jest.fn();
@@ -400,13 +407,10 @@ describe('components/EditPostModal', () => {
             instance.handleEditKeyPress({key: Constants.KeyCodes.ENTER[0], which: Constants.KeyCodes.ENTER[1], ctrlKey: false, preventDefault, shiftKey: false, altKey: false});
             expect(instance.handleEdit).not.toBeCalled();
             expect(preventDefault).not.toBeCalled();
-            instance.handleEditKeyPress({key: Constants.KeyCodes.ENTER[0], which: Constants.KeyCodes.ENTER[1], ctrlKey: true, preventDefault, shiftKey: false, altKey: false});
-            expect(instance.handleEdit).toBeCalled();
-            expect(preventDefault).toBeCalled();
         });
 
         it('for Chrome, ctrlSend false', () => {
-            global.navigator = {userAgent: 'Chrome'};
+            isMobile.mockReturnValue(false);
             const wrapper = shallowWithIntl(createEditPost({ctrlSend: false}));
             const instance = wrapper.instance();
             instance.editbox = {blur: jest.fn()};

--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -37,6 +37,7 @@ function mapStateToProps(state) {
     return {
         canEditPost,
         canDeletePost,
+        codeBlockOnCtrlEnter: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'code_block_ctrl_enter', true),
         ctrlSend: getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
         config,
         editingPost,

--- a/utils/post_utils.jsx
+++ b/utils/post_utils.jsx
@@ -178,8 +178,8 @@ function canAutomaticallyCloseBackticks(message) {
     return {allowSending: true};
 }
 
-function sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, isSendMessageOnCtrlEnter) {
-    const match = message.match(Constants.TRIPLE_BACK_TICKS);
+function sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, isSendMessageOnCtrlEnter, caretPosition) {
+    const match = message.substring(0, caretPosition).match(Constants.TRIPLE_BACK_TICKS);
     if (isSendMessageOnCtrlEnter && ctrlOrMetaKeyPressed && (!match || match.length % 2 === 0)) {
         return {allowSending: true};
     } else if (!isSendMessageOnCtrlEnter && (!match || match.length % 2 === 0)) {
@@ -191,7 +191,7 @@ function sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, isSendMessageOnCtrlEnter
     return {allowSending: false};
 }
 
-export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, sendCodeBlockOnCtrlEnter, now = 0, lastChannelSwitchAt = 0) {
+export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, sendCodeBlockOnCtrlEnter, now = 0, lastChannelSwitchAt = 0, caretPosition = 0) {
     if (!event) {
         return {allowSending: false};
     }
@@ -221,9 +221,9 @@ export function postMessageOnKeyPress(event, message, sendMessageOnCtrlEnter, se
     const ctrlOrMetaKeyPressed = event.ctrlKey || event.metaKey;
 
     if (sendMessageOnCtrlEnter) {
-        return sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, true);
+        return sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, true, caretPosition);
     } else if (sendCodeBlockOnCtrlEnter) {
-        return sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, false);
+        return sendOnCtrlEnter(message, ctrlOrMetaKeyPressed, false, caretPosition);
     }
 
     return {allowSending: false};

--- a/utils/post_utils.test.jsx
+++ b/utils/post_utils.test.jsx
@@ -276,7 +276,10 @@ describe('PostUtils.postMessageOnKeyPress', () => {
                 testCase.input.event,
                 testCase.input.message,
                 testCase.input.sendMessageOnCtrlEnter,
-                testCase.input.sendCodeBlockOnCtrlEnter
+                testCase.input.sendCodeBlockOnCtrlEnter,
+                0,
+                0,
+                testCase.input.message.length,
             );
 
             expect(output).toEqual(testCase.expected);
@@ -304,7 +307,10 @@ describe('PostUtils.postMessageOnKeyPress', () => {
                 testCase.input.event,
                 testCase.input.message,
                 testCase.input.sendMessageOnCtrlEnter,
-                testCase.input.sendCodeBlockOnCtrlEnter
+                testCase.input.sendCodeBlockOnCtrlEnter,
+                0,
+                0,
+                testCase.input.message.length,
             );
 
             expect(output).toEqual(testCase.expected);
@@ -384,7 +390,10 @@ describe('PostUtils.postMessageOnKeyPress', () => {
                 testCase.input.event,
                 testCase.input.message,
                 testCase.input.sendMessageOnCtrlEnter,
-                testCase.input.sendCodeBlockOnCtrlEnter
+                testCase.input.sendCodeBlockOnCtrlEnter,
+                0,
+                0,
+                testCase.input.message.length,
             );
 
             expect(output).toEqual(testCase.expected);
@@ -468,6 +477,10 @@ describe('PostUtils.postMessageOnKeyPress', () => {
         name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with inline opening backticks',
         input: {event: {keyCode: 13, ctrlKey: true}, message: '``` message', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
         expected: {allowSending: true},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with inline opening backticks',
+        input: {event: {keyCode: 13, ctrlKey: false}, message: '``` message ```', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: true, cursorPosition: 5},
+        expected: {allowSending: false},
     }];
 
     for (const testCase of sendCodeBlockOnCtrlEnterCases) {
@@ -476,7 +489,10 @@ describe('PostUtils.postMessageOnKeyPress', () => {
                 testCase.input.event,
                 testCase.input.message,
                 testCase.input.sendMessageOnCtrlEnter,
-                testCase.input.sendCodeBlockOnCtrlEnter
+                testCase.input.sendCodeBlockOnCtrlEnter,
+                0,
+                0,
+                testCase.input.cursorPosition ? testCase.input.cursorPosition : testCase.input.message.length,
             );
 
             expect(output).toEqual(testCase.expected);
@@ -522,7 +538,8 @@ describe('PostUtils.postMessageOnKeyPress', () => {
                 testCase.input.sendMessageOnCtrlEnter,
                 testCase.input.sendCodeBlockOnCtrlEnter,
                 testCase.input.now,
-                testCase.input.lastChannelSwitch
+                testCase.input.lastChannelSwitch,
+                testCase.input.message.length,
             );
 
             expect(output).toEqual(testCase.expected);

--- a/utils/post_utils.test.jsx
+++ b/utils/post_utils.test.jsx
@@ -478,9 +478,13 @@ describe('PostUtils.postMessageOnKeyPress', () => {
         input: {event: {keyCode: 13, ctrlKey: true}, message: '``` message', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: false},
         expected: {allowSending: true},
     }, {
-        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with inline opening backticks',
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, no ctrlKey|metaKey, with cursor between backticks',
         input: {event: {keyCode: 13, ctrlKey: false}, message: '``` message ```', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: true, cursorPosition: 5},
         expected: {allowSending: false},
+    }, {
+        name: 'sendCodeBlockOnCtrlEnter: Test for overriding sending of code block on CTRL+ENTER, with ctrlKey, with cursor between backticks',
+        input: {event: {keyCode: 13, ctrlKey: true}, message: '``` message ```', sendMessageOnCtrlEnter: true, sendCodeBlockOnCtrlEnter: true, cursorPosition: 5},
+        expected: {allowSending: true},
     }];
 
     for (const testCase of sendCodeBlockOnCtrlEnterCases) {


### PR DESCRIPTION
#### Summary
Adding enter inside blocks work properly on edit and take into consideration the position of the cursor

#### Ticket Link
[MM-20658](https://mattermost.atlassian.net/browse/MM-20658)