### PR TITLE
Fix inline markdown paragraph styles

### DIFF
--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -44,8 +44,7 @@ h6 {
 }
 
 .markdown__paragraph-inline {
-    display: inline-flex;
-    align-items: center;
+    display: inline;
 
     + .markdown__paragraph-inline {
         margin-left: 4px;
@@ -155,9 +154,9 @@ h6 {
         border: unset;
     }
 
-    .markdown__paragraph-inline {
-        display: inline-flex;
-        align-items: center;
+    div.markdown__paragraph-inline {
+        display: inline-block;
+        line-height: 22px;
     }
 
     .broken-image {

--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -198,15 +198,15 @@ export default class Renderer extends marked.Renderer {
 
     paragraph(text) {
         if (this.formattingOptions.singleline) {
-            let result = `<p class="markdown__paragraph-inline">${text}</p>`;
-            if (result.includes('class="markdown-inline-img"')) {
+            let result;
+            if (text.includes('class="markdown-inline-img"')) {
                 /*
-                ** remove p tag to allow other divs to be nested,
+                ** use a div tag instead of a p tag to allow other divs to be nested,
                 ** which avoids errors of incorrect DOM nesting (<div> inside <p>)
                 */
-                result = result.replace('<p class="markdown__paragraph-inline">',
-                    '<div className="markdown__paragraph-inline">');
-                result = result.replace('</p>', '</div>');
+                result = `<div class="markdown__paragraph-inline">${text}</div>`;
+            } else {
+                result = `<p class="markdown__paragraph-inline">${text}</p>`;
             }
             return result;
         }


### PR DESCRIPTION
#### Summary
Fixes a styles issue in inline markdown paragraphs, which is a regression from [this PR](https://github.com/mattermost/mattermost-webapp/pull/3877). It was specially affecting long channel header descriptions and system messages. Also, when an inline markdown image was used at the beginning of a long header description, its size was affected (way too small).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21284

#### Screenshots
**Examples before the fix**

**(A)**
![image](https://user-images.githubusercontent.com/25670682/70898718-e35e0c80-1ffd-11ea-94e5-caa46bc8fa2a.png)

**(B)**
![image](https://user-images.githubusercontent.com/25670682/70898748-f53faf80-1ffd-11ea-8b10-38967771706e.png)

**(C)**
![image](https://user-images.githubusercontent.com/25670682/70898964-641d0880-1ffe-11ea-861a-5b5913f96b23.png)


**Examples after the fix**

**(A)**
![image](https://user-images.githubusercontent.com/25670682/70898798-0c7e9d00-1ffe-11ea-9bf9-fe2efc479d23.png)

**(B)**
![image](https://user-images.githubusercontent.com/25670682/70898839-1dc7a980-1ffe-11ea-8a8b-781cb2ee1164.png)

**(C)**
![image](https://user-images.githubusercontent.com/25670682/70899024-7e56e680-1ffe-11ea-8e2a-43d0c0ac8db3.png)
