### PR TITLE
MM-20863 Fix for permalink to DM failing to load on daily

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -399,7 +399,7 @@ class Sidebar extends React.PureComponent {
     }
 
     updateScrollbarOnChannelChange = (channelId) => {
-        if (this.refs[channelId]) {
+        if (this.refs[channelId] && this.refs[channelId].getWrappedInstance().getWrappedInstance().refs.channel) {
             const curChannel = this.refs[channelId].getWrappedInstance().getWrappedInstance().refs.channel.getBoundingClientRect();
             if ((curChannel.top - Constants.CHANNEL_SCROLL_ADJUSTMENT < 0) || (curChannel.top + curChannel.height > this.refs.scrollbar.view.getBoundingClientRect().height)) {
                 this.refs.scrollbar.scrollTop(this.refs.scrollbar.view.scrollTop + (curChannel.top - Constants.CHANNEL_SCROLL_ADJUSTMENT));


### PR DESCRIPTION
#### Summary
Checking for channel ref before trying to get the value of it for LHS scroll correction.
If the ref does not exists as with DM's on load it will prevent the crash from happening but it will not scroll correct LHS. This follows the same behaviour as we had before
 
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20863
