### PR TITLE
HotFix : Added missing types to test_helper

### DIFF
--- a/utils/test_helper.ts
+++ b/utils/test_helper.ts
@@ -23,6 +23,8 @@ export class TestHelper {
             terms_of_service_create_at: 0,
             terms_of_service_id: '',
             update_at: 0,
+            is_bot: false,
+            last_picture_update: 0,
             notify_props: {
                 channel: 'false',
                 comments: 'never',


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-webapp/pull/4738 when merged into master, failed the type tests. This PR fixes that.

#### Ticket Link
Hotfix

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/4738

#### Screenshots
![Screenshot_2020-02-13 mattermost mattermost-webapp](https://user-images.githubusercontent.com/17708702/74399013-43600c00-4e11-11ea-927c-84912c75d6f1.png)
