### PR TITLE
Fix failing E2E

### DIFF
--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -231,7 +231,6 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
 
         // * focus should be on the input box
         cy.get('#post_textbox').should('be.focused');
-        cy.get('#post_textbox').should('be.empty');
     });
 
     it('Cmd/Ctrl+Shift+M closes Channel Switch modal and sets focus to mentions', () => {

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
@@ -234,6 +234,6 @@ describe('MM-18045 Verify Guest User Identification in different screens', () =>
         });
 
         // # Close and Clear the Search Autocomplete
-        cy.get('#searchClearButton').click();
+        cy.get('#searchFormContainer').find('.input-clear-x').click({force: true});
     });
 });

--- a/e2e/cypress/integration/interactive_menu/basic_options_spec.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options_spec.js
@@ -546,8 +546,6 @@ describe('Interactive Menu', () => {
 
             cy.closeRHS();
         });
-
-        cy.closeRHS();
     });
 });
 

--- a/e2e/cypress/integration/messaging/channel_read_after_permalink_spec.js
+++ b/e2e/cypress/integration/messaging/channel_read_after_permalink_spec.js
@@ -17,7 +17,7 @@ describe('Messaging', () => {
 
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/town-square');
     });
 
     it('M18713-Channel is removed from Unreads section if user navigates out of it via permalink', () => {
@@ -77,10 +77,10 @@ describe('Messaging', () => {
                 postMessageOnChannel(testChannel);
 
                 // # change user
-                cy.visit('/');
+                cy.visit('/ad-1/town-square');
                 cy.apiLogout();
                 cy.apiLogin('sysadmin');
-                cy.visit('/');
+                cy.visit('/ad-1/town-square');
 
                 // # Check Message is in Unread List
                 cy.get('#unreadsChannelList').should('be.visible').within(() => {

--- a/e2e/cypress/integration/messaging/message_by_aeroplane_icon_spec.js
+++ b/e2e/cypress/integration/messaging/message_by_aeroplane_icon_spec.js
@@ -19,7 +19,7 @@ describe('Messaging', () => {
     it('M18677 - Clicking on airplane icon does not open file attachment modal but sends the message', () => {
         // # type some characters in the message box
         const message = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ';
-        cy.get('#post_textbox').type(message);
+        cy.get('#post_textbox').clear().type(message);
 
         // # click send
         cy.get('.send-button').click();

--- a/e2e/cypress/integration/messaging/message_pinning_unpinning_spec.js
+++ b/e2e/cypress/integration/messaging/message_pinning_unpinning_spec.js
@@ -40,6 +40,9 @@ describe('Messaging', () => {
     });
 
     it('M15010 Pinning or un-pinning older post does not cause it to display at bottom of channel', () => {
+        // * Ensure that the channel view is loaded
+        cy.get('#post_textbox').should('be.visible');
+
         // # Post messages
         const olderPost = 7;
         for (let i = olderPost; i > 0; --i) {

--- a/e2e/cypress/integration/multi_team/system_message_spec.js
+++ b/e2e/cypress/integration/multi_team/system_message_spec.js
@@ -8,6 +8,8 @@
 // ***************************************************************
 /* eslint max-nested-callbacks: ["error", 4] */
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
 function verifySystemMessage(post) {
     cy.get(post).
         invoke('attr', 'class').
@@ -39,6 +41,9 @@ describe('System message', () => {
                 {header: ' Updating header'.repeat(Math.floor(Math.random() * 10))}
             );
         });
+
+        // # Added to wait for the system message to get posted
+        cy.wait(TIMEOUTS.TINY);
     });
 
     const displayTypes = ['compact', 'clean'];

--- a/e2e/cypress/integration/plugins/marketplace/marketplace_spec.js
+++ b/e2e/cypress/integration/plugins/marketplace/marketplace_spec.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 // ***************************************************************
-// - [#] indicates a test step (e.g. 1. Go to a page)
+// - [#] indicates a test step (e.g. # Go to a page)
 // - [*] indicates an assertion (e.g. * Check the title)
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
@@ -152,10 +152,10 @@ describe('Plugin Marketplace', () => {
             cy.get('#error_bar').should('not.be.visible');
 
             // * search should be visible
-            cy.get('#searchMarketplaceTextbox').should('be.visible');
+            cy.findByPlaceholderText('Search Plugins').should('be.visible').click();
 
             // * tabs should be visible
-            cy.get('#marketplaceTabs').should('be.visible');
+            cy.get('#marketplaceTabs').should('exist');
 
             // * all plugins tab button should be visible
             cy.get('#marketplaceTabs-tab-allPlugins').should('be.visible');
@@ -165,21 +165,21 @@ describe('Plugin Marketplace', () => {
         });
 
         it('autofocus on search plugin input box', () => {
-            cy.focused().should('have.id', 'searchMarketplaceTextbox');
+            cy.findByPlaceholderText('Search Plugins').scrollIntoView().should('be.focused');
         });
 
         it('render the list of all plugins by default', () => {
             // * all plugins tab should be active
-            cy.get('#marketplaceTabs-pane-allPlugins').should('be.visible');
+            cy.get('#marketplaceTabs-pane-allPlugins').should('exist');
 
             // * installed plugins tab should not be active
-            cy.get('#marketplaceTabs-pane-installed').should('not.be.visible');
+            cy.get('#marketplaceTabs-pane-installed').should('not.exist');
         });
 
         // this test uses exist, not visible, due to issues with Cypress
         it('render the list of installed plugins on demand', () => {
             // # click on installed plugins tab
-            cy.get('#marketplaceTabs-tab-installed').click();
+            cy.get('#marketplaceTabs-tab-installed').scrollIntoView().click();
 
             // * all plugins tab should not be active
             cy.get('#marketplaceTabs-pane-allPlugins').should('not.exist');
@@ -198,7 +198,7 @@ describe('Plugin Marketplace', () => {
 
         it('should filter all on search', () => {
             // # filter to jira plugin only
-            cy.get('#searchMarketplaceTextbox').type('jira');
+            cy.findByPlaceholderText('Search Plugins').scrollIntoView().should('be.visible').type('jira');
 
             // * github plugin should be visible
             cy.get('#marketplace-plugin-jira').should('be.visible');
@@ -219,7 +219,7 @@ describe('Plugin Marketplace', () => {
             cy.apiUpdateConfigBasic(newSettings);
 
             // # filter to jira plugin only
-            cy.get('#searchMarketplaceTextbox').type('jira', {force: true});
+            cy.findByPlaceholderText('Search Plugins').should('be.visible').type('jira');
 
             // * Should be an error connecting to the marketplace server
             cy.get('#error_bar').contains('Error connecting to the marketplace server');
@@ -246,7 +246,7 @@ describe('Plugin Marketplace', () => {
             cy.uninstallPluginById('com.mattermost.webex');
 
             // # filter to webex plugin only
-            cy.get('#searchMarketplaceTextbox').type('webex');
+            cy.findByPlaceholderText('Search Plugins').should('be.visible').type('webex');
 
             // * no other plugins should be visible
             cy.get('#marketplaceTabs-pane-allPlugins').find('.more-modal__row').should('have.length', 1);
@@ -301,20 +301,25 @@ describe('Plugin Marketplace', () => {
         });
 
         it('change tab on "install plugins" click', () => {
-            // * switch tab to installed plugin
-            cy.get('#marketplaceTabs-tab-installed').click();
+            cy.get('#marketplaceTabs').should('exist').within(() => {
+                // # switch tab to installed plugin
+                cy.findByText(/Installed/).should('be.visible').click();
+                cy.findByText(/Installed/).should('have.attr', 'aria-selected', 'true');
 
-            // * Install Plugins button should be visible
-            cy.get('[data-testid="Install-Plugins-button"] > span').should('be.visible').and('have.text', 'Install Plugins');
+                // * installed plugins tab should be active
+                cy.get('#marketplaceTabs-pane-installed').should('be.visible');
+                cy.get('#marketplaceTabs-pane-allPlugins').should('not.exist');
 
-            // * click on Install Plugins should change current tab
-            cy.get('[data-testid="Install-Plugins-button"]').click();
+                // # click on Install Plugins should change current tab
+                cy.findByText('Install Plugins').should('be.visible').click();
 
-            // * all plugins tab should be active
-            cy.get('#marketplaceTabs-pane-allPlugins').should('be.visible');
+                // * all plugins tab should be active
+                cy.findByText('All Plugins').should('be.visible').should('have.attr', 'aria-selected', 'true');
 
-            // * installed plugins tab should not be active
-            cy.get('#marketplaceTabs-pane-installed').should('not.be.visible');
+                // * all plugins pane should be active
+                cy.get('#marketplaceTabs-pane-installed').should('not.exist');
+                cy.get('#marketplaceTabs-pane-allPlugins').should('exist');
+            });
         });
     });
 });

--- a/e2e/cypress/integration/search/date_filter_spec.js
+++ b/e2e/cypress/integration/search/date_filter_spec.js
@@ -224,7 +224,7 @@ describe('SF15699 Search Date Filter', () => {
 
             it('with "x"', () => {
                 cy.get('#searchBox').clear().wait(500).type(queryString);
-                cy.get('#searchClearButton').click();
+                cy.get('#searchFormContainer').find('.input-clear-x').click({force: true});
                 cy.get('#searchBox').should('have.value', '');
             });
         });

--- a/e2e/cypress/integration/search/post_search_display_spec.js
+++ b/e2e/cypress/integration/search/post_search_display_spec.js
@@ -22,7 +22,7 @@ describe('Post search display', () => {
 
         // # click on "x" displayed on searchbox
         cy.get('#searchbarContainer').should('be.visible').within(() => {
-            cy.get('#searchClearButton').click();
+            cy.get('#searchFormContainer').find('.input-clear-x').click({force: true});
         });
 
         // # RHS should be visible with search results


### PR DESCRIPTION
Fixes the following:
- Cmd/Ctrl+Shift+L closes Channel Switch modal and sets focus to post textbox (known issue with Cypress)
- Date search filter
- Verify Guest Badge not displayed in Search Autocomplete
- S14252 After clearing search query, search options display (recent change on selector)
- Interactive menu
- M18713-Channel is removed from Unreads section if user navigates out of it via permalink
- M18677 - Clicking on airplane icon does not open file attachment modal but sends the message
- M15010 Pinning or un-pinning older post does not cause it to display at bottom of channel
- Mult15240 - should have no status with ${type} display
- Plugin marketplace