### PR TITLE
MM-20349 Improve typing performance

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -328,6 +328,11 @@ class CreatePost extends React.PureComponent {
         document.removeEventListener('paste', this.pasteHandler);
         document.removeEventListener('keydown', this.documentKeyHandler);
         this.removeOrientationListeners();
+        if (this.saveDraftFrame) {
+            const channelId = this.props.currentChannel.id;
+            this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, this.draftsForChannel[channelId]);
+            cancelAnimationFrame(this.saveDraftFrame);
+        }
     }
 
     updatePreview = (newState) => {
@@ -706,8 +711,10 @@ class CreatePost extends React.PureComponent {
             ...this.props.draft,
             message,
         };
-
-        this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, draft);
+        cancelAnimationFrame(this.saveDraftFrame);
+        this.saveDraftFrame = requestAnimationFrame(() => {
+            this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, draft);
+        });
         this.draftsForChannel[channelId] = draft;
     }
 

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -140,6 +140,15 @@ function createPost({
 /* eslint-enable react/prop-types */
 
 describe('components/create_post', () => {
+    jest.useFakeTimers();
+    beforeEach(() => {
+        jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => setTimeout(cb, 16));
+    });
+
+    afterEach(() => {
+        window.requestAnimationFrame.mockRestore();
+    });
+
     it('should match snapshot, init', () => {
         const wrapper = shallowWithIntl(createPost({}));
 
@@ -245,6 +254,8 @@ describe('components/create_post', () => {
 
         const postTextbox = wrapper.find('#post_textbox');
         postTextbox.simulate('change', {target: {value: 'change'}});
+        expect(setDraft).not.toHaveBeenCalled();
+        jest.runAllTimers();
         expect(setDraft).toHaveBeenCalledWith(StoragePrefixes.DRAFT + currentChannelProp.id, draft);
     });
 

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -173,7 +173,9 @@ class RhsComment extends React.PureComponent {
     };
 
     handleAlt = (e) => {
-        this.setState({alt: e.altKey});
+        if (this.state.alt !== e.altKey) {
+            this.setState({alt: e.altKey});
+        }
     }
 
     handleDropdownOpened = (isOpened) => {

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -139,7 +139,9 @@ class RhsRootPost extends React.PureComponent {
     };
 
     handleAlt = (e) => {
-        this.setState({alt: e.altKey});
+        if (this.state.alt !== e.altKey) {
+            this.setState({alt: e.altKey});
+        }
     }
 
     handleDropdownOpened = (isOpened) => {

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -487,14 +487,16 @@ export default class SuggestionBox extends React.Component {
     }
 
     clear = () => {
-        this.setState({
-            cleared: true,
-            matchedPretext: [],
-            terms: [],
-            items: [],
-            components: [],
-            selection: '',
-        });
+        if (!this.state.cleared) {
+            this.setState({
+                cleared: true,
+                matchedPretext: [],
+                terms: [],
+                items: [],
+                components: [],
+                selection: '',
+            });
+        }
     }
 
     hasSuggestions = () => {

--- a/components/suggestion/suggestion_box.test.jsx
+++ b/components/suggestion/suggestion_box.test.jsx
@@ -165,4 +165,19 @@ describe('components/SuggestionBox', () => {
         instance.nonDebouncedPretextChanged('hello world ');
         expect(wrapper.state('selection')).toEqual('');
     });
+
+    test('should call setState for clear based on present cleared state', () => {
+        const wrapper = mount(
+            <SuggestionBox {...baseProps}/>
+        );
+
+        const instance = wrapper.instance();
+        instance.setState = jest.fn();
+        instance.clear();
+        expect(instance.setState).not.toHaveBeenCalled();
+        wrapper.setState({cleared: false});
+        wrapper.update();
+        instance.clear();
+        expect(instance.setState).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
#### Summary
 * Fix couple of setState calls being called all the time when typing
    This is similar to https://github.com/mattermost/mattermost-webapp/pull/4664.
 * Delay setting draft to localstorage to improve performance
      * Setting of draft is triggering store update invalidating the cache for memoization of selectors
      * Delaying this by a little bit to to distribute the code execution so few more frames can be squeezed in. This mainly helps users with busy JS thread because of sidebar profiles

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20349

#### Screenshots
Before:
![Jan-18-2020 00-30-36](https://user-images.githubusercontent.com/4973621/72633645-771f5180-398b-11ea-9607-51f6b91291df.gif)
After:
![Jan-18-2020 00-45-38](https://user-images.githubusercontent.com/4973621/72633827-df6e3300-398b-11ea-9a19-485294b20ac0.gif)

For 5.19v branch there is a regression with memoization which needs to be fixed by cherry-picking https://github.com/mattermost/mattermost-redux/pull/1011  