### PR TITLE
[MM-21087] Remove IE11 workaround from size_aware_image  component

### DIFF
--- a/components/__snapshots__/size_aware_image.test.jsx.snap
+++ b/components/__snapshots__/size_aware_image.test.jsx.snap
@@ -26,12 +26,7 @@ exports[`components/SizeAwareImage should match snapshot when handleSmallImageCo
     className="file-preview__button"
     style={
       Object {
-        "height": 1,
-        "overflow": "hidden",
-        "position": "absolute",
-        "top": 0,
-        "visibility": "hidden",
-        "width": 1,
+        "display": "none",
       }
     }
   >
@@ -88,12 +83,7 @@ exports[`components/SizeAwareImage should render a placeholder and has loader wh
     className="file-preview__button"
     style={
       Object {
-        "height": 1,
-        "overflow": "hidden",
-        "position": "absolute",
-        "top": 0,
-        "visibility": "hidden",
-        "width": 1,
+        "display": "none",
       }
     }
   >

--- a/components/size_aware_image.jsx
+++ b/components/size_aware_image.jsx
@@ -192,7 +192,6 @@ export default class SizeAwareImage extends React.PureComponent {
         } = this.props;
 
         let placeHolder;
-        let imageStyleChangesOnLoad = {};
 
         if (this.dimensionsAvailable(dimensions) && !this.state.loaded) {
             placeHolder = (
@@ -210,18 +209,14 @@ export default class SizeAwareImage extends React.PureComponent {
             );
         }
 
-        //The css hack here for loading images in the background can be removed after IE11 is dropped in 5.16v
-        //We can go back to https://github.com/mattermost/mattermost-webapp/pull/2924/files
-        if (!this.state.loaded && this.dimensionsAvailable(dimensions)) {
-            imageStyleChangesOnLoad = {position: 'absolute', top: 0, height: 1, width: 1, visibility: 'hidden', overflow: 'hidden'};
-        }
+        const shouldShowImg = !this.dimensionsAvailable(dimensions) || this.state.loaded;
 
         return (
             <React.Fragment>
                 {placeHolder}
                 <div
                     className='file-preview__button'
-                    style={imageStyleChangesOnLoad}
+                    style={{display: shouldShowImg ? 'initial' : 'none'}}
                 >
                     {this.renderImageWithContainerIfNeeded()}
                 </div>

--- a/components/size_aware_image.test.jsx
+++ b/components/size_aware_image.test.jsx
@@ -25,14 +25,13 @@ describe('components/SizeAwareImage', () => {
 
     loadImage.mockReturnValue(() => ({}));
 
-    test('should render an svg when first mounted with dimensions and div display set to position absolute', () => {
+    test('should render an svg when first mounted with dimensions and img display set to none', () => {
         const wrapper = mount(<SizeAwareImage {...baseProps}/>);
 
         const viewBox = wrapper.find('svg').prop('viewBox');
         expect(viewBox).toEqual('0 0 300 200');
         const style = wrapper.find('.file-preview__button').prop('style');
-        expect(style).toHaveProperty('position', 'absolute');
-        expect(style).toHaveProperty('visibility', 'hidden');
+        expect(style).toHaveProperty('display', 'none');
     });
 
     test('img should have inherited class name from prop', () => {
@@ -53,12 +52,12 @@ describe('components/SizeAwareImage', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should not have position absolute on button when image is in loaded state', () => {
+    test('should have display set to initial in loaded state', () => {
         const wrapper = mount(<SizeAwareImage {...baseProps}/>);
         wrapper.setState({loaded: true, error: false});
 
         const style = wrapper.find('.file-preview__button').prop('style');
-        expect(style).not.toHaveProperty('position', 'absolute');
+        expect(style).toHaveProperty('display', 'initial');
     });
 
     test('should render the actual image when first mounted without dimensions', () => {


### PR DESCRIPTION
#### Summary
Remove code workaround that was added in `size_aware_image` component to support image attachments in IE11 (no longer supported).

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/13365
JIRA link https://mattermost.atlassian.net/browse/MM-21087