### PR TITLE
MM-21949 Fix type of children prop for TeamPermissionGate

### DIFF
--- a/components/permissions_gates/team_permission_gate/team_permission_gate.tsx
+++ b/components/permissions_gates/team_permission_gate/team_permission_gate.tsx
@@ -28,7 +28,7 @@ type Props = {
     /**
      * Content protected by the permissions gate
      */
-    children: React.ReactElement;
+    children: React.ReactNode;
 };
 
 export default class TeamPermissionGate extends React.Component<Props> {


### PR DESCRIPTION
The type of children got changed accidentally during the migration to TypeScript.

@jgilliam17 Skipping QA review on this since it just fixes a warning that only occurs during development.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21949