### PR TITLE
Mm 22430 - Regression &nbsp should not display

### DIFF
--- a/components/admin_console/team_channel_settings/group/__snapshots__/group_users_row.test.tsx.snap
+++ b/components/admin_console/team_channel_settings/group/__snapshots__/group_users_row.test.tsx.snap
@@ -32,13 +32,11 @@ exports[`admin_console/team_channel_settings/group/GroupUsersRow should match sn
         >
           <b>
             @test
-            &nbsp;
+             
           </b>
-          <div>
-            -
-            &nbsp;
-            Test display name
-          </div>
+          -
+           
+          Test display name
         </div>
         <div
           className="row email-group-row"
@@ -93,13 +91,11 @@ exports[`admin_console/team_channel_settings/group/GroupUsersRow should match sn
         >
           <b>
             @test
-            &nbsp;
+             
           </b>
-          <div>
-            -
-            &nbsp;
-            Test display name
-          </div>
+          -
+           
+          Test display name
         </div>
         <div
           className="row email-group-row"

--- a/components/admin_console/team_channel_settings/group/group_users_row.tsx
+++ b/components/admin_console/team_channel_settings/group/group_users_row.tsx
@@ -70,10 +70,9 @@ export default class AdminGroupUsersRow extends React.PureComponent<AdminGroupUs
                             />
                         </div>
                         <div className='col-sm-10'>
-                        <div className='row'>
+                            <div className='row'>
                                 <b>{'@' + user.username}&nbsp;</b>
-                                {'-'}&nbsp;
-                                {displayName}
+                                {'-'}&nbsp;{displayName}
                             </div>
                             <div className='row email-group-row'>{user.email}</div>
                         </div>

--- a/components/admin_console/team_channel_settings/group/group_users_row.tsx
+++ b/components/admin_console/team_channel_settings/group/group_users_row.tsx
@@ -71,6 +71,7 @@ export default class AdminGroupUsersRow extends React.PureComponent<AdminGroupUs
                         </div>
                         <div className='col-sm-10'>
                             <div className='row'>
+                                {/* eslint-disable react/jsx-no-literals */}
                                 <b>{'@' + user.username}&nbsp;</b>
                                 {'-'}&nbsp;{displayName}
                             </div>

--- a/components/admin_console/team_channel_settings/group/group_users_row.tsx
+++ b/components/admin_console/team_channel_settings/group/group_users_row.tsx
@@ -70,13 +70,10 @@ export default class AdminGroupUsersRow extends React.PureComponent<AdminGroupUs
                             />
                         </div>
                         <div className='col-sm-10'>
-                            <div className='row'>
-                                <b>
-                                    {'@' + user.username}{'&nbsp;'}
-                                </b>
-                                <div>
-                                    {'-'}{'&nbsp;'}{displayName}
-                                </div>
+                        <div className='row'>
+                                <b>{'@' + user.username}&nbsp;</b>
+                                {'-'}&nbsp;
+                                {displayName}
                             </div>
                             <div className='row email-group-row'>{user.email}</div>
                         </div>


### PR DESCRIPTION
#### Summary
Removing single quotes around '&nbsp', which is causing it display verbatim. Also removed the 'div' tag that was added as it was forcing Display name to a separate line.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22430

#### Screenshots
![Screen Shot 2020-02-11 at 3 23 09 PM](https://user-images.githubusercontent.com/12704875/74287408-1c0d2000-4ce7-11ea-993c-4fbf065bdece.png)
