### PR TITLE
MM-21953: Fixing x button alignment in invitation process

### DIFF
--- a/components/widgets/icons/close_icon.jsx
+++ b/components/widgets/icons/close_icon.jsx
@@ -14,8 +14,9 @@ export default class CloseIcon extends React.PureComponent {
                 >
                     {(ariaLabel) => (
                         <svg
-                            width='24'
-                            height='24'
+                            width='24px'
+                            height='24px'
+                            viewBox='0 0 24 24'
                             role='img'
                             aria-label={ariaLabel}
                         >


### PR DESCRIPTION
#### Summary
Fixing x button alignment in invitation process. This was introduced in the PR #4628, I checked the other places that it is used there and is not breaking the style.

Looks like the other similar change made to the `unread_bellow_icon.jsx` is working fine everywhere is used, so I didn't restore the `viewBox` there.

#### Ticket Link
[MM-21953](https://mattermost.atlassian.net/browse/MM-21953)

#### Screenshots
![image](https://user-images.githubusercontent.com/290303/73185657-bdf51000-411e-11ea-8cc9-57c988edd9e4.png)
