### PR TITLE
Fixed failures in Channel Moderation & Accessibility Tests

### DIFF
--- a/e2e/cypress/fixtures/account_setting_sections.json
+++ b/e2e/cypress/fixtures/account_setting_sections.json
@@ -32,6 +32,7 @@
       {"key": "languages", "label": "Language", "type": "dropdown"}
     ],
     "sidebar": [
+      {"key": "groupChannels", "label": "Channel Grouping and Sorting", "type": "multiple"},
       {"key": "channelSwitcher", "label": "Channel Switcher", "type": "radio"}
     ],
     "advanced": [

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation_spec.js
@@ -794,7 +794,7 @@ describe('Channel Moderation Test', () => {
         it('Effect of changing System Schemes on a Channel for which Channel Moderation Settings was never modified', () => {
             // # Reset system scheme to default and create a new channel to ensure that this channels moderation settings have never been modified
             const randomChannelName = 'NeverModifiedChannel' + getRandomInt(1000);
-            createNewChannel(randomChannelName, 'user-1');
+            createNewChannel(randomChannelName, 'sysadmin');
 
             goToSystemScheme();
             cy.get('#all_users-public_channel-manage_public_channel_members').click();
@@ -817,7 +817,7 @@ describe('Channel Moderation Test', () => {
         it('Effect of changing Team Override Schemes on a Channel for which Channel Moderation Settings was never modified', () => {
             // # Reset system scheme to default and create a new channel to ensure that this channels moderation settings have never been modified
             const randomChannelName = 'NeverModifiedChannel' + getRandomInt(1000);
-            createNewChannel(randomChannelName, 'user-1');
+            createNewChannel(randomChannelName, 'sysadmin');
             goToPermissionsAndCreateTeamOverrideScheme(`${randomChannelName}`);
             deleteOrEditTeamScheme(`${randomChannelName}`, 'edit');
             cy.get('#all_users-public_channel-manage_public_channel_members').click();

--- a/e2e/cypress/integration/enterprise/system_console/use_channel_mentions_system_scheme_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/use_channel_mentions_system_scheme_spec.js
@@ -165,13 +165,13 @@ describe('System Scheme Channel Mentions Permissions Test', () => {
         removePermission(usersTestId);
         saveConfig();
 
-        // * Ensure that the permission is removed from all roles
-        testIds.forEach((testId) => {
-            cy.findByTestId(testId).should('not.have.class', 'checked');
-        });
+        // * Ensure that the permission is not removed from all roles except All Members
+        cy.findByTestId(usersTestId).should('not.have.class', 'checked');
+        cy.findByTestId(channelTestId).should('have.class', 'checked');
+        cy.findByTestId(teamTestId).should('have.class', 'checked');
 
-        // # Enable permission for team admins and save
-        enablePermission(teamTestId);
+        // # Remove permission for channel admins and save
+        removePermission(channelTestId);
         saveConfig();
 
         // * Ensure that the permission is removed from all roles except team admins

--- a/e2e/cypress/integration/enterprise/system_console/use_channel_mentions_team_scheme_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/use_channel_mentions_team_scheme_spec.js
@@ -195,13 +195,13 @@ describe('Team Scheme Channel Mentions Permissions Test', () => {
             cy.get('#saveSetting').click();
             cy.visit(url);
 
-            // * Ensure that the permission is removed from all roles
-            testIds.forEach((testId) => {
-                cy.findByTestId(testId).should('not.have.class', 'checked');
-            });
+            // * Ensure that the permission is not removed for channel admins and team admins
+            cy.findByTestId(usersTestId).should('not.have.class', 'checked');
+            cy.findByTestId(channelTestId).should('have.class', 'checked');
+            cy.findByTestId(teamTestId).should('have.class', 'checked');
 
-            // # Enable permission for team admins and save
-            enablePermission(teamTestId);
+            // # Remove permission for channel admins and save
+            removePermission(channelTestId);
             cy.get('#saveSetting').click();
             cy.visit(url);
 


### PR DESCRIPTION
#### Summary
Fixed failures in channel_moderation_spec & accessibility_account_settings_spec
* channel_moderation_spec - Channel was created by a user and hence the user will be the Channel Admin and will not obey the Channel Moderation Settings. Modified the test to create channel as a different user. 
* accessibility_account_settings_spec - New Sidebar related Account setting was displayed. Updated the test to reflect the same. 
* use_channel_mentions_team_scheme_spec & use_channel_mentions_system_scheme_spec - A recent bug fix https://mattermost.atlassian.net/browse/MM-23430 caused changes in the expectations in the test. 

#### Ticket Link
NA. Fixed based on local & daily runs. 
