### PR TITLE
Automated cherry pick of #4792

### DIFF
--- a/components/suggestion/search_channel_provider.jsx
+++ b/components/suggestion/search_channel_provider.jsx
@@ -96,7 +96,7 @@ export default class SearchChannelProvider extends Provider {
                     // MM-12677 When this is migrated this needs to be fixed to pull the user's locale
                     //
                     const channels = data.sort(sortChannelsByTypeAndDisplayName.bind(null, 'en'));
-                    const channelNames = channels.map((channel) => channel.name);
+                    const channelNames = channels.map(itemToName);
 
                     resultsCallback({
                         matchedPretext: channelPrefix,


### PR DESCRIPTION
Cherry pick of #4792 on release-5.20.

- #4792: fix display name of search results

/cc  @reflog