### PR TITLE
Automated cherry pick of #4844

### DIFF
--- a/utils/markdown/index.test.js
+++ b/utils/markdown/index.test.js
@@ -37,7 +37,7 @@ describe('format', () => {
 - b
 - c`;
             const expected = `<ul className="markdown__list">
-<li>a</li><li>b</li><li>c</li></ul>`;
+<li><span>a</span></li><li><span>b</span></li><li><span>c</span></li></ul>`;
 
             const output = format(input);
             expect(output).toBe(expected);
@@ -48,7 +48,7 @@ describe('format', () => {
 2. b
 3. c`;
             const expected = `<ol className="markdown__list" style="counter-reset: list 0">
-<li>a</li><li>b</li><li>c</li></ol>`;
+<li><span>a</span></li><li><span>b</span></li><li><span>c</span></li></ol>`;
 
             const output = format(input);
             expect(output).toBe(expected);
@@ -59,7 +59,7 @@ describe('format', () => {
 1. b
 1. c`;
             const expected = `<ol className="markdown__list" style="counter-reset: list 998">
-<li>a</li><li>b</li><li>c</li></ol>`;
+<li><span>a</span></li><li><span>b</span></li><li><span>c</span></li></ol>`;
 
             const output = format(input);
             expect(output).toBe(expected);

--- a/utils/markdown/renderer.tsx
+++ b/utils/markdown/renderer.tsx
@@ -277,7 +277,9 @@ export default class Renderer extends marked.Renderer {
         '/> '}${text.replace(taskListReg, '')}</li>`;
         }
 
-        return `<li>${text}</li>`;
+        // Added a span because if not whitespace nodes only
+        // works in Firefox but not in Webkit
+        return `<li><span>${text}</span></li>`;
     }
 
     public text(txt: string) {


### PR DESCRIPTION
Cherry pick of #4844 on release-5.20.

- #4844: Wrap list elements in a span

/cc  @ethervoid