### PR TITLE
[MM-22962] Expose group mentions in the system console UI

### DIFF
--- a/components/admin_console/permission_schemes_settings/guest_permissions_tree/__snapshots__/guest_permissions_tree.test.jsx.snap
+++ b/components/admin_console/permission_schemes_settings/guest_permissions_tree/__snapshots__/guest_permissions_tree.test.jsx.snap
@@ -57,6 +57,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
               "remove_reaction",
             ],
           },
+          "use_group_mentions",
         ]
       }
       readOnly={false}
@@ -136,6 +137,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
               "remove_reaction",
             ],
           },
+          "use_group_mentions",
         ]
       }
       readOnly={false}
@@ -215,6 +217,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
               "remove_reaction",
             ],
           },
+          "use_group_mentions",
         ]
       }
       readOnly={true}
@@ -294,6 +297,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
               "remove_reaction",
             ],
           },
+          "use_group_mentions",
         ]
       }
       readOnly={false}
@@ -373,6 +377,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
               "remove_reaction",
             ],
           },
+          "use_group_mentions",
         ]
       }
       readOnly={false}
@@ -456,6 +461,7 @@ exports[`components/admin_console/permission_schemes_settings/permission_tree sh
               "remove_reaction",
             ],
           },
+          "use_group_mentions",
         ]
       }
       readOnly={false}

--- a/components/admin_console/permission_schemes_settings/guest_permissions_tree/guest_permissions_tree.jsx
+++ b/components/admin_console/permission_schemes_settings/guest_permissions_tree/guest_permissions_tree.jsx
@@ -54,6 +54,7 @@ export default class GuestPermissionsTree extends React.Component {
                     Permissions.REMOVE_REACTION,
                 ],
             },
+            Permissions.USE_GROUP_MENTIONS,
         ];
     }
 

--- a/components/admin_console/permission_schemes_settings/permission_schemes_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_schemes_settings.jsx
@@ -328,6 +328,8 @@ t('admin.permissions.permission.revoke_user_access_token.description');
 t('admin.permissions.permission.revoke_user_access_token.name');
 t('admin.permissions.permission.upload_file.description');
 t('admin.permissions.permission.upload_file.name');
+t('admin.permissions.permission.use_group_mentions.description');
+t('admin.permissions.permission.use_group_mentions.name')
 t('admin.permissions.permission.view_team.description');
 t('admin.permissions.permission.view_team.name');
 t('admin.permissions.permission.edit_others_posts.description');

--- a/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.jsx
@@ -39,6 +39,7 @@ const GUEST_INCLUDED_PERMISSIONS = [
     Permissions.DELETE_POST,
     Permissions.ADD_REACTION,
     Permissions.REMOVE_REACTION,
+    Permissions.USE_GROUP_MENTIONS,
 ];
 
 export default class PermissionSystemSchemeSettings extends React.Component {

--- a/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.jsx
+++ b/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.jsx
@@ -102,6 +102,7 @@ export default class PermissionsTree extends React.Component {
                             Permissions.REMOVE_REACTION,
                         ],
                     },
+                    Permissions.USE_GROUP_MENTIONS,
                 ],
             },
             {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1089,6 +1089,8 @@
   "admin.permissions.permission.revoke_user_access_token.name": "Revoke user access token",
   "admin.permissions.permission.upload_file.description": "Upload file",
   "admin.permissions.permission.upload_file.name": "Upload file",
+  "admin.permissions.permission.use_group_mentions.description": "Notify group members with a group mention",
+  "admin.permissions.permission.use_group_mentions.name": "Group Mentions",
   "admin.permissions.permission.view_team.description": "View team",
   "admin.permissions.permission.view_team.name": "View team",
   "admin.permissions.permissionSchemes": "Permission Schemes",

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -632,6 +632,7 @@ export const PermissionsScope = {
     [Permissions.DELETE_EMOJIS]: 'team_scope',
     [Permissions.DELETE_OTHERS_EMOJIS]: 'team_scope',
     [Permissions.USE_CHANNEL_MENTIONS]: 'channel_scope',
+    [Permissions.USE_GROUP_MENTIONS]: 'channel_scope',
 };
 
 export const DefaultRolePermissions = {
@@ -668,6 +669,7 @@ export const DefaultRolePermissions = {
         Permissions.LIST_PUBLIC_TEAMS,
         Permissions.JOIN_PUBLIC_TEAMS,
         Permissions.USE_CHANNEL_MENTIONS,
+        Permissions.USE_GROUP_MENTIONS,
     ],
     channel_admin: [
         Permissions.MANAGE_CHANNEL_ROLES,


### PR DESCRIPTION
#### Summary
Exposes the group mentions permission in the system console UI 
Defaults to Off for guests and true for members

#### Screenshots
![Screen Shot 2020-03-17 at 9 36 12 PM](https://user-images.githubusercontent.com/3207297/76916641-76297400-6897-11ea-8eb5-5dd54449bba0.png)
