### PR TITLE
[MM-23447] Fixes swith teams shortcut after reorder teams feature was added

### DIFF
--- a/components/legacy_team_sidebar/components/team_button.jsx
+++ b/components/legacy_team_sidebar/components/team_button.jsx
@@ -227,6 +227,7 @@ class TeamButton extends React.Component {
                             className={`team-container ${teamClass}`}
                         >
                             {teamButton}
+                            {orderIndicator}
                         </div>
                     );
                 }}

--- a/components/legacy_team_sidebar/legacy_team_sidebar_controller.jsx
+++ b/components/legacy_team_sidebar/legacy_team_sidebar_controller.jsx
@@ -117,7 +117,7 @@ export default class LegacyTeamSidebar extends React.Component {
     handleKeyDown = (e) => {
         if ((e.ctrlKey || e.metaKey) && e.altKey) {
             const {currentTeamId} = this.props;
-            const teams = filterAndSortTeamsByDisplayName(this.props.myTeams, this.props.locale);
+            const teams = filterAndSortTeamsByDisplayName(this.props.myTeams, this.props.locale, this.props.userTeamsOrderPreference);
 
             if (this.switchToPrevOrNextTeam(e, currentTeamId, teams)) {
                 return;
@@ -205,6 +205,8 @@ export default class LegacyTeamSidebar extends React.Component {
                     active={team.id === this.props.currentTeamId}
                     displayName={team.display_name}
                     unread={member.msg_count > 0}
+                    order={index + 1}
+                    showOrder={this.state.showOrder}
                     mentions={member.mention_count}
                     teamIconUrl={Utils.imageURLForTeam(team)}
                     switchTeam={this.props.actions.switchTeam}


### PR DESCRIPTION
#### Summary
The merge of https://github.com/mattermost/mattermost-webapp/pull/3678 didn't play well with the new team drag&drop feature, not showing the indicators when pressing `Ctrl + Alt` and not taking into account the user's team order when using the shortcut.

This PR fixes both issues

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23447