### PR TITLE
[MM-22937] Fix Edge case by using includes instead of contains

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1459,7 +1459,7 @@ export function fillArray(value, length) {
 // Slightly modified from http://stackoverflow.com/questions/6848043/how-do-i-detect-a-file-is-being-dragged-rather-than-a-draggable-element-on-my-pa
 export function isFileTransfer(files) {
     if (UserAgent.isInternetExplorer() || UserAgent.isEdge()) {
-        return files.types != null && files.types.contains('Files');
+        return files.types != null && files.types.includes('Files');
     }
 
     return files.types != null && (files.types.indexOf ? files.types.indexOf('Files') !== -1 : files.types.contains('application/x-moz-file'));


### PR DESCRIPTION
#### Summary
- Fixes an issue where dragging and dropping a file on pre-chromium edge would result in console errors and the overlay not appearing
- Edge does not support `.contains` so replacing it with `.includes` fixes the drag and drop issue 
- This issue is only reproducible on pre-chromium edge.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22937