### PR TITLE
MM-21872 Fix for toast showing o new messages

### DIFF
--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -70,6 +70,11 @@ class ToastWrapper extends React.PureComponent {
             showNewMessagesToast = true;
         }
 
+        if (!unreadCount) {
+            showNewMessagesToast = false;
+            showUnreadToast = false;
+        }
+
         return {
             unreadCount,
             showUnreadToast,
@@ -191,7 +196,7 @@ class ToastWrapper extends React.PureComponent {
             width: this.props.width,
         };
 
-        if (this.state.showUnreadToast && this.state.unreadCount > 0) {
+        if (this.state.showUnreadToast) {
             toastProps = {
                 ...toastProps,
                 onDismiss: this.hideUnreadToast,

--- a/components/toast_wrapper/toast_wrapper.test.jsx
+++ b/components/toast_wrapper/toast_wrapper.test.jsx
@@ -92,12 +92,22 @@ describe('components/ToastWrapper', () => {
         test('Should have unread toast channel is marked as unread', () => {
             const props = {
                 ...baseProps,
+                atLatestPost: true,
+                postListIds: [ //order of the postIds is in reverse order so unreadCount should be 3
+                    'post1',
+                    'post2',
+                    'post3',
+                    PostListRowListIds.START_OF_NEW_MESSAGES,
+                    DATE_LINE + 1551711600000,
+                    'post4',
+                    'post5',
+                ],
                 channelMarkedAsUnread: false,
+                atBottom: true,
             };
             const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
-
-            expect(wrapper.state('showUnreadToast')).toBe(false);
-            wrapper.setProps({channelMarkedAsUnread: true});
+            expect(wrapper.state('showUnreadToast')).toBe(undefined);
+            wrapper.setProps({channelMarkedAsUnread: true, atBottom: false});
             expect(wrapper.state('showUnreadToast')).toBe(true);
         });
 
@@ -247,6 +257,29 @@ describe('components/ToastWrapper', () => {
             expect(wrapper.state('showNewMessagesToast')).toBe(true);
             wrapper.instance().handleShortcut({key: 'ESC', keyCode: 27});
             expect(baseProps.updateLastViewedBottomAt).toHaveBeenCalledTimes(1);
+        });
+
+        test('Changing unreadCount to 0 should set the showNewMessagesToast state to false', () => {
+            const props = {
+                ...baseProps,
+                atLatestPost: true,
+                postListIds: [ //order of the postIds is in reverse order so unreadCount should be 3
+                    'post1',
+                    'post2',
+                    'post3',
+                    PostListRowListIds.START_OF_NEW_MESSAGES,
+                    DATE_LINE + 1551711600000,
+                    'post4',
+                    'post5',
+                ],
+            };
+
+            const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
+            wrapper.setState({atBottom: false, showUnreadToast: false});
+            wrapper.setProps({atBottom: false, lastViewedBottom: 1234, latestPostTimeStamp: 1235});
+            expect(wrapper.state('showNewMessagesToast')).toBe(true);
+            wrapper.setProps({postListIds: baseProps.postListIds});
+            expect(wrapper.state('showNewMessagesToast')).toBe(false);
         });
     });
 });


### PR DESCRIPTION
#### Summary
  * This happens because of a race with toastState and marking channel new message line at action.
  Toast state is set to true using `getDerivedStateFromProps` and then in componentDidUpdate we use `updateNewMessagesAtInChannel` to change new line position which makes the count to zero but the toast is not removed again in `getDerivedStateFromProps` causing the toast to keep the state true.
Ideally i wanted to solve this by not making the toast state to true in the first place but it is really hard to achieve and this solution seems to work just fine,
 
  * Fixing this by putting up a check to not show toasts when unread count goes to 0.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21872
