### PR TITLE
Fix mochawesome merge

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,7 +15,7 @@
     "mocha-junit-reporters": "1.23.6",
     "mocha-multi-reporters": "1.1.7",
     "mochawesome": "4.1.0",
-    "mochawesome-merge": "4.0.1",
+    "mochawesome-merge": "4.0.2",
     "mochawesome-report-generator": "4.1.0",
     "start-server-and-test": "1.10.8"
   },

--- a/e2e/run_tests.js
+++ b/e2e/run_tests.js
@@ -119,7 +119,7 @@ async function runTests() {
     }
 
     // Merge all json reports into one single json report
-    const jsonReport = await merge({reportDir: mochawesomeReportDir});
+    const jsonReport = await merge({files: [`${mochawesomeReportDir}/*.json`]});
 
     // Generate short summary, write to file and then send report via webhook
     const summary = generateShortSummary(jsonReport);


### PR DESCRIPTION
#### Summary
There's a breaking change in the latest mochawesome-merge where we should use `files` options instead of `reportDir`

https://www.npmjs.com/package/mochawesome-merge