### PR TITLE
MM-22698 Fix for unread channel getting stuck at Loading indicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18459,8 +18459,8 @@
       "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg=="
     },
     "react-window": {
-      "version": "github:mattermost/react-window#15e10c29122b53b10d69a4ca4800eb2631874236",
-      "from": "github:mattermost/react-window#15e10c29122b53b10d69a4ca4800eb2631874236",
+      "version": "github:mattermost/react-window#f8b7c8333c3c8e80f0fc80b95c45c56361b26253",
+      "from": "github:mattermost/react-window#f8b7c8333c3c8e80f0fc80b95c45c56361b26253",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-select": "2.4.4",
     "react-transition-group": "4.3.0",
     "react-virtualized-auto-sizer": "1.0.2",
-    "react-window": "github:mattermost/react-window#15e10c29122b53b10d69a4ca4800eb2631874236",
+    "react-window": "github:mattermost/react-window#f8b7c8333c3c8e80f0fc80b95c45c56361b26253",
     "rebound": "0.1.0",
     "redux": "4.0.4",
     "redux-batched-actions": "0.4.1",


### PR DESCRIPTION
 * Update react window hash

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22698

#### Related Pull Requests
https://github.com/mattermost/react-window/pull/26

Note: i don't know how we can QA review this. As we don't have a repo. Changes have a minimal impact as to log to console if the issue happens and not show a loading indicator and fallback to the changes we had for 5.20v
