### PR TITLE
[MM-20901] E2E tests for history arrows, channel switcher and new channel dropdown

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_direct_channel/sidebar_direct_channel.tsx
@@ -35,6 +35,14 @@ type State = {
 };
 
 class SidebarDirectChannel extends React.PureComponent<Props, State> {
+    constructor(props: Props) {
+        super(props);
+
+        this.state = {
+            svgErrorUrl: null,
+        };
+    }
+
     handleLeaveChannel = (callback: () => void) => {
         const id = this.props.channel.teammate_id;
         const category = Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;

--- a/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+import users from '../../fixtures/users';
+
+import {testWithConfig} from '../../support/hooks';
+
+import {getRandomInt} from '../../utils';
+
+const sysadmin = users.sysadmin;
+
+describe('Channel sidebar', () => {
+    testWithConfig({
+        ServiceSettings: {
+            ExperimentalChannelSidebarOrganization: 'default_on',
+        },
+    });
+
+    before(() => {
+        Cypress.config('userAgent', 'Mattermost/Electron');
+
+        cy.apiLogin('user-1');
+
+        cy.visit('/');
+    });
+
+    it('should go back and forth in history when clicking on the back/forward button', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('contain', teamName);
+
+        // # Click on Off Topic
+        cy.get('.SidebarChannel:contains(Off-Topic)').should('be.visible').click();
+
+        // * Verify that the channel changed
+        cy.url().should('include', `/${teamName}/channels/off-topic`);
+        cy.get('#channelHeaderTitle').should('contain', 'Off-Topic');
+
+        // # Click the Back button
+        cy.get('.SidebarChannelNavigator_backButton').should('be.visible').click();
+
+        // * Verify that the channel changed back to Town Square
+        cy.url().should('include', `/${teamName}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('contain', 'Town Square');
+
+        // # Click the Forward button
+        cy.get('.SidebarChannelNavigator_backButton').should('be.visible').click();
+
+        // * Verify that the channel changed back to Off-Topic
+        cy.url().should('include', `/${teamName}/channels/off-topic`);
+        cy.get('#channelHeaderTitle').should('contain', 'Off-Topic');
+    });
+});

--- a/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
@@ -49,7 +49,9 @@ describe('Channel sidebar', () => {
         cy.get('.SidebarChannelNavigator_jumpToButton').should('be.visible').click();
 
         // # Search for Off-Topic and press Enter
-        cy.get('.channel-switch__suggestion-box #quickSwitchInput').type('Off-Topic{enter}');
+        cy.get('.channel-switch__suggestion-box #quickSwitchInput').type('Off-Topic');
+        cy.get('.channel-switch__suggestion-box #suggestionList').should('be.visible');
+        cy.get('.channel-switch__suggestion-box #quickSwitchInput').type('{enter}');
 
         // * Verify that the channel switcher is closed and the active channel is now Off-Topic
         cy.get('.channel-switch__modal').should('not.be.visible');

--- a/e2e/cypress/integration/channel_sidebar/new_channel_dropdown_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/new_channel_dropdown_spec.js
@@ -1,0 +1,95 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+import {testWithConfig} from '../../support/hooks';
+
+import {getRandomInt} from '../../utils';
+
+describe('Channel sidebar', () => {
+    testWithConfig({
+        ServiceSettings: {
+            ExperimentalChannelSidebarOrganization: 'default_on',
+        },
+    });
+
+    before(() => {
+        cy.apiLogin('user-1');
+
+        cy.visit('/');
+    });
+
+    it('should create a new channel when using the new channel dropdown', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('contain', teamName);
+
+        // # Click the New Channel Dropdown button
+        cy.get('.AddChannelDropdown_dropdownButton').should('be.visible').click();
+
+        // # Click the Create New Channel dropdown item
+        cy.get('.AddChannelDropdown .MenuItem:contains(Create New Channel) button').should('be.visible').click();
+
+        // * Verify that the new channel modal is visible
+        cy.get('.new-channel__modal').should('be.visible');
+
+        // # Add the new channel name and press Create Channel
+        cy.get('.new-channel__modal #newChannelName').should('be.visible').type('Test Channel');
+        cy.get('.new-channel__modal #submitNewChannel').should('be.visible').click();
+
+        // Verify that new channel is in the sidebar and is active
+        cy.get('.new-channel__modal').should('not.be.visible');
+        cy.url().should('include', `/${teamName}/channels/test-channel`);
+        cy.get('#channelHeaderTitle').should('contain', 'Test Channel');
+        cy.get('.SidebarChannel.active:contains(Test Channel)').should('be.visible');
+    });
+
+    it('should join a new public channel when using the new channel dropdown', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('contain', teamName);
+
+        // # Switch to Off Topic
+        cy.visit(`/${teamName}/channels/off-topic`);
+
+        // # Wait for the channel to change
+        cy.get('#channelHeaderTitle').should('contain', 'Off-Topic');
+
+        // # Click on the channel menu and select Leave Channel
+        cy.get('#channelHeaderTitle').click();
+        cy.get('#channelLeaveChannel').click();
+
+        // * Verify that we've switched to Town Square
+        cy.url().should('include', `/${teamName}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('contain', 'Town Square');
+
+        // # Click the New Channel Dropdown button
+        cy.get('.AddChannelDropdown_dropdownButton').should('be.visible').click();
+
+        // # Click the Browse Channels dropdown item
+        cy.get('.AddChannelDropdown .MenuItem:contains(Browse Channels) button').should('be.visible').click();
+
+        // * Verify that the more channels modal is visible
+        cy.get('.more-modal').should('be.visible');
+
+        // Click the Off-Topic channel
+        cy.get('.more-modal button:contains(Off-Topic)').should('be.visible').click();
+
+        // Verify that new channel is in the sidebar and is active
+        cy.get('.more-modal').should('not.be.visible');
+        cy.url().should('include', `/${teamName}/channels/off-topic`);
+        cy.get('#channelHeaderTitle').should('contain', 'Off-Topic');
+        cy.get('.SidebarChannel.active:contains(Off-Topic)').should('be.visible');
+    });
+});


### PR DESCRIPTION
#### Summary
E2E tests for the new sidebar functionality.
I wasn't able to create one to test the history arrows, as they are specific to the desktop app and Cypress doesn't seem to have a reliable way to test the desktop app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20901
