### PR TITLE
[MM-22212] Update manage_members from server after switching channel privacy

### DIFF
--- a/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
@@ -125,7 +125,7 @@ export default class ChannelDetails extends React.Component<ChannelDetailsProps,
                 then(() => actions.getChannel(channelID)).
                 then(() => this.setState({groups: this.props.groups}))
             );
-            actionsToAwait.push(actions.getChannelModerations(channelID).then(() => this.updateChannelPermissions()));
+            actionsToAwait.push(actions.getChannelModerations(channelID).then(() => this.restrictChannelMentions()));
         }
 
         if (channel.team_id) {
@@ -142,7 +142,8 @@ export default class ChannelDetails extends React.Component<ChannelDetailsProps,
         await Promise.all(actionsToAwait);
     }
 
-    private updateChannelPermissions() {
+    private restrictChannelMentions() {
+        // Disabling use_channel_mentions on every role that create_post is either disabled or has a value of false
         let channelPermissions = this.props.channelPermissions;
         const currentCreatePostRoles: any = channelPermissions!.find((element) => element.name === Permissions.CHANNEL_MODERATED_PERMISSIONS.CREATE_POST)?.['roles'];
         for (const channelRole of Object.keys(currentCreatePostRoles)) {
@@ -407,7 +408,7 @@ export default class ChannelDetails extends React.Component<ChannelDetailsProps,
         if (result.error) {
             serverError = <FormError error={result.error.message}/>;
         }
-        this.updateChannelPermissions();
+        this.restrictChannelMentions();
 
         let privacyChanging = isPrivacyChanging;
         if (serverError == null) {

--- a/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
@@ -388,12 +388,15 @@ export default class ChannelDetails extends React.Component<ChannelDetailsProps,
                 }
             };
         });
-        const result = await actions.patchChannelModerations(channelID, patchChannelPermissionsArray);
-        if (result.error) {
-            serverError = <FormError error={result.error.message}/>;
-        } else {
-            actions.getChannelModerations(channelID).then(() => this.updateChannelPermissions());
-        }
+
+        await actions.patchChannelModerations(channelID, patchChannelPermissionsArray)
+            .then(((result: {data: any; error?: Error}) => {
+                if (result.error) {
+                    serverError = <FormError error={result.error.message}/>;
+                }
+                this.updateChannelPermissions();
+            })
+        );
 
         let privacyChanging = isPrivacyChanging;
         if (serverError == null) {

--- a/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
@@ -389,14 +389,13 @@ export default class ChannelDetails extends React.Component<ChannelDetailsProps,
             };
         });
 
-        await actions.patchChannelModerations(channelID, patchChannelPermissionsArray)
-            .then(((result: {data: any; error?: Error}) => {
+        await actions.patchChannelModerations(channelID, patchChannelPermissionsArray).
+            then(((result: {data: any; error?: Error}) => {
                 if (result.error) {
                     serverError = <FormError error={result.error.message}/>;
                 }
                 this.updateChannelPermissions();
-            })
-        );
+            }));
 
         let privacyChanging = isPrivacyChanging;
         if (serverError == null) {


### PR DESCRIPTION
#### Summary
- Updates the value of `manage_members` from the server after the user switches the channel privacy 
- Also fixes a bug where `isPrivacyChanging` would remain true even after submitting the form

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/13813

#### Screenshots
![captured](https://user-images.githubusercontent.com/3207297/76991966-dca6a480-6920-11ea-80ce-283ade81ec6e.gif)
