### PR TITLE
MM-17555 Only use shallowWithIntl and dive when necessary

### DIFF
--- a/components/__snapshots__/save_button.test.tsx.snap
+++ b/components/__snapshots__/save_button.test.tsx.snap
@@ -5,33 +5,6 @@ exports[`components/SaveButton should match snapshot, extraClasses 1`] = `
   className="save-button btn btn-primary some-class"
   disabled={false}
   id="saveSetting"
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
-    }
-  }
   type="submit"
 >
   <LoadingWrapper
@@ -60,33 +33,6 @@ exports[`components/SaveButton should match snapshot, on defaultMessage 1`] = `
   className="save-button btn btn-primary"
   disabled={false}
   id="saveSetting"
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
-    }
-  }
   type="submit"
 >
   <LoadingWrapper
@@ -115,33 +61,6 @@ exports[`components/SaveButton should match snapshot, on defaultMessage 2`] = `
   className="save-button btn btn-primary"
   disabled={false}
   id="saveSetting"
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
-    }
-  }
   type="submit"
 >
   <LoadingWrapper
@@ -166,33 +85,6 @@ exports[`components/SaveButton should match snapshot, on savingMessage 1`] = `
   className="save-button btn btn-primary"
   disabled={true}
   id="saveSetting"
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
-    }
-  }
   type="submit"
 >
   <LoadingWrapper
@@ -221,33 +113,6 @@ exports[`components/SaveButton should match snapshot, on savingMessage 2`] = `
   className="save-button btn btn-primary"
   disabled={true}
   id="saveSetting"
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
-    }
-  }
   type="submit"
 >
   <LoadingWrapper

--- a/components/admin_console/admin_sidebar/admin_sidebar.test.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.test.jsx
@@ -59,7 +59,7 @@ describe('components/AdminSidebar', () => {
 
     test('should match snapshot', () => {
         const props = {...defaultProps};
-        const wrapper = shallowWithIntl(<AdminSidebar {...props}/>).dive();
+        const wrapper = shallowWithIntl(<AdminSidebar {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -100,7 +100,7 @@ describe('components/AdminSidebar', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(<AdminSidebar {...props}/>).dive();
+        const wrapper = shallowWithIntl(<AdminSidebar {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -137,7 +137,7 @@ describe('components/AdminSidebar', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(<AdminSidebar {...props}/>).dive();
+        const wrapper = shallowWithIntl(<AdminSidebar {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -180,7 +180,7 @@ describe('components/AdminSidebar', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(<AdminSidebar {...props}/>).dive();
+        const wrapper = shallowWithIntl(<AdminSidebar {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -234,7 +234,7 @@ describe('components/AdminSidebar', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(<AdminSidebar {...props}/>).dive();
+        const wrapper = shallowWithIntl(<AdminSidebar {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -273,7 +273,7 @@ describe('components/AdminSidebar', () => {
         test('should refresh the index in case idx is already present and there is a change in plugins or adminDefinition prop', () => {
             generateIndex.mockReturnValue(['mocked-index']);
 
-            const wrapper = shallowWithIntl(<AdminSidebar {...props}/>).dive();
+            const wrapper = shallowWithIntl(<AdminSidebar {...props}/>);
             wrapper.instance().idx = ['some value'];
 
             expect(generateIndex).toHaveBeenCalledTimes(0);
@@ -288,7 +288,7 @@ describe('components/AdminSidebar', () => {
         test('should not call the generate index in case of idx is not already present', () => {
             generateIndex.mockReturnValue(['mocked-index']);
 
-            const wrapper = shallowWithIntl(<AdminSidebar {...props}/>).dive();
+            const wrapper = shallowWithIntl(<AdminSidebar {...props}/>);
 
             expect(generateIndex).toHaveBeenCalledTimes(0);
 
@@ -302,7 +302,7 @@ describe('components/AdminSidebar', () => {
         test('should not generate index in case of same props', () => {
             generateIndex.mockReturnValue(['mocked-index']);
 
-            const wrapper = shallowWithIntl(<AdminSidebar {...props}/>).dive();
+            const wrapper = shallowWithIntl(<AdminSidebar {...props}/>);
             wrapper.instance().idx = ['some value'];
 
             expect(generateIndex).toHaveBeenCalledTimes(0);
@@ -353,13 +353,13 @@ describe('components/AdminSidebar', () => {
         };
 
         test('should match snapshot', () => {
-            const wrapper = shallowWithIntl(<AdminSidebar {...props}/>).dive();
+            const wrapper = shallowWithIntl(<AdminSidebar {...props}/>);
 
             expect(wrapper).toMatchSnapshot();
         });
 
         test('should filter plugins', () => {
-            const wrapper = shallowWithIntl(<AdminSidebar {...props}/>).dive();
+            const wrapper = shallowWithIntl(<AdminSidebar {...props}/>);
 
             idx.search.mockReturnValue(['plugin_mattermost-autolink']);
             wrapper.find('#adminSidebarFilter').simulate('change', {target: {value: 'autolink'}});

--- a/components/admin_console/jobs/table.test.jsx
+++ b/components/admin_console/jobs/table.test.jsx
@@ -79,7 +79,7 @@ describe('components/admin_console/jobs/table', () => {
     test('should call create job func', () => {
         const wrapper = shallowWithIntl(
             <JobTable {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.find('.job-table__create-button > div > .btn-default').simulate('click', {preventDefault: jest.fn()});
         expect(createJob).toHaveBeenCalledTimes(1);
@@ -88,7 +88,7 @@ describe('components/admin_console/jobs/table', () => {
     test('should call cancel job func', () => {
         const wrapper = shallowWithIntl(
             <JobTable {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.find('.job-table__cancel-button').first().simulate('click', {preventDefault: jest.fn(), currentTarget: {getAttribute: () => '1234'}});
         expect(cancelJob).toHaveBeenCalledTimes(1);

--- a/components/admin_console/system_users/list/system_users_list.test.jsx
+++ b/components/admin_console/system_users/list/system_users_list.test.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import {Constants} from 'utils/constants';
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import SystemUsersList from 'components/admin_console/system_users/list/system_users_list.jsx';
 
@@ -75,7 +74,7 @@ describe('components/admin_console/system_users/list', () => {
 
     describe('should reset page', () => {
         it('when team changes', () => {
-            const wrapper = shallowWithIntl(
+            const wrapper = shallow(
                 <SystemUsersList {...defaultProps}/>
             );
 
@@ -87,7 +86,7 @@ describe('components/admin_console/system_users/list', () => {
         });
 
         it('when filter changes', () => {
-            const wrapper = shallowWithIntl(
+            const wrapper = shallow(
                 <SystemUsersList {...defaultProps}/>
             );
 
@@ -101,7 +100,7 @@ describe('components/admin_console/system_users/list', () => {
 
     describe('should not reset page', () => {
         it('when term changes', () => {
-            const wrapper = shallowWithIntl(
+            const wrapper = shallow(
                 <SystemUsersList {...defaultProps}/>
             );
 

--- a/components/audit_table/audit_table.test.jsx
+++ b/components/audit_table/audit_table.test.jsx
@@ -25,7 +25,7 @@ describe('components/audit_table/AuditTable', () => {
     test('should match snapshot with no audits', () => {
         const wrapper = shallowWithIntl(
             <AuditTable {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -55,7 +55,7 @@ describe('components/audit_table/AuditTable', () => {
         const props = {...baseProps, audits};
         const wrapper = shallowWithIntl(
             <AuditTable {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });

--- a/components/backstage/components/backstage_header.test.jsx
+++ b/components/backstage/components/backstage_header.test.jsx
@@ -1,21 +1,21 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import BackstageHeader from 'components/backstage/components/backstage_header.jsx';
 
 describe('components/backstage/components/BackstageHeader', () => {
     test('should match snapshot without children', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <BackstageHeader/>
         );
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot with children', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <BackstageHeader>
                 <div>{'Child 1'}</div>
                 <div>{'Child 2'}</div>

--- a/components/channel_header/channel_header.test.jsx
+++ b/components/channel_header/channel_header.test.jsx
@@ -54,14 +54,14 @@ describe('components/ChannelHeader', () => {
     test('should render properly when empty', () => {
         const wrapper = shallowWithIntl(
             <ChannelHeader {...baseProps}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should render properly when populated', () => {
         const wrapper = shallowWithIntl(
             <ChannelHeader {...populatedProps}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -92,7 +92,7 @@ describe('components/ChannelHeader', () => {
 
         const wrapper = shallowWithIntl(
             <ChannelHeader {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -104,7 +104,7 @@ describe('components/ChannelHeader', () => {
 
         const wrapper = shallowWithIntl(
             <ChannelHeader {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -116,7 +116,7 @@ describe('components/ChannelHeader', () => {
 
         const wrapper = shallowWithIntl(
             <ChannelHeader {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -128,7 +128,7 @@ describe('components/ChannelHeader', () => {
 
         const wrapper = shallowWithIntl(
             <ChannelHeader {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -140,7 +140,7 @@ describe('components/ChannelHeader', () => {
 
         const wrapper = shallowWithIntl(
             <ChannelHeader {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -152,7 +152,7 @@ describe('components/ChannelHeader', () => {
 
         const wrapper = shallowWithIntl(
             <ChannelHeader {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -172,7 +172,7 @@ describe('components/ChannelHeader', () => {
 
         const wrapper = shallowWithIntl(
             <ChannelHeader {...props}/>
-        ).dive();
+        );
         expect(wrapper.containsMatchingElement(
             <Markdown
                 message={props.currentUser.bot_description}

--- a/components/channel_header_dropdown/channel_header_dropdown.test.jsx
+++ b/components/channel_header_dropdown/channel_header_dropdown.test.jsx
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import ChannelHeaderDropdown from './channel_header_dropdown_items.js';
 
@@ -22,7 +21,7 @@ describe('components/ChannelHeaderDropdown', () => {
     };
 
     test('should match snapshot with no plugin items', () => {
-        const wrapper = shallowWithIntl(<ChannelHeaderDropdown {...defaultProps}/>);
+        const wrapper = shallow(<ChannelHeaderDropdown {...defaultProps}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -34,7 +33,7 @@ describe('components/ChannelHeaderDropdown', () => {
                 {id: 'plugin-2', action: jest.fn(), text: 'plugin-2-text'},
             ],
         };
-        const wrapper = shallowWithIntl(<ChannelHeaderDropdown {...props}/>);
+        const wrapper = shallow(<ChannelHeaderDropdown {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/components/create_comment/create_comment.test.jsx
+++ b/components/create_comment/create_comment.test.jsx
@@ -62,7 +62,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -80,7 +80,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         // should clear draft uploads on mount
         expect(clearCommentDraftUploads).toHaveBeenCalled();
@@ -100,7 +100,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.setState({draft});
         expect(wrapper).toMatchSnapshot();
@@ -109,7 +109,7 @@ describe('components/CreateComment', () => {
     test('should correctly change state when toggleEmojiPicker is called', () => {
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.instance().toggleEmojiPicker();
         expect(wrapper.state().showEmojiPicker).toBe(true);
@@ -121,7 +121,7 @@ describe('components/CreateComment', () => {
     test('should correctly change state when hideEmojiPicker is called', () => {
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.instance().hideEmojiPicker();
         expect(wrapper.state().showEmojiPicker).toBe(false);
@@ -139,7 +139,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         const mockImpl = () => {
             return {
@@ -192,7 +192,7 @@ describe('components/CreateComment', () => {
     test('handlePostError should update state with the correct error', () => {
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.instance().handlePostError('test error 1');
         expect(wrapper.state().postError).toBe('test error 1');
@@ -212,7 +212,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         const instance = wrapper.instance();
 
@@ -241,7 +241,7 @@ describe('components/CreateComment', () => {
     test('getFileCount should return the correct count', () => {
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper.instance().getFileCount()).toBe(3);
 
@@ -255,7 +255,7 @@ describe('components/CreateComment', () => {
     test('should correctly change state when showPostDeletedModal is called', () => {
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.instance().showPostDeletedModal();
         expect(wrapper.state().showPostDeletedModal).toBe(true);
@@ -266,7 +266,7 @@ describe('components/CreateComment', () => {
         const props = {...baseProps, resetCreatePostRequest};
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         wrapper.instance().hidePostDeletedModal();
         expect(wrapper.state().showPostDeletedModal).toBe(false);
@@ -284,7 +284,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         const focusTextbox = jest.fn();
         wrapper.setState({draft});
@@ -312,7 +312,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         const instance = wrapper.instance();
         wrapper.setState({draft});
@@ -334,7 +334,7 @@ describe('components/CreateComment', () => {
     it('check for uploadsProgressPercent state on handleUploadProgress callback', () => {
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.find(FileUpload).prop('onUploadProgress')({clientId: 'clientId', name: 'name', percent: 10, type: 'type'});
         expect(wrapper.find(FilePreview).prop('uploadsProgressPercent')).toEqual({clientId: {percent: 10, name: 'name', type: 'type'}});
@@ -353,7 +353,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         wrapper.setProps({createPostErrorId: 'api.post.create_post.root_id.app_error'});
         expect(wrapper.state('showPostDeletedModal')).toBe(true);
@@ -370,7 +370,7 @@ describe('components/CreateComment', () => {
             const props = {...baseProps, draft};
             const wrapper = shallowWithIntl(
                 <CreateComment {...props}/>
-            ).dive();
+            );
 
             const focusTextbox = jest.fn();
             wrapper.instance().focusTextbox = focusTextbox;
@@ -390,7 +390,7 @@ describe('components/CreateComment', () => {
             const props = {...baseProps, draft, selectedPostFocussedAt: 1000};
             const wrapper = shallowWithIntl(
                 <CreateComment {...props}/>
-            ).dive();
+            );
 
             const focusTextbox = jest.fn();
             wrapper.instance().focusTextbox = focusTextbox;
@@ -410,7 +410,7 @@ describe('components/CreateComment', () => {
             const props = {...baseProps, draft, selectedPostFocussedAt: 1000};
             const wrapper = shallowWithIntl(
                 <CreateComment {...props}/>
-            ).dive();
+            );
 
             const focusTextbox = jest.fn();
             wrapper.instance().focusTextbox = focusTextbox;
@@ -434,7 +434,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         const testMessage = 'new msg';
         const scrollToBottom = jest.fn();
@@ -465,7 +465,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         expect(wrapper.find('[id="postServerError"]').exists()).toBe(false);
 
@@ -495,7 +495,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         const scrollToBottom = jest.fn();
         wrapper.instance().scrollToBottom = scrollToBottom;
@@ -514,7 +514,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         const preventDefault = jest.fn();
         wrapper.instance().handleSubmit({preventDefault});
@@ -548,7 +548,7 @@ describe('components/CreateComment', () => {
 
                     const wrapper = shallowWithIntl(
                         <CreateComment {...props}/>
-                    ).dive();
+                    );
 
                     wrapper.instance().handleSubmit({preventDefault});
                     expect(onSubmit).toHaveBeenCalled();
@@ -571,7 +571,7 @@ describe('components/CreateComment', () => {
 
                     const wrapper = shallowWithIntl(
                         <CreateComment {...props}/>
-                    ).dive();
+                    );
 
                     wrapper.instance().handleSubmit({preventDefault});
                     expect(onSubmit).toHaveBeenCalled();
@@ -594,7 +594,7 @@ describe('components/CreateComment', () => {
 
                     const wrapper = shallowWithIntl(
                         <CreateComment {...props}/>
-                    ).dive();
+                    );
 
                     wrapper.instance().handleSubmit({preventDefault});
                     expect(onSubmit).toHaveBeenCalled();
@@ -618,7 +618,7 @@ describe('components/CreateComment', () => {
 
                 const wrapper = shallowWithIntl(
                     <CreateComment {...props}/>
-                ).dive();
+                );
 
                 wrapper.instance().handleSubmit({preventDefault});
                 expect(onSubmit).not.toHaveBeenCalled();
@@ -642,7 +642,7 @@ describe('components/CreateComment', () => {
 
                 const wrapper = shallowWithIntl(
                     <CreateComment {...props}/>
-                ).dive();
+                );
 
                 await wrapper.instance().handleSubmit({preventDefault});
                 wrapper.setState({channelTimezoneCount: 4});
@@ -670,7 +670,7 @@ describe('components/CreateComment', () => {
 
                 const wrapper = shallowWithIntl(
                     <CreateComment {...props}/>
-                ).dive();
+                );
 
                 await wrapper.instance().handleSubmit({preventDefault});
                 wrapper.setState({channelTimezoneCount: 0});
@@ -700,7 +700,7 @@ describe('components/CreateComment', () => {
 
             const wrapper = shallowWithIntl(
                 <CreateComment {...props}/>
-            ).dive();
+            );
 
             expect(wrapper.find('[id="postServerError"]').exists()).toBe(false);
 
@@ -734,7 +734,7 @@ describe('components/CreateComment', () => {
 
             const wrapper = shallowWithIntl(
                 <CreateComment {...props}/>
-            ).dive();
+            );
 
             const submitPromise = wrapper.instance().handleSubmit({preventDefault});
             expect(props.onUpdateCommentDraft).not.toHaveBeenCalled();
@@ -755,7 +755,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         wrapper.setState({draft});
 
@@ -782,7 +782,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
         expect(wrapper.state('draft')).toEqual(draft);
 
         const newDraft = {...draft, message: 'Test message edited'};
@@ -799,7 +799,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
         wrapper.setState({draft});
         expect(wrapper.state('draft')).toEqual(draft);
 
@@ -811,7 +811,7 @@ describe('components/CreateComment', () => {
         const props = {...baseProps, readOnlyChannel: true};
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -820,7 +820,7 @@ describe('components/CreateComment', () => {
         const props = {...baseProps, enableEmojiPicker: false};
         const wrapper = shallowWithIntl(
             <CreateComment {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -828,7 +828,7 @@ describe('components/CreateComment', () => {
     test('check for handleFileUploadChange callback for focus', () => {
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.focusTextbox = jest.fn();
 
@@ -850,7 +850,7 @@ describe('components/CreateComment', () => {
                 onMoveHistoryIndexForward={onMoveHistoryIndexForward}
                 onEditLatestPost={onEditLatestPost}
             />
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.commentMsgKeyPress = jest.fn();
         instance.focusTextbox = jest.fn();
@@ -928,7 +928,7 @@ describe('components/CreateComment', () => {
 
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.instance().scrollToBottom = jest.fn();
         expect(wrapper.instance().scrollToBottom).toBeCalledTimes(0);
@@ -957,7 +957,7 @@ describe('components/CreateComment', () => {
                 {...baseProps}
                 draft={draft}
             />
-        ).dive();
+        );
 
         wrapper.instance().scrollToBottom = jest.fn();
         expect(wrapper.instance().scrollToBottom).toBeCalledTimes(0);
@@ -984,7 +984,7 @@ describe('components/CreateComment', () => {
                 {...baseProps}
                 draft={draft}
             />
-        ).dive();
+        );
 
         const event = {
             target: {
@@ -1009,7 +1009,7 @@ describe('components/CreateComment', () => {
     test('should show preview and edit mode, and return focus on preview disable', () => {
         const wrapper = shallowWithIntl(
             <CreateComment {...baseProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.focusTextbox = jest.fn();
 

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -141,13 +141,13 @@ function createPost({
 
 describe('components/create_post', () => {
     it('should match snapshot, init', () => {
-        const wrapper = shallowWithIntl(createPost({})).dive();
+        const wrapper = shallowWithIntl(createPost({}));
 
         expect(wrapper).toMatchSnapshot();
     });
 
     it('should match snapshot for center textbox', () => {
-        const wrapper = shallowWithIntl(createPost({fullWidthTextBox: false})).dive();
+        const wrapper = shallowWithIntl(createPost({fullWidthTextBox: false}));
 
         expect(wrapper.find('#create_post').hasClass('center')).toBe(true);
         expect(wrapper).toMatchSnapshot();
@@ -160,13 +160,13 @@ describe('components/create_post', () => {
             clearDraftUploads,
         };
 
-        shallowWithIntl(createPost({actions})).dive();
+        shallowWithIntl(createPost({actions}));
 
         expect(clearDraftUploads).toHaveBeenCalled();
     });
 
     it('Check for state change on channelId change', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
         const draft = {
             ...draftProp,
             message: 'test',
@@ -187,7 +187,7 @@ describe('components/create_post', () => {
     });
 
     it('click toggleEmojiPicker', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
         wrapper.find('.emoji-picker__container').simulate('click');
         expect(wrapper.state('showEmojiPicker')).toBe(true);
         wrapper.find('.emoji-picker__container').simulate('click');
@@ -196,7 +196,7 @@ describe('components/create_post', () => {
     });
 
     it('Check for emoji click message states', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
         const mockImpl = () => {
             return {
                 setSelectionRange: jest.fn(),
@@ -241,7 +241,7 @@ describe('components/create_post', () => {
                     setDraft,
                 },
             })
-        ).dive();
+        );
 
         const postTextbox = wrapper.find('#post_textbox');
         postTextbox.simulate('change', {target: {value: 'change'}});
@@ -249,7 +249,7 @@ describe('components/create_post', () => {
     });
 
     it('onKeyPress textbox should call emitLocalUserTypingEvent', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
         wrapper.instance().refs = {textbox: {getWrappedInstance: () => ({blur: jest.fn()})}};
 
         wrapper.setState({
@@ -262,7 +262,7 @@ describe('components/create_post', () => {
     });
 
     it('onSubmit test for @all', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
 
         wrapper.setState({
             message: 'test @all',
@@ -288,7 +288,7 @@ describe('components/create_post', () => {
                 getChannelTimezones: jest.fn(() => Promise.resolve([])),
                 isTimezoneEnabled: true,
             })
-        ).dive();
+        );
 
         wrapper.setState({
             message: 'test @all',
@@ -316,7 +316,7 @@ describe('components/create_post', () => {
                 getChannelTimezones: jest.fn(() => Promise.resolve([])),
                 isTimezoneEnabled: false,
             })
-        ).dive();
+        );
 
         wrapper.setState({
             message: 'test @all',
@@ -347,7 +347,7 @@ describe('components/create_post', () => {
                     openModal,
                 },
             })
-        ).dive();
+        );
 
         wrapper.setState({
             message: '/header',
@@ -370,7 +370,7 @@ describe('components/create_post', () => {
                     openModal,
                 },
             })
-        ).dive();
+        );
 
         wrapper.setState({
             message: '/purpose',
@@ -384,7 +384,7 @@ describe('components/create_post', () => {
     });
 
     it('onSubmit test for "/rename" message', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
 
         wrapper.setState({
             message: '/rename',
@@ -400,7 +400,7 @@ describe('components/create_post', () => {
             executeCommand: jest.fn((message, _args, resolve) => resolve()),
         }));
 
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
 
         wrapper.setState({
             message: '/unknown',
@@ -420,7 +420,7 @@ describe('components/create_post', () => {
                     addReaction,
                 },
             })
-        ).dive();
+        );
 
         wrapper.setState({
             message: '+:smile:',
@@ -440,7 +440,7 @@ describe('components/create_post', () => {
                     removeReaction,
                 },
             })
-        ).dive();
+        );
 
         wrapper.setState({
             message: '-:smile:',
@@ -452,7 +452,7 @@ describe('components/create_post', () => {
     });
 
     /*it('check for postError state on handlePostError callback', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
         const textBox = wrapper.find('#post_textbox');
         const form = wrapper.find('#create_post');
 
@@ -470,7 +470,7 @@ describe('components/create_post', () => {
     });*/
 
     it('check for handleFileUploadChange callback for focus', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
         const instance = wrapper.instance();
         instance.focusTextbox = jest.fn();
 
@@ -488,7 +488,7 @@ describe('components/create_post', () => {
                     setDraft,
                 },
             })
-        ).dive();
+        );
 
         const instance = wrapper.instance();
         const clientIds = ['a'];
@@ -514,7 +514,7 @@ describe('components/create_post', () => {
                     setDraft,
                 },
             })
-        ).dive();
+        );
 
         const instance = wrapper.instance();
         const clientIds = ['a'];
@@ -554,7 +554,7 @@ describe('components/create_post', () => {
                     setDraft,
                 },
             })
-        ).dive();
+        );
 
         const instance = wrapper.instance();
         const uploadsInProgressDraft = {
@@ -574,7 +574,7 @@ describe('components/create_post', () => {
     });
 
     it('check for uploadsProgressPercent state on handleUploadProgress callback', () => {
-        const wrapper = shallowWithIntl(createPost({})).dive();
+        const wrapper = shallowWithIntl(createPost({}));
         wrapper.find(FileUpload).prop('onUploadProgress')({clientId: 'clientId', name: 'name', percent: 10, type: 'type'});
 
         expect(wrapper.state('uploadsProgressPercent')).toEqual({clientId: {percent: 10, name: 'name', type: 'type'}});
@@ -606,7 +606,7 @@ describe('components/create_post', () => {
                     ...uploadsInProgressDraft,
                 },
             })
-        ).dive();
+        );
 
         const instance = wrapper.instance();
         instance.handleFileUploadChange = jest.fn();
@@ -617,7 +617,7 @@ describe('components/create_post', () => {
     });
 
     it('Should call Shortcut modal on FORWARD_SLASH+cntrl/meta', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
         const instance = wrapper.instance();
         instance.documentKeyHandler({ctrlKey: true, key: Constants.KeyCodes.BACK_SLASH[0], keyCode: Constants.KeyCodes.BACK_SLASH[1], preventDefault: jest.fn()});
         expect(GlobalActions.toggleShortcutsModal).not.toHaveBeenCalled();
@@ -632,7 +632,7 @@ describe('components/create_post', () => {
     it('Should just return as ctrlSend is enabled and its ctrl+enter', () => {
         const wrapper = shallowWithIntl(createPost({
             ctrlSend: true,
-        })).dive();
+        }));
 
         const instance = wrapper.instance();
         instance.refs = {textbox: {getWrappedInstance: () => ({blur: jest.fn()})}};
@@ -650,7 +650,7 @@ describe('components/create_post', () => {
                 ...actionsProp,
                 setEditingPost,
             },
-        })).dive();
+        }));
         const instance = wrapper.instance();
         const type = Utils.localizeMessage('create_post.comment', Posts.MESSAGE_TYPES.COMMENT);
         instance.handleKeyDown({key: Constants.KeyCodes.UP[0], preventDefault: jest.fn()});
@@ -664,7 +664,7 @@ describe('components/create_post', () => {
                 ...actionsProp,
                 setEditingPost,
             },
-        })).dive();
+        }));
         const instance = wrapper.instance();
 
         wrapper.setProps({
@@ -689,7 +689,7 @@ describe('components/create_post', () => {
                 ...actionsProp,
                 moveHistoryIndexForward,
             },
-        })).dive();
+        }));
         const instance = wrapper.instance();
 
         instance.handleKeyDown({key: Constants.KeyCodes.DOWN[0], ctrlKey: true, preventDefault: jest.fn()});
@@ -709,7 +709,7 @@ describe('components/create_post', () => {
                 ...actionsProp,
                 moveHistoryIndexBack,
             },
-        })).dive();
+        }));
         const instance = wrapper.instance();
 
         instance.handleKeyDown({key: Constants.KeyCodes.UP[0], ctrlKey: true, preventDefault: jest.fn()});
@@ -719,12 +719,12 @@ describe('components/create_post', () => {
     it('Show tutorial', () => {
         const wrapper = shallowWithIntl(createPost({
             showTutorialTip: true,
-        })).dive();
+        }));
         expect(wrapper).toMatchSnapshot();
     });
 
     it('Toggle showPostDeletedModal state', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
         const instance = wrapper.instance();
         instance.showPostDeletedModal();
         expect(wrapper.state('showPostDeletedModal')).toBe(true);
@@ -740,7 +740,7 @@ describe('components/create_post', () => {
                 ...actionsProp,
                 onSubmitPost,
             },
-        })).dive();
+        }));
         const post = {message: 'message', file_ids: []};
         await wrapper.instance().sendMessage(post);
 
@@ -758,7 +758,7 @@ describe('components/create_post', () => {
                 selectPostFromRightHandSideSearchByPostId,
             },
             latestReplyablePostId,
-        })).dive();
+        }));
 
         wrapper.instance().replyToLastPost({preventDefault: jest.fn()});
         expect(selectPostFromRightHandSideSearchByPostId).not.toBeCalled();
@@ -771,12 +771,12 @@ describe('components/create_post', () => {
     });
 
     it('should match snapshot for read only channel', () => {
-        const wrapper = shallowWithIntl(createPost({readOnlyChannel: true})).dive();
+        const wrapper = shallowWithIntl(createPost({readOnlyChannel: true}));
         expect(wrapper).toMatchSnapshot();
     });
 
     it('should match snapshot when file upload disabled', () => {
-        const wrapper = shallowWithIntl(createPost({canUploadFiles: false})).dive();
+        const wrapper = shallowWithIntl(createPost({canUploadFiles: false}));
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -796,7 +796,7 @@ describe('components/create_post', () => {
                     onSubmitPost,
                 },
             })
-        ).dive();
+        );
 
         wrapper.setState({
             message: '/fakecommand some text',
@@ -835,7 +835,7 @@ describe('components/create_post', () => {
                     onSubmitPost,
                 },
             })
-        ).dive();
+        );
 
         wrapper.setState({
             message: '/fakecommand some text',
@@ -863,7 +863,7 @@ describe('components/create_post', () => {
     });
 
     it('should be able to format a pasted markdown table', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
 
         const event = {
             target: {
@@ -886,7 +886,7 @@ describe('components/create_post', () => {
     });
 
     it('should be preserve message when pasting a markdown table', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
 
         const message = 'message';
         wrapper.setState({message});
@@ -913,21 +913,21 @@ describe('components/create_post', () => {
     });
 
     it('should not enable the save button when message empty', () => {
-        const wrapper = shallowWithIntl(createPost()).dive();
+        const wrapper = shallowWithIntl(createPost());
         const saveButton = wrapper.find('.post-body__actions a');
 
         expect(saveButton.hasClass('disabled')).toBe(true);
     });
 
     it('should enable the save button when message not empty', () => {
-        const wrapper = shallowWithIntl(createPost({draft: {...draftProp, message: 'a message'}})).dive();
+        const wrapper = shallowWithIntl(createPost({draft: {...draftProp, message: 'a message'}}));
         const saveButton = wrapper.find('.post-body__actions a');
 
         expect(saveButton.hasClass('disabled')).toBe(false);
     });
 
     it('should enable the save button when a file is available for upload', () => {
-        const wrapper = shallowWithIntl(createPost({draft: {...draftProp, fileInfos: [{id: '1'}]}})).dive();
+        const wrapper = shallowWithIntl(createPost({draft: {...draftProp, fileInfos: [{id: '1'}]}}));
         const saveButton = wrapper.find('.post-body__actions a');
 
         expect(saveButton.hasClass('disabled')).toBe(false);

--- a/components/create_team/create_team.test.jsx
+++ b/components/create_team/create_team.test.jsx
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import CreateTeam from 'components/create_team/create_team.jsx';
 
@@ -28,13 +27,13 @@ describe('/components/create_team', () => {
     };
 
     test('should match snapshot', () => {
-        const wrapper = shallowWithIntl(<CreateTeam {...defaultProps}/>);
+        const wrapper = shallow(<CreateTeam {...defaultProps}/>);
 
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should run props.history.push with new state', () => {
-        const wrapper = shallowWithIntl(<CreateTeam {...defaultProps}/>);
+        const wrapper = shallow(<CreateTeam {...defaultProps}/>);
 
         const history = wrapper.instance().props.history;
         const state = {team: {name: 'team_name'}, wizard: ''};

--- a/components/dot_menu/dot_menu_empty.test.jsx
+++ b/components/dot_menu/dot_menu_empty.test.jsx
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import DotMenu from 'components/dot_menu/dot_menu.jsx';
 
@@ -41,7 +40,7 @@ describe('components/dot_menu/DotMenu returning empty ("")', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <DotMenu {...baseProps}/>
         );
 

--- a/components/dot_menu/dot_menu_mobile.test.jsx
+++ b/components/dot_menu/dot_menu_mobile.test.jsx
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import DotMenu from 'components/dot_menu/dot_menu.jsx';
 
@@ -41,7 +40,7 @@ describe('components/dot_menu/DotMenu on mobile view', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <DotMenu {...baseProps}/>
         );
 

--- a/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.jsx.snap
+++ b/components/edit_channel_header_modal/__snapshots__/edit_channel_header_modal.test.jsx.snap
@@ -1,227 +1,647 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/EditChannelHeaderModal edit direct message channel 1`] = `
-<EditChannelHeaderModal
-  actions={
-    Object {
-      "closeModal": [MockFunction],
-      "patchChannel": [MockFunction],
+<Modal
+  animation={true}
+  aria-labelledby="editChannelHeaderModalLabel"
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="a11y__modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
     }
   }
-  channel={
-    Object {
-      "header": "Fake Channel",
-      "id": "fake-id",
-      "type": "D",
-    }
-  }
-  ctrlSend={false}
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
-    }
-  }
-/>
+  onEntering={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  role="dialog"
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h1"
+      id="editChannelHeaderModalLabel"
+    >
+      <FormattedMessage
+        defaultMessage="Edit Header"
+        id="edit_channel_header_modal.title_dm"
+        values={Object {}}
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <div>
+      <p>
+        <FormattedMessage
+          defaultMessage="Edit the text appearing next to the channel name in the channel header."
+          id="edit_channel_header_modal.description"
+          values={Object {}}
+        />
+      </p>
+      <div
+        className="textarea-wrapper"
+      >
+        <Connect(Textbox)
+          characterLimit={1024}
+          createMessage="Edit the Channel Header..."
+          id="edit_textbox"
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          preview={false}
+          previewMessageLink="Edit Header"
+          suggestionListStyle="bottom"
+          supportsCommands={false}
+          value="Fake Channel"
+        />
+      </div>
+      <div
+        className="post-create-footer"
+      >
+        <TextboxLinks
+          characterLimit={1024}
+          message="Fake Channel"
+          showPreview={false}
+          updatePreview={[Function]}
+        />
+      </div>
+      <br />
+    </div>
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link cancel-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_channel_header_modal.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary save-button"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_channel_header_modal.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
 `;
 
 exports[`components/EditChannelHeaderModal error with intl message 1`] = `
-<EditChannelHeaderModal
-  actions={
-    Object {
-      "closeModal": [MockFunction],
-      "patchChannel": [MockFunction],
+<Modal
+  animation={true}
+  aria-labelledby="editChannelHeaderModalLabel"
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="a11y__modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
     }
   }
-  channel={
-    Object {
-      "header": "Fake Channel",
-      "id": "fake-id",
-    }
-  }
-  ctrlSend={false}
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
-    }
-  }
-/>
+  onEntering={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  role="dialog"
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h1"
+      id="editChannelHeaderModalLabel"
+    >
+      <FormattedMessage
+        defaultMessage="Edit Header for {channel}"
+        id="edit_channel_header_modal.title"
+        values={
+          Object {
+            "channel": undefined,
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <div>
+      <p>
+        <FormattedMessage
+          defaultMessage="Edit the text appearing next to the channel name in the channel header."
+          id="edit_channel_header_modal.description"
+          values={Object {}}
+        />
+      </p>
+      <div
+        className="textarea-wrapper"
+      >
+        <Connect(Textbox)
+          characterLimit={1024}
+          createMessage="Edit the Channel Header..."
+          id="edit_textbox"
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          preview={false}
+          previewMessageLink="Edit Header"
+          suggestionListStyle="bottom"
+          supportsCommands={false}
+          value="Fake Channel"
+        />
+      </div>
+      <div
+        className="post-create-footer"
+      >
+        <TextboxLinks
+          characterLimit={1024}
+          message="Fake Channel"
+          showPreview={false}
+          updatePreview={[Function]}
+        />
+      </div>
+      <br />
+      <div
+        className="form-group has-error"
+      >
+        <br />
+        <label
+          className="control-label"
+        >
+          This channel header is too long, please enter a shorter one
+        </label>
+      </div>
+    </div>
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link cancel-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_channel_header_modal.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary save-button"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_channel_header_modal.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
 `;
 
 exports[`components/EditChannelHeaderModal error without intl message 1`] = `
-<EditChannelHeaderModal
-  actions={
-    Object {
-      "closeModal": [MockFunction],
-      "patchChannel": [MockFunction],
+<Modal
+  animation={true}
+  aria-labelledby="editChannelHeaderModalLabel"
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="a11y__modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
     }
   }
-  channel={
-    Object {
-      "header": "Fake Channel",
-      "id": "fake-id",
-    }
-  }
-  ctrlSend={false}
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
-    }
-  }
-/>
+  onEntering={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  role="dialog"
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h1"
+      id="editChannelHeaderModalLabel"
+    >
+      <FormattedMessage
+        defaultMessage="Edit Header for {channel}"
+        id="edit_channel_header_modal.title"
+        values={
+          Object {
+            "channel": undefined,
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <div>
+      <p>
+        <FormattedMessage
+          defaultMessage="Edit the text appearing next to the channel name in the channel header."
+          id="edit_channel_header_modal.description"
+          values={Object {}}
+        />
+      </p>
+      <div
+        className="textarea-wrapper"
+      >
+        <Connect(Textbox)
+          characterLimit={1024}
+          createMessage="Edit the Channel Header..."
+          id="edit_textbox"
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          preview={false}
+          previewMessageLink="Edit Header"
+          suggestionListStyle="bottom"
+          supportsCommands={false}
+          value="Fake Channel"
+        />
+      </div>
+      <div
+        className="post-create-footer"
+      >
+        <TextboxLinks
+          characterLimit={1024}
+          message="Fake Channel"
+          showPreview={false}
+          updatePreview={[Function]}
+        />
+      </div>
+      <br />
+      <div
+        className="form-group has-error"
+      >
+        <br />
+        <label
+          className="control-label"
+        >
+          some error
+        </label>
+      </div>
+    </div>
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link cancel-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_channel_header_modal.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary save-button"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_channel_header_modal.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
 `;
 
 exports[`components/EditChannelHeaderModal should match snapshot, init 1`] = `
-<EditChannelHeaderModal
-  actions={
-    Object {
-      "closeModal": [MockFunction],
-      "patchChannel": [MockFunction],
+<Modal
+  animation={true}
+  aria-labelledby="editChannelHeaderModalLabel"
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="a11y__modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
     }
   }
-  channel={
-    Object {
-      "header": "Fake Channel",
-      "id": "fake-id",
-    }
-  }
-  ctrlSend={false}
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
-    }
-  }
-/>
+  onEntering={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  role="dialog"
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h1"
+      id="editChannelHeaderModalLabel"
+    >
+      <FormattedMessage
+        defaultMessage="Edit Header for {channel}"
+        id="edit_channel_header_modal.title"
+        values={
+          Object {
+            "channel": undefined,
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <div>
+      <p>
+        <FormattedMessage
+          defaultMessage="Edit the text appearing next to the channel name in the channel header."
+          id="edit_channel_header_modal.description"
+          values={Object {}}
+        />
+      </p>
+      <div
+        className="textarea-wrapper"
+      >
+        <Connect(Textbox)
+          characterLimit={1024}
+          createMessage="Edit the Channel Header..."
+          id="edit_textbox"
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          preview={false}
+          previewMessageLink="Edit Header"
+          suggestionListStyle="bottom"
+          supportsCommands={false}
+          value="Fake Channel"
+        />
+      </div>
+      <div
+        className="post-create-footer"
+      >
+        <TextboxLinks
+          characterLimit={1024}
+          message="Fake Channel"
+          showPreview={false}
+          updatePreview={[Function]}
+        />
+      </div>
+      <br />
+    </div>
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link cancel-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_channel_header_modal.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary save-button"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_channel_header_modal.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
 `;
 
 exports[`components/EditChannelHeaderModal submitted 1`] = `
-<EditChannelHeaderModal
-  actions={
-    Object {
-      "closeModal": [MockFunction],
-      "patchChannel": [MockFunction],
+<Modal
+  animation={true}
+  aria-labelledby="editChannelHeaderModalLabel"
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="a11y__modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
     }
   }
-  channel={
-    Object {
-      "header": "Fake Channel",
-      "id": "fake-id",
-    }
-  }
-  ctrlSend={false}
-  intl={
-    Object {
-      "defaultFormats": Object {},
-      "defaultLocale": "en",
-      "formatDate": [Function],
-      "formatHTMLMessage": [Function],
-      "formatMessage": [Function],
-      "formatNumber": [Function],
-      "formatPlural": [Function],
-      "formatRelative": [Function],
-      "formatTime": [Function],
-      "formats": Object {},
-      "formatters": Object {
-        "getDateTimeFormat": [Function],
-        "getMessageFormat": [Function],
-        "getNumberFormat": [Function],
-        "getPluralFormat": [Function],
-        "getRelativeFormat": [Function],
-      },
-      "locale": "en",
-      "messages": Object {},
-      "now": [Function],
-      "onError": [Function],
-      "textComponent": "span",
-      "timeZone": "Etc/UTC",
-    }
-  }
-/>
+  onEntering={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  role="dialog"
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h1"
+      id="editChannelHeaderModalLabel"
+    >
+      <FormattedMessage
+        defaultMessage="Edit Header for {channel}"
+        id="edit_channel_header_modal.title"
+        values={
+          Object {
+            "channel": undefined,
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <div>
+      <p>
+        <FormattedMessage
+          defaultMessage="Edit the text appearing next to the channel name in the channel header."
+          id="edit_channel_header_modal.description"
+          values={Object {}}
+        />
+      </p>
+      <div
+        className="textarea-wrapper"
+      >
+        <Connect(Textbox)
+          characterLimit={1024}
+          createMessage="Edit the Channel Header..."
+          id="edit_textbox"
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          preview={false}
+          previewMessageLink="Edit Header"
+          suggestionListStyle="bottom"
+          supportsCommands={false}
+          value="Fake Channel"
+        />
+      </div>
+      <div
+        className="post-create-footer"
+      >
+        <TextboxLinks
+          characterLimit={1024}
+          message="Fake Channel"
+          showPreview={false}
+          updatePreview={[Function]}
+        />
+      </div>
+      <br />
+    </div>
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link cancel-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_channel_header_modal.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary save-button"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_channel_header_modal.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
 `;

--- a/components/edit_channel_header_modal/edit_channel_header_modal.test.jsx
+++ b/components/edit_channel_header_modal/edit_channel_header_modal.test.jsx
@@ -90,7 +90,7 @@ describe('components/EditChannelHeaderModal', () => {
     test('should match state and called actions on handleSave', async () => {
         const wrapper = shallowWithIntl(
             <EditChannelHeaderModal {...baseProps}/>
-        ).dive();
+        );
 
         const instance = wrapper.instance();
 
@@ -115,7 +115,7 @@ describe('components/EditChannelHeaderModal', () => {
     test('change header', () => {
         const wrapper = shallowWithIntl(
             <EditChannelHeaderModal {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.find(Textbox).simulate('change', {target: {value: 'header'}});
 
@@ -127,7 +127,7 @@ describe('components/EditChannelHeaderModal', () => {
     test('patch on save button click', () => {
         const wrapper = shallowWithIntl(
             <EditChannelHeaderModal {...baseProps}/>
-        ).dive();
+        );
 
         const newHeader = 'New channel header';
         wrapper.setState({header: newHeader});
@@ -142,7 +142,7 @@ describe('components/EditChannelHeaderModal', () => {
                 {...baseProps}
                 ctrlSend={true}
             />
-        ).dive();
+        );
 
         const newHeader = 'New channel header';
         wrapper.setState({header: newHeader});
@@ -161,7 +161,7 @@ describe('components/EditChannelHeaderModal', () => {
     test('patch on enter keypress', () => {
         const wrapper = shallowWithIntl(
             <EditChannelHeaderModal {...baseProps}/>
-        ).dive();
+        );
 
         const newHeader = 'New channel header';
         wrapper.setState({header: newHeader});
@@ -183,7 +183,7 @@ describe('components/EditChannelHeaderModal', () => {
                 {...baseProps}
                 ctrlSend={true}
             />
-        ).dive();
+        );
 
         const newHeader = 'New channel header';
         wrapper.setState({header: newHeader});

--- a/components/edit_post_modal/edit_post_modal.test.jsx
+++ b/components/edit_post_modal/edit_post_modal.test.jsx
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import React from 'react';
 import ReactRouterEnzymeContext from 'react-router-enzyme-context';
 
@@ -63,7 +64,7 @@ function createEditPost({canEditPost, canDeletePost, ctrlSend, config, license, 
 
 describe('components/EditPostModal', () => {
     it('should match with default config', () => {
-        const wrapper = shallowWithIntl(createEditPost()).dive();
+        const wrapper = shallowWithIntl(createEditPost());
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -72,7 +73,7 @@ describe('components/EditPostModal', () => {
             PostEditTimeLimit: 300,
             EnableEmojiPicker: 'false',
         };
-        const wrapper = shallowWithIntl(createEditPost({config})).dive();
+        const wrapper = shallowWithIntl(createEditPost({config}));
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -97,7 +98,7 @@ describe('components/EditPostModal', () => {
             title: 'test',
         };
 
-        var wrapper = shallowWithIntl(createEditPost({actions, editingPost})).dive();
+        var wrapper = shallowWithIntl(createEditPost({actions, editingPost}));
         var instance = wrapper.instance();
         wrapper.setState({editText: ''});
         instance.handleEdit();
@@ -114,7 +115,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
         };
-        const wrapper = shallowWithIntl(createEditPost({actions})).dive();
+        const wrapper = shallowWithIntl(createEditPost({actions}));
 
         expect(actions.addMessageIntoHistory).not.toBeCalled();
         expect(actions.editPost).not.toBeCalled();
@@ -132,14 +133,14 @@ describe('components/EditPostModal', () => {
     });
 
     it('should show emojis on emojis click', () => {
-        const wrapper = shallowWithIntl(createEditPost()).dive();
+        const wrapper = shallowWithIntl(createEditPost());
         wrapper.find('.post-action').simulate('click');
 
         expect(wrapper).toMatchSnapshot();
     });
 
     it('should set the postError state when error happens', () => {
-        const wrapper = shallowWithIntl(createEditPost()).dive();
+        const wrapper = shallowWithIntl(createEditPost());
         const instance = wrapper.instance();
         expect(wrapper.state().postError).toBe('');
         instance.handlePostError('Test error message');
@@ -150,13 +151,13 @@ describe('components/EditPostModal', () => {
     });
 
     it('should show errors when it is set in the state', () => {
-        const wrapper = shallowWithIntl(createEditPost()).dive();
+        const wrapper = shallowWithIntl(createEditPost());
         wrapper.setState({postError: 'Test error message'});
         expect(wrapper).toMatchSnapshot();
     });
 
     it('should set the errorClass to animate when try to edit with an error', () => {
-        const wrapper = shallowWithIntl(createEditPost()).dive();
+        const wrapper = shallowWithIntl(createEditPost());
         wrapper.setState({postError: 'Test error message'});
         expect(wrapper.state().errorClass).toBe(null);
         wrapper.instance().handleEdit('Test error message');
@@ -166,7 +167,7 @@ describe('components/EditPostModal', () => {
     });
 
     it('should hide and toggle the emoji picker on correctly on (toggle/hide)EmojiPicker', () => {
-        const wrapper = shallowWithIntl(createEditPost()).dive();
+        const wrapper = shallowWithIntl(createEditPost());
         expect(wrapper.state().showEmojiPicker).toBe(false);
         wrapper.instance().toggleEmojiPicker();
         expect(wrapper.state().showEmojiPicker).toBe(true);
@@ -179,7 +180,7 @@ describe('components/EditPostModal', () => {
     });
 
     it('should add emoji to editText when an emoji is clicked', () => {
-        const wrapper = shallowWithIntl(createEditPost()).dive();
+        const wrapper = shallowWithIntl(createEditPost());
         const instance = wrapper.instance();
         const mockImpl = () => {
             return {
@@ -212,7 +213,7 @@ describe('components/EditPostModal', () => {
     });
 
     it('should set the focus and recalculate the size of the edit box after entering', () => {
-        const wrapper = shallowWithIntl(createEditPost()).dive();
+        const wrapper = shallowWithIntl(createEditPost());
         const instance = wrapper.instance();
         instance.editbox = {focus: jest.fn(), recalculateSize: jest.fn()};
 
@@ -225,7 +226,7 @@ describe('components/EditPostModal', () => {
     });
 
     it('should hide the preview when exiting', () => {
-        const wrapper = shallowWithIntl(createEditPost()).dive();
+        const wrapper = shallowWithIntl(createEditPost());
         const instance = wrapper.instance();
 
         instance.updatePreview(true);
@@ -241,7 +242,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
         };
-        const wrapper = shallowWithIntl(createEditPost({actions})).dive();
+        const wrapper = shallowWithIntl(createEditPost({actions}));
         const instance = wrapper.instance();
 
         expect(actions.hideEditPostModal).not.toBeCalled();
@@ -260,7 +261,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
         };
-        var wrapper = shallowWithIntl(createEditPost({actions})).dive();
+        var wrapper = shallowWithIntl(createEditPost({actions}));
         var instance = wrapper.instance();
 
         expect(actions.hideEditPostModal).not.toBeCalled();
@@ -286,7 +287,7 @@ describe('components/EditPostModal', () => {
 
         actions.hideEditPostModal.mockClear();
 
-        wrapper = shallowWithIntl(createEditPost({actions})).dive();
+        wrapper = shallowWithIntl(createEditPost({actions}));
         instance = wrapper.instance();
 
         expect(actions.hideEditPostModal).not.toBeCalled();
@@ -310,7 +311,7 @@ describe('components/EditPostModal', () => {
             openModal: jest.fn(),
         };
         global.scrollTo = jest.fn();
-        const wrapper = shallowWithIntl(createEditPost({actions})).dive();
+        const wrapper = shallowWithIntl(createEditPost({actions}));
         const instance = wrapper.instance();
 
         wrapper.setState({editText: 'new text'});
@@ -320,7 +321,7 @@ describe('components/EditPostModal', () => {
     });
 
     it('should update state after changing value in textbox', () => {
-        const wrapper = shallowWithIntl(createEditPost()).dive();
+        const wrapper = shallowWithIntl(createEditPost());
         const instance = wrapper.instance();
 
         wrapper.setState({editText: ''});
@@ -337,7 +338,7 @@ describe('components/EditPostModal', () => {
             openModal: jest.fn(),
         };
         const editingPost = {show: false};
-        const wrapper = shallowWithIntl(createEditPost({actions, editingPost})).dive();
+        const wrapper = shallowWithIntl(createEditPost({actions, editingPost}));
         const instance = wrapper.instance();
 
         wrapper.setState({editText: 'test', postError: 'test', errorClass: 'test', preview: true, showEmojiPicker: true});
@@ -353,7 +354,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
         };
-        const wrapper = shallowWithIntl(createEditPost({actions})).dive();
+        const wrapper = shallowWithIntl(createEditPost({actions}));
         const instance = wrapper.instance();
 
         const elem = document.createElement('INPUT');
@@ -370,7 +371,7 @@ describe('components/EditPostModal', () => {
 
     it('should handle edition on key down enter depending on the conditions', () => {
         const options = new ReactRouterEnzymeContext();
-        var wrapper = shallowWithIntl(createEditPost({ctrlSend: true}), {context: options.get()}).dive();
+        var wrapper = shallowWithIntl(createEditPost({ctrlSend: true}), {context: options.get()});
         var instance = wrapper.instance();
         instance.handleEdit = jest.fn();
         instance.handleKeyDown({keyCode: 1, ctrlKey: true});
@@ -380,7 +381,7 @@ describe('components/EditPostModal', () => {
         instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: true});
         expect(instance.handleEdit).toBeCalled();
 
-        wrapper = shallowWithIntl(createEditPost({ctrlSend: false})).dive();
+        wrapper = shallowWithIntl(createEditPost({ctrlSend: false}));
         instance = wrapper.instance();
         instance.handleEdit = jest.fn();
         instance.handleKeyDown({keyCode: 1, ctrlKey: true});
@@ -394,7 +395,7 @@ describe('components/EditPostModal', () => {
     describe('should handle edition on key press enter depending on the conditions', () => {
         it('for Mobile, ctrlSend true', () => {
             isMobile.mockReturnValue(true);
-            const wrapper = shallowWithIntl(createEditPost({ctrlSend: true})).dive();
+            const wrapper = shallowWithIntl(createEditPost({ctrlSend: true}));
             const instance = wrapper.instance();
             instance.setState({caretPosition: 3});
             instance.editbox = {blur: jest.fn()};
@@ -411,7 +412,7 @@ describe('components/EditPostModal', () => {
 
         it('for Chrome, ctrlSend false', () => {
             isMobile.mockReturnValue(false);
-            const wrapper = shallowWithIntl(createEditPost({ctrlSend: false})).dive();
+            const wrapper = shallowWithIntl(createEditPost({ctrlSend: false}));
             const instance = wrapper.instance();
             instance.editbox = {blur: jest.fn()};
 
@@ -433,7 +434,7 @@ describe('components/EditPostModal', () => {
     });
 
     it('should handle the escape key manually to hide the modal', () => {
-        const wrapper = shallowWithIntl(createEditPost({ctrlSend: true})).dive();
+        const wrapper = shallowWithIntl(createEditPost({ctrlSend: true}));
         const instance = wrapper.instance();
         instance.handleHide = jest.fn();
         instance.handleExit = jest.fn();
@@ -446,7 +447,7 @@ describe('components/EditPostModal', () => {
     });
 
     it('should handle the escape key manually to hide the modal, unless the emoji picker is shown', () => {
-        const wrapper = shallowWithIntl(createEditPost({ctrlSend: true})).dive();
+        const wrapper = shallowWithIntl(createEditPost({ctrlSend: true}));
         const instance = wrapper.instance();
         instance.handleHide = jest.fn();
         instance.handleExit = jest.fn();
@@ -464,7 +465,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
         };
-        const wrapper = shallowWithIntl(createEditPost({actions, canEditPost: false})).dive();
+        const wrapper = shallowWithIntl(createEditPost({actions, canEditPost: false}));
         wrapper.setState({editText: 'new message'});
         expect(wrapper).toMatchSnapshot();
 
@@ -477,7 +478,7 @@ describe('components/EditPostModal', () => {
     });
 
     it('should not disable the button on not canEditPost and no text in it with canDeletePost', () => {
-        const wrapper = shallowWithIntl(createEditPost({canEditPost: false})).dive();
+        const wrapper = shallowWithIntl(createEditPost({canEditPost: false}));
         wrapper.setState({editText: ''});
         expect(wrapper).toMatchSnapshot();
     });
@@ -489,7 +490,7 @@ describe('components/EditPostModal', () => {
             hideEditPostModal: jest.fn(),
             openModal: jest.fn(),
         };
-        const wrapper = shallowWithIntl(createEditPost({actions, canDeletePost: false})).dive();
+        const wrapper = shallowWithIntl(createEditPost({actions, canDeletePost: false}));
         wrapper.setState({editText: ''});
         expect(wrapper).toMatchSnapshot();
 
@@ -502,7 +503,7 @@ describe('components/EditPostModal', () => {
     });
 
     it('should not disable the button on not canDeletePost and text in it with canEditPost', () => {
-        const wrapper = shallowWithIntl(createEditPost({canDeletePost: false})).dive();
+        const wrapper = shallowWithIntl(createEditPost({canDeletePost: false}));
         wrapper.setState({editText: 'new message'});
         expect(wrapper).toMatchSnapshot();
     });
@@ -521,7 +522,7 @@ describe('components/EditPostModal', () => {
             show: true,
             title: 'test',
         };
-        var wrapper = shallowWithIntl(createEditPost({canDeletePost: false, editingPost})).dive();
+        var wrapper = shallowWithIntl(createEditPost({canDeletePost: false, editingPost}));
         wrapper.setState({editText: ''});
         expect(wrapper).toMatchSnapshot();
     });

--- a/components/file_upload/file_upload.test.jsx
+++ b/components/file_upload/file_upload.test.jsx
@@ -84,7 +84,7 @@ describe('components/FileUpload', () => {
     test('should match snapshot', () => {
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -92,7 +92,7 @@ describe('components/FileUpload', () => {
     test('should call onClick when fileInput is clicked', () => {
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.find('input').simulate('click');
         expect(baseProps.onClick).toHaveBeenCalledTimes(1);
@@ -104,7 +104,7 @@ describe('components/FileUpload', () => {
 
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.handleLocalFileUploaded = jest.fn();
         instance.fileInput = {
@@ -127,7 +127,7 @@ describe('components/FileUpload', () => {
 
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.handleLocalFileUploaded = jest.fn();
         instance.fileInput = {
@@ -150,7 +150,7 @@ describe('components/FileUpload', () => {
                 {...baseProps}
                 fileCount={4}
             />
-        ).dive();
+        );
 
         const evt = {preventDefault: jest.fn()};
         wrapper.instance().handleMaxUploadReached = jest.fn();
@@ -180,7 +180,7 @@ describe('components/FileUpload', () => {
 
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.instance().fileUploadSuccess(data, 'channel_id', 'root_id');
 
@@ -198,7 +198,7 @@ describe('components/FileUpload', () => {
 
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.instance().fileUploadFail(params.err, params.clientId, params.channelId, params.rootId);
 
@@ -221,7 +221,7 @@ describe('components/FileUpload', () => {
             <FileUpload
                 {...baseProps}
             />
-        ).dive();
+        );
         jest.spyOn(wrapper.instance(), 'containsEventTarget').mockReturnValue(true);
         const spy = jest.spyOn(wrapper.instance(), 'checkPluginHooksAndUploadFiles');
 
@@ -239,7 +239,7 @@ describe('components/FileUpload', () => {
 
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.instance().checkPluginHooksAndUploadFiles(files);
 
@@ -262,7 +262,7 @@ describe('components/FileUpload', () => {
 
         const wrapper = shallowWithIntl(
             <FileUpload {...props}/>
-        ).dive();
+        );
 
         wrapper.instance().checkPluginHooksAndUploadFiles(files);
 
@@ -281,7 +281,7 @@ describe('components/FileUpload', () => {
 
         const wrapper = shallowWithIntl(
             <FileUpload {...props}/>
-        ).dive();
+        );
 
         wrapper.instance().checkPluginHooksAndUploadFiles(files);
 
@@ -298,7 +298,7 @@ describe('components/FileUpload', () => {
 
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.instance().checkPluginHooksAndUploadFiles(files);
 
@@ -313,7 +313,7 @@ describe('components/FileUpload', () => {
     test('should functions when handleChange is called', () => {
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
-        ).dive();
+        );
 
         const e = {target: {files: [{name: 'file1.pdf'}]}};
         const instance = wrapper.instance();
@@ -333,7 +333,7 @@ describe('components/FileUpload', () => {
     test('should functions when handleDrop is called', () => {
         const wrapper = shallowWithIntl(
             <FileUpload {...baseProps}/>
-        ).dive();
+        );
 
         const e = {dataTransfer: {files: [{name: 'file1.pdf'}]}};
         const instance = wrapper.instance();
@@ -359,7 +359,7 @@ describe('components/FileUpload', () => {
 
         const wrapper = shallowWithIntl(
             <FileUpload {...props}/>
-        ).dive();
+        );
 
         wrapper.instance().checkPluginHooksAndUploadFiles(files);
 
@@ -380,7 +380,7 @@ describe('components/FileUpload', () => {
 
         const wrapper = shallowWithIntl(
             <FileUpload {...props}/>
-        ).dive();
+        );
 
         wrapper.instance().checkPluginHooksAndUploadFiles(files);
 

--- a/components/get_link_modal.test.tsx
+++ b/components/get_link_modal.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {shallow} from 'enzyme';
 
-import {shallowWithIntl, mountWithIntl} from 'tests/helpers/intl-test-helper';
+import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 import GetLinkModal from 'components/get_link_modal';
 
 describe('components/GetLinkModal', () => {
@@ -21,7 +21,7 @@ describe('components/GetLinkModal', () => {
         const helpText = 'help text';
         const props = {...requiredProps, helpText};
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <GetLinkModal {...props}/>
         );
 
@@ -29,7 +29,7 @@ describe('components/GetLinkModal', () => {
     });
 
     test('should match snapshot when helpText is not set', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <GetLinkModal {...requiredProps}/>
         );
 

--- a/components/invitation_modal/__snapshots__/invitation_modal.test.jsx.snap
+++ b/components/invitation_modal/__snapshots__/invitation_modal.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`components/invitation_modal/InvitationModal should match the snapshot 1`] = `
 <RootPortal>
-  <FullScreenModal
+  <InjectIntl(FullScreenModal)
     ariaLabelledBy="invitation_modal_title"
     onClose={[Function]}
     onGoBack={null}
@@ -46,13 +46,13 @@ exports[`components/invitation_modal/InvitationModal should match the snapshot 1
         teamName="Test name"
       />
     </div>
-  </FullScreenModal>
+  </InjectIntl(FullScreenModal)>
 </RootPortal>
 `;
 
 exports[`components/invitation_modal/InvitationModal should match the snapshot when I have no permission to add users 1`] = `
 <RootPortal>
-  <FullScreenModal
+  <InjectIntl(FullScreenModal)
     ariaLabelledBy="invitation_modal_title"
     onClose={[Function]}
     onGoBack={null}
@@ -102,13 +102,13 @@ exports[`components/invitation_modal/InvitationModal should match the snapshot w
         teamName="Test name"
       />
     </div>
-  </FullScreenModal>
+  </InjectIntl(FullScreenModal)>
 </RootPortal>
 `;
 
 exports[`components/invitation_modal/InvitationModal should match the snapshot when I have no permission to invite guests 1`] = `
 <RootPortal>
-  <FullScreenModal
+  <InjectIntl(FullScreenModal)
     ariaLabelledBy="invitation_modal_title"
     onClose={[Function]}
     onGoBack={null}
@@ -154,13 +154,13 @@ exports[`components/invitation_modal/InvitationModal should match the snapshot w
         teamName="Test name"
       />
     </div>
-  </FullScreenModal>
+  </InjectIntl(FullScreenModal)>
 </RootPortal>
 `;
 
 exports[`components/invitation_modal/InvitationModal should match the snapshot when not show 1`] = `
 <RootPortal>
-  <FullScreenModal
+  <InjectIntl(FullScreenModal)
     ariaLabelledBy="invitation_modal_title"
     onClose={[Function]}
     onGoBack={null}
@@ -204,6 +204,6 @@ exports[`components/invitation_modal/InvitationModal should match the snapshot w
         teamName="Test name"
       />
     </div>
-  </FullScreenModal>
+  </InjectIntl(FullScreenModal)>
 </RootPortal>
 `;

--- a/components/invitation_modal/invitation_modal.jsx
+++ b/components/invitation_modal/invitation_modal.jsx
@@ -80,21 +80,21 @@ export default class InvitationModal extends React.Component {
             this.setState({step: STEPS_INITIAL, hasChanges: false, lastInviteChannels: [], lastInviteMesssage: '', prevStep: this.state.step});
         }
         if (this.modal && this.modal.current) {
-            this.modal.current.resetFocus();
+            this.modal.current.getWrappedInstance().resetFocus();
         }
     }
 
     goToMembers = () => {
         this.setState({step: STEPS_INVITE_MEMBERS, prevStep: this.state.step, hasChanges: false, invitesSent: [], invitesNotSent: [], invitesType: InviteTypes.INVITE_MEMBER});
         if (this.modal && this.modal.current) {
-            this.modal.current.resetFocus();
+            this.modal.current.getWrappedInstance().resetFocus();
         }
     }
 
     goToGuests = () => {
         this.setState({step: STEPS_INVITE_GUESTS, prevStep: this.state.step, hasChanges: false, invitesSent: [], invitesNotSent: [], invitesType: InviteTypes.INVITE_GUEST});
         if (this.modal && this.modal.current) {
-            this.modal.current.resetFocus();
+            this.modal.current.getWrappedInstance().resetFocus();
         }
     }
 
@@ -105,7 +105,7 @@ export default class InvitationModal extends React.Component {
             this.setState({step: STEPS_INVITE_MEMBERS, prevStep: this.state.step, hasChanges: false, invitesSent: [], invitesNotSent: [], invitesType: InviteTypes.INVITE_MEMBER});
         }
         if (this.modal && this.modal.current) {
-            this.modal.current.resetFocus();
+            this.modal.current.getWrappedInstance().resetFocus();
         }
     }
 

--- a/components/invitation_modal/invitation_modal_members_step.test.jsx
+++ b/components/invitation_modal/invitation_modal_members_step.test.jsx
@@ -17,7 +17,7 @@ describe('components/invitation_modal/InvitationModalMembersStep', () => {
                 onSubmit={jest.fn()}
                 onEdit={jest.fn()}
             />
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/components/login/login_controller/login_controller.test.jsx
+++ b/components/login/login_controller/login_controller.test.jsx
@@ -41,7 +41,7 @@ describe('components/login/LoginController', () => {
     it('should match snapshot', () => {
         const wrapper = shallowWithIntl(
             <LoginController {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -52,7 +52,7 @@ describe('components/login/LoginController', () => {
         };
         const wrapper = shallowWithIntl(
             <LoginController {...props}/>
-        ).dive();
+        );
         wrapper.setState({sessionExpired: true});
 
         expect(wrapper).toMatchSnapshot();
@@ -65,7 +65,7 @@ describe('components/login/LoginController', () => {
         };
         const wrapper = shallowWithIntl(
             <LoginController {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -79,7 +79,7 @@ describe('components/login/LoginController', () => {
         LocalStorageStore.setWasLoggedIn(true);
         const wrapper = shallowWithIntl(
             <LoginController {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -96,7 +96,7 @@ describe('components/login/LoginController', () => {
         LocalStorageStore.setWasLoggedIn(true);
         const wrapper = shallowWithIntl(
             <LoginController {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -112,7 +112,7 @@ describe('components/login/LoginController', () => {
 
         const wrapper = shallowWithIntl(
             <LoginController {...props}/>
-        ).dive();
+        );
 
         wrapper.setState({sessionExpired: true});
 

--- a/components/main_menu/main_menu.test.jsx
+++ b/components/main_menu/main_menu.test.jsx
@@ -3,9 +3,9 @@
 
 import React from 'react';
 
-import {Constants} from 'utils/constants';
-
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
+
+import {Constants} from 'utils/constants';
 
 import MainMenu from './main_menu.jsx';
 
@@ -44,18 +44,18 @@ describe('components/Menu', () => {
 
     test('should match snapshot with id', () => {
         const props = {...defaultProps, id: 'test-id'};
-        const wrapper = shallowWithIntl(<MainMenu {...props}/>).dive();
+        const wrapper = shallowWithIntl(<MainMenu {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot with most of the thing disabled', () => {
-        const wrapper = shallowWithIntl(<MainMenu {...defaultProps}/>).dive();
+        const wrapper = shallowWithIntl(<MainMenu {...defaultProps}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot with most of the thing disabled in mobile', () => {
         const props = {...defaultProps, mobile: true};
-        const wrapper = shallowWithIntl(<MainMenu {...props}/>).dive();
+        const wrapper = shallowWithIntl(<MainMenu {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -77,7 +77,7 @@ describe('components/Menu', () => {
             reportAProblemLink: 'test-report-link',
             moreTeamsToJoin: true,
         };
-        const wrapper = shallowWithIntl(<MainMenu {...props}/>).dive();
+        const wrapper = shallowWithIntl(<MainMenu {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -100,7 +100,7 @@ describe('components/Menu', () => {
             reportAProblemLink: 'test-report-link',
             moreTeamsToJoin: true,
         };
-        const wrapper = shallowWithIntl(<MainMenu {...props}/>).dive();
+        const wrapper = shallowWithIntl(<MainMenu {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -112,7 +112,7 @@ describe('components/Menu', () => {
                 {id: 'plugin-2', action: jest.fn(), text: 'plugin-2-text', mobileIcon: 'plugin-2-mobile-icon'},
             ],
         };
-        const wrapper = shallowWithIntl(<MainMenu {...props}/>).dive();
+        const wrapper = shallowWithIntl(<MainMenu {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -125,13 +125,13 @@ describe('components/Menu', () => {
                 {id: 'plugin-2', action: jest.fn(), text: 'plugin-2-text', mobileIcon: 'plugin-2-mobile-icon'},
             ],
         };
-        const wrapper = shallowWithIntl(<MainMenu {...props}/>).dive();
+        const wrapper = shallowWithIntl(<MainMenu {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should show leave team option when primary team is set', () => {
         const props = {...defaultProps, teamIsGroupConstrained: false, experimentalPrimaryTeam: null};
-        const wrapper = shallowWithIntl(<MainMenu {...props}/>).dive();
+        const wrapper = shallowWithIntl(<MainMenu {...props}/>);
 
         // show leave team option when experimentalPrimaryTeam is not set
         expect(wrapper.find('#leaveTeam')).toHaveLength(1);

--- a/components/password_reset_form/password_reset_form.test.js
+++ b/components/password_reset_form/password_reset_form.test.js
@@ -1,9 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 
-import {shallowWithIntl, mountWithIntl} from 'tests/helpers/intl-test-helper';
+import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 
 import PasswordResetForm from './password_reset_form';
 
@@ -25,7 +26,7 @@ describe('components/PasswordResetForm', () => {
     };
 
     it('should match snapshot', () => {
-        const wrapper = shallowWithIntl(<PasswordResetForm {...baseProps}/>);
+        const wrapper = shallow(<PasswordResetForm {...baseProps}/>);
         expect(wrapper).toMatchSnapshot();
     });
 

--- a/components/password_reset_send_link/password_reset_send_link.test.js
+++ b/components/password_reset_send_link/password_reset_send_link.test.js
@@ -1,10 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 import {MemoryRouter} from 'react-router';
 
-import {shallowWithIntl, mountWithIntl} from 'tests/helpers/intl-test-helper';
+import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 
 import PasswordResetSendLink from './password_reset_send_link';
 
@@ -16,7 +17,7 @@ describe('components/PasswordResetSendLink', () => {
     };
 
     it('should match snapshot', () => {
-        const wrapper = shallowWithIntl(<PasswordResetSendLink {...baseProps}/>);
+        const wrapper = shallow(<PasswordResetSendLink {...baseProps}/>);
         expect(wrapper).toMatchSnapshot();
     });
 

--- a/components/permalink_redirector/permalink_redirector.test.jsx
+++ b/components/permalink_redirector/permalink_redirector.test.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
@@ -10,7 +11,6 @@ import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {ErrorPageTypes} from 'utils/constants';
 import {browserHistory} from 'utils/browser_history';
 import LocalStorageStore from 'stores/local_storage_store';
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import {redirect} from 'components/permalink_redirector/actions';
 import PermalinkRedirector from 'components/permalink_redirector/permalink_redirector.jsx';
 
@@ -50,7 +50,7 @@ describe('components/PermalinkRedirector', () => {
             ...baseProps,
             url: 'pl/post_id',
         };
-        shallowWithIntl(
+        shallow(
             <PermalinkRedirector {...props}/>
         );
 
@@ -63,7 +63,7 @@ describe('components/PermalinkRedirector', () => {
             ...baseProps,
             url: '/_redirect/integrations',
         };
-        shallowWithIntl(
+        shallow(
             <PermalinkRedirector {...props}/>
         );
 
@@ -76,7 +76,7 @@ describe('components/PermalinkRedirector', () => {
             ...baseProps,
             url: '/_redirect/integrations/bots',
         };
-        shallowWithIntl(
+        shallow(
             <PermalinkRedirector {...props}/>
         );
 

--- a/components/permalink_view/permalink_view.test.jsx
+++ b/components/permalink_view/permalink_view.test.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
@@ -10,7 +11,6 @@ import {getPostThread} from 'mattermost-redux/actions/posts';
 import {ErrorPageTypes} from 'utils/constants';
 import {browserHistory} from 'utils/browser_history';
 
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import {focusPost} from 'components/permalink_view/actions';
 import PermalinkView from 'components/permalink_view/permalink_view.jsx';
 
@@ -77,7 +77,7 @@ describe('components/PermalinkView', () => {
     };
 
     test('should match snapshot', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PermalinkView {...baseProps}/>,
         );
 
@@ -86,7 +86,7 @@ describe('components/PermalinkView', () => {
     });
 
     test('should call baseProps.actions.focusPost on doPermalinkEvent', async () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PermalinkView {...baseProps}/>
         );
 
@@ -99,7 +99,7 @@ describe('components/PermalinkView', () => {
     });
 
     test('should call baseProps.actions.focusPost when postid changes', async () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PermalinkView {...baseProps}/>
         );
         const newPostid = `${baseProps.match.params.postid}_new`;
@@ -112,7 +112,7 @@ describe('components/PermalinkView', () => {
     test('should match snapshot with archived channel', () => {
         const props = {...baseProps, channelIsArchived: true};
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PermalinkView {...props}/>
         );
 

--- a/components/plugin_marketplace/__snapshots__/marketplace_modal.test.js.snap
+++ b/components/plugin_marketplace/__snapshots__/marketplace_modal.test.js.snap
@@ -161,7 +161,7 @@ exports[`components/marketplace/ InstalledPlugins should render with one plugin 
 
 exports[`components/marketplace/ MarketplaceModal should render with error banner 1`] = `
 <RootPortal>
-  <FullScreenModal
+  <InjectIntl(FullScreenModal)
     ariaLabel="Plugin Marketplace"
     onClose={[Function]}
     show={true}
@@ -251,13 +251,13 @@ exports[`components/marketplace/ MarketplaceModal should render with error banne
         </Tab>
       </Uncontrolled(Tabs)>
     </div>
-  </FullScreenModal>
+  </InjectIntl(FullScreenModal)>
 </RootPortal>
 `;
 
 exports[`components/marketplace/ MarketplaceModal should render with no plugins installed 1`] = `
 <RootPortal>
-  <FullScreenModal
+  <InjectIntl(FullScreenModal)
     ariaLabel="Plugin Marketplace"
     onClose={[Function]}
     show={true}
@@ -333,13 +333,13 @@ exports[`components/marketplace/ MarketplaceModal should render with no plugins 
         </Tab>
       </Uncontrolled(Tabs)>
     </div>
-  </FullScreenModal>
+  </InjectIntl(FullScreenModal)>
 </RootPortal>
 `;
 
 exports[`components/marketplace/ MarketplaceModal should render with plugins installed 1`] = `
 <RootPortal>
-  <FullScreenModal
+  <InjectIntl(FullScreenModal)
     ariaLabel="Plugin Marketplace"
     onClose={[Function]}
     show={true}
@@ -430,7 +430,7 @@ exports[`components/marketplace/ MarketplaceModal should render with plugins ins
         </Tab>
       </Uncontrolled(Tabs)>
     </div>
-  </FullScreenModal>
+  </InjectIntl(FullScreenModal)>
 </RootPortal>
 `;
 

--- a/components/post_view/combined_system_message/combined_system_message.test.jsx
+++ b/components/post_view/combined_system_message/combined_system_message.test.jsx
@@ -52,7 +52,7 @@ describe('components/post_view/CombinedSystemMessage', () => {
     test('should match snapshot', () => {
         const wrapper = shallowWithIntl(
             <CombinedSystemMessage {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -71,7 +71,7 @@ describe('components/post_view/CombinedSystemMessage', () => {
         const props = {...baseProps, messageData, allUserIds};
         const wrapper = shallowWithIntl(
             <CombinedSystemMessage {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -82,7 +82,7 @@ describe('components/post_view/CombinedSystemMessage', () => {
                 {...baseProps}
                 showJoinLeave={false}
             />
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -101,7 +101,7 @@ describe('components/post_view/CombinedSystemMessage', () => {
         const props = {...baseProps, messageData, allUserIds, showJoinLeave: false};
         const wrapper = shallowWithIntl(
             <CombinedSystemMessage {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -123,7 +123,7 @@ describe('components/post_view/CombinedSystemMessage', () => {
         const props = {...baseProps, messageData, allUserIds};
         const wrapper = shallowWithIntl(
             <CombinedSystemMessage {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -140,7 +140,7 @@ describe('components/post_view/CombinedSystemMessage', () => {
 
         const wrapper = shallowWithIntl(
             <CombinedSystemMessage {...props}/>
-        ).dive();
+        );
 
         wrapper.instance().loadUserProfiles([], []);
         expect(props.actions.getMissingProfilesByIds).toHaveBeenCalledTimes(0);

--- a/components/post_view/combined_system_message/last_users.test.jsx
+++ b/components/post_view/combined_system_message/last_users.test.jsx
@@ -29,7 +29,7 @@ describe('components/post_view/combined_system_message/LastUsers', () => {
     test('should match snapshot', () => {
         const wrapper = shallowWithIntl(
             <LastUsers {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -37,7 +37,7 @@ describe('components/post_view/combined_system_message/LastUsers', () => {
     test('should match snapshot, expanded', () => {
         const wrapper = shallowWithIntl(
             <LastUsers {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.setState({expand: true});
         expect(wrapper).toMatchSnapshot();
@@ -46,7 +46,7 @@ describe('components/post_view/combined_system_message/LastUsers', () => {
     test('should match state on handleOnClick', () => {
         const wrapper = shallowWithIntl(
             <LastUsers {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.setState({expand: false});
         wrapper.instance().handleOnClick({preventDefault: jest.fn()});

--- a/components/post_view/new_message_separator/new_message_separator.test.jsx
+++ b/components/post_view/new_message_separator/new_message_separator.test.jsx
@@ -1,15 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import NewMessageSeparator from './new_message_separator.jsx';
 
 describe('components/post_view/new_message_separator', () => {
     test('should render new_message_separator', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <NewMessageSeparator separatorId='1234'/>
         );
         expect(wrapper).toMatchSnapshot();

--- a/components/post_view/post_list/post_list_virtualized.test.jsx
+++ b/components/post_view/post_list/post_list_virtualized.test.jsx
@@ -55,7 +55,7 @@ describe('PostList', () => {
         const postListIds = ['a', 'b', 'c', 'd'];
 
         test('should get previous item ID correctly for oldest row', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const row = shallow(wrapper.instance().renderRow({
                 data: postListIds,
                 itemId: 'd',
@@ -65,7 +65,7 @@ describe('PostList', () => {
         });
 
         test('should get previous item ID correctly for other rows', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const row = shallow(wrapper.instance().renderRow({
                 data: postListIds,
                 itemId: 'b',
@@ -80,7 +80,7 @@ describe('PostList', () => {
                 focusedPostId: 'b',
             };
 
-            const wrapper = shallowWithIntl(<PostList {...props}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...props}/>);
 
             let row = shallow(wrapper.instance().renderRow({
                 data: postListIds,
@@ -98,7 +98,7 @@ describe('PostList', () => {
 
     describe('new messages below', () => {
         test('should mount outside of permalink view', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
 
             expect(wrapper.find(NewMessagesBelow).exists()).toBe(true);
         });
@@ -109,14 +109,14 @@ describe('PostList', () => {
                 focusedPostId: '1234',
             };
 
-            const wrapper = shallowWithIntl(<PostList {...props}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...props}/>);
             expect(wrapper.find(NewMessagesBelow).exists()).toBe(false);
         });
     });
 
     describe('onScroll', () => {
         test('should call checkBottom', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             wrapper.instance().checkBottom = jest.fn();
 
             const scrollOffset = 1234;
@@ -135,7 +135,7 @@ describe('PostList', () => {
         });
 
         test('should call canLoadMorePosts with AFTER_ID if loader is visible', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const instance = wrapper.instance();
 
             const scrollOffset = 1234;
@@ -155,7 +155,7 @@ describe('PostList', () => {
         });
 
         test('should not call canLoadMorePosts with AFTER_ID if loader is below the fold by couple of messages', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const instance = wrapper.instance();
 
             const scrollOffset = 1234;
@@ -202,7 +202,7 @@ describe('PostList', () => {
             },
         ]) {
             test(testCase.name, () => {
-                const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+                const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
                 expect(wrapper.instance().isAtBottom(testCase.scrollOffset, scrollHeight, clientHeight)).toBe(testCase.expected);
             });
         }
@@ -210,7 +210,7 @@ describe('PostList', () => {
 
     describe('updateAtBottom', () => {
         test('should update atBottom and lastViewedBottom when atBottom changes', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             wrapper.setState({lastViewedBottom: 1234});
 
             wrapper.instance().updateAtBottom(true);
@@ -220,7 +220,7 @@ describe('PostList', () => {
         });
 
         test('should not update lastViewedBottom when atBottom does not change', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             wrapper.setState({lastViewedBottom: 1234});
 
             wrapper.instance().updateAtBottom(false);
@@ -231,7 +231,7 @@ describe('PostList', () => {
         test('should update lastViewedBottom with latestPostTimeStamp as that is greater than Date.now()', () => {
             Date.now = jest.fn().mockReturnValue(12344);
 
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             wrapper.setState({lastViewedBottom: 1234});
 
             wrapper.instance().updateAtBottom(true);
@@ -242,7 +242,7 @@ describe('PostList', () => {
         test('should update lastViewedBottom with Date.now() as it is greater than latestPostTimeStamp', () => {
             Date.now = jest.fn().mockReturnValue(12346);
 
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             wrapper.setState({lastViewedBottom: 1234});
 
             wrapper.instance().updateAtBottom(true);
@@ -253,7 +253,7 @@ describe('PostList', () => {
 
     describe('Scroll correction logic on mount of posts at the top', () => {
         test('should return previous scroll position from getSnapshotBeforeUpdate', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const instance = wrapper.instance();
             instance.componentDidUpdate = jest.fn();
 
@@ -277,7 +277,7 @@ describe('PostList', () => {
         });
 
         test('should not return previous scroll position from getSnapshotBeforeUpdate as list is at bottom', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const instance = wrapper.instance();
             instance.componentDidUpdate = jest.fn();
 
@@ -312,7 +312,7 @@ describe('PostList', () => {
                 postListIds,
             };
 
-            const wrapper = shallowWithIntl(<PostList {...props}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...props}/>);
             const instance = wrapper.instance();
             expect(instance.initRangeToRender).toEqual([0, 50]);
         });
@@ -329,7 +329,7 @@ describe('PostList', () => {
                 postListIds,
             };
 
-            const wrapper = shallowWithIntl(<PostList {...props}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...props}/>);
             const instance = wrapper.instance();
             expect(instance.initRangeToRender).toEqual([35, 95]);
         });
@@ -342,7 +342,7 @@ describe('PostList', () => {
                 postListIds: postListIdsForClassNames,
             };
 
-            const wrapper = shallowWithIntl(<PostList {...props}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...props}/>);
             const instance = wrapper.instance();
             const post3Row = shallow(instance.renderRow({
                 data: postListIdsForClassNames,
@@ -372,7 +372,7 @@ describe('PostList', () => {
                 ],
             };
 
-            const wrapper = shallowWithIntl(<PostList {...props}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...props}/>);
 
             const row = shallow(wrapper.instance().renderRow({
                 data: props.postListIds,
@@ -396,7 +396,7 @@ describe('PostList', () => {
                 ],
             };
 
-            const wrapper = shallowWithIntl(<PostList {...props}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...props}/>);
 
             const row = shallow(wrapper.instance().renderRow({
                 data: props.postListIds,
@@ -409,7 +409,7 @@ describe('PostList', () => {
 
     describe('updateFloatingTimestamp', () => {
         test('should not update topPostId as is it not mobile view', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const instance = wrapper.instance();
             wrapper.setState({isMobile: false});
             instance.onItemsRendered({visibleStartIndex: 0});
@@ -417,7 +417,7 @@ describe('PostList', () => {
         });
 
         test('should update topPostId with latest visible postId', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const instance = wrapper.instance();
             wrapper.setState({isMobile: true});
             instance.onItemsRendered({visibleStartIndex: 1});
@@ -430,7 +430,7 @@ describe('PostList', () => {
 
     describe('scrollToLatestMessages', () => {
         test('should call scrollToBottom', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             wrapper.setProps({atLatestPost: true});
             const instance = wrapper.instance();
             instance.scrollToBottom = jest.fn();
@@ -439,7 +439,7 @@ describe('PostList', () => {
         });
 
         test('should call changeUnreadChunkTimeStamp', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             const instance = wrapper.instance();
             instance.scrollToLatestMessages();
             expect(baseActions.changeUnreadChunkTimeStamp).toHaveBeenCalledWith('');
@@ -448,7 +448,7 @@ describe('PostList', () => {
 
     describe('postIds state', () => {
         test('should have LOAD_NEWER_MESSAGES_TRIGGER and LOAD_OLDER_MESSAGES_TRIGGER', () => {
-            const wrapper = shallowWithIntl(<PostList {...baseProps}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
             wrapper.setProps({autoRetryEnable: false});
             const postListIdsState = wrapper.state('postListIds');
             expect(postListIdsState[0]).toBe(PostListRowListIds.LOAD_NEWER_MESSAGES_TRIGGER);
@@ -473,7 +473,7 @@ describe('PostList', () => {
                 postListIds,
             };
 
-            const wrapper = shallowWithIntl(<PostList {...props}/>).dive();
+            const wrapper = shallowWithIntl(<PostList {...props}/>);
             const instance = wrapper.instance();
             const initScrollToIndex = instance.initScrollToIndex();
             expect(initScrollToIndex).toEqual({index: 6, position: 'start'});
@@ -495,7 +495,7 @@ describe('PostList', () => {
             postListIds,
         };
 
-        const wrapper = shallowWithIntl(<PostList {...props}/>).dive();
+        const wrapper = shallowWithIntl(<PostList {...props}/>);
         const instance = wrapper.instance();
         const initScrollToIndex = instance.initScrollToIndex();
         expect(initScrollToIndex).toEqual({index: 5, position: 'start'});

--- a/components/post_view/post_list_row/post_list_row.test.jsx
+++ b/components/post_view/post_list_row/post_list_row.test.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 
 import * as PostListUtils from 'mattermost-redux/utils/post_list';
@@ -11,7 +12,6 @@ import DateSeparator from 'components/post_view/date_separator';
 import NewMessageSeparator from 'components/post_view/new_message_separator/new_message_separator';
 import ChannelIntroMessage from 'components/post_view/channel_intro_message/';
 
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import {PostListRowListIds} from 'utils/constants';
 
 import PostListRow from './post_list_row.jsx';
@@ -22,7 +22,7 @@ describe('components/post_view/post_list_row', () => {
         const props = {
             listId,
         };
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PostListRow {...props}/>
         );
         expect(wrapper).toMatchSnapshot();
@@ -35,7 +35,7 @@ describe('components/post_view/post_list_row', () => {
             listId,
             loadOlderPosts,
         };
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PostListRow {...props}/>
         );
         expect(wrapper).toMatchSnapshot();
@@ -53,7 +53,7 @@ describe('components/post_view/post_list_row', () => {
             listId,
         };
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PostListRow {...props}/>
         );
         expect(wrapper).toMatchSnapshot();
@@ -65,7 +65,7 @@ describe('components/post_view/post_list_row', () => {
         const props = {
             listId,
         };
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PostListRow {...props}/>
         );
         expect(wrapper).toMatchSnapshot();
@@ -77,7 +77,7 @@ describe('components/post_view/post_list_row', () => {
         const props = {
             listId,
         };
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PostListRow {...props}/>
         );
         expect(wrapper).toMatchSnapshot();
@@ -90,7 +90,7 @@ describe('components/post_view/post_list_row', () => {
             listId: `${PostListUtils.COMBINED_USER_ACTIVITY}1234-5678`,
             previousListId: 'abcd',
         };
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PostListRow {...props}/>
         );
         expect(wrapper).toMatchSnapshot();
@@ -103,7 +103,7 @@ describe('components/post_view/post_list_row', () => {
             listId: '1234',
             previousListId: 'abcd',
         };
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <PostListRow {...props}/>
         );
         expect(wrapper).toMatchSnapshot();

--- a/components/profile_popover/profile_popover.test.jsx
+++ b/components/profile_popover/profile_popover.test.jsx
@@ -35,7 +35,7 @@ describe('components/ProfilePopover', () => {
 
         const wrapper = shallowWithIntl(
             <ProfilePopover {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -50,7 +50,7 @@ describe('components/ProfilePopover', () => {
 
         const wrapper = shallowWithIntl(
             <ProfilePopover {...props}/>
-        ).dive();
+        );
         expect(wrapper.containsMatchingElement(
             <div
                 key='bot-description'
@@ -66,7 +66,7 @@ describe('components/ProfilePopover', () => {
 
         const wrapper = shallowWithIntl(
             <ProfilePopover {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -77,7 +77,7 @@ describe('components/ProfilePopover', () => {
 
         const wrapper = shallowWithIntl(
             <ProfilePopover {...props}/>
-        ).dive();
+        );
 
         const pluggableProps = {
             hide,

--- a/components/recent_date.test.tsx
+++ b/components/recent_date.test.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import RecentDate, {
     isToday,
@@ -22,7 +21,7 @@ describe('RecentDate', () => {
             value: today,
         };
 
-        const wrapper = shallowWithIntl(<RecentDate {...props}/>);
+        const wrapper = shallow(<RecentDate {...props}/>);
 
         expect(wrapper.find(FormattedMessage).exists()).toBe(true);
         expect(wrapper.find(FormattedMessage).prop('id')).toBe('date_separator.today');
@@ -36,7 +35,7 @@ describe('RecentDate', () => {
             value: yesterday,
         };
 
-        const wrapper = shallowWithIntl(<RecentDate {...props}/>);
+        const wrapper = shallow(<RecentDate {...props}/>);
 
         expect(wrapper.find(FormattedMessage).exists()).toBe(true);
         expect(wrapper.find(FormattedMessage).prop('id')).toBe('date_separator.yesterday');
@@ -50,7 +49,7 @@ describe('RecentDate', () => {
             value: twoDaysAgo,
         };
 
-        const wrapper = shallowWithIntl(<RecentDate {...props}/>);
+        const wrapper = shallow(<RecentDate {...props}/>);
 
         expect(wrapper.text()).toMatch(reDateFormat);
     });
@@ -64,7 +63,7 @@ describe('RecentDate', () => {
             value: twoDaysAgo,
         };
 
-        const wrapper = shallowWithIntl(<RecentDate {...props}/>);
+        const wrapper = shallow(<RecentDate {...props}/>);
 
         expect(wrapper.text()).toMatch(reDateFormat);
     });

--- a/components/rename_channel_modal/rename_channel_modal.test.jsx
+++ b/components/rename_channel_modal/rename_channel_modal.test.jsx
@@ -31,7 +31,7 @@ describe('components/RenameChannelModal', () => {
     test('should match snapshot', () => {
         const wrapper = shallowWithIntl(
             <RenameChannelModal {...baseProps}/>
-        ).dive({disableLifecycleMethods: true});
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -41,7 +41,7 @@ describe('components/RenameChannelModal', () => {
         const props = {...baseProps, requestStatus: RequestStatus.STARTED};
         const wrapper = shallowWithIntl(
             <RenameChannelModal {...props}/>
-        ).dive({disableLifecycleMethods: true});
+        );
 
         wrapper.find('#save-button').simulate('click');
 
@@ -52,7 +52,7 @@ describe('components/RenameChannelModal', () => {
         const {actions: {patchChannel}} = baseProps;
         const wrapper = shallowWithIntl(
             <RenameChannelModal {...baseProps}/>
-        ).dive({disableLifecycleMethods: true});
+        );
 
         wrapper.find('#display_name').simulate(
             'change', {preventDefault: jest.fn(), target: {value: 'string-above-sixtyfour-characters-to-test-the-channel-maxlength-limit-properly-in-the-component'}}
@@ -66,7 +66,7 @@ describe('components/RenameChannelModal', () => {
     test('should change state when display_name is edited', () => {
         const wrapper = shallowWithIntl(
             <RenameChannelModal {...baseProps}/>
-        ).dive({disableLifecycleMethods: true});
+        );
 
         wrapper.find('#display_name').simulate(
             'change', {preventDefault: jest.fn(), target: {value: 'New Fake Channel'}}
@@ -78,7 +78,7 @@ describe('components/RenameChannelModal', () => {
     test('should call setError function', () => {
         const wrapper = shallowWithIntl(
             <RenameChannelModal {...baseProps}/>
-        ).dive({disableLifecycleMethods: true});
+        );
 
         const instance = wrapper.instance();
 
@@ -90,7 +90,7 @@ describe('components/RenameChannelModal', () => {
         const props = {...baseProps, serverError: {message: 'This is an error message'}};
         const wrapper = shallowWithIntl(
             <RenameChannelModal {...props}/>
-        ).dive({disableLifecycleMethods: true});
+        );
 
         wrapper.setState({serverError: props.serverError.message});
         expect(wrapper.state('serverError')).toBe('This is an error message');
@@ -109,7 +109,7 @@ describe('components/RenameChannelModal', () => {
                 {...baseProps}
                 actions={{patchChannel}}
             />
-        ).dive({disableLifecycleMethods: true});
+        );
 
         wrapper.setState({displayName: 'Changed Name', channelName: 'changed-name'});
 
@@ -136,7 +136,7 @@ describe('components/RenameChannelModal', () => {
     test('should call handleCancel', () => {
         const wrapper = shallowWithIntl(
             <RenameChannelModal {...baseProps}/>
-        ).dive({disableLifecycleMethods: true});
+        );
 
         const instance = wrapper.instance();
         instance.handleCancel();
@@ -147,7 +147,7 @@ describe('components/RenameChannelModal', () => {
     test('should call handleHide function', () => {
         const wrapper = shallowWithIntl(
             <RenameChannelModal {...baseProps}/>
-        ).dive({disableLifecycleMethods: true});
+        );
 
         const instance = wrapper.instance();
         instance.handleHide();
@@ -159,7 +159,7 @@ describe('components/RenameChannelModal', () => {
         const changedName = {target: {value: 'changed-name'}};
         const wrapper = shallowWithIntl(
             <RenameChannelModal {...baseProps}/>
-        ).dive({disableLifecycleMethods: true});
+        );
 
         const instance = wrapper.instance();
         instance.onNameChange(changedName);

--- a/components/rhs_comment/rhs_comment.test.jsx
+++ b/components/rhs_comment/rhs_comment.test.jsx
@@ -66,7 +66,7 @@ describe('components/RhsComment', () => {
     test('should match snapshot', () => {
         const wrapper = shallowWithIntl(
             <RhsComment {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -74,7 +74,7 @@ describe('components/RhsComment', () => {
     test('should match snapshot hovered', () => {
         const wrapper = shallowWithIntl(
             <RhsComment {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.setState({hover: true});
 
@@ -85,7 +85,7 @@ describe('components/RhsComment', () => {
         isMobile.mockImplementation(() => true);
         const wrapper = shallowWithIntl(
             <RhsComment {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -100,7 +100,7 @@ describe('components/RhsComment', () => {
         };
         const wrapper = shallowWithIntl(
             <RhsComment {...props}/>
-        ).dive();
+        );
         wrapper.setState({hover: true});
 
         expect(wrapper).toMatchSnapshot();
@@ -109,7 +109,7 @@ describe('components/RhsComment', () => {
     test('should show pointer when alt is held down', () => {
         const wrapper = shallowWithIntl(
             <RhsComment {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper.find('.post.cursor--pointer').exists()).toBe(false);
 
@@ -121,7 +121,7 @@ describe('components/RhsComment', () => {
     test('should call markPostAsUnread when post is alt+clicked on', () => {
         const wrapper = shallowWithIntl(
             <RhsComment {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.simulate('click', {altKey: false});
 

--- a/components/rhs_root_post/rhs_root_post.test.jsx
+++ b/components/rhs_root_post/rhs_root_post.test.jsx
@@ -61,7 +61,7 @@ describe('components/RhsRootPost', () => {
     test('should match snapshot', () => {
         const wrapper = shallowWithIntl(
             <RhsRootPost {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -73,7 +73,7 @@ describe('components/RhsRootPost', () => {
         };
         const wrapper = shallowWithIntl(
             <RhsRootPost {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -88,7 +88,7 @@ describe('components/RhsRootPost', () => {
         };
         const wrapper = shallowWithIntl(
             <RhsRootPost {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -104,7 +104,7 @@ describe('components/RhsRootPost', () => {
         };
         const wrapper = shallowWithIntl(
             <RhsRootPost {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -112,7 +112,7 @@ describe('components/RhsRootPost', () => {
     test('should show pointer when alt is held down', () => {
         const wrapper = shallowWithIntl(
             <RhsRootPost {...baseProps}/>
-        ).dive();
+        );
 
         expect(wrapper.find('.post.cursor--pointer').exists()).toBe(false);
 
@@ -124,7 +124,7 @@ describe('components/RhsRootPost', () => {
     test('should call markPostAsUnread when post is alt+clicked on', () => {
         const wrapper = shallowWithIntl(
             <RhsRootPost {...baseProps}/>
-        ).dive();
+        );
 
         wrapper.simulate('click', {altKey: false});
 

--- a/components/save_button.test.tsx
+++ b/components/save_button.test.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import SaveButton from 'components/save_button';
 
@@ -13,7 +12,7 @@ describe('components/SaveButton', () => {
     };
 
     test('should match snapshot, on defaultMessage', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <SaveButton {...baseProps}/>
         );
 
@@ -26,7 +25,7 @@ describe('components/SaveButton', () => {
 
     test('should match snapshot, on savingMessage', () => {
         const props = {...baseProps, saving: true, disabled: true};
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <SaveButton {...props}/>
         );
 
@@ -39,7 +38,7 @@ describe('components/SaveButton', () => {
 
     test('should match snapshot, extraClasses', () => {
         const props = {...baseProps, extraClasses: 'some-class'};
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <SaveButton {...props}/>
         );
 

--- a/components/search_results_item/search_results_item.test.jsx
+++ b/components/search_results_item/search_results_item.test.jsx
@@ -88,7 +88,7 @@ describe('components/SearchResultsItem', () => {
     test('should match snapshot for channel', () => {
         const wrapper = shallowWithIntl(
             <SearchResultsItem {...defaultProps}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -110,7 +110,7 @@ describe('components/SearchResultsItem', () => {
 
         const wrapper = shallowWithIntl(
             <SearchResultsItem {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -131,7 +131,7 @@ describe('components/SearchResultsItem', () => {
 
         const wrapper = shallowWithIntl(
             <SearchResultsItem {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -147,7 +147,7 @@ describe('components/SearchResultsItem', () => {
 
         const wrapper = shallowWithIntl(
             <SearchResultsItem {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
         expect(getDirectTeammate).toHaveBeenCalledWith('channel_id');
@@ -157,7 +157,7 @@ describe('components/SearchResultsItem', () => {
     test('Check for dotmenu dropdownOpened state', () => {
         const wrapper = shallowWithIntl(
             <SearchResultsItem {...defaultProps}/>
-        ).dive();
+        );
 
         const instance = wrapper.instance();
         instance.handleDropdownOpened(false);
@@ -178,7 +178,7 @@ describe('components/SearchResultsItem', () => {
 
         const wrapper = shallowWithIntl(
             <SearchResultsItem {...props}/>
-        ).dive();
+        );
 
         wrapper.find('CommentIcon').prop('handleCommentClick')({preventDefault: jest.fn()});
         expect(selectPost).toHaveBeenCalledTimes(1);
@@ -197,7 +197,7 @@ describe('components/SearchResultsItem', () => {
 
         const wrapper = shallowWithIntl(
             <SearchResultsItem {...props}/>
-        ).dive();
+        );
 
         wrapper.find('.search-item__jump').simulate('click', {preventDefault: jest.fn()});
         expect(setRhsExpanded).toHaveBeenCalledTimes(1);
@@ -213,7 +213,7 @@ describe('components/SearchResultsItem', () => {
 
         const wrapper = shallowWithIntl(
             <SearchResultsItem {...props}/>
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
     });

--- a/components/should_verify_email/should_verify_email.test.js
+++ b/components/should_verify_email/should_verify_email.test.js
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import ShouldVerifyEmail from './should_verify_email';
 
@@ -19,7 +18,7 @@ describe('components/ShouldVerifyEmail', () => {
     };
 
     it('should match snapshot', () => {
-        const wrapper = shallowWithIntl(<ShouldVerifyEmail {...baseProps}/>);
+        const wrapper = shallow(<ShouldVerifyEmail {...baseProps}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -31,7 +30,7 @@ describe('components/ShouldVerifyEmail', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(<ShouldVerifyEmail {...props}/>);
+        const wrapper = shallow(<ShouldVerifyEmail {...props}/>);
         wrapper.find('button').simulate('click');
 
         expect(props.actions.sendVerificationEmail).toHaveBeenCalledWith('test@example.com');

--- a/components/sidebar/sidebar.test.jsx
+++ b/components/sidebar/sidebar.test.jsx
@@ -145,7 +145,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
     test('should match snapshot, on sidebar show', () => {
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -157,7 +157,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
                     favoriteChannelIds: ['c1', 'c3', 'c5'],
                 }}
             />
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -170,7 +170,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
                     showUnreadSection: true,
                 }}
             />
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -183,7 +183,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
                     channelSwitcherOption: true,
                 }}
             />
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -195,7 +195,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
                     currentTeam: null,
                 }}
             />
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
         wrapper = shallowWithIntl(
             <Sidebar
@@ -204,7 +204,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
                     currentUser: null,
                 }}
             />
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -226,7 +226,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
 
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.updateScrollbarOnChannelChange = jest.fn();
         instance.componentDidUpdate = jest.fn();
@@ -315,7 +315,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
 
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.updateScrollbarOnChannelChange = jest.fn();
         instance.updateUnreadIndicators = jest.fn();
@@ -390,7 +390,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
 
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.handleOpenMoreDirectChannelsModal = jest.fn();
         expect(instance.handleOpenMoreDirectChannelsModal).not.toBeCalled();
@@ -409,7 +409,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
     test('set correctly the title when needed', () => {
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.updateTitle();
         instance.componentDidUpdate = jest.fn();
@@ -432,7 +432,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
     test('should show/hide correctly more channels modal', () => {
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.componentDidUpdate = jest.fn();
         instance.showMoreChannelsModal();
@@ -446,7 +446,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
     test('should show/hide correctly new channel modal', () => {
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.componentDidUpdate = jest.fn();
         instance.showNewChannelModal(Constants.PRIVATE_CHANNEL);
@@ -460,7 +460,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
     test('should show/hide correctly more direct channels modal', () => {
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.componentDidUpdate = jest.fn();
         instance.showMoreDirectChannelsModal([]);
@@ -474,7 +474,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
     test('should verify if the channel is displayed for props', () => {
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         expect(instance.channelIdIsDisplayedForProps(instance.props.orderedChannelIds, 'c1')).toBe(true);
         expect(instance.channelIdIsDisplayedForProps(instance.props.orderedChannelIds, 'c9')).toBe(false);
@@ -483,7 +483,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
     test('should handle correctly open more direct channels toggle', () => {
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
         instance.showMoreDirectChannelsModal = jest.fn();
         instance.hideMoreDirectChannelsModal = jest.fn();
@@ -503,7 +503,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
         document.removeEventListener = jest.fn();
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
-        ).dive();
+        );
         const instance = wrapper.instance();
 
         expect(document.addEventListener).toHaveBeenCalledTimes(2);

--- a/components/sidebar/sidebar_channel/sidebar_channel.test.jsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel.test.jsx
@@ -79,7 +79,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
         const props = defaultProps;
         const wrapper = shallowWithIntl(
             <SidebarChannel {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -88,7 +88,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
         const props = {...defaultProps, shouldHideChannel: true};
         const wrapper = shallowWithIntl(
             <SidebarChannel {...props}/>
-        ).dive();
+        );
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -113,7 +113,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStringified: JSON.stringify(channel),
         };
 
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -123,7 +123,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             ...defaultProps,
             active: true,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -134,7 +134,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             currentUserId: 'myself',
             channelTeammateId: 'myself',
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -146,7 +146,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelTeammateId: 'myself',
             hasDraft: true,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -160,7 +160,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelType: Constants.OPEN_CHANNEL,
             channelDisplayName: 'Town Square',
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -171,7 +171,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             membership: {mention_count: 3},
             unreadMentions: 4,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -182,7 +182,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             membership: {mention_count: 3},
             unreadMentions: 0,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -197,7 +197,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -212,7 +212,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -227,7 +227,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -242,7 +242,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -260,7 +260,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -278,7 +278,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -296,7 +296,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -314,7 +314,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelStatus: 'test',
             channelFake: false,
         };
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         expect(wrapper).toMatchSnapshot();
         expect(props.actions.openLhs).not.toBeCalled();
     });
@@ -333,7 +333,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         wrapper.instance().handleLeaveDirectChannel();
         expect(savePreferences).toBeCalledWith('user-id', [{user_id: 'user-id', category: Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: 'teammate-id', value: 'false'}]);
         expect(trackEvent).toBeCalledWith('ui', 'ui_direct_channel_x_button_clicked');
@@ -354,7 +354,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         wrapper.instance().handleLeaveDirectChannel();
         expect(savePreferences).toBeCalledWith('user-id', [{user_id: 'user-id', category: Constants.Preferences.CATEGORY_GROUP_CHANNEL_SHOW, name: 'test-channel-id', value: 'false'}]);
         expect(trackEvent).toBeCalledWith('ui', 'ui_direct_channel_x_button_clicked');
@@ -377,7 +377,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             active: true,
         };
 
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         wrapper.instance().handleLeaveDirectChannel();
         expect(savePreferences).toBeCalledWith('user-id', [{user_id: 'user-id', category: Constants.Preferences.CATEGORY_GROUP_CHANNEL_SHOW, name: 'test-channel-id', value: 'false'}]);
         expect(trackEvent).toBeCalledWith('ui', 'ui_direct_channel_x_button_clicked');
@@ -398,7 +398,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             active: true,
         };
 
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         const instance = wrapper.instance();
         instance.isLeaving = true;
         instance.handleLeaveDirectChannel();
@@ -419,7 +419,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         wrapper.instance().handleLeavePublicChannel();
         expect(leaveChannel).toBeCalledWith('test-channel-id');
         expect(trackEvent).toBeCalledWith('ui', 'ui_public_channel_x_button_clicked');
@@ -435,7 +435,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
             channelDisplayName: 'Channel display name',
         };
 
-        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>).dive();
+        const wrapper = shallowWithIntl(<SidebarChannel {...props}/>);
         wrapper.instance().handleLeavePrivateChannel();
         expect(showLeavePrivateChannelModal).toBeCalledWith({id: 'test-channel-id', display_name: 'Channel display name'});
         expect(trackEvent).toBeCalledWith('ui', 'ui_private_channel_x_button_clicked');

--- a/components/signup/signup_controller/signup_controller.test.jsx
+++ b/components/signup/signup_controller/signup_controller.test.jsx
@@ -1,9 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {browserHistory} from 'utils/browser_history';
 import {Constants} from 'utils/constants';
@@ -47,7 +47,7 @@ describe('components/SignupController', () => {
     };
 
     test('should match snapshot for all signup options enabled with isLicensed enabled', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <SignupController {...baseProps}/>
         );
         expect(wrapper).toMatchSnapshot();
@@ -59,7 +59,7 @@ describe('components/SignupController', () => {
             isLicensed: false,
         };
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <SignupController {...props}/>
         );
         expect(wrapper).toMatchSnapshot();
@@ -83,7 +83,7 @@ describe('components/SignupController', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <SignupController {...props}/>
         );
 
@@ -110,7 +110,7 @@ describe('components/SignupController', () => {
             },
         };
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <SignupController {...props}/>
         );
 

--- a/components/system_notice/system_notice.test.jsx
+++ b/components/system_notice/system_notice.test.jsx
@@ -1,9 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import mattermostIcon from 'images/icon50x50.png';
 
 import SystemNotice from 'components/system_notice/system_notice.jsx';
@@ -27,67 +27,67 @@ describe('components/SystemNotice', () => {
     };
 
     test('should match snapshot for regular user, regular notice', () => {
-        const wrapper = shallowWithIntl(<SystemNotice {...baseProps}/>);
+        const wrapper = shallow(<SystemNotice {...baseProps}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for regular user, no notice', () => {
         const props = {...baseProps, notices: []};
-        const wrapper = shallowWithIntl(<SystemNotice {...props}/>);
+        const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for regular user, admin notice', () => {
         const props = {...baseProps, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true, show: () => true}]};
-        const wrapper = shallowWithIntl(<SystemNotice {...props}/>);
+        const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for regular user, admin and regular notice', () => {
         const props = {...baseProps, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true}, {name: 'notice2', adminOnly: false, title: 'some title2', icon: mattermostIcon, body: 'some body2', allowForget: true, show: () => true}]};
-        const wrapper = shallowWithIntl(<SystemNotice {...props}/>);
+        const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for admin, regular notice', () => {
         const props = {...baseProps, isSystemAdmin: true};
-        const wrapper = shallowWithIntl(<SystemNotice {...props}/>);
+        const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for admin, admin notice', () => {
         const props = {...baseProps, isSystemAdmin: true, notices: [{name: 'notice1', adminOnly: true, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true, show: () => true}]};
-        const wrapper = shallowWithIntl(<SystemNotice {...props}/>);
+        const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for regular user, dismissed notice', () => {
         const props = {...baseProps, dismissedNotices: {notice1: true}};
-        const wrapper = shallowWithIntl(<SystemNotice {...props}/>);
+        const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for regular user, dont show again notice', () => {
         const props = {...baseProps, preferences: {notice1: {}}};
-        const wrapper = shallowWithIntl(<SystemNotice {...props}/>);
+        const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for show function returning false', () => {
         const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true, show: () => false}]};
-        const wrapper = shallowWithIntl(<SystemNotice {...props}/>);
+        const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for show function returning true', () => {
         const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: true, show: () => true}]};
-        const wrapper = shallowWithIntl(<SystemNotice {...props}/>);
+        const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should match snapshot for with allowForget equal false', () => {
         const props = {...baseProps, notices: [{name: 'notice1', adminOnly: false, title: 'some title', icon: mattermostIcon, body: 'some body', allowForget: false, show: () => true}]};
-        const wrapper = shallowWithIntl(<SystemNotice {...props}/>);
+        const wrapper = shallow(<SystemNotice {...props}/>);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/components/team_settings_modal/team_settings_modal.test.jsx
+++ b/components/team_settings_modal/team_settings_modal.test.jsx
@@ -2,21 +2,21 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import TeamSettingsModal from 'components/team_settings_modal/team_settings_modal.jsx';
 
 describe('components/team_settings_modal', () => {
     test('should match snapshot', () => {
-        const wrapper = shallowWithIntl(<TeamSettingsModal/>);
+        const wrapper = shallow(<TeamSettingsModal/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should call onHide callback when the modal is hidden', () => {
         const onHide = jest.fn();
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <TeamSettingsModal
                 onHide={onHide}
             />

--- a/components/tutorial/tutorial_intro_screens/tutorial_intro_screen.test.jsx
+++ b/components/tutorial/tutorial_intro_screens/tutorial_intro_screen.test.jsx
@@ -1,9 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import TutorialIntroScreens from 'components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx';
 import {Constants, Preferences} from 'utils/constants';
@@ -28,7 +27,7 @@ describe('components/tutorial/tutorial_intro_screens/TutorialIntroScreens', () =
     };
 
     test('should match snapshot', () => {
-        const wrapper = shallowWithIntl(<TutorialIntroScreens {...requiredProps}/>);
+        const wrapper = shallow(<TutorialIntroScreens {...requiredProps}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
@@ -36,7 +35,7 @@ describe('components/tutorial/tutorial_intro_screens/TutorialIntroScreens', () =
         const savePreferences = jest.fn();
 
         const props = {...requiredProps, actions: {savePreferences}};
-        const wrapper = shallowWithIntl(<TutorialIntroScreens {...props}/>);
+        const wrapper = shallow(<TutorialIntroScreens {...props}/>);
 
         wrapper.instance().handleNext();
         expect(savePreferences).toHaveBeenCalledTimes(0);
@@ -49,7 +48,7 @@ describe('components/tutorial/tutorial_intro_screens/TutorialIntroScreens', () =
         const savePreferences = jest.fn();
 
         const props = {...requiredProps, actions: {savePreferences}};
-        const wrapper = shallowWithIntl(<TutorialIntroScreens {...props}/>);
+        const wrapper = shallow(<TutorialIntroScreens {...props}/>);
 
         wrapper.instance().handleNext();
         wrapper.instance().handleNext();
@@ -70,7 +69,7 @@ describe('components/tutorial/tutorial_intro_screens/TutorialIntroScreens', () =
         const mockEvent = {preventDefault: jest.fn()};
 
         const props = {...requiredProps};
-        const wrapper = shallowWithIntl(<TutorialIntroScreens {...props}/>);
+        const wrapper = shallow(<TutorialIntroScreens {...props}/>);
 
         wrapper.instance().skipTutorial(mockEvent);
         expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
@@ -81,7 +80,7 @@ describe('components/tutorial/tutorial_intro_screens/TutorialIntroScreens', () =
         const mockEvent = {preventDefault: jest.fn()};
 
         const props = {...requiredProps, actions: {savePreferences}};
-        const wrapper = shallowWithIntl(<TutorialIntroScreens {...props}/>);
+        const wrapper = shallow(<TutorialIntroScreens {...props}/>);
 
         wrapper.instance().skipTutorial(mockEvent);
 

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.test.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.test.jsx
@@ -1,11 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 
 import {Preferences} from 'mattermost-redux/constants';
 
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import CustomThemeChooser from 'components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx';
 
 describe('components/user_settings/display/CustomThemeChooser', () => {
@@ -15,7 +15,7 @@ describe('components/user_settings/display/CustomThemeChooser', () => {
     };
 
     it('should match, init', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <CustomThemeChooser {...baseProps}/>
         );
 
@@ -23,7 +23,7 @@ describe('components/user_settings/display/CustomThemeChooser', () => {
     });
 
     it('should create a custom theme when the code theme changes', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <CustomThemeChooser {...baseProps}/>
         );
 

--- a/components/user_settings/display/user_settings_theme/user_settings_theme.test.jsx
+++ b/components/user_settings/display/user_settings_theme/user_settings_theme.test.jsx
@@ -1,11 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 
 import {Preferences} from 'mattermost-redux/constants';
 
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 import UserSettingsTheme from 'components/user_settings/display/user_settings_theme/user_settings_theme.jsx';
 
 describe('components/user_settings/display/user_settings_theme/user_settings_theme.jsx', () => {
@@ -25,7 +25,7 @@ describe('components/user_settings/display/user_settings_theme/user_settings_the
     };
 
     it('should match snapshot', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <UserSettingsTheme {...requiredProps}/>
         );
 
@@ -33,7 +33,7 @@ describe('components/user_settings/display/user_settings_theme/user_settings_the
     });
 
     it('should saveTheme', async () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <UserSettingsTheme {...requiredProps}/>
         );
 
@@ -57,7 +57,7 @@ describe('components/user_settings/display/user_settings_theme/user_settings_the
             },
         };
 
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <UserSettingsTheme {...props}/>
         );
 

--- a/components/user_settings/general/user_settings_general.test.js
+++ b/components/user_settings/general/user_settings_general.test.js
@@ -46,7 +46,7 @@ describe('components/user_settings/general/UserSettingsGeneral', () => {
     test('submitUser() should have called updateMe', () => {
         const updateMe = jest.fn().mockResolvedValue({data: true});
         const props = {...requiredProps, actions: {...requiredProps.actions, updateMe}};
-        const wrapper = shallowWithIntl(<UserSettingsGeneral {...props}/>).dive();
+        const wrapper = shallowWithIntl(<UserSettingsGeneral {...props}/>);
 
         wrapper.instance().submitUser(requiredProps.currentUser, '');
         expect(updateMe).toHaveBeenCalledTimes(1);
@@ -57,7 +57,7 @@ describe('components/user_settings/general/UserSettingsGeneral', () => {
         const updateMe = jest.fn(() => Promise.resolve({data: true}));
         const getMe = jest.fn();
         const props = {...requiredProps, actions: {...requiredProps.actions, updateMe, getMe}};
-        const wrapper = shallowWithIntl(<UserSettingsGeneral {...props}/>).dive();
+        const wrapper = shallowWithIntl(<UserSettingsGeneral {...props}/>);
 
         await wrapper.instance().submitUser(requiredProps.currentUser, '');
         expect(getMe).toHaveBeenCalledTimes(1);
@@ -67,7 +67,7 @@ describe('components/user_settings/general/UserSettingsGeneral', () => {
     test('submitPicture() should not have called uploadProfileImage', () => {
         const uploadProfileImage = jest.fn().mockResolvedValue({});
         const props = {...requiredProps, actions: {...requiredProps.actions, uploadProfileImage}};
-        const wrapper = shallowWithIntl(<UserSettingsGeneral {...props}/>).dive();
+        const wrapper = shallowWithIntl(<UserSettingsGeneral {...props}/>);
 
         wrapper.instance().submitPicture(requiredProps.currentUser, '');
         expect(uploadProfileImage).toHaveBeenCalledTimes(0);
@@ -76,7 +76,7 @@ describe('components/user_settings/general/UserSettingsGeneral', () => {
     test('submitPicture() should have called uploadProfileImage', async () => {
         const uploadProfileImage = jest.fn(() => Promise.resolve({data: true}));
         const props = {...requiredProps, actions: {...requiredProps.actions, uploadProfileImage}};
-        const wrapper = shallowWithIntl(<UserSettingsGeneral {...props}/>).dive();
+        const wrapper = shallowWithIntl(<UserSettingsGeneral {...props}/>);
 
         const mockFile = {type: 'image/jpeg', size: requiredProps.maxFileSize};
         const event = {target: {files: [mockFile]}};

--- a/components/user_settings/security/mfa_section/mfa_section.test.jsx
+++ b/components/user_settings/security/mfa_section/mfa_section.test.jsx
@@ -3,10 +3,11 @@
 
 jest.mock('utils/browser_history');
 
+import {shallow} from 'enzyme';
 import React from 'react';
 
 import MfaSection from 'components/user_settings/security/mfa_section/mfa_section';
-import {mountWithIntl, shallowWithIntl} from 'tests/helpers/intl-test-helper';
+import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 import {browserHistory} from 'utils/browser_history';
 
 describe('MfaSection', () => {
@@ -27,7 +28,7 @@ describe('MfaSection', () => {
                 ...baseProps,
                 mfaAvailable: false,
             };
-            const wrapper = shallowWithIntl(<MfaSection {...props}/>);
+            const wrapper = shallow(<MfaSection {...props}/>);
 
             expect(wrapper).toMatchSnapshot();
         });
@@ -38,7 +39,7 @@ describe('MfaSection', () => {
                 active: false,
                 mfaActive: false,
             };
-            const wrapper = shallowWithIntl(<MfaSection {...props}/>);
+            const wrapper = shallow(<MfaSection {...props}/>);
 
             expect(wrapper).toMatchSnapshot();
         });
@@ -49,7 +50,7 @@ describe('MfaSection', () => {
                 active: false,
                 mfaActive: true,
             };
-            const wrapper = shallowWithIntl(<MfaSection {...props}/>);
+            const wrapper = shallow(<MfaSection {...props}/>);
 
             expect(wrapper).toMatchSnapshot();
         });
@@ -59,7 +60,7 @@ describe('MfaSection', () => {
                 ...baseProps,
                 mfaActive: false,
             };
-            const wrapper = shallowWithIntl(<MfaSection {...props}/>);
+            const wrapper = shallow(<MfaSection {...props}/>);
 
             expect(wrapper).toMatchSnapshot();
         });
@@ -69,7 +70,7 @@ describe('MfaSection', () => {
                 ...baseProps,
                 mfaActive: true,
             };
-            const wrapper = shallowWithIntl(<MfaSection {...props}/>);
+            const wrapper = shallow(<MfaSection {...props}/>);
 
             expect(wrapper).toMatchSnapshot();
         });
@@ -80,7 +81,7 @@ describe('MfaSection', () => {
                 mfaActive: true,
                 mfaEnforced: true,
             };
-            const wrapper = shallowWithIntl(<MfaSection {...props}/>);
+            const wrapper = shallow(<MfaSection {...props}/>);
 
             expect(wrapper).toMatchSnapshot();
         });
@@ -90,7 +91,7 @@ describe('MfaSection', () => {
                 ...baseProps,
                 serverError: 'An error occurred',
             };
-            const wrapper = shallowWithIntl(<MfaSection {...props}/>);
+            const wrapper = shallow(<MfaSection {...props}/>);
 
             wrapper.setState({serverError: 'An error has occurred'});
 

--- a/components/user_settings/sidebar/user_settings_sidebar.test.jsx
+++ b/components/user_settings/sidebar/user_settings_sidebar.test.jsx
@@ -1,11 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
 import PropTypes from 'prop-types';
 import configureStore from 'redux-mock-store';
 
-import {mountWithIntl, shallowWithIntl} from 'tests/helpers/intl-test-helper';
+import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 
 import UserSettingsSidebar from 'components/user_settings/sidebar/user_settings_sidebar.jsx';
 
@@ -43,7 +44,7 @@ describe('components/user_settings/sidebar/UserSettingsSidebar', () => {
     const store = mockStore(state);
 
     test('should match snapshot', () => {
-        const wrapper = shallowWithIntl(<UserSettingsSidebar {...defaultProps}/>);
+        const wrapper = shallow(<UserSettingsSidebar {...defaultProps}/>);
 
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.state('isSaving')).toEqual(false);
@@ -61,7 +62,7 @@ describe('components/user_settings/sidebar/UserSettingsSidebar', () => {
         const newUpdateSection = jest.fn();
         const updateArg = 'unreadChannels';
         const props = {...defaultProps, updateSection: newUpdateSection};
-        const wrapper = shallowWithIntl(<UserSettingsSidebar {...props}/>);
+        const wrapper = shallow(<UserSettingsSidebar {...props}/>);
 
         wrapper.setState({isSaving: true,
             settings: {

--- a/components/widgets/inputs/channels_input.test.jsx
+++ b/components/widgets/inputs/channels_input.test.jsx
@@ -1,15 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import ChannelsInput from './channels_input.jsx';
 
 describe('components/widgets/inputs/ChannelsInput', () => {
     test('should match snapshot', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <ChannelsInput
                 placeholder='test'
                 ariaLabel='test'

--- a/components/widgets/inputs/users_emails_input.test.jsx
+++ b/components/widgets/inputs/users_emails_input.test.jsx
@@ -1,15 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import UsersEmailsInput from './users_emails_input.jsx';
 
 describe('components/widgets/inputs/UsersEmailsInput', () => {
     test('should match snapshot', () => {
-        const wrapper = shallowWithIntl(
+        const wrapper = shallow(
             <UsersEmailsInput
                 placeholder='test'
                 ariaLabel='test'

--- a/components/widgets/loading/loading_spinner.test.tsx
+++ b/components/widgets/loading/loading_spinner.test.tsx
@@ -1,15 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {shallow} from 'enzyme';
 import React from 'react';
-
-import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import LoadingSpinner from './loading_spinner';
 
 describe('components/widgets/loadingLoadingSpinner', () => {
     test('showing spinner with text', () => {
-        const wrapper = shallowWithIntl(<LoadingSpinner text='test'/>);
+        const wrapper = shallow(<LoadingSpinner text='test'/>);
         expect(wrapper).toMatchInlineSnapshot(`
 <span
   className="LoadingSpinner with-text"
@@ -30,7 +29,7 @@ describe('components/widgets/loadingLoadingSpinner', () => {
 `);
     });
     test('showing spinner without text', () => {
-        const wrapper = shallowWithIntl(<LoadingSpinner/>);
+        const wrapper = shallow(<LoadingSpinner/>);
         expect(wrapper).toMatchInlineSnapshot(`
 <span
   className="LoadingSpinner"

--- a/components/widgets/modals/full_screen_modal.tsx
+++ b/components/widgets/modals/full_screen_modal.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import {CSSTransition} from 'react-transition-group';
-import {intlShape} from 'react-intl';
+import {injectIntl} from 'react-intl';
 
 import CloseIcon from 'components/widgets/icons/close_icon';
 import BackIcon from 'components/widgets/icons/back_icon';
@@ -20,14 +20,11 @@ type Props = {
     children: React.ReactNode;
     ariaLabel?: string;
     ariaLabelledBy?: string;
+    intl: any; // TODO This needs to be replaced with IntlShape once react-intl is upgraded
 };
 
-export default class FullScreenModal extends React.Component<Props> {
+class FullScreenModal extends React.Component<Props> {
     private modal = React.createRef<HTMLDivElement>();
-
-    public static contextTypes = {
-        intl: intlShape.isRequired,
-    };
 
     public componentDidMount() {
         document.addEventListener('keydown', this.handleKeypress);
@@ -91,14 +88,14 @@ export default class FullScreenModal extends React.Component<Props> {
                             <button
                                 onClick={this.props.onGoBack}
                                 className='back'
-                                aria-label={this.context.intl.formatMessage({id: 'full_screen_modal.back', defaultMessage: 'Back'})}
+                                aria-label={this.props.intl.formatMessage({id: 'full_screen_modal.back', defaultMessage: 'Back'})}
                             >
                                 <BackIcon id='backIcon'/>
                             </button>}
                         <button
                             onClick={this.close}
                             className='close-x'
-                            aria-label={this.context.intl.formatMessage({id: 'full_screen_modal.close', defaultMessage: 'Close'})}
+                            aria-label={this.props.intl.formatMessage({id: 'full_screen_modal.close', defaultMessage: 'Close'})}
                         >
                             <CloseIcon id='closeIcon'/>
                         </button>
@@ -113,3 +110,5 @@ export default class FullScreenModal extends React.Component<Props> {
         );
     }
 }
+
+export default injectIntl(FullScreenModal);

--- a/plugins/test/main_menu_action.test.jsx
+++ b/plugins/test/main_menu_action.test.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 
 import MainMenu from 'components/main_menu/main_menu.jsx';
+
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 describe('plugins/MainMenuActions', () => {
@@ -43,7 +44,7 @@ describe('plugins/MainMenuActions', () => {
             <MainMenu
                 {...requiredProps}
             />
-        ).dive();
+        );
 
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.findWhere((node) => node.key() === 'someplugin_pluginmenuitem').props().text).toBe('some plugin text');

--- a/tests/helpers/intl-test-helper.jsx
+++ b/tests/helpers/intl-test-helper.jsx
@@ -10,10 +10,22 @@ import {intlShape} from 'utils/react_intl';
 const intlProvider = new IntlProvider({locale: 'en', timeZone: 'Etc/UTC'}, {});
 const {intl} = intlProvider.getChildContext();
 
+export function isIntlInjectedElement(element) {
+    const {type} = element;
+    if (typeof type === 'function' && type.name === 'InjectIntl') {
+        return true;
+    }
+    return false;
+}
+
 export function shallowWithIntl(node, {context} = {}) {
+    if (!isIntlInjectedElement(node)) {
+        throw new Error('shallowWithIntl() allows only components wrapped by injectIntl() HOC. Use shallow() instead.');
+    }
+
     return shallow(React.cloneElement(node, {intl}), {
         context: Object.assign({}, context, {intl}),
-    });
+    }).dive();
 }
 
 export function mountWithIntl(node, {context, childContextTypes} = {}) {


### PR DESCRIPTION
`shallowWithIntl` only needs to be used on components that are wrapped with `injectIntl`, and `dive` is needed for all `shallowWithIntl` calls, so it's now called automatically.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17555

#### Related Pull Requests
Part of https://github.com/mattermost/mattermost-webapp/pull/4615