### PR TITLE
[MM-22204] - Add target="_blank" to terms and policy links

### DIFF
--- a/components/signup/signup_email/signup_email.jsx
+++ b/components/signup/signup_email/signup_email.jsx
@@ -456,8 +456,8 @@ export default class SignupEmail extends React.Component {
                         defaultMessage='By proceeding to create your account and use {siteName}, you agree to our [Terms of Service]({TermsOfServiceLink}) and [Privacy Policy]({PrivacyPolicyLink}). If you do not agree, you cannot use {siteName}.'
                         values={{
                             siteName,
-                            TermsOfServiceLink: termsOfServiceLink,
-                            PrivacyPolicyLink: privacyPolicyLink,
+                            TermsOfServiceLink: `!${termsOfServiceLink}`,
+                            PrivacyPolicyLink: `!${privacyPolicyLink}`,
                         }}
                     />
                 </p>


### PR DESCRIPTION
I propose we make a ticket to refactor the formatted_markdown_message.jsx
because adding the '!' to activate target="_blank" is a very obscure way to
do it and it was a undocumented feature.

Proposition: We have the customRenderer, instead of passing href as a string, it can be an object that contains href, target, ref, etc and if the values exist, to append to the link.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-22204

