### PR TITLE
[MM-21729] Update name display to match teammate name display preference

### DIFF
--- a/components/suggestion/at_mention_provider/at_mention_suggestion.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_suggestion.jsx
@@ -87,7 +87,7 @@ export default class AtMentionSuggestion extends Suggestion {
             const displayName = Utils.getUserDisplayName(user);
 
             if (username !== displayName) {
-                description = `- ${displayName}`
+                description = `- ${displayName}`;
             }
 
             icon = (

--- a/components/suggestion/at_mention_provider/at_mention_suggestion.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_suggestion.jsx
@@ -84,13 +84,10 @@ export default class AtMentionSuggestion extends Suggestion {
             );
         } else {
             username = user.username;
+            const displayName = Utils.getUserDisplayName(user);
 
-            if ((user.first_name || user.last_name) && user.nickname) {
-                description = `- ${Utils.getFullName(user)} (${user.nickname})`;
-            } else if (user.nickname) {
-                description = `- (${user.nickname})`;
-            } else if (user.first_name || user.last_name) {
-                description = `- ${Utils.getFullName(user)}`;
+            if (username !== displayName) {
+                description = `- ${displayName}`
             }
 
             icon = (

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -11,7 +11,12 @@ import {Posts} from 'mattermost-redux/constants';
 import {getChannel, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTeammateNameDisplaySetting, getBool} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentUserId, getUser, getUserByUsername as getUserByUsernameRedux} from 'mattermost-redux/selectors/entities/users';
+import {
+    getCurrentUserId, 
+    getUser, 
+    getUserByUsername as getUserByUsernameRedux, 
+    makeGetDisplayName
+} from 'mattermost-redux/selectors/entities/users';
 import {
     blendColors,
     changeOpacity,
@@ -1282,6 +1287,11 @@ export function getDisplayName(user) {
     return user.username;
 }
 
+export function getUserDisplayName(user) {
+    const getDisplayName = makeGetDisplayName();
+    return getDisplayName(store.getState(), user.id);
+}
+
 export function getLongDisplayName(user) {
     let displayName = '@' + user.username;
     var fullName = getFullName(user);
@@ -1369,30 +1379,14 @@ export function displayEntireNameForUser(user) {
     }
 
     let displayName = '@' + user.username;
-    const fullName = getFullName(user);
+    const description = getUserDisplayName(user);
 
-    if (fullName && user.nickname) {
+    if (user.username !== description) {
         displayName = (
             <span>
                 {'@' + user.username}
                 {' - '}
-                <span className='light'>{fullName + ' (' + user.nickname + ')'}</span>
-            </span>
-        );
-    } else if (fullName) {
-        displayName = (
-            <span>
-                {'@' + user.username}
-                {' - '}
-                <span className='light'>{fullName}</span>
-            </span>
-        );
-    } else if (user.nickname) {
-        displayName = (
-            <span>
-                {'@' + user.username}
-                {' - '}
-                <span className='light'>{'(' + user.nickname + ')'}</span>
+                <span className='light'>{description}</span>
             </span>
         );
     }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -12,9 +12,9 @@ import {getChannel, getRedirectChannelNameForTeam} from 'mattermost-redux/select
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getTeammateNameDisplaySetting, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {
-    getCurrentUserId, 
-    getUser, 
-    getUserByUsername as getUserByUsernameRedux, 
+    getCurrentUserId,
+    getUser,
+    getUserByUsername as getUserByUsernameRedux,
     makeGetDisplayName
 } from 'mattermost-redux/selectors/entities/users';
 import {
@@ -1288,8 +1288,8 @@ export function getDisplayName(user) {
 }
 
 export function getUserDisplayName(user) {
-    const getDisplayName = makeGetDisplayName();
-    return getDisplayName(store.getState(), user.id);
+    const getCorrectDisplayName = makeGetDisplayName();
+    return getCorrectDisplayName(store.getState(), user.id);
 }
 
 export function getLongDisplayName(user) {


### PR DESCRIPTION
**Reviewers: Please hold back on Code and QA review as this needs to be reviewed by UX first**

#### Summary
<!--
A description of what this pull request does.
-->
The description being shown after username in different parts of the application were not aligning up with user's teammate name display preference. This PR aims to address this problem.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21729

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

I'm only showing the at mention and direct message modal. Other modals (manage members, add members to channel, etc) look exactly the same as the direct message modal since they use the same code to render the description. If there is any modal that needs verification, please let me know so I can double check and fix. 

**Teammate Name Display = Show Username**
![image](https://user-images.githubusercontent.com/17804942/73381330-89569500-4293-11ea-948e-43eb66ea8dd3.png)
![image](https://user-images.githubusercontent.com/17804942/73381368-98d5de00-4293-11ea-85e2-509cf4249e5f.png)

**Teammate Name Display = Show nickname if one exists, otherwise show first and last name**
![image](https://user-images.githubusercontent.com/17804942/73381998-be171c00-4294-11ea-90b4-ec96c1e1b69f.png)
![image](https://user-images.githubusercontent.com/17804942/73382032-cb340b00-4294-11ea-865c-4aec0afd7ee5.png)

**Teammate Name Display = Show first and last name**
![image](https://user-images.githubusercontent.com/17804942/73382145-020a2100-4295-11ea-9846-2c348531b35b.png)
![image](https://user-images.githubusercontent.com/17804942/73382190-151cf100-4295-11ea-9750-fb3ec8251eb8.png)







