### PR TITLE
[MM-20975] Fix spacing on RHS Pinned and flag icon

### DIFF
--- a/sass/layout/_sidebar-right.scss
+++ b/sass/layout/_sidebar-right.scss
@@ -66,7 +66,7 @@
             }
 
             .post__pinned-badge {
-                margin: 0 0 0 5px;
+                margin: 0 8px 0 5px;
             }
         }
 

--- a/sass/responsive/_tablet.scss
+++ b/sass/responsive/_tablet.scss
@@ -456,7 +456,7 @@
             .sidebar--right & .flag-icon__container, .sidebar--right & .card-icon__container {
                 left: auto;
                 position: relative;
-                top: 1px;
+                top: 2px;
             }
 
             &.same--root {


### PR DESCRIPTION
#### Summary
Fix to spacing around the flagged and pinned icons on the RHS when in compact mode.
Before:
![Screen Shot 2019-12-09 at 2 09 53 PM](https://user-images.githubusercontent.com/52460000/70464859-c53c5d80-1a8d-11ea-94b8-0986da5d909a.png)

After:
![Screen Shot 2019-12-09 at 2 09 13 PM](https://user-images.githubusercontent.com/52460000/70464868-c9687b00-1a8d-11ea-8728-2d8193578e0c.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20975