### PR TITLE
Fix commit hash of mattermost-redux for release-5.20 branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14395,8 +14395,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#5f5a8a5007661f6d54533c2b51299748338b5a65",
-      "from": "github:mattermost/mattermost-redux#5f5a8a5007661f6d54533c2b51299748338b5a65",
+      "version": "github:mattermost/mattermost-redux#a0e7a1cbedb2ec051e0d2411fd47ee19bb49d709",
+      "from": "github:mattermost/mattermost-redux#a0e7a1cbedb2ec051e0d2411fd47ee19bb49d709",
       "requires": {
         "core-js": "3.1.4",
         "form-data": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#5a06d1af25ca48927b9efe0d9c42c01c84e7839b",
-    "mattermost-redux": "github:mattermost/mattermost-redux#5f5a8a5007661f6d54533c2b51299748338b5a65",
+    "mattermost-redux": "github:mattermost/mattermost-redux#a0e7a1cbedb2ec051e0d2411fd47ee19bb49d709",
     "moment-timezone": "0.5.27",
     "pdfjs-dist": "2.0.489",
     "popmotion": "8.7.0",


### PR DESCRIPTION
Fix commit hash of mattermost-redux for release-5.20 branch -  https://github.com/mattermost/mattermost-redux/commit/a0e7a1cbedb2ec051e0d2411fd47ee19bb49d709
