### PR TITLE
edits to defaultMessage in components

### DIFF
--- a/components/activity_log_modal/components/__snapshots__/activity_log.test.jsx.snap
+++ b/components/activity_log_modal/components/__snapshots__/activity_log.test.jsx.snap
@@ -72,7 +72,7 @@ exports[`components/activity_log_modal/ActivityLog should match snapshot 1`] = `
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Logout"
+        defaultMessage="Log Out"
         id="activity_log.logout"
         values={Object {}}
       />

--- a/components/activity_log_modal/components/activity_log.jsx
+++ b/components/activity_log_modal/components/activity_log.jsx
@@ -197,7 +197,7 @@ export default class ActivityLog extends React.PureComponent {
                     >
                         <FormattedMessage
                             id='activity_log.logout'
-                            defaultMessage='Logout'
+                            defaultMessage='Log Out'
                         />
                     </button>
                 </div>

--- a/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
+++ b/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.jsx
@@ -106,7 +106,7 @@ class AdminNavbarDropdown extends React.Component {
                 <Menu.Group>
                     <Menu.ItemAction
                         onClick={this.handleLogout}
-                        text={formatMessage({id: 'navbar_dropdown.logout', defaultMessage: 'Logout'})}
+                        text={formatMessage({id: 'navbar_dropdown.logout', defaultMessage: 'Log Out'})}
                     />
                 </Menu.Group>
             </Menu>

--- a/components/admin_console/system_user_detail/team_list/team_list_dropdown.jsx
+++ b/components/admin_console/system_user_detail/team_list/team_list_dropdown.jsx
@@ -65,7 +65,7 @@ export default class TeamListDropdown extends React.Component {
                             id='removeFromTeam'
                             show={true}
                             onClick={() => this.props.doRemoveUserFromTeam(team.id)}
-                            text={localizeMessage('team_members_dropdown.leave_team', 'Remove From Team')}
+                            text={localizeMessage('team_members_dropdown.leave_team', 'Remove from Team')}
                             buttonClass='SystemUserDetail__action-remove-team'
                         />
                     </Menu>

--- a/components/channel_members_dropdown/__snapshots__/channel_members_dropdown.test.jsx.snap
+++ b/components/channel_members_dropdown/__snapshots__/channel_members_dropdown.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`components/channel_members_dropdown should match snapshot for channel_m
     <MenuItemAction
       onClick={[Function]}
       show={true}
-      text="Remove From Channel"
+      text="Remove from Channel"
     />
   </Menu>
 </MenuWrapper>
@@ -86,7 +86,7 @@ exports[`components/channel_members_dropdown should match snapshot for dropdown 
     <MenuItemAction
       onClick={[Function]}
       show={true}
-      text="Remove From Channel"
+      text="Remove from Channel"
     />
   </Menu>
 </MenuWrapper>
@@ -142,7 +142,7 @@ exports[`components/channel_members_dropdown should match snapshot for not dropd
     <MenuItemAction
       onClick={[Function]}
       show={true}
-      text="Remove From Channel"
+      text="Remove from Channel"
     />
   </Menu>
 </MenuWrapper>
@@ -188,7 +188,7 @@ exports[`components/channel_members_dropdown should match snapshot opening dropd
     <MenuItemAction
       onClick={[Function]}
       show={true}
-      text="Remove From Channel"
+      text="Remove from Channel"
     />
   </Menu>
 </MenuWrapper>

--- a/components/channel_members_dropdown/channel_members_dropdown.jsx
+++ b/components/channel_members_dropdown/channel_members_dropdown.jsx
@@ -154,7 +154,7 @@ export default class ChannelMembersDropdown extends React.Component {
                         <Menu.ItemAction
                             show={canRemoveUserFromChannel}
                             onClick={this.handleRemoveFromChannel}
-                            text={Utils.localizeMessage('channel_members_dropdown.remove_from_channel', 'Remove From Channel')}
+                            text={Utils.localizeMessage('channel_members_dropdown.remove_from_channel', 'Remove from Channel')}
                         />
                         {serverError && (
                             <div className='has-error'>

--- a/components/channel_members_modal/__snapshots__/channel_members_modal.test.jsx.snap
+++ b/components/channel_members_modal/__snapshots__/channel_members_modal.test.jsx.snap
@@ -60,7 +60,7 @@ exports[`components/ChannelMembersModal should match snapshot 1`] = `
         onClick={[Function]}
       >
         <FormattedMessage
-          defaultMessage=" Add New Members"
+          defaultMessage=" Add Members"
           id="channel_members_modal.addNew"
           values={Object {}}
         />

--- a/components/channel_members_modal/channel_members_modal.jsx
+++ b/components/channel_members_modal/channel_members_modal.jsx
@@ -96,7 +96,7 @@ export default class ChannelMembersModal extends React.PureComponent {
                             >
                                 <FormattedMessage
                                     id='channel_members_modal.addNew'
-                                    defaultMessage=' Add New Members'
+                                    defaultMessage=' Add Members'
                                 />
                             </a>
                         }

--- a/components/claim/components/email_to_ldap.jsx
+++ b/components/claim/components/email_to_ldap.jsx
@@ -234,7 +234,7 @@ export default class EmailToLDAP extends React.Component {
                     >
                         <FormattedMessage
                             id='claim.email_to_ldap.switchTo'
-                            defaultMessage='Switch account to AD/LDAP'
+                            defaultMessage='Switch Account to AD/LDAP'
                         />
                     </button>
                     {serverError}

--- a/components/claim/components/email_to_oauth.jsx
+++ b/components/claim/components/email_to_oauth.jsx
@@ -137,7 +137,7 @@ export default class EmailToOAuth extends React.PureComponent {
                     >
                         <FormattedMessage
                             id='claim.email_to_oauth.switchTo'
-                            defaultMessage='Switch account to {uiType}'
+                            defaultMessage='Switch Account to {uiType}'
                             values={{
                                 uiType,
                             }}

--- a/components/claim/components/oauth_to_email.jsx
+++ b/components/claim/components/oauth_to_email.jsx
@@ -136,7 +136,7 @@ export default class OAuthToEmail extends React.PureComponent {
                     >
                         <FormattedMessage
                             id='claim.oauth_to_email.switchTo'
-                            defaultMessage='Switch {type} to email and password'
+                            defaultMessage='Switch {type} to Email and Password'
                             values={{
                                 type: uiType,
                             }}

--- a/components/error_page/error_page.tsx
+++ b/components/error_page/error_page.tsx
@@ -104,7 +104,7 @@ export default class ErrorPage extends React.PureComponent<Props> {
                 <Link to='/'>
                     <FormattedMessage
                         id='error.generic.link_login'
-                        defaultMessage='Back to login page'
+                        defaultMessage='Back to Login Page'
                     />
                 </Link>
             );

--- a/components/help/components/attaching.tsx
+++ b/components/help/components/attaching.tsx
@@ -201,7 +201,7 @@ export default function HelpAttaching(): JSX.Element {
                     <Link to='/help/formatting'>
                         <FormattedMessage
                             id='help.link.formatting'
-                            defaultMessage='Formatting Messages using Markdown'
+                            defaultMessage='Formatting Messages Using Markdown'
                         />
                     </Link>
                 </li>

--- a/components/help/components/commands.tsx
+++ b/components/help/components/commands.tsx
@@ -133,7 +133,7 @@ export default function HelpCommands(): JSX.Element {
                     <Link to='/help/formatting'>
                         <FormattedMessage
                             id='help.link.formatting'
-                            defaultMessage='Formatting Messages using Markdown'
+                            defaultMessage='Formatting Messages Using Markdown'
                         />
                     </Link>
                 </li>

--- a/components/help/components/composing.tsx
+++ b/components/help/components/composing.tsx
@@ -134,7 +134,7 @@ export default function HelpComposing(): JSX.Element {
                     <Link to='/help/formatting'>
                         <FormattedMessage
                             id='help.link.formatting'
-                            defaultMessage='Formatting Messages using Markdown'
+                            defaultMessage='Formatting Messages Using Markdown'
                         />
                     </Link>
                 </li>

--- a/components/help/components/mentioning.tsx
+++ b/components/help/components/mentioning.tsx
@@ -133,7 +133,7 @@ export default function HelpMentioning(): JSX.Element {
                     <Link to='/help/formatting'>
                         <FormattedMessage
                             id='help.link.formatting'
-                            defaultMessage='Formatting Messages using Markdown'
+                            defaultMessage='Formatting Messages Using Markdown'
                         />
                     </Link>
                 </li>

--- a/components/help/components/messaging.tsx
+++ b/components/help/components/messaging.tsx
@@ -94,7 +94,7 @@ export default function HelpMessaging(): JSX.Element {
                     <Link to='/help/formatting'>
                         <FormattedMessage
                             id='help.link.formatting'
-                            defaultMessage='Formatting Messages using Markdown'
+                            defaultMessage='Formatting Messages Using Markdown'
                         />
                     </Link>
                 </li>

--- a/components/integrations/__snapshots__/abstract_command.test.jsx.snap
+++ b/components/integrations/__snapshots__/abstract_command.test.jsx.snap
@@ -159,7 +159,7 @@ exports[`components/integrations/AbstractCommand should match snapshot 1`] = `
                     target="_blank"
                   >
                     <FormattedMessage
-                      defaultMessage="see list of built-in slash commands"
+                      defaultMessage="See built-in slash commands"
                       id="add_command.trigger.helpReservedLinkText"
                       values={Object {}}
                     />
@@ -655,7 +655,7 @@ exports[`components/integrations/AbstractCommand should match snapshot, displays
                     target="_blank"
                   >
                     <FormattedMessage
-                      defaultMessage="see list of built-in slash commands"
+                      defaultMessage="See built-in slash commands"
                       id="add_command.trigger.helpReservedLinkText"
                       values={Object {}}
                     />

--- a/components/integrations/abstract_command.jsx
+++ b/components/integrations/abstract_command.jsx
@@ -442,7 +442,7 @@ export default class AbstractCommand extends React.PureComponent {
                                                 >
                                                     <FormattedMessage
                                                         id='add_command.trigger.helpReservedLinkText'
-                                                        defaultMessage='see list of built-in slash commands'
+                                                        defaultMessage='See built-in slash commands'
                                                     />
                                                 </a>
                                             ),

--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -479,7 +479,7 @@ export default class AddBot extends React.Component {
                                 >
                                     <FormattedMessage
                                         id='bots.image.upload'
-                                        defaultMessage='Upload an image'
+                                        defaultMessage='Upload Image'
                                     />
                                     <input
                                         accept='.jpg,.png,.bmp'

--- a/components/integrations/installed_commands/installed_commands.jsx
+++ b/components/integrations/installed_commands/installed_commands.jsx
@@ -140,7 +140,7 @@ export default class InstalledCommands extends React.PureComponent {
                                 >
                                     <FormattedMessage
                                         id='installed_commands.help.buildYourOwn'
-                                        defaultMessage='Build your own'
+                                        defaultMessage='Build Your Own'
                                     />
                                 </a>
                             ),

--- a/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.jsx
+++ b/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.jsx
@@ -169,7 +169,7 @@ export default class InstalledIncomingWebhooks extends React.PureComponent {
                                 >
                                     <FormattedMessage
                                         id='installed_incoming_webhooks.help.buildYourOwn'
-                                        defaultMessage='Build your own'
+                                        defaultMessage='Build Your Own'
                                     />
                                 </a>
                             ),

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -639,7 +639,7 @@ class LoginController extends React.Component {
                     <Link to={'/reset_password'}>
                         <FormattedMessage
                             id='login.forgot'
-                            defaultMessage='I forgot my password'
+                            defaultMessage='I forgot my password.'
                         />
                     </Link>
                 </div>

--- a/components/main_menu/__snapshots__/main_menu.test.jsx.snap
+++ b/components/main_menu/__snapshots__/main_menu.test.jsx.snap
@@ -160,7 +160,7 @@ exports[`components/Menu should match snapshot with id 1`] = `
         icon={false}
         id="createTeam"
         show={true}
-        text="Create a New Team"
+        text="Create a Team"
         to="/create_team"
       />
     </Connect(SystemPermissionGate)>
@@ -283,7 +283,7 @@ exports[`components/Menu should match snapshot with id 1`] = `
       id="logout"
       onClick={[Function]}
       show={true}
-      text="Logout"
+      text="Log Out"
     />
   </MenuGroup>
 </Menu>
@@ -448,7 +448,7 @@ exports[`components/Menu should match snapshot with most of the thing disabled 1
         icon={false}
         id="createTeam"
         show={true}
-        text="Create a New Team"
+        text="Create a Team"
         to="/create_team"
       />
     </Connect(SystemPermissionGate)>
@@ -571,7 +571,7 @@ exports[`components/Menu should match snapshot with most of the thing disabled 1
       id="logout"
       onClick={[Function]}
       show={true}
-      text="Logout"
+      text="Log Out"
     />
   </MenuGroup>
 </Menu>
@@ -778,7 +778,7 @@ exports[`components/Menu should match snapshot with most of the thing disabled i
         }
         id="createTeam"
         show={true}
-        text="Create a New Team"
+        text="Create a Team"
         to="/create_team"
       />
     </Connect(SystemPermissionGate)>
@@ -929,7 +929,7 @@ exports[`components/Menu should match snapshot with most of the thing disabled i
       id="logout"
       onClick={[Function]}
       show={true}
-      text="Logout"
+      text="Log Out"
     />
   </MenuGroup>
 </Menu>
@@ -1094,7 +1094,7 @@ exports[`components/Menu should match snapshot with most of the thing enabled 1`
         icon={false}
         id="createTeam"
         show={true}
-        text="Create a New Team"
+        text="Create a Team"
         to="/create_team"
       />
     </Connect(SystemPermissionGate)>
@@ -1217,7 +1217,7 @@ exports[`components/Menu should match snapshot with most of the thing enabled 1`
       id="logout"
       onClick={[Function]}
       show={true}
-      text="Logout"
+      text="Log Out"
     />
   </MenuGroup>
 </Menu>
@@ -1424,7 +1424,7 @@ exports[`components/Menu should match snapshot with most of the thing enabled in
         }
         id="createTeam"
         show={true}
-        text="Create a New Team"
+        text="Create a Team"
         to="/create_team"
       />
     </Connect(SystemPermissionGate)>
@@ -1575,7 +1575,7 @@ exports[`components/Menu should match snapshot with most of the thing enabled in
       id="logout"
       onClick={[Function]}
       show={true}
-      text="Logout"
+      text="Log Out"
     />
   </MenuGroup>
 </Menu>
@@ -1740,7 +1740,7 @@ exports[`components/Menu should match snapshot with plugins 1`] = `
         icon={false}
         id="createTeam"
         show={true}
-        text="Create a New Team"
+        text="Create a Team"
         to="/create_team"
       />
     </Connect(SystemPermissionGate)>
@@ -1880,7 +1880,7 @@ exports[`components/Menu should match snapshot with plugins 1`] = `
       id="logout"
       onClick={[Function]}
       show={true}
-      text="Logout"
+      text="Log Out"
     />
   </MenuGroup>
 </Menu>
@@ -2087,7 +2087,7 @@ exports[`components/Menu should match snapshot with plugins in mobile 1`] = `
         }
         id="createTeam"
         show={true}
-        text="Create a New Team"
+        text="Create a Team"
         to="/create_team"
       />
     </Connect(SystemPermissionGate)>
@@ -2255,7 +2255,7 @@ exports[`components/Menu should match snapshot with plugins in mobile 1`] = `
       id="logout"
       onClick={[Function]}
       show={true}
-      text="Logout"
+      text="Log Out"
     />
   </MenuGroup>
 </Menu>

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -257,7 +257,7 @@ class MainMenu extends React.PureComponent {
                         <Menu.ItemLink
                             id='createTeam'
                             to='/create_team'
-                            text={formatMessage({id: 'navbar_dropdown.create', defaultMessage: 'Create a New Team'})}
+                            text={formatMessage({id: 'navbar_dropdown.create', defaultMessage: 'Create a Team'})}
                             icon={this.props.mobile && <i className='fa fa-plus-square'/>}
                         />
                     </SystemPermissionGate>
@@ -362,7 +362,7 @@ class MainMenu extends React.PureComponent {
                     <Menu.ItemAction
                         id='logout'
                         onClick={this.handleEmitUserLoggedOutEvent}
-                        text={formatMessage({id: 'navbar_dropdown.logout', defaultMessage: 'Logout'})}
+                        text={formatMessage({id: 'navbar_dropdown.logout', defaultMessage: 'Log Out'})}
                         icon={this.props.mobile && <i className='fa fa-sign-out'/>}
                     />
                 </Menu.Group>

--- a/components/more_channels/__snapshots__/more_channels.test.jsx.snap
+++ b/components/more_channels/__snapshots__/more_channels.test.jsx.snap
@@ -63,7 +63,7 @@ exports[`components/MoreChannels should match snapshot and state 1`] = `
         type="button"
       >
         <FormattedMessage
-          defaultMessage="Create New Channel"
+          defaultMessage="Create Channel"
           id="more_channels.create"
           values={Object {}}
         />

--- a/components/more_channels/more_channels.jsx
+++ b/components/more_channels/more_channels.jsx
@@ -196,7 +196,7 @@ export default class MoreChannels extends React.Component {
                 >
                     <FormattedMessage
                         id='more_channels.create'
-                        defaultMessage='Create New Channel'
+                        defaultMessage='Create Channel'
                     />
                 </button>
             </TeamPermissionGate>

--- a/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
+++ b/components/new_channel_modal/__snapshots__/new_channel_modal.test.jsx.snap
@@ -285,7 +285,7 @@ exports[`components/NewChannelModal should match snapshot, display only private 
           type="submit"
         >
           <FormattedMessage
-            defaultMessage="Create New Channel"
+            defaultMessage="Create Channel"
             id="channel_modal.createNew"
             values={Object {}}
           />
@@ -581,7 +581,7 @@ exports[`components/NewChannelModal should match snapshot, display only public c
           type="submit"
         >
           <FormattedMessage
-            defaultMessage="Create New Channel"
+            defaultMessage="Create Channel"
             id="channel_modal.createNew"
             values={Object {}}
           />
@@ -919,7 +919,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
           type="submit"
         >
           <FormattedMessage
-            defaultMessage="Create New Channel"
+            defaultMessage="Create Channel"
             id="channel_modal.createNew"
             values={Object {}}
           />
@@ -1257,7 +1257,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
           type="submit"
         >
           <FormattedMessage
-            defaultMessage="Create New Channel"
+            defaultMessage="Create Channel"
             id="channel_modal.createNew"
             values={Object {}}
           />
@@ -1605,7 +1605,7 @@ exports[`components/NewChannelModal should match snapshot, on displayNameError 1
           type="submit"
         >
           <FormattedMessage
-            defaultMessage="Create New Channel"
+            defaultMessage="Create Channel"
             id="channel_modal.createNew"
             values={Object {}}
           />
@@ -1957,7 +1957,7 @@ exports[`components/NewChannelModal should match snapshot, on serverError 1`] = 
           type="submit"
         >
           <FormattedMessage
-            defaultMessage="Create New Channel"
+            defaultMessage="Create Channel"
             id="channel_modal.createNew"
             values={Object {}}
           />
@@ -2295,7 +2295,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
           type="submit"
         >
           <FormattedMessage
-            defaultMessage="Create New Channel"
+            defaultMessage="Create Channel"
             id="channel_modal.createNew"
             values={Object {}}
           />

--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -465,7 +465,7 @@ export default class NewChannelModal extends React.PureComponent {
                             >
                                 <FormattedMessage
                                     id='channel_modal.createNew'
-                                    defaultMessage='Create New Channel'
+                                    defaultMessage='Create Channel'
                                 />
                             </button>
                         </Modal.Footer>

--- a/components/post_view/post_list_row/__snapshots__/post_list_row.test.jsx.snap
+++ b/components/post_view/post_list_row/__snapshots__/post_list_row.test.jsx.snap
@@ -23,7 +23,7 @@ exports[`components/post_view/post_list_row should render manual load messages t
   onClick={[MockFunction]}
 >
   <FormattedMessage
-    defaultMessage="Load more messages"
+    defaultMessage="Load More Messages"
     id="posts_view.loadMore"
     values={Object {}}
   />

--- a/components/post_view/post_list_row/post_list_row.jsx
+++ b/components/post_view/post_list_row/post_list_row.jsx
@@ -59,7 +59,7 @@ export default class PostListRow extends React.PureComponent {
                 >
                     <FormattedMessage
                         id='posts_view.loadMore'
-                        defaultMessage='Load more messages'
+                        defaultMessage='Load More Messages'
                     />
                 </button>
             );

--- a/components/select_team/__snapshots__/select_team.test.jsx.snap
+++ b/components/select_team/__snapshots__/select_team.test.jsx.snap
@@ -84,7 +84,7 @@ exports[`components/select_team/SelectTeam should match snapshot 1`] = `
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a team"
+              defaultMessage="Create a new team"
               id="login.createTeam"
               values={Object {}}
             />
@@ -168,7 +168,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on error 1`] =
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a team"
+              defaultMessage="Create a new team"
               id="login.createTeam"
               values={Object {}}
             />
@@ -242,7 +242,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on loading 1`]
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a team"
+              defaultMessage="Create a new team"
               id="login.createTeam"
               values={Object {}}
             />
@@ -361,7 +361,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on no joinable
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a team"
+              defaultMessage="Create a new team"
               id="login.createTeam"
               values={Object {}}
             />
@@ -448,7 +448,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on no joinable
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a team"
+              defaultMessage="Create a new team"
               id="login.createTeam"
               values={Object {}}
             />
@@ -545,7 +545,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on no joinable
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a team"
+              defaultMessage="Create a new team"
               id="login.createTeam"
               values={Object {}}
             />

--- a/components/select_team/__snapshots__/select_team.test.jsx.snap
+++ b/components/select_team/__snapshots__/select_team.test.jsx.snap
@@ -84,7 +84,7 @@ exports[`components/select_team/SelectTeam should match snapshot 1`] = `
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a new team"
+              defaultMessage="Create a team"
               id="login.createTeam"
               values={Object {}}
             />
@@ -168,7 +168,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on error 1`] =
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a new team"
+              defaultMessage="Create a team"
               id="login.createTeam"
               values={Object {}}
             />
@@ -242,7 +242,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on loading 1`]
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a new team"
+              defaultMessage="Create a team"
               id="login.createTeam"
               values={Object {}}
             />
@@ -361,7 +361,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on no joinable
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a new team"
+              defaultMessage="Create a team"
               id="login.createTeam"
               values={Object {}}
             />
@@ -448,7 +448,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on no joinable
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a new team"
+              defaultMessage="Create a team"
               id="login.createTeam"
               values={Object {}}
             />
@@ -545,7 +545,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on no joinable
             to="/create_team"
           >
             <FormattedMessage
-              defaultMessage="Create a new team"
+              defaultMessage="Create a team"
               id="login.createTeam"
               values={Object {}}
             />

--- a/components/sidebar/__snapshots__/sidebar.test.jsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -45,7 +45,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -300,7 +300,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -313,7 +313,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -568,7 +568,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -581,7 +581,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -836,7 +836,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -849,7 +849,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1112,7 +1112,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1125,7 +1125,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1380,7 +1380,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1393,7 +1393,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1652,7 +1652,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1665,7 +1665,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1920,7 +1920,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1933,7 +1933,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -2188,7 +2188,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -2201,7 +2201,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -2456,7 +2456,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -2469,7 +2469,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More Unreads"
+          defaultMessage="More unreads"
           id="sidebar.unreads"
           values={Object {}}
         />

--- a/components/sidebar/__snapshots__/sidebar.test.jsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -45,7 +45,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -300,7 +300,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -313,7 +313,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -568,7 +568,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -581,7 +581,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -836,7 +836,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -849,7 +849,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1112,7 +1112,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1125,7 +1125,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1380,7 +1380,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1393,7 +1393,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1652,7 +1652,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1665,7 +1665,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1920,7 +1920,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -1933,7 +1933,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -2188,7 +2188,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -2201,7 +2201,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -2456,7 +2456,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />
@@ -2469,7 +2469,7 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
     <UnreadChannelIndicator
       content={
         <FormattedMessage
-          defaultMessage="More unreads"
+          defaultMessage="More Unreads"
           id="sidebar.unreads"
           values={Object {}}
         />

--- a/components/system_notice/__snapshots__/system_notice.test.jsx.snap
+++ b/components/system_notice/__snapshots__/system_notice.test.jsx.snap
@@ -51,7 +51,7 @@ exports[`components/SystemNotice should match snapshot for admin, admin notice 1
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Remind me later"
+        defaultMessage="Remind Me Later"
         id="system_notice.remind_me"
         values={Object {}}
       />
@@ -62,7 +62,7 @@ exports[`components/SystemNotice should match snapshot for admin, admin notice 1
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Don't show again"
+        defaultMessage="Don't Show Again"
         id="system_notice.dont_show"
         values={Object {}}
       />
@@ -103,7 +103,7 @@ exports[`components/SystemNotice should match snapshot for admin, regular notice
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Remind me later"
+        defaultMessage="Remind Me Later"
         id="system_notice.remind_me"
         values={Object {}}
       />
@@ -114,7 +114,7 @@ exports[`components/SystemNotice should match snapshot for admin, regular notice
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Don't show again"
+        defaultMessage="Don't Show Again"
         id="system_notice.dont_show"
         values={Object {}}
       />
@@ -155,7 +155,7 @@ exports[`components/SystemNotice should match snapshot for regular user, admin a
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Remind me later"
+        defaultMessage="Remind Me Later"
         id="system_notice.remind_me"
         values={Object {}}
       />
@@ -166,7 +166,7 @@ exports[`components/SystemNotice should match snapshot for regular user, admin a
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Don't show again"
+        defaultMessage="Don't Show Again"
         id="system_notice.dont_show"
         values={Object {}}
       />
@@ -215,7 +215,7 @@ exports[`components/SystemNotice should match snapshot for regular user, regular
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Remind me later"
+        defaultMessage="Remind Me Later"
         id="system_notice.remind_me"
         values={Object {}}
       />
@@ -226,7 +226,7 @@ exports[`components/SystemNotice should match snapshot for regular user, regular
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Don't show again"
+        defaultMessage="Don't Show Again"
         id="system_notice.dont_show"
         values={Object {}}
       />
@@ -269,7 +269,7 @@ exports[`components/SystemNotice should match snapshot for show function returni
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Remind me later"
+        defaultMessage="Remind Me Later"
         id="system_notice.remind_me"
         values={Object {}}
       />
@@ -280,7 +280,7 @@ exports[`components/SystemNotice should match snapshot for show function returni
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Don't show again"
+        defaultMessage="Don't Show Again"
         id="system_notice.dont_show"
         values={Object {}}
       />
@@ -321,7 +321,7 @@ exports[`components/SystemNotice should match snapshot for with allowForget equa
       onClick={[Function]}
     >
       <FormattedMessage
-        defaultMessage="Remind me later"
+        defaultMessage="Remind Me Later"
         id="system_notice.remind_me"
         values={Object {}}
       />

--- a/components/system_notice/system_notice.jsx
+++ b/components/system_notice/system_notice.jsx
@@ -138,7 +138,7 @@ export default class SystemNotice extends React.PureComponent {
                     >
                         <FormattedMessage
                             id='system_notice.remind_me'
-                            defaultMessage='Remind me later'
+                            defaultMessage='Remind Me Later'
                         />
                     </button>
                     {notice.allowForget &&
@@ -149,7 +149,7 @@ export default class SystemNotice extends React.PureComponent {
                         >
                             <FormattedMessage
                                 id='system_notice.dont_show'
-                                defaultMessage="Don't show again"
+                                defaultMessage="Don't Show Again"
                             />
                         </button>}
                 </div>

--- a/components/team_sidebar/team_sidebar_controller.jsx
+++ b/components/team_sidebar/team_sidebar_controller.jsx
@@ -115,7 +115,7 @@ export default class TeamSidebar extends React.PureComponent {
                         tip={
                             <FormattedMessage
                                 id='navbar_dropdown.create'
-                                defaultMessage='Create a New Team'
+                                defaultMessage='Create a Team'
                             />
                         }
                         content={'+'}

--- a/components/tutorial/tutorial_intro_screens/__snapshots__/tutorial_intro_screen.test.jsx.snap
+++ b/components/tutorial/tutorial_intro_screens/__snapshots__/tutorial_intro_screen.test.jsx.snap
@@ -92,7 +92,7 @@ exports[`components/tutorial/tutorial_intro_screens/TutorialIntroScreens should 
           onClick={[Function]}
         >
           <FormattedMessage
-            defaultMessage="Skip tutorial"
+            defaultMessage="Skip Tutorial"
             id="tutorial_intro.skip"
             values={Object {}}
           />

--- a/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
@@ -223,7 +223,7 @@ export default class TutorialIntroScreens extends React.Component {
                 >
                     <FormattedMessage
                         id='tutorial_intro.invite'
-                        defaultMessage='Invite teammates'
+                        defaultMessage='Invite Teammates'
                     />
                 </ModalToggleButtonRedux>
             );
@@ -345,7 +345,7 @@ export default class TutorialIntroScreens extends React.Component {
                             >
                                 <FormattedMessage
                                     id='tutorial_intro.skip'
-                                    defaultMessage='Skip tutorial'
+                                    defaultMessage='Skip Tutorial'
                                 />
                             </a>
                         </div>

--- a/components/user_settings/security/mfa_section/__snapshots__/mfa_section.test.jsx.snap
+++ b/components/user_settings/security/mfa_section/__snapshots__/mfa_section.test.jsx.snap
@@ -65,7 +65,7 @@ exports[`MfaSection rendering when section is expanded and MFA is active and enf
         onClick={[Function]}
       >
         <FormattedMessage
-          defaultMessage="Reset MFA on your account"
+          defaultMessage="Reset MFA on Account"
           id="user.settings.mfa.reset"
           values={Object {}}
         />
@@ -109,7 +109,7 @@ exports[`MfaSection rendering when section is expanded and MFA is active but not
         onClick={[Function]}
       >
         <FormattedMessage
-          defaultMessage="Remove MFA from your account"
+          defaultMessage="Remove MFA from Account"
           id="user.settings.mfa.remove"
           values={Object {}}
         />
@@ -153,7 +153,7 @@ exports[`MfaSection rendering when section is expanded and MFA is not active 1`]
         onClick={[Function]}
       >
         <FormattedMessage
-          defaultMessage="Add MFA to your account"
+          defaultMessage="Add MFA to Account"
           id="user.settings.mfa.add"
           values={Object {}}
         />
@@ -197,7 +197,7 @@ exports[`MfaSection rendering when section is expanded with a server error 1`] =
         onClick={[Function]}
       >
         <FormattedMessage
-          defaultMessage="Add MFA to your account"
+          defaultMessage="Add MFA to Account"
           id="user.settings.mfa.add"
           values={Object {}}
         />

--- a/components/user_settings/security/mfa_section/mfa_section.jsx
+++ b/components/user_settings/security/mfa_section/mfa_section.jsx
@@ -100,14 +100,14 @@ export default class MfaSection extends React.PureComponent {
                 buttonText = (
                     <FormattedMessage
                         id='user.settings.mfa.reset'
-                        defaultMessage='Reset MFA on your account'
+                        defaultMessage='Reset MFA on Account'
                     />
                 );
             } else {
                 buttonText = (
                     <FormattedMessage
                         id='user.settings.mfa.remove'
-                        defaultMessage='Remove MFA from your account'
+                        defaultMessage='Remove MFA from Account'
                     />
                 );
             }
@@ -130,7 +130,7 @@ export default class MfaSection extends React.PureComponent {
                 >
                     <FormattedMessage
                         id='user.settings.mfa.add'
-                        defaultMessage='Add MFA to your account'
+                        defaultMessage='Add MFA to Account'
                     />
                 </a>
             );

--- a/components/user_settings/security/user_access_token_section/user_access_token_section.jsx
+++ b/components/user_settings/security/user_access_token_section/user_access_token_section.jsx
@@ -527,7 +527,7 @@ export default class UserAccessTokenSection extends React.Component {
                 >
                     <FormattedMessage
                         id='user.settings.tokens.create'
-                        defaultMessage='Create New Token'
+                        defaultMessage='Create Token'
                     />
                 </a>
             );

--- a/components/user_settings/security/user_settings_security.jsx
+++ b/components/user_settings/security/user_settings_security.jsx
@@ -489,7 +489,7 @@ export default class SecurityTab extends React.PureComponent {
                             >
                                 <FormattedMessage
                                     id='user.settings.security.switchGitlab'
-                                    defaultMessage='Switch to using GitLab SSO'
+                                    defaultMessage='Switch to Using GitLab SSO'
                                 />
                             </Link>
                             <br/>
@@ -506,7 +506,7 @@ export default class SecurityTab extends React.PureComponent {
                             >
                                 <FormattedMessage
                                     id='user.settings.security.switchGoogle'
-                                    defaultMessage='Switch to using Google SSO'
+                                    defaultMessage='Switch to Using Google SSO'
                                 />
                             </Link>
                             <br/>
@@ -523,7 +523,7 @@ export default class SecurityTab extends React.PureComponent {
                             >
                                 <FormattedMessage
                                     id='user.settings.security.switchOffice365'
-                                    defaultMessage='Switch to using Office 365 SSO'
+                                    defaultMessage='Switch to Using Office 365 SSO'
                                 />
                             </Link>
                             <br/>
@@ -540,7 +540,7 @@ export default class SecurityTab extends React.PureComponent {
                             >
                                 <FormattedMessage
                                     id='user.settings.security.switchLdap'
-                                    defaultMessage='Switch to using AD/LDAP'
+                                    defaultMessage='Switch to Using AD/LDAP'
                                 />
                             </Link>
                             <br/>
@@ -557,7 +557,7 @@ export default class SecurityTab extends React.PureComponent {
                             >
                                 <FormattedMessage
                                     id='user.settings.security.switchSaml'
-                                    defaultMessage='Switch to using SAML SSO'
+                                    defaultMessage='Switch to Using SAML SSO'
                                 />
                             </Link>
                             <br/>
@@ -580,7 +580,7 @@ export default class SecurityTab extends React.PureComponent {
                         >
                             <FormattedMessage
                                 id='user.settings.security.switchEmail'
-                                defaultMessage='Switch to using email and password'
+                                defaultMessage='Switch to Using Email and Password'
                             />
                         </Link>
                         <br/>
@@ -942,7 +942,7 @@ export default class SecurityTab extends React.PureComponent {
                         </FormattedMessage>
                         <FormattedMessage
                             id='user.settings.security.logoutActiveSessions'
-                            defaultMessage='View and Logout of Active Sessions'
+                            defaultMessage='View and Log Out of Active Sessions'
                         />
                     </ToggleModalButton>
                 </div>

--- a/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
+++ b/plugins/test/__snapshots__/main_menu_action.test.jsx.snap
@@ -159,7 +159,7 @@ exports[`plugins/MainMenuActions should match snapshot and click plugin item for
         icon={false}
         id="createTeam"
         show={true}
-        text="Create a New Team"
+        text="Create a Team"
         to="/create_team"
       />
     </Connect(SystemPermissionGate)>
@@ -288,7 +288,7 @@ exports[`plugins/MainMenuActions should match snapshot and click plugin item for
       id="logout"
       onClick={[Function]}
       show={true}
-      text="Logout"
+      text="Log Out"
     />
   </MenuGroup>
 </Menu>


### PR DESCRIPTION
Part of GSoD'19 work

#### Summary

Edits to the corresponding default message of each component for which the in-product text was refined through PR#4555.

#### Ticket Link

Fixes @saturninoabril's comment at https://github.com/mattermost/mattermost-webapp/pull/4555/files#r371101441

#### Related Pull Requests

https://github.com/mattermost/mattermost-server/issues/10888

