### PR TITLE
MM-21933 Do not show toast when a channel is marked as unread and at bottom

### DIFF
--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -71,7 +71,7 @@ class ToastWrapper extends React.PureComponent {
 
         // show unread toast when a channel is remarked as unread using the change in lastViewedAt
         // lastViewedAt changes only if a channel is remarked as unread in channelMarkedAsUnread state
-        if (props.channelMarkedAsUnread && props.lastViewedAt !== prevState.lastViewedAt) {
+        if (props.channelMarkedAsUnread && props.lastViewedAt !== prevState.lastViewedAt && !props.atBottom) {
             showUnreadToast = true;
         }
 

--- a/components/toast_wrapper/toast_wrapper.test.jsx
+++ b/components/toast_wrapper/toast_wrapper.test.jsx
@@ -137,8 +137,34 @@ describe('components/ToastWrapper', () => {
             expect(wrapper.state('showUnreadToast')).toBe(true);
             wrapper.setProps({atBottom: true});
             expect(wrapper.state('showUnreadToast')).toBe(false);
+            wrapper.setProps({atBottom: false});
             wrapper.setProps({lastViewedAt: 12342});
             expect(wrapper.state('showUnreadToast')).toBe(true);
+        });
+
+        test('Should not have unread toast if channel is marked as unread and at bottom', () => {
+            const props = {
+                ...baseProps,
+                channelMarkedAsUnread: false,
+                atLatestPost: true,
+            };
+            const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
+            expect(wrapper.state('showUnreadToast')).toBe(false);
+            wrapper.setProps({atBottom: true});
+            wrapper.setProps({
+                channelMarkedAsUnread: true,
+                postListIds: [
+                    'post1',
+                    'post2',
+                    'post3',
+                    PostListRowListIds.START_OF_NEW_MESSAGES,
+                    DATE_LINE + 1551711600000,
+                    'post4',
+                    'post5',
+                ],
+            });
+
+            expect(wrapper.state('showUnreadToast')).toBe(false);
         });
 
         test('Should have showNewMessagesToast if there are unreads and lastViewedAt is less than latestPostTimeStamp', () => {


### PR DESCRIPTION
#### Summary
Adding check to prevent toast appearing when at bottom

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21933

