### PR TITLE
MM-22825 Add E2E on skipping Slack-compatible interactive message response

### DIFF
--- a/e2e/cypress/integration/interactive_menu/slack_parsing_message_button_spec.js
+++ b/e2e/cypress/integration/interactive_menu/slack_parsing_message_button_spec.js
@@ -1,0 +1,110 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+/**
+* Note: This test requires webhook server running. Initiate `npm run start:webhook` to start.
+*/
+
+import TIMEOUTS from '../../fixtures/timeouts';
+
+let channel;
+let incomingWebhook;
+
+describe('Interactive Menu', () => {
+    before(() => {
+        cy.requireWebhookServer();
+
+        // # Login as sysadmin
+        cy.apiLogin('sysadmin');
+
+        // Set required ServiceSettings
+        const newSettings = {
+            ServiceSettings: {
+                AllowedUntrustedInternalConnections: 'localhost',
+                EnablePostUsernameOverride: true,
+                EnablePostIconOverride: true,
+            },
+        };
+        cy.apiUpdateConfig(newSettings);
+
+        // # Update teammate name display setting is set to default 'username'
+        cy.apiSaveTeammateNameDisplayPreference('username');
+        cy.apiSaveMessageDisplayPreference('clean');
+
+        // # Create and visit new channel and create incoming webhook
+        cy.createAndVisitNewChannel().then((data) => {
+            channel = data;
+
+            const newIncomingHook = {
+                channel_id: channel.id,
+                channel_locked: true,
+                description: 'Incoming webhook interactive menu',
+                display_name: 'menuIn' + Date.now(),
+            };
+
+            cy.apiCreateWebhook(newIncomingHook).then((hook) => {
+                incomingWebhook = hook;
+            });
+        });
+    });
+
+    it('matches elements', () => {
+        const payload = getPayload(Cypress.env().webhookBaseUrl);
+
+        // # Post an incoming webhook
+        cy.postIncomingWebhook({url: incomingWebhook.url, data: payload});
+
+        // # Click on "Skip Parsing" button
+        cy.findByText('Skip Parsing').should('be.visible').click({force: true});
+        cy.wait(TIMEOUTS.TINY);
+
+        // * Verify that it renders original "spoiler" text
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#postMessageText_${postId}`).should('have.html', '<p>a &lt; a | b &gt; a</p>');
+        });
+
+        // # Click on "Do Parsing" button
+        cy.findByText('Do Parsing').should('be.visible').click({force: true});
+        cy.wait(TIMEOUTS.TINY);
+
+        // * Verify that it renders markdown with link
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#postMessageText_${postId}`).should('have.html', '<p>a <a class="theme markdown__link" href="http://a" rel="noreferrer" target="_blank"> b </a> a</p>');
+        });
+    });
+});
+
+function getPayload(webhookBaseUrl) {
+    return {
+        attachments: [{
+            pretext: 'Slack-compatible interactive message response',
+            actions: [{
+                name: 'Skip Parsing',
+                integration: {
+                    url: `${webhookBaseUrl}/slack_compatible_message_response`,
+                    context: {
+                        action: 'show_spoiler',
+                        spoiler: 'a < a | b > a',
+                        skipSlackParsing: true,
+                    },
+                }
+            }, {
+                name: 'Do Parsing',
+                integration: {
+                    url: `${webhookBaseUrl}/slack_compatible_message_response`,
+                    context: {
+                        action: 'show_spoiler',
+                        spoiler: 'a < a | b > a',
+                        skipSlackParsing: false,
+                    },
+                },
+            }],
+        }],
+    };
+}

--- a/e2e/cypress/integration/interactive_menu/slack_parsing_message_button_spec.js
+++ b/e2e/cypress/integration/interactive_menu/slack_parsing_message_button_spec.js
@@ -54,7 +54,7 @@ describe('Interactive Menu', () => {
         });
     });
 
-    it('matches elements', () => {
+    it('should parse text into Slack-compatible markdown depending on "skip_slack_parsing" property on response', () => {
         const payload = getPayload(Cypress.env().webhookBaseUrl);
 
         // # Post an incoming webhook

--- a/e2e/webhook_serve.js
+++ b/e2e/webhook_serve.js
@@ -25,8 +25,19 @@ server.post('/simple_dialog_request', onSimpleDialogRequest);
 server.post('/user_and_channel_dialog_request', onUserAndChannelDialogRequest);
 server.post('/dialog_submit', onDialogSubmit);
 server.post('/boolean_dialog_request', onBooleanDialogRequest);
+server.post('/slack_compatible_message_response', postSlackCompatibleMessageResponse);
 
 server.listen(port, () => console.log(`Webhook test server listening on port ${port}!`)); // eslint-disable-line no-console
+
+function postSlackCompatibleMessageResponse(req, res) {
+    const {spoiler, skipSlackParsing} = req.body.context;
+
+    res.setHeader('Content-Type', 'application/json');
+    return res.json({
+        ephemeral_text: spoiler,
+        skip_slack_parsing: skipSlackParsing,
+    });
+}
 
 function postMessageMenus(req, res) {
     let responseData = {};


### PR DESCRIPTION
#### Summary
Test Steps:
Text: `a < a | b > a`

1. Create an interactive message buttons via webhook
2. Click on a message button that skips parsing
  - verify that it renders original "Text"
3. Click on a message button that do parsing
  - verify that it renders as Markdown link (based on Slack link parsing)

#### Ticket Link
JIRA ticket - https://mattermost.atlassian.net/browse/MM-22825

#### Related Pull Requests
- Has server changes (https://github.com/mattermost/mattermost-server/pull/13976)
