### PR TITLE
MM-23458 Add missing atBottom condition for showMessageHistoryToast

### DIFF
--- a/components/toast_wrapper/toast_wrapper.jsx
+++ b/components/toast_wrapper/toast_wrapper.jsx
@@ -78,7 +78,7 @@ class ToastWrapper extends React.PureComponent {
             showUnreadToast = unreadCount > 0 && !props.atBottom;
         }
 
-        if (typeof showMessageHistoryToast === 'undefined' && props.focusedPostId !== '') {
+        if (typeof showMessageHistoryToast === 'undefined' && props.focusedPostId !== '' && props.atBottom !== null) {
             showMessageHistoryToast = props.initScrollOffsetFromBottom > 1000 || !props.atLatestPost;
         }
 

--- a/components/toast_wrapper/toast_wrapper.test.jsx
+++ b/components/toast_wrapper/toast_wrapper.test.jsx
@@ -164,9 +164,12 @@ describe('components/ToastWrapper', () => {
                 ...baseProps,
                 focusedPostId: 'asdasd',
                 atLatestPost: false,
+                atBottom: null
             };
             const wrapper = shallowWithIntl(<ToastWrapper {...props}/>);
+            expect(wrapper.state('showMessageHistoryToast')).toBe(undefined);
 
+            wrapper.setProps({atBottom: false});
             expect(wrapper.state('showMessageHistoryToast')).toBe(true);
         });
 


### PR DESCRIPTION
#### Summary
Based on the latest changes from https://github.com/mattermost/mattermost-webapp/pull/5109 we also need a check for `atBottom` for archive toast which was missed in the previous PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23458
