### PR TITLE
MM-17555 Use FormattedMessage in CustomThemeChooser 

### DIFF
--- a/components/user_settings/display/user_settings_theme/__snapshots__/custom_theme_chooser.test.jsx.snap
+++ b/components/user_settings/display/user_settings_theme/__snapshots__/custom_theme_chooser.test.jsx.snap
@@ -52,7 +52,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#145dbf"
           id="sidebarBg"
-          label="Sidebar BG"
+          label={
+            <FormattedMessage
+              defaultMessage="Sidebar BG"
+              id="user.settings.custom_theme.sidebarBg"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -63,7 +69,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#ffffff"
           id="sidebarText"
-          label="Sidebar Text"
+          label={
+            <FormattedMessage
+              defaultMessage="Sidebar Text"
+              id="user.settings.custom_theme.sidebarText"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -74,7 +86,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#1153ab"
           id="sidebarHeaderBg"
-          label="Sidebar Header BG"
+          label={
+            <FormattedMessage
+              defaultMessage="Sidebar Header BG"
+              id="user.settings.custom_theme.sidebarHeaderBg"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -85,7 +103,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#ffffff"
           id="sidebarHeaderTextColor"
-          label="Sidebar Header Text"
+          label={
+            <FormattedMessage
+              defaultMessage="Sidebar Header Text"
+              id="user.settings.custom_theme.sidebarHeaderTextColor"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -96,7 +120,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#ffffff"
           id="sidebarUnreadText"
-          label="Sidebar Unread Text"
+          label={
+            <FormattedMessage
+              defaultMessage="Sidebar Unread Text"
+              id="user.settings.custom_theme.sidebarUnreadText"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -107,7 +137,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#4578bf"
           id="sidebarTextHoverBg"
-          label="Sidebar Text Hover BG"
+          label={
+            <FormattedMessage
+              defaultMessage="Sidebar Text Hover BG"
+              id="user.settings.custom_theme.sidebarTextHoverBg"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -118,7 +154,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#579eff"
           id="sidebarTextActiveBorder"
-          label="Sidebar Text Active Border"
+          label={
+            <FormattedMessage
+              defaultMessage="Sidebar Text Active Border"
+              id="user.settings.custom_theme.sidebarTextActiveBorder"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -129,7 +171,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#ffffff"
           id="sidebarTextActiveColor"
-          label="Sidebar Text Active Color"
+          label={
+            <FormattedMessage
+              defaultMessage="Sidebar Text Active Color"
+              id="user.settings.custom_theme.sidebarTextActiveColor"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -140,7 +188,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#06d6a0"
           id="onlineIndicator"
-          label="Online Indicator"
+          label={
+            <FormattedMessage
+              defaultMessage="Online Indicator"
+              id="user.settings.custom_theme.onlineIndicator"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -151,7 +205,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#ffbc42"
           id="awayIndicator"
-          label="Away Indicator"
+          label={
+            <FormattedMessage
+              defaultMessage="Away Indicator"
+              id="user.settings.custom_theme.awayIndicator"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -162,7 +222,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#f74343"
           id="dndIndicator"
-          label="Do Not Disturb Indicator"
+          label={
+            <FormattedMessage
+              defaultMessage="Do Not Disturb Indicator"
+              id="user.settings.custom_theme.dndIndicator"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -173,7 +239,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#ffffff"
           id="mentionBg"
-          label="Mention Jewel BG"
+          label={
+            <FormattedMessage
+              defaultMessage="Mention Jewel BG"
+              id="user.settings.custom_theme.mentionBg"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -184,7 +256,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#145dbf"
           id="mentionColor"
-          label="Mention Jewel Text"
+          label={
+            <FormattedMessage
+              defaultMessage="Mention Jewel Text"
+              id="user.settings.custom_theme.mentionColor"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -239,7 +317,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#ffffff"
           id="centerChannelBg"
-          label="Center Channel BG"
+          label={
+            <FormattedMessage
+              defaultMessage="Center Channel BG"
+              id="user.settings.custom_theme.centerChannelBg"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -250,7 +334,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#3d3c40"
           id="centerChannelColor"
-          label="Center Channel Text"
+          label={
+            <FormattedMessage
+              defaultMessage="Center Channel Text"
+              id="user.settings.custom_theme.centerChannelColor"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -261,7 +351,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#ff8800"
           id="newMessageSeparator"
-          label="New Message Separator"
+          label={
+            <FormattedMessage
+              defaultMessage="New Message Separator"
+              id="user.settings.custom_theme.newMessageSeparator"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -272,7 +368,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#fd5960"
           id="errorTextColor"
-          label="Error Text Color"
+          label={
+            <FormattedMessage
+              defaultMessage="Error Text Color"
+              id="user.settings.custom_theme.errorTextColor"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -283,7 +385,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#ffe577"
           id="mentionHighlightBg"
-          label="Mention Highlight BG"
+          label={
+            <FormattedMessage
+              defaultMessage="Mention Highlight BG"
+              id="user.settings.custom_theme.mentionHighlightBg"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -294,7 +402,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#166de0"
           id="mentionHighlightLink"
-          label="Mention Highlight Link"
+          label={
+            <FormattedMessage
+              defaultMessage="Mention Highlight Link"
+              id="user.settings.custom_theme.mentionHighlightLink"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -305,7 +419,11 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <label
           className="custom-label"
         >
-          Code Theme
+          <FormattedMessage
+            defaultMessage="Code Theme"
+            id="user.settings.custom_theme.codeTheme"
+            values={Object {}}
+          />
         </label>
         <div
           className="input-group theme-group group--code dropdown"
@@ -428,7 +546,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#2389d7"
           id="linkColor"
-          label="Link Color"
+          label={
+            <FormattedMessage
+              defaultMessage="Link Color"
+              id="user.settings.custom_theme.linkColor"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -439,7 +563,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#166de0"
           id="buttonBg"
-          label="Button BG"
+          label={
+            <FormattedMessage
+              defaultMessage="Button BG"
+              id="user.settings.custom_theme.buttonBg"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>
@@ -450,7 +580,13 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
         <ColorChooser
           color="#ffffff"
           id="buttonColor"
-          label="Button Text"
+          label={
+            <FormattedMessage
+              defaultMessage="Button Text"
+              id="user.settings.custom_theme.buttonColor"
+              values={Object {}}
+            />
+          }
           onChange={[Function]}
         />
       </div>

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -11,7 +11,6 @@ import {t} from 'utils/i18n';
 import 'bootstrap-colorpicker';
 
 import Constants from 'utils/constants';
-import {intlShape} from 'utils/react_intl';
 import * as UserAgent from 'utils/user_agent';
 
 import LocalizedIcon from 'components/localized_icon';
@@ -118,10 +117,6 @@ export default class CustomThemeChooser extends React.Component {
     static propTypes = {
         theme: PropTypes.object.isRequired,
         updateTheme: PropTypes.func.isRequired,
-    };
-
-    static contextTypes = {
-        intl: intlShape.isRequired,
     };
 
     constructor(props) {
@@ -252,7 +247,6 @@ export default class CustomThemeChooser extends React.Component {
     }
 
     render() {
-        const {formatMessage} = this.context.intl;
         const theme = this.props.theme;
 
         const sidebarElements = [];
@@ -296,7 +290,9 @@ export default class CustomThemeChooser extends React.Component {
                         className='col-sm-6 form-group'
                         key={'custom-theme-key' + index}
                     >
-                        <label className='custom-label'>{formatMessage(messages[element.id])}</label>
+                        <label className='custom-label'>
+                            <FormattedMessage {...messages[element.id]}/>
+                        </label>
                         <div
                             className='input-group theme-group group--code dropdown'
                             id={element.id}
@@ -332,7 +328,7 @@ export default class CustomThemeChooser extends React.Component {
                     >
                         <ColorChooser
                             id={element.id}
-                            label={formatMessage(messages[element.id])}
+                            label={<FormattedMessage {...messages[element.id]}/>}
                             color={theme[element.id]}
                             onChange={this.handleColorChange}
                         />
@@ -352,7 +348,7 @@ export default class CustomThemeChooser extends React.Component {
                     >
                         <ColorChooser
                             id={element.id}
-                            label={formatMessage(messages[element.id])}
+                            label={<FormattedMessage {...messages[element.id]}/>}
                             color={color}
                             onChange={this.handleColorChange}
                         />
@@ -366,7 +362,7 @@ export default class CustomThemeChooser extends React.Component {
                     >
                         <ColorChooser
                             id={element.id}
-                            label={formatMessage(messages[element.id])}
+                            label={<FormattedMessage {...messages[element.id]}/>}
                             color={theme[element.id]}
                             onChange={this.handleColorChange}
                         />


### PR DESCRIPTION
This is another set of fairly trivial changes to get rid of `this.context.intl` in the custom theme chooser.

This PR is based on https://github.com/mattermost/mattermost-webapp/pull/4470. Changes specific to it are here: https://github.com/mattermost/mattermost-webapp/compare/mm17555h...mm17555j

For QA, please confirm that the custom theme picker in the account settings is still translated correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17555