### PR TITLE
[MM-23635] Only load bot icon url when it's been updated

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_direct_channel/index.ts
+++ b/components/sidebar/sidebar_channel/sidebar_direct_channel/index.ts
@@ -25,12 +25,16 @@ type OwnProps = {
 /**
  * Gets the LHS bot icon url for a given botUser.
  */
-function botIconImageUrl(botUser: UserProfile) {
+function botIconImageUrl(botUser: UserProfile & {bot_last_icon_update?: number}) {
     if (!botUser) {
         return null;
     }
 
-    return `${Client4.getBotRoute(botUser.id)}/icon?_=${((botUser as any).bot_last_icon_update || 0)}`;
+    if (!(botUser.is_bot && botUser.bot_last_icon_update)) {
+        return null;
+    }
+
+    return `${Client4.getBotRoute(botUser.id)}/icon?_=${(botUser.bot_last_icon_update || 0)}`;
 }
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {


### PR DESCRIPTION
#### Summary
The new sidebar was missing some logic from the old one that was causing some issues with loading bot icon images. The logic has been fixed in this PR.

This one isn't easy to reproduce, but with this fix you shouldn't see issues loading the icons for bot users like the GitHub and JIRA bots.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23635