### PR TITLE
MM-21721 Fix FullScreenModal not supporting refs

### DIFF
--- a/components/widgets/modals/full_screen_modal.tsx
+++ b/components/widgets/modals/full_screen_modal.tsx
@@ -111,4 +111,6 @@ class FullScreenModal extends React.Component<Props> {
     }
 }
 
-export default injectIntl(FullScreenModal);
+const wrappedComponent = injectIntl(FullScreenModal, {forwardRef: true});
+wrappedComponent.displayName = 'injectIntl(FullScreenModal)';
+export default wrappedComponent;


### PR DESCRIPTION
This component wasn't passing refs correctly previously because `injectIntl` can't take refs on its own.

I wasn't able to write unit tests for this because you're not able to test `InvitationModal` using `mount` (see https://mattermost.atlassian.net/browse/MM-21948), and I ran into some weird problems with testing refs on `FullScreenModal` directly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21721