### PR TITLE
[MM-20744] Add FullScreenModal--compact css class for narrow screens

### DIFF
--- a/components/widgets/modals/full_screen_modal.scss
+++ b/components/widgets/modals/full_screen_modal.scss
@@ -53,3 +53,19 @@
         transition: opacity 100ms;
     }
 }
+
+.FullScreenModal.FullScreenModal--compact {
+    .back {
+        top: 8px;
+        left: 16px;
+    }
+
+    .close-x {
+        top: 8px;
+        right: 16px;
+    }
+
+    .close-x, .back {
+        position: absolute;
+    }
+}


### PR DESCRIPTION
#### Summary

The `FullScreenModal` css class contains some css that causes issues in the Jira subscriptions modal when the user's screen is narrow, specifically the placement of the "back" and "close" buttons. Using a new css class `FullScreenModal--compact`, we can have the Jira plugin opt-in to using some reusable styling on the top of the existing class.

Discussion can be found here: https://github.com/mattermost/mattermost-plugin-jira/pull/413#pullrequestreview-336329676

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20744

#### Screenshots

Without new css class
X button is on top of the `New Subscription` button.
![image](https://user-images.githubusercontent.com/6913320/73320929-e9efbe80-420e-11ea-806a-66f627970014.png)

With new css class
Placement of buttons and content is reasonable.
![image](https://user-images.githubusercontent.com/6913320/73320677-20790980-420e-11ea-826a-ddc8af02e880.png)

Without new css class
In this scenario, we have scrolled down in a large form. Buttons are fixed and so interfere with the form.
![image](https://user-images.githubusercontent.com/6913320/73320907-dd6b6600-420e-11ea-821b-4d7350b2929c.png)

With new css class
Notice the X and Back buttons are not visible because they are at the top of the form with `position: absolute`.
![image](https://user-images.githubusercontent.com/6913320/73320696-3686ca00-420e-11ea-9032-0b1359372340.png)


