### PR TITLE
[MM-23833] Fix missing labels in Marketplace modal

### DIFF
--- a/components/plugin_marketplace/marketplace_list/marketplace_list.jsx
+++ b/components/plugin_marketplace/marketplace_list/marketplace_list.jsx
@@ -61,6 +61,7 @@ export default class MarketplaceList extends React.PureComponent {
                         downloadUrl={p.download_url}
                         homepageUrl={p.homepage_url}
                         releaseNotesUrl={p.release_notes_url}
+                        labels={p.labels}
                         iconData={p.icon_data}
                         installedVersion={p.installed_version}
                     />


### PR DESCRIPTION
#### Summary
This was broken in https://github.com/mattermost/mattermost-webapp/pull/4567. 

I assume the E2E test would have caught this bug, but they are broken for me locally. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23833

#### Screenshots
![Screenshot from 2020-04-03 16-57-23](https://user-images.githubusercontent.com/16541325/78374759-361efc80-75cc-11ea-8a0c-99ff8c03c0f9.png)
