### PR TITLE
MM-21255  - Search "in:@username" changes the label to "in:userid" in the search input

### DIFF
--- a/components/suggestion/search_channel_provider.jsx
+++ b/components/suggestion/search_channel_provider.jsx
@@ -96,7 +96,7 @@ export default class SearchChannelProvider extends Provider {
                     // MM-12677 When this is migrated this needs to be fixed to pull the user's locale
                     //
                     const channels = data.sort(sortChannelsByTypeAndDisplayName.bind(null, 'en'));
-                    const channelNames = channels.map((channel) => channel.name);
+                    const channelNames = channels.map(itemToName);
 
                     resultsCallback({
                         matchedPretext: channelPrefix,


### PR DESCRIPTION
#### Summary
There was a bug introduced in https://github.com/mattermost/mattermost-webapp/pull/4217 regarding passing the selected result back to searchbox

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-21255