### PR TITLE
Update redux hash to redux release-5.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14202,8 +14202,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#37080534ede275915c028a8e783c6aef4882a640",
-      "from": "github:mattermost/mattermost-redux#37080534ede275915c028a8e783c6aef4882a640",
+      "version": "github:mattermost/mattermost-redux#da29aa57072011ceffbb76d95c1c9bd2efb07939",
+      "from": "github:mattermost/mattermost-redux#da29aa57072011ceffbb76d95c1c9bd2efb07939",
       "requires": {
         "core-js": "3.1.4",
         "form-data": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#5a06d1af25ca48927b9efe0d9c42c01c84e7839b",
-    "mattermost-redux": "github:mattermost/mattermost-redux#37080534ede275915c028a8e783c6aef4882a640",
+    "mattermost-redux": "github:mattermost/mattermost-redux#da29aa57072011ceffbb76d95c1c9bd2efb07939",
     "moment-timezone": "0.5.27",
     "pdfjs-dist": "2.0.489",
     "popmotion": "8.7.0",


### PR DESCRIPTION
#### Summary
Updates the mattermost-redux hash to the latest 5.22 commit as opposed to master

Commit for reference https://github.com/mattermost/mattermost-redux/commit/da29aa57072011ceffbb76d95c1c9bd2efb07939