### PR TITLE
MM-22857 Fix lists being unable to start with 0

### DIFF
--- a/utils/markdown/index.test.js
+++ b/utils/markdown/index.test.js
@@ -54,6 +54,17 @@ describe('format', () => {
             expect(output).toBe(expected);
         });
 
+        test('ordered lists starting at 0 should include a start index', () => {
+            const input = `0. a
+1. b
+2. c`;
+            const expected = `<ol className="markdown__list" style="counter-reset: list -1">
+<li><span>a</span></li><li><span>b</span></li><li><span>c</span></li></ol>`;
+
+            const output = format(input);
+            expect(output).toBe(expected);
+        });
+
         test('ordered lists starting at any other number should include a start index', () => {
             const input = `999. a
 1. b

--- a/utils/markdown/renderer.tsx
+++ b/utils/markdown/renderer.tsx
@@ -257,7 +257,7 @@ export default class Renderer extends marked.Renderer {
         const type = ordered ? 'ol' : 'ul';
 
         let output = `<${type} className="markdown__list"`;
-        if (ordered && start) {
+        if (ordered && start !== undefined) { // eslint-disable-line no-undefined
             // The CSS that we use for lists hides the actual counter and uses ::before to simulate one so that we can
             // style it properly. We need to use a CSS counter to tell the ::before elements which numbers to show.
             output += ` style="counter-reset: list ${start - 1}"`;


### PR DESCRIPTION
The code that controls the index on numbered lists wasn't triggering when someone starts a list with 0 because the falsey value was causing the if condition to be fail incorrectly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22857