### PR TITLE
Allow firefox in hasSoundOptions

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -207,7 +207,7 @@ export function ding() {
 }
 
 export function hasSoundOptions() {
-    return (!(UserAgent.isFirefox()) && !(UserAgent.isEdge()));
+    return (!(UserAgent.isEdge()));
 }
 
 export function getDateForUnixTicks(ticks) {


### PR DESCRIPTION
#### Summary
Utils.hasSoundOptions currently excludes firefox while new Audio(mp3 resource).play() has worked for a long time now.

Should be time to allow firefox to play sounds too.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/13807