### PR TITLE
[MM-23454] Re-enable mention count on desktop app server tabs

### DIFF
--- a/components/sidebar/sidebar_category_list/__snapshots__/sidebar_category_list.test.tsx.snap
+++ b/components/sidebar/sidebar_category_list/__snapshots__/sidebar_category_list.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`components/sidebar/sidebar_category_list should match snapshot 1`] = `
 <div
   className="SidebarNavContainer a11y__region"
   data-a11y-sort-order="7"
+  id="sidebar-left"
 >
   <UnreadChannelIndicator
     content={
@@ -76,6 +77,7 @@ exports[`components/sidebar/sidebar_category_list should match snapshot when unr
 <div
   className="SidebarNavContainer a11y__region disabled"
   data-a11y-sort-order="7"
+  id="sidebar-left"
 >
   <UnreadChannelIndicator
     content={

--- a/components/sidebar/sidebar_category_list/sidebar_category_list.tsx
+++ b/components/sidebar/sidebar_category_list/sidebar_category_list.tsx
@@ -349,7 +349,10 @@ export default class SidebarCategoryList extends React.PureComponent<Props, Stat
         );
 
         return (
+
+            // NOTE: id attribute added to temporarily support the desktop app's at-mention DOM scraping of the old sidebar
             <div
+                id='sidebar-left'
                 className={classNames('SidebarNavContainer a11y__region', {disabled: this.props.isUnreadFilterEnabled})}
                 data-a11y-sort-order='7'
             >

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
 exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match snapshot with aria label prefix and unread mentions 1`] = `
 <Link
   aria-label="channel_label aria_label_prefix_ 2 mentions"
-  className="SidebarLink"
+  className="SidebarLink unread-title"
   id="sidebarItem_"
   onClick={[Function]}
   to="http://a.fake.link"

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.test.tsx
@@ -34,6 +34,7 @@ describe('components/sidebar/sidebar_channel/sidebar_channel_link', () => {
         unreadMentions: 0,
         unreadMsgs: 0,
         showUnreadForMsgs: false,
+        isMuted: false,
     };
 
     test('should match snapshot', () => {

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -148,6 +148,9 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         );
 
         let element;
+
+        // NOTE: class added to temporarily support the desktop app's at-mention DOM scraping of the old sidebar
+        const oldUnreadClass = this.showChannelAsUnread() ? ' unread-title' : '';
         if (isDesktopApp()) {
             element = (
                 <CopyUrlContextMenu
@@ -155,7 +158,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
                     menuId={channel.id}
                 >
                     <button
-                        className={'btn btn-link SidebarLink'}
+                        className={`btn btn-link SidebarLink${oldUnreadClass}`}
                         aria-label={this.getAriaLabel()}
                         onClick={this.handleClick}
                     >
@@ -166,7 +169,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         } else {
             element = (
                 <Link
-                    className={'SidebarLink'}
+                    className={`SidebarLink${oldUnreadClass}`}
                     id={`sidebarItem_${channel.name}`}
                     aria-label={this.getAriaLabel()}
                     to={link}


### PR DESCRIPTION
#### Summary
With the new experimental channel sidebar, unread/at-mention counts on the Desktop App server tabs stopped working. The Desktop app is looking for a specific DOM element ID (`#sidebar-left`) and class (`unread-title`), which is no longer used with the new experimental channel sidebar. Temporarily adding the id and class to the new experimental channel sidebar so the Desktop App continues to function as expected.

Longer term, this should be fixed on the Desktop App side by removing the DOM scraping and adding proper communication between the Webapp and Desktop App.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23454

#### Screenshots

![image](https://user-images.githubusercontent.com/3245614/77537027-cdb97800-6e73-11ea-98b6-fdb952bd7a8c.png)
