### PR TITLE
[MM-23441] - Animate drag and drop handles to transition out on drag

### DIFF
--- a/components/legacy_team_sidebar/components/team_button.jsx
+++ b/components/legacy_team_sidebar/components/team_button.jsx
@@ -7,6 +7,7 @@ import {Tooltip} from 'react-bootstrap';
 import {injectIntl} from 'react-intl';
 import {Link} from 'react-router-dom';
 import {Draggable} from 'react-beautiful-dnd';
+import classNames from 'classnames';
 
 import {mark, trackEvent} from 'actions/diagnostics_actions.jsx';
 import Constants from 'utils/constants';
@@ -218,13 +219,13 @@ class TeamButton extends React.Component {
                 draggableId={teamId}
                 index={teamIndex}
             >
-                {(provided) => {
+                {(provided, snapshot) => {
                     return (
                         <div
                             ref={provided.innerRef}
                             {...provided.draggableProps}
                             {...provided.dragHandleProps}
-                            className={`team-container ${teamClass}`}
+                            className={classNames([`team-container ${teamClass}`, {isDragging: snapshot.isDragging}])}
                         >
                             {teamButton}
                             {orderIndicator}

--- a/sass/layout/_team-sidebar.scss
+++ b/sass/layout/_team-sidebar.scss
@@ -45,22 +45,27 @@
             text-align: center;
             width: 100%;
 
+            &.isDragging:before {
+                transform: translateX(-100%) scaleY(0);
+            }
+
             &:not(.special):before{
                 @include border-radius(4px);
                 content: '';
-                height: 0px;
+
+                height: 32px;
+                transform: translateX(-8px) scaleY(0);
+                transform-origin: center center;
                 position: absolute;
-                left: -8px;
-                top: 18px;
-                transition: all ease-in-out 0.1s;
+                top: 8px;
+                left: 0;
+                transition: all 0.1s;
                 width: 8px;
                 background: $black;
             }
 
             &:hover::before {
-                height: 32px;
-                left: -4px;
-                top: 8px;
+                transform: translateX(-4px) scaleY(1);
             }
 
             a {
@@ -100,13 +105,21 @@
                 left: -4px;
                 position: absolute;
                 top: 3px;
-                transition: all ease-in-out 0.1s;
                 width: 8px;
+                transform: translateX(0) scaleY(1);
             }
 
-            &.active:hover::before {
-                height: 32px;
-                top: 8px;
+            &.active {
+                &:hover::before {
+                    height: 32px;
+                    top: 8px;
+                }
+
+                &.isDragging {
+                    &::before {
+                        transform: translateX(-100%) scaleY(0);
+                    }
+                }
             }
 
             &.unread:before {


### PR DESCRIPTION
#### Summary
Add a transition out effect on the drag handle of the team icons when the dragging is in progress

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23441
v5.22 (April 2020)