### PR TITLE
Update mmjstool version to support TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14914,8 +14914,8 @@
       }
     },
     "mmjstool": {
-      "version": "github:mattermost/mattermost-utilities#086f4ffdca4e31a0be22f6bcdfa093ed83fb29e8",
-      "from": "github:mattermost/mattermost-utilities#086f4ffdca4e31a0be22f6bcdfa093ed83fb29e8",
+      "version": "github:mattermost/mattermost-utilities#beffd8b4c5b985ef1bfb500e06f3306d40a67599",
+      "from": "github:mattermost/mattermost-utilities#beffd8b4c5b985ef1bfb500e06f3306d40a67599",
       "dev": true,
       "requires": {
         "estree-walk": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "jest-junit": "9.0.0",
     "jquery-deferred": "0.3.1",
     "mini-css-extract-plugin": "0.8.0",
-    "mmjstool": "github:mattermost/mattermost-utilities#086f4ffdca4e31a0be22f6bcdfa093ed83fb29e8",
+    "mmjstool": "github:mattermost/mattermost-utilities#beffd8b4c5b985ef1bfb500e06f3306d40a67599",
     "node-sass": "4.13.0",
     "react-router-enzyme-context": "1.2.0",
     "redux-mock-store": "1.5.3",


### PR DESCRIPTION
#### Summary
Update `mmjstool` version in the webapp so that `i18n-extract` reads TypeScript files.
Needed for https://github.com/mattermost/mattermost-webapp/pull/4747