### PR TITLE
MM-22311 Fix JS crash when leaving all teams

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -369,8 +369,12 @@ class Sidebar extends React.PureComponent {
 
     scrollToChannel = (channelId, scrollingToUnread = false) => {
         const element = $(ReactDOM.findDOMNode(this.refs[channelId]));
+        if (!element) {
+            return;
+        }
+
         const position = element.position();
-        if (!element || !position) {
+        if (!position) {
             return;
         }
 

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -369,11 +369,12 @@ class Sidebar extends React.PureComponent {
 
     scrollToChannel = (channelId, scrollingToUnread = false) => {
         const element = $(ReactDOM.findDOMNode(this.refs[channelId]));
-        if (!element) {
+        const position = element.position();
+        if (!element || !position) {
             return;
         }
 
-        const top = element.position().top;
+        const top = position.top;
         const bottom = top + element.height();
 
         const scrollTop = this.refs.scrollbar.getScrollTop();


### PR DESCRIPTION
#### Summary
`element.position()` can at times return `undefined` so we need to check for it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22311