### PR TITLE
 enable notification sounds in FF, update i18n strings with same 

### DIFF
--- a/components/user_settings/notifications/__snapshots__/desktop_notification_settings.test.jsx.snap
+++ b/components/user_settings/notifications/__snapshots__/desktop_notification_settings.test.jsx.snap
@@ -146,7 +146,7 @@ exports[`components/user_settings/notifications/DesktopNotificationSettings shou
             className="mt-5"
           >
             <FormattedMessage
-              defaultMessage="Notification sounds are available on Edge, Safari, Chrome and Mattermost Desktop Apps."
+              defaultMessage="Notification sounds are available on Firefox, Edge, Safari, Chrome and Mattermost Desktop Apps."
               id="user.settings.notifications.sounds_info"
               values={Object {}}
             />
@@ -444,7 +444,7 @@ exports[`components/user_settings/notifications/DesktopNotificationSettings shou
             className="mt-5"
           >
             <FormattedMessage
-              defaultMessage="Notification sounds are available on Edge, Safari, Chrome and Mattermost Desktop Apps."
+              defaultMessage="Notification sounds are available on Firefox, Edge, Safari, Chrome and Mattermost Desktop Apps."
               id="user.settings.notifications.sounds_info"
               values={Object {}}
             />

--- a/components/user_settings/notifications/desktop_notification_settings.jsx
+++ b/components/user_settings/notifications/desktop_notification_settings.jsx
@@ -97,7 +97,7 @@ export default class DesktopNotificationSettings extends React.Component {
                         <div className='mt-5'>
                             <FormattedMessage
                                 id='user.settings.notifications.sounds_info'
-                                defaultMessage='Notification sounds are available on Edge, Safari, Chrome and Mattermost Desktop Apps.'
+                                defaultMessage='Notification sounds are available on Firefox, Edge, Safari, Chrome and Mattermost Desktop Apps.'
                             />
                         </div>
                     </fieldset>

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "Ihr groß-/kleinschreibungsabhängiger Benutzername \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Weitere nicht groß-/kleinschreibungsabhängige Wörter, getrennt mit Komma:",
   "user.settings.notifications.soundConfig": "Bitte konfigurieren Sie die Benachrichtigungstöne in ihren Browsereinstellungen",
-  "user.settings.notifications.sounds_info": "Benachrichtigungstöne sind in IE11, Safari, Chrome und den Mattermost-Desktop-Apps verfügbar.",
+  "user.settings.notifications.sounds_info": "Benachrichtigungstöne sind in Firefox, IE11, Safari, Chrome und den Mattermost-Desktop-Apps verfügbar.",
   "user.settings.notifications.title": "Benachrichtigungseinstellungen",
   "user.settings.notifications.wordsTrigger": "Wörter, welche Erwähnungen auslösen",
   "user.settings.push_notification.allActivity": "Für alle Aktivitäten",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3566,7 +3566,7 @@
   "user.settings.notifications.sensitiveUsername": "Your non-case sensitive username \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Other non-case sensitive words, separated by commas:",
   "user.settings.notifications.soundConfig": "Please configure notification sounds in your browser settings",
-  "user.settings.notifications.sounds_info": "Notification sounds are available on Edge, Safari, Chrome and Mattermost Desktop Apps.",
+  "user.settings.notifications.sounds_info": "Notification sounds are available on Firefox, Edge, Safari, Chrome and Mattermost Desktop Apps.",
   "user.settings.notifications.title": "Notification Settings",
   "user.settings.notifications.wordsTrigger": "Words That Trigger Mentions",
   "user.settings.push_notification.allActivity": "For all activity",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -3012,7 +3012,7 @@
   "user.settings.notifications.sensitiveUsername": "Tu nombre de usuario sin distinción de mayúsculas \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Otras palabras sin distinción de mayúsculas, separadas por comas:",
   "user.settings.notifications.soundConfig": "Por favor configura los sonidos de notificación en los ajustes de tu navegador",
-  "user.settings.notifications.sounds_info": "Los sonidos de notificación están disponibles en IE11, Edge, Safari, Chrome y Aplicaciones de Escritorio de Mattermost.",
+  "user.settings.notifications.sounds_info": "Los sonidos de notificación están disponibles en Firefox, IE11, Edge, Safari, Chrome y Aplicaciones de Escritorio de Mattermost.",
   "user.settings.notifications.title": "Configuracón de Notificaciones",
   "user.settings.notifications.wordsTrigger": "Palabras que desencadenan menciones",
   "user.settings.push_notification.allActivity": "Para toda actividad",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "Votre nom d'utilisateur (insensible à la casse) « {username} »",
   "user.settings.notifications.sensitiveWords": "Autres mots insensibles à la casse, séparés par des virgules :",
   "user.settings.notifications.soundConfig": "Configurez les sons des notifications dans les paramètres de votre navigateur",
-  "user.settings.notifications.sounds_info": "Les sons de notification sont disponibles sur IE11, Edge, Safari, Chrome et les applications de bureau Mattermost.",
+  "user.settings.notifications.sounds_info": "Les sons de notification sont disponibles sur Firefox, IE11, Edge, Safari, Chrome et les applications de bureau Mattermost.",
   "user.settings.notifications.title": "Paramètres de notification",
   "user.settings.notifications.wordsTrigger": "Mots qui déclenchent des mentions",
   "user.settings.push_notification.allActivity": "Pour toute activité",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "Nome (nessuna differenza tra maiuscolo e minuscole) \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Altre parole non sensibili a maiuscole e minuscole, separate da virgola:",
   "user.settings.notifications.soundConfig": "Configura i suoni di notifica nel tuo browser",
-  "user.settings.notifications.sounds_info": "I suoni di notifica sono disponibili in IE11, Edge, Safari, Chrome e l'app desktop di Mattermost.",
+  "user.settings.notifications.sounds_info": "I suoni di notifica sono disponibili in Firefox, IE11, Edge, Safari, Chrome e l'app desktop di Mattermost.",
   "user.settings.notifications.title": "Impostazioni delle notifiche",
   "user.settings.notifications.wordsTrigger": "Parole che attivano notifiche per citazione",
   "user.settings.push_notification.allActivity": "Per tutte le attività",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "あなたのユーザー名は、大文字小文字を区別せず\"{username}\"です",
   "user.settings.notifications.sensitiveWords": "他の単語をカンマで区切って入力してください。大文字小文字は区別されません:",
   "user.settings.notifications.soundConfig": "ブラウザーの設定画面で、通知音について設定してください",
-  "user.settings.notifications.sounds_info": "通知音はIE11、Safari、Chrome、Mattermostデスクトップアプリで利用できます。",
+  "user.settings.notifications_info": "通知音はFirefox、IE11、Safari、Chrome、Mattermostデスクトップアプリで利用できます。",
   "user.settings.notifications.title": "通知の設定",
   "user.settings.notifications.wordsTrigger": "あなたについての投稿となる単語",
   "user.settings.push_notification.allActivity": "全てのアクティビティーについて",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "내 사용자명 \"{username}\" (대소문자 구별 안함)",
   "user.settings.notifications.sensitiveWords": "다른 알림받을 단어들을 쉼표로 구분하여 입력: (대소문자 구별 안함)",
   "user.settings.notifications.soundConfig": "브라우저 설정에서 알림 소리를 변경하세요",
-  "user.settings.notifications.sounds_info": "알림 사운드는 IE11, Edge, Safari, Chrome 및 Mattermost 데스크탑 애플리케이션에서 사용할 수 있습니다.",
+  "user.settings.notifications.sounds_info": "알림 사운드는 Firefox, IE11, Edge, Safari, Chrome 및 Mattermost 데스크탑 애플리케이션에서 사용할 수 있습니다.",
   "user.settings.notifications.title": "알림 설정",
   "user.settings.notifications.wordsTrigger": "멘션 알림",
   "user.settings.push_notification.allActivity": "모든 활동",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "Uw niet-hoofdlettergevoelige gebruikersnaam \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Andere niet-hoofdlettergevoelige woorden, gescheiden door komma's:",
   "user.settings.notifications.soundConfig": "Configureer de meldings-geluiden in de instellingen van uw browser",
-  "user.settings.notifications.sounds_info": "Notification sounds are available on IE11, Safari, Chrome and Mattermost Desktop Apps.",
+  "user.settings.notifications.sounds_info": "Notification sounds are available on Firefox, IE11, Safari, Chrome and Mattermost Desktop Apps.",
   "user.settings.notifications.title": "Meldings-instellingen",
   "user.settings.notifications.wordsTrigger": "Woorden die een vermelding triggeren",
   "user.settings.push_notification.allActivity": "Voor alle activiteiten",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "Twoja nazwa użytkownika bez rozróżniania wielkości liter \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Inne słowa oddzielone przecinkami:",
   "user.settings.notifications.soundConfig": "Proszę skonfigurować dźwięki powiadomień w ustawieniach przeglądarki",
-  "user.settings.notifications.sounds_info": "Dźwięk powiadomień dostępny jest w IE11, Safari, Chrome i aplikacjach pulpitowych Mattermost.",
+  "user.settings.notifications.sounds_info": "Dźwięk powiadomień dostępny jest w Firefox, IE11, Safari, Chrome i aplikacjach pulpitowych Mattermost.",
   "user.settings.notifications.title": "Ustawienia Powiadomień",
   "user.settings.notifications.wordsTrigger": "Słowa, które uruchamiają wzmianki",
   "user.settings.push_notification.allActivity": "Dla wszystkich aktywności",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "Seu usuário não sensível a maiúsculas \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Outras palavras não sensível a maiúscula, separadas por virgulas:",
   "user.settings.notifications.soundConfig": "Por favor configurar sons de notificações nas configurações do seu navegador",
-  "user.settings.notifications.sounds_info": "Sons para notificações estão disponíveis no IE11, Safari, Chrome e Mattermost Desktop Apps.",
+  "user.settings.notifications.sounds_info": "Sons para notificações estão disponíveis no Firefox, IE11, Safari, Chrome e Mattermost Desktop Apps.",
   "user.settings.notifications.title": "Configurações de Notificação",
   "user.settings.notifications.wordsTrigger": "Palavras que desencadeiam menções",
   "user.settings.push_notification.allActivity": "Para todas as atividades",

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "Numele dvs. de utilizator sensibil non-case \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Alte cuvinte sensibile, separate prin virgule:",
   "user.settings.notifications.soundConfig": "Configurați sunetele de notificare în setările browserului dvs",
-  "user.settings.notifications.sounds_info": "Sunetele de notificare sunt disponibile pe aplicațiile Desktop IE11, Safari, Chrome și Mattermost.",
+  "user.settings.notifications.sounds_info": "Sunetele de notificare sunt disponibile pe aplicațiile Desktop Firefox, IE11, Safari, Chrome și Mattermost.",
   "user.settings.notifications.title": "Setări Notificări",
   "user.settings.notifications.wordsTrigger": "Cuvintele care declanșează mențiunile",
   "user.settings.push_notification.allActivity": "Pentru toată activitatea",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "Ваше независимое от регистра имя пользователя \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Другие независящие от регистра слова, разделенные запятыми:",
   "user.settings.notifications.soundConfig": "Пожалуйста, настройте звуковые уведомления в настройках браузера",
-  "user.settings.notifications.sounds_info": "Звуки уведомлений доступны в IE11, Edge, Safari, Chrome и Mattermost Desktop.",
+  "user.settings.notifications.sounds_info": "Звуки уведомлений доступны в Firefox, IE11, Edge, Safari, Chrome и Mattermost Desktop.",
   "user.settings.notifications.title": "Настройки уведомлений",
   "user.settings.notifications.wordsTrigger": "Ключевые слова для упоминаний",
   "user.settings.push_notification.allActivity": "При любой активности",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "Büyük küçük harfe duyarsız adınız \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Diğer büyük küçük harfe duyarsız sözcükler, virgül ile ayırarak yazın:",
   "user.settings.notifications.soundConfig": "Web tarayıcısı ayarlarınızdan bildirim sesi ayarlarını yapın",
-  "user.settings.notifications.sounds_info": "Bildirim sesleri IE11, Safari, Chrome ve Mattermost Masaüstü Uygulaması ile kullanılabilir.",
+  "user.settings.notifications.sounds_info": "Bildirim sesleri Firefox, IE11, Safari, Chrome ve Mattermost Masaüstü Uygulaması ile kullanılabilir.",
   "user.settings.notifications.title": "Bildirim Ayarları",
   "user.settings.notifications.wordsTrigger": "Anmaları Tetikleyecek Sözcükler",
   "user.settings.push_notification.allActivity": "Tüm işlemler için",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "Ваше незалежне ім'я користувача \"{username}\"",
   "user.settings.notifications.sensitiveWords": "Інші не залежні від регістра слова, розділені комами:",
   "user.settings.notifications.soundConfig": "Будь-ласка, налаштуйте звукові повідомлення в налаштуваннях браузера",
-  "user.settings.notifications.sounds_info": "Звуки повідомлень доступні в IE11, Edge, Safari, Chrome і Mattermost Desktop.",
+  "user.settings.notifications.sounds_info": "Звуки повідомлень доступні в Firefox, IE11, Edge, Safari, Chrome і Mattermost Desktop.",
   "user.settings.notifications.title": "Налаштування повідомлень ",
   "user.settings.notifications.wordsTrigger": "Ключові слова для згадок",
   "user.settings.push_notification.allActivity": "При будь-якій активності ",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "不区分大小写的用户名\"{username}\"",
   "user.settings.notifications.sensitiveWords": "其他不区分大小写的词汇，以逗号分隔：",
   "user.settings.notifications.soundConfig": "请在您的浏览器中配置消息通知声音设置",
-  "user.settings.notifications.sounds_info": "通知声音可在 IE11、Edge、Safari、Chrome 以及 Mattermost 桌面应用使用。",
+  "user.settings.notifications.sounds_info": "通知声音可在 Firefox、IE11、Edge、Safari、Chrome 以及 Mattermost 桌面应用使用。",
   "user.settings.notifications.title": "通知设置",
   "user.settings.notifications.wordsTrigger": "触发提及词",
   "user.settings.push_notification.allActivity": "所有活动",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -3009,7 +3009,7 @@
   "user.settings.notifications.sensitiveUsername": "您的使用者名稱，不區分大小寫：\"{username}\"",
   "user.settings.notifications.sensitiveWords": "其他不區分大小寫的字，用逗號分隔：",
   "user.settings.notifications.soundConfig": "請在瀏覽器設置中設定通知聲音",
-  "user.settings.notifications.sounds_info": "通知音效支援 IE11、Safari、Chrome 跟 Mattermost 桌面應用程式。",
+  "user.settings.notifications.sounds_info": "通知音效支援 Firefox、IE11、Safari、Chrome 跟 Mattermost 桌面應用程式。",
   "user.settings.notifications.title": "通知設定",
   "user.settings.notifications.wordsTrigger": "觸發提及的字",
   "user.settings.push_notification.allActivity": "所有的活動",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11466,7 +11466,10 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
       "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -12465,6 +12468,12 @@
       "requires": {
         "postcss": "^7.0.14"
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -207,7 +207,7 @@ export function ding() {
 }
 
 export function hasSoundOptions() {
-    return (!(UserAgent.isFirefox()) && !(UserAgent.isEdge()));
+    return (!(UserAgent.isEdge()));
 }
 
 export function getDateForUnixTicks(ticks) {


### PR DESCRIPTION
#### Summary

Allow web app notification sounds in Firefox, update Account Settings -> Notifications -> Desktop Notifications with default and `user.settings.notifications.sounds_info` for i18n. 

#### Ticket Link

[Utils.hasSoundOptions shouldn't exclude firefox #13807](https://github.com/mattermost/mattermost-server/issues/13807)

#### Related Pull Requests

NA

#### Screenshots

NA