### PR TITLE
[MM-23414] Fix up multiselect styling

### DIFF
--- a/components/multiselect/__snapshots__/multiselect.test.tsx.snap
+++ b/components/multiselect/__snapshots__/multiselect.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`components/multiselect/multiselect should match snapshot 1`] = `
     className="filter-row filter-row--full"
   >
     <div
-      className="multi-select__container react-select""
+      className="multi-select__container react-select"
     >
       <StateManager
         className=""

--- a/components/multiselect/__snapshots__/multiselect.test.tsx.snap
+++ b/components/multiselect/__snapshots__/multiselect.test.tsx.snap
@@ -8,11 +8,11 @@ exports[`components/multiselect/multiselect should match snapshot 1`] = `
     className="filter-row filter-row--full"
   >
     <div
-      className="multi-select__container react-select"
+      className="multi-select__container"
     >
       <StateManager
         className=""
-        classNamePrefix="react-select"
+        classNamePrefix="multi-select"
         components={
           Object {
             "IndicatorsContainer": [Function],
@@ -197,11 +197,11 @@ exports[`components/multiselect/multiselect should match snapshot for page 2 1`]
     className="filter-row filter-row--full"
   >
     <div
-      className="multi-select__container react-select"
+      className="multi-select__container"
     >
       <StateManager
         className=""
-        classNamePrefix="react-select"
+        classNamePrefix="multi-select"
         components={
           Object {
             "IndicatorsContainer": [Function],

--- a/components/multiselect/__snapshots__/multiselect.test.tsx.snap
+++ b/components/multiselect/__snapshots__/multiselect.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`components/multiselect/multiselect should match snapshot 1`] = `
     className="filter-row filter-row--full"
   >
     <div
-      className="multi-select__container"
+      className="multi-select__container react-select""
     >
       <StateManager
         className=""
@@ -197,7 +197,7 @@ exports[`components/multiselect/multiselect should match snapshot for page 2 1`]
     className="filter-row filter-row--full"
   >
     <div
-      className="multi-select__container"
+      className="multi-select__container react-select"
     >
       <StateManager
         className=""

--- a/components/multiselect/multiselect.tsx
+++ b/components/multiselect/multiselect.tsx
@@ -362,7 +362,7 @@ export default class MultiSelect<T extends Value> extends React.Component<Props<
         return (
             <div className='filtered-user-list'>
                 <div className='filter-row filter-row--full'>
-                    <div className='multi-select__container react-select'>
+                    <div className='multi-select__container'>
                         <ReactSelect
                             id='selectItems'
                             ref={this.reactSelectRef as React.RefObject<any>} // type of ref on @types/react-select is outdated
@@ -387,7 +387,7 @@ export default class MultiSelect<T extends Value> extends React.Component<Props<
                             getOptionLabel={this.props.ariaLabelRenderer}
                             aria-label={this.props.placeholderText}
                             className={this.state.a11yActive ? 'multi-select__focused' : ''}
-                            classNamePrefix='react-select'
+                            classNamePrefix='multi-select'
                         />
                         <SaveButton
                             id='saveItems'
@@ -439,7 +439,7 @@ const nullComponent = () => null;
 const paddedComponent = (WrappedComponent: any) => {
     return (props: {data: any}) => {
         return (
-            <div style={{paddingRight: '5px', paddingLeft: '5px', borderRight: '1px solid rgba(0, 126, 255, 0.24)'}}>
+            <div style={{paddingLeft: '10px'}}>
                 <WrappedComponent {...props}/>
             </div>
         );

--- a/components/multiselect/multiselect.tsx
+++ b/components/multiselect/multiselect.tsx
@@ -362,7 +362,7 @@ export default class MultiSelect<T extends Value> extends React.Component<Props<
         return (
             <div className='filtered-user-list'>
                 <div className='filter-row filter-row--full'>
-                    <div className='multi-select__container'>
+                    <div className='multi-select__container react-select'>
                         <ReactSelect
                             id='selectItems'
                             ref={this.reactSelectRef as React.RefObject<any>} // type of ref on @types/react-select is outdated

--- a/sass/components/_multi-select.scss
+++ b/sass/components/_multi-select.scss
@@ -4,12 +4,72 @@
     display: table;
     padding: 0 15px;
     width: 100%;
+    vertical-align: top;
 
     .btn {
         display: table-cell;
         height: 36px;
         min-width: 60px;
         vertical-align: top;
+    }
+
+    .multi-select__control {
+        background: v(center-channel-bg);
+        border-color: v(center-channel-color-20);
+
+        &:hover {
+            border-color: v(button-bg);
+
+            .multi-select__indicator {
+                opacity: .8;
+            }
+        }
+    }
+
+    .multi-select__control--is-focused {
+        box-shadow: 0 0 0 1px v(button-bg);
+        border-color: v(button-bg);
+
+        &:hover {
+            box-shadow: 0 0 0 1px v(button-bg);
+        }
+    }
+
+    .multi-select__input {
+        color: v(center-channel-color);
+    }
+
+    .multi-select__multi-value {
+        align-items: center;
+        background: var(--center-channel-color-10);
+        padding: 2px;
+        border-radius: 16px;
+        color: var(--center-channel-color);
+        margin: 4px;
+        &:nth-last-child(2) {
+            margin: 4px 0px 4px 4px;
+        }
+    }
+
+    .multi-select__multi-value__remove {
+        cursor: pointer;
+        span {
+            height: 16px;
+            width: 16px;
+            display: flex;
+        }
+        &:hover {
+            background: none;
+        }
+        svg {
+            height: 16px;
+            width: 16px;
+            fill: var(--center-channel-color-60);
+            &:hover {
+                fill: var(--center-channel-color-80);
+            }
+            opacity: .6;
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
- The original issue was just that the dark mode styles were too dark - the cause of which i traced back to https://github.com/mattermost/mattermost-webapp/pull/5011
- Turns out the select input of this modal never modified its colours to match the current theme so I made some changes to its styles to look good in both dark and light themes
- A lot of the styles were borrowed heavily from `/components/widgets/inputs/user_emails_input.scss` (from the invite team members select list) 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23414

#### Before 
![Screen Shot 2020-03-19 at 5 01 19 PM](https://user-images.githubusercontent.com/3207297/77114664-4c8d5b80-6a03-11ea-8f94-e75bed971a98.png)
![Screen Shot 2020-03-19 at 5 00 59 PM](https://user-images.githubusercontent.com/3207297/77114672-4d25f200-6a03-11ea-88ae-5071f85cccf9.png)

#### After
![Screen Shot 2020-03-19 at 5 02 11 PM](https://user-images.githubusercontent.com/3207297/77114723-66c73980-6a03-11ea-85bd-30b1532e55c4.png)
![Screen Shot 2020-03-19 at 5 02 03 PM](https://user-images.githubusercontent.com/3207297/77114726-675fd000-6a03-11ea-9232-6654bda0d8f2.png)


