### PR TITLE
[MM-23428] - Check for single new lines in channel header popover

### DIFF
--- a/components/channel_header/__snapshots__/channel_header.test.jsx.snap
+++ b/components/channel_header/__snapshots__/channel_header.test.jsx.snap
@@ -1326,6 +1326,7 @@ exports[`components/ChannelHeader should render properly when populated with cha
             <Overlay
               animation={[Function]}
               onEnter={[Function]}
+              onHide={[Function]}
               placement="bottom"
               rootClose={true}
               show={false}

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -484,7 +484,7 @@ class ChannelHeader extends React.PureComponent {
                         >{popoverContent}</Overlay>
 
                         <Markdown
-                            message={headerText.replace(/\n/, '\n\n')}
+                            message={headerText.replace(/\n/g, '\n\n')}
                             options={this.getHeaderMarkdownOptions(channelNamesMap)}
                         />
                     </span>

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -462,7 +462,7 @@ class ChannelHeader extends React.PureComponent {
                         ref={this.headerPopoverTextMeasurerRef}
                     >
                         <Markdown
-                            message={headerText.replace(/\n{2,}/g, ' ').replace(/\n/, ' ')}
+                            message={headerText.replace(/\n+/g, ' ')}
                             options={this.getHeaderMarkdownOptions(channelNamesMap)}
                         /></div>
                     <span

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -442,7 +442,7 @@ class ChannelHeader extends React.PureComponent {
                         onClick={this.handleFormattedTextClick}
                     >
                         <Markdown
-                            message={headerText}
+                            message={headerText.replace(/\n/, '\n\n')}
                             options={this.getPopoverMarkdownOptions(channelNamesMap)}
                         />
                     </span>
@@ -484,7 +484,7 @@ class ChannelHeader extends React.PureComponent {
                         >{popoverContent}</Overlay>
 
                         <Markdown
-                            message={headerText}
+                            message={headerText.replace(/\n/, '\n\n')}
                             options={this.getHeaderMarkdownOptions(channelNamesMap)}
                         />
                     </span>

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -462,7 +462,7 @@ class ChannelHeader extends React.PureComponent {
                         ref={this.headerPopoverTextMeasurerRef}
                     >
                         <Markdown
-                            message={headerText.replace(/\n+/g, ' ')}
+                            message={headerText.replace(/\n+/g, '\n\n')}
                             options={this.getHeaderMarkdownOptions(channelNamesMap)}
                         /></div>
                     <span

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -462,7 +462,7 @@ class ChannelHeader extends React.PureComponent {
                         ref={this.headerPopoverTextMeasurerRef}
                     >
                         <Markdown
-                            message={headerText.replace(/\n+/g, '\n\n')}
+                            message={headerText.replace(/\n+/g, ' ')}
                             options={this.getHeaderMarkdownOptions(channelNamesMap)}
                         /></div>
                     <span

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -262,7 +262,7 @@ class ChannelHeader extends React.PureComponent {
         const headerDescriptionRect = this.headerDescriptionRef.current.getBoundingClientRect();
         const headerPopoverTextMeasurerRect = this.headerPopoverTextMeasurerRef.current.getBoundingClientRect();
 
-        if (headerPopoverTextMeasurerRect.width > headerDescriptionRect.width || headerText.match(/\n{2,}/g, ' ')) {
+        if (headerPopoverTextMeasurerRect.width > headerDescriptionRect.width || headerText.match(/\n{2,}/g)) {
             this.setState({showChannelHeaderPopover: true});
         }
     }
@@ -462,7 +462,7 @@ class ChannelHeader extends React.PureComponent {
                         ref={this.headerPopoverTextMeasurerRef}
                     >
                         <Markdown
-                            message={headerText.replace(/\n{2,}/g, ' ')}
+                            message={headerText.replace(/\n{2,}/g, ' ').replace(/\n/, ' ')}
                             options={this.getHeaderMarkdownOptions(channelNamesMap)}
                         /></div>
                     <span
@@ -480,6 +480,7 @@ class ChannelHeader extends React.PureComponent {
                             target={this.headerDescriptionRef.current}
                             ref='headerOverlay'
                             onEnter={this.setPopoverOverlayWidth}
+                            onHide={() => this.setState({showChannelHeaderPopover: false})}
                         >{popoverContent}</Overlay>
 
                         <Markdown


### PR DESCRIPTION
#### Summary
After merging the functionality for the new channel header popover to expand on hover and also show only when the lines are longer than the space available, there was a bug introduced, when there are bullet points in the description but the first line was as long as the space available, you couldn't expand the popover. This fix checks for single new lines as well and it seems to cover all edge cases. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23428

Fix versions
v5.22 (April 2020)