### PR TITLE
Fix error message due to pass string to boolean value on dialog element

### DIFF
--- a/components/interactive_dialog/dialog_element/dialog_element.jsx
+++ b/components/interactive_dialog/dialog_element/dialog_element.jsx
@@ -174,7 +174,7 @@ export default class DialogElement extends React.PureComponent {
                 <BoolSetting
                     id={name}
                     label={displayNameContent}
-                    value={value || false}
+                    value={value === 'true'}
                     helpText={helpTextContent}
                     placeholder={placeholder}
                     onChange={onChange}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Fix error message due to pass string to boolean value on dialog element
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21787
#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
None

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
None