### PR TITLE
MM-23203 Fix for missing new messages line on socket reconnect

### DIFF
--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -117,7 +117,7 @@ class ToastWrapper extends React.PureComponent {
         const prevPostsCount = prevProps.postListIds.length;
         const presentPostsCount = this.props.postListIds.length;
         const postsAddedAtBottom = presentPostsCount !== prevPostsCount && this.props.postListIds[0] !== prevProps.postListIds[0];
-        const notBottomWithLatestPosts = !this.props.atBottom && this.props.atLatestPost && presentPostsCount > 0;
+        const notBottomWithLatestPosts = this.props.atBottom === false && this.props.atLatestPost && presentPostsCount > 0;
 
         //Marking existing messages as read based on last time user reached to the bottom
         //This moves the new message indicator to the latest posts and keeping in sync with the toast count

--- a/components/toast_wrapper/toast_wrapper.test.jsx
+++ b/components/toast_wrapper/toast_wrapper.test.jsx
@@ -387,5 +387,54 @@ describe('components/ToastWrapper', () => {
             wrapper.setProps({postListIds: baseProps.postListIds});
             expect(wrapper.state('showNewMessagesToast')).toBe(false);
         });
+
+        test('Should call updateNewMessagesAtInChannel on addition of posts at the bottom of channel and user not at bottom', () => {
+            const props = {
+                ...baseProps,
+                atLatestPost: true,
+                postListIds: [
+                    'post2',
+                    'post3',
+                    PostListRowListIds.START_OF_NEW_MESSAGES,
+                    DATE_LINE + 1551711600000,
+                    'post4',
+                    'post5',
+                ],
+                atBottom: true,
+            };
+
+            const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
+
+            wrapper.setProps({atBottom: null});
+            wrapper.setProps({
+                postListIds: [
+                    'post1',
+                    'post2',
+                    'post3',
+                    PostListRowListIds.START_OF_NEW_MESSAGES,
+                    DATE_LINE + 1551711600000,
+                    'post4',
+                    'post5',
+                ]
+            });
+
+            //should not call if atBottom is null
+            expect(baseProps.updateNewMessagesAtInChannel).toHaveBeenCalledTimes(0);
+
+            wrapper.setProps({
+                atBottom: false,
+                postListIds: [
+                    'post0',
+                    'post1',
+                    'post2',
+                    'post3',
+                    PostListRowListIds.START_OF_NEW_MESSAGES,
+                    DATE_LINE + 1551711600000,
+                    'post4',
+                    'post5',
+                ],
+            });
+            expect(baseProps.updateNewMessagesAtInChannel).toHaveBeenCalledTimes(1);
+        });
     });
 });


### PR DESCRIPTION
#### Summary
  * Add an additional check to `atBottom` with `null`

Theoretically this could happen with this series of events
1. User switches channel to a previously visited out of sync channel(System from sleep)
2. atBottom value is not set yet but the posts from since API loads.

The condition `this.props.postListIds[0] !== prevProps.postListIds[0];` is true and `!this.props.atBottom` is also true making a call `updateNewMessagesAtInChannel` and updating the line.

It would have been perfect if the logic was considered only for new messages but atm it is not possible and has a high dev cost to it too. Possibly with upcoming changes to redux state idata .e marking channels out of sync can help.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23203
