### PR TITLE
Automated cherry pick of #4734

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -850,7 +850,6 @@
             cursor: pointer;
         }
 
-        &:hover,
         &.more-modal__row--selected  {
             background: v(center-channel-color-05);
 


### PR DESCRIPTION
Cherry pick of #4734 on release-5.20.

- #4734: Fix double highlight when using mouse and keyboard together

/cc  @larkox