### PR TITLE
Added step to ensure that new users are added to default team ad-1

### DIFF
--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -712,6 +712,14 @@ Cypress.Commands.add('createNewUser', (user = {}, teamIds = [], bypassTutorial =
                     forEach((teamId) => {
                         cy.apiAddUserToTeam(teamId, userId);
                     });
+
+                // Also add the user to the default team ad-1
+                teamsResponse.body.
+                    filter((t) => t.name === 'ad-1').
+                    map((t) => t.id).
+                    forEach((teamId) => {
+                        cy.apiAddUserToTeam(teamId, userId);
+                    });
             });
         }
 


### PR DESCRIPTION
#### Summary
Certain tests expect new users to be assigned to the team `ad-1` by default. However the existing logic picks the first 2 teams from the teams API response. At times, the default team is not present in the first 2 teams and hence the testcases fails. I have now added a step to ensure that a new user gets assigned to the team `ad-1` by default. 

#### Ticket Link
NA. Fixed based on analysis of daily runs. 