### PR TITLE
MM-22199 Disable scrolling to channel on switch

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -232,7 +232,8 @@ class Sidebar extends React.PureComponent {
 
         // Scroll to selected channel so it's in view
         if (this.props.currentChannel.id !== prevProps.currentChannel.id) {
-            this.scrollToChannel(this.props.currentChannel.id);
+            // This will be re-enabled after 5.20 when the weird scrolling behaviour when switching teams can be resolved
+            // this.scrollToChannel(this.props.currentChannel.id);
         }
 
         // close the LHS on mobile when you change channels


### PR DESCRIPTION
We're temporarily reverting this behaviour for 5.20 since we aren't able to make it scroll to the current channel on team switch without an animation. I have a separate fix planned for master once this goes in, but it's more involved, so I don't want to risk it for 5.22.

With this PR, the sidebar will still scroll to channels by clicking on the More Unread indicators or when using the alt+up/down hotkeys, but it will no longer scroll when you use the channel switcher or click on a channel link to switch channels.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22199