### PR TITLE
MM-21222 Hover effect on inline markdown images cutoff on the right edge in RHS

### DIFF
--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -75,6 +75,11 @@ h6 {
         }
     }
 
+    .markdown-inline-img__container {
+        display: inline-block;
+        width: calc(100% - 5px);
+    }
+
     .markdown-inline-img--hover {
         border: 1px solid transparent;
         &:hover {

--- a/utils/__snapshots__/message_html_to_component.test.jsx.snap
+++ b/utils/__snapshots__/message_html_to_component.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`messageHtmlToComponent Inline markdown image 1`] = `
 <div
-  className="style--none"
+  className="markdown-inline-img__container"
 >
   <MarkdownImage
     alt="Mattermost"
@@ -17,7 +17,7 @@ exports[`messageHtmlToComponent Inline markdown image 1`] = `
 
 exports[`messageHtmlToComponent Inline markdown image where image is link 1`] = `
 <div
-  className="style--none"
+  className="markdown-inline-img__container"
 >
   <a
     className="theme markdown__link"

--- a/utils/text_formatting.jsx
+++ b/utils/text_formatting.jsx
@@ -71,7 +71,7 @@ export function formatText(text, inputOptions) {
             ** which allows markdown images to open preview window
             */
             const replacer = (match) => {
-                return match === '<p>' ? '<div className="style--none">' : '</div>';
+                return match === '<p>' ? '<div className="markdown-inline-img__container">' : '</div>';
             };
             output = output.replace(/<p>|<\/p>/g, replacer);
         }

--- a/utils/text_formatting_imgs.test.jsx
+++ b/utils/text_formatting_imgs.test.jsx
@@ -60,7 +60,7 @@ describe('Text-formatted inline markdown images', () => {
 
         assert.equal(
             output,
-            '<div className="style--none"><img src="/images/icon.png" alt="Mattermost" class="markdown-inline-img"></div>'
+            '<div className="markdown-inline-img__container"><img src="/images/icon.png" alt="Mattermost" class="markdown-inline-img"></div>'
         );
 
         done();


### PR DESCRIPTION
#### Summary
 * Add a class for the container of markdown images and decrease the width to show the
   hover effect
 * Update snapshots

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21222

#### Screenshots
Check before image in ticket for reference.

After: 
<img width="385" alt="Screenshot 2019-12-13 at 6 33 34 PM" src="https://user-images.githubusercontent.com/4973621/70799012-12e0ff00-1ddb-11ea-8fe2-4fc6bbb1d5a0.png">
