### PR TITLE
MM-22233 Fix 2 byte character drafts not being cleared

### DIFF
--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -484,6 +484,7 @@ class CreatePost extends React.PureComponent {
             postError: null,
         });
 
+        cancelAnimationFrame(this.saveDraftFrame);
         this.props.actions.setDraft(StoragePrefixes.DRAFT + channelId, null);
         this.draftsForChannel[channelId] = null;
 


### PR DESCRIPTION
#### Summary
Edge case regression caused by some performance improvements. Thanks to @sudheerDev for finding the fix.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22233