### PR TITLE
Fix basic options spec

### DIFF
--- a/e2e/cypress/integration/interactive_menu/basic_options_spec.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options_spec.js
@@ -61,12 +61,12 @@ describe('Interactive Menu', () => {
 
             cy.getCurrentTeamId().then((teamId) => {
                 longUsername = `name-of-64-abcdefghijklmnopqrstuvwxyz-123456789-${Date.now()}`;
-    
+
                 // # Create a new user with 64 chars lenght
                 cy.createNewUser({username: longUsername}, [teamId]);
             });
-    
-            // Login again, this is a temp fix as cy.createNewUser, logs out the current user
+
+            // # Login again, this is a temp fix as cy.createNewUser, logs out the current user
             cy.apiLogin('sysadmin').visit(`/ad-1/channels/${channelId}`);
         });
     });

--- a/e2e/cypress/support/task_commands.js
+++ b/e2e/cypress/support/task_commands.js
@@ -28,7 +28,7 @@ Cypress.Commands.add('postMessageAs', ({sender, message, channelId, rootId, crea
 * @param {Object} data - payload on incoming webhook
 */
 Cypress.Commands.add('postIncomingWebhook', ({url, data}) => {
-    cy.task('postIncomingWebhook', {url, data}).its('status').should('be.equal', 200).wait(TIMEOUTS.TINY);
+    cy.task('postIncomingWebhook', {url, data}).its('status').should('be.equal', 200).wait(TIMEOUTS.MEDIUM);
 });
 
 /**


### PR DESCRIPTION
#### Summary
Fix failing basic options spec. I have observed at least two ways it fails intermittently
- timeout issue on webhook
- use of crowded town-square takes time for the channel to load

Hence,
- cleaned up timeouts for webhook and increased from TINY to MEDIUM (sometimes it still fails on SMALL)
- created new channel for the run instead of using town-square


#### Ticket Link
none, failing on daily Cypress test