### PR TITLE
[MM-23715] Modify all calls to imageURLForUser to pass a user id and default last_picture_update to 0

### DIFF
--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -39,6 +39,11 @@ export default class AddBot extends React.Component {
         bot: PropTypes.object,
 
         /**
+        *  Bot user
+        */
+        user: PropTypes.object,
+
+        /**
         *  Roles of the bot to edit (if editing)
         */
         roles: PropTypes.string,
@@ -402,7 +407,11 @@ export default class AddBot extends React.Component {
         );
         let imageStyles = null;
         if (this.props.bot && !this.state.pictureFile) {
-            imageURL = Utils.imageURLForUser(this.props.bot.user_id);
+            if (this.props.user) {
+                imageURL = Utils.imageURLForUser(this.props.user);
+            } else {
+                imageURL = Utils.imageURLForUser({id: this.props.bot.user_id});
+            }
         } else {
             imageURL = this.state.image;
             imageStyles = this.state.orientationStyles;

--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -408,9 +408,9 @@ export default class AddBot extends React.Component {
         let imageStyles = null;
         if (this.props.bot && !this.state.pictureFile) {
             if (this.props.user) {
-                imageURL = Utils.imageURLForUser(this.props.user);
+                imageURL = Utils.imageURLForUser(this.props.user.id, this.props.user.last_picture_update);
             } else {
-                imageURL = Utils.imageURLForUser({id: this.props.bot.user_id});
+                imageURL = Utils.imageURLForUser(this.props.bot.user_id);
             }
         } else {
             imageURL = this.state.image;

--- a/components/integrations/bots/bot.jsx
+++ b/components/integrations/bots/bot.jsx
@@ -449,7 +449,7 @@ export default class Bot extends React.PureComponent {
             );
         }
 
-        const imageURL = Utils.imageURLForUser(this.props.user);
+        const imageURL = Utils.imageURLForUser(this.props.user.id, this.props.user.last_picture_update);
 
         return (
             <div className='backstage-list__item'>

--- a/components/integrations/bots/bot.jsx
+++ b/components/integrations/bots/bot.jsx
@@ -45,6 +45,11 @@ export default class Bot extends React.PureComponent {
         owner: PropTypes.object,
 
         /**
+        * User of the bot we are displaying
+        */
+        user: PropTypes.object,
+
+        /**
         * The access tokens of the bot user
         */
         accessTokens: PropTypes.object.isRequired,
@@ -444,7 +449,7 @@ export default class Bot extends React.PureComponent {
             );
         }
 
-        const imageURL = Utils.imageURLForUser(this.props.bot.user_id);
+        const imageURL = Utils.imageURLForUser(this.props.user);
 
         return (
             <div className='backstage-list__item'>

--- a/components/integrations/bots/bot.test.jsx
+++ b/components/integrations/bots/bot.test.jsx
@@ -17,9 +17,13 @@ describe('components/integrations/bots/Bot', () => {
 
     it('regular bot', () => {
         const bot = TestHelper.fakeBot();
+        const user = {
+            id: bot.user_id,
+        };
         const wrapper = shallow(
             <Bot
                 bot={bot}
+                user={user}
                 owner={null}
                 accessTokens={{}}
                 team={team}
@@ -60,9 +64,13 @@ describe('components/integrations/bots/Bot', () => {
     it('disabled bot', () => {
         const bot = TestHelper.fakeBot();
         bot.delete_at = 100; // disabled
+        const user = {
+            id: bot.user_id,
+        };
         const wrapper = shallow(
             <Bot
                 bot={bot}
+                user={user}
                 owner={null}
                 accessTokens={{}}
                 team={team}
@@ -99,16 +107,20 @@ describe('components/integrations/bots/Bot', () => {
 
     it('bot with owner', () => {
         const bot = TestHelper.fakeBot();
-        const user = TestHelper.fakeUser();
+        const owner = TestHelper.fakeUser();
+        const user = {
+            id: bot.user_id,
+        };
         const wrapper = shallow(
             <Bot
                 bot={bot}
-                owner={user}
+                owner={owner}
+                user={user}
                 accessTokens={{}}
                 team={team}
             />
         );
-        expect(wrapper.contains(user.username)).toEqual(true);
+        expect(wrapper.contains(owner.username)).toEqual(true);
         expect(wrapper.contains('plugin')).toEqual(false);
 
         // if bot is not managed by plugin, ability to edit from UI is retained
@@ -135,7 +147,9 @@ describe('components/integrations/bots/Bot', () => {
     it('bot with access tokens', () => {
         const bot = TestHelper.fakeBot();
         const tokenId = TestHelper.generateId();
-
+        const user = {
+            id: bot.user_id,
+        };
         const accessTokens = {
             tokenId: {
                 id: tokenId,
@@ -149,6 +163,7 @@ describe('components/integrations/bots/Bot', () => {
             <Bot
                 bot={bot}
                 owner={null}
+                user={user}
                 accessTokens={accessTokens}
                 team={team}
             />
@@ -172,6 +187,9 @@ describe('components/integrations/bots/Bot', () => {
     it('bot with disabled access tokens', () => {
         const bot = TestHelper.fakeBot();
         const tokenId = TestHelper.generateId();
+        const user = {
+            id: bot.user_id,
+        };
 
         const accessTokens = {
             tokenId: {
@@ -186,6 +204,7 @@ describe('components/integrations/bots/Bot', () => {
             <Bot
                 bot={bot}
                 owner={null}
+                user={user}
                 accessTokens={accessTokens}
                 team={team}
             />

--- a/components/integrations/bots/bots.jsx
+++ b/components/integrations/bots/bots.jsx
@@ -32,6 +32,11 @@ export default class Bots extends React.PureComponent {
         */
         owners: PropTypes.object.isRequired,
 
+        /**
+        *  Map from botUserId to user.
+        */
+        users: PropTypes.object.isRequired,
+
         createBots: PropTypes.bool,
 
         actions: PropTypes.shape({
@@ -149,6 +154,7 @@ export default class Bots extends React.PureComponent {
                 key={bot.user_id}
                 bot={bot}
                 owner={this.props.owners[bot.user_id]}
+                user={this.props.users[bot.user_id]}
                 accessTokens={this.props.accessTokens[bot.user_id] || {}}
                 actions={this.props.actions}
                 team={this.props.team}

--- a/components/integrations/bots/bots.test.jsx
+++ b/components/integrations/bots/bots.test.jsx
@@ -33,12 +33,18 @@ describe('components/integrations/bots/Bots', () => {
             [bot2.user_id]: bot2,
             [bot3.user_id]: bot3,
         };
+        const users = {
+            [bot1.user_id]: {id: bot1.user_id},
+            [bot2.user_id]: {id: bot2.user_id},
+            [bot3.user_id]: {id: bot3.user_id},
+        };
         const wrapperFull = shallow(
             <Bots
                 bots={bots}
                 team={team}
                 accessTokens={{}}
                 owners={{}}
+                users={users}
                 actions={actions}
             />
         );
@@ -50,6 +56,7 @@ describe('components/integrations/bots/Bots', () => {
                 key={bot1.user_id}
                 bot={bot1}
                 owner={undefined}
+                user={users[bot1.user_id]}
                 accessTokens={{}}
                 team={team}
                 actions={actions}
@@ -60,6 +67,7 @@ describe('components/integrations/bots/Bots', () => {
                 key={bot2.user_id}
                 bot={bot2}
                 owner={undefined}
+                user={users[bot2.user_id]}
                 accessTokens={{}}
                 team={team}
                 actions={actions}
@@ -70,6 +78,7 @@ describe('components/integrations/bots/Bots', () => {
                 key={bot3.user_id}
                 bot={bot3}
                 owner={undefined}
+                user={users[bot3.user_id]}
                 accessTokens={{}}
                 team={team}
                 actions={actions}
@@ -87,12 +96,20 @@ describe('components/integrations/bots/Bots', () => {
             user_id: 'owner',
         };
 
+        const user = {
+            id: bot1.user_id,
+        };
+
         const passedTokens = {
             id: 'token',
         };
 
         const owners = {
             [bot1.user_id]: owner,
+        };
+
+        const users = {
+            [bot1.user_id]: user,
         };
 
         const tokens = {
@@ -105,6 +122,7 @@ describe('components/integrations/bots/Bots', () => {
                 team={team}
                 accessTokens={tokens}
                 owners={owners}
+                users={users}
                 actions={actions}
             />
         );
@@ -116,6 +134,7 @@ describe('components/integrations/bots/Bots', () => {
                 key={bot1.user_id}
                 bot={bot1}
                 owner={owner}
+                user={user}
                 accessTokens={passedTokens}
                 team={team}
                 actions={actions}

--- a/components/integrations/bots/index.js
+++ b/components/integrations/bots/index.js
@@ -15,16 +15,24 @@ function mapStateToProps(state) {
     const config = getConfig(state);
     const createBots = config.EnableBotAccountCreation === 'true';
     const bots = getBotAccounts(state);
-    const owners = Object.values(bots).
+    const botValues = Object.values(bots);
+    const owners = botValues.
         reduce((result, bot) => {
             result[bot.user_id] = UserSelectors.getUser(state, bot.owner_id);
             return result;
         }, {});
+    const users = botValues.
+        reduce((result, bot) => {
+            result[bot.user_id] = UserSelectors.getUser(state, bot.user_id);
+            return result;
+        }, {});
+
     return {
         createBots,
         bots,
         accessTokens: state.entities.admin.userAccessTokensByUser,
         owners,
+        users,
     };
 }
 

--- a/components/invitation_modal/invitation_modal_confirm_step_row.jsx
+++ b/components/invitation_modal/invitation_modal_confirm_step_row.jsx
@@ -28,7 +28,7 @@ export default class InvitationModalConfirmStepRow extends React.Component {
         let guestBadge;
         if (invitation.user) {
             className = 'name';
-            const profileImg = imageURLForUser(invitation.user);
+            const profileImg = imageURLForUser(invitation.user.id, invitation.user.last_picture_update);
             icon = (
                 <Avatar
                     username={invitation.user.username}

--- a/components/post_profile_picture/post_profile_picture.jsx
+++ b/components/post_profile_picture/post_profile_picture.jsx
@@ -35,7 +35,7 @@ export default class PostProfilePicture extends React.PureComponent {
         if (user && user.id === post.user_id) {
             return Utils.imageURLForUser(user);
         } else if (post.user_id) {
-            return Utils.imageURLForUser(post.user_id);
+            return Utils.imageURLForUser({id: post.user_id});
         }
 
         return '';

--- a/components/post_profile_picture/post_profile_picture.jsx
+++ b/components/post_profile_picture/post_profile_picture.jsx
@@ -33,9 +33,9 @@ export default class PostProfilePicture extends React.PureComponent {
         const {post, user} = this.props;
 
         if (user && user.id === post.user_id) {
-            return Utils.imageURLForUser(user);
+            return Utils.imageURLForUser(user.id, user.last_picture_update);
         } else if (post.user_id) {
-            return Utils.imageURLForUser({id: post.user_id});
+            return Utils.imageURLForUser(post.user_id);
         }
 
         return '';

--- a/components/post_view/channel_intro_message/channel_intro_message.jsx
+++ b/components/post_view/channel_intro_message/channel_intro_message.jsx
@@ -84,7 +84,7 @@ function createGMIntroMessage(channel, centeredIntro, profiles, currentUserId) {
             map((profile) => (
                 <ProfilePicture
                     key={'introprofilepicture' + profile.id}
-                    src={Utils.imageURLForUser(profile)}
+                    src={Utils.imageURLForUser(profile.id, profile.last_picture_update)}
                     size='xl'
                     userId={profile.id}
                     username={profile.username}
@@ -138,7 +138,7 @@ function createDMIntroMessage(channel, centeredIntro, teammate, teammateName) {
             >
                 <div className='post-profile-img__container channel-intro-img'>
                     <ProfilePicture
-                        src={Utils.imageURLForUser(teammate)}
+                        src={Utils.imageURLForUser(teammate.id, teammate.last_picture_update)}
                         size='xl'
                         userId={teammate.id}
                         username={teammate.username}

--- a/components/suggestion/at_mention_provider/at_mention_suggestion.jsx
+++ b/components/suggestion/at_mention_provider/at_mention_suggestion.jsx
@@ -97,7 +97,7 @@ export default class AtMentionSuggestion extends Suggestion {
                 <Avatar
                     size='xs'
                     username={user && user.username}
-                    url={Utils.imageURLForUser(user)}
+                    url={Utils.imageURLForUser(user.id, user.last_picture_update)}
                 />
             );
         }

--- a/components/suggestion/search_user_provider.jsx
+++ b/components/suggestion/search_user_provider.jsx
@@ -45,7 +45,7 @@ class SearchUserSuggestion extends Suggestion {
                 <Avatar
                     size='xs'
                     username={username}
-                    url={Utils.imageURLForUser(item)}
+                    url={Utils.imageURLForUser(item.id, item.last_picture_update)}
                 />
                 <div className='mention--align'>
                     <span>

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -155,7 +155,7 @@ function mapStateToPropsForSwitchChannelSuggestion(state, ownProps) {
     const channelId = channel ? channel.id : '';
     const draft = channelId ? getPostDraft(state, StoragePrefixes.DRAFT, channelId) : false;
     const user = channel && getUser(state, channel.userId);
-    const userImageUrl = user && Utils.imageURLForUser(user);
+    const userImageUrl = user && Utils.imageURLForUser(user.id, user.last_picture_update);
     let dmChannelTeammate = channel && channel.type === Constants.DM_CHANNEL && Utils.getDirectTeammate(state, channel.id);
     if (channel && Utils.isEmptyObject(dmChannelTeammate)) {
         dmChannelTeammate = getUser(state, channel.userId);

--- a/components/user_profile/user_profile.jsx
+++ b/components/user_profile/user_profile.jsx
@@ -68,7 +68,7 @@ export default class UserProfile extends PureComponent {
 
         let profileImg = '';
         if (user) {
-            profileImg = imageURLForUser(user);
+            profileImg = imageURLForUser(user.id, user.last_picture_update);
         }
 
         return (

--- a/components/user_settings/general/user_settings_general.jsx
+++ b/components/user_settings/general/user_settings_general.jsx
@@ -1183,7 +1183,7 @@ class UserSettingsGeneralTab extends React.Component {
                     title={formatMessage(holders.profilePicture)}
                     onSubmit={this.submitPicture}
                     onSetDefault={user.last_picture_update > 0 ? this.setDefaultProfilePicture : null}
-                    src={Utils.imageURLForUser(user)}
+                    src={Utils.imageURLForUser(user.id, user.last_picture_update)}
                     defaultImageSrc={Utils.defaultImageURLForUser(user.id)}
                     serverError={serverError}
                     clientError={clientError}

--- a/components/widgets/inputs/users_emails_input.jsx
+++ b/components/widgets/inputs/users_emails_input.jsx
@@ -95,7 +95,7 @@ export default class UsersEmailsInput extends React.Component {
     }
 
     formatOptionLabel = (user, options) => {
-        const profileImg = imageURLForUser(user);
+        const profileImg = imageURLForUser(user.id, user.last_picture_update);
         let guestBadge = null;
         if (!isEmail(user.value) && isGuest(user)) {
             guestBadge = <GuestBadge/>;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1348,12 +1348,7 @@ export function displayEntireNameForUser(user) {
     return displayName;
 }
 
-export function imageURLForUser(userIdOrObject) {
-    let user = userIdOrObject;
-    if (typeof userIdOrObject === 'string') {
-        const state = store.getState();
-        user = getUser(state, userIdOrObject) || {id: userIdOrObject};
-    }
+export function imageURLForUser(user) {
     return Client4.getUsersRoute() + '/' + user.id + '/image?_=' + (user.last_picture_update || 0);
 }
 

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1348,8 +1348,8 @@ export function displayEntireNameForUser(user) {
     return displayName;
 }
 
-export function imageURLForUser(user) {
-    return Client4.getUsersRoute() + '/' + user.id + '/image?_=' + (user.last_picture_update || 0);
+export function imageURLForUser(userId, lastPictureUpdate = 0) {
+    return Client4.getUsersRoute() + '/' + userId + '/image?_=' + lastPictureUpdate;
 }
 
 export function defaultImageURLForUser(userId) {

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1349,7 +1349,12 @@ export function displayEntireNameForUser(user) {
 }
 
 export function imageURLForUser(userIdOrObject) {
-    return Client4.getUsersRoute() + '/' + userIdOrObject.id + '/image?_=' + (userIdOrObject.last_picture_update || 0);
+    let user = userIdOrObject;
+    if (typeof userIdOrObject === 'string') {
+        const state = store.getState();
+        user = getUser(state, userIdOrObject) || {id: userIdOrObject};
+    }
+    return Client4.getUsersRoute() + '/' + user.id + '/image?_=' + (user.last_picture_update || 0);
 }
 
 export function defaultImageURLForUser(userId) {
@@ -1357,8 +1362,8 @@ export function defaultImageURLForUser(userId) {
 }
 
 // in contrast to Client4.getTeamIconUrl, for ui logic this function returns null if last_team_icon_update is unset
-export function imageURLForTeam(teamIdOrObject) {
-    return teamIdOrObject.last_team_icon_update ? Client4.getTeamIconUrl(teamIdOrObject.id, teamIdOrObject.last_team_icon_update) : null;
+export function imageURLForTeam(team) {
+    return team.last_team_icon_update ? Client4.getTeamIconUrl(team.id, team.last_team_icon_update) : null;
 }
 
 // Converts a file size in bytes into a human-readable string of the form '123MB'.

--- a/utils/utils.test.jsx
+++ b/utils/utils.test.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import assert from 'assert';
-import {GeneralTypes, UserTypes} from 'mattermost-redux/action_types';
+import {GeneralTypes} from 'mattermost-redux/action_types';
 
 import store from 'stores/redux_store.jsx';
 
@@ -744,25 +744,10 @@ describe('Utils.imageURLForUser', () => {
         expect(imageUrl).toEqual('/api/v4/users/foobar-123/image?_=123456');
     });
 
-    test('should get user from store if user exists in the store and id is given', () => {
-        store.dispatch({
-            type: UserTypes.RECEIVED_PROFILES,
-            data: {
-                user_id: {
-                    id: 'user_id',
-                    last_picture_update: 1,
-                },
-                user_id_2: {
-                    id: 'user_id_2',
-                    last_picture_update: 2,
-                },
-            },
+    test('should return url when user object is given without last_picture_update', () => {
+        const imageUrl = Utils.imageURLForUser({
+            id: 'foobar-123',
         });
-
-        expect(Utils.imageURLForUser('user_id')).toEqual('/api/v4/users/user_id/image?_=1');
-    });
-
-    test('should use given user id if user does not exist in store', () => {
-        expect(Utils.imageURLForUser('user_id_3')).toEqual('/api/v4/users/user_id_3/image?_=0');
+        expect(imageUrl).toEqual('/api/v4/users/foobar-123/image?_=0');
     });
 });

--- a/utils/utils.test.jsx
+++ b/utils/utils.test.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import assert from 'assert';
-import {GeneralTypes} from 'mattermost-redux/action_types';
+import {GeneralTypes, UserTypes} from 'mattermost-redux/action_types';
 
 import store from 'stores/redux_store.jsx';
 
@@ -732,5 +732,37 @@ describe('Utils.getSortedUsers', () => {
             users,
             ['You', 'username_2', 'username_3']
         );
+    });
+});
+
+describe('Utils.imageURLForUser', () => {
+    test('should return url when user object is given', () => {
+        const imageUrl = Utils.imageURLForUser({
+            id: 'foobar-123',
+            last_picture_update: 123456,
+        });
+        expect(imageUrl).toEqual('/api/v4/users/foobar-123/image?_=123456');
+    });
+
+    test('should get user from store if user exists in the store and id is given', () => {
+        store.dispatch({
+            type: UserTypes.RECEIVED_PROFILES,
+            data: {
+                user_id: {
+                    id: 'user_id',
+                    last_picture_update: 1,
+                },
+                user_id_2: {
+                    id: 'user_id_2',
+                    last_picture_update: 2,
+                },
+            },
+        });
+
+        expect(Utils.imageURLForUser('user_id')).toEqual('/api/v4/users/user_id/image?_=1');
+    });
+
+    test('should use given user id if user does not exist in store', () => {
+        expect(Utils.imageURLForUser('user_id_3')).toEqual('/api/v4/users/user_id_3/image?_=0');
     });
 });

--- a/utils/utils.test.jsx
+++ b/utils/utils.test.jsx
@@ -736,18 +736,13 @@ describe('Utils.getSortedUsers', () => {
 });
 
 describe('Utils.imageURLForUser', () => {
-    test('should return url when user object is given', () => {
-        const imageUrl = Utils.imageURLForUser({
-            id: 'foobar-123',
-            last_picture_update: 123456,
-        });
+    test('should return url when user id and last_picture_update is given', () => {
+        const imageUrl = Utils.imageURLForUser('foobar-123', 123456);
         expect(imageUrl).toEqual('/api/v4/users/foobar-123/image?_=123456');
     });
 
-    test('should return url when user object is given without last_picture_update', () => {
-        const imageUrl = Utils.imageURLForUser({
-            id: 'foobar-123',
-        });
+    test('should return url when user id is given without last_picture_update', () => {
+        const imageUrl = Utils.imageURLForUser('foobar-123');
         expect(imageUrl).toEqual('/api/v4/users/foobar-123/image?_=0');
     });
 });


### PR DESCRIPTION
#### Summary
- The utility method `imageURLForUser` has a single method `userIdOrObject` but it looks like it always expects a user object as opposed to a user_id.
- ~Since there were a lot of places that called it with just an id I decided to modify the existing method to handle strings _or_ user object as it looks like thats how it was defined.~
- Modified all places that call the utility function to pass in a user or an object with an id property
- Also renamed the parameters for `imageURLForUser` and `imageURLForTeam` since they only expect `user` and `team` objects and id strings

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-23751

#### Test steps
- Go to `integrations/bots`, create a bot and give it an avatar.
- Observe that the avatar is loaded when hitting the integrations/bots page after reloading

#### Screenshots
![Screen Shot 2020-03-31 at 4 27 20 PM](https://user-images.githubusercontent.com/3207297/78072101-89930f80-736c-11ea-8a90-4a3b04a0991a.png)
