### PR TITLE
[MM-22310] Remove back button when user has no accounts

### DIFF
--- a/components/signup/signup_email/index.js
+++ b/components/signup/signup_email/index.js
@@ -22,7 +22,7 @@ function mapStateToProps(state) {
     const termsOfServiceLink = config.TermsOfServiceLink;
     const privacyPolicyLink = config.PrivacyPolicyLink;
     const customDescriptionText = config.CustomDescriptionText;
-    const noAccounts = config.NoAccounts === 'true';
+    const hasAccounts = config.NoAccounts === 'false';
 
     return {
         enableSignUpWithEmail,
@@ -31,7 +31,7 @@ function mapStateToProps(state) {
         privacyPolicyLink,
         customDescriptionText,
         passwordConfig: getPasswordConfig(config),
-        noAccounts,
+        hasAccounts,
     };
 }
 

--- a/components/signup/signup_email/index.js
+++ b/components/signup/signup_email/index.js
@@ -22,6 +22,7 @@ function mapStateToProps(state) {
     const termsOfServiceLink = config.TermsOfServiceLink;
     const privacyPolicyLink = config.PrivacyPolicyLink;
     const customDescriptionText = config.CustomDescriptionText;
+    const noAccounts = config.NoAccounts === 'true';
 
     return {
         enableSignUpWithEmail,
@@ -30,6 +31,7 @@ function mapStateToProps(state) {
         privacyPolicyLink,
         customDescriptionText,
         passwordConfig: getPasswordConfig(config),
+        noAccounts,
     };
 }
 

--- a/components/signup/signup_email/signup_email.jsx
+++ b/components/signup/signup_email/signup_email.jsx
@@ -31,6 +31,7 @@ export default class SignupEmail extends React.Component {
         privacyPolicyLink: PropTypes.string,
         customDescriptionText: PropTypes.string,
         passwordConfig: PropTypes.object,
+        noAccounts: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             createUser: PropTypes.func.isRequired,
             loginById: PropTypes.func.isRequired,
@@ -65,6 +66,10 @@ export default class SignupEmail extends React.Component {
         const {inviteId} = this.state;
         if (inviteId && inviteId.length > 0) {
             this.getInviteInfo(inviteId);
+        }
+
+        if (this.props.noAccounts) {
+            document.body.classList.remove('sticky');
         }
     }
 
@@ -422,6 +427,7 @@ export default class SignupEmail extends React.Component {
             privacyPolicyLink,
             siteName,
             termsOfServiceLink,
+            noAccounts,
         } = this.props;
 
         let serverError = null;
@@ -470,7 +476,7 @@ export default class SignupEmail extends React.Component {
 
         return (
             <div>
-                <BackButton/>
+                {!noAccounts && <BackButton/>}
                 <div
                     id='signup_email_section'
                     className='col-sm-12'

--- a/components/signup/signup_email/signup_email.jsx
+++ b/components/signup/signup_email/signup_email.jsx
@@ -31,7 +31,7 @@ export default class SignupEmail extends React.Component {
         privacyPolicyLink: PropTypes.string,
         customDescriptionText: PropTypes.string,
         passwordConfig: PropTypes.object,
-        noAccounts: PropTypes.bool.isRequired,
+        hasAccounts: PropTypes.bool.isRequired,
         actions: PropTypes.shape({
             createUser: PropTypes.func.isRequired,
             loginById: PropTypes.func.isRequired,
@@ -68,7 +68,7 @@ export default class SignupEmail extends React.Component {
             this.getInviteInfo(inviteId);
         }
 
-        if (this.props.noAccounts) {
+        if (!this.props.hasAccounts) {
             document.body.classList.remove('sticky');
         }
     }
@@ -427,7 +427,7 @@ export default class SignupEmail extends React.Component {
             privacyPolicyLink,
             siteName,
             termsOfServiceLink,
-            noAccounts,
+            hasAccounts,
         } = this.props;
 
         let serverError = null;
@@ -476,7 +476,7 @@ export default class SignupEmail extends React.Component {
 
         return (
             <div>
-                {!noAccounts && <BackButton/>}
+                {hasAccounts && <BackButton/>}
                 <div
                     id='signup_email_section'
                     className='col-sm-12'


### PR DESCRIPTION

#### Summary
 Removed 'back' button when the user has no accounts. I had to remove the 'sticky' class because it was adding a second scroll to the page.

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-22310
