### PR TITLE
Stop propagating divider click handler to avoid toggle

### DIFF
--- a/components/widgets/menu/menu.test.tsx
+++ b/components/widgets/menu/menu.test.tsx
@@ -31,6 +31,7 @@ describe('components/Menu', () => {
 >
   <ul
     className="Menu__content dropdown-menu"
+    onClick={[Function]}
     style={Object {}}
   >
     text
@@ -58,6 +59,7 @@ describe('components/Menu', () => {
 >
   <ul
     className="Menu__content dropdown-menu"
+    onClick={[Function]}
     style={Object {}}
   >
     text
@@ -88,6 +90,7 @@ describe('components/Menu', () => {
 >
   <ul
     className="Menu__content dropdown-menu"
+    onClick={[Function]}
     style={Object {}}
   >
     text
@@ -118,6 +121,7 @@ describe('components/Menu', () => {
 >
   <ul
     className="Menu__content dropdown-menu"
+    onClick={[Function]}
     style={
       Object {
         "bottom": "100%",

--- a/components/widgets/menu/menu.tsx
+++ b/components/widgets/menu/menu.tsx
@@ -96,10 +96,10 @@ export default class Menu extends React.PureComponent<Props> {
         return null;
     }
 
-    handleClick = (e) => {
-        if (e.target == this.node.current) {
+    handleMenuClick = (e: React.MouseEvent) => {
+        if (e.target === this.node.current) {
             e.preventDefault();
-            e.stopPropagation()
+            e.stopPropagation();
         }
     }
 
@@ -130,7 +130,7 @@ export default class Menu extends React.PureComponent<Props> {
                     ref={this.node}
                     style={styles}
                     className='Menu__content dropdown-menu'
-                    onClick={this.handleClick}
+                    onClick={this.handleMenuClick}
                 >
                     {children}
                 </ul>

--- a/components/widgets/menu/menu.tsx
+++ b/components/widgets/menu/menu.tsx
@@ -96,6 +96,13 @@ export default class Menu extends React.PureComponent<Props> {
         return null;
     }
 
+    handleClick = (e) => {
+        if (e.target == this.node.current) {
+            e.preventDefault();
+            e.stopPropagation()
+        }
+    }
+
     public render() {
         const {children, openUp, openLeft, id, ariaLabel, customStyles} = this.props;
         let styles: React.CSSProperties = {};
@@ -123,6 +130,7 @@ export default class Menu extends React.PureComponent<Props> {
                     ref={this.node}
                     style={styles}
                     className='Menu__content dropdown-menu'
+                    onClick={this.handleClick}
                 >
                     {children}
                 </ul>

--- a/components/widgets/menu/menu_group.test.tsx
+++ b/components/widgets/menu/menu_group.test.tsx
@@ -14,6 +14,7 @@ describe('components/MenuItem', () => {
 <Fragment>
   <li
     className="MenuGroup menu-divider"
+    onClick={[Function]}
   />
   text
 </Fragment>

--- a/components/widgets/menu/menu_group.tsx
+++ b/components/widgets/menu/menu_group.tsx
@@ -11,10 +11,14 @@ type Props = {
 }
 
 export default class MenuGroup extends React.PureComponent<Props> {
+    handleDividerClick = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+    }
     public render() {
         const {children} = this.props;
 
-        const divider = this.props.divider || <li className='MenuGroup menu-divider'/>;
+        const divider = this.props.divider || <li className='MenuGroup menu-divider' onClick={this.handleDividerClick}/>;
 
         return (
             <React.Fragment>

--- a/components/widgets/menu/menu_group.tsx
+++ b/components/widgets/menu/menu_group.tsx
@@ -11,14 +11,16 @@ type Props = {
 }
 
 export default class MenuGroup extends React.PureComponent<Props> {
-    handleDividerClick = (e) => {
+    handleDividerClick = (e: React.MouseEvent) => {
         e.preventDefault();
         e.stopPropagation();
     }
+
     public render() {
         const {children} = this.props;
 
-        const divider = this.props.divider || <li className='MenuGroup menu-divider' onClick={this.handleDividerClick}/>;
+        const divider = this.props.divider || <li className='MenuGroup menu-divider'
+                                                  onClick={this.handleDividerClick}/>;
 
         return (
             <React.Fragment>

--- a/components/widgets/menu/menu_group.tsx
+++ b/components/widgets/menu/menu_group.tsx
@@ -19,8 +19,12 @@ export default class MenuGroup extends React.PureComponent<Props> {
     public render() {
         const {children} = this.props;
 
-        const divider = this.props.divider || <li className='MenuGroup menu-divider'
-                                                  onClick={this.handleDividerClick}/>;
+        const divider = this.props.divider || (
+            <li
+                className='MenuGroup menu-divider'
+                onClick={this.handleDividerClick}
+            />
+        );
 
         return (
             <React.Fragment>

--- a/e2e/cypress/integration/menus/hamburguer_menu_spec.js
+++ b/e2e/cypress/integration/menus/hamburguer_menu_spec.js
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+const testCases = [
+    {command: '/away', ariaLabel: 'Away Icon', message: 'You are now away'},
+    {command: '/dnd', ariaLabel: 'Do Not Disturb Icon', message: 'Do Not Disturb is enabled. You will not receive desktop or mobile push notifications until Do Not Disturb is turned off.'},
+    {command: '/offline', ariaLabel: 'Offline Icon', message: 'You are now offline'},
+    {command: '/online', ariaLabel: 'Online Icon', message: 'You are now online'},
+];
+
+describe('Hamburguer menu', () => {
+    beforeEach(() => {
+        cy.apiLogin('user-1');
+        cy.visit('/');
+    });
+
+    it('MM-20861 - Click on menu item should toggle the menu', () => {
+        cy.get('#lhsHeader').should('be.visible').within(() => {
+            cy.get('#sidebarHeaderDropdownButton').click();
+            cy.get('.dropdown-menu').should('be.visible');
+            cy.get('#accountSettings').should('be.visible').click();
+            cy.get('.dropdown-menu').should('not.be.visible');
+        });
+    });
+
+    it('MM-20861 - Click on menu divider shouldn\'t toggle the menu', () => {
+        cy.get('#lhsHeader').should('be.visible').within(() => {
+            cy.get('#sidebarHeaderDropdownButton').click();
+            cy.get('.dropdown-menu').should('be.visible').within((el) => {
+                cy.get('.menu-divider:visible').first().click();
+                cy.wrap(el).should('be.visible');
+            });
+        });
+    });
+});

--- a/e2e/cypress/integration/menus/hamburguer_menu_spec.js
+++ b/e2e/cypress/integration/menus/hamburguer_menu_spec.js
@@ -7,13 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-const testCases = [
-    {command: '/away', ariaLabel: 'Away Icon', message: 'You are now away'},
-    {command: '/dnd', ariaLabel: 'Do Not Disturb Icon', message: 'Do Not Disturb is enabled. You will not receive desktop or mobile push notifications until Do Not Disturb is turned off.'},
-    {command: '/offline', ariaLabel: 'Offline Icon', message: 'You are now offline'},
-    {command: '/online', ariaLabel: 'Online Icon', message: 'You are now online'},
-];
-
 describe('Hamburguer menu', () => {
     beforeEach(() => {
         cy.apiLogin('user-1');


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR fixes the problem when a user clicks on a divider and the menu toggles

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-20861

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![Peek 2019-12-17 14-42](https://user-images.githubusercontent.com/741240/71000378-8769b580-20db-11ea-9847-ba175c5cc284.gif)
