### PR TITLE
Not needed getWrappedInstance in this case

### DIFF
--- a/components/invitation_modal/invitation_modal.jsx
+++ b/components/invitation_modal/invitation_modal.jsx
@@ -92,21 +92,21 @@ export default class InvitationModal extends React.Component {
             this.setState({step: STEPS_INITIAL, hasChanges: false, lastInviteChannels: [], lastInviteMesssage: '', prevStep: this.state.step});
         }
         if (this.modal && this.modal.current) {
-            this.modal.current.getWrappedInstance().resetFocus();
+            this.modal.current.resetFocus();
         }
     }
 
     goToMembers = () => {
         this.setState({step: STEPS_INVITE_MEMBERS, prevStep: this.state.step, hasChanges: false, invitesSent: [], invitesNotSent: [], invitesType: InviteTypes.INVITE_MEMBER});
         if (this.modal && this.modal.current) {
-            this.modal.current.getWrappedInstance().resetFocus();
+            this.modal.current.resetFocus();
         }
     }
 
     goToGuests = () => {
         this.setState({step: STEPS_INVITE_GUESTS, prevStep: this.state.step, hasChanges: false, invitesSent: [], invitesNotSent: [], invitesType: InviteTypes.INVITE_GUEST});
         if (this.modal && this.modal.current) {
-            this.modal.current.getWrappedInstance().resetFocus();
+            this.modal.current.resetFocus();
         }
     }
 
@@ -117,7 +117,7 @@ export default class InvitationModal extends React.Component {
             this.setState({step: STEPS_INVITE_MEMBERS, prevStep: this.state.step, hasChanges: false, invitesSent: [], invitesNotSent: [], invitesType: InviteTypes.INVITE_MEMBER});
         }
         if (this.modal && this.modal.current) {
-            this.modal.current.getWrappedInstance().resetFocus();
+            this.modal.current.resetFocus();
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR fixes errors caused by calling `getWrapperInstance` when is not available.

Looks like the [source PR](https://github.com/mattermost/mattermost-webapp/pull/4637).

Harrison explained it offline:

```
It's only currently needed for components wrapped with `connect`, but previously, it was 
also needed for components wrapped with `injectIntl`. The react-intl upgrade I did recently 
made it so that `injectIntl` no longer needs it
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-22099