### PR TITLE
[MM-21920] Enforce use_channel_mentions permissions

### DIFF
--- a/components/__snapshots__/textbox.test.jsx.snap
+++ b/components/__snapshots__/textbox.test.jsx.snap
@@ -50,6 +50,7 @@ exports[`components/TextBox should match snapshot with required props 1`] = `
             },
           ],
           "requestStarted": false,
+          "useChannelMentions": true,
         },
         ChannelMentionProvider {
           "autocompleteChannels": [MockFunction],
@@ -134,6 +135,7 @@ exports[`components/TextBox should throw error when new property is too long 1`]
             },
           ],
           "requestStarted": false,
+          "useChannelMentions": true,
         },
         ChannelMentionProvider {
           "autocompleteChannels": [MockFunction],
@@ -218,6 +220,7 @@ exports[`components/TextBox should throw error when value is too long 1`] = `
             },
           ],
           "requestStarted": false,
+          "useChannelMentions": true,
         },
         ChannelMentionProvider {
           "autocompleteChannels": [MockFunction],

--- a/components/admin_console/reset_password_modal/reset_password_modal.test.tsx
+++ b/components/admin_console/reset_password_modal/reset_password_modal.test.tsx
@@ -42,7 +42,9 @@ describe('components/admin_console/reset_password_modal/reset_password_modal.tsx
         terms_of_service_create_at: 0,
         terms_of_service_id: '',
         update_at: 0,
-        username: ''
+        username: '',
+        is_bot: false,
+        last_picture_update: 0,
     };
     const baseProps = {
         actions: {adminResetPassword: jest.fn(() => {})},

--- a/components/create_comment/__snapshots__/create_comment.test.jsx.snap
+++ b/components/create_comment/__snapshots__/create_comment.test.jsx.snap
@@ -42,6 +42,7 @@ exports[`components/CreateComment should match snapshot read only channel 1`] = 
           popoverMentionKeyClick={true}
           preview={false}
           suggestionListStyle="top"
+          useChannelMentions={true}
           value=""
         />
         <span
@@ -296,6 +297,7 @@ exports[`components/CreateComment should match snapshot, comment with message 1`
           popoverMentionKeyClick={true}
           preview={false}
           suggestionListStyle="top"
+          useChannelMentions={true}
           value="Test message"
         />
         <span
@@ -459,6 +461,7 @@ exports[`components/CreateComment should match snapshot, emoji picker disabled 1
           popoverMentionKeyClick={true}
           preview={false}
           suggestionListStyle="top"
+          useChannelMentions={true}
           value="Test message"
         />
         <span
@@ -610,6 +613,7 @@ exports[`components/CreateComment should match snapshot, empty comment 1`] = `
           popoverMentionKeyClick={true}
           preview={false}
           suggestionListStyle="top"
+          useChannelMentions={true}
           value=""
         />
         <span
@@ -773,6 +777,7 @@ exports[`components/CreateComment should match snapshot, non-empty message and u
           popoverMentionKeyClick={true}
           preview={false}
           suggestionListStyle="top"
+          useChannelMentions={true}
           value="Test message"
         />
         <span

--- a/components/create_comment/__snapshots__/create_comment.test.jsx.snap
+++ b/components/create_comment/__snapshots__/create_comment.test.jsx.snap
@@ -170,6 +170,7 @@ exports[`components/CreateComment should match snapshot when cannot post 1`] = `
           popoverMentionKeyClick={true}
           preview={false}
           suggestionListStyle="top"
+          useChannelMentions={true}
           value=""
         />
         <span

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -186,6 +186,11 @@ class CreateComment extends React.PureComponent {
         selectedPostFocussedAt: PropTypes.number.isRequired,
 
         canPost: PropTypes.bool.isRequired,
+        /**
+         * To determine if the current user can send special channel mentions
+         */
+        useChannelMentions: PropTypes.bool.isRequired,
+
     }
 
     static getDerivedStateFromProps(props, state) {
@@ -426,7 +431,7 @@ class CreateComment extends React.PureComponent {
         this.updatePreview(false);
 
         const membersCount = this.props.channelMembersCount;
-        const notificationsToChannel = this.props.enableConfirmNotificationsToChannel;
+        const notificationsToChannel = this.props.enableConfirmNotificationsToChannel && this.props.useChannelMentions;
         if (notificationsToChannel &&
             membersCount > Constants.NOTIFY_ALL_MEMBERS &&
             containsAtChannel(this.state.draft.message)) {
@@ -996,6 +1001,7 @@ class CreateComment extends React.PureComponent {
                                 suggestionListStyle={this.state.suggestionListStyle}
                                 badConnection={this.props.badConnection}
                                 listenForMentionKeyClick={true}
+                                useChannelMentions={this.props.useChannelMentions}
                             />
                             <span
                                 ref='createCommentControls'

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -186,11 +186,11 @@ class CreateComment extends React.PureComponent {
         selectedPostFocussedAt: PropTypes.number.isRequired,
 
         canPost: PropTypes.bool.isRequired,
+
         /**
          * To determine if the current user can send special channel mentions
          */
         useChannelMentions: PropTypes.bool.isRequired,
-
     }
 
     static getDerivedStateFromProps(props, state) {

--- a/components/create_comment/create_comment.test.jsx
+++ b/components/create_comment/create_comment.test.jsx
@@ -49,6 +49,7 @@ describe('components/CreateComment', () => {
         isTimezoneEnabled: false,
         selectedPostFocussedAt: 0,
         canPost: true,
+        useChannelMentions: true,
     };
 
     test('should match snapshot, empty comment', () => {
@@ -585,6 +586,30 @@ describe('components/CreateComment', () => {
                         ...baseProps,
                         draft: {
                             message: `Test message ${mention}`,
+                            uploadsInProgress: [],
+                            fileInfos: [{}, {}, {}],
+                        },
+                        onSubmit,
+                        channelMembersCount: 8,
+                        enableConfirmNotificationsToChannel: true,
+                    };
+
+                    const wrapper = shallowWithIntl(
+                        <CreateComment {...props}/>
+                    );
+
+                    wrapper.instance().handleSubmit({preventDefault});
+                    expect(onSubmit).toHaveBeenCalled();
+                    expect(preventDefault).toHaveBeenCalled();
+                    expect(wrapper.state('showConfirmModal')).toBe(false);
+                });
+
+                it('when user has insufficient permissions', () => {
+                    const props = {
+                        ...baseProps,
+                        useChannelMentions: false,
+                        draft: {
+                            message: `Test message @${mention}`,
                             uploadsInProgress: [],
                             fileInfos: [{}, {}, {}],
                         },

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -11,8 +11,6 @@ import {getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
 import {makeGetMessageInHistoryItem} from 'mattermost-redux/selectors/entities/posts';
 import {resetCreatePostRequest, resetHistoryIndex} from 'mattermost-redux/actions/posts';
 import {getChannelTimezones} from 'mattermost-redux/actions/channels';
-
-import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions, Preferences, Posts} from 'mattermost-redux/constants';
 
 import {connectionErrorCount} from 'selectors/views/system';

--- a/components/create_comment/index.js
+++ b/components/create_comment/index.js
@@ -5,14 +5,15 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
+import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {getAllChannelStats} from 'mattermost-redux/selectors/entities/channels';
 import {makeGetMessageInHistoryItem} from 'mattermost-redux/selectors/entities/posts';
 import {resetCreatePostRequest, resetHistoryIndex} from 'mattermost-redux/actions/posts';
 import {getChannelTimezones} from 'mattermost-redux/actions/channels';
-import {Preferences, Posts} from 'mattermost-redux/constants';
+
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
-import Permissions from 'mattermost-redux/constants/permissions';
+import {Permissions, Preferences, Posts} from 'mattermost-redux/constants';
 
 import {connectionErrorCount} from 'selectors/views/system';
 
@@ -58,6 +59,10 @@ function makeMapStateToProps() {
                 permission: Permissions.CREATE_POST,
             }
         );
+        const useChannelMentions = haveIChannelPermission(state, {
+            channel: ownProps.channelId,
+            permission: Permissions.USE_CHANNEL_MENTIONS,
+        });
 
         return {
             draft,
@@ -78,6 +83,7 @@ function makeMapStateToProps() {
             isTimezoneEnabled,
             selectedPostFocussedAt: getSelectedPostFocussedAt(state),
             canPost,
+            useChannelMentions,
         };
     };
 }

--- a/components/create_post/__snapshots__/create_post.test.jsx.snap
+++ b/components/create_post/__snapshots__/create_post.test.jsx.snap
@@ -518,6 +518,7 @@ exports[`components/create_post should match snapshot when cannot post 1`] = `
           onKeyUp={[Function]}
           onMouseUp={[Function]}
           preview={false}
+          useChannelMentions={true}
           value=""
         />
         <span

--- a/components/create_post/__snapshots__/create_post.test.jsx.snap
+++ b/components/create_post/__snapshots__/create_post.test.jsx.snap
@@ -39,6 +39,7 @@ exports[`components/create_post Show tutorial 1`] = `
           onKeyUp={[Function]}
           onMouseUp={[Function]}
           preview={false}
+          useChannelMentions={true}
           value=""
         />
         <span
@@ -230,6 +231,7 @@ exports[`components/create_post should match snapshot for center textbox 1`] = `
           onKeyUp={[Function]}
           onMouseUp={[Function]}
           preview={false}
+          useChannelMentions={true}
           value=""
         />
         <span
@@ -390,6 +392,7 @@ exports[`components/create_post should match snapshot for read only channel 1`] 
           onKeyUp={[Function]}
           onMouseUp={[Function]}
           preview={false}
+          useChannelMentions={true}
           value=""
         />
         <span
@@ -675,6 +678,7 @@ exports[`components/create_post should match snapshot when file upload disabled 
           onKeyUp={[Function]}
           onMouseUp={[Function]}
           preview={false}
+          useChannelMentions={true}
           value=""
         />
         <span
@@ -835,6 +839,7 @@ exports[`components/create_post should match snapshot, init 1`] = `
           onKeyUp={[Function]}
           onMouseUp={[Function]}
           preview={false}
+          useChannelMentions={true}
           value=""
         />
         <span

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -178,6 +178,7 @@ class CreatePost extends React.PureComponent {
         isTimezoneEnabled: PropTypes.bool.isRequired,
 
         canPost: PropTypes.bool.isRequired,
+
         /**
          * To determine if the current user can send special channel mentions
          */

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -178,6 +178,10 @@ class CreatePost extends React.PureComponent {
         isTimezoneEnabled: PropTypes.bool.isRequired,
 
         canPost: PropTypes.bool.isRequired,
+        /**
+         * To determine if the current user can send special channel mentions
+         */
+        useChannelMentions: PropTypes.bool.isRequired,
 
         intl: intlShape.isRequired,
 
@@ -531,7 +535,7 @@ class CreatePost extends React.PureComponent {
         } = this.props;
 
         const currentMembersCount = this.props.currentChannelMembersCount;
-        const notificationsToChannel = this.props.enableConfirmNotificationsToChannel;
+        const notificationsToChannel = this.props.enableConfirmNotificationsToChannel && this.props.useChannelMentions;
         if (notificationsToChannel &&
             currentMembersCount > Constants.NOTIFY_ALL_MEMBERS &&
             containsAtChannel(this.state.message)) {
@@ -1298,6 +1302,7 @@ class CreatePost extends React.PureComponent {
                                 preview={this.state.showPreview}
                                 badConnection={this.props.badConnection}
                                 listenForMentionKeyClick={true}
+                                useChannelMentions={this.props.useChannelMentions}
                             />
                             <span
                                 ref='createPostControls'

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -135,6 +135,7 @@ function createPost({
             badConnection={false}
             isTimezoneEnabled={false}
             canPost={true}
+            useChannelMentions={true}
         />
     );
 }

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -9,6 +9,7 @@ import Permissions from 'mattermost-redux/constants/permissions';
 
 import {getCurrentChannel, getCurrentChannelStats} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId, isCurrentUserSystemAdmin, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
+import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {getChannelTimezones} from 'mattermost-redux/actions/channels';
 import {get, getInt, getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {
@@ -25,8 +26,9 @@ import {
     moveHistoryIndexForward,
     removeReaction,
 } from 'mattermost-redux/actions/posts';
-import {Posts, Preferences as PreferencesRedux} from 'mattermost-redux/constants';
+
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
+import {Permissions, Posts, Preferences as PreferencesRedux} from 'mattermost-redux/constants';
 
 import {connectionErrorCount} from 'selectors/views/system';
 
@@ -74,6 +76,10 @@ function makeMapStateToProps() {
                 permission: Permissions.CREATE_POST,
             }
         );
+        const useChannelMentions = haveIChannelPermission(state, {
+            channel: currentChannel.id,
+            permission: Permissions.USE_CHANNEL_MENTIONS,
+        });
 
         return {
             currentTeamId: getCurrentTeamId(state),
@@ -102,6 +108,7 @@ function makeMapStateToProps() {
             badConnection,
             isTimezoneEnabled,
             canPost,
+            useChannelMentions,
         };
     };
 }

--- a/components/create_post/index.js
+++ b/components/create_post/index.js
@@ -5,7 +5,6 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import Permissions from 'mattermost-redux/constants/permissions';
 
 import {getCurrentChannel, getCurrentChannelStats} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId, isCurrentUserSystemAdmin, getStatusForUserId} from 'mattermost-redux/selectors/entities/users';
@@ -26,8 +25,6 @@ import {
     moveHistoryIndexForward,
     removeReaction,
 } from 'mattermost-redux/actions/posts';
-
-import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions, Posts, Preferences as PreferencesRedux} from 'mattermost-redux/constants';
 
 import {connectionErrorCount} from 'selectors/views/system';

--- a/components/suggestion/at_mention_provider/at_mention_provider.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_provider.jsx
@@ -25,16 +25,17 @@ export default class AtMentionProvider extends Provider {
 
     // setProps gives the provider additional context for matching pretexts. Ideally this would
     // just be something akin to a connected component with access to the store itself.
-    setProps({currentUserId, profilesInChannel, profilesNotInChannel, autocompleteUsersInChannel}) {
+    setProps({currentUserId, profilesInChannel, profilesNotInChannel, autocompleteUsersInChannel, useChannelMentions}) {
         this.currentUserId = currentUserId;
         this.profilesInChannel = profilesInChannel;
         this.profilesNotInChannel = profilesNotInChannel;
         this.autocompleteUsersInChannel = autocompleteUsersInChannel;
+        this.useChannelMentions = useChannelMentions;
     }
 
     // specialMentions matches one of @here, @channel or @all, unless using /msg.
     specialMentions() {
-        if (this.latestPrefix.startsWith('/msg')) {
+        if (this.latestPrefix.startsWith('/msg') || !this.useChannelMentions) {
             return [];
         }
 

--- a/components/suggestion/at_mention_provider/at_mention_provider.test.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_provider.test.jsx
@@ -20,6 +20,7 @@ describe('components/suggestion/at_mention_provider/AtMentionProvider', () => {
         currentUserId: 'userid1',
         profilesInChannel: [userid10, userid3, userid1, userid2],
         autocompleteUsersInChannel: jest.fn().mockResolvedValue(false),
+        useChannelMentions: true,
     };
 
     it('should ignore pretexts that are not at-mentions', () => {
@@ -953,6 +954,33 @@ describe('components/suggestion/at_mention_provider/AtMentionProvider', () => {
                 ],
                 component: AtMentionSuggestion,
             });
+        });
+    });
+
+    it('should ignore channel mentions - @here, @channel and @all when useChannelMentions is false', () => {
+        const pretext = '@';
+        const matchedPretext = '@';
+        const params = {
+            ...baseParams,
+            useChannelMentions: false,
+            profilesInChannel: [],
+            autocompleteUsersInChannel: jest.fn().mockImplementation(() => new Promise((resolve) => {
+                resolve({data: {
+                    users: [],
+                    out_of_channel: [],
+                }});
+            })),
+        };
+
+        const provider = new AtMentionProvider(params);
+        const resultCallback = jest.fn();
+        expect(provider.handlePretextChanged(pretext, resultCallback)).toEqual(true);
+
+        expect(resultCallback).toHaveBeenNthCalledWith(1, {
+            matchedPretext,
+            terms: [],
+            items: [],
+            component: AtMentionSuggestion,
         });
     });
 });

--- a/components/textbox.test.jsx
+++ b/components/textbox.test.jsx
@@ -21,9 +21,7 @@ describe('components/TextBox', () => {
             autocompleteUsersInChannel: jest.fn(),
             autocompleteChannels: jest.fn(),
         },
-        permissions: {
-            useChannelMentions: true,
-        },
+        useChannelMentions: true,
     };
 
     test('should match snapshot with required props', () => {

--- a/components/textbox.test.jsx
+++ b/components/textbox.test.jsx
@@ -21,6 +21,9 @@ describe('components/TextBox', () => {
             autocompleteUsersInChannel: jest.fn(),
             autocompleteChannels: jest.fn(),
         },
+        permissions: {
+            useChannelMentions: true,
+        },
     };
 
     test('should match snapshot with required props', () => {

--- a/components/textbox/index.js
+++ b/components/textbox/index.js
@@ -5,21 +5,33 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getCurrentUserId, makeGetProfilesInChannel, makeGetProfilesNotInChannel} from 'mattermost-redux/selectors/entities/users';
+import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
+import {Permissions} from 'mattermost-redux/constants';
 
 import {autocompleteUsersInChannel} from 'actions/views/channel';
 import {autocompleteChannels} from 'actions/channel_actions';
 
 import Textbox from './textbox.jsx';
 
-const makeMapStateToProps = () => {
+const mapStateToProps = (state, ownProps) => {
     const getProfilesInChannel = makeGetProfilesInChannel();
     const getProfilesNotInChannel = makeGetProfilesNotInChannel();
+    const permissions = {
+        useChannelMentions: haveIChannelPermission(
+            state,
+            {
+                channel: ownProps.channelId,
+                permission: Permissions.USE_CHANNEL_MENTIONS,
+            }
+        ),
+    };
 
-    return (state, ownProps) => ({
+    return {
         currentUserId: getCurrentUserId(state),
         profilesInChannel: getProfilesInChannel(state, ownProps.channelId, true),
         profilesNotInChannel: getProfilesNotInChannel(state, ownProps.channelId, true),
-    });
+        permissions,
+    };
 };
 
 const mapDispatchToProps = (dispatch) => ({
@@ -29,4 +41,4 @@ const mapDispatchToProps = (dispatch) => ({
     }, dispatch),
 });
 
-export default connect(makeMapStateToProps, mapDispatchToProps, null, {withRef: true})(Textbox);
+export default connect(mapStateToProps, mapDispatchToProps, null, {withRef: true})(Textbox);

--- a/components/textbox/index.js
+++ b/components/textbox/index.js
@@ -11,15 +11,15 @@ import {autocompleteChannels} from 'actions/channel_actions';
 
 import Textbox from './textbox.jsx';
 
-const mapStateToProps = (state, ownProps) => {
+const makeMapStateToProps = () => {
     const getProfilesInChannel = makeGetProfilesInChannel();
     const getProfilesNotInChannel = makeGetProfilesNotInChannel();
 
-    return {
+    return (state, ownProps) => ({
         currentUserId: getCurrentUserId(state),
         profilesInChannel: getProfilesInChannel(state, ownProps.channelId, true),
         profilesNotInChannel: getProfilesNotInChannel(state, ownProps.channelId, true),
-    };
+    });
 };
 
 const mapDispatchToProps = (dispatch) => ({
@@ -29,4 +29,4 @@ const mapDispatchToProps = (dispatch) => ({
     }, dispatch),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps, null, {withRef: true})(Textbox);
+export default connect(makeMapStateToProps, mapDispatchToProps, null, {withRef: true})(Textbox);

--- a/components/textbox/index.js
+++ b/components/textbox/index.js
@@ -5,8 +5,6 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {getCurrentUserId, makeGetProfilesInChannel, makeGetProfilesNotInChannel} from 'mattermost-redux/selectors/entities/users';
-import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
-import {Permissions} from 'mattermost-redux/constants';
 
 import {autocompleteUsersInChannel} from 'actions/views/channel';
 import {autocompleteChannels} from 'actions/channel_actions';
@@ -16,21 +14,11 @@ import Textbox from './textbox.jsx';
 const mapStateToProps = (state, ownProps) => {
     const getProfilesInChannel = makeGetProfilesInChannel();
     const getProfilesNotInChannel = makeGetProfilesNotInChannel();
-    const permissions = {
-        useChannelMentions: haveIChannelPermission(
-            state,
-            {
-                channel: ownProps.channelId,
-                permission: Permissions.USE_CHANNEL_MENTIONS,
-            }
-        ),
-    };
 
     return {
         currentUserId: getCurrentUserId(state),
         profilesInChannel: getProfilesInChannel(state, ownProps.channelId, true),
         profilesNotInChannel: getProfilesNotInChannel(state, ownProps.channelId, true),
-        permissions,
     };
 };
 

--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -46,6 +46,7 @@ export default class Textbox extends React.PureComponent {
             autocompleteUsersInChannel: PropTypes.func.isRequired,
             autocompleteChannels: PropTypes.func.isRequired,
         }),
+        permissions: PropTypes.object.isRequired,
     };
 
     static defaultProps = {
@@ -63,6 +64,7 @@ export default class Textbox extends React.PureComponent {
                 profilesInChannel: this.props.profilesInChannel,
                 profilesNotInChannel: this.props.profilesNotInChannel,
                 autocompleteUsersInChannel: (prefix) => this.props.actions.autocompleteUsersInChannel(prefix, props.channelId),
+                useChannelMentions: this.props.permissions.useChannelMentions,
             }),
             new ChannelMentionProvider(props.actions.autocompleteChannels),
             new EmoticonProvider(),
@@ -94,6 +96,7 @@ export default class Textbox extends React.PureComponent {
                         profilesInChannel: this.props.profilesInChannel,
                         profilesNotInChannel: this.props.profilesNotInChannel,
                         autocompleteUsersInChannel: (prefix) => this.props.actions.autocompleteUsersInChannel(prefix, this.props.channelId),
+                        useChannelMentions: this.props.permissions.useChannelMentions,
                     });
                 }
             }

--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -46,7 +46,7 @@ export default class Textbox extends React.PureComponent {
             autocompleteUsersInChannel: PropTypes.func.isRequired,
             autocompleteChannels: PropTypes.func.isRequired,
         }),
-        permissions: PropTypes.object.isRequired,
+        useChannelMentions: PropTypes.bool.isRequired,
     };
 
     static defaultProps = {
@@ -64,7 +64,7 @@ export default class Textbox extends React.PureComponent {
                 profilesInChannel: this.props.profilesInChannel,
                 profilesNotInChannel: this.props.profilesNotInChannel,
                 autocompleteUsersInChannel: (prefix) => this.props.actions.autocompleteUsersInChannel(prefix, props.channelId),
-                useChannelMentions: this.props.permissions.useChannelMentions,
+                useChannelMentions: this.props.useChannelMentions,
             }),
             new ChannelMentionProvider(props.actions.autocompleteChannels),
             new EmoticonProvider(),
@@ -96,7 +96,7 @@ export default class Textbox extends React.PureComponent {
                         profilesInChannel: this.props.profilesInChannel,
                         profilesNotInChannel: this.props.profilesNotInChannel,
                         autocompleteUsersInChannel: (prefix) => this.props.actions.autocompleteUsersInChannel(prefix, this.props.channelId),
-                        useChannelMentions: this.props.permissions.useChannelMentions,
+                        useChannelMentions: this.props.useChannelMentions,
                     });
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14929,8 +14929,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#5f5a8a5007661f6d54533c2b51299748338b5a65",
-      "from": "github:mattermost/mattermost-redux#5f5a8a5007661f6d54533c2b51299748338b5a65",
+      "version": "github:mattermost/mattermost-redux#571d2b41deef6c79ddbf1323b3bac343c6377fd8",
+      "from": "github:mattermost/mattermost-redux#571d2b41deef6c79ddbf1323b3bac343c6377fd8",
       "requires": {
         "core-js": "3.1.4",
         "form-data": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#5a06d1af25ca48927b9efe0d9c42c01c84e7839b",
-    "mattermost-redux": "github:mattermost/mattermost-redux#5f5a8a5007661f6d54533c2b51299748338b5a65",
+    "mattermost-redux": "github:mattermost/mattermost-redux#571d2b41deef6c79ddbf1323b3bac343c6377fd8",
     "moment-timezone": "0.5.27",
     "pdfjs-dist": "2.0.489",
     "popmotion": "8.7.0",


### PR DESCRIPTION
#### Summary
- Enforces the new `use_channel_mentions` permission when showing suggestions for @mentions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21920

#### Related Pull Requests
- Has server changes https://github.com/mattermost/mattermost-server/pull/13781
- Has redux changes https://github.com/mattermost/mattermost-redux/pull/1046

#### Screenshots
![Screen Shot 2020-01-29 at 8 12 32 PM](https://user-images.githubusercontent.com/3207297/73411535-c0e53180-42d3-11ea-95fd-2d2be160334b.png)
![Screen Shot 2020-01-29 at 8 12 48 PM](https://user-images.githubusercontent.com/3207297/73411536-c0e53180-42d3-11ea-9947-f4aa1886b46d.png)

