### PR TITLE
Fixing Team icons opacity in teams menu

### DIFF
--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -57,6 +57,17 @@
                 }
             }
 
+            .TeamIcon__content {
+                @include opacity(.5);
+                &:hover {
+                    @include opacity(.8);
+
+                    &.no-hover {
+                        @include opacity(.5);
+                    }
+                }
+            }
+
             button {
                 border: none;
                 padding: 0;


### PR DESCRIPTION
#### Summary
Fixing Team icons opacity in teams menu

This was broken here: dee85fb1acc405232a4f89834239f6546308c6ee to fix a problem
of visualization of the team icons in the admin console. This fix is respecting
that change and fixing the current bug.

#### Ticket Link
[MM-21082](https://mattermost.atlassian.net/browse/MM-21082)