### PR TITLE
[MM-23449] Remove extra line break in reaction overlay

### DIFF
--- a/components/post_view/reaction/__snapshots__/reaction.test.jsx.snap
+++ b/components/post_view/reaction/__snapshots__/reaction.test.jsx.snap
@@ -44,7 +44,6 @@ exports[`components/post_view/Reaction should disable add reaction when you do n
             }
           }
         />
-        <br />
       </Tooltip>
     }
     placement="top"
@@ -121,7 +120,6 @@ exports[`components/post_view/Reaction should disable remove reaction when you d
             }
           }
         />
-        <br />
       </Tooltip>
     }
     placement="top"
@@ -199,7 +197,6 @@ exports[`components/post_view/Reaction should match snapshot 1`] = `
             }
           }
         />
-        <br />
         <FormattedMessage
           defaultMessage="(click to add)"
           id="reaction.clickToAdd"
@@ -282,7 +279,6 @@ exports[`components/post_view/Reaction should match snapshot when a current user
             }
           }
         />
-        <br />
         <FormattedMessage
           defaultMessage="(click to remove)"
           id="reaction.clickToRemove"

--- a/components/post_view/reaction/reaction.jsx
+++ b/components/post_view/reaction/reaction.jsx
@@ -237,7 +237,6 @@ export default class Reaction extends React.PureComponent {
                     overlay={
                         <Tooltip id={`${this.props.post.id}-${this.props.emojiName}-reaction`}>
                             {tooltip}
-                            <br/>
                             {clickTooltip}
                         </Tooltip>
                     }


### PR DESCRIPTION
#### Summary
- Removes the line break present in the reaction overlay

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23449

#### Screenshots
![Screen Shot 2020-03-25 at 1 24 08 PM](https://user-images.githubusercontent.com/3207297/77566402-feada300-6e9b-11ea-8975-26d3eff12131.png)
