### PR TITLE
[MM-23899] Revert "Remove extra line break in reaction overlay"

### DIFF
--- a/components/post_view/reaction/__snapshots__/reaction.test.jsx.snap
+++ b/components/post_view/reaction/__snapshots__/reaction.test.jsx.snap
@@ -44,6 +44,7 @@ exports[`components/post_view/Reaction should disable add reaction when you do n
             }
           }
         />
+        <br />
       </Tooltip>
     }
     placement="top"
@@ -120,6 +121,7 @@ exports[`components/post_view/Reaction should disable remove reaction when you d
             }
           }
         />
+        <br />
       </Tooltip>
     }
     placement="top"
@@ -197,6 +199,7 @@ exports[`components/post_view/Reaction should match snapshot 1`] = `
             }
           }
         />
+        <br />
         <FormattedMessage
           defaultMessage="(click to add)"
           id="reaction.clickToAdd"
@@ -279,6 +282,7 @@ exports[`components/post_view/Reaction should match snapshot when a current user
             }
           }
         />
+        <br />
         <FormattedMessage
           defaultMessage="(click to remove)"
           id="reaction.clickToRemove"

--- a/components/post_view/reaction/reaction.jsx
+++ b/components/post_view/reaction/reaction.jsx
@@ -237,6 +237,7 @@ export default class Reaction extends React.PureComponent {
                     overlay={
                         <Tooltip id={`${this.props.post.id}-${this.props.emojiName}-reaction`}>
                             {tooltip}
+                            <br/>
                             {clickTooltip}
                         </Tooltip>
                     }


### PR DESCRIPTION
#### Summary
- Reverting my change made here https://github.com/mattermost/mattermost-webapp/pull/5161 since it seems like this line break is needed once more.
- I'm not sure how there were multiple line breaks occurring before but I am entirely unable to reproduce that on master now after re-adding in the original line break. I'm assuming that it was some css that was modified that I cant find.  

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23899

#### Screenshots
Before 
![Screen Shot 2020-04-06 at 6 04 36 PM](https://user-images.githubusercontent.com/3207297/78609752-5dc2ce80-7831-11ea-9536-b3b7b95142c1.png)

After
![Screen Shot 2020-04-06 at 6 03 35 PM](https://user-images.githubusercontent.com/3207297/78609761-61565580-7831-11ea-94a6-ad55314c85aa.png)

