### PR TITLE
MM-22970: fix highlighting of at mentions of self (#4994)

### DIFF
--- a/components/post_markdown/__snapshots__/post_markdown.test.jsx.snap
+++ b/components/post_markdown/__snapshots__/post_markdown.test.jsx.snap
@@ -140,3 +140,17 @@ exports[`components/PostMarkdown should render properly with an empty post 1`] =
   proxyImages={true}
 />
 `;
+
+exports[`components/PostMarkdown should render properly without highlight a post 1`] = `
+<Connect(Markdown)
+  imageProps={Object {}}
+  isRHS={false}
+  message="No highlight"
+  options={
+    Object {
+      "mentionHighlight": false,
+    }
+  }
+  proxyImages={true}
+/>
+`;

--- a/components/post_markdown/post_markdown.test.jsx
+++ b/components/post_markdown/post_markdown.test.jsx
@@ -50,6 +50,21 @@ describe('components/PostMarkdown', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should render properly without highlight a post', () => {
+        const props = {
+            ...baseProps,
+            message: 'No highlight',
+            options: {
+                mentionHighlight: false,
+            },
+            post: {},
+        };
+        const wrapper = shallow(
+            <PostMarkdown {...props}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should correctly pass postId down', () => {
         const props = {
             ...baseProps,


### PR DESCRIPTION
(cherry picked from commit 2a78ea9af6fe7a7a253d48c71337ca056d656712)
#### Summary
This is a cherry pick for a commit that went directly to release-v5.21. It was cp'ed forward because a couple of additional tests were added. This cp only contains those additional tests, the code changes already exist in master.
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22703

#### Related Pull Requests
Original PR to release-5.21
https://github.com/mattermost/mattermost-webapp/pull/4994
