### PR TITLE
[MM-23101] - Fix error in RHS posts with emoji

### DIFF
--- a/components/rhs_comment/index.js
+++ b/components/rhs_comment/index.js
@@ -15,6 +15,7 @@ import {isSystemMessage} from 'mattermost-redux/utils/post_utils';
 
 import {markPostAsUnread, emitShortcutReactToLastPostFrom} from 'actions/post_actions.jsx';
 import {isEmbedVisible} from 'selectors/posts';
+import {getEmojiMap} from 'selectors/emojis';
 
 import {isArchivedChannel} from 'utils/channel_utils';
 import {Preferences} from 'utils/constants';
@@ -47,6 +48,7 @@ function isConsecutivePost(state, ownProps) {
 function mapStateToProps(state, ownProps) {
     const getReactionsForPost = makeGetReactionsForPost();
     const getDisplayName = makeGetDisplayName();
+    const emojiMap = getEmojiMap(state);
 
     const config = getConfig(state);
     const enableEmojiPicker = config.EnableEmojiPicker === 'true';
@@ -69,6 +71,7 @@ function mapStateToProps(state, ownProps) {
         isFlagged: get(state, Preferences.CATEGORY_FLAGGED_POST, ownProps.post.id, null) != null,
         compactDisplay: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.MESSAGE_DISPLAY, Preferences.MESSAGE_DISPLAY_DEFAULT) === Preferences.MESSAGE_DISPLAY_COMPACT,
         shortcutReactToLastPostEmittedFrom,
+        emojiMap,
     };
 }
 

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -72,6 +72,7 @@ class RhsComment extends React.PureComponent {
              */
             emitShortcutReactToLastPostFrom: PropTypes.func
         }),
+        emojiMap: PropTypes.object.isRequired,
     };
 
     constructor(props) {
@@ -271,8 +272,8 @@ class RhsComment extends React.PureComponent {
     }
 
     handlePostFocus = () => {
-        const {post, author, reactions, isFlagged} = this.props;
-        this.setState({currentAriaLabel: PostUtils.createAriaLabelForPost(post, author, isFlagged, reactions, this.props.intl)});
+        const {post, author, reactions, isFlagged, intl, emojiMap} = this.props;
+        this.setState({currentAriaLabel: PostUtils.createAriaLabelForPost(post, author, isFlagged, reactions, intl, emojiMap)});
     }
 
     render() {

--- a/components/rhs_comment/rhs_comment.test.jsx
+++ b/components/rhs_comment/rhs_comment.test.jsx
@@ -8,6 +8,7 @@ import {Posts} from 'mattermost-redux/constants';
 import {shallowWithIntl} from 'tests/helpers/intl-test-helper';
 
 import RhsComment from 'components/rhs_comment/rhs_comment.jsx';
+import EmojiMap from 'utils/emoji_map';
 
 jest.mock('utils/post_utils.jsx', () => ({
     isEdited: jest.fn().mockReturnValue(true),
@@ -62,6 +63,7 @@ describe('components/RhsComment', () => {
         actions: {
             markPostAsUnread: jest.fn(),
         },
+        emojiMap: new EmojiMap(new Map())
     };
 
     test('should match snapshot', () => {


### PR DESCRIPTION
#### Summary
Fixes the JS error caused by not passing emojiMap to createAriaLabelForPost in rhs_comment.jsx

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23101

Fix versions
v5.22 (April 2020)
