### PR TITLE
Revert to mattermost:// protocol for mobile and to store app if that fails

### DIFF
--- a/components/linking_landing_page/linking_landing_page.tsx
+++ b/components/linking_landing_page/linking_landing_page.tsx
@@ -40,13 +40,12 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
         super(props);
 
         const location = window.location.href.replace('/landing#', '');
-        const defaultProtocol = Utils.isMobile() ? 'mattermost-mobile' : 'mattermost';
 
         this.state = {
             rememberChecked: false,
             redirectPage: false,
             location,
-            nativeLocation: location.replace(/^(https|http)/, defaultProtocol),
+            nativeLocation: location.replace(/^(https|http)/, 'mattermost'),
             brandImageError: false,
             navigating: false,
         };
@@ -141,16 +140,25 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
     }
 
     renderGoNativeAppMessage = () => {
-        const downloadLink = this.getDownloadLink();
-
         return (
             <a
-                href={this.state.nativeLocation}
+                href={Utils.isMobile() ? '#' : this.state.nativeLocation}
                 onMouseDown={() => {
                     this.setPreference(LandingPreferenceTypes.MATTERMOSTAPP, true);
                 }}
                 onClick={() => {
                     this.setState({redirectPage: true, navigating: true});
+                    if (Utils.isMobile()) {
+                        window.location.replace(this.state.nativeLocation);
+                        var timeout = setTimeout(() => {
+                            window.location.replace(this.getDownloadLink()!);
+                        }, 2000);
+                        if (UserAgent.isAndroidWeb()) {
+                            window.addEventListener('blur', () => {
+                                clearTimeout(timeout);
+                            });
+                        }
+                    }
                 }}
                 className='btn btn-primary btn-lg get-app__download'
             >

--- a/components/linking_landing_page/linking_landing_page.tsx
+++ b/components/linking_landing_page/linking_landing_page.tsx
@@ -150,7 +150,7 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
                     this.setState({redirectPage: true, navigating: true});
                     if (Utils.isMobile()) {
                         window.location.replace(this.state.nativeLocation);
-                        var timeout = setTimeout(() => {
+                        const timeout = setTimeout(() => {
                             window.location.replace(this.getDownloadLink()!);
                         }, 2000);
                         if (UserAgent.isAndroidWeb()) {


### PR DESCRIPTION
#### Summary
This PR reverts back to using the `mattermost://` deep linking protocol for mobile apps. It also allows the store app to open up if the protocol does not succeed.

### Ticket Link
https://mattermost.atlassian.net/browse/MM-22005