### PR TITLE
Added step to run LDAP Sync before running tests related to Groups

### DIFF
--- a/components/admin_console/jobs/table.jsx
+++ b/components/admin_console/jobs/table.jsx
@@ -336,7 +336,10 @@ class JobTable extends React.PureComponent {
                     </div>
                 </div>
                 <div className='job-table__table'>
-                    <table className='table'>
+                    <table
+                        className='table'
+                        data-testid='jobTable'
+                    >
                         <thead>
                             <tr>
                                 <th width='30px'/>

--- a/e2e/cypress/integration/enterprise/system_console/channel_modes_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_modes_spec.js
@@ -13,6 +13,9 @@ describe('Test channel public/private toggle', () => {
         cy.apiUpdateConfig({
             LdapSettings: {Enable: true},
         });
+
+        // # Check and run LDAP Sync job
+        cy.checkRunLDAPSync();
     });
 
     it('Verify that System Admin can change channel privacy using toggle', () => {

--- a/e2e/cypress/integration/enterprise/system_console/groups_assign_roles_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/groups_assign_roles_spec.js
@@ -44,6 +44,11 @@ const getChannelsAssociatedToGroupAndUnlink = (groupId) => {
 };
 
 describe('System Console', () => {
+    before(() => {
+        // # Check and run LDAP Sync job
+        cy.checkRunLDAPSync();
+    });
+
     it('MM-20058 - System Admin can map roles to teams and channels via group configuration page', () => {
         cy.apiLogin('sysadmin');
 

--- a/e2e/cypress/integration/enterprise/system_console/team_and_channel_asign_roles_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/team_and_channel_asign_roles_spec.js
@@ -14,6 +14,11 @@ const waitUntilConfigSave = () => {
 };
 
 describe('System Console', () => {
+    before(() => {
+        // # Check and run LDAP Sync job
+        cy.checkRunLDAPSync();
+    });
+
     it('MM-20059 - System Admin can map roles to groups from Team Configuration screen', () => {
         const teamName = 'eligendi';
         cy.apiLogin('sysadmin');

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -1137,6 +1137,22 @@ Cypress.Commands.add('apiAccessToken', (userId, description) => {
     });
 });
 
+/**
+ * Get LDAP Group Sync Job Status
+ *
+ */
+Cypress.Commands.add('apiGetLDAPSync', () => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/jobs/type/ldap_sync?page=0&per_page=50',
+        method: 'GET',
+        timeout: 60000,
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        return cy.wrap(response);
+    });
+});
+
 // *****************************************************************************
 // Roles
 // https://api.mattermost.com/#tag/roles
@@ -1177,4 +1193,3 @@ Cypress.Commands.add('patchRole', (roleID, patch) => {
         return cy.wrap(response);
     });
 });
-

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -491,3 +491,41 @@ Cypress.Commands.add('systemConsolePluginManagement', () => {
     cy.get('li.filter-container').find('input#adminSidebarFilter.filter').
         wait(TIMEOUTS.TINY).should('be.visible').type('plugin Management').click();
 });
+
+/**
+ * Navigate to system console-PluginManagement from account settings
+ */
+Cypress.Commands.add('checkRunLDAPSync', () => {
+    cy.apiLogin('sysadmin');
+    cy.apiGetLDAPSync().then((response) => {
+        var jobs = response.body;
+        var currentTime = new Date();
+
+        // # Run LDAP Sync if no job exists (or) last status is an error (or) last run time is more than 1 day old
+        if (jobs.length === 0 || jobs[0].status === 'error' || ((currentTime - (new Date(jobs[0].last_activity_at))) > 8640000)) {
+            // # Go to system admin LDAP page and run the group sync
+            cy.visit('/admin_console/authentication/ldap');
+
+            // # Click on AD/LDAP Synchronize Now button
+            cy.findByText('AD/LDAP Synchronize Now').click().wait(1000);
+
+            // * Get the First row
+            cy.findByTestId('jobTable').
+                find('tbody > tr').
+                eq(0).
+                as('firstRow');
+
+            // * Wait until first row updates to say Success
+            cy.waitUntil(() => {
+                return cy.get('@firstRow').then((el) => {
+                    return el.find('.status-icon-success').length > 0;
+                });
+            }
+            , {
+                timeout: TIMEOUTS.FOUR_MINS,
+                interval: 2000,
+                errorMsg: 'AD/LDAP Sync Job did not finish',
+            });
+        }
+    });
+});


### PR DESCRIPTION
#### Summary
Fixed tests related to LDAP Groups. The tests were expecting the Groups to be pre-populated before running the test. However since we clean the database on every CI run, I have now added a step to check and then LDAP Group Sync job before running the tests. 

#### Ticket Link
NA. Fixed based on daily run. 