### PR TITLE
Fix message reply input box expand spec

### DIFF
--- a/e2e/cypress/integration/messaging/message_reply_input_box_expand_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_input_box_expand_spec.js
@@ -20,8 +20,8 @@ describe('Messaging', () => {
     it('M18706-Input box on reply thread can expand', () => {
         const maxReplyCount = 15;
         const halfViewportHeight = Cypress.config('viewportHeight') / 2;
-        const padding = 4;
-        const postCreateContainerDefaultHeight = 184 - padding;
+        const padding = 7;
+        const postCreateContainerDefaultHeight = 187;
         const replyTextBoxDefaultHeight = 100;
         const postCreateContainerClassName = 'post-create__container';
         const replyTextBoxId = 'reply_textbox';
@@ -45,7 +45,7 @@ describe('Messaging', () => {
             const replyTextBox = doc.getElementById(replyTextBoxId);
 
             // * Check if post create container has default offset height and less than 50% of viewport height
-            expect(postCreateContainer.offsetHeight - padding).to.eq(postCreateContainerDefaultHeight).and.lessThan(halfViewportHeight);
+            expect(postCreateContainer.offsetHeight).to.eq(postCreateContainerDefaultHeight).and.lessThan(halfViewportHeight);
 
             // * Check if reply text box has default offset height and less than post create container default offset height
             expect(replyTextBox.offsetHeight).to.eq(replyTextBoxDefaultHeight).and.lessThan(postCreateContainerDefaultHeight);


### PR DESCRIPTION
#### Summary
Fix failing message reply input box expand spec
- fix padding and height comparison issue, based on actual size window (no zoom in/out)

#### Ticket Link
none, failing on daily Cypress test