### PR TITLE
Update mattermost-redux to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#5a06d1af25ca48927b9efe0d9c42c01c84e7839b",
-    "mattermost-redux": "github:mattermost/mattermost-redux#b82aca85930c690a04900e77c307d5615eddef01",
+    "mattermost-redux": "github:mattermost/mattermost-redux#5a0163bf77f29b2a17618b2f8529fd7171084205",
     "moment-timezone": "0.5.27",
     "pdfjs-dist": "2.0.489",
     "popmotion": "8.7.0",


### PR DESCRIPTION
### Summary

With my latest PR merged to master, an older version of redux was merged. This PR fixes this.