### PR TITLE
[MM-21408] Get correct display name for DM and modals

### DIFF
--- a/components/sidebar/sidebar_channel/index.js
+++ b/components/sidebar/sidebar_channel/index.js
@@ -16,12 +16,10 @@ import {
 } from 'mattermost-redux/selectors/entities/channels';
 import {getMyChannelMemberships} from 'mattermost-redux/selectors/entities/common';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
-import {getUserIdsInChannels, getUser} from 'mattermost-redux/selectors/entities/users';
-import {getInt, getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
+import {getUserIdsInChannels, getUser, makeGetDisplayName} from 'mattermost-redux/selectors/entities/users';
+import {getInt} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {isChannelMuted, isFavoriteChannel} from 'mattermost-redux/utils/channel_utils';
-
-import {displayUsername} from 'mattermost-redux/utils/user_utils';
 
 import {Constants, NotificationLevels, StoragePrefixes} from 'utils/constants';
 
@@ -33,6 +31,7 @@ import SidebarChannel from './sidebar_channel.jsx';
 
 function makeMapStateToProps() {
     const getChannel = makeGetChannel();
+    const getDisplayName = makeGetDisplayName();
 
     return (state, ownProps) => {
         const channelId = ownProps.channelId;
@@ -72,7 +71,6 @@ function makeMapStateToProps() {
             }
         }
 
-        const teammateNameDisplay = getTeammateNameDisplaySetting(state);
         let teammate = null;
         let channelTeammateId = '';
         let channelTeammateDeletedAt = 0;
@@ -96,7 +94,7 @@ function makeMapStateToProps() {
                     botIconUrl = botIconImageUrl(teammate);
                 }
             }
-            channelDisplayName = displayUsername(teammate, teammateNameDisplay, false);
+            channelDisplayName = getDisplayName(state, channel.teammate_id);
         }
 
         let shouldHideChannel = false;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -10,13 +10,12 @@ import {Client4} from 'mattermost-redux/client';
 import {Posts} from 'mattermost-redux/constants';
 import {getChannel, getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getTeammateNameDisplaySetting, getBool} from 'mattermost-redux/selectors/entities/preferences';
-import {getCurrentUserId, getUser, getUserByUsername as getUserByUsernameRedux} from 'mattermost-redux/selectors/entities/users';
+import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {getCurrentUserId, getUser, getUserByUsername as getUserByUsernameRedux, makeGetDisplayName} from 'mattermost-redux/selectors/entities/users';
 import {
     blendColors,
     changeOpacity,
 } from 'mattermost-redux/utils/theme_utils';
-import {displayUsername} from 'mattermost-redux/utils/user_utils';
 import {getCurrentTeamId, getCurrentRelativeTeamUrl, getTeam} from 'mattermost-redux/selectors/entities/teams';
 import {logError} from 'mattermost-redux/actions/errors';
 import cssVars from 'css-vars-ponyfill';
@@ -1315,9 +1314,9 @@ export function getDisplayNameByUserId(userId) {
  */
 export function getDisplayNameByUser(user) {
     const state = store.getState();
-    const teammateNameDisplay = getTeammateNameDisplaySetting(state);
+    const getDisplayNameFromRedux = makeGetDisplayName();
     if (user) {
-        return displayUsername(user, teammateNameDisplay);
+        return getDisplayNameFromRedux(state, user.id);
     }
 
     return '';


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When the System Admin locks the `lock teammate name display` and updates the teammate name display in the system console for all users, the DM names and the manage members modal names were not updating accordingly. This PR aims to resolve this issue.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21408

#### Screenshots (The names in the red squares update accordingly when system admin updates the teammate name display and locks it in system console)
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![image](https://user-images.githubusercontent.com/17804942/75256604-aeb2c200-57b1-11ea-84e8-d6859f69e541.png)
