### PR TITLE
[MM-23995] [MM-23996] Fix improper rendering of bot profile picture and bot roles

### DIFF
--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -572,18 +572,12 @@ export default class AddBot extends React.Component {
                                     <option
                                         value={roleOptionMember}
                                     >
-                                        <FormattedMessage
-                                            id='bot.add.role.member'
-                                            defaultMessage='Member'
-                                        />
+                                        {Utils.localizeMessage('bot.add.role.member', 'Member')}
                                     </option>
                                     <option
                                         value={roleOptionSystemAdmin}
                                     >
-                                        <FormattedMessage
-                                            id='bot.add.role.admin'
-                                            defaultMessage='System Admin'
-                                        />
+                                        {Utils.localizeMessage('bot.add.role.admin', 'System Admin')}
                                     </option>
                                 </select>
                                 <div className='form__help'>

--- a/components/integrations/bots/add_bot/index.js
+++ b/components/integrations/bots/add_bot/index.js
@@ -8,7 +8,7 @@ import {updateUserRoles, uploadProfileImage, setDefaultProfileImage, createUserA
 import {createBot, patchBot} from 'mattermost-redux/actions/bots';
 import {getBotAccounts} from 'mattermost-redux/selectors/entities/bots';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
-import {getUsers} from 'mattermost-redux/selectors/entities/common';
+import {getUser} from 'mattermost-redux/selectors/entities/users';
 import {haveISystemPermission} from 'mattermost-redux/selectors/entities/roles';
 import {Permissions} from 'mattermost-redux/constants';
 
@@ -19,13 +19,14 @@ function mapStateToProps(state, ownProps) {
     const botId = (new URLSearchParams(ownProps.location.search)).get('id');
     const bots = getBotAccounts(state);
     const bot = bots ? bots[botId] : null;
-    const user = bot ? getUsers(state)[bot.user_id] : null;
+    const user = bot ? getUser(state, bot.user_id) : null;
     const roles = user ? user.roles : null;
     return {
         maxFileSize: parseInt(config.MaxFileSize, 10),
         bot,
         roles,
         editingUserHasManageSystem: haveISystemPermission(state, {permission: Permissions.MANAGE_SYSTEM}),
+        user,
     };
 }
 


### PR DESCRIPTION
#### Summary
- Fixes a case where `FormattedMessage` was used as a select option resulting in `object Object` being shown as the text
- Fixes user not being passed as prop to add bot
- Also modified call to `getUsers(state)[id]` into `getUser(state, id)`

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-23995
- https://mattermost.atlassian.net/browse/MM-23996

#### Screenshots
![Screen Shot 2020-04-08 at 1 58 29 PM](https://user-images.githubusercontent.com/3207297/78817368-0ba0bb00-79a1-11ea-9171-879112883b00.png)
