### PR TITLE
[MM-23997] Ensure channel mentions permission is set on edit post

### DIFF
--- a/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
+++ b/components/edit_post_modal/__snapshots__/edit_post_modal.test.jsx.snap
@@ -82,6 +82,7 @@ exports[`components/EditPostModal should disable the button on not canDeletePost
           suggestionListStyle="bottom"
           supportsCommands={false}
           tabIndex="0"
+          useChannelMentions={true}
           value=""
         />
         <div
@@ -242,6 +243,7 @@ exports[`components/EditPostModal should disable the button on not canEditPost a
           suggestionListStyle="bottom"
           supportsCommands={false}
           tabIndex="0"
+          useChannelMentions={true}
           value="new message"
         />
         <div
@@ -306,6 +308,167 @@ exports[`components/EditPostModal should disable the button on not canEditPost a
     <button
       className="btn btn-primary"
       disabled={true}
+      id="editButton"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Save"
+        id="edit_post.save"
+        values={Object {}}
+      />
+    </button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`components/EditPostModal should match snapshot with useChannelMentions set to false 1`] = `
+<Modal
+  animation={true}
+  aria-labelledby="editPostModalLabel"
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogClassName="a11y__modal edit-modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  id="editPostModal"
+  keyboard={false}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onEntered={[Function]}
+  onExit={[Function]}
+  onExited={[Function]}
+  onHide={[Function]}
+  onKeyDown={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  role="dialog"
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={true}
+    closeLabel="Close"
+    onHide={[Function]}
+  >
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h1"
+      id="editPostModalLabel"
+    >
+      <FormattedMessage
+        defaultMessage="Edit {title}"
+        id="edit_post.edit"
+        values={
+          Object {
+            "title": "test",
+          }
+        }
+      />
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body edit-modal-body"
+    componentClass="div"
+  >
+    <div
+      className="post-create__container"
+    >
+      <div
+        className="textarea-wrapper"
+      >
+        <Connect(Textbox)
+          channelId="5"
+          characterLimit={4000}
+          createMessage="Edit the post..."
+          emojiEnabled={true}
+          handlePostError={[Function]}
+          id="edit_textbox"
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseUp={[Function]}
+          preview={false}
+          suggestionListStyle="bottom"
+          supportsCommands={false}
+          tabIndex="0"
+          useChannelMentions={false}
+          value=""
+        />
+        <div
+          className="post-body__actions"
+        >
+          <div>
+            <EmojiPickerOverlay
+              container={[Function]}
+              enableGifPicker={false}
+              onEmojiClick={[Function]}
+              onGifClick={[Function]}
+              onHide={[Function]}
+              show={false}
+              spaceRequiredAbove={476}
+              spaceRequiredBelow={497}
+              target={[Function]}
+              topOffset={-20}
+            />
+            <button
+              aria-label="emoji picker"
+              className="style--none post-action"
+              id="editPostEmoji"
+              onClick={[Function]}
+            >
+              <EmojiIcon
+                className="icon icon--emoji"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="post-create-footer"
+      >
+        <Connect(TextboxLinks)
+          characterLimit={4000}
+          message=""
+          showPreview={false}
+          updatePreview={[Function]}
+        />
+        <div
+          className="edit-post-footer"
+        />
+      </div>
+    </div>
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <button
+      className="btn btn-link"
+      onClick={[Function]}
+      type="button"
+    >
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="edit_post.cancel"
+        values={Object {}}
+      />
+    </button>
+    <button
+      className="btn btn-primary"
+      disabled={false}
       id="editButton"
       onClick={[Function]}
       type="button"
@@ -402,6 +565,7 @@ exports[`components/EditPostModal should match with default config 1`] = `
           suggestionListStyle="bottom"
           supportsCommands={false}
           tabIndex="0"
+          useChannelMentions={true}
           value=""
         />
         <div
@@ -562,6 +726,7 @@ exports[`components/EditPostModal should match without emoji picker 1`] = `
           suggestionListStyle="bottom"
           supportsCommands={false}
           tabIndex="0"
+          useChannelMentions={true}
           value=""
         />
         <div
@@ -697,6 +862,7 @@ exports[`components/EditPostModal should not disable the button on not canDelete
           suggestionListStyle="bottom"
           supportsCommands={false}
           tabIndex="0"
+          useChannelMentions={true}
           value="new message"
         />
         <div
@@ -857,6 +1023,7 @@ exports[`components/EditPostModal should not disable the button on not canEditPo
           suggestionListStyle="bottom"
           supportsCommands={false}
           tabIndex="0"
+          useChannelMentions={true}
           value=""
         />
         <div
@@ -1017,6 +1184,7 @@ exports[`components/EditPostModal should not disable the save button on not canD
           suggestionListStyle="bottom"
           supportsCommands={false}
           tabIndex="0"
+          useChannelMentions={true}
           value=""
         />
         <div
@@ -1177,6 +1345,7 @@ exports[`components/EditPostModal should show emojis on emojis click 1`] = `
           suggestionListStyle="bottom"
           supportsCommands={false}
           tabIndex="0"
+          useChannelMentions={true}
           value=""
         />
         <div
@@ -1337,6 +1506,7 @@ exports[`components/EditPostModal should show errors when it is set in the state
           suggestionListStyle="bottom"
           supportsCommands={false}
           tabIndex="0"
+          useChannelMentions={true}
           value=""
         />
         <div

--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -30,6 +30,8 @@ class EditPostModal extends React.PureComponent {
         intl: intlShape.isRequired,
         maxPostSize: PropTypes.number.isRequired,
         shouldShowPreview: PropTypes.bool.isRequired,
+        useChannelMentions: PropTypes.bool.isRequired,
+
         editingPost: PropTypes.shape({
             post: PropTypes.object,
             postId: PropTypes.string,
@@ -406,6 +408,7 @@ class EditPostModal extends React.PureComponent {
                                 ref={this.setEditboxRef}
                                 characterLimit={this.props.maxPostSize}
                                 preview={this.props.shouldShowPreview}
+                                useChannelMentions={this.props.useChannelMentions}
                             />
                             <div className='post-body__actions'>
                                 {emojiPicker}

--- a/components/edit_post_modal/edit_post_modal.test.jsx
+++ b/components/edit_post_modal/edit_post_modal.test.jsx
@@ -19,9 +19,10 @@ jest.mock('utils/user_agent', () => ({
     isMobile: jest.fn().mockReturnValue(false),
 }));
 
-function createEditPost({canEditPost, canDeletePost, ctrlSend, config, license, editingPost, actions} = {canEditPost: true, canDeletePost: true}) { //eslint-disable-line react/prop-types
+function createEditPost({canEditPost, canDeletePost, useChannelMentions, ctrlSend, config, license, editingPost, actions} = {canEditPost: true, canDeletePost: true}) { //eslint-disable-line react/prop-types
     const canEditPostProp = canEditPost === undefined ? true : canEditPost;
     const canDeletePostProp = canDeletePost === undefined ? true : canDeletePost;
+    const useChannelMentionsProp = useChannelMentions === undefined ? true : useChannelMentions;
     const ctrlSendProp = ctrlSend || false;
     const configProp = config || {
         PostEditTimeLimit: 300,
@@ -60,6 +61,7 @@ function createEditPost({canEditPost, canDeletePost, ctrlSend, config, license, 
             editingPost={editingPostProp}
             actions={actionsProp}
             maxPostSize={Constants.DEFAULT_CHARACTER_LIMIT}
+            useChannelMentions={useChannelMentionsProp}
         />
     );
 }
@@ -543,6 +545,11 @@ describe('components/EditPostModal', () => {
         };
         var wrapper = shallowWithIntl(createEditPost({canDeletePost: false, editingPost}));
         wrapper.setState({editText: ''});
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should match snapshot with useChannelMentions set to false', () => {
+        var wrapper = shallowWithIntl(createEditPost({useChannelMentions: false}));
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -27,7 +27,7 @@ function mapStateToProps(state) {
     const editingPost = getEditingPost(state);
     const currentUserId = getCurrentUserId(state);
     const channelId = getCurrentChannelId(state);
-    const teamId =  getCurrentTeamId(state);
+    const teamId = getCurrentTeamId(state);
     let canDeletePost = false;
     let canEditPost = false;
     if (editingPost && editingPost.post && editingPost.post.user_id === currentUserId) {

--- a/components/edit_post_modal/index.js
+++ b/components/edit_post_modal/index.js
@@ -26,15 +26,23 @@ function mapStateToProps(state) {
     const config = getConfig(state);
     const editingPost = getEditingPost(state);
     const currentUserId = getCurrentUserId(state);
+    const channelId = getCurrentChannelId(state);
+    const teamId =  getCurrentTeamId(state);
     let canDeletePost = false;
     let canEditPost = false;
     if (editingPost && editingPost.post && editingPost.post.user_id === currentUserId) {
-        canDeletePost = haveIChannelPermission(state, {channel: getCurrentChannelId(state), team: getCurrentTeamId(state), permission: Permissions.DELETE_POST});
-        canEditPost = haveIChannelPermission(state, {channel: getCurrentChannelId(state), team: getCurrentTeamId(state), permission: Permissions.EDIT_POST});
+        canDeletePost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.DELETE_POST});
+        canEditPost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.EDIT_POST});
     } else {
-        canDeletePost = haveIChannelPermission(state, {channel: getCurrentChannelId(state), team: getCurrentTeamId(state), permission: Permissions.DELETE_OTHERS_POSTS});
-        canEditPost = haveIChannelPermission(state, {channel: getCurrentChannelId(state), team: getCurrentTeamId(state), permission: Permissions.EDIT_OTHERS_POSTS});
+        canDeletePost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.DELETE_OTHERS_POSTS});
+        canEditPost = haveIChannelPermission(state, {channel: channelId, team: teamId, permission: Permissions.EDIT_OTHERS_POSTS});
     }
+
+    const useChannelMentions = haveIChannelPermission(state, {
+        channel: channelId,
+        team: teamId,
+        permission: Permissions.USE_CHANNEL_MENTIONS,
+    });
 
     return {
         canEditPost,
@@ -45,6 +53,7 @@ function mapStateToProps(state) {
         editingPost,
         shouldShowPreview: showPreviewOnEditPostModal(state),
         maxPostSize: parseInt(config.MaxPostSize, 10) || Constants.DEFAULT_CHARACTER_LIMIT,
+        useChannelMentions,
     };
 }
 


### PR DESCRIPTION
#### Summary
- Pass `useChannelMentions` to the `Textbox` component on the edit post modal

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23997

#### Screenshots
![Screen Shot 2020-04-08 at 2 36 28 PM](https://user-images.githubusercontent.com/3207297/78820752-58d35b80-79a6-11ea-89da-a605baed444a.png)
