### PR TITLE
[MM-23589] Fixed the handleRemovedUserEvent to wait for the user to leave the channel before redirecting

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -734,7 +734,7 @@ function handleUserAddedEvent(msg) {
     }
 }
 
-export function handleUserRemovedEvent(msg) {
+export async function handleUserRemovedEvent(msg) {
     const state = getState();
     const currentChannel = getCurrentChannel(state) || {};
     const currentUser = getCurrentUser(state);
@@ -746,6 +746,11 @@ export function handleUserRemovedEvent(msg) {
         if (msg.data.channel_id === rhsChannelId) {
             dispatch(closeRightHandSide());
         }
+
+        await dispatch({
+            type: ChannelTypes.LEAVE_CHANNEL,
+            data: {id: msg.data.channel_id, user_id: msg.broadcast.user_id},
+        });
 
         if (msg.data.channel_id === currentChannel.id) {
             if (msg.data.remover_id === msg.broadcast.user_id) {
@@ -768,10 +773,6 @@ export function handleUserRemovedEvent(msg) {
             }
         }
 
-        dispatch({
-            type: ChannelTypes.LEAVE_CHANNEL,
-            data: {id: msg.data.channel_id, user_id: msg.broadcast.user_id},
-        });
         if (isGuest(currentUser)) {
             dispatch(removeNotVisibleUsers());
         }

--- a/e2e/cypress/integration/websocket/handle_removed_user_spec.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user_spec.js
@@ -42,9 +42,10 @@ describe('Handle removed user - old sidebar', () => {
             const userId = res.body.id;
             return cy.removeUserFromChannel(channelId, userId);
         }).then(() => {
-            // * Verify that the channel changed back to Town Square
+            // * Verify that the channel changed back to Town Square and that Off-Topic has been removed
             cy.url().should('include', `/${teamName}/channels/town-square`);
             cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+            cy.get('.SidebarChannel:contains(Off-Topic)').should('not.exist');
         });
     });
 });

--- a/e2e/cypress/integration/websocket/handle_removed_user_spec.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user_spec.js
@@ -1,0 +1,96 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+import users from '../../fixtures/users';
+
+import {testWithConfig} from '../../support/hooks';
+
+import {getRandomInt} from '../../utils';
+
+describe('Handle removed user - old sidebar', () => {
+    before(() => {
+        cy.apiLogin('user-1');
+
+        cy.visit('/');
+    });
+
+    it('should be redirected to last channel when a user is removed from their current channel', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('be.visible').should('be.visible').should('contain', teamName);
+
+        // # Click on Off Topic
+        cy.get('.SidebarChannel:contains(Off-Topic)').should('be.visible').click();
+
+        // * Verify that the channel changed
+        cy.url().should('include', `/${teamName}/channels/off-topic`);
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Off-Topic');
+
+        // # Remove the Guest User from channel
+        let channelId;
+        cy.getCurrentChannelId().then((res) => {
+            channelId = res;
+            return cy.apiGetMe();
+        }).then((res) => {
+            const userId = res.body.id;
+            return cy.removeUserFromChannel(channelId, userId);
+        }).then(() => {
+            // * Verify that the channel changed back to Town Square
+            cy.url().should('include', `/${teamName}/channels/town-square`);
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+        });
+    });
+});
+
+describe('Handle removed user - new sidebar', () => {
+    testWithConfig({
+        ServiceSettings: {
+            ExperimentalChannelSidebarOrganization: 'default_on',
+        },
+    });
+
+    before(() => {
+        cy.apiLogin('user-1');
+
+        cy.visit('/');
+    });
+
+    it('should be redirected to last channel when a user is removed from their current channel', () => {
+        // # Start with a new team
+        const teamName = `team-${getRandomInt(999999)}`;
+        cy.createNewTeam(teamName, teamName);
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName').should('be.visible').should('be.visible').should('contain', teamName);
+
+        // # Click on Off Topic
+        cy.get('.SidebarChannel:contains(Off-Topic)').should('be.visible').click();
+
+        // * Verify that the channel changed
+        cy.url().should('include', `/${teamName}/channels/off-topic`);
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Off-Topic');
+
+        // # Remove the Guest User from channel
+        let channelId;
+        cy.getCurrentChannelId().then((res) => {
+            channelId = res;
+            return cy.apiGetMe();
+        }).then((res) => {
+            const userId = res.body.id;
+            return cy.removeUserFromChannel(channelId, userId);
+        }).then(() => {
+            // * Verify that the channel changed back to Town Square
+            cy.url().should('include', `/${teamName}/channels/town-square`);
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+        });
+    });
+});

--- a/e2e/cypress/integration/websocket/handle_removed_user_spec.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user_spec.js
@@ -7,8 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-import users from '../../fixtures/users';
-
 import {testWithConfig} from '../../support/hooks';
 
 import {getRandomInt} from '../../utils';


### PR DESCRIPTION
#### Summary
The websocket action for removing a user from a channel was dispatching the `LEAVE_CHANNEL` action too late, so that `redirectUserToDefaultTeam` would redirect the user back to the same channel they just left.

This PR fixes that behaviour and adds tests for the new and old sidebar (since the old sidebar handled this by calling `redirectUserToDefaultTeam` after the state had updated)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23589