### PR TITLE
MM-20939 - File picker opens twice when trying to attach a file through the paperclip button in mobile view

### DIFF
--- a/components/file_upload/__snapshots__/file_upload.test.jsx.snap
+++ b/components/file_upload/__snapshots__/file_upload.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`components/FileUpload should match snapshot 1`] = `
       className="style--none post-action icon icon--attachment"
       id="fileUploadButton"
       onClick={[Function]}
-      onTouchEnd={[Function]}
+      onTouchEnd={false}
       type="button"
     >
       <AttachmentIcon />

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -572,9 +572,10 @@ export default class FileUpload extends PureComponent {
     }
 
     render() {
+        const isMobile = isMobileApp();
         const {formatMessage} = this.context.intl;
         let multiple = true;
-        if (isMobileApp()) {
+        if (isMobile) {
             // iOS WebViews don't upload videos properly in multiple mode
             multiple = false;
         }
@@ -598,8 +599,8 @@ export default class FileUpload extends PureComponent {
                         id='fileUploadButton'
                         aria-label={ariaLabel}
                         className='style--none post-action icon icon--attachment'
-                        onClick={!isMobileApp() && this.simulateInputClick}
-                        onTouchEnd={isMobileApp() && this.simulateInputClick}
+                        onClick={!isMobile && this.simulateInputClick}
+                        onTouchEnd={isMobile && this.simulateInputClick}
                     >
                         <AttachmentIcon/>
                     </button>
@@ -670,8 +671,8 @@ export default class FileUpload extends PureComponent {
                             <li>
                                 <a
                                     href='#'
-                                    onClick={!isMobileApp() && this.simulateInputClick}
-                                    onTouchEnd={isMobileApp() && this.simulateInputClick}
+                                    onClick={!isMobile && this.simulateInputClick}
+                                    onTouchEnd={isMobile && this.simulateInputClick}
                                 >
                                     <span className='margin-right'><i className='fa fa-laptop'/></span>
                                     <FormattedMessage

--- a/components/file_upload/file_upload.jsx
+++ b/components/file_upload/file_upload.jsx
@@ -598,8 +598,8 @@ export default class FileUpload extends PureComponent {
                         id='fileUploadButton'
                         aria-label={ariaLabel}
                         className='style--none post-action icon icon--attachment'
-                        onClick={this.simulateInputClick}
-                        onTouchEnd={this.simulateInputClick}
+                        onClick={!isMobileApp() && this.simulateInputClick}
+                        onTouchEnd={isMobileApp() && this.simulateInputClick}
                     >
                         <AttachmentIcon/>
                     </button>
@@ -670,8 +670,8 @@ export default class FileUpload extends PureComponent {
                             <li>
                                 <a
                                     href='#'
-                                    onClick={this.simulateInputClick}
-                                    onTouchEnd={this.simulateInputClick}
+                                    onClick={!isMobileApp() && this.simulateInputClick}
+                                    onTouchEnd={isMobileApp() && this.simulateInputClick}
                                 >
                                     <span className='margin-right'><i className='fa fa-laptop'/></span>
                                     <FormattedMessage

--- a/components/file_upload/file_upload.test.jsx
+++ b/components/file_upload/file_upload.test.jsx
@@ -9,6 +9,7 @@ import {clearFileInput} from 'utils/utils';
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import FileUpload from 'components/file_upload/file_upload.jsx';
+import * as UserAgent from 'utils/user_agent';
 
 const generatedIdRegex = /[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/;
 
@@ -97,7 +98,33 @@ describe('components/FileUpload', () => {
         expect(baseProps.onClick).toHaveBeenCalledTimes(1);
     });
 
-    test('should call onClick on fileInput when button is touched', () => {
+    test('should call onClick on fileInput when button is touched when isMobileApp=true', () => {
+        const origIsMobileApp = UserAgent.isMobileApp;
+        UserAgent.isMobileApp = jest.fn().mockImplementation(() => true);
+
+        const wrapper = shallowWithIntl(
+            <FileUpload {...baseProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.handleLocalFileUploaded = jest.fn();
+        instance.fileInput = {
+            current: {
+                click: () => instance.handleLocalFileUploaded(),
+            },
+        };
+        wrapper.find('button').simulate('click');
+        expect(instance.handleLocalFileUploaded).toHaveBeenCalledTimes(0);
+
+        wrapper.find('button').simulate('touchend');
+        expect(instance.handleLocalFileUploaded).toHaveBeenCalledTimes(1);
+
+        UserAgent.isMobileApp = origIsMobileApp;
+    });
+
+    test('should call onClick on fileInput when button is touched when isMobileApp=false', () => {
+        const origIsMobileApp = UserAgent.isMobileApp;
+        UserAgent.isMobileApp = jest.fn().mockImplementation(() => false);
+
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
         );
@@ -109,7 +136,12 @@ describe('components/FileUpload', () => {
             },
         };
         wrapper.find('button').simulate('touchend');
+        expect(instance.handleLocalFileUploaded).toHaveBeenCalledTimes(0);
+
+        wrapper.find('button').simulate('click');
         expect(instance.handleLocalFileUploaded).toHaveBeenCalledTimes(1);
+
+        UserAgent.isMobileApp = origIsMobileApp;
     });
 
     test('should match state and call handleMaxUploadReached or props.onClick on handleLocalFileUploaded', () => {


### PR DESCRIPTION
#### Summary
Attaching only 1 click handler when in mobile view or not in mobile view.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-20939

#### Related Pull Requests

 