### PR TITLE
[MM-22715] - Fix line-height for emojis on Catalina OS

### DIFF
--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -26,10 +26,10 @@
 
     &--unicode {
         font-size: 21px;
-        line-height: 1.3;
 
         .os--windows & {
             font-size: 16px;
+            line-height: 1.3;
         }
     }
 }


### PR DESCRIPTION

#### Summary
Removes the added line-height for devices apart from windows OS in order to not cut off the emojis on Catalina OS

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22715
Fix version: 5.22.0