### PR TITLE
MM-22970: Fix highlighting of at mentions of self

### DIFF
--- a/components/post_markdown/__snapshots__/post_markdown.test.jsx.snap
+++ b/components/post_markdown/__snapshots__/post_markdown.test.jsx.snap
@@ -12,6 +12,11 @@ exports[`components/PostMarkdown plugin hooks can build upon other hook message 
   imageProps={Object {}}
   isRHS={false}
   message="hello world!"
+  options={
+    Object {
+      "mentionHighlight": true,
+    }
+  }
   proxyImages={true}
 />
 `;
@@ -28,6 +33,11 @@ exports[`components/PostMarkdown plugin hooks can overwrite other hooks messages
   imageProps={Object {}}
   isRHS={false}
   message="world!"
+  options={
+    Object {
+      "mentionHighlight": true,
+    }
+  }
   proxyImages={true}
 />
 `;
@@ -37,6 +47,11 @@ exports[`components/PostMarkdown should correctly pass postId down 1`] = `
   imageProps={Object {}}
   isRHS={false}
   message="message"
+  options={
+    Object {
+      "mentionHighlight": true,
+    }
+  }
   postId="post_id"
   proxyImages={true}
 />
@@ -105,6 +120,11 @@ exports[`components/PostMarkdown should render properly with a post 1`] = `
   imageProps={Object {}}
   isRHS={false}
   message="See ~test"
+  options={
+    Object {
+      "mentionHighlight": true,
+    }
+  }
   proxyImages={true}
 />
 `;
@@ -114,6 +134,21 @@ exports[`components/PostMarkdown should render properly with an empty post 1`] =
   imageProps={Object {}}
   isRHS={false}
   message="message"
+  options={Object {}}
+  proxyImages={true}
+/>
+`;
+
+exports[`components/PostMarkdown should render properly without highlight a post 1`] = `
+<Connect(Markdown)
+  imageProps={Object {}}
+  isRHS={false}
+  message="No highlight"
+  options={
+    Object {
+      "mentionHighlight": false,
+    }
+  }
   proxyImages={true}
 />
 `;

--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -45,6 +45,7 @@ export default class PostMarkdown extends React.PureComponent {
     static defaultProps = {
         isRHS: false,
         pluginHooks: [],
+        options: {},
     };
 
     render() {
@@ -60,7 +61,7 @@ export default class PostMarkdown extends React.PureComponent {
         const channelNamesMap = this.props.post && this.props.post.props && this.props.post.props.channel_mentions;
 
         let {message} = this.props;
-        const {post} = this.props;
+        const {post, options} = this.props;
 
         this.props.pluginHooks.forEach((o) => {
             if (o && o.hook && post) {
@@ -68,13 +69,17 @@ export default class PostMarkdown extends React.PureComponent {
             }
         });
 
+        if (post && post.props) {
+            options.mentionHighlight = !post.props.mentionHighlightDisabled;
+        }
+
         return (
             <Markdown
                 imageProps={this.props.imageProps}
                 isRHS={this.props.isRHS}
                 message={message}
                 proxyImages={proxyImages}
-                options={this.props.options}
+                options={options}
                 channelNamesMap={channelNamesMap}
                 hasPluginTooltips={this.props.hasPluginTooltips}
                 imagesMetadata={this.props.post && this.props.post.metadata && this.props.post.metadata.images}

--- a/components/post_markdown/post_markdown.test.jsx
+++ b/components/post_markdown/post_markdown.test.jsx
@@ -50,6 +50,21 @@ describe('components/PostMarkdown', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should render properly without highlight a post', () => {
+        const props = {
+            ...baseProps,
+            message: 'No highlight',
+            options: {
+                mentionHighlight: false,
+            },
+            post: {},
+        };
+        const wrapper = shallow(
+            <PostMarkdown {...props}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should correctly pass postId down', () => {
         const props = {
             ...baseProps,


### PR DESCRIPTION
#### Summary
This PR fixes and issue with highlighting at mention myself followed by a Period(.) or underscore (_). This issue has already been fixed in master by this PR -
https://github.com/mattermost/mattermost-webapp/pull/4916

However, that PR, was for another feature and is too large to cherry-pick back to v5.21. This PR only contains the changes necessary to fix the highlighting issue.

This issue was introduced when fixing the highlighting of the header - https://github.com/mattermost/mattermost-webapp/pull/4819
I made sure this fix was retained, see screenshot. 

Essentially, when the `options.mentionHighlight` is not set, it gets passed as false. Therefore, when it is empty, it needs set to true by default. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22970

#### Related Pull Requests

#### Screenshots
<img width="1287" alt="Screen Shot 2020-03-05 at 8 16 45 PM" src="https://user-images.githubusercontent.com/12704875/76047991-ab41d800-5f21-11ea-92f0-7a8388e4e2a6.png">
