### PR TITLE
MM-22703: Channel switcher up/down functionality is broken

### DIFF
--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -51,6 +51,7 @@ import Provider from './provider.jsx';
 import Suggestion from './suggestion.jsx';
 
 const getState = store.getState;
+const duplicateSuffix = '[dup]';
 
 class SwitchChannelSuggestion extends Suggestion {
     static get propTypes() {
@@ -362,6 +363,7 @@ export default class SwitchChannelProvider extends Provider {
         const config = getConfig(state);
         const viewArchivedChannels = config.ExperimentalViewArchivedChannels === 'true';
 
+        let names = new Set();
         for (const id of Object.keys(allChannels)) {
             const channel = allChannels[id];
 
@@ -424,6 +426,11 @@ export default class SwitchChannelProvider extends Provider {
                 }
 
                 completedChannels[channel.id] = true;
+
+                while(names.has(wrappedChannel.name)){
+                    wrappedChannel.name = wrappedChannel.name + duplicateSuffix;
+                }
+                names.add(wrappedChannel.name);
                 channels.push(wrappedChannel);
             }
         }
@@ -449,12 +456,17 @@ export default class SwitchChannelProvider extends Provider {
             }
 
             completedChannels[user.id] = true;
+            while(names.has(wrappedChannel.name)){
+                wrappedChannel.name = wrappedChannel.name + duplicateSuffix;
+            }
+            names.add(wrappedChannel.name);
+
             channels.push(wrappedChannel);
         }
 
         const channelNames = channels.
             sort(quickSwitchSorter).
-            map((wrappedChannel) => wrappedChannel.channel.name);
+            map((wrappedChannel) => wrappedChannel.name);
 
         if (skipNotInChannel) {
             channels.push({

--- a/components/suggestion/switch_channel_provider.test.jsx
+++ b/components/suggestion/switch_channel_provider.test.jsx
@@ -1,0 +1,182 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import configureStore from 'redux-mock-store';
+
+import {getState} from 'stores/redux_store';
+
+import SwitchChannelProvider from 'components/suggestion/switch_channel_provider.jsx';
+
+jest.mock('stores/redux_store', () => ({
+    dispatch: jest.fn(),
+    getState: jest.fn(),
+}));
+
+jest.mock('mattermost-redux/utils/channel_utils', () => ({
+    ...jest.requireActual('mattermost-redux/utils/channel_utils'),
+    isGroupChannelVisible: jest.fn(() => {return true;}),
+    isDirectChannelVisible: jest.fn(() => {return true;}),
+    isUnreadChannel: jest.fn(() => {return false;}),
+}));
+
+const latestPost = {
+    id: 'latest_post_id',
+    user_id: 'current_user_id',
+    message: 'test msg',
+    channel_id: 'current_channel_id',
+};
+
+describe('components/SwitchChannelProvider', () => {
+    const defaultState = {
+        entities: {
+            general: {
+                config: {},
+            },
+            channels: {
+                myMembers: {
+                    current_channel_id: {
+                        channel_id: 'current_channel_id',
+                        user_id: 'current_user_id',
+                        roles: 'channel_role',
+                        mention_count: 1,
+                        msg_count: 9,
+                    },
+                },
+            },
+            preferences: {
+                myPreferences: {
+                    'display_settings--name_format': {
+                        category: 'display_settings',
+                        name: 'name_format',
+                        user_id: 'current_user_id',
+                        value: 'username',
+                    },
+                },
+            },
+            users: {
+                profiles: {                
+                    current_user_id: {roles: 'system_role'},
+                },
+                currentUserId: 'current_user_id',
+                profilesInChannel: {
+                    current_user_id: ['user_1'],
+                },
+            },
+            posts: {
+                posts: {
+                    [latestPost.id]: latestPost,
+                },
+                postsInChannel: {
+                    current_channel_id: [
+                        {order: [latestPost.id], recent: true},
+                    ],
+                },
+                postsInThread: {},
+            },
+        },
+    };
+
+    let switchProvider = new SwitchChannelProvider();
+    let mockStore = configureStore();
+    let resultsCallback = jest.fn();
+    const store = mockStore(defaultState);
+
+    getState.mockImplementation(store.getState);
+
+    it('should change name on wrapper to be unique with same name user channel and public channel', () => {
+        const users = [
+            {
+                id: "other_user",
+                display_name:"other_user",
+                username: "other_user"
+            }
+        ];
+        const channels = [{
+                id: "channel_other_user",
+                type: 'O',
+                name: 'other_user',
+                display_name: 'other_user',
+                delete_at: 0,
+            },
+            {
+                id: "direct_other_user",
+                type: 'D',
+                name: 'current_user_id__other_user',
+                display_name: 'other_user',
+                delete_at: 0,
+            }];
+        const searchText = 'other';
+
+        switchProvider.startNewRequest();
+        switchProvider.formatChannelsAndDispatch(searchText, resultsCallback, channels, users);
+
+        expect(resultsCallback).toHaveBeenCalled();
+        
+        let wrappers = resultsCallback.mock.calls[0][0];
+        var set = new Set(wrappers.terms);
+        expect(set.size).toEqual(wrappers.items.length);
+
+        var set2 = new Set(wrappers.items.map(o => o.channel.name));
+        expect(set2.size).toEqual(1);
+        expect(wrappers.items.length).toEqual(2);
+    });
+
+    it('should change name on wrapper to be unique with same name user in channel and public channel', () => {
+        const users = [{
+                id: "other_user",
+                display_name:"other_user",
+                username:"other_user"
+            },
+        ];
+        const channels = [{
+                id: "channel_other_user",
+                type: 'O',
+                name: 'other_user',
+                display_name: 'other_user',
+                delete_at: 0,
+            },
+        ];
+        const searchText = 'other';
+
+        switchProvider.startNewRequest();
+        switchProvider.formatChannelsAndDispatch(searchText, resultsCallback, channels, users);
+        
+        expect(resultsCallback).toHaveBeenCalled();
+
+        let wrappers = resultsCallback.mock.calls[0][0];
+        var set = new Set(wrappers.terms);
+        expect(set.size).toEqual(wrappers.items.length);
+
+        var set2 = new Set(wrappers.items.map(o => o.channel.name));
+        expect(set2.size).toEqual(1);
+        expect(wrappers.items.length).toEqual(2);
+    });
+
+    it('should not fail if nothing matches', () => {
+        const users = [];
+        const channels = [{
+                id: "channel_other_user",
+                type: 'O',
+                name: 'other_user',
+                display_name: 'other_user',
+                delete_at: 0,
+            },
+            {
+                id: "direct_other_user",
+                type: 'D',
+                name: 'current_user_id__other_user',
+                display_name: 'other_user',
+                delete_at: 0,
+            }];
+        const searchText = 'something else';
+
+        switchProvider.startNewRequest();
+        switchProvider.formatChannelsAndDispatch(searchText, resultsCallback, channels, users);
+        
+        expect(resultsCallback).toHaveBeenCalled();
+        let wrappers = resultsCallback.mock.calls[0][0];
+        expect(wrappers.terms.length).toEqual(0);
+        expect(wrappers.items.length).toEqual(0);
+    });
+
+});


### PR DESCRIPTION
#### Summary
The SwitchChannelProvider accesses positions in the list via name rather than index. When a duplicate name is encountered, it has no way of determining which one is current and selects the first on. 

The channels get created in a channel wrapper and ensuring the channel wrapper name handles this without changing the actual channel object. Change the channels[] to a map, and verify uniqueness before adding to the map.

Also added units test, as this code had none.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22703
