### PR TITLE
E2E: Set default config of TeamSettings.ExperimentalTownSquareIsReadOnly=false

### DIFF
--- a/e2e/cypress/fixtures/partial_default_config.json
+++ b/e2e/cypress/fixtures/partial_default_config.json
@@ -65,6 +65,7 @@
     "TeamSettings": {
         "EnableCustomBrand": false,
         "EnableOpenServer": true,
+        "ExperimentalTownSquareIsReadOnly": false,
         "ExperimentalViewArchivedChannels": false,
         "LockTeammateNameDisplay": false,
         "SiteName": "Mattermost",


### PR DESCRIPTION
#### Summary
This is a quick fix on several failing test on daily.

#### Ticket Link
none
