### PR TITLE
[MM-23841] Allow confirm modal to update when state.checked is modified

### DIFF
--- a/components/confirm_modal.test.tsx
+++ b/components/confirm_modal.test.tsx
@@ -22,6 +22,7 @@ describe('ConfirmModal', () => {
         const wrapper = shallow(<ConfirmModal {...props}/>);
 
         expect(wrapper.state('checked')).toBe(false);
+        expect(wrapper.find('input[type="checkbox"]').prop('checked')).toBe(false);
         expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true);
 
         wrapper.find('#confirmModalButton').simulate('click');
@@ -31,6 +32,7 @@ describe('ConfirmModal', () => {
         wrapper.find('input[type="checkbox"]').simulate('change', {target: {checked: true}});
 
         expect(wrapper.state('checked')).toBe(true);
+        expect(wrapper.find('input[type="checkbox"]').prop('checked')).toBe(true);
 
         wrapper.find('#confirmModalButton').simulate('click');
 
@@ -46,6 +48,7 @@ describe('ConfirmModal', () => {
         const wrapper = shallow(<ConfirmModal {...props}/>);
 
         expect(wrapper.state('checked')).toBe(false);
+        expect(wrapper.find('input[type="checkbox"]').prop('checked')).toBe(false);
         expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true);
 
         wrapper.find('#cancelModalButton').simulate('click');
@@ -55,6 +58,7 @@ describe('ConfirmModal', () => {
         wrapper.find('input[type="checkbox"]').simulate('change', {target: {checked: true}});
 
         expect(wrapper.state('checked')).toBe(true);
+        expect(wrapper.find('input[type="checkbox"]').prop('checked')).toBe(true);
 
         wrapper.find('#cancelModalButton').simulate('click');
 

--- a/components/confirm_modal.tsx
+++ b/components/confirm_modal.tsx
@@ -104,8 +104,11 @@ export default class ConfirmModal extends React.Component<Props, State> {
         document.removeEventListener('keydown', this.handleKeypress);
     }
 
-    shouldComponentUpdate(nextProps: Props) {
-        return nextProps.show !== this.props.show;
+    shouldComponentUpdate(nextProps: Props, nextState: State) {
+        return (
+            nextProps.show !== this.props.show ||
+            nextState.checked !== this.state.checked
+        );
     }
 
     componentDidUpdate(prevProps: Props) {


### PR DESCRIPTION
#### Summary
- The component was not updating when checked was enabled so the checkbox would never toggle from on to off, this PR fixes that 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23841
