### PR TITLE
MM-21057 Fix for New message line cutoff at the top of channel

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -15,6 +15,7 @@ exports[`components/SizeAwareImage should match snapshot when handleSmallImageCo
         Object {
           "maxHeight": 200,
           "maxWidth": 300,
+          "verticalAlign": "middle",
         }
       }
       viewBox="0 0 300 200"
@@ -76,6 +77,7 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
         Object {
           "maxHeight": 200,
           "maxWidth": 300,
+          "verticalAlign": "middle",
         }
       }
       viewBox="0 0 300 200"

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -204,7 +204,7 @@ export default class SizeAwareImage extends React.PureComponent {
                     <svg
                         xmlns='http://www.w3.org/2000/svg'
                         viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
-                        style={{maxHeight: dimensions.height, maxWidth: dimensions.width}}
+                        style={{maxHeight: dimensions.height, maxWidth: dimensions.width, verticalAlign: 'middle'}}
                     />
                 </div>
             );

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -540,10 +540,6 @@
     position: relative;
     max-height: inherit;
     overflow: hidden;
-
-    &.markdown-inline-img svg {
-        margin: 5px 0px;
-    }
 }
 
 .file-preview__button {

--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -65,7 +65,7 @@ h6 {
         min-width: 50px;
         display: inline-block;
         width: 100%;
-        vertical-align: middle;
+        vertical-align: top;
     }
 
     .post {
@@ -79,7 +79,7 @@ h6 {
 
     .markdown-inline-img__container {
         display: inline-block;
-        width: 100%;
+        width: calc(100% - 5px);
     }
 
     .markdown-inline-img--loading {
@@ -87,9 +87,7 @@ h6 {
     }
 
     .markdown-inline-img--hover {
-        max-width: calc(100% - 5px);
         border: 1px solid transparent;
-
         &:hover {
             @include single-transition(all, .1s, linear);
             @include box-shadow(0 2px 5px 0 rgba($black, 0.1), 0 2px 5px 0 rgba($black, 0.1));


### PR DESCRIPTION
#### Summary
  * With some of the recent changes to show image preview on click we changed the max dimensions of the markdown images causing a difference in placeholder image size and rendered image size. This causes a minor scroll pop causing the new message line to move above

The reason why `calc(100% - 5px)` was added is to make sure markdown image on RHS is not cutoff https://github.com/mattermost/mattermost-webapp/pull/3639#pullrequestreview-288559800. I was able to solve this by changing the container styles so the svg-placeholder also inherits this style.
Retaining hover effect on RHS
<img width="419" alt="Screenshot 2019-12-11 at 6 40 44 PM" src="https://user-images.githubusercontent.com/4973621/70619505-b8fc0000-1c47-11ea-8b94-70e0a6b8cd1f.png">


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21057

#### Screenshots
Before:

![Dec-11-2019 18-53-30](https://user-images.githubusercontent.com/4973621/70619476-a8e42080-1c47-11ea-81b1-c8974eb1b251.gif)

After:
![Dec-11-2019 18-52-05](https://user-images.githubusercontent.com/4973621/70619319-5c004a00-1c47-11ea-8ce0-4e36e995f603.gif)
