### PR TITLE
MM-22326 Fix non-DM/GM autocomplete in search box

### DIFF
--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -23,7 +23,7 @@ import Popover from 'components/widgets/popover';
 
 const {KeyCodes} = Constants;
 
-export default class SearchBar extends React.PureComponent {
+export default class SearchBar extends React.Component {
     static propTypes = {
         isSearchingTerm: PropTypes.bool,
         searchTerms: PropTypes.string,

--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -23,7 +23,7 @@ import Popover from 'components/widgets/popover';
 
 const {KeyCodes} = Constants;
 
-export default class SearchBar extends React.Component {
+export default class SearchBar extends React.PureComponent {
     static propTypes = {
         isSearchingTerm: PropTypes.bool,
         searchTerms: PropTypes.string,

--- a/components/suggestion/search_channel_provider.jsx
+++ b/components/suggestion/search_channel_provider.jsx
@@ -27,6 +27,19 @@ function itemToName(item) {
     return item.name;
 }
 
+function itemToTerm(item) {
+    if (item.type === Constants.DM_CHANNEL) {
+        return '@' + item.display_name;
+    }
+    if (item.type === Constants.GM_CHANNEL) {
+        return '@' + item.display_name.replace(/ /g, '');
+    }
+    if (item.type === Constants.OPEN_CHANNEL || item.type === Constants.PRIVATE_CHANNEL) {
+        return item.name;
+    }
+    return item.name;
+}
+
 class SearchChannelSuggestion extends Suggestion {
     render() {
         const {item, isSelection} = this.props;
@@ -96,7 +109,7 @@ export default class SearchChannelProvider extends Provider {
                     // MM-12677 When this is migrated this needs to be fixed to pull the user's locale
                     //
                     const channels = data.sort(sortChannelsByTypeAndDisplayName.bind(null, 'en'));
-                    const channelNames = channels.map(itemToName);
+                    const channelNames = channels.map(itemToTerm);
 
                     resultsCallback({
                         matchedPretext: channelPrefix,


### PR DESCRIPTION
#### Summary
The `itemToName` function was used for display names only (which are the same for GMs/DMs but not other channels). Fixed by creating a similar function but to be used specifically for creating the search term.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22326