### PR TITLE
Fix timeout issues

### DIFF
--- a/e2e/cypress/integration/channel/send_message_via_profile_popover_spec.js
+++ b/e2e/cypress/integration/channel/send_message_via_profile_popover_spec.js
@@ -29,7 +29,7 @@ describe('Profile popover', () => {
 
                 const message = `Testing ${Date.now()}`;
                 cy.get('@currentChannelId').then((currentChannelId) => {
-                    cy.postMessageAs({sender: newUser, message, channelId: currentChannelId}).wait(TIMEOUTS.TINY);
+                    cy.postMessageAs({sender: newUser, message, channelId: currentChannelId}).wait(TIMEOUTS.SMALL);
                 });
 
                 cy.waitUntil(() => cy.getLastPost().then((el) => {

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_invitation_ui_spec.js
@@ -27,6 +27,7 @@ function changeGuestFeatureSettings(featureFlag = true, emailInvitation = true, 
         },
         ServiceSettings: {
             EnableEmailInvitations: emailInvitation,
+            IdleTimeout: 300,
         },
     });
 }

--- a/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
@@ -85,6 +85,7 @@ describe('Guest Account - Member Invitation Flow', () => {
             },
             ServiceSettings: {
                 EnableEmailInvitations: true,
+                IdleTimeout: 300,
             },
         });
 


### PR DESCRIPTION
#### Summary
Fix timeout issues.
- invitation timeout issues found in cypress builds might be due to new IdleTimeout config which is defaulted to 60s. Before IdleTimeout, it used to read session timeout from ReadTimeout which is 300s
- I was able to replicate popover message timeout and increased from TINY to SMALL to fix

#### Ticket Link
none, failing on daily Cypress test