### PR TITLE
MM-23577 Update More Unread Indicators after animations

### DIFF
--- a/components/sidebar/sidebar_category_list/__snapshots__/sidebar_category_list.test.tsx.snap
+++ b/components/sidebar/sidebar_category_list/__snapshots__/sidebar_category_list.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`components/sidebar/sidebar_category_list should match snapshot 1`] = `
   className="SidebarNavContainer a11y__region"
   data-a11y-sort-order="7"
   id="sidebar-left"
+  onTransitionEnd={[Function]}
 >
   <UnreadChannelIndicator
     content={
@@ -78,6 +79,7 @@ exports[`components/sidebar/sidebar_category_list should match snapshot when unr
   className="SidebarNavContainer a11y__region disabled"
   data-a11y-sort-order="7"
   id="sidebar-left"
+  onTransitionEnd={[Function]}
 >
   <UnreadChannelIndicator
     content={

--- a/components/sidebar/sidebar_category_list/sidebar_category_list.tsx
+++ b/components/sidebar/sidebar_category_list/sidebar_category_list.tsx
@@ -6,8 +6,8 @@ import {FormattedMessage} from 'react-intl';
 import Scrollbars from 'react-custom-scrollbars';
 import {Spring, SpringSystem} from 'rebound';
 import classNames from 'classnames';
+import debounce from 'lodash/debounce';
 
-import {debounce} from 'mattermost-redux/actions/helpers';
 import {Channel} from 'mattermost-redux/types/channels';
 import {ChannelCategory} from 'mattermost-redux/types/channel_categories';
 import {Team} from 'mattermost-redux/types/teams';

--- a/components/sidebar/sidebar_category_list/sidebar_category_list.tsx
+++ b/components/sidebar/sidebar_category_list/sidebar_category_list.tsx
@@ -7,6 +7,7 @@ import Scrollbars from 'react-custom-scrollbars';
 import {Spring, SpringSystem} from 'rebound';
 import classNames from 'classnames';
 
+import {debounce} from 'mattermost-redux/actions/helpers';
 import {Channel} from 'mattermost-redux/types/channels';
 import {ChannelCategory} from 'mattermost-redux/types/channel_categories';
 import {Team} from 'mattermost-redux/types/teams';
@@ -325,6 +326,10 @@ export default class SidebarCategoryList extends React.PureComponent<Props, Stat
         this.updateUnreadIndicators();
     }
 
+    onTransitionEnd = debounce(() => {
+        this.updateUnreadIndicators();
+    }, 100);
+
     render() {
         const {categories} = this.props;
         const renderedCategories = categories.map(this.renderCategory);
@@ -350,6 +355,7 @@ export default class SidebarCategoryList extends React.PureComponent<Props, Stat
                 id='sidebar-left'
                 className={classNames('SidebarNavContainer a11y__region', {disabled: this.props.isUnreadFilterEnabled})}
                 data-a11y-sort-order='7'
+                onTransitionEnd={this.onTransitionEnd}
             >
                 <UnreadChannelIndicator
                     name='Top'


### PR DESCRIPTION
@devinbinnie @bradjcoughlin Let me know what you think about the 100ms debounce time for this. We could probably drop it since all of the `onTransitionEnd` events from each child should come in faster than that, but I default to 100ms for this sort of thing.

I also haven't figured out a way to add tests for this since I haven't been able to reproduce it, but if anyone has any suggestions, I'd appreciate them.

@srkgupta I haven't been able to reproduce the exact issue as you're seeing it, but I'm not surprised there's some edge cases around the showing and hiding of those indicators. I've added some extra logic to update them after an animation happens, so hopefully this should reduce the chances that we run into an edge case like that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23577