### PR TITLE
MM 21985 - InvitePeople options should not be visible for group-synced teams.

### DIFF
--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -189,6 +189,7 @@ class MainMenu extends React.PureComponent {
                     >
                         <Menu.ItemToggleModalRedux
                             id='invitePeople'
+                            show={!teamIsGroupConstrained}
                             modalId={ModalIdentifiers.INVITATION}
                             dialogType={InvitationModal}
                             text={formatMessage({id: 'navbar_dropdown.invitePeople', defaultMessage: 'Invite People'})}

--- a/components/team_members_modal/__snapshots__/team_members_modal.test.tsx.snap
+++ b/components/team_members_modal/__snapshots__/team_members_modal.test.tsx.snap
@@ -51,28 +51,6 @@ exports[`components/TeamMembersModal should match snapshot 1`] = `
         }
       />
     </ModalTitle>
-    <Connect(TeamPermissionGate)
-      permissions={
-        Array [
-          "add_user_to_team",
-          "invite_guest",
-        ]
-      }
-      teamId="id"
-    >
-      <button
-        className="btn btn-primary invite-people-btn"
-        id="invitePeople"
-        onClick={[Function]}
-        type="button"
-      >
-        <FormattedMessage
-          defaultMessage="Invite People"
-          id="team_member_modal.invitePeople"
-          values={Object {}}
-        />
-      </button>
-    </Connect(TeamPermissionGate)>
   </ModalHeader>
   <ModalBody
     bsClass="modal-body"

--- a/components/team_members_modal/team_members_modal.test.tsx
+++ b/components/team_members_modal/team_members_modal.test.tsx
@@ -15,7 +15,8 @@ describe('components/TeamMembersModal', () => {
             <TeamMembersModal
                 currentTeam={{
                     id: 'id',
-                    display_name: 'display name'
+                    display_name: 'display name',
+                    group_constrained: true,
                 }}
                 onHide={emptyFunction}
                 onLoad={emptyFunction}
@@ -34,7 +35,8 @@ describe('components/TeamMembersModal', () => {
             <TeamMembersModal
                 currentTeam={{
                     id: 'id',
-                    display_name: 'display name'
+                    display_name: 'display name',
+                    group_constrained: false,
                 }}
                 onHide={onHide}
                 onLoad={emptyFunction}

--- a/components/team_members_modal/team_members_modal.tsx
+++ b/components/team_members_modal/team_members_modal.tsx
@@ -17,6 +17,7 @@ type Props = {
     currentTeam: {
         id: string;
         display_name: string;
+        group_constrained: boolean;
     };
     onHide: () => void;
     onLoad?: () => void;
@@ -88,6 +89,7 @@ export default class TeamMembersModal extends React.PureComponent<Props, State> 
                             }}
                         />
                     </Modal.Title>
+                    if (!this.props.currentTeam.group_constrained) {
                     <TeamPermissionGate
                         teamId={this.props.currentTeam.id}
                         permissions={[Permissions.ADD_USER_TO_TEAM, Permissions.INVITE_GUEST]}
@@ -104,6 +106,7 @@ export default class TeamMembersModal extends React.PureComponent<Props, State> 
                             />
                         </button>
                     </TeamPermissionGate>
+                    }
                 </Modal.Header>
                 <Modal.Body>
                     <MemberListTeam

--- a/components/team_members_modal/team_members_modal.tsx
+++ b/components/team_members_modal/team_members_modal.tsx
@@ -77,13 +77,13 @@ export default class TeamMembersModal extends React.PureComponent<Props, State> 
                         className='btn btn-primary invite-people-btn'
                         onClick={this.handleInvitePeople}
                     >
-                    <FormattedMessage
-                        id='team_member_modal.invitePeople'
-                        defaultMessage='Invite People'
-                    />
+                        <FormattedMessage
+                            id='team_member_modal.invitePeople'
+                            defaultMessage='Invite People'
+                        />
                     </button>
                 </TeamPermissionGate>
-            )
+            );
         }
 
         return (

--- a/components/team_members_modal/team_members_modal.tsx
+++ b/components/team_members_modal/team_members_modal.tsx
@@ -17,6 +17,7 @@ type Props = {
     currentTeam: {
         id: string;
         display_name: string;
+        group_constrained: boolean;
     };
     onHide: () => void;
     onLoad?: () => void;

--- a/components/team_members_modal/team_members_modal.tsx
+++ b/components/team_members_modal/team_members_modal.tsx
@@ -65,6 +65,27 @@ export default class TeamMembersModal extends React.PureComponent<Props, State> 
         if (this.props.currentTeam) {
             teamDisplayName = this.props.currentTeam.display_name;
         }
+        let invitePeopleSection = null;
+        if (!this.props.currentTeam.group_constrained) {
+            invitePeopleSection = (
+                <TeamPermissionGate
+                    teamId={this.props.currentTeam.id}
+                    permissions={[Permissions.ADD_USER_TO_TEAM, Permissions.INVITE_GUEST]}
+                >
+                    <button
+                        id='invitePeople'
+                        type='button'
+                        className='btn btn-primary invite-people-btn'
+                        onClick={this.handleInvitePeople}
+                    >
+                    <FormattedMessage
+                        id='team_member_modal.invitePeople'
+                        defaultMessage='Invite People'
+                    />
+                    </button>
+                </TeamPermissionGate>
+            )
+        }
 
         return (
             <Modal
@@ -89,24 +110,7 @@ export default class TeamMembersModal extends React.PureComponent<Props, State> 
                             }}
                         />
                     </Modal.Title>
-                    if (!this.props.currentTeam.group_constrained) {
-                    <TeamPermissionGate
-                        teamId={this.props.currentTeam.id}
-                        permissions={[Permissions.ADD_USER_TO_TEAM, Permissions.INVITE_GUEST]}
-                    >
-                        <button
-                            id='invitePeople'
-                            type='button'
-                            className='btn btn-primary invite-people-btn'
-                            onClick={this.handleInvitePeople}
-                        >
-                            <FormattedMessage
-                                id='team_member_modal.invitePeople'
-                                defaultMessage='Invite People'
-                            />
-                        </button>
-                    </TeamPermissionGate>
-                    }
+                    {invitePeopleSection}
                 </Modal.Header>
                 <Modal.Body>
                     <MemberListTeam

--- a/components/team_members_modal/team_members_modal.tsx
+++ b/components/team_members_modal/team_members_modal.tsx
@@ -17,7 +17,6 @@ type Props = {
     currentTeam: {
         id: string;
         display_name: string;
-        group_constrained: boolean;
     };
     onHide: () => void;
     onLoad?: () => void;

--- a/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
+++ b/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
@@ -64,7 +64,7 @@ exports[`plugins/MainMenuActions should match snapshot and click plugin item for
         icon={false}
         id="invitePeople"
         modalId="invitation"
-        show={true}
+        show={false}
         text="Invite People"
       />
     </Connect(TeamPermissionGate)>


### PR DESCRIPTION
#### Summary
InvitePeople options should not be visible for group-synced teams.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21985

Note: Dependent on UX guidance, currently under review.