### PR TITLE
MM-17555 Update tests that use string refs

### DIFF
--- a/components/change_url_modal/change_url_modal.test.jsx
+++ b/components/change_url_modal/change_url_modal.test.jsx
@@ -65,7 +65,7 @@ describe('components/ChangeURLModal', () => {
         const wrapper = mountWithIntl(
             <ChangeURLModal {...baseProps}/>
         );
-        const refURLInput = wrapper.ref('urlinput');
+        const refURLInput = wrapper.find('input[type="text"]').instance();
         refURLInput.value = 'urlexample';
 
         wrapper.instance().onSubmit({preventDefault: jest.fn()});
@@ -78,7 +78,7 @@ describe('components/ChangeURLModal', () => {
         const wrapper = mountWithIntl(
             <ChangeURLModal {...baseProps}/>
         );
-        const refURLInput = wrapper.ref('urlinput');
+        const refURLInput = wrapper.find('input[type="text"]').instance();
         refURLInput.value = value;
 
         wrapper.instance().onSubmit({preventDefault: jest.fn()});

--- a/components/channel_header_mobile/channel_info_button/channel_info_button.test.js
+++ b/components/channel_header_mobile/channel_info_button/channel_info_button.test.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {OverlayTrigger} from 'react-bootstrap';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 
@@ -26,10 +27,13 @@ describe('components/ChannelHeaderMobile/ChannelInfoButton', () => {
 
         expect(wrapper).toMatchSnapshot();
 
-        const ref = wrapper.ref('headerOverlay');
-        ref.hide = jest.fn();
+        const hide = jest.fn();
+
+        const ref = wrapper.find(OverlayTrigger);
+        ref.instance().hide = hide;
         wrapper.instance().hide();
-        expect(ref.hide).toBeCalled();
+
+        expect(hide).toBeCalled();
     });
 
     test('should match snapshot, without channel header', () => {
@@ -40,11 +44,13 @@ describe('components/ChannelHeaderMobile/ChannelInfoButton', () => {
 
         expect(wrapper).toMatchSnapshot();
 
-        const ref = wrapper.ref('headerOverlay');
-        ref.hide = jest.fn();
+        const hide = jest.fn();
+
+        const ref = wrapper.find(OverlayTrigger);
+        ref.instance().hide = hide;
         wrapper.instance().showEditChannelHeaderModal();
 
-        expect(ref.hide).toBeCalled();
+        expect(hide).toBeCalled();
         expect(props.actions.openModal).toBeCalled();
     });
 });


### PR DESCRIPTION
These tests that use string refs will break when react-intl is upgraded, so I modified them slightly to not use the refs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17555

#### Related Pull Requests
Part of https://github.com/mattermost/mattermost-webapp/pull/4615