### PR TITLE
[MM-21542] Fix Cypress test report

### DIFF
--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -3,6 +3,7 @@
 
 /* eslint-disable no-await-in-loop, no-console */
 
+const axios = require('axios');
 const cypress = require('cypress');
 const fse = require('fs-extra');
 const {merge} = require('mochawesome-merge');
@@ -117,15 +118,78 @@ async function runTests() {
     // Merge all json reports into one single json report
     const jsonReport = await merge({reportDir: mochawesomeReportDir});
 
-    // Generate short summary to easily pickup via hook
+    // Generate short summary, write to file and then send report via webhook
     const summary = generateShortSummary(jsonReport);
     writeJsonToFile(summary, 'summary.json', mochawesomeReportDir);
+    await sendReport(summary);
 
     // Generate the html report file
     await generator.create(jsonReport, {reportDir: mochawesomeReportDir});
 
     // eslint-disable-next-line
     process.exit(failedTests); // exit with the number of failed tests
+}
+
+const result = [
+    {status: 'Passed', priority: 'none', cutOff: 100, color: '#43A047'},
+    {status: 'Failed', priority: 'low', cutOff: 98, color: '#FFEB3B'},
+    {status: 'Failed', priority: 'medium', cutOff: 95, color: '#FF9800'},
+    {status: 'Failed', priority: 'high', cutOff: 0, color: '#F44336'},
+];
+
+function generateReport(summary) {
+    const {BRANCH, BUILD_ID} = process.env;
+    const {statsFieldValue, stats} = summary;
+
+    let testResult;
+    for (let i = 0; i < result.length; i++) {
+        if (stats.passPercent >= result[i].cutOff) {
+            testResult = result[i];
+            break;
+        }
+    }
+
+    return {
+        username: 'Cypress UI Test',
+        icon_url: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
+        attachments: [{
+            color: testResult.color,
+            author_name: 'Cypress UI Test',
+            author_icon: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
+            author_link: 'https://www.mattermost.com',
+            title: `[${BRANCH}] Cypress UI Test Automation #${BUILD_ID} ${testResult.status}!`,
+            fields: [{
+                short: false,
+                title: 'Test Report',
+                value: `[Link to the report](https://build-push.internal.mattermost.com/job/mattermost-ui-testing/job/mattermost-cypress/${BUILD_ID}/artifact/mattermost-webapp/e2e/results/mochawesome-report/mochawesome.html)`,
+            }, {
+                short: false,
+                title: 'Screenshots',
+                value: `[Link to the screenshots](https://build-push.internal.mattermost.com/job/mattermost-ui-testing/job/mattermost-cypress/${BUILD_ID}/artifact/mattermost-webapp/e2e/results/mochawesome-report/screenshots/)`,
+            }, {
+                short: false,
+                title: `Key metrics (required support: ${testResult.priority})`,
+                value: statsFieldValue,
+            }],
+            image_url: 'https://pbs.twimg.com/profile_images/1044345247440896001/pXI1GDHW_bigger.jpg'
+        }],
+    };
+}
+
+async function sendReport(summary) {
+    const data = generateReport(summary);
+
+    const response = await axios({
+        method: 'post',
+        url: process.env.WEBHOOK_URL,
+        data,
+    });
+
+    if (response.data) {
+        console.log('Successfully sent report via webhook');
+    }
+
+    return response;
 }
 
 runTests();


### PR DESCRIPTION
#### Summary
This is P1 in improving Cypress test reports. (P2 - save JSON file to S3;  P3 - generate historical reports)

This fixes the issue on daily Cypress test where report is not being sent to community server. Move here the processing of report instead of Jenkins.

Key Changes:
- added branch to title to determine if the tests is run against what branch - "[__master__] Cypress UI Test Automation #123 Passed!"
- added indication on required support - "Key metrics (required support: __none__)"; options are none, low, medium and high.

Follow up PRs (non-blocking):
- on shared pipelines to remove report generation and add env variables for `BRANCH`, `BUILD_ID`, `WEBHOOK_URL`.
- add documentation at https://developers.mattermost.com/internal/qa/.  Title could be "Cypress Test Report"

#### Ticket Link
Jira ticket: https://mattermost.atlassian.net/browse/MM-21542

#### Screenshots
![Screen Shot 2020-02-10 at 7 37 27 PM](https://user-images.githubusercontent.com/5334504/74147443-36d78a00-4c3e-11ea-9548-bebc79951da0.png)
![Screen Shot 2020-02-10 at 7 37 41 PM](https://user-images.githubusercontent.com/5334504/74147473-4525a600-4c3e-11ea-8851-12e224aa4487.png)
