### PR TITLE
MM-22351: Fix users/emails autocompletion when user emails is not available

### DIFF
--- a/components/widgets/inputs/channels_input.jsx
+++ b/components/widgets/inputs/channels_input.jsx
@@ -53,7 +53,7 @@ export default class ChannelsInput extends React.Component {
     getOptionValue = (channel) => channel.id
 
     handleInputChange = (inputValue, action) => {
-        if (action.action === 'input-blur') {
+        if (action.action === 'input-blur' && inputValue !== '') {
             for (const option of this.state.options) {
                 if (this.props.inputValue === option.name) {
                     this.onChange([...this.props.value, option]);

--- a/components/widgets/inputs/users_emails_input.jsx
+++ b/components/widgets/inputs/users_emails_input.jsx
@@ -200,7 +200,7 @@ export default class UsersEmailsInput extends React.Component {
     };
 
     handleInputChange = (inputValue, action) => {
-        if (action.action === 'input-blur') {
+        if (action.action === 'input-blur' && inputValue !== '') {
             const values = this.props.value.map((v) => {
                 if (v.id) {
                     return v;


### PR DESCRIPTION
#### Summary
When the users emails is not publicly available and you try to add a user, when
you blur the input field, during the blur the first match is used (which is
going to be the first match in the list because the empty string is going to
match with the empty email address.

To avoid this, i remove entirely the posibility of autocompletion with empty
string here and in the channels selector.

#### Ticket Link
[MM-22351](https://mattermost.atlassian.net/browse/MM-22351)