### PR TITLE
MM-21148 -  `make i18n-extract` throws an error if mobile repo is not checked out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5257,7 +5257,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true,
           "optional": true
@@ -7418,14 +7418,14 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true,
           "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "optional": true,
@@ -12380,7 +12380,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "optional": true,
@@ -14728,8 +14728,8 @@
       }
     },
     "mmjstool": {
-      "version": "github:mattermost/mattermost-utilities#3a3122a132e84a48591290afb2ad7625ae549803",
-      "from": "github:mattermost/mattermost-utilities#3a3122a132e84a48591290afb2ad7625ae549803",
+      "version": "github:mattermost/mattermost-utilities#086f4ffdca4e31a0be22f6bcdfa093ed83fb29e8",
+      "from": "github:mattermost/mattermost-utilities#086f4ffdca4e31a0be22f6bcdfa093ed83fb29e8",
       "dev": true,
       "requires": {
         "estree-walk": "2.2.0",
@@ -15830,7 +15830,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "jest-junit": "9.0.0",
     "jquery-deferred": "0.3.1",
     "mini-css-extract-plugin": "0.8.0",
-    "mmjstool": "github:mattermost/mattermost-utilities#3a3122a132e84a48591290afb2ad7625ae549803",
+    "mmjstool": "github:mattermost/mattermost-utilities#086f4ffdca4e31a0be22f6bcdfa093ed83fb29e8",
     "node-sass": "4.13.0",
     "react-router-enzyme-context": "1.2.0",
     "redux-mock-store": "1.5.3",


### PR DESCRIPTION
#### Summary
updated mmjstool reference

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-21148

#### Related Pull Requests
mmjstool - https://github.com/mattermost/mattermost-utilities/pull/21
mobile - https://github.com/mattermost/mattermost-mobile/pull/3754