### PR TITLE
MM-23012 - Hiding scrollbars in IE from LHS/RHS

### DIFF
--- a/sass/components/_scrollbar.scss
+++ b/sass/components/_scrollbar.scss
@@ -52,6 +52,7 @@ body {
     .browser--ie & {
         margin: 0 !important;
         overflow-x: hidden !important;
+        -ms-overflow-style: none;
 
         .scrollbar--vertical {
             visibility: hidden;


### PR DESCRIPTION
#### Summary
MM-23012 - Hiding scrollbars in IE from LHS/RHS
The scrollbars should be hidden now from the LHS/RHS (but not from the center channel).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23012

#### Screenshots
![Screenshot_2](https://user-images.githubusercontent.com/11034289/75973215-a1ef4600-5ef6-11ea-86cb-1358efb2cbfb.png)
