### PR TITLE
[MM-21979] Fix incorrect placeholder prop for searchable user list

### DIFF
--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -210,7 +210,7 @@ class SearchableUserList extends React.Component {
         if (this.props.renderFilterRow) {
             filterRow = this.props.renderFilterRow(this.handleInput);
         } else {
-            const searchUsersTxt = formatMessage({id: t('filtered_user_list.search'), defaultMessage: 'Search users'}).toLowerCase();
+            const searchUsersPlaceholder = {id: t('filtered_user_list.search'), defaultMessage: 'Search users'};
             filterRow = (
                 <div className='col-xs-12'>
                     <label
@@ -226,11 +226,11 @@ class SearchableUserList extends React.Component {
                         id='searchUsersInput'
                         ref='filter'
                         className='form-control filter-textbox'
-                        placeholder={searchUsersTxt}
+                        placeholder={searchUsersPlaceholder}
                         inputComponent={LocalizedInput}
                         value={this.props.term}
                         onInput={this.handleInput}
-                        aria-label={searchUsersTxt}
+                        aria-label={formatMessage(searchUsersPlaceholder).toLowerCase()}
                     />
                 </div>
             );


### PR DESCRIPTION
#### Summary
Placeholder is expected to be of type 
```
    placeholder: {
        id: string;
        defaultMessage: string;
        values?: {string: any};
    };
 ```
however there was a recent commit changing the type being passed down to a string causing any component referencing `SearchableUserList` to error on load

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21979

