### PR TITLE
MM-20900 Add basic E2E tests for new sidebar

### DIFF
--- a/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
@@ -1,0 +1,130 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+import users from '../../fixtures/users';
+
+import {testWithConfig} from '../../support/hooks';
+
+import {getRandomInt} from '../../utils';
+
+const sysadmin = users.sysadmin;
+
+describe('Channel sidebar', () => {
+    testWithConfig({
+        ServiceSettings: {
+            ExperimentalChannelSidebarOrganization: 'default_on',
+        },
+    });
+
+    before(() => {
+        cy.apiLogin('user-1');
+
+        cy.visit('/');
+    });
+
+    it('should switch channels when clicking on a channel in the sidebar', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('contain', teamName);
+
+        // # Click on Off Topic
+        cy.get('.SidebarChannel:contains(Off-Topic)').should('be.visible').click();
+
+        // * Verify that the channel changed
+        cy.url().should('include', `/${teamName}/channels/off-topic`);
+        cy.get('#channelHeaderTitle').should('contain', 'Off-Topic');
+
+        // # Click on Town Square
+        cy.get('.SidebarChannel:contains(Town Square)').should('be.visible').click();
+
+        // * Verify that the channel changed
+        cy.url().should('include', `/${teamName}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('contain', 'Town Square');
+    });
+
+    it('should mark channel as read and unread in sidebar', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('contain', teamName);
+
+        // * Verify that both Off Topic and Town Square are read
+        cy.get('.SidebarChannel:not(.unread):contains(Off-Topic)').should('be.visible');
+        cy.get('.SidebarChannel:not(.unread):contains(Town Square)').should('be.visible');
+
+        // # Have another user post in the Off Topic channel
+        cy.apiGetChannelByName(teamName, 'off-topic').then((response) => {
+            expect(response.status).to.equal(200);
+
+            const channel = response.body;
+            cy.postMessageAs({sender: sysadmin, message: 'Test', channelId: channel.id});
+        });
+
+        // * Verify that Off Topic is unread and Town Square is read
+        cy.get('.SidebarChannel.unread:contains(Off-Topic)').should('be.visible');
+        cy.get('.SidebarChannel:not(.unread):contains(Town Square)').should('be.visible');
+    });
+
+    it('should remove channel from sidebar after leaving it', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('contain', teamName);
+
+        // # Switch to Off Topic
+        cy.visit(`/${teamName}/channels/off-topic`);
+
+        // # Wait for the channel to change
+        cy.get('#channelHeaderTitle').should('contain', 'Off-Topic');
+
+        // # Click on the channel menu and select Leave Channel
+        cy.get('#channelHeaderTitle').click();
+        cy.get('#channelLeaveChannel').click();
+
+        // * Verify that we've switched to Town Square
+        cy.url().should('include', `/${teamName}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('contain', 'Town Square');
+
+        // * Verify that Off Topic has disappeared from the sidebar
+        cy.get('.SidebarChannel:contains(Off-Topic)').should('not.exist');
+    });
+
+    it('MM-23239 should remove channel from sidebar after deleting it', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('contain', teamName);
+
+        // # Switch to Off Topic
+        cy.visit(`/${teamName}/channels/off-topic`);
+
+        // # Wait for the channel to change
+        cy.get('#channelHeaderTitle').should('contain', 'Off-Topic');
+
+        // # Click on the channel menu and select Leave Channel
+        cy.get('#channelHeaderTitle').click();
+        cy.get('#channelArchiveChannel').click();
+
+        // * Verify that we've switched to Town Square
+        cy.url().should('include', `/${teamName}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('contain', 'Town Square');
+
+        // * Verify that Off Topic has disappeared from the sidebar
+        cy.get('.SidebarChannel:contains(Off-Topic)').should('not.exist');
+    });
+});

--- a/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
@@ -119,6 +119,7 @@ describe('Channel sidebar', () => {
         // # Click on the channel menu and select Leave Channel
         cy.get('#channelHeaderTitle').click();
         cy.get('#channelArchiveChannel').click();
+        cy.get('#deleteChannelModalDeleteButton').click();
 
         // * Verify that we've switched to Town Square
         cy.url().should('include', `/${teamName}/channels/town-square`);

--- a/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
@@ -1,0 +1,113 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+import users from '../../fixtures/users';
+
+import {testWithConfig} from '../../support/hooks';
+
+import {getRandomInt} from '../../utils';
+
+const sysadmin = users.sysadmin;
+
+describe('Channel switching', () => {
+    testWithConfig({
+        ServiceSettings: {
+            ExperimentalChannelSidebarOrganization: 'default_on',
+        },
+    });
+
+    before(() => {
+        cy.apiLogin('user-1');
+
+        cy.visit('/');
+    });
+
+    const cmdOrCtrl = Cypress.platform === 'darwin' ? '{cmd}' : '{ctrl}';
+
+    it('should switch channels when pressing the alt + arrow hotkeys', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('contain', teamName);
+
+        // # Press alt + up
+        cy.get('body').type('{alt}', {release: false}).type('{uparrow}').type('{alt}', {release: true});
+
+        // * Verify that the channel changed to the Off-Topic channel
+        cy.url().should('include', `/${teamName}/channels/off-topic`);
+        cy.get('#channelHeaderTitle').should('contain', 'Off-Topic');
+
+        // # Press alt + down
+        cy.get('body').type('{alt}', {release: false}).type('{downarrow}').type('{alt}', {release: true});
+
+        // * Verify that the channel changed to the Town Square
+        cy.url().should('include', `/${teamName}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('contain', 'Town Square');
+    });
+
+    it('should switch to unread channels when pressing the alt + shift + arrow hotkeys', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('contain', teamName);
+
+        cy.getCurrentChannelId().as('townSquareId');
+
+        // # Create a new channel
+        // cy.createAndVisitNewChannel().as('testChannel');
+        cy.getCurrentTeamId().then((teamId) => {
+            cy.apiCreateChannel(teamId, 'test-channel', 'Test Channel').then((response) => {
+                expect(response.status).to.equal(201);
+
+                cy.wrap(response.body).as('testChannel');
+            });
+        });
+
+        // # Have another user post a message in the new channel
+        cy.get('@testChannel').then((testChannel) => cy.postMessageAs({sender: sysadmin, message: 'Test', channelId: testChannel.id}));
+
+        // # Press alt + shift + up
+        cy.get('body').type('{alt}{shift}', {release: false}).type('{uparrow}').type('{alt}{shift}', {release: true});
+
+        // * Verify that the channel changed to Test Channel and skipped Off Topic
+        cy.url().should('include', `/${teamName}/channels/test-channel`);
+        cy.get('#channelHeaderTitle').should('contain', 'Test Channel');
+
+        // # Have another user post a message in the town square
+        cy.get('@townSquareId').then((townSquareId) => cy.postMessageAs({sender: sysadmin, message: 'Test', channelId: townSquareId}));
+
+        // # Press alt + shift + down
+        cy.get('body').type('{alt}{shift}', {release: false}).type('{downarrow}').type('{alt}{shift}', {release: true});
+
+        // * Verify that the channel changed back to Town Square and skipped Off Topic
+        cy.url().should('include', `/${teamName}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('contain', 'Town Square');
+    });
+
+    it('should open and close channel switcher on ctrl/cmd + k', () => {
+        // * Verify that the channel has loaded
+        cy.get('#channelHeaderTitle').should('be.visible');
+
+        // # Press ctrl/cmd + k
+        cy.get('body').type(cmdOrCtrl, {release: false}).type('k').type(cmdOrCtrl, {release: true});
+
+        // * Verify that the modal has been opened
+        cy.get('.channel-switch__modal').should('be.visible');
+
+        // # Press ctrl/cmd + k
+        cy.get('body').type(cmdOrCtrl, {release: false}).type('k').type(cmdOrCtrl, {release: true});
+
+        // * Verify that the modal has been closed
+        cy.get('.channel-switch__modal').should('not.be.visible');
+    });
+});

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -852,6 +852,8 @@ Cypress.Commands.add('apiUpdateConfigBasic', (newSettings = {}) => {
             headers: {'X-Requested-With': 'XMLHttpRequest'},
             method: 'PUT',
             body: settings,
+        }).then((updateResponse) => {
+            expect(updateResponse.status).to.equal(200);
         });
     });
 });
@@ -871,6 +873,8 @@ Cypress.Commands.add('apiUpdateConfig', (newSettings = {}) => {
             headers: {'X-Requested-With': 'XMLHttpRequest'},
             method: 'PUT',
             body: settings,
+        }).then((updateResponse) => {
+            expect(updateResponse.status).to.equal(200);
         });
     });
 

--- a/e2e/cypress/support/hooks.js
+++ b/e2e/cypress/support/hooks.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Updates the config with the provided values before the test suite and then resets the config to the previous value
+// after the test suite has finished.
+export function testWithConfig(config) {
+    before(() => {
+        let originalConfig;
+        cy.apiGetConfig().then((resp) => {
+            originalConfig = resp.body;
+        });
+
+        cy.apiUpdateConfig(config);
+
+        after(() => {
+            cy.apiUpdateConfig(originalConfig);
+        });
+    });
+}


### PR DESCRIPTION
This adds some E2E tests for the new sidebar around:
- Unread state of channels
- Behaviour of channels when leaving/archiving them
- Switching to channels by clicking on them
- Using alt+arrow hotkeys for switching channels
- Using ctrl/cmd+k to open the channel switcher

I also added a hook to set up test conditions with a specific server config. Let me know what you think about that since it might be useful to set up some other testing conditions since calling it once covers both setup and teardown of the test state.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20900