### PR TITLE
[MM-21911] Moved favicon and titlebar update to its own component

### DIFF
--- a/components/channel_layout/channel_controller.jsx
+++ b/components/channel_layout/channel_controller.jsx
@@ -27,6 +27,7 @@ import * as Utils from 'utils/utils';
 import * as UserAgent from 'utils/user_agent';
 import CenterChannel from 'components/channel_layout/center_channel';
 import LoadingScreen from 'components/loading_screen';
+import FaviconTitleHandler from 'components/favicon_title_handler';
 
 export default class ChannelController extends React.Component {
     static propTypes = {
@@ -73,6 +74,7 @@ export default class ChannelController extends React.Component {
             >
                 <AnnouncementBarController/>
                 <SystemNotice/>
+                <FaviconTitleHandler/>
 
                 <div className='container-fluid'>
                     <SidebarRight/>

--- a/components/favicon_title_handler/favicon_title_handler.test.jsx
+++ b/components/favicon_title_handler/favicon_title_handler.test.jsx
@@ -1,0 +1,84 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
+
+import {Constants} from 'utils/constants';
+
+import FaviconTitleHandler from 'components/favicon_title_handler/favicon_title_handler';
+
+jest.mock('utils/user_agent', () => {
+    const original = require.requireActual('utils/user_agent');
+    return {
+        ...original,
+        isFirefox: () => true,
+    };
+});
+
+describe('components/FaviconTitleHandler', () => {
+    const defaultProps = {
+        unreads: {
+            messageCount: 0,
+            mentionCount: 0,
+        },
+        siteName: 'Test site',
+        currentChannel: {
+            id: 'c1',
+            display_name: 'Public test 1',
+            name: 'public-test-1',
+            type: Constants.OPEN_CHANNEL,
+        },
+        currentTeam: {
+            id: 'team_id',
+            name: 'test-team',
+            display_name: 'Test team display name',
+            description: 'Test team description',
+            type: 'team-type',
+        },
+        currentTeammate: null,
+    };
+
+    test('set correctly the title when needed', () => {
+        const wrapper = shallowWithIntl(
+            <FaviconTitleHandler {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.updateTitle();
+        instance.componentDidUpdate = jest.fn();
+        instance.render = jest.fn();
+        expect(document.title).toBe('Public test 1 - Test team display name Test site');
+        wrapper.setProps({siteName: null});
+        instance.updateTitle();
+        expect(document.title).toBe('Public test 1 - Test team display name');
+        wrapper.setProps({currentChannel: {id: 1, type: Constants.DM_CHANNEL}, currentTeammate: {display_name: 'teammate'}});
+        instance.updateTitle();
+        expect(document.title).toBe('teammate - Test team display name');
+        wrapper.setProps({unreads: {mentionCount: 3, messageCount: 4}});
+        instance.updateTitle();
+        expect(document.title).toBe('(3) * teammate - Test team display name');
+        wrapper.setProps({currentChannel: {}, currentTeammate: {}});
+        instance.updateTitle();
+        expect(document.title).toBe('Mattermost - Join a team');
+    });
+
+    test('should display correct favicon', () => {
+        const link = document.createElement('link');
+        link.rel = 'icon';
+        link.sizes = '16x16';
+        document.head.appendChild(link);
+
+        const wrapper = shallowWithIntl(
+            <FaviconTitleHandler {...defaultProps}/>
+        );
+        const instance = wrapper.instance();
+        instance.updateFavicon = jest.fn();
+
+        wrapper.setProps({unreads: {mentionCount: 3, messageCount: 4}});
+        expect(instance.updateFavicon).lastCalledWith(true);
+
+        wrapper.setProps({unreads: {mentionCount: 0, messageCount: 4}});
+        expect(instance.updateFavicon).lastCalledWith(false);
+    });
+});

--- a/components/favicon_title_handler/favicon_title_handler.tsx
+++ b/components/favicon_title_handler/favicon_title_handler.tsx
@@ -29,11 +29,7 @@ type Props = {
     currentTeammate: Channel | null;
 };
 
-type State = {
-
-};
-
-class FaviconTitleHandler extends React.PureComponent<Props, State> {
+class FaviconTitleHandler extends React.PureComponent<Props> {
     badgesActive: boolean;
     lastBadgesActive: boolean;
 
@@ -44,12 +40,12 @@ class FaviconTitleHandler extends React.PureComponent<Props, State> {
         this.lastBadgesActive = false;
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps: Props) {
         this.updateTitle();
-        this.setBadgesActiveAndFavicon();
+        this.setBadgesActiveAndFavicon(prevProps.unreads.mentionCount > 0);
     }
 
-    setBadgesActiveAndFavicon() {
+    setBadgesActiveAndFavicon(lastBadgesActive: boolean) {
         if (!(UserAgent.isFirefox() || UserAgent.isChrome())) {
             return;
         }
@@ -60,11 +56,10 @@ class FaviconTitleHandler extends React.PureComponent<Props, State> {
             return;
         }
 
-        this.lastBadgesActive = this.badgesActive;
         this.badgesActive = this.props.unreads.mentionCount > 0;
 
         // update the favicon to show if there are any notifications
-        if (this.lastBadgesActive !== this.badgesActive) {
+        if (lastBadgesActive !== this.badgesActive) {
             this.updateFavicon(this.badgesActive);
         }
     }

--- a/components/favicon_title_handler/favicon_title_handler.tsx
+++ b/components/favicon_title_handler/favicon_title_handler.tsx
@@ -1,0 +1,121 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {injectIntl, IntlShape} from 'react-intl';
+
+import {Channel} from 'mattermost-redux/types/channels';
+import {Team} from 'mattermost-redux/types/teams';
+
+import * as UserAgent from 'utils/user_agent';
+import {Constants} from 'utils/constants';
+
+import favicon16x16 from 'images/favicon/favicon-16x16.png';
+import favicon32x32 from 'images/favicon/favicon-32x32.png';
+import favicon96x96 from 'images/favicon/favicon-96x96.png';
+import redDotFavicon16x16 from 'images/favicon/favicon-reddot-16x16.png';
+import redDotFavicon32x32 from 'images/favicon/favicon-reddot-32x32.png';
+import redDotFavicon96x96 from 'images/favicon/favicon-reddot-96x96.png';
+
+type Props = {
+    intl: IntlShape;
+    unreads: {
+        messageCount: number;
+        mentionCount: number;
+    };
+    siteName?: string;
+    currentChannel: Channel;
+    currentTeam: Team;
+    currentTeammate: Channel | null;
+};
+
+type State = {
+
+};
+
+class FaviconTitleHandler extends React.PureComponent<Props, State> {
+    badgesActive: boolean;
+    lastBadgesActive: boolean;
+
+    constructor(props: Props) {
+        super(props);
+
+        this.badgesActive = false;
+        this.lastBadgesActive = false;
+    }
+
+    componentDidUpdate() {
+        this.updateTitle();
+        this.setBadgesActiveAndFavicon();
+    }
+
+    setBadgesActiveAndFavicon() {
+        if (!(UserAgent.isFirefox() || UserAgent.isChrome())) {
+            return;
+        }
+
+        const link = document.querySelector('link[rel="icon"]');
+
+        if (!link) {
+            return;
+        }
+
+        this.lastBadgesActive = this.badgesActive;
+        this.badgesActive = this.props.unreads.mentionCount > 0;
+
+        // update the favicon to show if there are any notifications
+        if (this.lastBadgesActive !== this.badgesActive) {
+            this.updateFavicon(this.badgesActive);
+        }
+    }
+
+    updateTitle = () => {
+        const {
+            siteName,
+            currentChannel,
+            currentTeam,
+            currentTeammate,
+            unreads,
+        } = this.props;
+        const {formatMessage} = this.props.intl;
+
+        const currentSiteName = siteName || '';
+
+        if (currentChannel && currentTeam && currentChannel.id) {
+            let currentChannelName = currentChannel.display_name;
+            if (currentChannel.type === Constants.DM_CHANNEL) {
+                if (currentTeammate != null) {
+                    currentChannelName = currentTeammate.display_name;
+                }
+            }
+
+            const mentionTitle = unreads.mentionCount > 0 ? '(' + unreads.mentionCount + ') ' : '';
+            const unreadTitle = unreads.messageCount > 0 ? '* ' : '';
+            document.title = mentionTitle + unreadTitle + currentChannelName + ' - ' + currentTeam.display_name + ' ' + currentSiteName;
+        } else {
+            document.title = formatMessage({id: 'sidebar.team_select', defaultMessage: '{siteName} - Join a team'}, {siteName: currentSiteName || 'Mattermost'});
+        }
+    }
+
+    updateFavicon = (active: boolean) => {
+        const link16x16 = document.querySelector<HTMLLinkElement>('link[rel="icon"][sizes="16x16"]');
+        const link32x32 = document.querySelector<HTMLLinkElement>('link[rel="icon"][sizes="32x32"]');
+        const link96x96 = document.querySelector<HTMLLinkElement>('link[rel="icon"][sizes="96x96"]');
+
+        if (active) {
+            link16x16!.href = typeof redDotFavicon16x16 === 'string' ? redDotFavicon16x16 : '';
+            link32x32!.href = typeof redDotFavicon32x32 === 'string' ? redDotFavicon32x32 : '';
+            link96x96!.href = typeof redDotFavicon96x96 === 'string' ? redDotFavicon96x96 : '';
+        } else {
+            link16x16!.href = typeof favicon16x16 === 'string' ? favicon16x16 : '';
+            link32x32!.href = typeof favicon32x32 === 'string' ? favicon32x32 : '';
+            link96x96!.href = typeof favicon96x96 === 'string' ? favicon96x96 : '';
+        }
+    }
+
+    render() {
+        return null;
+    }
+}
+
+export default injectIntl(FaviconTitleHandler);

--- a/components/favicon_title_handler/index.ts
+++ b/components/favicon_title_handler/index.ts
@@ -1,0 +1,38 @@
+
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+import {bindActionCreators, Dispatch} from 'redux';
+
+import {getCurrentChannel, getUnreads} from 'mattermost-redux/selectors/entities/channels';
+import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {GlobalState} from 'mattermost-redux/types/store';
+import {GenericAction} from 'mattermost-redux/types/actions';
+
+import FaviconTitleHandler from './favicon_title_handler';
+
+function mapStateToProps(state: GlobalState) {
+    const config = getConfig(state);
+    const currentChannel = getCurrentChannel(state);
+    const currentTeammate = (currentChannel && currentChannel.teammate_id) ? currentChannel : null;
+    const currentTeam = getCurrentTeam(state);
+
+    return {
+        currentChannel,
+        currentTeam,
+        currentTeammate,
+        siteName: config.SiteName,
+        unreads: getUnreads(state),
+    };
+}
+
+function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
+    return {
+        actions: bindActionCreators({
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(FaviconTitleHandler);

--- a/components/legacy_sidebar/sidebar.jsx
+++ b/components/legacy_sidebar/sidebar.jsx
@@ -16,15 +16,9 @@ import {redirectUserToDefaultTeam} from 'actions/global_actions';
 import * as ChannelUtils from 'utils/channel_utils.jsx';
 import {Constants, ModalIdentifiers, SidebarChannelGroups} from 'utils/constants';
 import {intlShape} from 'utils/react_intl';
-import * as UserAgent from 'utils/user_agent';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n';
-import favicon16x16 from 'images/favicon/favicon-16x16.png';
-import favicon32x32 from 'images/favicon/favicon-32x32.png';
-import favicon96x96 from 'images/favicon/favicon-96x96.png';
-import redDotFavicon16x16 from 'images/favicon/favicon-reddot-16x16.png';
-import redDotFavicon32x32 from 'images/favicon/favicon-reddot-32x32.png';
-import redDotFavicon96x96 from 'images/favicon/favicon-reddot-96x96.png';
+
 import MoreChannels from 'components/more_channels';
 import MoreDirectChannels from 'components/more_direct_channels';
 import QuickSwitchModal from 'components/quick_switch_modal';
@@ -244,10 +238,6 @@ class LegacySidebar extends React.PureComponent {
             }
         }
 
-        this.updateTitle();
-
-        this.setBadgesActiveAndFavicon();
-
         this.setFirstAndLastUnreadChannels();
         this.updateUnreadIndicators();
     }
@@ -259,42 +249,6 @@ class LegacySidebar extends React.PureComponent {
         this.animate.deregisterSpring(this.scrollAnimation);
         this.animate.removeAllListeners();
         this.scrollAnimation.destroy();
-    }
-
-    setBadgesActiveAndFavicon() {
-        if (!(UserAgent.isFirefox() || UserAgent.isChrome())) {
-            return;
-        }
-
-        const link = document.querySelector('link[rel="icon"]');
-
-        if (!link) {
-            return;
-        }
-
-        this.lastBadgesActive = this.badgesActive;
-        this.badgesActive = this.props.unreads.mentionCount > 0;
-
-        // update the favicon to show if there are any notifications
-        if (this.lastBadgesActive !== this.badgesActive) {
-            this.updateFavicon(this.badgesActive);
-        }
-    }
-
-    updateFavicon = (active) => {
-        const link16x16 = document.querySelector('link[rel="icon"][sizes="16x16"]');
-        const link32x32 = document.querySelector('link[rel="icon"][sizes="32x32"]');
-        const link96x96 = document.querySelector('link[rel="icon"][sizes="96x96"]');
-
-        if (active) {
-            link16x16.href = typeof redDotFavicon16x16 === 'string' ? redDotFavicon16x16 : '';
-            link32x32.href = typeof redDotFavicon32x32 === 'string' ? redDotFavicon32x32 : '';
-            link96x96.href = typeof redDotFavicon96x96 === 'string' ? redDotFavicon96x96 : '';
-        } else {
-            link16x16.href = typeof favicon16x16 === 'string' ? favicon16x16 : '';
-            link32x32.href = typeof favicon32x32 === 'string' ? favicon32x32 : '';
-            link96x96.href = typeof favicon96x96 === 'string' ? favicon96x96 : '';
-        }
     }
 
     setFirstAndLastUnreadChannels() {
@@ -318,34 +272,6 @@ class LegacySidebar extends React.PureComponent {
             this.hideMoreDirectChannelsModal();
         } else {
             this.showMoreDirectChannelsModal();
-        }
-    }
-
-    updateTitle = () => {
-        const {
-            config,
-            currentChannel,
-            currentTeam,
-            currentTeammate,
-            unreads,
-        } = this.props;
-        const {formatMessage} = this.props.intl;
-
-        const currentSiteName = config.SiteName || '';
-
-        if (currentChannel && currentTeam && currentChannel.id) {
-            let currentChannelName = currentChannel.display_name;
-            if (currentChannel.type === Constants.DM_CHANNEL) {
-                if (currentTeammate != null) {
-                    currentChannelName = currentTeammate.display_name;
-                }
-            }
-
-            const mentionTitle = unreads.mentionCount > 0 ? '(' + unreads.mentionCount + ') ' : '';
-            const unreadTitle = unreads.messageCount > 0 ? '* ' : '';
-            document.title = mentionTitle + unreadTitle + currentChannelName + ' - ' + this.props.currentTeam.display_name + ' ' + currentSiteName;
-        } else {
-            document.title = formatMessage({id: 'sidebar.team_select', defaultMessage: '{siteName} - Join a team'}, {siteName: currentSiteName || 'Mattermost'});
         }
     }
 

--- a/components/legacy_sidebar/sidebar.test.jsx
+++ b/components/legacy_sidebar/sidebar.test.jsx
@@ -414,29 +414,6 @@ describe('component/legacy_sidebar/sidebar_channel/SidebarChannel', () => {
         expect(instance.handleOpenMoreDirectChannelsModal).toHaveBeenCalledTimes(2);
     });
 
-    test('set correctly the title when needed', () => {
-        const wrapper = shallowWithIntl(
-            <Sidebar {...defaultProps}/>
-        );
-        const instance = wrapper.instance();
-        instance.updateTitle();
-        instance.componentDidUpdate = jest.fn();
-        instance.render = jest.fn();
-        expect(document.title).toBe('Public test 1 - Test team display name Test site');
-        wrapper.setProps({config: {SiteName: null}});
-        instance.updateTitle();
-        expect(document.title).toBe('Public test 1 - Test team display name');
-        wrapper.setProps({currentChannel: {id: 1, type: Constants.DM_CHANNEL}, currentTeammate: {display_name: 'teammate'}});
-        instance.updateTitle();
-        expect(document.title).toBe('teammate - Test team display name');
-        wrapper.setProps({unreads: {mentionCount: 3, messageCount: 4}});
-        instance.updateTitle();
-        expect(document.title).toBe('(3) * teammate - Test team display name');
-        wrapper.setProps({currentChannel: {}, currentTeammate: {}});
-        instance.updateTitle();
-        expect(document.title).toBe('Mattermost - Join a team');
-    });
-
     test('should show/hide correctly more channels modal', () => {
         const wrapper = shallowWithIntl(
             <Sidebar {...defaultProps}/>
@@ -518,24 +495,5 @@ describe('component/legacy_sidebar/sidebar_channel/SidebarChannel', () => {
         expect(document.removeEventListener).not.toBeCalled();
         instance.componentWillUnmount();
         expect(document.removeEventListener).toHaveBeenCalledTimes(2);
-    });
-
-    test('should display correct favicon', () => {
-        const link = document.createElement('link');
-        link.rel = 'icon';
-        link.sizes = '16x16';
-        document.head.appendChild(link);
-
-        const wrapper = shallowWithIntl(
-            <Sidebar {...defaultProps}/>
-        );
-        const instance = wrapper.instance();
-        instance.updateFavicon = jest.fn();
-
-        wrapper.setProps({unreads: {mentionCount: 3, messageCount: 4}});
-        expect(instance.updateFavicon).lastCalledWith(true);
-
-        wrapper.setProps({unreads: {mentionCount: 0, messageCount: 4}});
-        expect(instance.updateFavicon).lastCalledWith(false);
     });
 });


### PR DESCRIPTION
#### Summary
Favicon and titlebar control is now in its own component for both sidebars.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21911
