### PR TITLE
E2E: Make explicit visit to team and channel

### DIFF
--- a/e2e/cypress/integration/account_settings/display/channel_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/channel_display_mode_spec.js
@@ -16,7 +16,7 @@ describe('Account Settings > Display > Channel Display Mode', () => {
         cy.apiSaveMessageDisplayPreference();
 
         // Post a message to a channel
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
         cy.postMessage('Test for channel display mode');
     });
 

--- a/e2e/cypress/integration/account_settings/display/code_theme_colors_spec.js
+++ b/e2e/cypress/integration/account_settings/display/code_theme_colors_spec.js
@@ -40,7 +40,7 @@ describe('AS14319 Theme Colors - Code', () => {
     before(() => {
         // # Login and navigate to the app
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Enter in code block for message
         cy.get('#post_textbox').clear().type('```\ncode\n```{enter}');

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -16,7 +16,7 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
     before(() => {
         // # Login and visit "/"
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Create a test team and channels
         cy.apiCreateTeam('test-team', 'Test Team').then((response) => {

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_ui_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_ui_spec.js
@@ -10,7 +10,7 @@
 describe('Account Settings > Sidebar > Channel Switcher', () => {
     before(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Go to Account Settings with "user-1"
         cy.toAccountSettingsModal(null, true);

--- a/e2e/cypress/integration/at_mentions/at_mentions_user_spec.js
+++ b/e2e/cypress/integration/at_mentions/at_mentions_user_spec.js
@@ -24,7 +24,7 @@ describe('Mention user', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M19761 autocomplete should match on cases', () => {

--- a/e2e/cypress/integration/channel/add_users_to_channel_spec.js
+++ b/e2e/cypress/integration/channel/add_users_to_channel_spec.js
@@ -52,7 +52,7 @@ function addNumberOfUsersToChannel(num = 1) {
 describe('CS15445 Join/leave messages', () => {
     before(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('Single User: Usernames are links, open profile popovers', () => {

--- a/e2e/cypress/integration/channel/autocomplete_shown_each_channel_spec.js
+++ b/e2e/cypress/integration/channel/autocomplete_shown_each_channel_spec.js
@@ -11,7 +11,7 @@ describe('Identical Message Drafts', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Clear channel textbox
         cy.clearPostTextbox('town-square');

--- a/e2e/cypress/integration/channel/channel_menu_spec.js
+++ b/e2e/cypress/integration/channel/channel_menu_spec.js
@@ -35,7 +35,7 @@ describe('Channel header menu', () => {
         let channel;
 
         // # Go to "/"
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         cy.getCurrentTeamId().then((teamId) => {
             // # Create new test channel

--- a/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
+++ b/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
@@ -41,7 +41,7 @@ describe('channel name tooltips', () => {
             loggedUser = user;
 
             // # Go to "/"
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
         });
     });
 

--- a/e2e/cypress/integration/channel/channel_routing_spec.js
+++ b/e2e/cypress/integration/channel/channel_routing_spec.js
@@ -10,7 +10,7 @@
 describe('Channel routing', () => {
     before(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('should go to town square channel view', () => {

--- a/e2e/cypress/integration/channel/collapsed_message_spec.js
+++ b/e2e/cypress/integration/channel/collapsed_message_spec.js
@@ -27,7 +27,7 @@ describe('Long message', () => {
     it('M14321 will show more/less content correctly', () => {
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Post message with kitchen sink markdown text
         cy.postMessageFromFile('long_text_post.txt');

--- a/e2e/cypress/integration/channel/create_post_permission_spec.js
+++ b/e2e/cypress/integration/channel/create_post_permission_spec.js
@@ -15,7 +15,7 @@ function removeCreatePostPermission() {
         cy.patchRole(role.id, role);
     });
     cy.apiLogin('user-1');
-    cy.visit('/');
+    cy.visit('/ad-1/channels/town-square');
 }
 
 function addCreatePostPermission() {
@@ -28,7 +28,7 @@ function addCreatePostPermission() {
 
     // * Check that the post input is enabled again.
     cy.apiLogin('user-1');
-    cy.visit('/');
+    cy.visit('/ad-1/channels/town-square');
 }
 
 function openTheRHS() {
@@ -40,7 +40,7 @@ function openTheRHS() {
 describe('Message', () => {
     before(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('MM-21924 Post input is disabled without create_post permission', () => {

--- a/e2e/cypress/integration/channel/edit_message_spec.js
+++ b/e2e/cypress/integration/channel/edit_message_spec.js
@@ -17,7 +17,7 @@ describe('Edit Message', () => {
 
     it('M13909 Escape should not close modal when an autocomplete drop down is in use', () => {
         // # and go to /
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Post message "Hello"
         cy.postMessage('Hello World!');
@@ -70,7 +70,7 @@ describe('Edit Message', () => {
 
     it('M13482 Display correct timestamp for edited message', () => {
         // # and go to /
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Post a message
         cy.postMessage('Checking timestamp');
@@ -115,7 +115,7 @@ describe('Edit Message', () => {
 
     it('M15519 Open edit modal immediately after making a post when post is pending', () => {
         // # and go to /. We set fetch to null here so that we can intercept XHR network requests
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Enter first message
         cy.postMessage('Hello');

--- a/e2e/cypress/integration/channel/mark_as_unread_spec.js
+++ b/e2e/cypress/integration/channel/mark_as_unread_spec.js
@@ -16,7 +16,7 @@ describe('Mark as Unread', () => {
 
     before(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     beforeEach(() => {

--- a/e2e/cypress/integration/channel/message_bullets_spec.js
+++ b/e2e/cypress/integration/channel/message_bullets_spec.js
@@ -11,7 +11,7 @@ describe('Message', () => {
     it('M13326 Text in bullet points is the same size as text above and below it', () => {
         // # Login and navigate to the app
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Post a message
         cy.get('#post_textbox').clear().

--- a/e2e/cypress/integration/channel/message_draft_with_attachment_then_switch_channel_spec.js
+++ b/e2e/cypress/integration/channel/message_draft_with_attachment_then_switch_channel_spec.js
@@ -11,7 +11,7 @@ describe('Message Draft with attachment and Switch Channels', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
     const channelName1 = `test-channel-1-${Date.now()}`;
     const channelName2 = `test-channel-2-${Date.now()}`;

--- a/e2e/cypress/integration/channel/message_emoji_jumbo_spec.js
+++ b/e2e/cypress/integration/channel/message_emoji_jumbo_spec.js
@@ -35,7 +35,7 @@ describe('Message', () => {
     it('M15011 - Emojis show as jumbo in reply thread', () => {
         // # Login and navigate to the app
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Post a message
         const messageText = 'This is a test message';

--- a/e2e/cypress/integration/channel/message_reaction_spec.js
+++ b/e2e/cypress/integration/channel/message_reaction_spec.js
@@ -11,7 +11,7 @@ describe("Click another user's emoji reaction to add it", () => {
     it("M15113 - Click another user's emoji reaction to add it", () => {
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Post a message
         cy.postMessage('test');
@@ -21,7 +21,7 @@ describe("Click another user's emoji reaction to add it", () => {
 
         // # Login as "user-2" and go to /
         cy.apiLogin('user-2');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Mouseover the last post
         cy.getLastPost().trigger('mouseover');
@@ -42,7 +42,7 @@ describe("Click another user's emoji reaction to add it", () => {
 
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         cy.getLastPostId().then((postId) => {
             // # Click on the "slightly_frowning_face" emoji of the last post and the background color changes

--- a/e2e/cypress/integration/channel/message_shortlinking_spec.js
+++ b/e2e/cypress/integration/channel/message_shortlinking_spec.js
@@ -5,7 +5,7 @@ describe('Message', () => {
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
 
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M17451 Channel shortlinking still works when placed in brackets', () => {

--- a/e2e/cypress/integration/channel/message_spec.js
+++ b/e2e/cypress/integration/channel/message_spec.js
@@ -37,7 +37,7 @@ describe('Message', () => {
     before(() => {
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M13701 Consecutive message does not repeat profile info', () => {

--- a/e2e/cypress/integration/channel/more_channels_spec.js
+++ b/e2e/cypress/integration/channel/more_channels_spec.js
@@ -145,7 +145,7 @@ function verifyMoreChannelsModalWithArchivedSelection(isEnabled) {
 }
 
 function verifyMoreChannelsModal(isEnabled) {
-    cy.visit('/');
+    cy.visit('/ad-1/channels/town-square');
 
     // # Select "More..." on the left hand side menu
     cy.get('#publicChannelList').should('be.visible').within(() => {

--- a/e2e/cypress/integration/channel/user_to_admin_updates_manage_channel_members_modal_spec.js
+++ b/e2e/cypress/integration/channel/user_to_admin_updates_manage_channel_members_modal_spec.js
@@ -16,7 +16,7 @@ describe('View Members modal', () => {
             // # Promote user-1 as a system admin
             // # Visit default channel and verify members modal
             promoteToSysAdmin(res.body);
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
             verifyMemberDropdownAction(true);
 
             // # Make user a regular member

--- a/e2e/cypress/integration/channel/user_to_channel_admin_member_updates_manage_channel_members_modal_spec.js
+++ b/e2e/cypress/integration/channel/user_to_channel_admin_member_updates_manage_channel_members_modal_spec.js
@@ -47,7 +47,7 @@ describe('Change Roles', () => {
             userInfo = res.body;
 
             // # Visit Town square and go to view members modal
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
             cy.get('#sidebarItem_town-square').click({force: true});
 
             // # Get channel membership

--- a/e2e/cypress/integration/emoji/custom_emoji_spec.js
+++ b/e2e/cypress/integration/emoji/custom_emoji_spec.js
@@ -10,7 +10,7 @@
 describe('Custom emojis', () => {
     before(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('MM-9777 User cant add custom emoji with the same name as a system one', async () => {

--- a/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
+++ b/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
@@ -13,7 +13,7 @@ describe('Recent Emoji', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin();
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M14014 Recently used emojis are shown 1st', async () => {

--- a/e2e/cypress/integration/emoji/sorted_emojis_spec.js
+++ b/e2e/cypress/integration/emoji/sorted_emojis_spec.js
@@ -10,7 +10,7 @@
 describe('M16739 - Filtered emojis are sorted', () => {
     before(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
         cy.clearLocalStorage(/recent_emojis/);
     });
 

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
@@ -29,7 +29,7 @@ describe('Guest Account - Guest User Experience', () => {
         // # Login as a guest user and go to /
         cy.loginAsNewGuestUser().then((userResponse) => {
             guest = userResponse;
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
         });
     });
 

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
@@ -29,7 +29,6 @@ describe('Guest Account - Guest User Experience', () => {
         // # Login as a guest user and go to /
         cy.loginAsNewGuestUser().then((userResponse) => {
             guest = userResponse;
-            cy.visit('/ad-1/channels/town-square');
         });
     });
 

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
@@ -50,7 +50,7 @@ describe('Guest Account - Guest User Removal Experience', () => {
         // # Login as new user
         cy.loginAsNewUser().then((userResponse) => {
             guest = userResponse;
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
 
             // # Get the Current Team Id
             cy.getCurrentTeamId().then((teamId) => {

--- a/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
@@ -92,7 +92,6 @@ describe('Guest Account - Member Invitation Flow', () => {
         // # Create new team and visit its URL
         cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
             testTeam = response.body;
-            cy.visit('/ad-1/channels/town-square');
             cy.visit(`/${testTeam.name}`);
         });
     });
@@ -190,7 +189,6 @@ describe('Guest Account - Member Invitation Flow', () => {
         cy.createNewUser().then((newUser) => {
             cy.apiAddUserToTeam(testTeam.id, newUser.id);
             cy.apiLogin(newUser.username, newUser.password);
-            cy.visit('/ad-1/channels/town-square');
             cy.visit(`/${testTeam.name}`);
         });
 

--- a/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
@@ -92,7 +92,7 @@ describe('Guest Account - Member Invitation Flow', () => {
         // # Create new team and visit its URL
         cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
             testTeam = response.body;
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
             cy.visit(`/${testTeam.name}`);
         });
     });
@@ -190,7 +190,7 @@ describe('Guest Account - Member Invitation Flow', () => {
         cy.createNewUser().then((newUser) => {
             cy.apiAddUserToTeam(testTeam.id, newUser.id);
             cy.apiLogin(newUser.username, newUser.password);
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
             cy.visit(`/${testTeam.name}`);
         });
 

--- a/e2e/cypress/integration/enterprise/guest_accounts/system_console_manage_guest_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/system_console_manage_guest_spec.js
@@ -155,14 +155,14 @@ describe('Guest Account - Verify Manage Guest Users', () => {
 
         // # Login as Guest User to verify if Revoke Session works
         cy.apiLogin(guest.username, guest.password);
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
         cy.get('#sidebarItem_town-square').click({force: true});
 
         // # Issue a Request to Revoke All Sessions as SysAdmin
         const baseUrl = Cypress.config('baseUrl');
         cy.externalRequest({user: users.sysadmin, method: 'post', baseUrl, path: `users/${guest.id}/sessions/revoke/all`}).then(() => {
             // # Initiate browser activity like visit on "/"
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
 
             // * Verify if the regular member is logged out and redirected to login page
             cy.url({timeout: TIMEOUTS.LARGE}).should('include', '/login');

--- a/e2e/cypress/integration/enterprise/system_console/channel_modes_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_modes_spec.js
@@ -17,7 +17,7 @@ describe('Test channel public/private toggle', () => {
 
     it('Verify that System Admin can change channel privacy using toggle', () => {
         cy.apiLogin('sysadmin');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
         cy.getCurrentTeamId().then((teamId) => {
             return cy.apiCreateChannel(teamId, 'test-channel', 'Test Channel');
         }).then((res) => {
@@ -46,7 +46,7 @@ describe('Test channel public/private toggle', () => {
 
     it('Verify that resetting sync toggle doesn\'t alter channel privacy toggle', () => {
         cy.apiLogin('sysadmin');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
         cy.getCurrentTeamId().then((teamId) => {
             return cy.apiCreateChannel(teamId, 'test-channel', 'Test Channel');
         }).then((res) => {
@@ -66,7 +66,7 @@ describe('Test channel public/private toggle', () => {
 
     it('Verify that toggles are disabled for default channel', () => {
         cy.apiLogin('sysadmin');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
         cy.get('#sidebarItem_town-square').scrollIntoView().click({force: true});
         cy.getCurrentChannelId().then((id) => {
             cy.visit(`/admin_console/user_management/channels/${id}`);

--- a/e2e/cypress/integration/enterprise/system_console/sidebar_link_navigation_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/sidebar_link_navigation_spec.js
@@ -17,7 +17,7 @@ describe('System Console - Enterprise', () => {
         // # Login as System Admin
         cy.apiLogin('sysadmin');
 
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     const testCases = [

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -56,5 +56,5 @@ describe('I18456 Built-in slash commands: common', () => {
 
 function loginAndVisitDefaultChannel(user) {
     cy.apiLogin(user);
-    cy.visit('/');
+    cy.visit('/ad-1/channels/town-square');
 }

--- a/e2e/cypress/integration/integrations/builtin_commands/user_status_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/user_status_commands_spec.js
@@ -28,7 +28,7 @@ describe('Integrations', () => {
 
     it('I18456 Built-in slash commands: change user status via post', () => {
         cy.apiSaveMessageDisplayPreference('compact');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         testCases.forEach((testCase) => {
             cy.postMessage(testCase.command + ' ');
@@ -39,7 +39,7 @@ describe('Integrations', () => {
 
     it('I18456 Built-in slash commands: change user status via suggestion list', () => {
         cy.apiSaveMessageDisplayPreference('clean');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         testCases.forEach((testCase) => {
             // # Type "/" on textbox

--- a/e2e/cypress/integration/menus/hamburguer_menu_spec.js
+++ b/e2e/cypress/integration/menus/hamburguer_menu_spec.js
@@ -10,7 +10,7 @@
 describe('Hamburguer menu', () => {
     beforeEach(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('MM-20861 - Click on menu item should toggle the menu', () => {

--- a/e2e/cypress/integration/messaging/collapse_link_spec.js
+++ b/e2e/cypress/integration/messaging/collapse_link_spec.js
@@ -26,7 +26,7 @@ describe('Messaging', () => {
 
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18708-Link preview - Removing it from my view removes it from other user\'s view', () => {

--- a/e2e/cypress/integration/messaging/emoji_keyboard_entry_spec.js
+++ b/e2e/cypress/integration/messaging/emoji_keyboard_entry_spec.js
@@ -11,7 +11,7 @@ describe('M16738 - Use keyboard navigation in emoji picker', () => {
     before(() => {
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     beforeEach(() => {

--- a/e2e/cypress/integration/messaging/emoji_size_spec.js
+++ b/e2e/cypress/integration/messaging/emoji_size_spec.js
@@ -27,7 +27,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M15381 - Whitespace with emojis does not affect size', () => {

--- a/e2e/cypress/integration/messaging/emoji_to_markdown_spec.js
+++ b/e2e/cypress/integration/messaging/emoji_to_markdown_spec.js
@@ -43,7 +43,7 @@ function createAndVerifyMessage(message, isCode) {
 describe('Messaging', () => {
     before(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M17446 - Emojis preceded by 4 or more spaces are treated as Markdown', () => {

--- a/e2e/cypress/integration/messaging/file_upload_in_center_channel_spec.js
+++ b/e2e/cypress/integration/messaging/file_upload_in_center_channel_spec.js
@@ -18,7 +18,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Set the default image preview setting to Expanded
         cy.apiSavePreviewCollapsedPreference('false');

--- a/e2e/cypress/integration/messaging/focus_move_spec.js
+++ b/e2e/cypress/integration/messaging/focus_move_spec.js
@@ -51,7 +51,7 @@ describe('Messaging', () => {
     });
 
     beforeEach(() => {
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M15406 - Focus move from Recent Mentions to main input box when a character key is selected', () => {

--- a/e2e/cypress/integration/messaging/invalid_emojis_as_text_spec.js
+++ b/e2e/cypress/integration/messaging/invalid_emojis_as_text_spec.js
@@ -11,7 +11,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M17443 - Terms that are not valid emojis render as plain text', () => {

--- a/e2e/cypress/integration/messaging/long_draft_spec.js
+++ b/e2e/cypress/integration/messaging/long_draft_spec.js
@@ -18,7 +18,7 @@ describe('Messaging', () => {
         cy.apiLogin('user-1');
         cy.visit('/ad-1/channels/off-topic');
         cy.wait(TIMEOUTS.SMALL);
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18699-Leave a long draft in the main input box', () => {

--- a/e2e/cypress/integration/messaging/markdown_preview_inline_image_spec.js
+++ b/e2e/cypress/integration/messaging/markdown_preview_inline_image_spec.js
@@ -12,7 +12,7 @@ describe('Messaging', () => {
         // # Login, set the Show Markdown Preview preference, then go to /
         cy.apiLogin('user-1');
         cy.apiSaveShowMarkdownPreviewPreference();
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18714-Markdown preview: inline image', () => {

--- a/e2e/cypress/integration/messaging/markdown_quotation_paragraphs_spec.js
+++ b/e2e/cypress/integration/messaging/markdown_quotation_paragraphs_spec.js
@@ -11,7 +11,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18703-Markdown quotation paragraphs', () => {

--- a/e2e/cypress/integration/messaging/mention_autocomplete_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/mention_autocomplete_overlap_spec.js
@@ -13,7 +13,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18667-At-mention user autocomplete does not overlap with channel header when drafting a long message containing a file attachment (standard viewport)', () => {

--- a/e2e/cypress/integration/messaging/message_by_aeroplane_icon_spec.js
+++ b/e2e/cypress/integration/messaging/message_by_aeroplane_icon_spec.js
@@ -10,7 +10,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # resize window to mobile view
         cy.viewport('iphone-6');

--- a/e2e/cypress/integration/messaging/message_channel_reference_spec.js
+++ b/e2e/cypress/integration/messaging/message_channel_reference_spec.js
@@ -12,7 +12,7 @@ import * as TIMEOUTS from '../../fixtures/timeouts';
 describe('Messaging', () => {
     before(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18707 - Autocomplete should close if tildes are deleted using backspace', () => {

--- a/e2e/cypress/integration/messaging/message_in_another_language_spec.js
+++ b/e2e/cypress/integration/messaging/message_in_another_language_spec.js
@@ -10,7 +10,7 @@
 describe('Messaging', () => {
     before(() => {
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M17456 - Message in another language should be displayed properly', () => {

--- a/e2e/cypress/integration/messaging/message_parse_spec.js
+++ b/e2e/cypress/integration/messaging/message_parse_spec.js
@@ -11,7 +11,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M17444 - correctly parses "://///" as Markdown and does not break the channel', () => {

--- a/e2e/cypress/integration/messaging/message_permalink_spec.js
+++ b/e2e/cypress/integration/messaging/message_permalink_spec.js
@@ -13,7 +13,7 @@ describe('Message permalink', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M13675-Copy a permalink and paste into another channel', () => {

--- a/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
@@ -13,7 +13,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18701-Permalink to first post in channel shows endless loading indicator above', () => {

--- a/e2e/cypress/integration/messaging/permalink_message_edit_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_message_edit_spec.js
@@ -11,7 +11,7 @@ describe('Permalink message edit', () => {
     it('M18717 - Edit a message in permalink view', () => {
         // # Login as "user-1" and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         const searchWord = `searchtest ${Date.now()}`;
 
@@ -44,7 +44,7 @@ describe('Permalink message edit', () => {
 
             // # Login as "user-2" and go to /
             cy.apiLogin('user-2');
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
 
             // # Find searchWord and verify edited post
             cy.get('#searchBox').type(searchWord).type('{enter}');

--- a/e2e/cypress/integration/messaging/quick_send_spec.js
+++ b/e2e/cypress/integration/messaging/quick_send_spec.js
@@ -13,7 +13,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18698-Posts change order when being sent quickly', () => {

--- a/e2e/cypress/integration/messaging/quote_notation_spec.js
+++ b/e2e/cypress/integration/messaging/quote_notation_spec.js
@@ -11,7 +11,7 @@ describe('Compact view: Markdown quotation', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18704-Compact view: Markdown quotation', () => {

--- a/e2e/cypress/integration/messaging/receive_message_on_socket_reconnect_spec.js
+++ b/e2e/cypress/integration/messaging/receive_message_on_socket_reconnect_spec.js
@@ -18,7 +18,7 @@ describe('Messaging', () => {
 
         // # Login and go to /
         cy.apiLogin('sysadmin');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Get ChannelID to use later
         cy.getCurrentChannelId().then((id) => {

--- a/e2e/cypress/integration/messaging/remove_gif_spec.js
+++ b/e2e/cypress/integration/messaging/remove_gif_spec.js
@@ -28,7 +28,7 @@ describe('Messaging', () => {
 
         // # Login and go to /
         cy.apiLogin('sysadmin');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18692-Delete a GIF from RHS reply thread, other user viewing in center and RHS sees GIF preview disappear from both', () => {

--- a/e2e/cypress/integration/messaging/strikethrough_spec.js
+++ b/e2e/cypress/integration/messaging/strikethrough_spec.js
@@ -13,7 +13,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18710-Edit post with "strikethrough" and ensure channel auto-complete closes after second tilde (~~)', () => {

--- a/e2e/cypress/integration/messaging/typing_on_middle_spec.js
+++ b/e2e/cypress/integration/messaging/typing_on_middle_spec.js
@@ -13,7 +13,7 @@ describe('Messaging', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('M18683-Trying to type in middle of text should not send the cursor to end of textbox', () => {

--- a/e2e/cypress/integration/multi_team/existing_channel_name_spec.js
+++ b/e2e/cypress/integration/multi_team/existing_channel_name_spec.js
@@ -88,7 +88,7 @@ describe('Channel', () => {
     beforeEach(() => {
         // Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('Mult14635 Should not create new channel with existing public channel name', () => {

--- a/e2e/cypress/integration/multi_team/system_message_spec.js
+++ b/e2e/cypress/integration/multi_team/system_message_spec.js
@@ -29,7 +29,7 @@ describe('System message', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Post a regular message
         cy.postMessage('Test for no status of a system message');

--- a/e2e/cypress/integration/plugins/marketplace/marketplace_spec.js
+++ b/e2e/cypress/integration/plugins/marketplace/marketplace_spec.js
@@ -50,7 +50,7 @@ describe('Plugin Marketplace', () => {
 
             // # Login as non admin user
             cy.apiLogin('user-1');
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
         });
 
         it('when marketplace disabled', () => {
@@ -66,7 +66,7 @@ describe('Plugin Marketplace', () => {
 
             // # Login as sysadmin
             cy.apiLogin('sysadmin');
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
         });
 
         it('when plugins disabled', () => {
@@ -82,7 +82,7 @@ describe('Plugin Marketplace', () => {
 
             // # Login as sysadmin
             cy.apiLogin('sysadmin');
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
         });
     });
     describe('invalid marketplace, should', () => {
@@ -104,7 +104,7 @@ describe('Plugin Marketplace', () => {
             cy.apiLogin('sysadmin');
 
             // # Go to main channel
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
 
             cy.wait(TIMEOUTS.TINY).get('#lhsHeader').should('be.visible').within(() => {
                 // # Click hamburger main menu
@@ -180,7 +180,7 @@ describe('Plugin Marketplace', () => {
 
             // # Login as sysadmin
             cy.apiLogin('sysadmin');
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
 
             cy.wait(TIMEOUTS.TINY).get('#lhsHeader').should('be.visible').within(() => {
                 // # Click hamburger main menu
@@ -397,7 +397,7 @@ describe('Plugin Marketplace', () => {
 
             // # Login as sysadmin
             cy.apiLogin('sysadmin');
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
 
             // # Click hamburger main menu
             cy.wait(TIMEOUTS.TINY).get('#sidebarHeaderDropdownButton').click();

--- a/e2e/cypress/integration/search/clear_input_spec.js
+++ b/e2e/cypress/integration/search/clear_input_spec.js
@@ -13,7 +13,7 @@ describe('Search', () => {
     before(() => {
         // # Login as the sysadmin.
         cy.apiLogin('sysadmin');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('QuickInput clear X', () => {

--- a/e2e/cypress/integration/search/post_search_display_spec.js
+++ b/e2e/cypress/integration/search/post_search_display_spec.js
@@ -11,7 +11,7 @@ describe('Post search display', () => {
     it('S14252 After clearing search query, search options display', () => {
         // # Login and navigate to the app
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
         const searchWord = 'Hello';
 
         // # post message

--- a/e2e/cypress/integration/search/results_post_comment_spec.js
+++ b/e2e/cypress/integration/search/results_post_comment_spec.js
@@ -11,7 +11,7 @@ describe('Search', () => {
     it('S14548 Search results Right-Hand-Side: Post a comment', () => {
         // # Login and navigate to the app
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         const message = `asparagus${Date.now()}`;
         const comment = 'Replying to asparagus';

--- a/e2e/cypress/integration/search/results_post_spec.js
+++ b/e2e/cypress/integration/search/results_post_spec.js
@@ -11,7 +11,7 @@ describe('Search', () => {
     before(() => {
         // # Login and navigate to the app
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('S19944 Highlighting does not change to what is being typed in the search input box', () => {

--- a/e2e/cypress/integration/search/search_user_post_spec.js
+++ b/e2e/cypress/integration/search/search_user_post_spec.js
@@ -28,7 +28,7 @@ describe('Search in DMs', () => {
     it('S14672 Search "in:[username]" returns results in DMs', () => {
         // # Login and navigate to the app
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
         const message = 'Hello' + Date.now();
 
         // # Ensure Direct Message is visible in LHS sidebar

--- a/e2e/cypress/integration/signin_authentication/forgot_password_spec.js
+++ b/e2e/cypress/integration/signin_authentication/forgot_password_spec.js
@@ -66,7 +66,7 @@ function resetPasswordAndLogin(user, feedbackEmail, supportEmail) {
     const newPassword = 'newpasswd';
 
     // # Visit '/'
-    cy.visit('/');
+    cy.visit('/ad-1/channels/town-square');
 
     // * Verify that it redirects to /login
     cy.url().should('contain', '/login');

--- a/e2e/cypress/integration/system_console/lock_teammate_name_display_spec.js
+++ b/e2e/cypress/integration/system_console/lock_teammate_name_display_spec.js
@@ -25,7 +25,7 @@ describe('System Console', () => {
         cy.get('#saveSetting').click();
 
         // # Go to main page
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Go to Account settings
         cy.toAccountSettingsModal(null, true);
@@ -56,7 +56,7 @@ describe('System Console', () => {
         cy.get('#saveSetting').click();
 
         // # Go to main page
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Go to Account settings
         cy.toAccountSettingsModal(null, true);

--- a/e2e/cypress/integration/system_console/plugin_upload_spec.js
+++ b/e2e/cypress/integration/system_console/plugin_upload_spec.js
@@ -23,7 +23,7 @@ describe('Draw Plugin - Upload', () => {
 
         // # Login as sysadmin
         cy.apiLogin('sysadmin');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // #If draw plugin is already enabled , unInstall it
         cy.uninstallPluginById(pluginId);

--- a/e2e/cypress/integration/system_console/revoke_all_sessions_spec.js
+++ b/e2e/cypress/integration/system_console/revoke_all_sessions_spec.js
@@ -46,14 +46,14 @@ describe('SC17020 - Revoke All Sessions from System Console', () => {
     it('Verify for Regular Member', () => {
         // # Login as a regular member and navigate to Town Square Chat channel
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
         cy.get('#sidebarItem_town-square').click({force: true});
 
         // # Issue a Request to Revoke All Sessions as SysAdmin
         const baseUrl = Cypress.config('baseUrl');
         cy.externalRequest({user: users.sysadmin, method: 'post', baseUrl, path: 'users/sessions/revoke/all'}).then(() => {
             // # Initiate browser activity like visit on "/"
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
 
             // * Verify if the regular member is logged out and redirected to login page
             cy.url({timeout: TIMEOUTS.LARGE}).should('include', '/login');

--- a/e2e/cypress/integration/system_console/sidebar_link_navigation_spec.js
+++ b/e2e/cypress/integration/system_console/sidebar_link_navigation_spec.js
@@ -17,7 +17,7 @@ describe('System Console', () => {
         // # Login as System Admin
         cy.apiLogin('sysadmin');
 
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('can go to admin console by clicking System Console', () => {

--- a/e2e/cypress/integration/team/create_a_team_spec.js
+++ b/e2e/cypress/integration/team/create_a_team_spec.js
@@ -13,7 +13,7 @@ describe('Teams Suite', () => {
     before(() => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
     });
 
     it('TS13872 Create a team', async () => {

--- a/e2e/cypress/integration/team/invite_members_spec.js
+++ b/e2e/cypress/integration/team/invite_members_spec.js
@@ -95,7 +95,6 @@ describe('Invite Members', () => {
             // # Create new team and visit its URL
             cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
                 testTeam = response.body;
-                cy.visit('/ad-1/channels/town-square');
                 cy.visit(`/${testTeam.name}`);
             });
         });

--- a/e2e/cypress/integration/team/invite_members_spec.js
+++ b/e2e/cypress/integration/team/invite_members_spec.js
@@ -95,7 +95,7 @@ describe('Invite Members', () => {
             // # Create new team and visit its URL
             cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
                 testTeam = response.body;
-                cy.visit('/');
+                cy.visit('/ad-1/channels/town-square');
                 cy.visit(`/${testTeam.name}`);
             });
         });

--- a/e2e/cypress/integration/team/teams_spec.js
+++ b/e2e/cypress/integration/team/teams_spec.js
@@ -26,7 +26,7 @@ describe('Teams Suite', () => {
     it('TS12995 Cancel out of leaving a team', () => {
         // # Login and go to /
         cy.apiLogin('user-1');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // * check the team name
         cy.get('#headerTeamName').should('contain', 'eligendi');
@@ -74,7 +74,7 @@ describe('Teams Suite', () => {
         // # Login as System Admin, update teammate name display preference to "username" and visit "/"
         cy.apiLogin(sysadmin.username);
         cy.apiSaveTeammateNameDisplayPreference('username');
-        cy.visit('/');
+        cy.visit('/ad-1/channels/town-square');
 
         // # Create team
         cy.createNewTeam(teamName, teamURL);

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -906,14 +906,14 @@ Cypress.Commands.add('loginAsNewGuestUser', (user = {}, bypassTutorial = true) =
 
     // # Create a New Team for Guest User
     return cy.apiCreateTeam('guest-team', 'Guest Team').then((createResponse) => {
-        const teamId = createResponse.body.id;
+        const team = createResponse.body;
         cy.getCookie('MMUSERID').then((cookie) => {
             // #Assign Sysadmin user to the newly created team
-            cy.apiAddUserToTeam(teamId, cookie.value);
+            cy.apiAddUserToTeam(team.id, cookie.value);
         });
 
         // #Create New User
-        return cy.createNewUser(user, [teamId], bypassTutorial).then((newUser) => {
+        return cy.createNewUser(user, [team.id], bypassTutorial).then((newUser) => {
             // # Demote Regular Member to Guest User
             cy.demoteUser(newUser.id);
             cy.request({
@@ -922,7 +922,7 @@ Cypress.Commands.add('loginAsNewGuestUser', (user = {}, bypassTutorial = true) =
                 method: 'POST',
                 body: {login_id: newUser.username, password: newUser.password},
             }).then(() => {
-                cy.visit('/ad-1/channels/town-square');
+                cy.visit(`/${team.name}`);
                 return cy.wrap(newUser);
             });
         });

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -747,7 +747,7 @@ Cypress.Commands.add('loginAsNewUser', (user = {}, teamIds = [], bypassTutorial 
             body: {login_id: newUser.username, password: newUser.password},
         }).then((response) => {
             expect(response.status).to.equal(200);
-            cy.visit('/');
+            cy.visit('/ad-1/channels/town-square');
 
             return cy.wrap(newUser);
         });
@@ -922,7 +922,7 @@ Cypress.Commands.add('loginAsNewGuestUser', (user = {}, bypassTutorial = true) =
                 method: 'POST',
                 body: {login_id: newUser.username, password: newUser.password},
             }).then(() => {
-                cy.visit('/');
+                cy.visit('/ad-1/channels/town-square');
                 return cy.wrap(newUser);
             });
         });

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -14,13 +14,13 @@ Cypress.Commands.add('logout', () => {
 
 Cypress.Commands.add('toMainChannelView', (username = 'user-1', password) => {
     cy.apiLogin(username, password);
-    cy.visit('/');
+    cy.visit('/ad-1/channels/town-square');
 
     cy.get('#post_textbox').should('be.visible');
 });
 
 Cypress.Commands.add('getSubpath', () => {
-    cy.visit('/');
+    cy.visit('/ad-1/channels/town-square');
     cy.url().then((url) => {
         cy.location().its('origin').then((origin) => {
             if (url === origin) {
@@ -51,7 +51,7 @@ Cypress.Commands.add('toAccountSettingsModal', (username = 'user-1', isLoggedInA
         cy.apiLogin(username);
     }
 
-    cy.visit('/');
+    cy.visit('/ad-1/channels/town-square');
     cy.get('#channel_view').should('be.visible');
     cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
     cy.get('#accountSettings').should('be.visible').click();


### PR DESCRIPTION
#### Summary
Make explicit visit to a team and channel to exactly identify which team or channel a user is currently in, posting a message, etc.
This fixes an issue where an assertion is made to `ad-1` team but for some reason, the test user is currently viewing a different team.

Note: I'll add this to E2E guidelines.