### PR TITLE
Avoid forced lowercase when "you" needs an uppercase in certain languages

### DIFF
--- a/components/post_view/combined_system_message/combined_system_message.jsx
+++ b/components/post_view/combined_system_message/combined_system_message.jsx
@@ -264,9 +264,6 @@ class CombinedSystemMessage extends React.PureComponent {
         const {currentUserId, currentUsername} = this.props;
         const usernames = this.getUsernamesByIds(userIds);
         let actor = actorId ? this.getUsernamesByIds([actorId])[0] : '';
-        if (actor && (actorId === currentUserId || actorId === currentUsername)) {
-            actor = actor.toLowerCase();
-        }
 
         const firstUser = usernames[0];
         const secondUser = usernames[1];


### PR DESCRIPTION
#### Summary
`XXX and YYY were added to the channel by you`, the "you" is forced to lowercase, which could cause some issue when localizing the app to other languages like German ("Sie") and Dutch ("U").

This patch only removes the forcing to lowercase.

However, I would like to receive some guidance over there, to know whether removing that lowercase forcing could cause some issues in the event other nicknames are registered in uppercase in the database (this shouldn't be the case, so...).

See the discussion led [over here, on the Mattermost community instance](https://community.mattermost.com/core/pl/tqfa6y5qdt8u5dku5j4dum9mko).

#### Ticket Link
N/A, I haven't reported it as a ticket on Jira.

#### Related Pull Requests
N/A

#### Screenshots
N/A