### PR TITLE
MM-21197: Hides some groups-related inputs and menu items without the…

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2465,9 +2465,9 @@ const AdminDefinition = {
                         placeholder: t('admin.ldap.groupFilterEx'),
                         placeholder_default: 'E.g.: "(objectClass=group)"',
                         isDisabled: it.stateIsFalse('LdapSettings.EnableSync'),
-                        isHidden: (config, state, license) => {
-                            return license.LDAPGroups !== 'true';
-                        },
+                        isHidden: it.either(
+                            it.isnt(it.licensedForFeature('LDAPGroups')),
+                        ),
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_TEXT,
@@ -2479,9 +2479,9 @@ const AdminDefinition = {
                         placeholder: t('admin.ldap.groupDisplayNameAttributeEx'),
                         placeholder_default: 'E.g.: "cn"',
                         isDisabled: it.stateIsFalse('LdapSettings.EnableSync'),
-                        isHidden: (config, state, license) => {
-                            return license.LDAPGroups !== 'true';
-                        },
+                        isHidden: it.either(
+                            it.isnt(it.licensedForFeature('LDAPGroups')),
+                        ),
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_TEXT,
@@ -2494,9 +2494,9 @@ const AdminDefinition = {
                         placeholder: t('admin.ldap.groupIdAttributeEx'),
                         placeholder_default: 'E.g.: "objectGUID" or "entryUUID"',
                         isDisabled: it.stateIsFalse('LdapSettings.EnableSync'),
-                        isHidden: (config, state, license) => {
-                            return license.LDAPGroups !== 'true';
-                        },
+                        isHidden: it.either(
+                            it.isnt(it.licensedForFeature('LDAPGroups')),
+                        ),
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_TEXT,

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2465,6 +2465,9 @@ const AdminDefinition = {
                         placeholder: t('admin.ldap.groupFilterEx'),
                         placeholder_default: 'E.g.: "(objectClass=group)"',
                         isDisabled: it.stateIsFalse('LdapSettings.EnableSync'),
+                        isHidden: (config, state, license) => {
+                            return license.LDAPGroups !== 'true';
+                        },
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_TEXT,
@@ -2476,6 +2479,9 @@ const AdminDefinition = {
                         placeholder: t('admin.ldap.groupDisplayNameAttributeEx'),
                         placeholder_default: 'E.g.: "cn"',
                         isDisabled: it.stateIsFalse('LdapSettings.EnableSync'),
+                        isHidden: (config, state, license) => {
+                            return license.LDAPGroups !== 'true';
+                        },
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_TEXT,
@@ -2488,6 +2494,9 @@ const AdminDefinition = {
                         placeholder: t('admin.ldap.groupIdAttributeEx'),
                         placeholder_default: 'E.g.: "objectGUID" or "entryUUID"',
                         isDisabled: it.stateIsFalse('LdapSettings.EnableSync'),
+                        isHidden: (config, state, license) => {
+                            return license.LDAPGroups !== 'true';
+                        },
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_TEXT,

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -2465,9 +2465,7 @@ const AdminDefinition = {
                         placeholder: t('admin.ldap.groupFilterEx'),
                         placeholder_default: 'E.g.: "(objectClass=group)"',
                         isDisabled: it.stateIsFalse('LdapSettings.EnableSync'),
-                        isHidden: it.either(
-                            it.isnt(it.licensedForFeature('LDAPGroups')),
-                        ),
+                        isHidden: it.isnt(it.licensedForFeature('LDAPGroups'))
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_TEXT,
@@ -2479,9 +2477,7 @@ const AdminDefinition = {
                         placeholder: t('admin.ldap.groupDisplayNameAttributeEx'),
                         placeholder_default: 'E.g.: "cn"',
                         isDisabled: it.stateIsFalse('LdapSettings.EnableSync'),
-                        isHidden: it.either(
-                            it.isnt(it.licensedForFeature('LDAPGroups')),
-                        ),
+                        isHidden: it.isnt(it.licensedForFeature('LDAPGroups'))
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_TEXT,
@@ -2494,9 +2490,7 @@ const AdminDefinition = {
                         placeholder: t('admin.ldap.groupIdAttributeEx'),
                         placeholder_default: 'E.g.: "objectGUID" or "entryUUID"',
                         isDisabled: it.stateIsFalse('LdapSettings.EnableSync'),
-                        isHidden: it.either(
-                            it.isnt(it.licensedForFeature('LDAPGroups')),
-                        ),
+                        isHidden: it.isnt(it.licensedForFeature('LDAPGroups'))
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_TEXT,

--- a/components/channel_header_dropdown/channel_header_dropdown_items.js
+++ b/components/channel_header_dropdown/channel_header_dropdown_items.js
@@ -45,6 +45,7 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
         isArchived: PropTypes.bool.isRequired,
         isMobile: PropTypes.bool.isRequired,
         penultimateViewedChannelName: PropTypes.string.isRequired,
+        isLicensedForLDAPGroups: PropTypes.bool,
     }
 
     render() {
@@ -58,6 +59,7 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
             isArchived,
             isMobile,
             penultimateViewedChannelName,
+            isLicensedForLDAPGroups,
         } = this.props;
 
         const isPrivate = channel.type === Constants.PRIVATE_CHANNEL;
@@ -155,14 +157,14 @@ export default class ChannelHeaderDropdown extends React.PureComponent {
                     >
                         <Menu.ItemToggleModalRedux
                             id='channelAddGroups'
-                            show={channel.type !== Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL && !isArchived && !isDefault && isGroupConstrained}
+                            show={channel.type !== Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL && !isArchived && !isDefault && isGroupConstrained && isLicensedForLDAPGroups}
                             modalId={ModalIdentifiers.ADD_GROUPS_TO_CHANNEL}
                             dialogType={AddGroupsToChannelModal}
                             text={localizeMessage('navbar.addGroups', 'Add Groups')}
                         />
                         <Menu.ItemToggleModalRedux
                             id='channelManageGroups'
-                            show={channel.type !== Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL && !isArchived && !isDefault && isGroupConstrained}
+                            show={channel.type !== Constants.DM_CHANNEL && channel.type !== Constants.GM_CHANNEL && !isArchived && !isDefault && isGroupConstrained && isLicensedForLDAPGroups}
                             modalId={ModalIdentifiers.MANAGE_CHANNEL_GROUPS}
                             dialogType={ChannelGroupsManageModal}
                             dialogProps={{channelID: channel.id}}

--- a/components/channel_header_dropdown/index.js
+++ b/components/channel_header_dropdown/index.js
@@ -60,6 +60,7 @@ const mapStateToProps = (state) => ({
     isReadonly: isCurrentChannelReadOnly(state),
     isArchived: isCurrentChannelArchived(state),
     penultimateViewedChannelName: getPenultimateViewedChannelName(state) || getRedirectChannelNameForTeam(state, getCurrentTeamId(state)),
+    isLicensedForLDAPGroups: state.entities.general.license.LDAPGroups === 'true',
 });
 
 const mobileMapStateToProps = (state) => {

--- a/components/main_menu/index.jsx
+++ b/components/main_menu/index.jsx
@@ -75,6 +75,7 @@ function mapStateToProps(state) {
         currentUser,
         isMentionSearch: rhsState === RHSStates.MENTION,
         teamIsGroupConstrained: Boolean(currentTeam.group_constrained),
+        isLicensedForLDAPGroups: state.entities.general.license.LDAPGroups === 'true',
     };
 }
 

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -55,6 +55,7 @@ export default class MainMenu extends React.PureComponent {
         pluginMenuItems: PropTypes.arrayOf(PropTypes.object),
         isMentionSearch: PropTypes.bool,
         teamIsGroupConstrained: PropTypes.bool.isRequired,
+        isLicensedForLDAPGroups: PropTypes.bool,
         actions: PropTypes.shape({
             openModal: PropTypes.func.isRequred,
             showMentions: PropTypes.func,
@@ -115,7 +116,7 @@ export default class MainMenu extends React.PureComponent {
     }
 
     render() {
-        const {currentUser, teamIsGroupConstrained} = this.props;
+        const {currentUser, teamIsGroupConstrained, isLicensedForLDAPGroups} = this.props;
 
         if (!currentUser) {
             return null;
@@ -177,7 +178,7 @@ export default class MainMenu extends React.PureComponent {
                     >
                         <Menu.ItemToggleModalRedux
                             id='addGroupsToTeam'
-                            show={teamIsGroupConstrained}
+                            show={teamIsGroupConstrained && isLicensedForLDAPGroups}
                             modalId={ModalIdentifiers.ADD_GROUPS_TO_TEAM}
                             dialogType={AddGroupsToTeamModal}
                             text={localizeMessage('navbar_dropdown.addGroupsToTeam', 'Add Groups to Team')}
@@ -217,7 +218,7 @@ export default class MainMenu extends React.PureComponent {
                     >
                         <Menu.ItemToggleModalRedux
                             id='manageGroups'
-                            show={teamIsGroupConstrained}
+                            show={teamIsGroupConstrained && isLicensedForLDAPGroups}
                             modalId={ModalIdentifiers.MANAGE_TEAM_GROUPS}
                             dialogProps={{
                                 teamID: this.props.teamId,


### PR DESCRIPTION
… proper license for the LDAPGroups feature.

#### Summary

Hides some inputs and menu items related to groups that should not be shown if not licensed for `LDAPGroups` feature.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-21197