### PR TITLE
MM-17555 Add dummy OverlayTrigger component

### DIFF
--- a/components/admin_console/brand_image_setting/brand_image_setting.jsx
+++ b/components/admin_console/brand_image_setting/brand_image_setting.jsx
@@ -5,12 +5,13 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedHTMLMessage, FormattedMessage} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {Client4} from 'mattermost-redux/client';
 
 import {uploadBrandImage, deleteBrandImage} from 'actions/admin_actions.jsx';
 import {Constants} from 'utils/constants';
 import FormError from 'components/form_error';
+import OverlayTrigger from 'components/overlay_trigger';
 
 const HTTP_STATUS_OK = 200;
 

--- a/components/admin_console/permission_schemes_settings/permissions_scheme_summary/permissions_scheme_summary.jsx
+++ b/components/admin_console/permission_schemes_settings/permissions_scheme_summary/permissions_scheme_summary.jsx
@@ -4,10 +4,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Link} from 'react-router-dom';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import ConfirmModal from 'components/confirm_modal.jsx';
+import OverlayTrigger from 'components/overlay_trigger';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
 
 import * as Utils from 'utils/utils.jsx';

--- a/components/admin_console/team_channel_settings/group/group_users_row.jsx
+++ b/components/admin_console/team_channel_settings/group/group_users_row.jsx
@@ -6,11 +6,12 @@ import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 
 import {Client4} from 'mattermost-redux/client';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 
 import {t} from 'utils/i18n';
 import * as Utils from 'utils/utils';
 
+import OverlayTrigger from 'components/overlay_trigger';
 import Avatar from 'components/widgets/users/avatar';
 
 export default class AdminGroupUsersRow extends React.PureComponent {

--- a/components/analytics/table_chart.tsx
+++ b/components/analytics/table_chart.tsx
@@ -2,7 +2,9 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants from 'utils/constants';
 

--- a/components/announcement_bar/announcement_bar.jsx
+++ b/components/announcement_bar/announcement_bar.jsx
@@ -3,10 +3,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Tooltip, OverlayTrigger} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 
 import {Constants, AnnouncementBarTypes} from 'utils/constants';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
+import OverlayTrigger from 'components/overlay_trigger';
 
 export default class AnnouncementBar extends React.PureComponent {
     static propTypes = {

--- a/components/change_url_modal/change_url_modal.jsx
+++ b/components/change_url_modal/change_url_modal.jsx
@@ -3,8 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Modal, OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Modal, Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants from 'utils/constants';
 import {getShortenedURL, cleanUpUrlable} from 'utils/url';

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage, injectIntl} from 'react-intl';
 import {Permissions} from 'mattermost-redux/constants';
 import {memoizeResult} from 'mattermost-redux/utils/helpers';
@@ -12,6 +12,7 @@ import 'bootstrap';
 
 import EditChannelHeaderModal from 'components/edit_channel_header_modal';
 import Markdown from 'components/markdown';
+import OverlayTrigger from 'components/overlay_trigger';
 import PopoverListMembers from 'components/popover_list_members';
 import SearchBar from 'components/search_bar';
 import StatusIcon from 'components/status_icon';

--- a/components/channel_header/components/header_icon_wrapper.js
+++ b/components/channel_header/components/header_icon_wrapper.js
@@ -4,7 +4,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import {localizeMessage} from 'utils/utils.jsx';
 import {Constants} from 'utils/constants';

--- a/components/channel_header_mobile/channel_info_button/channel_info_button.js
+++ b/components/channel_header_mobile/channel_info_button/channel_info_button.js
@@ -3,7 +3,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import {ModalIdentifiers} from 'utils/constants';
@@ -11,6 +10,7 @@ import {localizeMessage} from 'utils/utils.jsx';
 
 import EditChannelHeaderModal from 'components/edit_channel_header_modal';
 import Markdown from 'components/markdown';
+import OverlayTrigger from 'components/overlay_trigger';
 import InfoIcon from 'components/widgets/icons/info_icon';
 import Popover from 'components/widgets/popover';
 const headerMarkdownOptions = {mentionHighlight: false};

--- a/components/common/comment_icon.tsx
+++ b/components/common/comment_icon.tsx
@@ -2,11 +2,12 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import {localizeMessage} from 'utils/utils.jsx';
 
+import OverlayTrigger from 'components/overlay_trigger';
 import ReplyIcon from 'components/widgets/icons/reply_icon';
 
 type Props = {

--- a/components/copy_text.tsx
+++ b/components/copy_text.tsx
@@ -3,7 +3,9 @@
 
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants from 'utils/constants';
 import {copyToClipboard} from 'utils/utils.jsx';

--- a/components/create_team/components/team_url/team_url.jsx
+++ b/components/create_team/components/team_url/team_url.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Button, OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Button, Tooltip} from 'react-bootstrap';
 import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
@@ -13,6 +13,7 @@ import * as URL from 'utils/url';
 import logoImage from 'images/logo.png';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
+import OverlayTrigger from 'components/overlay_trigger';
 
 export default class TeamUrl extends React.PureComponent {
     static propTypes = {

--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -4,13 +4,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 
 import Permissions from 'mattermost-redux/constants/permissions';
 
 import {showGetPostLinkModal} from 'actions/global_actions.jsx';
 import {Locations, ModalIdentifiers, Constants} from 'utils/constants';
 import DeletePostModal from 'components/delete_post_modal';
+import OverlayTrigger from 'components/overlay_trigger';
 import DelayedAction from 'utils/delayed_action';
 import * as PostUtils from 'utils/post_utils.jsx';
 import * as Utils from 'utils/utils.jsx';

--- a/components/file_attachment/filename_overlay.jsx
+++ b/components/file_attachment/filename_overlay.jsx
@@ -3,9 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
 
+import OverlayTrigger from 'components/overlay_trigger';
 import AttachmentIcon from 'components/widgets/icons/attachment_icon';
 import {trimFilename} from 'utils/file_utils';
 import {localizeMessage} from 'utils/utils.jsx';

--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router-dom';
 import {FormattedMessage} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 
 import * as UserUtils from 'mattermost-redux/utils/user_utils';
 import {General} from 'mattermost-redux/constants';
@@ -14,6 +14,7 @@ import BotDefaultIcon from 'images/bot_default_icon.png';
 
 import {browserHistory} from 'utils/browser_history';
 import BackstageHeader from 'components/backstage/components/backstage_header.jsx';
+import OverlayTrigger from 'components/overlay_trigger';
 import SpinnerButton from 'components/spinner_button';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 import FormError from 'components/form_error';

--- a/components/overlay_trigger.tsx
+++ b/components/overlay_trigger.tsx
@@ -1,0 +1,9 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// This dummy component will be replaced by a functional one when react-intl is upgrade. For now, it just exists
+// to reduce the size of eventual diff of that upgrade.
+
+import {OverlayTrigger as BaseOverlayTrigger} from 'react-bootstrap';
+
+export default BaseOverlayTrigger;

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.js
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import {Tooltip, OverlayTrigger} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import semver from 'semver';
 
 import {FormattedMessage, FormattedHTMLMessage} from 'react-intl';
@@ -12,6 +12,7 @@ import {FormattedMessage, FormattedHTMLMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 
 import ConfirmModal from 'components/confirm_modal.jsx';
+import OverlayTrigger from 'components/overlay_trigger';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper.tsx';
 import PluginIcon from 'components/widgets/icons/plugin_icon.jsx';
 

--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Overlay, OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Overlay, Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import {browserHistory} from 'utils/browser_history';
@@ -12,6 +12,7 @@ import {Constants} from 'utils/constants';
 import * as Utils from 'utils/utils.jsx';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import ChannelMembersModal from 'components/channel_members_modal';
+import OverlayTrigger from 'components/overlay_trigger';
 import MemberIcon from 'components/widgets/icons/member_icon';
 import Popover from 'components/widgets/popover';
 import TeamMembersModal from 'components/team_members_modal';

--- a/components/post_view/post_flag_icon/post_flag_icon.js
+++ b/components/post_view/post_flag_icon/post_flag_icon.js
@@ -3,9 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
+import OverlayTrigger from 'components/overlay_trigger';
 import FlagIcon from 'components/widgets/icons/flag_icon';
 import FlagIconFilled from 'components/widgets/icons/flag_icon_filled';
 import Constants, {Locations, A11yCustomEventTypes} from 'utils/constants';

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 
 import {Posts} from 'mattermost-redux/constants';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
@@ -14,6 +14,7 @@ import * as Utils from 'utils/utils.jsx';
 import Constants from 'utils/constants';
 import CommentIcon from 'components/common/comment_icon';
 import DotMenu from 'components/dot_menu';
+import OverlayTrigger from 'components/overlay_trigger';
 import PostFlagIcon from 'components/post_view/post_flag_icon';
 import PostReaction from 'components/post_view/post_reaction';
 import PostTime from 'components/post_view/post_time';

--- a/components/post_view/post_reaction/post_reaction.jsx
+++ b/components/post_view/post_reaction/post_reaction.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import Permissions from 'mattermost-redux/constants/permissions';
@@ -11,6 +11,7 @@ import Permissions from 'mattermost-redux/constants/permissions';
 import {Locations} from 'utils/constants';
 import {localizeMessage} from 'utils/utils.jsx';
 
+import OverlayTrigger from 'components/overlay_trigger';
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 import EmojiIcon from 'components/widgets/icons/emoji_icon';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';

--- a/components/post_view/reaction/reaction.jsx
+++ b/components/post_view/reaction/reaction.jsx
@@ -3,8 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import * as Utils from 'utils/utils.jsx';
 

--- a/components/post_view/reaction_list/reaction_list.jsx
+++ b/components/post_view/reaction_list/reaction_list.jsx
@@ -3,13 +3,14 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import Permissions from 'mattermost-redux/constants/permissions';
 
 import Constants from 'utils/constants';
 import Reaction from 'components/post_view/reaction';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
+import OverlayTrigger from 'components/overlay_trigger';
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 import {localizeMessage} from 'utils/utils.jsx';
 

--- a/components/profile_picture.tsx
+++ b/components/profile_picture.tsx
@@ -2,8 +2,8 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {OverlayTrigger} from 'react-bootstrap';
 
+import OverlayTrigger from 'components/overlay_trigger';
 import ProfilePopover from 'components/profile_popover';
 import StatusIcon from 'components/status_icon';
 import Avatar from 'components/widgets/users/avatar';

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -3,12 +3,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage, injectIntl} from 'react-intl';
 
 import EventEmitter from 'mattermost-redux/utils/event_emitter';
 
 import LocalDateTime from 'components/local_date_time';
+import OverlayTrigger from 'components/overlay_trigger';
 import UserSettingsModal from 'components/user_settings/modal';
 import {browserHistory} from 'utils/browser_history';
 import * as GlobalActions from 'actions/global_actions.jsx';

--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -4,7 +4,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants from 'utils/constants.jsx';
 

--- a/components/rename_channel_modal/rename_channel_modal.jsx
+++ b/components/rename_channel_modal/rename_channel_modal.jsx
@@ -3,10 +3,11 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Modal, OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Modal, Tooltip} from 'react-bootstrap';
 import {defineMessages, FormattedMessage, injectIntl} from 'react-intl';
 
 import LocalizedInput from 'components/localized_input/localized_input';
+import OverlayTrigger from 'components/overlay_trigger';
 import {browserHistory} from 'utils/browser_history';
 import Constants from 'utils/constants.jsx';
 import {intlShape} from 'utils/react_intl';

--- a/components/rhs_card_header/rhs_card_header.jsx
+++ b/components/rhs_card_header/rhs_card_header.jsx
@@ -3,8 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants, {RHSStates} from 'utils/constants';
 

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage, injectIntl} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {Posts} from 'mattermost-redux/constants/index';
 import {
     isPostEphemeral,
@@ -17,6 +17,7 @@ import {intlShape} from 'utils/react_intl';
 import {isMobile} from 'utils/utils.jsx';
 import DotMenu from 'components/dot_menu';
 import FileAttachmentListContainer from 'components/file_attachment_list';
+import OverlayTrigger from 'components/overlay_trigger';
 import PostProfilePicture from 'components/post_profile_picture';
 import FailedPostOptions from 'components/post_view/failed_post_options';
 import PostFlagIcon from 'components/post_view/post_flag_icon';

--- a/components/rhs_header_post/rhs_header_post.jsx
+++ b/components/rhs_header_post/rhs_header_post.jsx
@@ -3,8 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants, {RHSStates} from 'utils/constants';
 

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {FormattedMessage, injectIntl} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {Posts} from 'mattermost-redux/constants';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
 
@@ -14,6 +14,7 @@ import {intlShape} from 'utils/react_intl';
 import * as Utils from 'utils/utils.jsx';
 import DotMenu from 'components/dot_menu';
 import FileAttachmentListContainer from 'components/file_attachment_list';
+import OverlayTrigger from 'components/overlay_trigger';
 import PostProfilePicture from 'components/post_profile_picture';
 import PostFlagIcon from 'components/post_view/post_flag_icon';
 import ReactionList from 'components/post_view/reaction_list';

--- a/components/search_results_header/search_results_header.jsx
+++ b/components/search_results_header/search_results_header.jsx
@@ -3,8 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants from 'utils/constants';
 

--- a/components/search_results_item/search_results_item.jsx
+++ b/components/search_results_item/search_results_item.jsx
@@ -6,12 +6,13 @@ import PropTypes from 'prop-types';
 import {FormattedMessage, injectIntl} from 'react-intl';
 import {Posts} from 'mattermost-redux/constants/index';
 import * as ReduxPostUtils from 'mattermost-redux/utils/post_utils';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 
 import PostMessageContainer from 'components/post_view/post_message_view';
 import FileAttachmentListContainer from 'components/file_attachment_list';
 import CommentIcon from 'components/common/comment_icon';
 import DotMenu from 'components/dot_menu';
+import OverlayTrigger from 'components/overlay_trigger';
 import PostProfilePicture from 'components/post_profile_picture';
 import UserProfile from 'components/user_profile';
 import DateSeparator from 'components/post_view/date_separator';

--- a/components/select_team/components/select_team_item.jsx
+++ b/components/select_team/components/select_team_item.jsx
@@ -3,9 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 
 import LocalizedIcon from 'components/localized_icon';
+import OverlayTrigger from 'components/overlay_trigger';
 import TeamInfoIcon from 'components/widgets/icons/team_info_icon';
 
 import {t} from 'utils/i18n';

--- a/components/setting_picture.jsx
+++ b/components/setting_picture.jsx
@@ -4,16 +4,16 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {FormattedMessage} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 
 import {Constants} from 'utils/constants';
 import {fileSizeToString, localizeMessage} from 'utils/utils.jsx';
 import * as FileUtils from 'utils/file_utils.jsx';
 
-import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
 import FormError from 'components/form_error';
-
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
+import OverlayTrigger from 'components/overlay_trigger';
+import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
 
 export default class SettingPicture extends Component {
     static defaultProps = {

--- a/components/sidebar/channel_create.jsx
+++ b/components/sidebar/channel_create.jsx
@@ -2,9 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import {PropTypes} from 'prop-types';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import * as Utils from 'utils/utils.jsx';
 

--- a/components/sidebar/channel_name.jsx
+++ b/components/sidebar/channel_name.jsx
@@ -3,8 +3,10 @@
 
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {PropTypes} from 'prop-types';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';

--- a/components/sidebar/header/sidebar_header_dropdown_button.jsx
+++ b/components/sidebar/header/sidebar_header_dropdown_button.jsx
@@ -3,10 +3,11 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import {localizeMessage} from 'utils/utils.jsx';
+import OverlayTrigger from 'components/overlay_trigger';
 import MenuIcon from 'components/widgets/icons/menu_icon';
 import Constants from 'utils/constants';
 

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Link} from 'react-router-dom';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 
 import {localizeMessage} from 'utils/utils.jsx';
 import {browserHistory} from 'utils/browser_history';
@@ -12,6 +12,7 @@ import {mark, trackEvent} from 'actions/diagnostics_actions.jsx';
 import {isDesktopApp} from 'utils/user_agent';
 import Constants from 'utils/constants';
 import CopyUrlContextMenu from 'components/copy_url_context_menu';
+import OverlayTrigger from 'components/overlay_trigger';
 
 import SidebarChannelButtonOrLinkIcon from './sidebar_channel_button_or_link_icon.jsx';
 import SidebarChannelButtonOrLinkCloseButton from './sidebar_channel_button_or_link_close_button.jsx';

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.test.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.test.jsx
@@ -3,7 +3,9 @@
 
 import React from 'react';
 import {shallow} from 'enzyme';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import {Constants} from 'utils/constants';
 import SidebarChannelButtonOrLink from 'components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx';

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link_close_button.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link_close_button.jsx
@@ -2,9 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import {Constants} from 'utils/constants';
 

--- a/components/team_sidebar/components/team_button.jsx
+++ b/components/team_sidebar/components/team_button.jsx
@@ -3,7 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {Tooltip} from 'react-bootstrap';
 import {injectIntl} from 'react-intl';
 import {Link} from 'react-router-dom';
 
@@ -13,6 +13,7 @@ import {intlShape} from 'utils/react_intl';
 import {isDesktopApp} from 'utils/user_agent';
 import {localizeMessage} from 'utils/utils.jsx';
 import CopyUrlContextMenu from 'components/copy_url_context_menu';
+import OverlayTrigger from 'components/overlay_trigger';
 import TeamIcon from '../../widgets/team_icon/team_icon';
 
 // eslint-disable-next-line react/require-optimization

--- a/components/user_profile/user_profile.jsx
+++ b/components/user_profile/user_profile.jsx
@@ -3,10 +3,10 @@
 
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
-import {OverlayTrigger} from 'react-bootstrap';
 
 import {imageURLForUser, isMobile, isGuest} from 'utils/utils.jsx';
 
+import OverlayTrigger from 'components/overlay_trigger';
 import ProfilePopover from 'components/profile_popover';
 import BotBadge from 'components/widgets/badges/bot_badge';
 import GuestBadge from 'components/widgets/badges/guest_badge';

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -4,7 +4,6 @@
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {OverlayTrigger} from 'react-bootstrap';
 import {defineMessages, FormattedMessage} from 'react-intl';
 
 import {t} from 'utils/i18n';
@@ -14,6 +13,7 @@ import Constants from 'utils/constants';
 import * as UserAgent from 'utils/user_agent';
 
 import LocalizedIcon from 'components/localized_icon';
+import OverlayTrigger from 'components/overlay_trigger';
 import Popover from 'components/widgets/popover';
 
 import ColorChooser from './color_chooser.jsx';

--- a/components/widgets/popover/popover.stories.js
+++ b/components/widgets/popover/popover.stories.js
@@ -5,7 +5,8 @@ import React from 'react';
 
 import {storiesOf} from '@storybook/react';
 import {text, withKnobs} from '@storybook/addon-knobs';
-import {OverlayTrigger} from 'react-bootstrap';
+
+import OverlayTrigger from 'components/overlay_trigger';
 
 import Popover from '.';
 


### PR DESCRIPTION
We need to add our own OverlayTrigger as part of the react-intl upgrade. This PR adds the file for our custom OverlayTrigger, but that just points back to the one provided by react-bootstrap for now.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17555

#### Related Pull Requests
Part of https://github.com/mattermost/mattermost-webapp/pull/4615