### PR TITLE
[MM-23412] - Align mention and close icon horizontally

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -35,8 +35,8 @@
     .badge {
         background: var(--mention-bg);
         color: var(--mention-color);
-        margin-right: 20px;
-        height: 16px;
+        margin-right: 16px;
+        height: 17px;
         min-width: 16px;
     }
 
@@ -459,7 +459,7 @@
             width: 24px;
             height: 20px;
             line-height: 16px;
-            margin-right: 7px;
+            margin-right: 16px;
             text-align: center;
 
             &:hover {


### PR DESCRIPTION

#### Summary
Aligns the close and mention icon horizontally 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23412

Fix 5.22.0
