### PR TITLE
MM-22634: Add Team Name back to team list

### DIFF
--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/__snapshots__/team_in_list.test.jsx.snap
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/__snapshots__/team_in_list.test.jsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/team_in_list should match snapshot with team 1`] = `
+<div
+  className="team"
+  key="12345"
+>
+  <div
+    className="team-info-block"
+  >
+    <TeamIcon
+      name="testTeam"
+      size="md"
+      url={null}
+    />
+    <div
+      className="team-data"
+    >
+      <div
+        className="title"
+      >
+        testTeam
+      </div>
+    </div>
+  </div>
+  <a
+    className="remove"
+    onClick={[Function]}
+  >
+    <FormattedMessage
+      defaultMessage="Remove"
+      id="admin.permissions.teamScheme.removeTeam"
+      values={Object {}}
+    />
+  </a>
+</div>
+`;

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/team_in_list.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/team_in_list.jsx
@@ -22,10 +22,15 @@ export default class TeamInList extends React.Component {
                 className='team'
                 key={team.id}
             >
-                <TeamIcon
-                    name={team.display_name}
-                    url={imageURLForTeam(team)}
-                />
+                <div className='team-info-block'>
+                    <TeamIcon
+                        name={team.display_name}
+                        url={imageURLForTeam(team)}
+                    />
+                    <div className='team-data'>
+                        <div className='title'>{team.display_name}</div>
+                    </div>
+                </div>
                 <a
                     className='remove'
                     onClick={() => this.props.onRemoveTeam(team.id)}

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/team_in_list.test.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/team_in_list.test.jsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import TeamInList from 'components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/team_in_list.jsx';
+
+describe('components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/team_in_list', () => {
+    test('should match snapshot with team', () => {
+        const props = {
+            team: {
+                id: 12345,
+                display_name: 'testTeam'
+            }
+        };
+
+        const wrapper = shallow(
+            <TeamInList {...props}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Summary
Add Team Display Name back to the TeamInList component. When TeamInfo object was replaced with the TeamIcon component, the Team Name was dropped.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22634

#### Screenshots
![Screen Shot 2020-02-27 at 1 09 47 PM](https://user-images.githubusercontent.com/12704875/75482649-769eb100-5962-11ea-9ab6-e9082a02bb57.png)

