### PR TITLE
MM-20988 Fix post time due to unsupported timezone by react-intl

### DIFF
--- a/components/local_date_time/local_date_time.test.tsx
+++ b/components/local_date_time/local_date_time.test.tsx
@@ -77,7 +77,11 @@ describe('components/LocalDateTime', () => {
         );
 
         expect(wrapper.find('time').prop('title')).toBe('Sat Jan 13 2018 07:15:13 GMT+1100 (Australia/Sydney)');
-        expect(wrapper.find('span').text()).toBe('7:15 AM');
+        expect(wrapper.find('span').text()).toBe('07:15 AM');
+
+        wrapper.setProps({timeZone: 'US/Hawaii'});
+        expect(wrapper.find('time').prop('title')).toBe('Fri Jan 12 2018 10:15:13 GMT-1000 (US/Hawaii)');
+        expect(wrapper.find('span').text()).toBe('10:15 AM');
     });
 
     test('should render date with timezone enabled, in military time', () => {
@@ -92,5 +96,9 @@ describe('components/LocalDateTime', () => {
 
         expect(wrapper.find('time').prop('title')).toBe('Sat Jan 13 2018 15:15:13 GMT+1100 (Australia/Sydney)');
         expect(wrapper.find('span').text()).toBe('15:15');
+
+        wrapper.setProps({timeZone: 'US/Alaska'});
+        expect(wrapper.find('time').prop('title')).toBe('Fri Jan 12 2018 19:15:13 GMT-0900 (US/Alaska)');
+        expect(wrapper.find('span').text()).toBe('19:15');
     });
 });

--- a/components/local_date_time/local_date_time.test.tsx
+++ b/components/local_date_time/local_date_time.test.tsx
@@ -78,7 +78,12 @@ describe('components/LocalDateTime', () => {
         expect(wrapper.find('time').prop('title')).toBe('Sat Jan 13 2018 07:15:13 GMT+1100 (Australia/Sydney)');
         expect(wrapper.find('span').text()).toBe('07:15 AM');
 
-        wrapper = mountWithIntl(<LocalDateTime {...baseProps} timeZone={'US/Hawaii'}/>);
+        wrapper = mountWithIntl(
+            <LocalDateTime
+                {...baseProps}
+                timeZone={'US/Hawaii'}
+            />
+        );
         expect(wrapper.find('time').prop('title')).toBe('Fri Jan 12 2018 10:15:13 GMT-1000 (US/Hawaii)');
         expect(wrapper.find('span').text()).toBe('10:15 AM');
     });
@@ -96,7 +101,12 @@ describe('components/LocalDateTime', () => {
         expect(wrapper.find('time').prop('title')).toBe('Sat Jan 13 2018 15:15:13 GMT+1100 (Australia/Sydney)');
         expect(wrapper.find('span').text()).toBe('15:15');
 
-        wrapper = mountWithIntl(<LocalDateTime {...baseProps} timeZone={'US/Alaska'}/>);
+        wrapper = mountWithIntl(
+            <LocalDateTime
+                {...baseProps}
+                timeZone={'US/Alaska'}
+            />
+        );
         expect(wrapper.find('time').prop('title')).toBe('Fri Jan 12 2018 19:15:13 GMT-0900 (US/Alaska)');
         expect(wrapper.find('span').text()).toBe('19:15');
     });

--- a/components/local_date_time/local_date_time.test.tsx
+++ b/components/local_date_time/local_date_time.test.tsx
@@ -68,36 +68,35 @@ describe('components/LocalDateTime', () => {
     });
 
     test('should render date with timezone enabled', () => {
-        const wrapper = mountWithIntl(
-            <LocalDateTime
-                eventTime={new Date('Fri Jan 12 2018 20:15:13 GMT+0000 (+00)').getTime()}
-                enableTimezone={true}
-                timeZone={'Australia/Sydney'}
-            />
-        );
+        const baseProps = {
+            eventTime: new Date('Fri Jan 12 2018 20:15:13 GMT+0000 (+00)').getTime(),
+            enableTimezone: true,
+            timeZone: 'Australia/Sydney',
+        };
 
+        let wrapper = mountWithIntl(<LocalDateTime {...baseProps}/>);
         expect(wrapper.find('time').prop('title')).toBe('Sat Jan 13 2018 07:15:13 GMT+1100 (Australia/Sydney)');
         expect(wrapper.find('span').text()).toBe('07:15 AM');
 
-        wrapper.setProps({timeZone: 'US/Hawaii'});
+        wrapper = mountWithIntl(<LocalDateTime {...baseProps} timeZone={'US/Hawaii'}/>);
         expect(wrapper.find('time').prop('title')).toBe('Fri Jan 12 2018 10:15:13 GMT-1000 (US/Hawaii)');
         expect(wrapper.find('span').text()).toBe('10:15 AM');
     });
 
     test('should render date with timezone enabled, in military time', () => {
-        const wrapper = mountWithIntl(
-            <LocalDateTime
-                eventTime={new Date('Fri Jan 12 2018 20:15:13 GMT-0800 (+00)').getTime()}
-                useMilitaryTime={true}
-                enableTimezone={true}
-                timeZone={'Australia/Sydney'}
-            />
-        );
+        const baseProps = {
+            eventTime: new Date('Fri Jan 12 2018 20:15:13 GMT-0800 (+00)').getTime(),
+            useMilitaryTime: true,
+            enableTimezone: true,
+            timeZone: 'Australia/Sydney',
+        };
+
+        let wrapper = mountWithIntl(<LocalDateTime {...baseProps}/>);
 
         expect(wrapper.find('time').prop('title')).toBe('Sat Jan 13 2018 15:15:13 GMT+1100 (Australia/Sydney)');
         expect(wrapper.find('span').text()).toBe('15:15');
 
-        wrapper.setProps({timeZone: 'US/Alaska'});
+        wrapper = mountWithIntl(<LocalDateTime {...baseProps} timeZone={'US/Alaska'}/>);
         expect(wrapper.find('time').prop('title')).toBe('Fri Jan 12 2018 19:15:13 GMT-0900 (US/Alaska)');
         expect(wrapper.find('span').text()).toBe('19:15');
     });

--- a/components/local_date_time/local_date_time.tsx
+++ b/components/local_date_time/local_date_time.tsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedTime} from 'react-intl';
 import moment from 'moment-timezone';
 
 type Props = {
@@ -29,7 +28,7 @@ type Props = {
 }
 
 export default class LocalDateTime extends React.PureComponent<Props> {
-    public render() {
+    getFormattedTime = () => {
         const {
             enableTimezone,
             eventTime,
@@ -37,29 +36,36 @@ export default class LocalDateTime extends React.PureComponent<Props> {
             useMilitaryTime,
         } = this.props;
 
-        const date = eventTime ? new Date(eventTime) : new Date();
+        const value = eventTime ? new Date(eventTime) : new Date();
+        const momentDate = moment(value);
+        const format = useMilitaryTime ? 'HH:mm' : 'hh:mm A';
 
-        const titleMoment = moment(date);
-        let titleString = titleMoment.toString();
         if (enableTimezone && timeZone) {
-            titleMoment.tz(timeZone);
-            titleString = titleMoment.toString() + ' (' + titleMoment.tz() + ')';
+            momentDate.tz(timeZone);
+
+            return {
+                isoDate: momentDate.toString() + ' (' + momentDate.tz() + ')',
+                time: moment.tz(value, timeZone).format(format),
+            };
         }
 
-        const timezoneProps = enableTimezone && timeZone ? {timeZone} : {};
+        return {
+            isoDate: momentDate.toString(),
+            time: momentDate.format(format),
+        };
+    };
+
+    public render() {
+        const {isoDate, time} = this.getFormattedTime();
 
         return (
             <time
-                aria-label={date.toString()}
+                aria-label={isoDate}
                 className='post__time'
-                dateTime={date.toISOString()}
-                title={titleString}
+                dateTime={isoDate}
+                title={isoDate}
             >
-                <FormattedTime
-                    {...timezoneProps}
-                    hour12={!useMilitaryTime}
-                    value={date}
-                />
+                <span>{time}</span>
             </time>
         );
     }

--- a/components/local_date_time/local_date_time.tsx
+++ b/components/local_date_time/local_date_time.tsx
@@ -36,21 +36,17 @@ export default class LocalDateTime extends React.PureComponent<Props> {
             useMilitaryTime,
         } = this.props;
 
-        const value = eventTime ? new Date(eventTime) : new Date();
-        const momentDate = moment(value);
+        const momentDate = eventTime ? moment(eventTime) : moment();
         const format = useMilitaryTime ? 'HH:mm' : 'hh:mm A';
 
+        let withTimezone;
         if (enableTimezone && timeZone) {
             momentDate.tz(timeZone);
-
-            return {
-                isoDate: momentDate.toString() + ' (' + momentDate.tz() + ')',
-                time: moment.tz(value, timeZone).format(format),
-            };
+            withTimezone = momentDate.toString() + ' (' + momentDate.tz() + ')';
         }
 
         return {
-            isoDate: momentDate.toString(),
+            isoDate: withTimezone || momentDate.toString(),
             time: momentDate.format(format),
         };
     };

--- a/components/local_date_time/local_date_time.tsx
+++ b/components/local_date_time/local_date_time.tsx
@@ -27,8 +27,13 @@ type Props = {
     enableTimezone?: boolean;
 }
 
+type FormattedTimeResult = {
+    isoDate: string;
+    time: string;
+};
+
 export default class LocalDateTime extends React.PureComponent<Props> {
-    private getFormattedTime = (): {isoDate: string; time: string;} => {
+    private getFormattedTime: () => FormattedTimeResult = () => {
         const {
             enableTimezone,
             eventTime,

--- a/components/local_date_time/local_date_time.tsx
+++ b/components/local_date_time/local_date_time.tsx
@@ -28,7 +28,7 @@ type Props = {
 }
 
 export default class LocalDateTime extends React.PureComponent<Props> {
-    private getFormattedTime = (): {isoDate: string, time: string} => {
+    private getFormattedTime = (): {isoDate: string; time: string;} => {
         const {
             enableTimezone,
             eventTime,

--- a/components/local_date_time/local_date_time.tsx
+++ b/components/local_date_time/local_date_time.tsx
@@ -28,7 +28,7 @@ type Props = {
 }
 
 export default class LocalDateTime extends React.PureComponent<Props> {
-    getFormattedTime = () => {
+    private getFormattedTime = (): {isoDate: string, time: string} => {
         const {
             enableTimezone,
             eventTime,


### PR DESCRIPTION
#### Summary
The issue happened when user's timezone is not supported by react-intl. Instead of react-intl, use moment-timezone to handle timezone conversion of post time.

#### Ticket Link
Jira ticket: https://mattermost.atlassian.net/browse/MM-20988

#### Test steps
See steps on Jira
