### PR TITLE
MM-23458 Fix missing toast for unreads

### DIFF
--- a/components/post_view/post_list_virtualized/post_list_virtualized.jsx
+++ b/components/post_view/post_list_virtualized/post_list_virtualized.jsx
@@ -568,7 +568,7 @@ class PostList extends React.PureComponent {
                             <AutoSizer>
                                 {({height, width}) => (
                                     <React.Fragment>
-                                        <div>{this.state.atBottom !== null && this.renderToasts(width)}</div>
+                                        <div>{this.renderToasts(width)}</div>
                                         <DynamicSizeList
                                             ref={this.listRef}
                                             height={height}

--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -40,10 +40,8 @@ class ToastWrapper extends React.PureComponent {
 
     constructor(props) {
         super(props);
-        const showMessageHistoryToast = props.focusedPostId !== '' && (props.initScrollOffsetFromBottom > 1000 || !props.atLatestPost);
         this.state = {
             unreadCountInChannel: props.unreadCountInChannel,
-            showMessageHistoryToast,
         };
     }
 
@@ -57,7 +55,7 @@ class ToastWrapper extends React.PureComponent {
     }
 
     static getDerivedStateFromProps(props, prevState) {
-        let {showUnreadToast, showNewMessagesToast} = prevState;
+        let {showUnreadToast, showNewMessagesToast, showMessageHistoryToast} = prevState;
         let unreadCount;
 
         if (props.atLatestPost) {
@@ -71,6 +69,10 @@ class ToastWrapper extends React.PureComponent {
         // show unread toast on mount when channel is not at bottom and unread count greater than 0
         if (typeof showUnreadToast === 'undefined' && props.atBottom !== null) {
             showUnreadToast = unreadCount > 0 && !props.atBottom;
+        }
+
+        if (typeof showMessageHistoryToast === 'undefined' && props.focusedPostId !== '') {
+            showMessageHistoryToast = props.initScrollOffsetFromBottom > 1000 || !props.atLatestPost;
         }
 
         // show unread toast when a channel is marked as unread
@@ -99,6 +101,7 @@ class ToastWrapper extends React.PureComponent {
             showNewMessagesToast,
             lastViewedAt: props.lastViewedAt,
             channelMarkedAsUnread: props.channelMarkedAsUnread,
+            showMessageHistoryToast,
         };
     }
 
@@ -235,7 +238,7 @@ class ToastWrapper extends React.PureComponent {
         };
 
         const archiveToastProps = {
-            show: this.state.showMessageHistoryToast,
+            show: this.state.showMessageHistoryToast || false,
             width: this.props.width,
             onDismiss: this.hideArchiveToast,
             onClick: this.scrollToLatestMessages,

--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -238,7 +238,7 @@ class ToastWrapper extends React.PureComponent {
         };
 
         const archiveToastProps = {
-            show: this.state.showMessageHistoryToast || false,
+            show: Boolean(this.state.showMessageHistoryToast),
             width: this.props.width,
             onDismiss: this.hideArchiveToast,
             onClick: this.scrollToLatestMessages,


### PR DESCRIPTION
#### Summary
This should be a race cause with atBottom somehow changing this to be how it used to be in 5.20v. I changed the condition for not mounting the toasts till `atBottom` has an assigned value is because to have a simpler logic on mount. 
The change was made at https://github.com/mattermost/mattermost-webapp/pull/4825/files#diff-dacf7e63a72c7be54c626d95244525efL560 

* Not sure of the tests to add here, suggestions are welcome.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23458

#### Related Tickets
Ticket to fix the onScroll event in virt list https://mattermost.atlassian.net/browse/MM-23494
