### PR TITLE
MM-21421: Fix height and width parameters for inline image. (#4623)

### DIFF
--- a/components/markdown_image.jsx
+++ b/components/markdown_image.jsx
@@ -19,6 +19,8 @@ export default class MarkdownImage extends React.PureComponent {
         alt: PropTypes.string,
         imageMetadata: PropTypes.object,
         src: PropTypes.string.isRequired,
+        height: PropTypes.number,
+        width: PropTypes.number,
         title: PropTypes.string,
         className: PropTypes.string.isRequired,
         postId: PropTypes.string.isRequired,
@@ -90,12 +92,16 @@ export default class MarkdownImage extends React.PureComponent {
                         this.props.className :
                         `${this.props.className} markdown-inline-img--hover cursor--pointer a11y--active`;
 
+                    const {height, width, title} = this.props;
                     return (
                         <>
                             <SizeAwareImage
                                 alt={alt}
                                 className={className}
                                 src={safeSrc}
+                                height={height}
+                                width={width}
+                                title={title}
                                 dimensions={imageMetadata}
                                 showLoader={true}
                                 onClick={this.showModal}

--- a/components/markdown_image.test.jsx
+++ b/components/markdown_image.test.jsx
@@ -114,4 +114,35 @@ describe('components/MarkdownImage', () => {
         wrapper.instance().showModal();
         expect(wrapper.state('showModal')).toEqual(false);
     });
+
+    test('should render image with title, height, width', () => {
+        const props = {
+            alt: 'test image',
+            title: 'test title',
+            className: 'markdown-inline-img',
+            postId: 'post_id',
+            src: 'https://example.com/image.png',
+            imageIsLink: false,
+            height: 76,
+            width: 50
+        };
+
+        const wrapper = shallow(
+            <MarkdownImage {...props}/>
+        );
+        wrapper.instance().setState({loaded: true});
+
+        const childrenNode = wrapper.props().children(props.src);
+
+        // using a div as a workaround because shallow doesn't support react fragments
+        const childrenWrapper = shallow(<div>{childrenNode}</div>);
+
+        expect(childrenWrapper.find(SizeAwareImage)).toHaveLength(1);
+        expect(childrenWrapper.find(SizeAwareImage).prop('className')).
+            toEqual(`${props.className} markdown-inline-img--hover cursor--pointer a11y--active`);
+
+        expect(childrenWrapper.find(SizeAwareImage).prop('width')).toEqual(50);
+        expect(childrenWrapper.find(SizeAwareImage).prop('height')).toEqual(76);
+        expect(childrenWrapper.find(SizeAwareImage).prop('title')).toEqual('test title');
+    });
 });


### PR DESCRIPTION
Automatic Merge

(cherry picked from commit 2d496bf1986f4da5ad5ef941b08aa073de780e7d)

#### Summary
This component was changed to inherit from PureComponent. When that was done, the variable props included more than just the properties for the image. When this was done, instead of passing props to the SizeAwareImage, individual properties were set and passed.

Width and Height and Title are no longer being passed to SizeAwareImage. This PR adds those three properties, so that SizeAwareImage will set them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21421
