### PR TITLE
MM-21144- Disable Marketplace URL if RemoteMarketplace is false

### DIFF
--- a/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
+++ b/components/admin_console/plugin_management/__snapshots__/plugin_management.test.jsx.snap
@@ -199,15 +199,15 @@ exports[`components/PluginManagement should match snapshot 1`] = `
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -233,15 +233,15 @@ exports[`components/PluginManagement should match snapshot 1`] = `
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -512,6 +512,40 @@ exports[`components/PluginManagement should match snapshot when \`Enable Plugins
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+              />
+            }
+            id="automaticPrepackagedPlugins"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
                 defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
                 id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
@@ -521,6 +555,285 @@ exports[`components/PluginManagement should match snapshot when \`Enable Plugins
               <FormattedMessage
                 defaultMessage="Enable Remote Marketplace:"
                 id="admin.plugins.settings.enableRemoteMarketplace"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <AdminTextSetting
+            disabled={false}
+            helpText={
+              <div>
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="URL of the marketplace server."
+                  id="admin.plugins.settings.marketplaceUrlDesc"
+                />
+              </div>
+            }
+            id="marketplaceUrl"
+            label={
+              <FormattedMessage
+                defaultMessage="Marketplace URL:"
+                id="admin.plugins.settings.marketplaceUrl"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            type="input"
+            value="marketplace.example.com"
+          />
+          <div
+            className="form-group"
+          >
+            <label
+              className="control-label col-sm-4"
+            >
+              <FormattedMessage
+                defaultMessage="Installed Plugins: "
+                id="admin.plugin.installedTitle"
+                values={Object {}}
+              />
+            </label>
+            <div
+              className="col-sm-8"
+            >
+              <p
+                className="help-text"
+              >
+                <FormattedHTMLMessage
+                  defaultMessage="Installed plugins on your Mattermost server. Pre-packaged plugins are installed by default, and can be disabled but not removed."
+                  id="admin.plugin.installedDesc"
+                  values={Object {}}
+                />
+              </p>
+              <br />
+            </div>
+          </div>
+        </SettingsGroup>
+      </div>
+    </div>
+    <div
+      className="admin-console-save"
+    >
+      <SaveButton
+        btnClass="btn-primary"
+        disabled={true}
+        extraClasses=""
+        onClick={[Function]}
+        saving={false}
+        savingMessage="Saving Config..."
+      />
+      <div
+        className="error-message"
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <FormError
+          error={null}
+          errors={Array []}
+        />
+      </div>
+      <Overlay
+        animation={[Function]}
+        placement="top"
+        rootClose={false}
+        show={false}
+      >
+        <Tooltip
+          bsClass="tooltip"
+          id="error-tooltip"
+          placement="right"
+        />
+      </Overlay>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`components/PluginManagement should match snapshot when \`Enable Remote Marketplace\` is false 1`] = `
+<form
+  className="form-horizontal"
+  onSubmit={[Function]}
+  role="form"
+>
+  <div
+    className="wrapper--fixed"
+  >
+    <AdminHeader>
+      <FormattedMessage
+        defaultMessage="Management"
+        id="admin.plugin.management.title"
+        values={Object {}}
+      />
+    </AdminHeader>
+    <div
+      className="admin-console__wrapper"
+    >
+      <div
+        className="admin-console__content"
+      >
+        <SettingsGroup
+          container={false}
+          id="PluginSettings"
+          show={true}
+        >
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, enables plugins on your Mattermost server. Use plugins to integrate with third-party systems, extend functionality, or customize the user interface of your Mattermost server. See [documentation](https://about.mattermost.com/default-plugin-uploads) to learn more."
+                id="admin.plugins.settings.enableDesc"
+              />
+            }
+            id="enable"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Plugins: "
+                id="admin.plugins.settings.enable"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={true}
+          />
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, uploading plugins is disabled and may only be installed through the Marketplace. Plugins are always verified during Mattermost server startup and initialization. See [documentation](!https://mattermost.com/pl/default-plugin-signing) to learn more."
+                id="admin.plugins.settings.requirePluginSignatureDesc"
+              />
+            }
+            id="requirePluginSignature"
+            label={
+              <FormattedMessage
+                defaultMessage="Require Plugin Signature:"
+                id="admin.plugins.settings.requirePluginSignature"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
+          />
+          <div
+            className="form-group"
+          >
+            <label
+              className="control-label col-sm-4"
+            >
+              <FormattedMessage
+                defaultMessage="Upload Plugin: "
+                id="admin.plugin.uploadTitle"
+                values={Object {}}
+              />
+            </label>
+            <div
+              className="col-sm-8"
+            >
+              <div
+                className="file__upload"
+              >
+                <button
+                  className="btn btn-primary"
+                  disabled={false}
+                >
+                  <FormattedMessage
+                    defaultMessage="Choose File"
+                    id="admin.plugin.choose"
+                    values={Object {}}
+                  />
+                </button>
+                <input
+                  accept=".gz"
+                  disabled={false}
+                  onChange={[Function]}
+                  type="file"
+                />
+              </div>
+              <button
+                className="btn"
+                disabled={true}
+                onClick={[Function]}
+              >
+                <FormattedMessage
+                  defaultMessage="Upload"
+                  id="admin.plugin.upload"
+                  values={Object {}}
+                />
+              </button>
+              <div
+                className="help-text no-margin"
+              />
+              <p
+                className="help-text"
+              >
+                <InjectIntl(FormattedMarkdownMessage)
+                  defaultMessage="Upload a plugin for your Mattermost server. See [documentation](!https://about.mattermost.com/default-plugin-uploads) to learn more."
+                  id="admin.plugin.uploadDesc"
+                />
+              </p>
+            </div>
+          </div>
+          <BooleanSetting
+            disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, enables System Administrators to install plugins from the [marketplace](!https://mattermost.com/pl/default-mattermost-marketplace.html)."
+                id="admin.plugins.settings.enableMarketplaceDesc"
+              />
+            }
+            id="enableMarketplace"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Marketplace:"
+                id="admin.plugins.settings.enableMarketplace"
                 values={Object {}}
               />
             }
@@ -569,8 +882,42 @@ exports[`components/PluginManagement should match snapshot when \`Enable Plugins
             }
             value={true}
           />
-          <AdminTextSetting
+          <BooleanSetting
             disabled={false}
+            falseText={
+              <FormattedMessage
+                defaultMessage="false"
+                id="admin.false"
+                values={Object {}}
+              />
+            }
+            helpText={
+              <InjectIntl(FormattedMarkdownMessage)
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+              />
+            }
+            id="enableRemoteMarketplace"
+            label={
+              <FormattedMessage
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
+                values={Object {}}
+              />
+            }
+            onChange={[Function]}
+            setByEnv={false}
+            trueText={
+              <FormattedMessage
+                defaultMessage="true"
+                id="admin.true"
+                values={Object {}}
+              />
+            }
+            value={false}
+          />
+          <AdminTextSetting
+            disabled={true}
             helpText={
               <div>
                 <InjectIntl(FormattedMarkdownMessage)
@@ -859,15 +1206,15 @@ exports[`components/PluginManagement should match snapshot when \`Require Signat
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -893,15 +1240,15 @@ exports[`components/PluginManagement should match snapshot when \`Require Signat
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -1206,15 +1553,15 @@ exports[`components/PluginManagement should match snapshot, No installed plugins
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -1240,15 +1587,15 @@ exports[`components/PluginManagement should match snapshot, No installed plugins
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -1558,15 +1905,15 @@ exports[`components/PluginManagement should match snapshot, allow insecure URL e
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -1592,15 +1939,15 @@ exports[`components/PluginManagement should match snapshot, allow insecure URL e
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -1905,15 +2252,15 @@ exports[`components/PluginManagement should match snapshot, disabled 1`] = `
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -1939,15 +2286,15 @@ exports[`components/PluginManagement should match snapshot, disabled 1`] = `
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -2225,15 +2572,15 @@ exports[`components/PluginManagement should match snapshot, text entered into th
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -2259,15 +2606,15 @@ exports[`components/PluginManagement should match snapshot, text entered into th
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -2572,15 +2919,15 @@ exports[`components/PluginManagement should match snapshot, upload disabled 1`] 
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -2606,15 +2953,15 @@ exports[`components/PluginManagement should match snapshot, upload disabled 1`] 
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -2919,15 +3266,15 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -2953,15 +3300,15 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -3329,15 +3676,15 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -3363,15 +3710,15 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -3707,15 +4054,15 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -3741,15 +4088,15 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -4085,15 +4432,15 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -4119,15 +4466,15 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }
@@ -4463,15 +4810,15 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
-                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
+                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
+                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
               />
             }
-            id="enableRemoteMarketplace"
+            id="automaticPrepackagedPlugins"
             label={
               <FormattedMessage
-                defaultMessage="Enable Remote Marketplace:"
-                id="admin.plugins.settings.enableRemoteMarketplace"
+                defaultMessage="Enable Automatic Prepackaged Plugins:"
+                id="admin.plugins.settings.automaticPrepackagedPlugins"
                 values={Object {}}
               />
             }
@@ -4497,15 +4844,15 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
             }
             helpText={
               <InjectIntl(FormattedMarkdownMessage)
-                defaultMessage="When true, automatically installs any prepackaged plugin found to be enabled in the server configuration."
-                id="admin.plugins.settings.automaticPrepackagedPluginsDesc"
+                defaultMessage="When true, marketplace fetches latest plugins from the configured Marketplace URL."
+                id="admin.plugins.settings.enableRemoteMarketplaceDesc"
               />
             }
-            id="automaticPrepackagedPlugins"
+            id="enableRemoteMarketplace"
             label={
               <FormattedMessage
-                defaultMessage="Enable Automatic Prepackaged Plugins:"
-                id="admin.plugins.settings.automaticPrepackagedPlugins"
+                defaultMessage="Enable Remote Marketplace:"
+                id="admin.plugins.settings.enableRemoteMarketplace"
                 values={Object {}}
               />
             }

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -1049,25 +1049,6 @@ export default class PluginManagement extends AdminSettings {
                             setByEnv={this.isSetByEnv('PluginSettings.EnableMarketplace')}
                         />
                         <BooleanSetting
-                            id='enableRemoteMarketplace'
-                            label={
-                                <FormattedMessage
-                                    id='admin.plugins.settings.enableRemoteMarketplace'
-                                    defaultMessage='Enable Remote Marketplace:'
-                                />
-                            }
-                            helpText={
-                                <FormattedMarkdownMessage
-                                    id='admin.plugins.settings.enableRemoteMarketplaceDesc'
-                                    defaultMessage='When true, marketplace fetches latest plugins from the configured Marketplace URL.'
-                                />
-                            }
-                            value={this.state.enableRemoteMarketplace}
-                            disabled={!this.state.enable}
-                            onChange={this.handleChange}
-                            setByEnv={this.isSetByEnv('PluginSettings.EnableRemoteMarketplace')}
-                        />
-                        <BooleanSetting
                             id='automaticPrepackagedPlugins'
                             label={
                                 <FormattedMessage
@@ -1086,7 +1067,25 @@ export default class PluginManagement extends AdminSettings {
                             onChange={this.handleChange}
                             setByEnv={this.isSetByEnv('PluginSettings.AutomaticPrepackagedPlugins')}
                         />
-
+                        <BooleanSetting
+                            id='enableRemoteMarketplace'
+                            label={
+                                <FormattedMessage
+                                    id='admin.plugins.settings.enableRemoteMarketplace'
+                                    defaultMessage='Enable Remote Marketplace:'
+                                />
+                            }
+                            helpText={
+                                <FormattedMarkdownMessage
+                                    id='admin.plugins.settings.enableRemoteMarketplaceDesc'
+                                    defaultMessage='When true, marketplace fetches latest plugins from the configured Marketplace URL.'
+                                />
+                            }
+                            value={this.state.enableRemoteMarketplace}
+                            disabled={!this.state.enable}
+                            onChange={this.handleChange}
+                            setByEnv={this.isSetByEnv('PluginSettings.EnableRemoteMarketplace')}
+                        />
                         <TextSetting
                             id={'marketplaceUrl'}
                             type={'input'}
@@ -1098,7 +1097,7 @@ export default class PluginManagement extends AdminSettings {
                             }
                             helpText={this.getMarketplaceUrlHelpText(this.state.marketplaceUrl)}
                             value={this.state.marketplaceUrl}
-                            disabled={!this.state.enable || !this.state.enableMarketplace}
+                            disabled={!this.state.enable || !this.state.enableMarketplace || !this.state.enableRemoteMarketplace}
                             onChange={this.handleChange}
                             setByEnv={this.isSetByEnv('PluginSettings.MarketplaceUrl')}
                         />

--- a/components/admin_console/plugin_management/plugin_management.test.jsx
+++ b/components/admin_console/plugin_management/plugin_management.test.jsx
@@ -153,6 +153,21 @@ describe('components/PluginManagement', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should match snapshot when `Enable Remote Marketplace` is false', () => {
+        const props = {
+            ...defaultProps,
+            config: {
+                ...defaultProps.config,
+                PluginSettings: {
+                    ...defaultProps.config.PluginSettings,
+                    EnableRemoteMarketplace: false,
+                },
+            },
+        };
+        const wrapper = shallow(<PluginManagement {...props}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should match snapshot, upload disabled', () => {
         const props = {
             ...defaultProps,


### PR DESCRIPTION
#### Summary

In System Console, the marketplace URL is disabled if Enable Remote Marketplace is disabled. 

Additionally, moved the Enable Remote Marketplace setting next to the Marketplace URL that are directly related and affect each other behavior. 

#### Ticket Link
[MM-21144](https://mattermost.atlassian.net/browse/MM-21144)

#### Screenshots

**Enabled Remote Marketplace `true`:**

<img width="959" alt="Screen Shot 2019-12-13 at 5 39 17 PM" src="https://user-images.githubusercontent.com/936315/70836908-d1972200-1dcf-11ea-9a7b-46751a9e6e11.png">


**Enable Remote Marketplace `false`:**

<img width="929" alt="Screen Shot 2019-12-13 at 5 39 26 PM" src="https://user-images.githubusercontent.com/936315/70836915-d6f46c80-1dcf-11ea-9f7b-20932a652645.png">

