### PR TITLE
Automated cherry pick of #4685

### DIFF
--- a/components/channel_layout/channel_identifier_router/actions.js
+++ b/components/channel_layout/channel_identifier_router/actions.js
@@ -15,6 +15,7 @@ import * as Utils from 'utils/utils.jsx';
 const LENGTH_OF_ID = 26;
 const LENGTH_OF_GROUP_ID = 40;
 const LENGTH_OF_USER_ID_PAIR = 54;
+const USER_ID_PAIR_REGEXP = new RegExp('^[a-zA-Z0-9]{'+LENGTH_OF_ID+'}__[a-zA-Z0-9]{'+LENGTH_OF_ID+'}$');
 
 function onChannelByIdentifierEnter({match, history}) {
     return async (dispatch, getState) => {
@@ -43,7 +44,7 @@ function onChannelByIdentifierEnter({match, history}) {
                 }
             } else if (identifier.length === LENGTH_OF_GROUP_ID) {
                 dispatch(exportFunctions.goToGroupChannelByGroupId(match, history));
-            } else if (identifier.length === LENGTH_OF_USER_ID_PAIR) {
+            } else if (isDirectChannelIdentifier(identifier)) {
                 dispatch(exportFunctions.goToDirectChannelByUserIds(match, history));
             } else {
                 dispatch(exportFunctions.goToChannelByChannelName(match, history));
@@ -263,6 +264,10 @@ function doChannelChange(channel) {
 function handleError(match, history, defaultChannel) {
     const {team} = match.params;
     history.push(team ? `/${team}/channels/${defaultChannel}` : '/');
+}
+
+function isDirectChannelIdentifier(identifier) {
+    return identifier.length === LENGTH_OF_USER_ID_PAIR && USER_ID_PAIR_REGEXP.test(identifier);
 }
 
 async function handleChannelJoinError(match, history, defaultChannel) {

--- a/components/channel_layout/channel_identifier_router/actions.js
+++ b/components/channel_layout/channel_identifier_router/actions.js
@@ -15,7 +15,7 @@ import * as Utils from 'utils/utils.jsx';
 const LENGTH_OF_ID = 26;
 const LENGTH_OF_GROUP_ID = 40;
 const LENGTH_OF_USER_ID_PAIR = 54;
-const USER_ID_PAIR_REGEXP = new RegExp('^[a-zA-Z0-9]{'+LENGTH_OF_ID+'}__[a-zA-Z0-9]{'+LENGTH_OF_ID+'}$');
+const USER_ID_PAIR_REGEXP = new RegExp('^[a-zA-Z0-9]{' + LENGTH_OF_ID + '}__[a-zA-Z0-9]{' + LENGTH_OF_ID + '}$');
 
 function onChannelByIdentifierEnter({match, history}) {
     return async (dispatch, getState) => {

--- a/components/channel_layout/channel_identifier_router/actions.js
+++ b/components/channel_layout/channel_identifier_router/actions.js
@@ -17,7 +17,7 @@ const LENGTH_OF_GROUP_ID = 40;
 const LENGTH_OF_USER_ID_PAIR = 54;
 const USER_ID_PAIR_REGEXP = new RegExp(`^[a-zA-Z0-9]{${LENGTH_OF_ID}}__[a-zA-Z0-9]{${LENGTH_OF_ID}}$`);
 
-function onChannelByIdentifierEnter({match, history}) {
+export function onChannelByIdentifierEnter({match, history}) {
     return async (dispatch, getState) => {
         const state = getState();
         const {path, identifier, team} = match.params;
@@ -66,7 +66,7 @@ function onChannelByIdentifierEnter({match, history}) {
     };
 }
 
-function goToChannelByChannelId(match, history) {
+export function goToChannelByChannelId(match, history) {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -95,7 +95,7 @@ function goToChannelByChannelId(match, history) {
     };
 }
 
-function goToChannelByChannelName(match, history) {
+export function goToChannelByChannelName(match, history) {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -166,7 +166,7 @@ function goToDirectChannelByUsername(match, history) {
     };
 }
 
-function goToDirectChannelByUserId(match, history, userId) {
+export function goToDirectChannelByUserId(match, history, userId) {
     return async (dispatch, getState) => {
         const state = getState();
         const {team} = match.params;
@@ -187,7 +187,7 @@ function goToDirectChannelByUserId(match, history, userId) {
     };
 }
 
-function goToDirectChannelByUserIds(match, history) {
+export function goToDirectChannelByUserIds(match, history) {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -209,7 +209,7 @@ function goToDirectChannelByUserIds(match, history) {
     };
 }
 
-function goToDirectChannelByEmail(match, history) {
+export function goToDirectChannelByEmail(match, history) {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -274,16 +274,3 @@ async function handleChannelJoinError(match, history, defaultChannel) {
     const {team} = match.params;
     history.push(team ? `/error?type=channel_not_found&returnTo=/${team}/channels/${defaultChannel}` : '/');
 }
-
-const exportFunctions = {
-    onChannelByIdentifierEnter,
-    goToChannelByChannelId,
-    goToChannelByChannelName,
-    goToDirectChannelByUserId,
-    goToDirectChannelByUserIds,
-    goToDirectChannelByEmail,
-    goToGroupChannelByGroupId,
-    goToDirectChannelByUsername,
-};
-
-export default exportFunctions;

--- a/components/channel_layout/channel_identifier_router/actions.js
+++ b/components/channel_layout/channel_identifier_router/actions.js
@@ -33,32 +33,32 @@ export function onChannelByIdentifierEnter({match, history}) {
 
         const channelPath = getPathFromIdentifier(state, path, identifier);
 
-        switch(channelPath) {
-            case 'channel_name':
-                dispatch(goToChannelByChannelName(match, history));
-                break;
-            case 'channel_id':
-                dispatch(goToChannelByChannelId(match, history));
-                break;
-            case 'group_channel_group_id':
-                dispatch(goToGroupChannelByGroupId(match, history));
-                break;
-            case 'direct_channel_username':
-                dispatch(goToDirectChannelByUsername(match, history));
-                break;
-            case 'direct_channel_email':
-                dispatch(goToDirectChannelByEmail(match, history));
-                break;
-            case 'direct_channel_user_ids':
-                dispatch(goToDirectChannelByUserIds(match, history));
-                break;
-            case 'direct_channel_user_id':
-                dispatch(goToDirectChannelByUserId(match, history, identifier));
-                break;
-            case 'messages_error':
-                await dispatch(fetchMyChannelsAndMembers(teamObj.id));
-                handleError(match, history, getRedirectChannelNameForTeam(state, teamObj.id));
-                break;
+        switch (channelPath) {
+        case 'channel_name':
+            dispatch(goToChannelByChannelName(match, history));
+            break;
+        case 'channel_id':
+            dispatch(goToChannelByChannelId(match, history));
+            break;
+        case 'group_channel_group_id':
+            dispatch(goToGroupChannelByGroupId(match, history));
+            break;
+        case 'direct_channel_username':
+            dispatch(goToDirectChannelByUsername(match, history));
+            break;
+        case 'direct_channel_email':
+            dispatch(goToDirectChannelByEmail(match, history));
+            break;
+        case 'direct_channel_user_ids':
+            dispatch(goToDirectChannelByUserIds(match, history));
+            break;
+        case 'direct_channel_user_id':
+            dispatch(goToDirectChannelByUserId(match, history, identifier));
+            break;
+        case 'error':
+            await dispatch(fetchMyChannelsAndMembers(teamObj.id));
+            handleError(match, history, getRedirectChannelNameForTeam(state, teamObj.id));
+            break;
         }
     };
 }
@@ -75,9 +75,8 @@ export function getPathFromIdentifier(state, path, identifier) {
             return 'group_channel_group_id';
         } else if (isDirectChannelIdentifier(identifier)) {
             return 'direct_channel_user_ids';
-        } else {
-            return 'channel_name';
         }
+        return 'channel_name';
     } else if (path === 'messages') {
         if (identifier.indexOf('@') === 0) {
             return 'direct_channel_username';
@@ -87,10 +86,11 @@ export function getPathFromIdentifier(state, path, identifier) {
             return 'direct_channel_user_id';
         } else if (identifier.length === LENGTH_OF_GROUP_ID) {
             return 'group_channel_group_id';
-        } else {
-            return 'messages_error';
         }
+        return 'error';
     }
+
+    return 'error';
 }
 
 export function goToChannelByChannelId(match, history) {

--- a/components/channel_layout/channel_identifier_router/actions.js
+++ b/components/channel_layout/channel_identifier_router/actions.js
@@ -16,7 +16,7 @@ const LENGTH_OF_ID = 26;
 const LENGTH_OF_GROUP_ID = 40;
 const LENGTH_OF_USER_ID_PAIR = 54;
 
-export function onChannelByIdentifierEnter({match, history}) {
+function onChannelByIdentifierEnter({match, history}) {
     return async (dispatch, getState) => {
         const state = getState();
         const {path, identifier, team} = match.params;
@@ -37,26 +37,26 @@ export function onChannelByIdentifierEnter({match, history}) {
                 const channelsByName = getChannelByName(state, identifier);
                 const moreChannelsByName = getOtherChannels(state).find((chan) => chan.name === identifier);
                 if (channelsByName || moreChannelsByName) {
-                    dispatch(goToChannelByChannelName(match, history));
+                    dispatch(exportFunctions.goToChannelByChannelName(match, history));
                 } else {
-                    dispatch(goToChannelByChannelId(match, history));
+                    dispatch(exportFunctions.goToChannelByChannelId(match, history));
                 }
             } else if (identifier.length === LENGTH_OF_GROUP_ID) {
-                dispatch(goToGroupChannelByGroupId(match, history));
+                dispatch(exportFunctions.goToGroupChannelByGroupId(match, history));
             } else if (identifier.length === LENGTH_OF_USER_ID_PAIR) {
-                dispatch(goToDirectChannelByUserIds(match, history));
+                dispatch(exportFunctions.goToDirectChannelByUserIds(match, history));
             } else {
-                dispatch(goToChannelByChannelName(match, history));
+                dispatch(exportFunctions.goToChannelByChannelName(match, history));
             }
         } else if (path === 'messages') {
             if (identifier.indexOf('@') === 0) {
-                dispatch(goToDirectChannelByUsername(match, history));
+                dispatch(exportFunctions.goToDirectChannelByUsername(match, history));
             } else if (identifier.indexOf('@') > 0) {
-                dispatch(goToDirectChannelByEmail(match, history));
+                dispatch(exportFunctions.goToDirectChannelByEmail(match, history));
             } else if (identifier.length === LENGTH_OF_ID) {
-                dispatch(goToDirectChannelByUserId(match, history, identifier));
+                dispatch(exportFunctions.goToDirectChannelByUserId(match, history, identifier));
             } else if (identifier.length === LENGTH_OF_GROUP_ID) {
-                dispatch(goToGroupChannelByGroupId(match, history));
+                dispatch(exportFunctions.goToGroupChannelByGroupId(match, history));
             } else {
                 await dispatch(fetchMyChannelsAndMembers(teamObj.id));
                 handleError(match, history, getRedirectChannelNameForTeam(state, teamObj.id));
@@ -65,7 +65,7 @@ export function onChannelByIdentifierEnter({match, history}) {
     };
 }
 
-export function goToChannelByChannelId(match, history) {
+function goToChannelByChannelId(match, history) {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -94,7 +94,7 @@ export function goToChannelByChannelId(match, history) {
     };
 }
 
-export function goToChannelByChannelName(match, history) {
+function goToChannelByChannelName(match, history) {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -165,7 +165,7 @@ function goToDirectChannelByUsername(match, history) {
     };
 }
 
-export function goToDirectChannelByUserId(match, history, userId) {
+function goToDirectChannelByUserId(match, history, userId) {
     return async (dispatch, getState) => {
         const state = getState();
         const {team} = match.params;
@@ -186,7 +186,7 @@ export function goToDirectChannelByUserId(match, history, userId) {
     };
 }
 
-export function goToDirectChannelByUserIds(match, history) {
+function goToDirectChannelByUserIds(match, history) {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -208,7 +208,7 @@ export function goToDirectChannelByUserIds(match, history) {
     };
 }
 
-export function goToDirectChannelByEmail(match, history) {
+function goToDirectChannelByEmail(match, history) {
     return async (dispatch, getState) => {
         const state = getState();
         const {team, identifier} = match.params;
@@ -269,3 +269,16 @@ async function handleChannelJoinError(match, history, defaultChannel) {
     const {team} = match.params;
     history.push(team ? `/error?type=channel_not_found&returnTo=/${team}/channels/${defaultChannel}` : '/');
 }
+
+const exportFunctions = {
+    onChannelByIdentifierEnter,
+    goToChannelByChannelId,
+    goToChannelByChannelName,
+    goToDirectChannelByUserId,
+    goToDirectChannelByUserIds,
+    goToDirectChannelByEmail,
+    goToGroupChannelByGroupId,
+    goToDirectChannelByUsername,
+};
+
+export default exportFunctions;

--- a/components/channel_layout/channel_identifier_router/actions.js
+++ b/components/channel_layout/channel_identifier_router/actions.js
@@ -15,7 +15,7 @@ import * as Utils from 'utils/utils.jsx';
 const LENGTH_OF_ID = 26;
 const LENGTH_OF_GROUP_ID = 40;
 const LENGTH_OF_USER_ID_PAIR = 54;
-const USER_ID_PAIR_REGEXP = new RegExp('^[a-zA-Z0-9]{' + LENGTH_OF_ID + '}__[a-zA-Z0-9]{' + LENGTH_OF_ID + '}$');
+const USER_ID_PAIR_REGEXP = new RegExp(`^[a-zA-Z0-9]{${LENGTH_OF_ID}}__[a-zA-Z0-9]{${LENGTH_OF_ID}}$`);
 
 function onChannelByIdentifierEnter({match, history}) {
     return async (dispatch, getState) => {

--- a/components/channel_layout/channel_identifier_router/actions.test.js
+++ b/components/channel_layout/channel_identifier_router/actions.test.js
@@ -20,6 +20,7 @@ jest.mock('mattermost-redux/actions/channels', () => ({
 
 jest.mock('mattermost-redux/actions/users', () => ({
     getUserByEmail: jest.fn(() => ({type: '', data: {id: 'user_id3', email: 'user3@bladekick.com', username: 'user3'}})),
+    getUser: jest.fn(() => ({type: '', data: {id: 'user_id3', email: 'user3@bladekick.com', username: 'user3'}})),
 }));
 
 const mockStore = configureStore([thunk]);
@@ -58,6 +59,33 @@ describe('Actions', () => {
             preferences: {myPreferences: {}},
         },
     };
+
+    describe('onChannelByIdentifierEnter', () => {
+        test('Channels with identifier <userid>--<userid> should go to channels', async () => {
+            const spy1 = jest.spyOn(channelActions, 'goToDirectChannelByUserIds');
+            const spy2 = jest.spyOn(channelActions, 'goToChannelByChannelName');
+            const testStore = await mockStore(initialState);
+            await testStore.dispatch(channelActions.onChannelByIdentifierEnter({match: {params: {team: 'team1',
+                                                                         identifier: 'j8oc4oizsp88mqju98pwxr1tgr--j8oc4oizsp88mqju98pwxr1tgr',
+                                                                         path: 'channels'}}, history: history}));
+            expect(spy1).not.toBeCalled();
+            expect(spy2).toBeCalled();
+            spy1.mockClear();
+            spy2.mockClear();
+        });
+        test('Channels with identifier <userid>__<userid> should go to messages', async () => {
+            const spy1 = jest.spyOn(channelActions, 'goToDirectChannelByUserIds');
+            const spy2 = jest.spyOn(channelActions, 'goToChannelByChannelName');
+            const testStore = await mockStore(initialState);
+            await testStore.dispatch(channelActions.onChannelByIdentifierEnter({match: {params: {team: 'team1',
+                                                                         identifier: 'j8oc4oizsp88mqju98pwxr1tgr__j8oc4oizsp88mqju98pwxr1tgr',
+                                                                         path: 'channels'}}, history: history}));
+            expect(spy1).toBeCalled();
+            expect(spy2).not.toBeCalled();
+            spy1.mockClear();
+            spy2.mockClear();
+        });
+    });
 
     describe('goToChannelByChannelId', () => {
         test('switch to public channel we have locally but need to join', async () => {

--- a/components/channel_layout/channel_identifier_router/actions.test.js
+++ b/components/channel_layout/channel_identifier_router/actions.test.js
@@ -65,9 +65,15 @@ describe('Actions', () => {
             const spy1 = jest.spyOn(channelActions, 'goToDirectChannelByUserIds');
             const spy2 = jest.spyOn(channelActions, 'goToChannelByChannelName');
             const testStore = await mockStore(initialState);
-            await testStore.dispatch(channelActions.onChannelByIdentifierEnter({match: {params: {team: 'team1',
-                                                                         identifier: 'j8oc4oizsp88mqju98pwxr1tgr--j8oc4oizsp88mqju98pwxr1tgr',
-                                                                         path: 'channels'}}, history: history}));
+            await testStore.dispatch(channelActions.onChannelByIdentifierEnter({
+                match: {
+                    params: {
+                        team: 'team1',
+                        identifier: 'j8oc4oizsp88mqju98pwxr1tgr--j8oc4oizsp88mqju98pwxr1tgr',
+                        path: 'channels'}
+                },
+                history
+            }));
             expect(spy1).not.toBeCalled();
             expect(spy2).toBeCalled();
             spy1.mockClear();
@@ -77,9 +83,15 @@ describe('Actions', () => {
             const spy1 = jest.spyOn(channelActions, 'goToDirectChannelByUserIds');
             const spy2 = jest.spyOn(channelActions, 'goToChannelByChannelName');
             const testStore = await mockStore(initialState);
-            await testStore.dispatch(channelActions.onChannelByIdentifierEnter({match: {params: {team: 'team1',
-                                                                         identifier: 'j8oc4oizsp88mqju98pwxr1tgr__j8oc4oizsp88mqju98pwxr1tgr',
-                                                                         path: 'channels'}}, history: history}));
+            await testStore.dispatch(channelActions.onChannelByIdentifierEnter({
+                match: {
+                    params: {
+                        team: 'team1',
+                        identifier: 'j8oc4oizsp88mqju98pwxr1tgr__j8oc4oizsp88mqju98pwxr1tgr',
+                        path: 'channels'}
+                },
+                history
+            }));
             expect(spy1).toBeCalled();
             expect(spy2).not.toBeCalled();
             spy1.mockClear();

--- a/components/channel_layout/channel_identifier_router/actions.test.js
+++ b/components/channel_layout/channel_identifier_router/actions.test.js
@@ -8,7 +8,13 @@ import {joinChannel} from 'mattermost-redux/actions/channels';
 import {getUserByEmail} from 'mattermost-redux/actions/users';
 
 import {emitChannelClickEvent} from 'actions/global_actions.jsx';
-import channelActions from 'components/channel_layout/channel_identifier_router/actions';
+import {
+    goToChannelByChannelName,
+    goToDirectChannelByUserId,
+    goToDirectChannelByUserIds,
+    goToChannelByChannelId,
+    goToDirectChannelByEmail,
+} from 'components/channel_layout/channel_identifier_router/actions';
 
 jest.mock('actions/global_actions.jsx', () => ({
     emitChannelClickEvent: jest.fn(),
@@ -60,51 +66,12 @@ describe('Actions', () => {
         },
     };
 
-    describe('onChannelByIdentifierEnter', () => {
-        test('Channels with identifier <userid>--<userid> should go to channels', async () => {
-            const spy1 = jest.spyOn(channelActions, 'goToDirectChannelByUserIds');
-            const spy2 = jest.spyOn(channelActions, 'goToChannelByChannelName');
-            const testStore = await mockStore(initialState);
-            await testStore.dispatch(channelActions.onChannelByIdentifierEnter({
-                match: {
-                    params: {
-                        team: 'team1',
-                        identifier: 'j8oc4oizsp88mqju98pwxr1tgr--j8oc4oizsp88mqju98pwxr1tgr',
-                        path: 'channels'}
-                },
-                history
-            }));
-            expect(spy1).not.toBeCalled();
-            expect(spy2).toBeCalled();
-            spy1.mockClear();
-            spy2.mockClear();
-        });
-        test('Channels with identifier <userid>__<userid> should go to messages', async () => {
-            const spy1 = jest.spyOn(channelActions, 'goToDirectChannelByUserIds');
-            const spy2 = jest.spyOn(channelActions, 'goToChannelByChannelName');
-            const testStore = await mockStore(initialState);
-            await testStore.dispatch(channelActions.onChannelByIdentifierEnter({
-                match: {
-                    params: {
-                        team: 'team1',
-                        identifier: 'j8oc4oizsp88mqju98pwxr1tgr__j8oc4oizsp88mqju98pwxr1tgr',
-                        path: 'channels'}
-                },
-                history
-            }));
-            expect(spy1).toBeCalled();
-            expect(spy2).not.toBeCalled();
-            spy1.mockClear();
-            spy2.mockClear();
-        });
-    });
-
     describe('goToChannelByChannelId', () => {
         test('switch to public channel we have locally but need to join', async () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(channelActions.goToChannelByChannelId({params: {team: 'team1', identifier: 'channel_id3'}}, history));
+            await testStore.dispatch(goToChannelByChannelId({params: {team: 'team1', identifier: 'channel_id3'}}, history));
             expect(joinChannel).toHaveBeenCalledWith('current_user_id', 'team_id1', 'channel_id3', null);
             expect(history.replace).toHaveBeenCalledWith('/team1/channels/achannel3');
         });
@@ -114,14 +81,14 @@ describe('Actions', () => {
         test('switch to channel on different team with same name', async () => {
             const testStore = await mockStore(initialState);
 
-            await testStore.dispatch(channelActions.goToChannelByChannelName({params: {team: 'team2', identifier: 'achannel'}}, {}));
+            await testStore.dispatch(goToChannelByChannelName({params: {team: 'team2', identifier: 'achannel'}}, {}));
             expect(emitChannelClickEvent).toHaveBeenCalledWith(channel2);
         });
 
         test('switch to public channel we have locally but need to join', async () => {
             const testStore = await mockStore(initialState);
 
-            await testStore.dispatch(channelActions.goToChannelByChannelName({params: {team: 'team1', identifier: 'achannel3'}}, {}));
+            await testStore.dispatch(goToChannelByChannelName({params: {team: 'team1', identifier: 'achannel3'}}, {}));
             expect(joinChannel).toHaveBeenCalledWith('current_user_id', 'team_id1', null, 'achannel3');
             expect(emitChannelClickEvent).toHaveBeenCalledWith(channel3);
         });
@@ -132,7 +99,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(channelActions.goToDirectChannelByUserId({params: {team: 'team1'}}, history, 'user_id2'));
+            await testStore.dispatch(goToDirectChannelByUserId({params: {team: 'team1'}}, history, 'user_id2'));
             expect(history.replace).toHaveBeenCalledWith('/team1/messages/@user2');
         });
 
@@ -140,7 +107,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(channelActions.goToDirectChannelByUserId({params: {team: 'team2'}}, history, 'user_id2'));
+            await testStore.dispatch(goToDirectChannelByUserId({params: {team: 'team2'}}, history, 'user_id2'));
             expect(history.replace).toHaveBeenCalledWith('/team2/messages/@user2');
         });
     });
@@ -150,7 +117,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(channelActions.goToDirectChannelByUserIds({params: {team: 'team1', identifier: 'current_user_id__user_id2'}}, history));
+            await testStore.dispatch(goToDirectChannelByUserIds({params: {team: 'team1', identifier: 'current_user_id__user_id2'}}, history));
             expect(history.replace).toHaveBeenCalledWith('/team1/messages/@user2');
         });
 
@@ -158,7 +125,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(channelActions.goToDirectChannelByUserIds({params: {team: 'team2', identifier: 'current_user_id__user_id2'}}, history));
+            await testStore.dispatch(goToDirectChannelByUserIds({params: {team: 'team2', identifier: 'current_user_id__user_id2'}}, history));
             expect(history.replace).toHaveBeenCalledWith('/team2/messages/@user2');
         });
     });
@@ -168,7 +135,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(channelActions.goToDirectChannelByEmail({params: {team: 'team1', identifier: 'user2@bladekick.com'}}, history));
+            await testStore.dispatch(goToDirectChannelByEmail({params: {team: 'team1', identifier: 'user2@bladekick.com'}}, history));
             expect(getUserByEmail).not.toHaveBeenCalled();
             expect(history.replace).toHaveBeenCalledWith('/team1/messages/@user2');
         });
@@ -177,7 +144,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(channelActions.goToDirectChannelByEmail({params: {team: 'team1', identifier: 'user3@bladekick.com'}}, history));
+            await testStore.dispatch(goToDirectChannelByEmail({params: {team: 'team1', identifier: 'user3@bladekick.com'}}, history));
             expect(getUserByEmail).toHaveBeenCalledWith('user3@bladekick.com');
             expect(history.replace).toHaveBeenCalledWith('/team1/messages/@user3');
         });

--- a/components/channel_layout/channel_identifier_router/actions.test.js
+++ b/components/channel_layout/channel_identifier_router/actions.test.js
@@ -14,6 +14,7 @@ import {
     goToDirectChannelByUserIds,
     goToChannelByChannelId,
     goToDirectChannelByEmail,
+    getPathFromIdentifier,
 } from 'components/channel_layout/channel_identifier_router/actions';
 
 jest.mock('actions/global_actions.jsx', () => ({
@@ -65,6 +66,45 @@ describe('Actions', () => {
             preferences: {myPreferences: {}},
         },
     };
+
+    describe('getPathFromIdentifier', () => {
+        test ('Should return channel_name if identifier is a channel name', () => {
+            const path = getPathFromIdentifier(initialState, 'channels', 'channelName');
+            expect(path).toEqual('channel_name');
+        });
+        test ('Should return channel_id if identifier is a channel id', () => {
+            const path = getPathFromIdentifier(initialState, 'channels', 'pjz4yj7jw7nzmmo3upi4htmt1y');
+            expect(path).toEqual('channel_id');
+        });
+        test ('Should return group_id path if identifier is a group id', () => {
+            const path = getPathFromIdentifier(initialState, 'channels', '9c992e32cc7b3e5651f68b0ead4935fdf40d67ff');
+            expect(path).toEqual('group_channel_group_id');
+        });
+        test ('Should return group_id path if identifier is a group id', () => {
+            const path = getPathFromIdentifier(initialState, 'messages', '9c992e32cc7b3e5651f68b0ead4935fdf40d67ff');
+            expect(path).toEqual('group_channel_group_id');
+        });
+        test ('Should return direct channel path if identifier is in the format userid__userid2', () => {
+            const path = getPathFromIdentifier(initialState, 'channels', '3y8ujrgtbfn78ja5nfms3qm5jw__3y8ujrgtbfn78ja5nfms3qm5jw');
+            expect(path).toEqual('direct_channel_user_ids');
+        });
+        test ('Should return channel by name path if identifier is in the format userid--userid2', () => {
+            const path = getPathFromIdentifier(initialState, 'channels', '3y8ujrgtbfn78ja5nfms3qm5jw--3y8ujrgtbfn78ja5nfms3qm5jw');
+            expect(path).toEqual('channel_name');
+        });
+        test ('Should return direct channel by username if identifier is the username', () => {
+            const path = getPathFromIdentifier(initialState, 'messages', '@user1');
+            expect(path).toEqual('direct_channel_username');
+        });
+        test ('Should return direct channel by email if identifier is the user email', () => {
+            const path = getPathFromIdentifier(initialState, 'messages', 'user1@bladekick.com');
+            expect(path).toEqual('direct_channel_email');
+        });
+        test ('Should return direct channel by id if identifier is the user id', () => {
+            const path = getPathFromIdentifier(initialState, 'messages', '3y8ujrgtbfn78ja5nfms3qm5jw');
+            expect(path).toEqual('direct_channel_user_id');
+        });
+    });
 
     describe('goToChannelByChannelId', () => {
         test('switch to public channel we have locally but need to join', async () => {

--- a/components/channel_layout/channel_identifier_router/actions.test.js
+++ b/components/channel_layout/channel_identifier_router/actions.test.js
@@ -8,13 +8,7 @@ import {joinChannel} from 'mattermost-redux/actions/channels';
 import {getUserByEmail} from 'mattermost-redux/actions/users';
 
 import {emitChannelClickEvent} from 'actions/global_actions.jsx';
-import {
-    goToChannelByChannelName,
-    goToDirectChannelByUserId,
-    goToDirectChannelByUserIds,
-    goToChannelByChannelId,
-    goToDirectChannelByEmail,
-} from 'components/channel_layout/channel_identifier_router/actions';
+import channelActions from 'components/channel_layout/channel_identifier_router/actions';
 
 jest.mock('actions/global_actions.jsx', () => ({
     emitChannelClickEvent: jest.fn(),
@@ -70,7 +64,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(goToChannelByChannelId({params: {team: 'team1', identifier: 'channel_id3'}}, history));
+            await testStore.dispatch(channelActions.goToChannelByChannelId({params: {team: 'team1', identifier: 'channel_id3'}}, history));
             expect(joinChannel).toHaveBeenCalledWith('current_user_id', 'team_id1', 'channel_id3', null);
             expect(history.replace).toHaveBeenCalledWith('/team1/channels/achannel3');
         });
@@ -80,14 +74,14 @@ describe('Actions', () => {
         test('switch to channel on different team with same name', async () => {
             const testStore = await mockStore(initialState);
 
-            await testStore.dispatch(goToChannelByChannelName({params: {team: 'team2', identifier: 'achannel'}}, {}));
+            await testStore.dispatch(channelActions.goToChannelByChannelName({params: {team: 'team2', identifier: 'achannel'}}, {}));
             expect(emitChannelClickEvent).toHaveBeenCalledWith(channel2);
         });
 
         test('switch to public channel we have locally but need to join', async () => {
             const testStore = await mockStore(initialState);
 
-            await testStore.dispatch(goToChannelByChannelName({params: {team: 'team1', identifier: 'achannel3'}}, {}));
+            await testStore.dispatch(channelActions.goToChannelByChannelName({params: {team: 'team1', identifier: 'achannel3'}}, {}));
             expect(joinChannel).toHaveBeenCalledWith('current_user_id', 'team_id1', null, 'achannel3');
             expect(emitChannelClickEvent).toHaveBeenCalledWith(channel3);
         });
@@ -98,7 +92,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(goToDirectChannelByUserId({params: {team: 'team1'}}, history, 'user_id2'));
+            await testStore.dispatch(channelActions.goToDirectChannelByUserId({params: {team: 'team1'}}, history, 'user_id2'));
             expect(history.replace).toHaveBeenCalledWith('/team1/messages/@user2');
         });
 
@@ -106,7 +100,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(goToDirectChannelByUserId({params: {team: 'team2'}}, history, 'user_id2'));
+            await testStore.dispatch(channelActions.goToDirectChannelByUserId({params: {team: 'team2'}}, history, 'user_id2'));
             expect(history.replace).toHaveBeenCalledWith('/team2/messages/@user2');
         });
     });
@@ -116,7 +110,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(goToDirectChannelByUserIds({params: {team: 'team1', identifier: 'current_user_id__user_id2'}}, history));
+            await testStore.dispatch(channelActions.goToDirectChannelByUserIds({params: {team: 'team1', identifier: 'current_user_id__user_id2'}}, history));
             expect(history.replace).toHaveBeenCalledWith('/team1/messages/@user2');
         });
 
@@ -124,7 +118,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(goToDirectChannelByUserIds({params: {team: 'team2', identifier: 'current_user_id__user_id2'}}, history));
+            await testStore.dispatch(channelActions.goToDirectChannelByUserIds({params: {team: 'team2', identifier: 'current_user_id__user_id2'}}, history));
             expect(history.replace).toHaveBeenCalledWith('/team2/messages/@user2');
         });
     });
@@ -134,7 +128,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(goToDirectChannelByEmail({params: {team: 'team1', identifier: 'user2@bladekick.com'}}, history));
+            await testStore.dispatch(channelActions.goToDirectChannelByEmail({params: {team: 'team1', identifier: 'user2@bladekick.com'}}, history));
             expect(getUserByEmail).not.toHaveBeenCalled();
             expect(history.replace).toHaveBeenCalledWith('/team1/messages/@user2');
         });
@@ -143,7 +137,7 @@ describe('Actions', () => {
             const testStore = await mockStore(initialState);
             const history = {replace: jest.fn()};
 
-            await testStore.dispatch(goToDirectChannelByEmail({params: {team: 'team1', identifier: 'user3@bladekick.com'}}, history));
+            await testStore.dispatch(channelActions.goToDirectChannelByEmail({params: {team: 'team1', identifier: 'user3@bladekick.com'}}, history));
             expect(getUserByEmail).toHaveBeenCalledWith('user3@bladekick.com');
             expect(history.replace).toHaveBeenCalledWith('/team1/messages/@user3');
         });

--- a/components/channel_layout/channel_identifier_router/actions.test.js
+++ b/components/channel_layout/channel_identifier_router/actions.test.js
@@ -68,41 +68,45 @@ describe('Actions', () => {
     };
 
     describe('getPathFromIdentifier', () => {
-        test ('Should return channel_name if identifier is a channel name', () => {
+        test('Should return channel_name if identifier is a channel name', () => {
             const path = getPathFromIdentifier(initialState, 'channels', 'channelName');
             expect(path).toEqual('channel_name');
         });
-        test ('Should return channel_id if identifier is a channel id', () => {
+        test('Should return channel_id if identifier is a channel id', () => {
             const path = getPathFromIdentifier(initialState, 'channels', 'pjz4yj7jw7nzmmo3upi4htmt1y');
             expect(path).toEqual('channel_id');
         });
-        test ('Should return group_id path if identifier is a group id', () => {
+        test('Should return group_id path if identifier is a group id', () => {
             const path = getPathFromIdentifier(initialState, 'channels', '9c992e32cc7b3e5651f68b0ead4935fdf40d67ff');
             expect(path).toEqual('group_channel_group_id');
         });
-        test ('Should return group_id path if identifier is a group id', () => {
+        test('Should return group_id path if identifier is a group id', () => {
             const path = getPathFromIdentifier(initialState, 'messages', '9c992e32cc7b3e5651f68b0ead4935fdf40d67ff');
             expect(path).toEqual('group_channel_group_id');
         });
-        test ('Should return direct channel path if identifier is in the format userid__userid2', () => {
+        test('Should return direct channel path if identifier is in the format userid__userid2', () => {
             const path = getPathFromIdentifier(initialState, 'channels', '3y8ujrgtbfn78ja5nfms3qm5jw__3y8ujrgtbfn78ja5nfms3qm5jw');
             expect(path).toEqual('direct_channel_user_ids');
         });
-        test ('Should return channel by name path if identifier is in the format userid--userid2', () => {
+        test('Should return channel by name path if identifier is in the format userid--userid2', () => {
             const path = getPathFromIdentifier(initialState, 'channels', '3y8ujrgtbfn78ja5nfms3qm5jw--3y8ujrgtbfn78ja5nfms3qm5jw');
             expect(path).toEqual('channel_name');
         });
-        test ('Should return direct channel by username if identifier is the username', () => {
+        test('Should return direct channel by username if identifier is the username', () => {
             const path = getPathFromIdentifier(initialState, 'messages', '@user1');
             expect(path).toEqual('direct_channel_username');
         });
-        test ('Should return direct channel by email if identifier is the user email', () => {
+        test('Should return direct channel by email if identifier is the user email', () => {
             const path = getPathFromIdentifier(initialState, 'messages', 'user1@bladekick.com');
             expect(path).toEqual('direct_channel_email');
         });
-        test ('Should return direct channel by id if identifier is the user id', () => {
+        test('Should return direct channel by id if identifier is the user id', () => {
             const path = getPathFromIdentifier(initialState, 'messages', '3y8ujrgtbfn78ja5nfms3qm5jw');
             expect(path).toEqual('direct_channel_user_id');
+        });
+        test('Should return error in case the path is not right', () => {
+            const path = getPathFromIdentifier(initialState, 'messages', 'test');
+            expect(path).toEqual('error');
         });
     });
 

--- a/components/channel_layout/channel_identifier_router/index.js
+++ b/components/channel_layout/channel_identifier_router/index.js
@@ -12,7 +12,7 @@ import ChannelIdentifierRouter from './channel_identifier_router.jsx';
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            onChannelByIdentifierEnter: onChannelByIdentifierEnter
+            onChannelByIdentifierEnter
         }, dispatch),
     };
 }

--- a/components/channel_layout/channel_identifier_router/index.js
+++ b/components/channel_layout/channel_identifier_router/index.js
@@ -5,14 +5,14 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {withRouter} from 'react-router-dom';
 
-import channelActions from './actions';
+import {onChannelByIdentifierEnter} from './actions';
 
 import ChannelIdentifierRouter from './channel_identifier_router.jsx';
 
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            onChannelByIdentifierEnter: channelActions.onChannelByIdentifierEnter
+            onChannelByIdentifierEnter: onChannelByIdentifierEnter
         }, dispatch),
     };
 }

--- a/components/channel_layout/channel_identifier_router/index.js
+++ b/components/channel_layout/channel_identifier_router/index.js
@@ -5,14 +5,14 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {withRouter} from 'react-router-dom';
 
-import {onChannelByIdentifierEnter} from './actions';
+import channelActions from './actions';
 
 import ChannelIdentifierRouter from './channel_identifier_router.jsx';
 
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
-            onChannelByIdentifierEnter,
+            onChannelByIdentifierEnter: channelActions.onChannelByIdentifierEnter
         }, dispatch),
     };
 }

--- a/e2e/cypress/integration/channel/channel_routing_spec.js
+++ b/e2e/cypress/integration/channel/channel_routing_spec.js
@@ -14,15 +14,21 @@ describe('Channel routing', () => {
     });
 
     it('should go to town square channel view', () => {
+        // # Go to town square channel
         cy.visit('/ad-1/channels/town-square');
+        // * Check if the channel is loaded correctly
         cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
     });
 
     it('should go to private channel view', () => {
         cy.getCurrentTeamId().then((teamId) => {
+            // # Create a private channel
             cy.apiCreateChannel(teamId, 'private-channel', 'Private channel', 'P').then((response) => {
+                // # Go to the newly created channel
                 cy.visit(`/ad-1/channels/${response.body.name}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Private channel');
+                // # Remove the created channel
                 cy.apiDeleteChannel(response.body.id);
             });
         });
@@ -31,14 +37,23 @@ describe('Channel routing', () => {
     it('should go to self direct channel using the multiple ways to go', () => {
         cy.apiGetUsers(['user-1']).then((userResponse) => {
             const user = userResponse.body[0];
+            // # Create a self direct channel
             cy.apiCreateDirectChannel([user.id, user.id]).then((response) => {
+                // # Visit the channel using the channel name
                 cy.visit(`/ad-1/channels/${user.id}__${user.id}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+                // # Visit the channel using the channel id
                 cy.visit(`/ad-1/channels/${response.body.id}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+                // # Visit the channel using the username
                 cy.visit(`/ad-1/messages/@${user.username}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+                // # Visit the channel using the user email
                 cy.visit(`/ad-1/messages/${user.email}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
             });
         });
@@ -49,14 +64,23 @@ describe('Channel routing', () => {
             const user1 = userResponse.body[1];
             const user2 = userResponse.body[0];
             const userIds = [user2.id, user1.id];
+            // # Create a direct channel between two users
             cy.apiCreateDirectChannel(userIds).then((response) => {
+                // # Visit the channel using the channel name
                 cy.visit(`/ad-1/channels/${user1.id}__${user2.id}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+                // # Visit the channel using the channel id
                 cy.visit(`/ad-1/channels/${response.body.id}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+                // # Visit the channel using the target username
                 cy.visit(`/ad-1/messages/@${user2.username}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+                // # Visit the channel using the target user email
                 cy.visit(`/ad-1/messages/${user2.email}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
             });
         });
@@ -65,10 +89,16 @@ describe('Channel routing', () => {
         const users = ['user-1', 'aaron.peterson', 'sysadmin'];
         cy.apiGetUsers(users).then((userResponse) => {
             const userGroupIds = [userResponse.body[2].id, userResponse.body[1].id, userResponse.body[0].id];
+            // # Create a group channel for 3 users
+            cy.apiCreateDirectChannel(userIds).then((response) => {
             cy.apiCreateGroupChannel(userGroupIds).then((response) => {
+                // # Visit the channel using the name using the channels route
                 cy.visit(`/ad-1/channels/${response.body.name}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'aaron.peterson, sysadmin');
+                // # Visit the channel using the name using the messages route
                 cy.visit(`/ad-1/messages/${response.body.name}`);
+                // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'aaron.peterson, sysadmin');
             });
         });

--- a/e2e/cypress/integration/channel/channel_routing_spec.js
+++ b/e2e/cypress/integration/channel/channel_routing_spec.js
@@ -46,7 +46,7 @@ describe('Channel routing', () => {
 
     it('should go to other user direct channel using multiple ways to go', () => {
         cy.apiGetUsers(['user-1', 'sysadmin']).then((userResponse) => {
-            const user1 = userResponse.body[1]
+            const user1 = userResponse.body[1];
             const user2 = userResponse.body[0];
             const userIds = [user2.id, user1.id];
             cy.apiCreateDirectChannel(userIds).then((response) => {

--- a/e2e/cypress/integration/channel/channel_routing_spec.js
+++ b/e2e/cypress/integration/channel/channel_routing_spec.js
@@ -1,0 +1,76 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+describe('Channel routing', () => {
+    before(() => {
+        cy.apiLogin('user-1');
+        cy.visit('/');
+    });
+
+    it('should go to town square channel view', () => {
+        cy.visit('/ad-1/channels/town-square');
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+    });
+
+    it('should go to private channel view', () => {
+        cy.getCurrentTeamId().then((teamId) => {
+            cy.apiCreateChannel(teamId, 'private-channel', 'Private channel', 'P').then((response) => {
+                cy.visit(`/ad-1/channels/${response.body.name}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Private channel');
+                cy.apiDeleteChannel(response.body.id);
+            });
+        });
+    });
+
+    it('should go to self direct channel using the multiple ways to go', () => {
+        cy.apiGetUsers(['user-1']).then((userResponse) => {
+            const user = userResponse.body[0];
+            cy.apiCreateDirectChannel([user.id, user.id]).then((response) => {
+                cy.visit(`/ad-1/channels/${user.id}__${user.id}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+                cy.visit(`/ad-1/channels/${response.body.id}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+                cy.visit(`/ad-1/messages/@${user.username}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+                cy.visit(`/ad-1/messages/${user.email}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+            });
+        });
+    });
+
+    it('should go to other user direct channel using multiple ways to go', () => {
+        cy.apiGetUsers(['user-1', 'sysadmin']).then((userResponse) => {
+            const user1 = userResponse.body[1]
+            const user2 = userResponse.body[0];
+            const userIds = [user2.id, user1.id];
+            cy.apiCreateDirectChannel(userIds).then((response) => {
+                cy.visit(`/ad-1/channels/${user1.id}__${user2.id}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+                cy.visit(`/ad-1/channels/${response.body.id}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+                cy.visit(`/ad-1/messages/@${user2.username}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+                cy.visit(`/ad-1/messages/${user2.email}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+            });
+        });
+    });
+    it('should go group channel using group id', () => {
+        const users = ['user-1', 'aaron.peterson', 'sysadmin'];
+        cy.apiGetUsers(users).then((userResponse) => {
+            const userGroupIds = [userResponse.body[2].id, userResponse.body[1].id, userResponse.body[0].id];
+            cy.apiCreateGroupChannel(userGroupIds).then((response) => {
+                cy.visit(`/ad-1/channels/${response.body.name}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'aaron.peterson, sysadmin');
+                cy.visit(`/ad-1/messages/${response.body.name}`);
+                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'aaron.peterson, sysadmin');
+            });
+        });
+    });
+});

--- a/e2e/cypress/integration/channel/channel_routing_spec.js
+++ b/e2e/cypress/integration/channel/channel_routing_spec.js
@@ -16,6 +16,7 @@ describe('Channel routing', () => {
     it('should go to town square channel view', () => {
         // # Go to town square channel
         cy.visit('/ad-1/channels/town-square');
+
         // * Check if the channel is loaded correctly
         cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
     });
@@ -26,8 +27,10 @@ describe('Channel routing', () => {
             cy.apiCreateChannel(teamId, 'private-channel', 'Private channel', 'P').then((response) => {
                 // # Go to the newly created channel
                 cy.visit(`/ad-1/channels/${response.body.name}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Private channel');
+
                 // # Remove the created channel
                 cy.apiDeleteChannel(response.body.id);
             });
@@ -37,22 +40,30 @@ describe('Channel routing', () => {
     it('should go to self direct channel using the multiple ways to go', () => {
         cy.apiGetUsers(['user-1']).then((userResponse) => {
             const user = userResponse.body[0];
+
             // # Create a self direct channel
             cy.apiCreateDirectChannel([user.id, user.id]).then((response) => {
                 // # Visit the channel using the channel name
                 cy.visit(`/ad-1/channels/${user.id}__${user.id}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+
                 // # Visit the channel using the channel id
                 cy.visit(`/ad-1/channels/${response.body.id}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+
                 // # Visit the channel using the username
                 cy.visit(`/ad-1/messages/@${user.username}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+
                 // # Visit the channel using the user email
                 cy.visit(`/ad-1/messages/${user.email}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
             });
@@ -64,22 +75,30 @@ describe('Channel routing', () => {
             const user1 = userResponse.body[1];
             const user2 = userResponse.body[0];
             const userIds = [user2.id, user1.id];
+
             // # Create a direct channel between two users
             cy.apiCreateDirectChannel(userIds).then((response) => {
                 // # Visit the channel using the channel name
                 cy.visit(`/ad-1/channels/${user1.id}__${user2.id}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+
                 // # Visit the channel using the channel id
                 cy.visit(`/ad-1/channels/${response.body.id}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+
                 // # Visit the channel using the target username
                 cy.visit(`/ad-1/messages/@${user2.username}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+
                 // # Visit the channel using the target user email
                 cy.visit(`/ad-1/messages/${user2.email}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
             });
@@ -89,14 +108,18 @@ describe('Channel routing', () => {
         const users = ['user-1', 'aaron.peterson', 'sysadmin'];
         cy.apiGetUsers(users).then((userResponse) => {
             const userGroupIds = [userResponse.body[2].id, userResponse.body[1].id, userResponse.body[0].id];
+
             // # Create a group channel for 3 users
             cy.apiCreateGroupChannel(userGroupIds).then((response) => {
                 // # Visit the channel using the name using the channels route
                 cy.visit(`/ad-1/channels/${response.body.name}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'aaron.peterson, sysadmin');
+
                 // # Visit the channel using the name using the messages route
                 cy.visit(`/ad-1/messages/${response.body.name}`);
+
                 // * Check you can go to the channel without problem
                 cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'aaron.peterson, sysadmin');
             });

--- a/e2e/cypress/integration/channel/channel_routing_spec.js
+++ b/e2e/cypress/integration/channel/channel_routing_spec.js
@@ -90,7 +90,6 @@ describe('Channel routing', () => {
         cy.apiGetUsers(users).then((userResponse) => {
             const userGroupIds = [userResponse.body[2].id, userResponse.body[1].id, userResponse.body[0].id];
             // # Create a group channel for 3 users
-            cy.apiCreateDirectChannel(userIds).then((response) => {
             cy.apiCreateGroupChannel(userGroupIds).then((response) => {
                 // # Visit the channel using the name using the channels route
                 cy.visit(`/ad-1/channels/${response.body.name}`);


### PR DESCRIPTION
Cherry pick of #4685 on release-5.20.

- #4685: Export functions to be able to spy on them in the tests

/cc  @ethervoid