### PR TITLE
[MM-23429] Fixed an issue where the new sidebar will not load with a DM with a bot

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
@@ -35,6 +35,14 @@ type State = {
 };
 
 class SidebarDirectChannel extends React.PureComponent<Props, State> {
+    constructor(props: Props) {
+        super(props);
+
+        this.state = {
+            svgErrorUrl: null,
+        };
+    }
+
     handleLeaveChannel = (callback: () => void) => {
         const id = this.props.channel.teammate_id;
         const category = Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;


### PR DESCRIPTION
#### Summary
When loading the new Experimental Channel Sidebar, if you have a DM with a bot, you will get a white screen. This was caused by the state not being initialized when the component was loaded. This PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23429
