### PR TITLE
Fix send message via profile popover spec

### DIFF
--- a/e2e/cypress/integration/channel/send_message_via_profile_popover_spec.js
+++ b/e2e/cypress/integration/channel/send_message_via_profile_popover_spec.js
@@ -68,21 +68,25 @@ function verifyDMChannelViaSendMessage(postId, profileSelector, user) {
     cy.visit('/ad-1/channels/town-square');
 
     // # Visit post thread on RHS and verify that RHS is opened
+    cy.wait(TIMEOUTS.TINY);
     cy.clickPostCommentIcon(postId);
     cy.get('#rhsContainer').should('be.visible');
 
     // # Open profile popover with the given selector
+    cy.wait(TIMEOUTS.TINY);
     cy.get(`#rhsPost_${postId}`).should('be.visible').within(() => {
         cy.get(profileSelector).should('be.visible').click();
     });
 
     // * Verify that profile popover is opened
+    cy.wait(TIMEOUTS.TINY);
     cy.get('#user-profile-popover').should('be.visible').within(() => {
         // # Click "Send Message" on profile popover
         cy.findByText('Send Message').should('be.visible').click();
     });
 
     // * Verify that profile popover is closed
+    cy.wait(TIMEOUTS.TINY);
     cy.get('#user-profile-popover').should('not.be.visible');
 
     // * Verify that it redirects into the DM channel and matches channel intro


### PR DESCRIPTION
#### Summary
Fix failing send message via profile popover spec. Added waits for elements to load after clicks. For some reason, the components become detached from DOM (maybe due to app component refresh in the background); hence wait needs to happen before cypress element query.

#### Ticket Link
none, failing on daily Cypress test