### PR TITLE
MM-20622 Only wrap code without a language tag

### DIFF
--- a/utils/markdown/index.test.js
+++ b/utils/markdown/index.test.js
@@ -30,4 +30,28 @@ describe('format', () => {
 
         expect(output).not.toContain('<span class="post-code__language">');
     });
+
+    test('should wrap code without a language tag', () => {
+        const output = format(`~~~
+this is long text this is long text this is long text this is long text this is long text this is long text
+~~~`);
+
+        expect(output).toContain('post-code--wrap');
+    });
+
+    test('should not wrap code with a valid language tag', () => {
+        const output = format(`~~~java
+this is long text this is long text this is long text this is long text this is long text this is long text
+~~~`);
+
+        expect(output).not.toContain('post-code--wrap');
+    });
+
+    test('should not wrap code with an invalid language', () => {
+        const output = format(`~~~nowrap
+this is long text this is long text this is long text this is long text this is long text this is long text
+~~~`);
+
+        expect(output).not.toContain('post-code--wrap');
+    });
 });

--- a/utils/markdown/renderer.jsx
+++ b/utils/markdown/renderer.jsx
@@ -33,10 +33,13 @@ export default class Renderer extends marked.Renderer {
         }
 
         let className = 'post-code';
-        let codeClassName = 'hljs hljs-ln';
-        if (!SyntaxHighlighting.canHighlight(usedLanguage)) {
+        let codeClassName = 'hljs';
+        if (!usedLanguage) {
             className += ' post-code--wrap';
-            codeClassName = 'hljs';
+        }
+
+        if (SyntaxHighlighting.canHighlight(usedLanguage)) {
+            codeClassName = 'hljs hljs-ln';
         }
 
         let header = '';


### PR DESCRIPTION
Basically, this makes it so that there's 3 cases for the code block:
1. If there's no language tag, the text wraps. This matches the old behaviour.
    ```
    this doesn't wrap
    ```
2. If there's a valid language tag, the text wraps and shows line numbers. This is the relatively new behaviour added in 5.18
    ```java
    this.doesnt("wrap").andHas("lineNumbers");
    ```
3. If there's an invalid language tag, the text doesn't wrap or show line numbers. This matches the old behaviour.
    ```nowrap
    this doesn't wrap or have line numbers
    ```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20622