### PR TITLE
IS-299: Checkout server over HTTPS on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
 
             mkdir -p ~/.ssh/
             echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
-            git clone git@github.com:mattermost/mattermost-server.git
+            git clone https://github.com/mattermost/mattermost-server.git
 
             cd mattermost-server
             export MM_PACKAGE=https://pr-builds.mattermost.com/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}/mattermost-enterprise-linux-amd64.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,8 +162,6 @@ jobs:
           command: |
             export TAG="${CIRCLE_SHA1:0:7}"
 
-            mkdir -p ~/.ssh/
-            echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
             git clone https://github.com/mattermost/mattermost-server.git
 
             cd mattermost-server


### PR DESCRIPTION

#### Summary
Checkout the server repo over HTTPS on CircleCI to avoid `StrictHostKeyChecking=no`.

#### Ticket Link
https://mattermost.atlassian.net/browse/IS-299
