### PR TITLE
[MM-22370] Fix channel modal not showing updated roles

### DIFF
--- a/components/member_list_channel/index.ts
+++ b/components/member_list_channel/index.ts
@@ -7,7 +7,7 @@ import {createSelector} from 'reselect';
 import {searchProfilesInCurrentChannel, getProfilesInCurrentChannel} from 'mattermost-redux/selectors/entities/users';
 import {getMembersInCurrentChannel, getCurrentChannelStats, getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getMembersInCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
-import {getChannelStats} from 'mattermost-redux/actions/channels';
+import {getChannelStats, getChannelMembers} from 'mattermost-redux/actions/channels';
 import {searchProfiles} from 'mattermost-redux/actions/users';
 import {sortByUsername} from 'mattermost-redux/utils/user_utils';
 import {GlobalState} from 'mattermost-redux/types/store';
@@ -91,6 +91,7 @@ function mapStateToProps(state: State) {
 
 type Actions = {
     searchProfiles: (term: string, options?: {}) => Promise<{data: UserProfile[]}>;
+    getChannelMembers: (channelId: string) => Promise<{data: ChannelMembership[]}>;
     getChannelStats: (channelId: string) => Promise<{data: {}}>;
     setModalSearchTerm: (term: string) => Promise<{
         data: boolean;
@@ -109,6 +110,7 @@ type Actions = {
 function mapDispatchToProps(dispatch: Dispatch) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc>, Actions>({
+            getChannelMembers,
             searchProfiles,
             getChannelStats,
             setModalSearchTerm,

--- a/components/member_list_channel/member_list_channel.tsx
+++ b/components/member_list_channel/member_list_channel.tsx
@@ -30,6 +30,7 @@ type Props = {
     channel: Channel;
     actions: {
         searchProfiles: (term: string, options?: {}) => Promise<{data: UserProfile[]}>;
+        getChannelMembers: (channelId: string) => Promise<{data: ChannelMembership[]}>;
         getChannelStats: (channelId: string) => Promise<{data: {}}>;
         setModalSearchTerm: (term: string) => Promise<{
             data: boolean;
@@ -63,20 +64,19 @@ export default class MemberListChannel extends React.PureComponent<Props, State>
         };
     }
 
-    componentDidMount() {
+    async componentDidMount() {
         const {
             actions,
             currentChannelId,
             currentTeamId,
         } = this.props;
 
-        actions.loadProfilesAndTeamMembersAndChannelMembers(0, Constants.PROFILE_CHUNK_SIZE, currentTeamId, currentChannelId).then(({data}) => {
-            if (data) {
-                this.loadComplete();
-            }
-        });
-
-        actions.getChannelStats(currentChannelId);
+        await Promise.all([
+            actions.loadProfilesAndTeamMembersAndChannelMembers(0, Constants.PROFILE_CHUNK_SIZE, currentTeamId, currentChannelId),
+            actions.getChannelMembers(currentChannelId),
+            actions.getChannelStats(currentChannelId),
+        ]);
+        this.loadComplete();
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
When members roles are updated and the manage members role in a channel is loaded, the updated roles were not being shown. This PR fixes this problem.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-22370

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![MM-22370](https://user-images.githubusercontent.com/17804942/74904051-d69cc280-5378-11ea-9655-769f7eaf4703.gif)
