### PR TITLE
[Build] Fix XML output of unit test results so circle-ci can find and upload it

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,8 @@
     "testURL": "http://localhost:8065"
   },
   "jest-junit": {
-    "output": "build/test-results.xml"
+    "outputDirectory": "build",
+    "outputName": "test-results.xml"
   },
   "scripts": {
     "check": "eslint --ext .js --ext .jsx --ext tsx --ext ts . --quiet",


### PR DESCRIPTION
#### Summary

The automated check `ci/circleci: test` doesn't contain metadata/results of the unit tests. (See screenshot.)

This config change corrects the output file. The current configuration isn't recognized and reverts to the default `./junit.xml` instead of the desired `build/test-results.xml`.

#### Ticket Link

None

#### Related Pull Requests

None

#### Screenshots

<img width="308" alt="Screen Shot 2019-12-23 at 13 52 12" src="https://user-images.githubusercontent.com/11724372/71377851-77dee680-258b-11ea-8234-5463a52aac76.png">
