### PR TITLE
[MM-23641] Fixed a bad import of a redux component in new sidebar

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 
 import {Channel} from 'mattermost-redux/types/channels';
 
-import CopyUrlContextMenu from 'components/copy_url_context_menu/copy_url_context_menu';
+import CopyUrlContextMenu from 'components/copy_url_context_menu';
 import OverlayTrigger from 'components/overlay_trigger';
 
 import {mark, trackEvent} from 'actions/diagnostics_actions';


### PR DESCRIPTION
#### Summary
Was incorrectly importing `CopyUrlContextMenu`, so that clicking 'Copy Link' would throw a JS error. This PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23641