### PR TITLE
MM-22757 Fix for date toast placement in web mobile view

### DIFF
--- a/actions/views/channel.js
+++ b/actions/views/channel.js
@@ -327,3 +327,12 @@ export function markChannelAsReadOnFocus(channelId) {
         dispatch(markChannelAsRead(channelId));
     };
 }
+
+export function updateToastStatus(status) {
+    return (dispatch) => {
+        dispatch({
+            type: ActionTypes.UPDATE_TOAST_STATUS,
+            data: status,
+        });
+    };
+}

--- a/actions/views/channel.test.js
+++ b/actions/views/channel.test.js
@@ -519,4 +519,15 @@ describe('channel view actions', () => {
             expect(markChannelAsRead).not.toHaveBeenCalled();
         });
     });
+
+    describe('updateToastStatus', () => {
+        test('should disptach updateToastStatus action with the true as argument', async () => {
+            await store.dispatch(Actions.updateToastStatus(true));
+
+            expect(store.getActions()).toEqual([{
+                data: true,
+                type: 'UPDATE_TOAST_STATUS'
+            }]);
+        });
+    });
 });

--- a/components/post_view/floating_timestamp/__snapshots__/floating_timestamp.test.jsx.snap
+++ b/components/post_view/floating_timestamp/__snapshots__/floating_timestamp.test.jsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/post_view/FloatingTimestamp should match snapshot 1`] = `
+<div
+  className="post-list__timestamp scrolling toastAdjustment"
+  data-testid="floatingTimestamp"
+>
+  <div>
+    <span>
+      <injectIntl(RecentDate)
+        day="2-digit"
+        month="short"
+        value={1234}
+        weekday="short"
+        year="numeric"
+      />
+    </span>
+  </div>
+</div>
+`;

--- a/components/post_view/floating_timestamp/floating_timestamp.jsx
+++ b/components/post_view/floating_timestamp/floating_timestamp.jsx
@@ -14,22 +14,24 @@ export default class FloatingTimestamp extends React.PureComponent {
             PropTypes.instanceOf(Date),
             PropTypes.number,
         ]).isRequired,
+        toastPresent: PropTypes.bool,
         isRhsPost: PropTypes.bool,
-        stylesOverride: PropTypes.object,
     }
 
     render() {
-        if (!this.props.isMobile) {
+        const {isMobile, createAt, isScrolling, isRhsPost, toastPresent} = this.props;
+
+        if (!isMobile) {
             return null;
         }
 
-        if (this.props.createAt === 0) {
+        if (createAt === 0) {
             return null;
         }
 
         const dateString = (
             <RecentDate
-                value={this.props.createAt}
+                value={createAt}
                 weekday='short'
                 day='2-digit'
                 month='short'
@@ -38,18 +40,18 @@ export default class FloatingTimestamp extends React.PureComponent {
         );
 
         let className = 'post-list__timestamp';
-        if (this.props.isScrolling) {
+        if (isScrolling) {
             className += ' scrolling';
         }
 
-        if (this.props.isRhsPost) {
+        if (isRhsPost) {
             className += ' rhs';
         }
 
         return (
             <div
                 className={className}
-                style={this.props.stylesOverride}
+                style={toastPresent ? {top: '50px'} : null}
                 data-testid='floatingTimestamp'
             >
                 <div>

--- a/components/post_view/floating_timestamp/floating_timestamp.jsx
+++ b/components/post_view/floating_timestamp/floating_timestamp.jsx
@@ -48,10 +48,13 @@ export default class FloatingTimestamp extends React.PureComponent {
             className += ' rhs';
         }
 
+        if (toastPresent) {
+            className += ' toastAdjustment';
+        }
+
         return (
             <div
                 className={className}
-                style={toastPresent ? {top: '50px'} : null}
                 data-testid='floatingTimestamp'
             >
                 <div>

--- a/components/post_view/floating_timestamp/floating_timestamp.jsx
+++ b/components/post_view/floating_timestamp/floating_timestamp.jsx
@@ -3,6 +3,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import classNames from 'classnames';
 
 import RecentDate from 'components/recent_date';
 
@@ -21,11 +22,7 @@ export default class FloatingTimestamp extends React.PureComponent {
     render() {
         const {isMobile, createAt, isScrolling, isRhsPost, toastPresent} = this.props;
 
-        if (!isMobile) {
-            return null;
-        }
-
-        if (createAt === 0) {
+        if (!isMobile || createAt === 0) {
             return null;
         }
 
@@ -39,22 +36,15 @@ export default class FloatingTimestamp extends React.PureComponent {
             />
         );
 
-        let className = 'post-list__timestamp';
-        if (isScrolling) {
-            className += ' scrolling';
-        }
-
-        if (isRhsPost) {
-            className += ' rhs';
-        }
-
-        if (toastPresent) {
-            className += ' toastAdjustment';
-        }
+        const classes = classNames('post-list__timestamp', {
+            scrolling: isScrolling,
+            rhs: isRhsPost,
+            toastAdjustment: toastPresent,
+        });
 
         return (
             <div
-                className={className}
+                className={classes}
                 data-testid='floatingTimestamp'
             >
                 <div>

--- a/components/post_view/floating_timestamp/floating_timestamp.test.jsx
+++ b/components/post_view/floating_timestamp/floating_timestamp.test.jsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import FloatingTimestamp from './floating_timestamp.jsx';
+
+describe('components/post_view/FloatingTimestamp', () => {
+    const baseProps = {
+        isScrolling: true,
+        isMobile: true,
+        createAt: 1234,
+        toastPresent: true,
+        isRhsPost: false,
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(<FloatingTimestamp {...baseProps}/>);
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.hasClass('toastAdjustment')).toBe(true);
+    });
+});

--- a/components/post_view/floating_timestamp/index.js
+++ b/components/post_view/floating_timestamp/index.js
@@ -6,6 +6,8 @@ import {connect} from 'react-redux';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import * as PostListUtils from 'mattermost-redux/utils/post_list';
 
+import {getToastStatus} from 'selectors/views/channel';
+
 import FloatingTimestamp from './floating_timestamp';
 
 function mapStateToProps(state, ownProps) {
@@ -18,8 +20,10 @@ function mapStateToProps(state, ownProps) {
 
     const post = getPost(state, postId);
 
+    const toastPresent = getToastStatus(state);
     return {
         createAt: post ? post.create_at : 0,
+        toastPresent,
     };
 }
 

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -494,7 +494,7 @@ class PostList extends React.PureComponent {
         this.props.actions.updateNewMessagesAtInChannel(this.props.channelId, lastViewedAt);
     }
 
-    renderToastsAndFloatingTimestamp = (width) => {
+    renderToasts = (width) => {
         return (
             <ToastWrapper
                 atLatestPost={this.props.atLatestPost}
@@ -510,13 +510,7 @@ class PostList extends React.PureComponent {
                 channelId={this.props.channelId}
                 focusedPostId={this.props.focusedPostId}
                 initScrollOffsetFromBottom={this.state.initScrollOffsetFromBottom}
-            >
-                <FloatingTimestamp
-                    isScrolling={this.state.isScrolling}
-                    isMobile={true}
-                    postId={this.state.topPostId}
-                />
-            </ToastWrapper>
+            />
         );
     }
 
@@ -540,6 +534,11 @@ class PostList extends React.PureComponent {
             >
                 {this.state.isMobile && (
                     <React.Fragment>
+                        <FloatingTimestamp
+                            isScrolling={this.state.isScrolling}
+                            isMobile={true}
+                            postId={this.state.topPostId}
+                        />
                         <ScrollToBottomArrows
                             isScrolling={this.state.isScrolling}
                             atBottom={this.state.atBottom}
@@ -569,7 +568,7 @@ class PostList extends React.PureComponent {
                             <AutoSizer>
                                 {({height, width}) => (
                                     <React.Fragment>
-                                        <div>{this.state.atBottom !== null && this.renderToastsAndFloatingTimestamp(width)}</div>
+                                        <div>{this.state.atBottom !== null && this.renderToasts(width)}</div>
                                         <DynamicSizeList
                                             ref={this.listRef}
                                             height={height}

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -510,7 +510,13 @@ class PostList extends React.PureComponent {
                 channelId={this.props.channelId}
                 focusedPostId={this.props.focusedPostId}
                 initScrollOffsetFromBottom={this.state.initScrollOffsetFromBottom}
-            />
+            >
+                <FloatingTimestamp
+                    isScrolling={this.state.isScrolling}
+                    isMobile={true}
+                    postId={this.state.topPostId}
+                />
+            </ToastWrapper>
         );
     }
 
@@ -534,11 +540,6 @@ class PostList extends React.PureComponent {
             >
                 {this.state.isMobile && (
                     <React.Fragment>
-                        <FloatingTimestamp
-                            isScrolling={this.state.isScrolling}
-                            isMobile={true}
-                            postId={this.state.topPostId}
-                        />
                         <ScrollToBottomArrows
                             isScrolling={this.state.isScrolling}
                             atBottom={this.state.atBottom}

--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -494,7 +494,7 @@ class PostList extends React.PureComponent {
         this.props.actions.updateNewMessagesAtInChannel(this.props.channelId, lastViewedAt);
     }
 
-    renderToasts = (width) => {
+    renderToastsAndFloatingTimestamp = (width) => {
         return (
             <ToastWrapper
                 atLatestPost={this.props.atLatestPost}
@@ -569,7 +569,7 @@ class PostList extends React.PureComponent {
                             <AutoSizer>
                                 {({height, width}) => (
                                     <React.Fragment>
-                                        <div>{this.state.atBottom !== null && this.renderToasts(width)}</div>
+                                        <div>{this.state.atBottom !== null && this.renderToastsAndFloatingTimestamp(width)}</div>
                                         <DynamicSizeList
                                             ref={this.listRef}
                                             height={height}

--- a/components/toast_wrapper/index.jsx
+++ b/components/toast_wrapper/index.jsx
@@ -2,12 +2,15 @@
 // See LICENSE.txt for license information.
 
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {createSelector} from 'reselect';
 import {Posts} from 'mattermost-redux/constants';
 import {getAllPosts, getPostIdsInChannel} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {makePreparePostIdsForPostList} from 'mattermost-redux/utils/post_list';
 import {countCurrentChannelUnreadMessages, isManuallyUnread} from 'mattermost-redux/selectors/entities/channels';
+
+import {updateToastStatus} from 'actions/views/channel';
 
 import ToastWrapper from './toast_wrapper.jsx';
 
@@ -67,4 +70,12 @@ function makeMapStateToProps() {
     };
 }
 
-export default connect(makeMapStateToProps)(ToastWrapper);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            updateToastStatus,
+        }, dispatch),
+    };
+}
+
+export default connect(makeMapStateToProps, mapDispatchToProps)(ToastWrapper);

--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -270,7 +270,7 @@ class ToastWrapper extends React.PureComponent {
         };
 
         const archiveToastProps = {
-            show: Boolean(this.state.showMessageHistoryToast),
+            show: Boolean(showMessageHistoryToast),
             width,
             onDismiss: this.hideArchiveToast,
             onClick: this.scrollToLatestMessages,

--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -115,7 +115,7 @@ class ToastWrapper extends React.PureComponent {
     componentDidMount() {
         this.mounted = true;
         const {showUnreadToast, showNewMessagesToast, showMessageHistoryToast} = this.state;
-        const toastPresent = showUnreadToast || showNewMessagesToast || showMessageHistoryToast;
+        const toastPresent = Boolean(showUnreadToast || showNewMessagesToast || showMessageHistoryToast);
         document.addEventListener('keydown', this.handleShortcut);
         this.props.actions.updateToastStatus(toastPresent);
     }

--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -153,7 +153,7 @@ class ToastWrapper extends React.PureComponent {
                                   prevState.showMessageHistoryToast !== showMessageHistoryToast;
 
         if (toastStateChanged) {
-            const toastPresent = showUnreadToast || showNewMessagesToast || showMessageHistoryToast;
+            const toastPresent = Boolean(showUnreadToast || showNewMessagesToast || showMessageHistoryToast);
             actions.updateToastStatus(toastPresent);
         }
     }

--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -32,6 +32,7 @@ class ToastWrapper extends React.PureComponent {
         scrollToNewMessage: PropTypes.func,
         scrollToLatestMessages: PropTypes.func,
         updateLastViewedBottomAt: PropTypes.func,
+        children: PropTypes.element
     };
 
     static defaultProps = {
@@ -229,14 +230,18 @@ class ToastWrapper extends React.PureComponent {
     }
 
     render() {
+        const {atLatestPost, atBottom, width, lastViewedAt, children} = this.props;
+        const {showUnreadToast, showNewMessagesToast, showMessageHistoryToast, unreadCount} = this.state;
+        const toastPresent = showUnreadToast || showNewMessagesToast || showMessageHistoryToast;
+
         let unreadToastProps = {
             show: false,
-            width: this.props.width,
+            width,
         };
 
         const archiveToastProps = {
-            show: this.state.showMessageHistoryToast,
-            width: this.props.width,
+            show: showMessageHistoryToast,
+            width,
             onDismiss: this.hideArchiveToast,
             onClick: this.scrollToLatestMessages,
             onClickMessage: Utils.localizeMessage('postlist.toast.scrollToBottom', 'Jump to recents'),
@@ -244,30 +249,31 @@ class ToastWrapper extends React.PureComponent {
             extraClasses: 'toast__history',
         };
 
-        if (this.state.showUnreadToast && this.state.unreadCount > 0) {
+        if (showUnreadToast && unreadCount > 0) {
             unreadToastProps = {
                 ...unreadToastProps,
                 onDismiss: this.hideUnreadToast,
                 onClick: this.scrollToLatestMessages,
                 onClickMessage: Utils.localizeMessage('postlist.toast.scrollToBottom', 'Jump to recents'),
                 show: true,
-                showActions: !this.props.atLatestPost || (this.props.atLatestPost && !this.props.atBottom),
+                showActions: !atLatestPost || (atLatestPost && !atBottom),
             };
-        } else if (this.state.showNewMessagesToast) {
+        } else if (showNewMessagesToast) {
             unreadToastProps = {
                 ...unreadToastProps,
                 onDismiss: this.hideNewMessagesToast,
                 onClick: this.scrollToNewMessage,
                 onClickMessage: Utils.localizeMessage('postlist.toast.scrollToLatest', 'Jump to new messages'),
                 show: true,
-                showActions: !this.props.atLatestPost || (this.props.atLatestPost && !this.props.atBottom),
+                showActions: !atLatestPost || (atLatestPost && !atBottom),
             };
         }
 
         return (
             <React.Fragment>
+                {React.cloneElement(children, {toastPresent})}
                 <Toast {...unreadToastProps}>
-                    {this.newMessagesToastText(this.state.unreadCount, this.props.lastViewedAt)}
+                    {this.newMessagesToastText(unreadCount, lastViewedAt)}
                 </Toast>
                 <Toast {...archiveToastProps}>
                     {this.archiveToastText()}

--- a/components/toast_wrapper/toast_wrapper.test.jsx
+++ b/components/toast_wrapper/toast_wrapper.test.jsx
@@ -32,6 +32,9 @@ describe('components/ToastWrapper', () => {
         scrollToLatestMessages: jest.fn(),
         updateLastViewedBottomAt: jest.fn(),
         lastViewedAt: 12344,
+        actions: {
+            updateToastStatus: jest.fn(),
+        }
     };
 
     describe('unread count logic', () => {
@@ -386,6 +389,22 @@ describe('components/ToastWrapper', () => {
             expect(wrapper.state('showNewMessagesToast')).toBe(true);
             wrapper.setProps({postListIds: baseProps.postListIds});
             expect(wrapper.state('showNewMessagesToast')).toBe(false);
+        });
+
+        test('Should call updateToastStatus on toasts state change', () => {
+            const props = {
+                ...baseProps,
+                unreadCountInChannel: 10,
+                newRecentMessagesCount: 5
+            };
+            const updateToastStatus = baseProps.actions.updateToastStatus;
+
+            const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
+            expect(wrapper.state('showUnreadToast')).toBe(true);
+            expect(updateToastStatus).toHaveBeenCalledWith(true);
+            wrapper.setProps({atBottom: true, atLatestPost: true});
+            expect(updateToastStatus).toHaveBeenCalledTimes(2);
+            expect(updateToastStatus).toHaveBeenCalledWith(false);
         });
     });
 });

--- a/reducers/views/channel.js
+++ b/reducers/views/channel.js
@@ -139,6 +139,17 @@ function lastGetPosts(state = {}, action) {
     }
 }
 
+function toastStatus(state = {}, action) {
+    switch (action.type) {
+    case ActionTypes.SELECT_CHANNEL_WITH_MEMBER:
+        return false;
+    case ActionTypes.UPDATE_TOAST_STATUS:
+        return action.data;
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
     postVisibility,
     lastChannelViewTime,
@@ -147,4 +158,5 @@ export default combineReducers({
     mobileView,
     keepChannelIdAsUnread,
     lastGetPosts,
+    toastStatus,
 });

--- a/reducers/views/channel.js
+++ b/reducers/views/channel.js
@@ -139,7 +139,7 @@ function lastGetPosts(state = {}, action) {
     }
 }
 
-function toastStatus(state = {}, action) {
+function toastStatus(state = false, action) {
     switch (action.type) {
     case ActionTypes.SELECT_CHANNEL_WITH_MEMBER:
         return false;

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -315,6 +315,10 @@
         top: 98px;
     }
 
+    &.toastAdjustment {
+        top: 50px;
+    }
+
     > div {
         @include border-radius(3px);
         @include font-smoothing(initial);

--- a/selectors/views/channel.js
+++ b/selectors/views/channel.js
@@ -2,3 +2,4 @@
 // See LICENSE.txt for license information.
 
 export const getLastPostsApiTimeForChannel = (state, channelId) => state.views.channel.lastGetPosts[channelId];
+export const getToastStatus = (state) => state.views.channel.toastStatus;

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -193,6 +193,7 @@ export const ActionTypes = keyMirror({
     POST_UNREAD_SUCCESS: null,
 
     SET_UNREAD_FILTER_ENABLED: null,
+    UPDATE_TOAST_STATUS: null,
 });
 
 export const PostRequestTypes = keyMirror({


### PR DESCRIPTION
#### Summary
Push the toast by 50px when toast is present

Issue: `FloatingTimestamp` component need to know if any toasts are present in the UI. toasts state is only available in ToastWrapper as of now.

Solutions:
1. Either use DOM manipulation like we do in few places of codebase and add a class when toast is present with `add.classList`
2. Add a redux state to keep track of toast and use a selector 
3. Use something like ReactClone and get the required prop from `ToastWrapper`.
4. We could have `FloatingTimestamp` in ToastWrapper 

i went with 3 reasons being
1. Really hacky and msot places we use in codebase tend to fail and cause regressions 
2. Feel like too much of work for such a small use case
4. need to add couple more props to ToastWrapper so it can be passed to  `FloatingTimestamp`

#### Ticket Link
![Mar-20-2020 03-38-41](https://user-images.githubusercontent.com/4973621/77119375-58593c00-6a5c-11ea-882d-61884dbbc4e2.gif)
https://mattermost.atlassian.net/browse/MM-22757
