### PR TITLE
[MM-23583] Fix all channel mentions getting highlighted even when they shouldn't

### DIFF
--- a/components/post_markdown/__snapshots__/post_markdown.test.jsx.snap
+++ b/components/post_markdown/__snapshots__/post_markdown.test.jsx.snap
@@ -47,11 +47,7 @@ exports[`components/PostMarkdown should correctly pass postId down 1`] = `
   imageProps={Object {}}
   isRHS={false}
   message="message"
-  options={
-    Object {
-      "mentionHighlight": true,
-    }
-  }
+  options={Object {}}
   postId="post_id"
   proxyImages={true}
 />

--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -63,7 +63,8 @@ export default class PostMarkdown extends React.PureComponent {
         const channelNamesMap = this.props.post && this.props.post.props && this.props.post.props.channel_mentions;
 
         let {message} = this.props;
-        const {post, options} = this.props;
+        const {post} = this.props;
+        const options = {...this.props.options};
 
         this.props.pluginHooks.forEach((o) => {
             if (o && o.hook && post) {


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
All channel mentions getting highlighted even when they shouldn't has been fixed in this PR. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23583

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![image](https://user-images.githubusercontent.com/17804942/77545942-8cc86000-6e81-11ea-9666-425bbdecfadb.png)
