### PR TITLE
MM-23513 Default autoclosing DMs to true with new sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5398,7 +5398,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true,
           "optional": true
@@ -7463,14 +7463,14 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true,
           "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "optional": true,
@@ -10717,7 +10717,10 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
       "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.63.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -11663,6 +11666,12 @@
         "postcss": "^7.0.14"
       }
     },
+    "icu4c-data": {
+      "version": "0.63.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.63.2.tgz",
+      "integrity": "sha512-vT6/47CcBzDemlhRzkL7dZLoNvuUWjjiuKZHMt5T4dbkKAqLBh7ZQ33GU13ecC/aIcMlIdBOqtF4uIYTgWML4Q==",
+      "dev": true
+    },
     "identity-obj-proxy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
@@ -12331,7 +12340,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "optional": true,
@@ -14202,8 +14211,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#5a0163bf77f29b2a17618b2f8529fd7171084205",
-      "from": "github:mattermost/mattermost-redux#5a0163bf77f29b2a17618b2f8529fd7171084205",
+      "version": "github:mattermost/mattermost-redux#697df2ceb165873ab81e4368a2a10dba7845a953",
+      "from": "github:mattermost/mattermost-redux#697df2ceb165873ab81e4368a2a10dba7845a953",
       "requires": {
         "core-js": "3.1.4",
         "form-data": "2.5.1",
@@ -15749,7 +15758,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#5a06d1af25ca48927b9efe0d9c42c01c84e7839b",
-    "mattermost-redux": "github:mattermost/mattermost-redux#5a0163bf77f29b2a17618b2f8529fd7171084205",
+    "mattermost-redux": "github:mattermost/mattermost-redux#697df2ceb165873ab81e4368a2a10dba7845a953",
     "moment-timezone": "0.5.27",
     "pdfjs-dist": "2.0.489",
     "popmotion": "8.7.0",


### PR DESCRIPTION
I misread [this line](https://github.com/mattermost/mattermost-redux/blob/master/src/utils/channel_utils.ts#L168) of the old channel selectors, so the new channel selectors treated an undefined value for the "autoclose unused DMs" setting as "false" previously. This fixes that, so people that didn't explicitly turn on the setting had their unused DMs reappear with the new sidebar.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23513

#### Related PRs
https://github.com/mattermost/mattermost-redux/pull/1093