### PR TITLE
Automated cherry pick of #4650

### DIFF
--- a/components/post_view/date_separator/__snapshots__/date_separator.test.jsx.snap
+++ b/components/post_view/date_separator/__snapshots__/date_separator.test.jsx.snap
@@ -44,7 +44,7 @@ exports[`components/post_view/DateSeparator should render date with timezone ena
       <div
         className="separator__text"
       >
-        <RecentDate
+        <InjectIntl(RecentDate)
           day="2-digit"
           month="short"
           timeZone="Australia/Sydney"
@@ -52,8 +52,44 @@ exports[`components/post_view/DateSeparator should render date with timezone ena
           weekday="short"
           year="numeric"
         >
-          Sat, Jan 13, 2018
-        </RecentDate>
+          <RecentDate
+            day="2-digit"
+            intl={
+              Object {
+                "defaultFormats": Object {},
+                "defaultLocale": "en",
+                "formatDate": [Function],
+                "formatHTMLMessage": [Function],
+                "formatMessage": [Function],
+                "formatNumber": [Function],
+                "formatPlural": [Function],
+                "formatRelative": [Function],
+                "formatTime": [Function],
+                "formats": Object {},
+                "formatters": Object {
+                  "getDateTimeFormat": [Function],
+                  "getMessageFormat": [Function],
+                  "getNumberFormat": [Function],
+                  "getPluralFormat": [Function],
+                  "getRelativeFormat": [Function],
+                },
+                "locale": "en",
+                "messages": Object {},
+                "now": [Function],
+                "onError": [Function],
+                "textComponent": "span",
+                "timeZone": "Etc/UTC",
+              }
+            }
+            month="short"
+            timeZone="Australia/Sydney"
+            value={2018-01-12T20:15:13.000Z}
+            weekday="short"
+            year="numeric"
+          >
+            Sat, Jan 13, 2018
+          </RecentDate>
+        </InjectIntl(RecentDate)>
       </div>
     </div>
   </BasicSeparator>
@@ -102,15 +138,50 @@ exports[`components/post_view/DateSeparator should render date without timezone 
       <div
         className="separator__text"
       >
-        <RecentDate
+        <InjectIntl(RecentDate)
           day="2-digit"
           month="short"
           value={2018-01-12T12:15:13.000Z}
           weekday="short"
           year="numeric"
         >
-          Fri, Jan 12, 2018
-        </RecentDate>
+          <RecentDate
+            day="2-digit"
+            intl={
+              Object {
+                "defaultFormats": Object {},
+                "defaultLocale": "en",
+                "formatDate": [Function],
+                "formatHTMLMessage": [Function],
+                "formatMessage": [Function],
+                "formatNumber": [Function],
+                "formatPlural": [Function],
+                "formatRelative": [Function],
+                "formatTime": [Function],
+                "formats": Object {},
+                "formatters": Object {
+                  "getDateTimeFormat": [Function],
+                  "getMessageFormat": [Function],
+                  "getNumberFormat": [Function],
+                  "getPluralFormat": [Function],
+                  "getRelativeFormat": [Function],
+                },
+                "locale": "en",
+                "messages": Object {},
+                "now": [Function],
+                "onError": [Function],
+                "textComponent": "span",
+                "timeZone": "Etc/UTC",
+              }
+            }
+            month="short"
+            value={2018-01-12T12:15:13.000Z}
+            weekday="short"
+            year="numeric"
+          >
+            Fri, Jan 12, 2018
+          </RecentDate>
+        </InjectIntl(RecentDate)>
       </div>
     </div>
   </BasicSeparator>
@@ -161,15 +232,50 @@ exports[`components/post_view/DateSeparator should render date without timezone 
       <div
         className="separator__text"
       >
-        <RecentDate
+        <InjectIntl(RecentDate)
           day="2-digit"
           month="short"
           value={2018-01-12T12:15:13.000Z}
           weekday="short"
           year="numeric"
         >
-          Fri, Jan 12, 2018
-        </RecentDate>
+          <RecentDate
+            day="2-digit"
+            intl={
+              Object {
+                "defaultFormats": Object {},
+                "defaultLocale": "en",
+                "formatDate": [Function],
+                "formatHTMLMessage": [Function],
+                "formatMessage": [Function],
+                "formatNumber": [Function],
+                "formatPlural": [Function],
+                "formatRelative": [Function],
+                "formatTime": [Function],
+                "formats": Object {},
+                "formatters": Object {
+                  "getDateTimeFormat": [Function],
+                  "getMessageFormat": [Function],
+                  "getNumberFormat": [Function],
+                  "getPluralFormat": [Function],
+                  "getRelativeFormat": [Function],
+                },
+                "locale": "en",
+                "messages": Object {},
+                "now": [Function],
+                "onError": [Function],
+                "textComponent": "span",
+                "timeZone": "Etc/UTC",
+              }
+            }
+            month="short"
+            value={2018-01-12T12:15:13.000Z}
+            weekday="short"
+            year="numeric"
+          >
+            Fri, Jan 12, 2018
+          </RecentDate>
+        </InjectIntl(RecentDate)>
       </div>
     </div>
   </BasicSeparator>

--- a/components/post_view/date_separator/__snapshots__/date_separator.test.jsx.snap
+++ b/components/post_view/date_separator/__snapshots__/date_separator.test.jsx.snap
@@ -36,6 +36,7 @@ exports[`components/post_view/DateSeparator should render date with timezone ena
   <BasicSeparator>
     <div
       className="Separator BasicSeparator"
+      data-testid="basicSeparator"
     >
       <hr
         className="separator__hr"
@@ -93,6 +94,7 @@ exports[`components/post_view/DateSeparator should render date without timezone 
   <BasicSeparator>
     <div
       className="Separator BasicSeparator"
+      data-testid="basicSeparator"
     >
       <hr
         className="separator__hr"
@@ -151,6 +153,7 @@ exports[`components/post_view/DateSeparator should render date without timezone 
   <BasicSeparator>
     <div
       className="Separator BasicSeparator"
+      data-testid="basicSeparator"
     >
       <hr
         className="separator__hr"

--- a/components/post_view/date_separator/__snapshots__/date_separator.test.jsx.snap
+++ b/components/post_view/date_separator/__snapshots__/date_separator.test.jsx.snap
@@ -44,7 +44,7 @@ exports[`components/post_view/DateSeparator should render date with timezone ena
       <div
         className="separator__text"
       >
-        <InjectIntl(RecentDate)
+        <RecentDate
           day="2-digit"
           month="short"
           timeZone="Australia/Sydney"
@@ -52,44 +52,8 @@ exports[`components/post_view/DateSeparator should render date with timezone ena
           weekday="short"
           year="numeric"
         >
-          <RecentDate
-            day="2-digit"
-            intl={
-              Object {
-                "defaultFormats": Object {},
-                "defaultLocale": "en",
-                "formatDate": [Function],
-                "formatHTMLMessage": [Function],
-                "formatMessage": [Function],
-                "formatNumber": [Function],
-                "formatPlural": [Function],
-                "formatRelative": [Function],
-                "formatTime": [Function],
-                "formats": Object {},
-                "formatters": Object {
-                  "getDateTimeFormat": [Function],
-                  "getMessageFormat": [Function],
-                  "getNumberFormat": [Function],
-                  "getPluralFormat": [Function],
-                  "getRelativeFormat": [Function],
-                },
-                "locale": "en",
-                "messages": Object {},
-                "now": [Function],
-                "onError": [Function],
-                "textComponent": "span",
-                "timeZone": "Etc/UTC",
-              }
-            }
-            month="short"
-            timeZone="Australia/Sydney"
-            value={2018-01-12T20:15:13.000Z}
-            weekday="short"
-            year="numeric"
-          >
-            Sat, Jan 13, 2018
-          </RecentDate>
-        </InjectIntl(RecentDate)>
+          Sat, Jan 13, 2018
+        </RecentDate>
       </div>
     </div>
   </BasicSeparator>
@@ -138,50 +102,15 @@ exports[`components/post_view/DateSeparator should render date without timezone 
       <div
         className="separator__text"
       >
-        <InjectIntl(RecentDate)
+        <RecentDate
           day="2-digit"
           month="short"
           value={2018-01-12T12:15:13.000Z}
           weekday="short"
           year="numeric"
         >
-          <RecentDate
-            day="2-digit"
-            intl={
-              Object {
-                "defaultFormats": Object {},
-                "defaultLocale": "en",
-                "formatDate": [Function],
-                "formatHTMLMessage": [Function],
-                "formatMessage": [Function],
-                "formatNumber": [Function],
-                "formatPlural": [Function],
-                "formatRelative": [Function],
-                "formatTime": [Function],
-                "formats": Object {},
-                "formatters": Object {
-                  "getDateTimeFormat": [Function],
-                  "getMessageFormat": [Function],
-                  "getNumberFormat": [Function],
-                  "getPluralFormat": [Function],
-                  "getRelativeFormat": [Function],
-                },
-                "locale": "en",
-                "messages": Object {},
-                "now": [Function],
-                "onError": [Function],
-                "textComponent": "span",
-                "timeZone": "Etc/UTC",
-              }
-            }
-            month="short"
-            value={2018-01-12T12:15:13.000Z}
-            weekday="short"
-            year="numeric"
-          >
-            Fri, Jan 12, 2018
-          </RecentDate>
-        </InjectIntl(RecentDate)>
+          Fri, Jan 12, 2018
+        </RecentDate>
       </div>
     </div>
   </BasicSeparator>
@@ -232,50 +161,15 @@ exports[`components/post_view/DateSeparator should render date without timezone 
       <div
         className="separator__text"
       >
-        <InjectIntl(RecentDate)
+        <RecentDate
           day="2-digit"
           month="short"
           value={2018-01-12T12:15:13.000Z}
           weekday="short"
           year="numeric"
         >
-          <RecentDate
-            day="2-digit"
-            intl={
-              Object {
-                "defaultFormats": Object {},
-                "defaultLocale": "en",
-                "formatDate": [Function],
-                "formatHTMLMessage": [Function],
-                "formatMessage": [Function],
-                "formatNumber": [Function],
-                "formatPlural": [Function],
-                "formatRelative": [Function],
-                "formatTime": [Function],
-                "formats": Object {},
-                "formatters": Object {
-                  "getDateTimeFormat": [Function],
-                  "getMessageFormat": [Function],
-                  "getNumberFormat": [Function],
-                  "getPluralFormat": [Function],
-                  "getRelativeFormat": [Function],
-                },
-                "locale": "en",
-                "messages": Object {},
-                "now": [Function],
-                "onError": [Function],
-                "textComponent": "span",
-                "timeZone": "Etc/UTC",
-              }
-            }
-            month="short"
-            value={2018-01-12T12:15:13.000Z}
-            weekday="short"
-            year="numeric"
-          >
-            Fri, Jan 12, 2018
-          </RecentDate>
-        </InjectIntl(RecentDate)>
+          Fri, Jan 12, 2018
+        </RecentDate>
       </div>
     </div>
   </BasicSeparator>

--- a/components/recent_date.tsx
+++ b/components/recent_date.tsx
@@ -2,20 +2,21 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedMessage, DateSource, intlShape} from 'react-intl';
+import {
+    DateSource,
+    FormattedMessage,
+    injectIntl,
+} from 'react-intl';
 import moment from 'moment-timezone';
 
 type Props = {
     timeZone?: string;
     value: DateSource;
     children?(val: string): React.ReactElement | null;
+    intl: any; // TODO This needs to be replaced with IntlShape once react-intl is upgraded
 }
 
-export default class RecentDate extends React.PureComponent<Props> {
-    public static contextTypes = {
-        intl: intlShape.isRequired,
-    };
-
+class RecentDate extends React.PureComponent<Props> {
     public render() {
         const {value, timeZone} = this.props;
         const date = new Date(value);
@@ -43,7 +44,7 @@ export default class RecentDate extends React.PureComponent<Props> {
             day: '2-digit',
             year: 'numeric'
         };
-        const formattedDate = this.context.intl.formatDate(value, options);
+        const formattedDate = this.props.intl.formatDate(value, options);
 
         // `formatDate` returns unformatted date string on error like in the case of (react-intl) unsupported timezone.
         // Therefore, use react-intl by default or moment-timezone for unsupported timezone.
@@ -77,3 +78,5 @@ export function isYesterday(date: Date) {
 
     return isSameDay(date, yesterday);
 }
+
+export default injectIntl(RecentDate);

--- a/components/recent_date.tsx
+++ b/components/recent_date.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {FormattedMessage, DateSource} from 'react-intl';
+import {FormattedMessage, DateSource, intlShape} from 'react-intl';
 import moment from 'moment-timezone';
 
 type Props = {
@@ -12,6 +12,10 @@ type Props = {
 }
 
 export default class RecentDate extends React.PureComponent<Props> {
+    public static contextTypes = {
+        intl: intlShape.isRequired,
+    };
+
     public render() {
         const {value, timeZone} = this.props;
         const date = new Date(value);
@@ -30,6 +34,21 @@ export default class RecentDate extends React.PureComponent<Props> {
                     defaultMessage='Yesterday'
                 />
             );
+        }
+
+        const options = {
+            timeZone,
+            weekday: 'short',
+            month: 'short',
+            day: '2-digit',
+            year: 'numeric'
+        };
+        const formattedDate = this.context.intl.formatDate(value, options);
+
+        // `formatDate` returns unformatted date string on error like in the case of (react-intl) unsupported timezone.
+        // Therefore, use react-intl by default or moment-timezone for unsupported timezone.
+        if (formattedDate !== String(date)) {
+            return formattedDate;
         }
 
         const momentDate = value ? moment(value) : moment();

--- a/components/recent_date.tsx
+++ b/components/recent_date.tsx
@@ -2,21 +2,20 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {
-    DateSource,
-    FormattedMessage,
-    injectIntl,
-} from 'react-intl';
+import {FormattedMessage, DateSource, intlShape} from 'react-intl';
 import moment from 'moment-timezone';
 
 type Props = {
     timeZone?: string;
     value: DateSource;
     children?(val: string): React.ReactElement | null;
-    intl: any; // TODO This needs to be replaced with IntlShape once react-intl is upgraded
 }
 
-class RecentDate extends React.PureComponent<Props> {
+export default class RecentDate extends React.PureComponent<Props> {
+    public static contextTypes = {
+        intl: intlShape.isRequired,
+    };
+
     public render() {
         const {value, timeZone} = this.props;
         const date = new Date(value);
@@ -44,7 +43,7 @@ class RecentDate extends React.PureComponent<Props> {
             day: '2-digit',
             year: 'numeric'
         };
-        const formattedDate = this.props.intl.formatDate(value, options);
+        const formattedDate = this.context.intl.formatDate(value, options);
 
         // `formatDate` returns unformatted date string on error like in the case of (react-intl) unsupported timezone.
         // Therefore, use react-intl by default or moment-timezone for unsupported timezone.
@@ -78,5 +77,3 @@ export function isYesterday(date: Date) {
 
     return isSameDay(date, yesterday);
 }
-
-export default injectIntl(RecentDate);

--- a/components/widgets/separator/__snapshots__/separator.test.tsx.snap
+++ b/components/widgets/separator/__snapshots__/separator.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`components/widgets/separator date separator with text 1`] = `
 <div
   className="Separator BasicSeparator"
+  data-testid="basicSeparator"
 >
   <hr
     className="separator__hr"

--- a/components/widgets/separator/basic-separator.tsx
+++ b/components/widgets/separator/basic-separator.tsx
@@ -8,7 +8,10 @@ export default class BasicSeparator extends React.PureComponent<React.PropsWithC
     public render() {
         const {children} = this.props;
         return (
-            <div className='Separator BasicSeparator'>
+            <div
+                data-testid='basicSeparator'
+                className='Separator BasicSeparator'
+            >
                 <hr className='separator__hr'/>
                 {children && (
                     <div className='separator__text'>

--- a/e2e/cypress/integration/messaging/date_separator_spec.js
+++ b/e2e/cypress/integration/messaging/date_separator_spec.js
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+import users from '../../fixtures/users.json';
+
+const sysadmin = users.sysadmin;
+
+describe('Messaging', () => {
+    let newChannel;
+
+    before(() => {
+        // # Login as user-1 and set preferences for locale and timezone
+        cy.apiLogin('user-1');
+        cy.apiPatchMe({
+            locale: 'en',
+            timezone: {automaticTimezone: '', manualTimezone: 'UTC', useAutomaticTimezone: 'false'},
+        });
+
+        // # Create and visit new channel
+        cy.createAndVisitNewChannel().then((channel) => {
+            newChannel = channel;
+        });
+    });
+
+    it('MM-21482 Date separators should translate correctly', () => {
+        function verifyDateSeparator(index, match) {
+            cy.findAllByTestId('basicSeparator').eq(index).within(() => {
+                cy.findByText(match);
+            });
+        }
+
+        // # Post a message with old date
+        const oldDate = Date.UTC(2020, 0, 5, 12, 30); // Jan 5, 2020 12:30pm
+        cy.postMessageAs({sender: sysadmin, message: 'Hello from Jan 5, 2020 12:30pm', channelId: newChannel.id, createAt: oldDate});
+
+        // # Post message from yesterday
+        const yesterdaysDate = Cypress.moment().subtract(1, 'days').valueOf();
+        cy.postMessageAs({sender: sysadmin, message: 'Hello from yesterday', channelId: newChannel.id, createAt: yesterdaysDate});
+
+        // # Post a message for today
+        cy.postMessage('Hello from today');
+
+        // # Reload to re-arrange post order
+        cy.reload();
+
+        // * Verify that the date separators are rendered in English
+        verifyDateSeparator(0, /^(Sat|Sun), Jan (04|05), 2020/);
+        verifyDateSeparator(1, 'Yesterday');
+        verifyDateSeparator(2, 'Today');
+
+        // # Change user locale to "es" and reload
+        cy.apiPatchMe({locale: 'es'});
+        cy.reload();
+
+        // * Verify that the date separators are rendered in Spanish
+        verifyDateSeparator(0, /^(sáb|dom)., (04|05) ene. 2020/);
+        verifyDateSeparator(1, 'Yesterday');
+        verifyDateSeparator(2, 'Today');
+
+        // # Change user timezone which is not supported by react-intl and reload
+        cy.apiPatchMe({timezone: {automaticTimezone: '', manualTimezone: 'NZ-CHAT', useAutomaticTimezone: 'false'}});
+        cy.reload();
+
+        // * Verify that it renders in English as default and in short format of "ddd, MMM D, YYYY"
+        verifyDateSeparator(0, /^(Sun|Mon), Jan (5|6), 2020/);
+    });
+});


### PR DESCRIPTION
Cherry pick of #4650 on release-5.19.

- #4650: use react-intl by default or moment-timezone for

/cc  @saturninoabril