### PR TITLE
[MM-22777] - Fix dot menu highlight on desktop app

### DIFF
--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -166,8 +166,7 @@ export default class DotMenu extends React.PureComponent {
         }
     }
 
-    copyLink = (e) => {
-        e.preventDefault();
+    copyLink = () => {
         const postUrl = `${this.props.currentTeamUrl}/pl/${this.props.post.id}`;
 
         const clipboard = navigator.clipboard;


### PR DESCRIPTION
#### Summary
On desktop app, in some cases when you click on dot menu and copy permalink, the dot menu stayed highlighted. Removing preventDefault seems to fix the issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22777

Fix versions
v5.22 (April 2020)