### PR TITLE
[MM-22005] Cut auto redirect to app store on failed deep link for iOS

### DIFF
--- a/components/linking_landing_page/linking_landing_page.tsx
+++ b/components/linking_landing_page/linking_landing_page.tsx
@@ -149,15 +149,15 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
                 onClick={() => {
                     this.setState({redirectPage: true, navigating: true});
                     if (Utils.isMobile()) {
-                        window.location.replace(this.state.nativeLocation);
-                        const timeout = setTimeout(() => {
-                            window.location.replace(this.getDownloadLink()!);
-                        }, 2000);
                         if (UserAgent.isAndroidWeb()) {
+                            const timeout = setTimeout(() => {
+                                window.location.replace(this.getDownloadLink()!);
+                            }, 2000);
                             window.addEventListener('blur', () => {
                                 clearTimeout(timeout);
                             });
                         }
+                        window.location.replace(this.state.nativeLocation);
                     }
                 }}
                 className='btn btn-primary btn-lg get-app__download'


### PR DESCRIPTION
#### Summary
On iOS, the auto redirect to the app store when failing to deep link (ie. the app is not installed) was causing issues when the app was actually installed. The `setTimeout()` would not be cleared once the app switched over and thus the app store would still open on successful deep link.

This PR cuts the feature from iOS for the time being while we look into other options.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22005