### PR TITLE
MM-21874 Merge styling props for children of custom OverlayTrigger

### DIFF
--- a/components/__snapshots__/quick_input.test.jsx.snap
+++ b/components/__snapshots__/quick_input.test.jsx.snap
@@ -57,8 +57,17 @@ exports[`components/QuickInput should match snapshot when clearable and with val
           delayShow={400}
           overlay={
             <OverlayWrapper
+              bsClass="tooltip"
+              id="InputClearTooltip"
               intl={null}
-            />
+              placement="right"
+            >
+              <FormattedMessage
+                defaultMessage="Clear input"
+                id="input.clear"
+                values={Object {}}
+              />
+            </OverlayWrapper>
           }
           placement="bottom"
           trigger={

--- a/components/channel_header_mobile/channel_info_button/__snapshots__/channel_info_button.test.js.snap
+++ b/components/channel_header_mobile/channel_info_button/__snapshots__/channel_info_button.test.js.snap
@@ -51,6 +51,8 @@ exports[`components/ChannelHeaderMobile/ChannelInfoButton should match snapshot,
       defaultOverlayShown={false}
       overlay={
         <OverlayWrapper
+          className="navbar__popover"
+          id="header-popover"
           intl={
             Object {
               "defaultFormats": Object {},
@@ -82,7 +84,25 @@ exports[`components/ChannelHeaderMobile/ChannelInfoButton should match snapshot,
               "timeZone": "Etc/UTC",
             }
           }
-        />
+          placement="bottom"
+          popoverSize="sm"
+          popoverStyle="info"
+        >
+          <Connect(Markdown)
+            message="channel header"
+            options={
+              Object {
+                "mentionHighlight": false,
+              }
+            }
+          />
+          <div
+            className="close visible-xs-block"
+            onClick={[Function]}
+          >
+            ×
+          </div>
+        </OverlayWrapper>
       }
       placement="bottom"
       rootClose={true}
@@ -218,6 +238,8 @@ exports[`components/ChannelHeaderMobile/ChannelInfoButton should match snapshot,
       defaultOverlayShown={false}
       overlay={
         <OverlayWrapper
+          className="navbar__popover"
+          id="header-popover"
           intl={
             Object {
               "defaultFormats": Object {},
@@ -249,7 +271,45 @@ exports[`components/ChannelHeaderMobile/ChannelInfoButton should match snapshot,
               "timeZone": "Etc/UTC",
             }
           }
-        />
+          placement="bottom"
+          popoverSize="sm"
+          popoverStyle="info"
+        >
+          <div>
+            <FormattedMessage
+              defaultMessage="No channel header yet."
+              id="navbar.noHeader"
+              values={Object {}}
+            />
+            <React.Fragment>
+              <br />
+              <FormattedMessage
+                defaultMessage="{clickHere} to add one."
+                id="navbar.clickToAddHeader"
+                values={
+                  Object {
+                    "clickHere": <a
+                      href="#"
+                      onClick={[Function]}
+                    >
+                      <FormattedMessage
+                        defaultMessage="Click here"
+                        id="navbar.click"
+                        values={Object {}}
+                      />
+                    </a>,
+                  }
+                }
+              />
+            </React.Fragment>
+          </div>
+          <div
+            className="close visible-xs-block"
+            onClick={[Function]}
+          >
+            ×
+          </div>
+        </OverlayWrapper>
       }
       placement="bottom"
       rootClose={true}

--- a/components/overlay_trigger.test.tsx
+++ b/components/overlay_trigger.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {mount, shallow} from 'enzyme';
+import {mount} from 'enzyme';
 import React from 'react';
-import {Overlay, OverlayTrigger as BaseOverlayTrigger} from 'react-bootstrap';
+import {OverlayTrigger as BaseOverlayTrigger} from 'react-bootstrap';
 import {FormattedMessage, IntlProvider} from 'react-intl';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';

--- a/components/overlay_trigger.test.tsx
+++ b/components/overlay_trigger.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {mount} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import React from 'react';
-import {OverlayTrigger as BaseOverlayTrigger} from 'react-bootstrap';
+import {Overlay, OverlayTrigger as BaseOverlayTrigger} from 'react-bootstrap';
 import {FormattedMessage, IntlProvider} from 'react-intl';
 
 import {mountWithIntl} from 'tests/helpers/intl-test-helper';
@@ -58,7 +58,7 @@ describe('OverlayTrigger', () => {
         expect(console.error).toHaveBeenCalled();
     });
 
-    test('custom OverlayTrigger should fail to pass intl to overlay', () => {
+    test('custom OverlayTrigger should pass intl to overlay', () => {
         const wrapper = mount(
             <IntlProvider {...intlProviderProps}>
                 <OverlayTrigger {...baseProps}>
@@ -89,5 +89,43 @@ describe('OverlayTrigger', () => {
         );
 
         expect(ref.current).toBe(wrapper.find(BaseOverlayTrigger).instance());
+    });
+
+    test('style and className should correctly be passed to overlay', () => {
+        const props = {
+            ...baseProps,
+            overlay: (
+                <span
+                    className='test-overlay-className'
+                    style={{backgroundColor: 'red'}}
+                >
+                    {'test-overlay'}
+                </span>
+            ),
+            defaultOverlayShown: true, // Make sure the overlay is visible
+        };
+
+        const wrapper = mount(
+            <IntlProvider {...intlProviderProps}>
+                <OverlayTrigger {...props}>
+                    <span/>
+                </OverlayTrigger>
+            </IntlProvider>
+        );
+
+        // Dive into the react-bootstrap internals to find our overlay
+        const overlay = mount(wrapper.find(BaseOverlayTrigger).instance()._overlay).find('span'); // eslint-disable-line no-underscore-dangle
+
+        // Confirm that we've found the right span
+        expect(overlay.exists()).toBe(true);
+        expect(overlay.text()).toBe('test-overlay');
+
+        // Confirm that our props are included
+        expect(overlay.prop('className')).toContain('test-overlay-className');
+        expect(overlay.prop('style').backgroundColor).toBe('red');
+
+        // And confirm that react-bootstrap's props are included
+        expect(overlay.prop('placement')).toBe('right');
+        expect(overlay.prop('positionTop')).toBe(0);
     });
 });

--- a/components/overlay_trigger.test.tsx
+++ b/components/overlay_trigger.test.tsx
@@ -114,7 +114,7 @@ describe('OverlayTrigger', () => {
         );
 
         // Dive into the react-bootstrap internals to find our overlay
-        const overlay = mount(wrapper.find(BaseOverlayTrigger).instance()._overlay).find('span'); // eslint-disable-line no-underscore-dangle
+        const overlay = mount((wrapper.find(BaseOverlayTrigger).instance() as any)._overlay).find('span'); // eslint-disable-line no-underscore-dangle
 
         // Confirm that we've found the right span
         expect(overlay.exists()).toBe(true);
@@ -122,7 +122,7 @@ describe('OverlayTrigger', () => {
 
         // Confirm that our props are included
         expect(overlay.prop('className')).toContain('test-overlay-className');
-        expect(overlay.prop('style').backgroundColor).toBe('red');
+        expect(overlay.prop('style')).toMatchObject({backgroundColor: 'red'});
 
         // And confirm that react-bootstrap's props are included
         expect(overlay.prop('className')).toContain('fade in');

--- a/components/overlay_trigger.test.tsx
+++ b/components/overlay_trigger.test.tsx
@@ -125,6 +125,7 @@ describe('OverlayTrigger', () => {
         expect(overlay.prop('style').backgroundColor).toBe('red');
 
         // And confirm that react-bootstrap's props are included
+        expect(overlay.prop('className')).toContain('fade in');
         expect(overlay.prop('placement')).toBe('right');
         expect(overlay.prop('positionTop')).toBe(0);
     });

--- a/components/overlay_trigger.tsx
+++ b/components/overlay_trigger.tsx
@@ -26,7 +26,12 @@ const OverlayTrigger = React.forwardRef((props: Props, ref?: React.Ref<BaseOverl
                 <BaseOverlayTrigger
                     {...otherProps}
                     ref={ref}
-                    overlay={<OverlayWrapper intl={intl}/>}
+                    overlay={
+                        <OverlayWrapper
+                            {...overlay.props}
+                            intl={intl}
+                        />
+                    }
                 />
             )}
         </IntlContext.Consumer>

--- a/plugins/channel_header_plug/__snapshots__/channel_header_plug.test.jsx.snap
+++ b/plugins/channel_header_plug/__snapshots__/channel_header_plug.test.jsx.snap
@@ -71,8 +71,16 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with one extended compo
           delayShow={400}
           overlay={
             <OverlayWrapper
+              bsClass="tooltip"
+              className=""
+              id="pluginTooltip"
               intl={null}
-            />
+              placement="right"
+            >
+              <span>
+                some tooltip text
+              </span>
+            </OverlayWrapper>
           }
           placement="bottom"
           trigger={


### PR DESCRIPTION
This PR is based off of #4701. To see the changes exclusive to it, go here: https://github.com/mattermost/mattermost-webapp/compare/mm21880...mm21874

In the custom `OverlayTrigger`, the way that we were using `React.cloneElement` to render the overlay was causing the `className` and `style` props given to us by `react-bootstrap` to overwrite any that we specified, such as the `className` given to the Channel Header popover to position it. react-bootstrap's `OverlayTrigger` handles merging these props itself, as long as the props are passed into the overlay correctly. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21874