### PR TITLE
MM-17555 Implement custom intlShape

### DIFF
--- a/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
+++ b/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
@@ -3,13 +3,14 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 
 import {filterAndSortTeamsByDisplayName} from 'utils/team_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {ModalIdentifiers} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 
 import AboutBuildModal from 'components/about_build_modal';
 

--- a/components/admin_console/admin_sidebar/admin_sidebar.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import {Tooltip, OverlayTrigger} from 'react-bootstrap';
 import Scrollbars from 'react-custom-scrollbars';
 import isEqual from 'lodash/isEqual';
@@ -12,6 +12,7 @@ import * as Utils from 'utils/utils.jsx';
 import Constants from 'utils/constants';
 import {generateIndex} from 'utils/admin_console_index.jsx';
 import {browserHistory} from 'utils/browser_history';
+import {intlShape} from 'utils/react_intl';
 
 import AdminSidebarCategory from 'components/admin_console/admin_sidebar_category.jsx';
 import AdminSidebarHeader from 'components/admin_console/admin_sidebar_header';

--- a/components/admin_console/jobs/table.jsx
+++ b/components/admin_console/jobs/table.jsx
@@ -3,9 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedDate, FormattedMessage, FormattedTime, injectIntl, intlShape} from 'react-intl';
+import {FormattedDate, FormattedMessage, FormattedTime, injectIntl} from 'react-intl';
 
 import {JobStatuses} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 
 class JobTable extends React.PureComponent {

--- a/components/admin_console/permission_schemes_settings/permission_description.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_description.jsx
@@ -3,10 +3,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FormattedMessage, FormattedHTMLMessage, injectIntl, intlShape} from 'react-intl';
+import {FormattedMessage, FormattedHTMLMessage, injectIntl} from 'react-intl';
 import {Overlay, Tooltip} from 'react-bootstrap';
 
 import {generateId} from 'utils/utils.jsx';
+import {intlShape} from 'utils/react_intl';
 import Constants from 'utils/constants';
 
 export class PermissionDescription extends React.Component {

--- a/components/announcement_bar/configuration_bar/configuration_bar.jsx
+++ b/components/announcement_bar/configuration_bar/configuration_bar.jsx
@@ -4,10 +4,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import {isLicenseExpired, isLicenseExpiring, isLicensePastGracePeriod} from 'utils/license_utils.jsx';
 import {AnnouncementBarTypes, AnnouncementBarMessages} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 
 import {t} from 'utils/i18n';
 

--- a/components/audit_table/audit_table.jsx
+++ b/components/audit_table/audit_table.jsx
@@ -3,10 +3,11 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {defineMessages, FormattedDate, FormattedMessage, FormattedTime, injectIntl, intlShape} from 'react-intl';
+import {defineMessages, FormattedDate, FormattedMessage, FormattedTime, injectIntl} from 'react-intl';
 
-import {getDirectTeammate, isSystemAdmin, toTitleCase} from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
+import {intlShape} from 'utils/react_intl';
+import {getDirectTeammate, isSystemAdmin, toTitleCase} from 'utils/utils.jsx';
 
 const holders = defineMessages({
     sessionRevoked: {

--- a/components/backstage/components/backstage_header.jsx
+++ b/components/backstage/components/backstage_header.jsx
@@ -3,7 +3,8 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {intlShape} from 'react-intl';
+
+import {intlShape} from 'utils/react_intl';
 
 export default class BackstageHeader extends React.Component {
     static propTypes = {

--- a/components/channel_groups_manage_modal/channel_groups_manage_modal.jsx
+++ b/components/channel_groups_manage_modal/channel_groups_manage_modal.jsx
@@ -3,13 +3,14 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import {Groups} from 'mattermost-redux/constants';
 
 import AddGroupsToChannelModal from 'components/add_groups_to_channel_modal';
 
 import {ModalIdentifiers} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 
 import ListModal, {DEFAULT_NUM_PER_PAGE} from 'components/list_modal.jsx';
 

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import {Permissions} from 'mattermost-redux/constants';
 import {memoizeResult} from 'mattermost-redux/utils/helpers';
 
@@ -33,6 +33,7 @@ import {
     NotificationLevels,
     RHSStates,
 } from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils';
 
 import ChannelHeaderPlug from 'plugins/channel_header_plug';

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -4,13 +4,14 @@
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import {sortFileInfos} from 'mattermost-redux/utils/file_utils';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 
 import Constants from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import * as UserAgent from 'utils/user_agent';
 import * as Utils from 'utils/utils.jsx';
 import {containsAtChannel, postMessageOnKeyPress, shouldFocusMainTextbox, isErrorInvalidSlashCommand, splitMessageBasedOnCaretPosition} from 'utils/post_utils.jsx';

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import {Posts} from 'mattermost-redux/constants';
 import {sortFileInfos} from 'mattermost-redux/utils/file_utils';
@@ -18,6 +18,7 @@ import {
     splitMessageBasedOnCaretPosition,
 } from 'utils/post_utils.jsx';
 import {getTable, formatMarkdownTableMessage} from 'utils/paste';
+import {intlShape} from 'utils/react_intl';
 import * as UserAgent from 'utils/user_agent';
 import * as Utils from 'utils/utils.jsx';
 

--- a/components/edit_channel_header_modal/edit_channel_header_modal.jsx
+++ b/components/edit_channel_header_modal/edit_channel_header_modal.jsx
@@ -1,13 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Modal} from 'react-bootstrap';
-import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
+import {defineMessages, FormattedMessage, injectIntl} from 'react-intl';
 
 import Textbox from 'components/textbox';
 import TextboxLinks from 'components/textbox/textbox_links.jsx';
 import Constants, {ModalIdentifiers} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import {isMobile} from 'utils/user_agent';
 import {isKeyPressed, localizeMessage} from 'utils/utils.jsx';
 import {t} from 'utils/i18n';

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -3,12 +3,13 @@
 
 import React from 'react';
 import {Modal} from 'react-bootstrap';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {Constants, ModalIdentifiers} from 'utils/constants';
 import {splitMessageBasedOnCaretPosition, postMessageOnKeyPress} from 'utils/post_utils.jsx';
 
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 
 import DeletePostModal from 'components/delete_post_modal';

--- a/components/emoji_picker/components/emoji_picker_item.jsx
+++ b/components/emoji_picker/components/emoji_picker_item.jsx
@@ -5,9 +5,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import debounce from 'lodash/debounce';
 import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
-import {intlShape} from 'react-intl';
 
 import imgTrans from 'images/img_trans.gif';
+import {intlShape} from 'utils/react_intl';
 
 const SCROLLING_ADDITIONAL_VISUAL_SPACING = 10; // to make give the emoji some visual 'breathing room'
 const EMOJI_LAZY_LOAD_SCROLL_THROTTLE = 150;

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
 import ReactDOM from 'react-dom';
-import {defineMessages, intlShape, FormattedMessage} from 'react-intl';
+import {defineMessages, FormattedMessage} from 'react-intl';
 
 import dragster from 'utils/dragster';
 import Constants from 'utils/constants';
@@ -15,6 +15,7 @@ import {
     isMobileApp,
 } from 'utils/user_agent';
 import {getTable} from 'utils/paste';
+import {intlShape} from 'utils/react_intl';
 import {
     clearFileInput,
     cmdOrCtrlPressed,

--- a/components/formatted_markdown_message.jsx
+++ b/components/formatted_markdown_message.jsx
@@ -2,9 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {injectIntl, intlShape} from 'react-intl';
+import {injectIntl} from 'react-intl';
 import PropTypes from 'prop-types';
 import marked from 'marked';
+
+import {intlShape} from 'utils/react_intl';
 
 const TARGET_BLANK_URL_PREFIX = '!';
 

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, injectIntl, intlShape} from 'react-intl';
+import {FormattedMessage, injectIntl} from 'react-intl';
 import {Link} from 'react-router-dom';
 
 import {Client4} from 'mattermost-redux/client';
@@ -14,6 +14,7 @@ import LocalStorageStore from 'stores/local_storage_store';
 import {browserHistory} from 'utils/browser_history';
 import Constants from 'utils/constants.jsx';
 import messageHtmlToComponent from 'utils/message_html_to_component';
+import {intlShape} from 'utils/react_intl';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {showNotification} from 'utils/notifications';

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -4,10 +4,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Permissions} from 'mattermost-redux/constants';
-import {intlShape} from 'react-intl';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {Constants, ModalIdentifiers} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import {cmdOrCtrlPressed, isKeyPressed, localizeMessage} from 'utils/utils';
 import {useSafeUrl} from 'utils/url';
 import * as UserAgent from 'utils/user_agent';

--- a/components/permalink_view/permalink_view.jsx
+++ b/components/permalink_view/permalink_view.jsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
 import ChannelHeader from 'components/channel_header';
@@ -11,6 +11,7 @@ import PostView from 'components/post_view';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
 import Constants from 'utils/constants.jsx';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 
 export default class PermalinkView extends React.PureComponent {

--- a/components/post_view/combined_system_message/combined_system_message.jsx
+++ b/components/post_view/combined_system_message/combined_system_message.jsx
@@ -3,11 +3,11 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {intlShape} from 'react-intl';
 
 import {Posts} from 'mattermost-redux/constants';
 
 import {t} from 'utils/i18n';
+import {intlShape} from 'utils/react_intl';
 
 import Markdown from 'components/markdown';
 

--- a/components/post_view/combined_system_message/last_users.jsx
+++ b/components/post_view/combined_system_message/last_users.jsx
@@ -3,11 +3,11 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {intlShape} from 'react-intl';
 
 import {Posts} from 'mattermost-redux/constants';
 
 import {t} from 'utils/i18n';
+import {intlShape} from 'utils/react_intl';
 
 import Markdown from 'components/markdown';
 

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -4,11 +4,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Posts} from 'mattermost-redux/constants';
-import {intlShape} from 'react-intl';
 import {isMeMessage as checkIsMeMessage} from 'mattermost-redux/utils/post_utils';
 
 import * as PostUtils from 'utils/post_utils.jsx';
 import {A11yCustomEventTypes} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import PostProfilePicture from 'components/post_profile_picture';
 import PostBody from 'components/post_view/post_body';
 import PostHeader from 'components/post_view/post_header';

--- a/components/post_view/post_list/post_list_virtualized.jsx
+++ b/components/post_view/post_list/post_list_virtualized.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {DynamicSizeList} from 'react-window';
-import {intlShape} from 'react-intl';
 import {isDateLine, isStartOfNewMessages} from 'mattermost-redux/utils/post_list';
 
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
@@ -13,6 +12,7 @@ import EventEmitter from 'mattermost-redux/utils/event_emitter';
 import Constants, {PostListRowListIds, EventTypes, PostRequestTypes} from 'utils/constants';
 import DelayedAction from 'utils/delayed_action';
 import {getPreviousPostId, getLatestPostId} from 'utils/post_utils.jsx';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 
 import FloatingTimestamp from 'components/post_view/floating_timestamp';

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
-import {FormattedMessage, intlShape, injectIntl} from 'react-intl';
+import {FormattedMessage, injectIntl} from 'react-intl';
 
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
@@ -13,6 +13,7 @@ import UserSettingsModal from 'components/user_settings/modal';
 import {browserHistory} from 'utils/browser_history';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import Constants, {ModalIdentifiers, UserStatuses} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 import Pluggable from 'plugins/pluggable';
 

--- a/components/rename_channel_modal/rename_channel_modal.jsx
+++ b/components/rename_channel_modal/rename_channel_modal.jsx
@@ -4,11 +4,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal, OverlayTrigger, Tooltip} from 'react-bootstrap';
-import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
+import {defineMessages, FormattedMessage, injectIntl} from 'react-intl';
 
 import LocalizedInput from 'components/localized_input/localized_input';
 import {browserHistory} from 'utils/browser_history';
 import Constants from 'utils/constants.jsx';
+import {intlShape} from 'utils/react_intl';
 import {cleanUpUrlable, getShortenedURL} from 'utils/url';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {Posts} from 'mattermost-redux/constants/index';
 import {
@@ -13,6 +13,7 @@ import {
 
 import Constants, {Locations, A11yCustomEventTypes} from 'utils/constants';
 import * as PostUtils from 'utils/post_utils.jsx';
+import {intlShape} from 'utils/react_intl';
 import {isMobile} from 'utils/utils.jsx';
 import DotMenu from 'components/dot_menu';
 import FileAttachmentListContainer from 'components/file_attachment_list';

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -3,13 +3,14 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {Posts} from 'mattermost-redux/constants';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
 
 import Constants, {Locations} from 'utils/constants';
 import * as PostUtils from 'utils/post_utils.jsx';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 import DotMenu from 'components/dot_menu';
 import FileAttachmentListContainer from 'components/file_attachment_list';

--- a/components/save_button.tsx
+++ b/components/save_button.tsx
@@ -2,9 +2,9 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {intlShape} from 'react-intl';
 
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
+import {intlShape} from 'utils/react_intl';
 
 type Props = {
     saving: boolean;

--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -5,10 +5,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Scrollbars from 'react-custom-scrollbars';
 
-import {injectIntl, intlShape} from 'react-intl';
+import {injectIntl} from 'react-intl';
 
 import {debounce} from 'mattermost-redux/actions/helpers';
 
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 
 import SearchResultsHeader from 'components/search_results_header';

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FormattedMessage, injectIntl, intlShape} from 'react-intl';
+import {FormattedMessage, injectIntl} from 'react-intl';
 import {Posts} from 'mattermost-redux/constants/index';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
@@ -25,6 +25,7 @@ import InfoSmallIcon from 'components/widgets/icons/info_small_icon';
 
 import Constants, {Locations} from 'utils/constants';
 import * as PostUtils from 'utils/post_utils.jsx';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 
 class SearchResultsItem extends React.PureComponent {

--- a/components/select_team/components/select_team_item.jsx
+++ b/components/select_team/components/select_team_item.jsx
@@ -3,10 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {intlShape} from 'react-intl';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 import TeamInfoIcon from 'components/widgets/icons/team_info_icon';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 
 export default class SelectTeamItem extends React.PureComponent {

--- a/components/shortcuts_modal.jsx
+++ b/components/shortcuts_modal.jsx
@@ -4,10 +4,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
-import {defineMessages, injectIntl, intlShape} from 'react-intl';
+import {defineMessages, injectIntl} from 'react-intl';
 
 import ModalStore from 'stores/modal_store.jsx';
 import Constants from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import {t} from 'utils/i18n';
 
 const allShortcuts = defineMessages({

--- a/components/sidebar/channel_more.jsx
+++ b/components/sidebar/channel_more.jsx
@@ -2,11 +2,12 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import {PropTypes} from 'prop-types';
 import {Permissions} from 'mattermost-redux/constants';
 
 import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
+import {intlShape} from 'utils/react_intl';
 
 export default class ChannelMore extends React.PureComponent {
     static propTypes = {

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -4,7 +4,7 @@
 import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import {PropTypes} from 'prop-types';
 import classNames from 'classnames';
 
@@ -15,6 +15,7 @@ import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import {redirectUserToDefaultTeam} from 'actions/global_actions';
 import * as ChannelUtils from 'utils/channel_utils.jsx';
 import {Constants, ModalIdentifiers, SidebarChannelGroups} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
 import favicon from 'images/favicon/favicon-16x16.png';

--- a/components/sidebar/sidebar_channel/sidebar_channel.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.jsx
@@ -2,11 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {intlShape} from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {browserHistory} from 'utils/browser_history';
 import {Constants} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import SidebarChannelButtonOrLink from '../sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx';

--- a/components/signup/signup_controller/signup_controller.jsx
+++ b/components/signup/signup_controller/signup_controller.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 import {Client4} from 'mattermost-redux/client';
 
@@ -16,6 +16,7 @@ import FormError from 'components/form_error';
 
 import LoadingScreen from 'components/loading_screen';
 import {Constants} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 
 export default class SignupController extends React.Component {
     static propTypes = {

--- a/components/system_notice/system_notice.jsx
+++ b/components/system_notice/system_notice.jsx
@@ -3,9 +3,10 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import {Preferences} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import MattermostLogo from 'components/widgets/icons/mattermost_logo';
 
 export default class SystemNotice extends React.PureComponent {

--- a/components/team_groups_manage_modal/team_groups_manage_modal.jsx
+++ b/components/team_groups_manage_modal/team_groups_manage_modal.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import {Groups} from 'mattermost-redux/constants';
 
@@ -12,6 +12,7 @@ import ConfirmModal from 'components/confirm_modal.jsx';
 import AddGroupsToTeamModal from 'components/add_groups_to_team_modal';
 
 import {ModalIdentifiers} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 
 import ListModal, {DEFAULT_NUM_PER_PAGE} from 'components/list_modal.jsx';
 

--- a/components/team_import_tab.jsx
+++ b/components/team_import_tab.jsx
@@ -3,9 +3,10 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
+import {defineMessages, FormattedMessage, injectIntl} from 'react-intl';
 
 import * as utils from 'utils/utils.jsx';
+import {intlShape} from 'utils/react_intl';
 import {t} from 'utils/i18n';
 
 import LoadingSpinner from 'components/widgets/loading/loading_spinner';

--- a/components/team_sidebar/components/team_button.jsx
+++ b/components/team_sidebar/components/team_button.jsx
@@ -3,12 +3,12 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {intlShape} from 'react-intl';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {Link} from 'react-router-dom';
 
 import {mark, trackEvent} from 'actions/diagnostics_actions.jsx';
 import Constants from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import {isDesktopApp} from 'utils/user_agent';
 import {localizeMessage} from 'utils/utils.jsx';
 import CopyUrlContextMenu from 'components/copy_url_context_menu';

--- a/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
+++ b/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
@@ -3,7 +3,8 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {intlShape} from 'react-intl';
+
+import {intlShape} from 'utils/react_intl';
 
 export default class ModalToggleButtonRedux extends React.Component {
     static propTypes = {

--- a/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
@@ -3,10 +3,11 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import {Constants, Preferences, ModalIdentifiers} from 'utils/constants.jsx';
+import {intlShape} from 'utils/react_intl';
 import {useSafeUrl} from 'utils/url';
 import AppIcons from 'images/appIcons.png';
 import ModalToggleButtonRedux from 'components/toggle_modal_button_redux';

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -5,12 +5,13 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {OverlayTrigger} from 'react-bootstrap';
-import {defineMessages, FormattedMessage, intlShape} from 'react-intl';
+import {defineMessages, FormattedMessage} from 'react-intl';
 
 import {t} from 'utils/i18n';
 import 'bootstrap-colorpicker';
 
 import Constants from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import * as UserAgent from 'utils/user_agent';
 
 import Popover from 'components/widgets/popover';

--- a/components/user_settings/general/user_settings_general.jsx
+++ b/components/user_settings/general/user_settings_general.jsx
@@ -3,11 +3,12 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {defineMessages, FormattedDate, FormattedMessage, injectIntl, intlShape} from 'react-intl';
+import {defineMessages, FormattedDate, FormattedMessage, injectIntl} from 'react-intl';
 
 import {isEmail} from 'mattermost-redux/utils/helpers';
 
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
 

--- a/components/user_settings/modal/user_settings_modal.jsx
+++ b/components/user_settings/modal/user_settings_modal.jsx
@@ -5,10 +5,11 @@ import $ from 'jquery';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 import ReactDOM from 'react-dom';
-import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-intl';
+import {defineMessages, FormattedMessage, injectIntl} from 'react-intl';
 import PropTypes from 'prop-types';
 
 import Constants from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
 import ConfirmModal from '../../confirm_modal.jsx';

--- a/components/user_settings/sidebar/user_settings_sidebar.jsx
+++ b/components/user_settings/sidebar/user_settings_sidebar.jsx
@@ -3,11 +3,12 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage, intlShape} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 
 import Constants from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 import {isMac} from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
 

--- a/components/widgets/icons/fa_next_icon.tsx
+++ b/components/widgets/icons/fa_next_icon.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import {intlShape} from 'react-intl';
+import {intlShape} from 'utils/react_intl';
 
 type Props = {
     additionalClassName: string | null;

--- a/components/widgets/icons/fa_previous_icon.tsx
+++ b/components/widgets/icons/fa_previous_icon.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import {intlShape} from 'react-intl';
+import {intlShape} from 'utils/react_intl';
 
 type Props = {
     additionalClassName: string | null;

--- a/components/widgets/icons/fa_warning_icon.tsx
+++ b/components/widgets/icons/fa_warning_icon.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import {intlShape} from 'react-intl';
+import {intlShape} from 'utils/react_intl';
 
 type Props = {
     additionalClassName: string | null;

--- a/components/widgets/inputs/channels_input.jsx
+++ b/components/widgets/inputs/channels_input.jsx
@@ -4,11 +4,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import AsyncSelect from 'react-select/lib/Async';
-import {intlShape} from 'react-intl';
 import {components} from 'react-select';
 import classNames from 'classnames';
 
 import {Constants} from 'utils/constants';
+import {intlShape} from 'utils/react_intl';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 import PublicChannelIcon from 'components/widgets/icons/globe_icon.jsx';

--- a/components/widgets/inputs/users_emails_input.jsx
+++ b/components/widgets/inputs/users_emails_input.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import AsyncSelect from 'react-select/lib/AsyncCreatable';
 import {components} from 'react-select';
-import {intlShape} from 'react-intl';
 import classNames from 'classnames';
 
 import {isEmail} from 'mattermost-redux/utils/helpers';
@@ -20,6 +19,7 @@ import Avatar from 'components/widgets/users/avatar';
 import {imageURLForUser, getDisplayName, getLongDisplayNameParts} from 'utils/utils.jsx';
 
 import {t} from 'utils/i18n.jsx';
+import {intlShape} from 'utils/react_intl';
 import {isGuest} from 'utils/utils';
 
 import './users_emails_input.scss';

--- a/components/widgets/loading/loading_spinner.tsx
+++ b/components/widgets/loading/loading_spinner.tsx
@@ -2,7 +2,8 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {intlShape} from 'react-intl';
+
+import {intlShape} from 'utils/react_intl';
 
 type Props = {
     text: React.ReactNode;

--- a/tests/helpers/intl-test-helper.jsx
+++ b/tests/helpers/intl-test-helper.jsx
@@ -2,8 +2,10 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {IntlProvider, intlShape} from 'react-intl';
+import {IntlProvider} from 'react-intl';
 import {mount, shallow} from 'enzyme';
+
+import {intlShape} from 'utils/react_intl';
 
 const intlProvider = new IntlProvider({locale: 'en', timeZone: 'Etc/UTC'}, {});
 const {intl} = intlProvider.getChildContext();

--- a/utils/react_intl.ts
+++ b/utils/react_intl.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import PropTypes from 'prop-types';
+
+// Prop types copied from the old version of
+
+export const intlConfigPropTypes = {
+    locale: PropTypes.string,
+    timeZone: PropTypes.string,
+    formats: PropTypes.object,
+    messages: PropTypes.object,
+    textComponent: PropTypes.any,
+
+    defaultLocale: PropTypes.string,
+    defaultFormats: PropTypes.object,
+
+    onError: PropTypes.func,
+};
+
+export const intlFormatPropTypes = {
+    formatDate: PropTypes.func.isRequired,
+    formatTime: PropTypes.func.isRequired,
+    formatRelative: PropTypes.func.isRequired,
+    formatNumber: PropTypes.func.isRequired,
+    formatPlural: PropTypes.func.isRequired,
+    formatMessage: PropTypes.func.isRequired,
+    formatHTMLMessage: PropTypes.func.isRequired,
+};
+
+export const intlShape = PropTypes.shape({
+    ...intlConfigPropTypes,
+    ...intlFormatPropTypes,
+    formatters: PropTypes.object,
+    now: PropTypes.func.isRequired,
+});


### PR DESCRIPTION
react-intl v3 switches to TypeScript and removes the prop-types version of intlShape, so this is switching to our own copy of the object to make this migration easier.

There should be no functional changes here.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17555