### PR TITLE
Added Cypress test to verify Accessibility Support in Dropdown Menus

### DIFF
--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -132,7 +132,10 @@ export default class StatusDropdown extends React.Component {
                         {dropdownIcon}
                     </span>
                 </div>
-                <Menu ariaLabel={localizeMessage('status_dropdown.menuAriaLabel', 'set status')}>
+                <Menu
+                    ariaLabel={localizeMessage('status_dropdown.menuAriaLabel', 'set status')}
+                    id='statusDropdownMenu'
+                >
                     <Menu.Group>
                         <Menu.ItemAction
                             show={this.isUserOutOfOffice()}

--- a/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
@@ -1,0 +1,105 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// * Verify the accessibility support in the menu items
+function verifyMenuItems(menuEl, labels) {
+    cy.get(`${menuEl} .MenuItem`).each((child, index) => {
+        cy.wrap(child).then((el) => {
+            cy.wrap(el).should('have.attr', 'role', 'menuitem');
+            const label = labels[index];
+            if (el.find('button').length) {
+                if (label) {
+                    cy.wrap(el).children('button').should('have.attr', 'aria-label', label).and('have.class', 'a11y--active a11y--focused').tab();
+                } else {
+                    cy.wrap(el).children('button').should('have.class', 'a11y--active a11y--focused').tab();
+                }
+            } else {
+                cy.wrap(el).children('a').should('have.class', 'a11y--active a11y--focused').tab();
+            }
+        });
+    });
+}
+
+describe('Verify Accessibility Support in Dropdown Menus', () => {
+    before(() => {
+        cy.apiLogin('sysadmin');
+    });
+
+    beforeEach(() => {
+        // Visit the Off Topic channel
+        cy.visit('/ad-1/channels/off-topic');
+    });
+
+    it('MM-22627 Accessibility Support in Channel Menu Dropdown', () => {
+        // # Press tab from the Channel Favorite button
+        cy.get('#toggleFavorite').focus().tab({shift: true}).tab().tab();
+
+        // * Verify the aria-label in channel menu button
+        cy.get('#channelHeaderDropdownButton button').should('have.attr', 'aria-label', 'channel menu').and('have.class', 'a11y--active a11y--focused').click();
+
+        // * Verify the accessibility support in the Channel Dropdown menu
+        cy.get('#channelHeaderDropdownMenu').should('have.attr', 'aria-label', 'channel menu').and('have.class', 'a11y__popup').and('have.attr', 'role', 'menu');
+
+        // * Verify the first option is not selected by default
+        cy.get('#channelHeaderDropdownMenu .MenuItem').children().eq(0).should('not.have.class', 'a11y--active a11y--focused');
+
+        // # Press tab
+        cy.focused().tab();
+
+        // * Verify the accessibility support in the Channel Dropdown menu items
+        const labels = ['View Info dialog', 'Notification Preferences dialog', '', 'Add Members dialog', 'Manage Members dialog', 'Edit Channel Header dialog', 'Edit Channel Purpose dialog', 'Rename Channel dialog', 'Convert to Private Channel dialog', 'Archive Channel dialog', ''];
+        verifyMenuItems('#channelHeaderDropdownMenu', labels);
+    });
+
+    it('MM-22627 Accessibility Support in Main Menu Dropdown', () => {
+        // # Press tab from the Set Status button
+        cy.get('.status-wrapper button.status').focus().tab({shift: true}).tab().tab();
+
+        // * Verify the aria-label in main menu button
+        cy.get('#headerInfo button').should('have.attr', 'aria-label', 'main menu').and('have.class', 'a11y--active a11y--focused').click();
+
+        // * Verify the accessibility support in the Main Menu Dropdown
+        cy.get('#sidebarDropdownMenu').should('have.attr', 'aria-label', 'main menu').and('have.class', 'a11y__popup').and('have.attr', 'role', 'menu');
+
+        // * Verify the first option is not selected by default
+        cy.get('#sidebarDropdownMenu .MenuItem').children().eq(0).should('not.have.class', 'a11y--active a11y--focused');
+
+        // # Press tab
+        cy.focused().tab();
+
+        // * Verify the accessibility support in the Main Menu Dropdown items
+        const labels = ['Account Settings dialog', 'Invite People dialog', 'Team Settings dialog', 'Manage Members dialog', '', '', 'Leave Team dialog', '', 'Plugin Marketplace dialog', '', '', '', '', '', 'About Mattermost dialog', ''];
+        verifyMenuItems('#sidebarDropdownMenu', labels);
+
+        cy.get('#sidebarDropdownMenu .MenuItem').each((el) => {
+            cy.wrap(el).should('have.attr', 'role', 'menuitem');
+        });
+    });
+
+    it('MM-22627 Accessibility Support in Status Dropdown', () => {
+        // # Press tab from Add Team button
+        cy.get('#select_teamTeamButton').focus().tab({shift: true}).tab().tab();
+
+        // * Verify the aria-label in status menu button
+        cy.get('.status-wrapper button.status').should('have.attr', 'aria-label', 'set status').and('have.class', 'a11y--active a11y--focused').click();
+
+        // * Verify the accessibility support in the Status Dropdown
+        cy.get('#statusDropdownMenu').should('have.attr', 'aria-label', 'set status').and('have.class', 'a11y__popup').and('have.attr', 'role', 'menu');
+
+        // * Verify the first option is not selected by default
+        cy.get('#statusDropdownMenu .MenuItem').children().eq(0).should('not.have.class', 'a11y--active a11y--focused');
+
+        // # Press tab
+        cy.focused().tab();
+
+        // * Verify the accessibility support in the Status Dropdown menu items
+        const labels = ['online', 'away', 'do not disturb. disables desktop, email and push notifications', 'offline'];
+        verifyMenuItems('#statusDropdownMenu', labels);
+    });
+});

--- a/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
@@ -55,6 +55,10 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
         // * Verify the accessibility support in the Channel Dropdown menu items
         const labels = ['View Info dialog', 'Notification Preferences dialog', '', 'Add Members dialog', 'Manage Members dialog', 'Edit Channel Header dialog', 'Edit Channel Purpose dialog', 'Rename Channel dialog', 'Convert to Private Channel dialog', 'Archive Channel dialog', ''];
         verifyMenuItems('#channelHeaderDropdownMenu', labels);
+
+        // * Verify if menu is closed when we press Escape
+        cy.get('body').type('{esc}', {force: true});
+        cy.get('#channelHeaderDropdownMenu').should('not.exist');
     });
 
     it('MM-22627 Accessibility Support in Main Menu Dropdown', () => {
@@ -80,6 +84,10 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
         cy.get('#sidebarDropdownMenu .MenuItem').each((el) => {
             cy.wrap(el).should('have.attr', 'role', 'menuitem');
         });
+
+        // * Verify if menu is closed when we press Escape
+        cy.get('body').type('{esc}', {force: true});
+        cy.get('#sidebarDropdownMenu').should('not.exist');
     });
 
     it('MM-22627 Accessibility Support in Status Dropdown', () => {
@@ -101,5 +109,9 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
         // * Verify the accessibility support in the Status Dropdown menu items
         const labels = ['online', 'away', 'do not disturb. disables desktop, email and push notifications', 'offline'];
         verifyMenuItems('#statusDropdownMenu', labels);
+
+        // * Verify if menu is closed when we press Escape
+        cy.get('body').type('{esc}', {force: true});
+        cy.get('#statusDropdownMenu').should('not.exist');
     });
 });

--- a/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
@@ -29,6 +29,14 @@ function verifyMenuItems(menuEl, labels) {
 describe('Verify Accessibility Support in Dropdown Menus', () => {
     before(() => {
         cy.apiLogin('sysadmin');
+
+        // # Ensure an open team is available to join
+        cy.getCurrentUserId().then((userId) => {
+            cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
+                const teamId = response.body.id;
+                cy.removeUserFromTeam(teamId, userId);
+            });
+        });
     });
 
     beforeEach(() => {

--- a/e2e/cypress/integration/messaging/local_date_time_spec.js
+++ b/e2e/cypress/integration/messaging/local_date_time_spec.js
@@ -13,6 +13,13 @@ const sysadmin = users.sysadmin;
 
 describe('Messaging', () => {
     before(() => {
+        // # Enable Timezone
+        cy.apiUpdateConfig({
+            DisplaySettings: {
+                ExperimentalTimezone: true,
+            },
+        });
+
         // # Login as user-1
         cy.apiLogin('user-1');
 

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -956,6 +956,18 @@ Cypress.Commands.add('removeUserFromChannel', (channelId, userId) => {
 });
 
 /**
+ * Remove a User from a Team directly via API
+ * @param {String} teamID - The team ID
+ * @param {String} userId - The user ID
+ * All parameter required
+ */
+Cypress.Commands.add('removeUserFromTeam', (teamId, userId) => {
+    //Remove a User from a Channel
+    const baseUrl = Cypress.config('baseUrl');
+    cy.externalRequest({user: users.sysadmin, method: 'delete', baseUrl, path: `teams/${teamId}/members/${userId}`});
+});
+
+/**
  * Promote a Guest to a Member directly via API
  * @param {String} userId - The user ID
  * All parameter required

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -182,18 +182,21 @@ function generateReport(summary) {
 
 async function sendReport(summary) {
     const data = generateReport(summary);
+    try {
+        const response = await axios({
+            method: 'post',
+            url: process.env.WEBHOOK_URL,
+            data,
+        });
 
-    const response = await axios({
-        method: 'post',
-        url: process.env.WEBHOOK_URL,
-        data,
-    });
-
-    if (response.data) {
-        console.log('Successfully sent report via webhook');
+        if (response.data) {
+            console.log('Successfully sent report via webhook');
+        }
+        return response;
+    } catch (er) {
+        console.log('Something went wrong while sending report via webhook', er);
+        return false;
     }
-
-    return response;
 }
 
 runTests();


### PR DESCRIPTION
#### Summary
- Added Cypress test to verify Accessibility Support in Dropdown Menus. 
- Minor fixes based on run on localhost
   - Updated run_test to continue to generate report (mochawesome.html) even if it fails to send report via webhook
   - Enable Timezone before running the local_date_time_spec

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-22627

#### Screenshots
<img width="857" alt="Screenshot 2020-02-25 at 5 56 16 PM" src="https://user-images.githubusercontent.com/1429138/75247637-68348600-57f8-11ea-8b04-590411bdcf77.png">
