### PR TITLE
MM-22289 Fix for toast appearing when scrolled up 

### DIFF
--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -130,6 +130,7 @@ class PostList extends React.PureComponent {
             postListIds: [channelIntroMessage],
             topPostId: '',
             postMenuOpened: false,
+            initScrollCompleted: false,
             dynamicListStyle: {
                 willChange: 'transform',
             },
@@ -324,6 +325,10 @@ class PostList extends React.PureComponent {
     }
 
     onScroll = ({scrollDirection, scrollOffset, scrollUpdateWasRequested, clientHeight, scrollHeight}) => {
+        if (scrollHeight <= 0) {
+            return;
+        }
+
         const didUserScrollBackwards = scrollDirection === 'backward' && !scrollUpdateWasRequested;
         const didUserScrollForwards = scrollDirection === 'forward' && !scrollUpdateWasRequested;
         const isOffsetWithInRange = scrollOffset < HEIGHT_TRIGGER_FOR_MORE_POSTS;
@@ -347,6 +352,8 @@ class PostList extends React.PureComponent {
             }
         }
 
+        this.checkBottom(scrollOffset, scrollHeight, clientHeight);
+
         if (scrollUpdateWasRequested) { //if scroll change is programatically requested i.e by calling scrollTo
             //This is a private method on virtlist
             const postsRenderedRange = this.listRef.current._getRangeToRender(); //eslint-disable-line no-underscore-dangle
@@ -355,10 +362,12 @@ class PostList extends React.PureComponent {
             if (postsRenderedRange[3] <= 1 && !this.props.atLatestPost) {
                 this.props.actions.canLoadMorePosts(PostRequestTypes.AFTER_ID);
             }
-        }
 
-        if (scrollHeight > 0) {
-            this.checkBottom(scrollOffset, scrollHeight, clientHeight);
+            if (!this.state.initScrollCompleted) {
+                this.setState({
+                    initScrollCompleted: true,
+                });
+            }
         }
     }
 
@@ -491,6 +500,7 @@ class PostList extends React.PureComponent {
                 updateNewMessagesAtInChannel={this.updateNewMessagesAtInChannel}
                 updateLastViewedBottomAt={this.updateLastViewedBottomAt}
                 channelId={this.props.channelId}
+                initScrollCompleted={this.state.initScrollCompleted}
             />
         );
     }

--- a/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.test.jsx
@@ -155,6 +155,27 @@ describe('PostList', () => {
 
             expect(baseProps.actions.canLoadMorePosts).not.toHaveBeenCalled();
         });
+
+        test('should set initScrollCompleted on first onScroll when scrollUpdateWasRequested', () => {
+            const wrapper = shallowWithIntl(<PostList {...baseProps}/>);
+            const instance = wrapper.instance();
+
+            const scrollOffset = 1234;
+            const scrollHeight = 1000;
+            const clientHeight = 500;
+
+            instance.listRef = {current: {_getRangeToRender: () => [0, 70, 70, 70]}};
+            expect(wrapper.state('initScrollCompleted')).toBe(false);
+            instance.onScroll({
+                scrollDirection: 'forward',
+                scrollOffset,
+                scrollUpdateWasRequested: true,
+                scrollHeight,
+                clientHeight,
+            });
+
+            expect(wrapper.state('initScrollCompleted')).toBe(true);
+        });
     });
 
     describe('isAtBottom', () => {

--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -25,6 +25,7 @@ class ToastWrapper extends React.PureComponent {
         lastViewedBottom: PropTypes.number,
         width: PropTypes.number,
         lastViewedAt: PropTypes.number,
+        initScrollCompleted: PropTypes.bool,
         updateNewMessagesAtInChannel: PropTypes.func,
         scrollToNewMessage: PropTypes.func,
         scrollToLatestMessages: PropTypes.func,
@@ -60,8 +61,8 @@ class ToastWrapper extends React.PureComponent {
         }
 
         // show unread toast on mount when channel is not at bottom and unread count greater than 0
-        if (typeof showUnreadToast === 'undefined' && !props.atBottom) {
-            showUnreadToast = unreadCount > 0;
+        if (typeof showUnreadToast === 'undefined' && props.initScrollCompleted) {
+            showUnreadToast = unreadCount > 0 && !props.atBottom;
         }
 
         // show unread toast when a channel is marked as unread

--- a/components/toast_wrapper/toast_wrapper.test.jsx
+++ b/components/toast_wrapper/toast_wrapper.test.jsx
@@ -32,6 +32,7 @@ describe('components/ToastWrapper', () => {
         scrollToLatestMessages: jest.fn(),
         updateLastViewedBottomAt: jest.fn(),
         lastViewedAt: 12344,
+        initScrollCompleted: true,
     };
 
     describe('unread count logic', () => {
@@ -90,6 +91,20 @@ describe('components/ToastWrapper', () => {
             expect(wrapper.state('showUnreadToast')).toBe(true);
         });
 
+        test('Should set state of have unread toast when initScrollCompleted is true', () => {
+            const props = {
+                ...baseProps,
+                unreadCountInChannel: 10,
+                newRecentMessagesCount: 5,
+                initScrollCompleted: false,
+            };
+
+            const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
+            expect(wrapper.state('showUnreadToast')).toBe(undefined);
+            wrapper.setProps({initScrollCompleted: true});
+            expect(wrapper.state('showUnreadToast')).toBe(true);
+        });
+
         test('Should have unread toast channel is marked as unread', () => {
             const props = {
                 ...baseProps,
@@ -107,7 +122,7 @@ describe('components/ToastWrapper', () => {
                 atBottom: true,
             };
             const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
-            expect(wrapper.state('showUnreadToast')).toBe(undefined);
+            expect(wrapper.state('showUnreadToast')).toBe(false);
             wrapper.setProps({channelMarkedAsUnread: true, atBottom: false});
             expect(wrapper.state('showUnreadToast')).toBe(true);
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18047,8 +18047,8 @@
       "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
     },
     "react-window": {
-      "version": "github:mattermost/react-window#15e10c29122b53b10d69a4ca4800eb2631874236",
-      "from": "github:mattermost/react-window#15e10c29122b53b10d69a4ca4800eb2631874236",
+      "version": "github:mattermost/react-window#1017d1231685ddc052ee8c820b5a7d3bac3a48c1",
+      "from": "github:mattermost/react-window#1017d1231685ddc052ee8c820b5a7d3bac3a48c1",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-select": "2.4.4",
     "react-transition-group": "4.3.0",
     "react-virtualized-auto-sizer": "1.0.2",
-    "react-window": "github:mattermost/react-window#15e10c29122b53b10d69a4ca4800eb2631874236",
+    "react-window": "github:mattermost/react-window#1017d1231685ddc052ee8c820b5a7d3bac3a48c1",
     "rebound": "0.1.0",
     "redux": "4.0.4",
     "redux-batched-actions": "0.4.1",


### PR DESCRIPTION
#### Summary
```
typeof showUnreadToast === 'undefined' && !props.atBottom
```
The above lines were used to set the initial state of toast but if toast state is never set and scrolled up the above lines execute causing the toast to show up.

  * The core issue of the problem is that toast state should be decided after the initial Scroll Correction is done. There was no way to determine before this causing an issue on when to set the state for toast.

  * Adding a state in virt list to know when init scroll is completed. So using this we set the initial state of toast so that when scrolling up the 


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22289

