### PR TITLE
[MM-22877] - Fix download image button tooltip

### DIFF
--- a/components/file_attachment/__snapshots__/filename_overlay.test.jsx.snap
+++ b/components/file_attachment/__snapshots__/filename_overlay.test.jsx.snap
@@ -64,7 +64,7 @@ exports[`components/file_attachment/FilenameOverlay should match snapshot, stand
           id="file-name__tooltip"
           placement="right"
         >
-          download
+          Download
         </Tooltip>
       }
       placement="top"
@@ -101,7 +101,7 @@ exports[`components/file_attachment/FilenameOverlay should match snapshot, with 
           id="file-name__tooltip"
           placement="right"
         >
-          download
+          Download
         </Tooltip>
       }
       placement="top"

--- a/components/file_attachment/filename_overlay.jsx
+++ b/components/file_attachment/filename_overlay.jsx
@@ -93,7 +93,7 @@ export default class FilenameOverlay extends React.PureComponent {
                             placement='top'
                             overlay={
                                 <Tooltip id='file-name__tooltip'>
-                                    {localizeMessage('view_image_popover.download', 'Download').toLowerCase()}
+                                    {localizeMessage('view_image_popover.download', 'Download')}
                                 </Tooltip>
                             }
                         >

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -438,6 +438,10 @@
         top: 0;
         width: 50px;
 
+        span {
+            padding-top: 12px;
+        }
+
         svg {
             @include opacity(.7);
             @include single-transition(all, .1s, linear);

--- a/sass/components/_files.scss
+++ b/sass/components/_files.scss
@@ -439,7 +439,7 @@
         width: 50px;
 
         span {
-            padding-top: 12px;
+            display: inline-block;
         }
 
         svg {


### PR DESCRIPTION
#### Summary
Fixes the download image tooltip that was off-centre because it was relating to the svg and not the whole button.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22877

Fix versions
v5.22 (April 2020)