### PR TITLE
[MM-22670] - Hide tooltips in header when the dropdowns are open

### DIFF
--- a/components/channel_header/components/header_icon_wrapper.js
+++ b/components/channel_header/components/header_icon_wrapper.js
@@ -129,4 +129,5 @@ HeaderIconWrapper.propTypes = {
     onClick: PropTypes.func.isRequired,
     tooltipKey: PropTypes.string,
     tooltipText: PropTypes.node,
+    isRhsOpen: PropTypes.bool,
 };

--- a/components/channel_header/components/header_icon_wrapper.js
+++ b/components/channel_header/components/header_icon_wrapper.js
@@ -20,6 +20,7 @@ export default function HeaderIconWrapper({
     onClick,
     tooltipKey,
     tooltipText,
+    isRhsOpen,
 }) {
     const toolTips = {
         flaggedPosts: {
@@ -92,7 +93,7 @@ export default function HeaderIconWrapper({
                     trigger={['hover']}
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='bottom'
-                    overlay={tooltip}
+                    overlay={isRhsOpen ? <></> : tooltip}
                 >
                     <button
                         id={buttonId}

--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -228,7 +228,7 @@ export default class PopoverListMembers extends React.Component {
                     <OverlayTrigger
                         delayShow={Constants.OVERLAY_TIME_DELAY}
                         placement='bottom'
-                        overlay={channelMembersTooltip}
+                        overlay={this.state.showPopover ? <></> : channelMembersTooltip}
                     >
                         <div>
                             <span

--- a/components/search_bar/index.jsx
+++ b/components/search_bar/index.jsx
@@ -13,7 +13,7 @@ import {
 } from 'actions/views/rhs';
 import {autocompleteChannelsForSearch} from 'actions/channel_actions';
 import {autocompleteUsersInTeam} from 'actions/user_actions';
-import {getRhsState, getSearchTerms, getIsSearchingTerm} from 'selectors/rhs';
+import {getRhsState, getSearchTerms, getIsSearchingTerm, getIsRhsOpen} from 'selectors/rhs';
 import {RHSStates} from 'utils/constants';
 
 import SearchBar from './search_bar.jsx';
@@ -26,6 +26,7 @@ function mapStateToProps(state) {
         searchTerms: getSearchTerms(state),
         isMentionSearch: rhsState === RHSStates.MENTION,
         isFlaggedPosts: rhsState === RHSStates.FLAG,
+        isRhsOpen: getIsRhsOpen(state),
     };
 }
 

--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -32,6 +32,7 @@ export default class SearchBar extends React.Component {
         showMentionFlagBtns: PropTypes.bool,
         isFocus: PropTypes.bool,
         isSideBarRight: PropTypes.bool,
+        isRhsOpen: PropTypes.bool,
         actions: PropTypes.shape({
             updateSearchTerms: PropTypes.func,
             showSearchResults: PropTypes.func,
@@ -197,6 +198,7 @@ export default class SearchBar extends React.Component {
                     buttonId={this.props.isSideBarRight ? 'sbrChannelHeaderMentionButton' : 'channelHeaderMentionButton'}
                     onClick={this.searchMentions}
                     tooltipKey={'recentMentions'}
+                    isRhsOpen={this.props.isRhsOpen}
                 />
             );
 
@@ -212,6 +214,7 @@ export default class SearchBar extends React.Component {
                     buttonId={this.props.isSideBarRight ? 'sbrChannelHeaderFlagButton' : 'channelHeaderFlagButton'}
                     onClick={this.getFlagged}
                     tooltipKey={'flaggedPosts'}
+                    isRhsOpen={this.props.isRhsOpen}
                 />
             );
         }

--- a/plugins/channel_header_plug/channel_header_plug.jsx
+++ b/plugins/channel_header_plug/channel_header_plug.jsx
@@ -165,7 +165,7 @@ export default class ChannelHeaderPlug extends React.PureComponent {
                         <OverlayTrigger
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='bottom'
-                            overlay={(
+                            overlay={this.state.dropdownOpen ? <></> : (
                                 <Tooltip id='removeIcon'>
                                     <div aria-hidden={true}>
                                         <FormattedMessage


### PR DESCRIPTION
#### Summary
Hides the tooltips that are displayed when the user clicks on a channel popover item and the dropdown is displayed

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-22670

Fix versions
v5.22 (April 2020)