### PR TITLE
MM-21667 fix redirection on leave channel with subpath

### DIFF
--- a/stores/local_storage_store.jsx
+++ b/stores/local_storage_store.jsx
@@ -38,6 +38,13 @@ class LocalStorageStoreClass {
         localStorage.setItem(getPathScopedKey(basePath, key), value);
     }
 
+    removeItem(key) {
+        const state = store.getState();
+        const basePath = getBasePath(state);
+
+        localStorage.removeItem(getPathScopedKey(basePath, key));
+    }
+
     getPreviousChannelName(userId, teamId) {
         return this.getItem(getPreviousChannelNameKey(userId, teamId)) || getRedirectChannelNameForTeam(teamId);
     }
@@ -55,8 +62,8 @@ class LocalStorageStoreClass {
     }
 
     removePreviousChannelName(userId, teamId) {
-        localStorage.setItem(getPreviousChannelNameKey(userId, teamId), this.getPenultimateChannelName(userId, teamId));
-        localStorage.removeItem(getPenultimateChannelNameKey(userId, teamId));
+        this.setItem(getPreviousChannelNameKey(userId, teamId), this.getPenultimateChannelName(userId, teamId));
+        this.removeItem(getPenultimateChannelNameKey(userId, teamId));
     }
 
     getPreviousTeamId(userId) {

--- a/stores/local_storage_store.test.jsx
+++ b/stores/local_storage_store.test.jsx
@@ -120,7 +120,7 @@ describe('stores/LocalStorageStore', () => {
         });
     });
 
-    describe('testing previous channel', () => {        
+    describe('testing previous channel', () => {
         test('should remove previous channel without subpath', () => {
             const userId1 = 'userId1';
             const teamId1 = 'teamId1';

--- a/stores/local_storage_store.test.jsx
+++ b/stores/local_storage_store.test.jsx
@@ -119,4 +119,39 @@ describe('stores/LocalStorageStore', () => {
             assert.deepEqual(LocalStorageStore.getRecentEmojis(userId), recentEmojis1);
         });
     });
+
+    describe('testing previous channel', () => {        
+        test('should remove previous channel without subpath', () => {
+            const userId1 = 'userId1';
+            const teamId1 = 'teamId1';
+            const channel1 = 'channel1';
+            const channel2 = 'channel2';
+
+            LocalStorageStore.setPreviousChannelName(userId1, teamId1, channel1);
+            assert.equal(LocalStorageStore.getPreviousChannelName(userId1, teamId1), channel1);
+
+            LocalStorageStore.setPenultimateChannelName(userId1, teamId1, channel2);
+            assert.equal(LocalStorageStore.getPenultimateChannelName(userId1, teamId1), channel2);
+
+            LocalStorageStore.removePreviousChannelName(userId1, teamId1);
+            assert.equal(LocalStorageStore.getPreviousChannelName(userId1, teamId1), channel2);
+        });
+
+        test('should remove previous channel using subpath', () => {
+            const userId1 = 'userId1';
+            const teamId1 = 'teamId1';
+            const channel1 = 'channel1';
+            const channel2 = 'channel2';
+
+            window.basename = '/subpath';
+            LocalStorageStore.setPreviousChannelName(userId1, teamId1, channel1);
+            assert.equal(LocalStorageStore.getPreviousChannelName(userId1, teamId1), channel1);
+
+            LocalStorageStore.setPenultimateChannelName(userId1, teamId1, channel2);
+            assert.equal(LocalStorageStore.getPenultimateChannelName(userId1, teamId1), channel2);
+
+            LocalStorageStore.removePreviousChannelName(userId1, teamId1);
+            assert.equal(LocalStorageStore.getPreviousChannelName(userId1, teamId1), channel2);
+        });
+    });
 });


### PR DESCRIPTION
#### Summary
Fixes a couple issues with local storage. The removePreviousChannelName() was calling `localStorage` directly. In order to properly concatenate the key with the base path, it should be calling the local functions. 

Changed to call local functions and created local function for removeItem().

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21667
