### PR TITLE
Don't compress already-compressed files, after uploaded, as it's very…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -194,7 +194,8 @@ var config = {
                 ],
             },
             {
-                test: /\.(png|eot|tiff|svg|woff2|woff|ttf|gif|mp3|jpg)$/,
+                // svg and ttf are certainly not compressed already
+                test: /\.(svg|ttf)$/,
                 use: [
                     {
                         loader: 'file-loader',
@@ -205,6 +206,20 @@ var config = {
                     {
                         loader: 'image-webpack-loader',
                         options: {},
+                    },
+                ],
+            },
+            {
+                // all these file formats are certainly already compressed
+                // There is virtually no disk space savings in compressing them again.
+                // tiff is a strange exception.  It's sometimes compressed.
+                test: /\.(png|eot|tiff|woff2|woff|gif|mp3|jpg)$/,
+                use: [
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            name: 'files/[hash].[ext]',
+                        },
                     },
                 ],
             },


### PR DESCRIPTION
…, very CPU-expensive!

Please read starting from here:
https://forum.mattermost.org/t/processing-during-image-upload/8655/7?u=esbeeb
Basically:
1) imagemin is a very inefficient way to compress things, compared to just zip (72x faster) or tar (30x faster) on the command line.
2) There is little to no disk space saved (like 1%), from compressing already-compressed image files.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->