### PR TITLE
[MM-21739] Change Disable Guest Access button behaviour and text to include Save

### DIFF
--- a/components/admin_console/__snapshots__/custom_enable_disable_guest_accounts_setting.test.tsx.snap
+++ b/components/admin_console/__snapshots__/custom_enable_disable_guest_accounts_setting.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`components/AdminConsole/CustomEnableDisableGuestAccountsSetting initial
     confirmButtonClass="btn btn-primary"
     confirmButtonText={
       <FormattedMessage
-        defaultMessage="Disable Guest Access"
+        defaultMessage="Save Disable Guest Access"
         id="admin.guest_access.disableConfirmButton"
         values={Object {}}
       />
@@ -107,7 +107,7 @@ exports[`components/AdminConsole/CustomEnableDisableGuestAccountsSetting initial
     confirmButtonClass="btn btn-primary"
     confirmButtonText={
       <FormattedMessage
-        defaultMessage="Disable Guest Access"
+        defaultMessage="Save Disable Guest Access"
         id="admin.guest_access.disableConfirmButton"
         values={Object {}}
       />

--- a/components/admin_console/__snapshots__/custom_enable_disable_guest_accounts_setting.test.tsx.snap
+++ b/components/admin_console/__snapshots__/custom_enable_disable_guest_accounts_setting.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`components/AdminConsole/CustomEnableDisableGuestAccountsSetting initial
     confirmButtonClass="btn btn-primary"
     confirmButtonText={
       <FormattedMessage
-        defaultMessage="Save Disable Guest Access"
+        defaultMessage="Save and Disable Guest Access"
         id="admin.guest_access.disableConfirmButton"
         values={Object {}}
       />
@@ -107,7 +107,7 @@ exports[`components/AdminConsole/CustomEnableDisableGuestAccountsSetting initial
     confirmButtonClass="btn btn-primary"
     confirmButtonText={
       <FormattedMessage
-        defaultMessage="Save Disable Guest Access"
+        defaultMessage="Save and Disable Guest Access"
         id="admin.guest_access.disableConfirmButton"
         values={Object {}}
       />

--- a/components/admin_console/custom_enable_disable_guest_accounts_setting.test.tsx
+++ b/components/admin_console/custom_enable_disable_guest_accounts_setting.test.tsx
@@ -53,7 +53,7 @@ describe('components/AdminConsole/CustomEnableDisableGuestAccountsSetting', () =
             );
 
             wrapper.instance().handleChange('MySetting', true);
-            expect(props.onChange).toBeCalledWith(baseProps.id, true);
+            expect(props.onChange).toBeCalledWith(baseProps.id, true, false);
             expect(wrapper.state().showConfirm).toBe(false);
         });
 
@@ -83,7 +83,7 @@ describe('components/AdminConsole/CustomEnableDisableGuestAccountsSetting', () =
             );
 
             wrapper.instance().handleChange('MySetting', false, true);
-            expect(props.onChange).toBeCalledWith(baseProps.id, false);
+            expect(props.onChange).toBeCalledWith(baseProps.id, false, true);
             expect(wrapper.state().showConfirm).toBe(false);
         });
     });

--- a/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
+++ b/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
@@ -32,12 +32,12 @@ export default class CustomEnableDisableGuestAccountsSetting extends React.Compo
     }
 
     public handleChange = (id: string, value: boolean, confirm?: boolean) => {
-        const submit = confirm || false;
+        const submitImmediately = confirm || false;
 
         if (!value && !confirm) {
             this.setState({showConfirm: true});
         } else {
-            this.props.onChange(id, value, submit);
+            this.props.onChange(id, value, submitImmediately);
         }
     };
 

--- a/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
+++ b/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
@@ -13,7 +13,7 @@ import BooleanSetting from './boolean_setting';
 type Props = {
     id: string;
     value: boolean;
-    onChange: (id: string, value: any) => void;
+    onChange: (id: string, value: any, submit: boolean) => void;
     disabled?: boolean;
     setByEnv: boolean;
 }
@@ -32,10 +32,12 @@ export default class CustomEnableDisableGuestAccountsSetting extends React.Compo
     }
 
     public handleChange = (id: string, value: boolean, confirm?: boolean) => {
+        const submit = confirm || false;
+
         if (!value && !confirm) {
             this.setState({showConfirm: true});
         } else {
-            this.props.onChange(id, value);
+            this.props.onChange(id, value, submit);
         }
     };
 

--- a/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
+++ b/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
@@ -13,7 +13,7 @@ import BooleanSetting from './boolean_setting';
 type Props = {
     id: string;
     value: boolean;
-    onChange: (id: string, value: any, submit: boolean) => void;
+    onChange: (id: string, value: any, submitImmediately: boolean) => void;
     disabled?: boolean;
     setByEnv: boolean;
 }
@@ -82,7 +82,7 @@ export default class CustomEnableDisableGuestAccountsSetting extends React.Compo
                     confirmButtonText={
                         <FormattedMessage
                             id='admin.guest_access.disableConfirmButton'
-                            defaultMessage='Save Disable Guest Access'
+                            defaultMessage='Save and Disable Guest Access'
                         />
                     }
                     onConfirm={() => {

--- a/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
+++ b/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
@@ -80,7 +80,7 @@ export default class CustomEnableDisableGuestAccountsSetting extends React.Compo
                     confirmButtonText={
                         <FormattedMessage
                             id='admin.guest_access.disableConfirmButton'
-                            defaultMessage='Disable Guest Access'
+                            defaultMessage='Save Disable Guest Access'
                         />
                     }
                     onConfirm={() => {

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -97,7 +97,9 @@ export default class SchemaAdminSettings extends React.Component {
     }
 
     handleSubmit = async (e) => {
-        e.preventDefault();
+        if (e) {
+            e.preventDefault();
+        }
 
         this.setState({
             saving: true,
@@ -621,16 +623,16 @@ export default class SchemaAdminSettings extends React.Component {
         this.handleChange(id, s.replace('+', '-').replace('/', '_'));
     }
 
-    handleChange = (id, value) => {
+    handleChange = (id, value, submit = false) => {
         let saveNeeded = 'config';
         if (this.state.saveNeeded === 'permissions') {
             saveNeeded = 'both';
         }
-        this.setState({
-            saveNeeded,
-            [id]: value,
+        this.setState({saveNeeded, [id]: value}, () => {
+            if (submit) {
+                this.handleSubmit();
+            }
         });
-
         this.props.setNavigationBlocked(true);
     }
 

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -97,9 +97,7 @@ export default class SchemaAdminSettings extends React.Component {
     }
 
     handleSubmit = async (e) => {
-        if (e) {
-            e.preventDefault();
-        }
+        e.preventDefault();
 
         this.setState({
             saving: true,
@@ -623,21 +621,17 @@ export default class SchemaAdminSettings extends React.Component {
         this.handleChange(id, s.replace('+', '-').replace('/', '_'));
     }
 
-    handleChange = (id, value, submit = false) => {
+    handleChange = (id, value, submitImmediately = false) => {
         let saveNeeded = this.state.saveNeeded;
 
         // Only set saveNeeded & block navigation if the config is not going to immediately be saved
-        if (!submit) {
-            if (saveNeeded === 'permissions') {
-                saveNeeded = 'both';
-            } else {
-                saveNeeded = 'config';
-            }
+        if (!submitImmediately) {
+            saveNeeded = saveNeeded === 'permissions' ? 'both' : 'config';
             this.props.setNavigationBlocked(true);
         }
 
         this.setState({saveNeeded, [id]: value}, () => {
-            if (submit) {
+            if (submitImmediately) {
                 this.submitSetting(null, id, value);
             }
         });

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -134,7 +134,7 @@ export default class SchemaAdminSettings extends React.Component {
         }
 
         if (this.state.saveNeeded === 'both' || this.state.saveNeeded === 'config') {
-            this.doSubmit(null, SchemaAdminSettings.getStateFromConfig);
+            this.doSubmit(SchemaAdminSettings.getStateFromConfig);
         } else {
             this.setState({
                 saving: false,
@@ -873,7 +873,7 @@ export default class SchemaAdminSettings extends React.Component {
         this.setState({errorTooltip: isElipsis});
     }
 
-    submitSetting = async (callback, key, value) => {
+    submitSetting = async (key, value) => {
         const config = JSON.parse(JSON.stringify(this.props.config));
         const category = key.split('.')[0];
         const setting = key.split('.')[1];
@@ -886,13 +886,9 @@ export default class SchemaAdminSettings extends React.Component {
                 serverErrorId: error.id,
             });
         }
-
-        if (callback) {
-            callback();
-        }
     }
 
-    doSubmit = async (callback, getStateFromConfig) => {
+    doSubmit = async (getStateFromConfig) => {
         this.setState({
             saving: true,
             serverError: null,
@@ -910,10 +906,6 @@ export default class SchemaAdminSettings extends React.Component {
             });
         } else {
             this.setState(getStateFromConfig(config));
-        }
-
-        if (callback) {
-            callback();
         }
 
         if (this.handleSaved) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -698,7 +698,7 @@
   "admin.group_teams_and_channels_row.channelAdmin": "Channel Admin",
   "admin.group_teams_and_channels_row.member": "Member",
   "admin.group_teams_and_channels_row.teamAdmin": "Team Admin",
-  "admin.guest_access.disableConfirmButton": "Disable Guest Access",
+  "admin.guest_access.disableConfirmButton": "Save Disable Guest Access",
   "admin.guest_access.disableConfirmMessage": "Disabling guest access will revoke all current Guest Account sessions. Guests will no longer be able to login and new guests cannot be invited into Mattermost. Guest users will be marked as inactive in user lists. Enabling this feature will not reinstate previous guest accounts.",
   "admin.guest_access.disableConfirmTitle": "Disable Guest Access?",
   "admin.guest_access.enableDescription": "When true, external guest can be invited to channels within teams. Please see [Permissions Schemes](../user_management/permissions/system_scheme) for which roles can invite guests.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -698,7 +698,7 @@
   "admin.group_teams_and_channels_row.channelAdmin": "Channel Admin",
   "admin.group_teams_and_channels_row.member": "Member",
   "admin.group_teams_and_channels_row.teamAdmin": "Team Admin",
-  "admin.guest_access.disableConfirmButton": "Save Disable Guest Access",
+  "admin.guest_access.disableConfirmButton": "Save and Disable Guest Access",
   "admin.guest_access.disableConfirmMessage": "Disabling guest access will revoke all current Guest Account sessions. Guests will no longer be able to login and new guests cannot be invited into Mattermost. Guest users will be marked as inactive in user lists. Enabling this feature will not reinstate previous guest accounts.",
   "admin.guest_access.disableConfirmTitle": "Disable Guest Access?",
   "admin.guest_access.enableDescription": "When true, external guest can be invited to channels within teams. Please see [Permissions Schemes](../user_management/permissions/system_scheme) for which roles can invite guests.",


### PR DESCRIPTION
#### Summary
- Changes the wording of the disable guest access confirmation to be `Save and Disable Guest Access`
- Also changes the behaviour to call save after the `Save and Disable Guest Access` button is pressed - preventing the user from having to press save twice to actually save the attribute
- I accomplished this by adding an optional parameter to `handleChange` to trigger a save if `submit` is set to `true`, open to suggestions on a better way to achieve the desired behaviour.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21739

#### Related Pull Requests
None

#### Screenshots
![captured](https://user-images.githubusercontent.com/3207297/72392158-4cb86480-36fd-11ea-956d-b27222aba345.gif)
