### PR TITLE
Changes to handle a recent change done for toast not to appear when the bottom is in view

### DIFF
--- a/e2e/cypress/integration/channel/toast_spec.js
+++ b/e2e/cypress/integration/channel/toast_spec.js
@@ -39,7 +39,7 @@ describe('toasts', () => {
 
         // * check that the message is correct
         cy.get('div.toast__message>span').first().contains('30 new messages');
-        cy.get('div.post-list__dynamic').scrollTo('bottom');
+        cy.get('div.post-list__dynamic').scrollTo('bottom', {duration: 1000});
 
         // * should hide the scroll to new message button as it is at the bottom
         cy.get('div.toast__jump').should('not.be.visible');
@@ -64,7 +64,7 @@ describe('toasts', () => {
         scrollUpAndPostAMessage().then(() => {
             // * find the toast
             cy.get('div.toast').should('be.visible');
-            cy.get('div.post-list__dynamic').scrollTo('bottom');
+            cy.get('div.post-list__dynamic').scrollTo('bottom', {duration: 1000});
 
             // * should hide the scroll to new message button as it is at the bottom
             cy.get('div.toast__jump').should('not.be.visible');
@@ -78,7 +78,7 @@ describe('toasts', () => {
         visitTownSquareAndWaitForPageToLoad();
 
         // # Scroll up so bottom is not visible
-        cy.get('div.post-list__dynamic').scrollTo(0, '70%');
+        cy.get('div.post-list__dynamic').scrollTo(0, '70%', {duration: 1000});
 
         // # Post few new message
         for (let index = 0; index < 4; index++) {
@@ -127,6 +127,9 @@ describe('toasts', () => {
         cy.postMessageAs({sender: otherUser, message: 'This is a new message', channelId: townsquareChannelId});
         cy.go('back');
 
+        // # Scroll up so bottom is not visible
+        cy.get('div.post-list__dynamic').scrollTo(0, '70%', {duration: 1000});
+
         // # Post a new message
         cy.get('div.toast').should('be.visible');
         cy.get('div.toast__dismiss').click();
@@ -174,6 +177,13 @@ describe('toasts', () => {
             // # Mark post as unread
             cy.get(`#post_${postId} #unread_post_${postId}`).click();
 
+            // # Visit another channel and come back to the same channel again
+            cy.visit('/ad-1/channels/off-topic');
+            cy.visit('/ad-1/channels/town-square');
+
+            // # Scroll up so bottom is not visible
+            cy.get('div.post-list__dynamic').scrollTo(0, '70%', {duration: 1000});
+
             // # Toast apprears and has the appropriate message
             cy.get('div.toast').should('be.visible');
             cy.get('div.toast__message>span').first().contains('1 new message');
@@ -183,12 +193,15 @@ describe('toasts', () => {
     it('New message line should move if user is scrolled up and new messages arrive', () => {
         visitTownSquareAndWaitForPageToLoad();
 
+        // # Scroll to the last post
+        cy.get('div.post-list__dynamic').scrollTo('bottom', {duration: 1000});
+
         // # Post a new message
         cy.postMessageAs({sender: otherUser, message: 'post1', channelId: townsquareChannelId}).then(() => {
             // * The new messages line should appear above the last post
             cy.get('.NotificationSeparator').should('exist');
             cy.get('.NotificationSeparator').parent().parent().next().should('contain', 'post1');
-            cy.get('div.post-list__dynamic').scrollTo(0, '70%');
+            cy.get('div.post-list__dynamic').scrollTo(0, '70%', {duration: 1000});
             cy.postMessageAs({sender: otherUser, message: 'post2', channelId: townsquareChannelId}).then(() => {
                 // * The new messages line should have moved to the last post
                 cy.get('.NotificationSeparator').parent().parent().next().should('contain', 'post2');
@@ -204,7 +217,7 @@ function visitTownSquareAndWaitForPageToLoad() {
 
 function scrollUpAndPostAMessage() {
     // # Scroll up so bottom is not visible
-    cy.get('div.post-list__dynamic').scrollTo(0, '70%');
+    cy.get('div.post-list__dynamic').scrollTo(0, '70%', {duration: 1000});
 
     // # Without the wait the tests seem to fun flaky. Possibly because of ScrollTo having a race with post of message
     cy.wait(20); // eslint-disable-line cypress/no-unnecessary-waiting


### PR DESCRIPTION
#### Summary
Changes done in the toast spec to handle a recent change done for toast not to appear when the bottom is in view. 

#### Screenshots
Status of the tests before this change:
<img width="1176" alt="Screenshot 2020-02-10 at 7 55 01 PM" src="https://user-images.githubusercontent.com/1429138/74158175-9d10dc80-4c3f-11ea-8eb8-d117cce0e3a1.png">

Status of tests after this change:
<img width="724" alt="Screenshot 2020-02-10 at 7 51 02 PM" src="https://user-images.githubusercontent.com/1429138/74158226-b4e86080-4c3f-11ea-86cd-322218560c3f.png">
