### PR TITLE
[MM-23445] - Fix chevron icon on Firefox

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -358,8 +358,6 @@
       
         i.icon-chevron-down {
             max-width: 16px;
-            max-height: 16px;
-            line-height: 18px;
 
             &.hide-arrow {
                 visibility: hidden;


### PR DESCRIPTION

#### Summary
Fixes the chevron icon positioning on firefox. From what I tested on Chrome and Safari, the max-height and line-height are redundant here as they get the line-height from the icons:before selector, but on firefox the specificity was different. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23445
