### PR TITLE
[MM-23977] Ensure users not in team when searching for users

### DIFF
--- a/components/invitation_modal/__snapshots__/invitation_modal.test.jsx.snap
+++ b/components/invitation_modal/__snapshots__/invitation_modal.test.jsx.snap
@@ -149,6 +149,7 @@ exports[`components/invitation_modal/InvitationModal should match the snapshot w
         }
       />
       <injectIntl(InvitationModalMembersStep)
+        currentTeamId="test"
         emailInvitationsEnabled={true}
         inviteId="test-invite-id"
         onEdit={[Function]}

--- a/components/invitation_modal/invitation_modal.jsx
+++ b/components/invitation_modal/invitation_modal.jsx
@@ -261,6 +261,7 @@ export default class InvitationModal extends React.Component {
                         {this.state.step === STEPS_INVITE_MEMBERS &&
                             <InvitationModalMembersStep
                                 teamName={this.props.currentTeam.display_name}
+                                currentTeamId={this.props.currentTeam.id}
                                 inviteId={this.props.currentTeam.invite_id}
                                 searchProfiles={this.props.actions.searchProfiles}
                                 emailInvitationsEnabled={this.props.emailInvitationsEnabled}

--- a/components/invitation_modal/invitation_modal_members_step.jsx
+++ b/components/invitation_modal/invitation_modal_members_step.jsx
@@ -23,6 +23,7 @@ import './invitation_modal_members_step.scss';
 class InvitationModalMembersStep extends React.Component {
     static propTypes = {
         teamName: PropTypes.string.isRequired,
+        currentTeamId: PropTypes.string.isRequired,
         intl: PropTypes.any,
         inviteId: PropTypes.string.isRequired,
         searchProfiles: PropTypes.func.isRequired,
@@ -70,7 +71,7 @@ class InvitationModalMembersStep extends React.Component {
     }
 
     debouncedSearchProfiles = debounce((term, callback) => {
-        this.props.searchProfiles(term).then(({data}) => {
+        this.props.searchProfiles(term, {not_in_team_id: this.props.currentTeamId}).then(({data}) => {
             callback(data);
             if (data.length === 0) {
                 this.setState({termWithoutResults: term});

--- a/components/invitation_modal/invitation_modal_members_step.test.jsx
+++ b/components/invitation_modal/invitation_modal_members_step.test.jsx
@@ -12,6 +12,7 @@ describe('components/invitation_modal/InvitationModalMembersStep', () => {
         const wrapper = shallowWithIntl(
             <InvitationModalMembersStep
                 teamName='Test Team'
+                currentTeamId='test-team-id'
                 inviteId='123'
                 searchProfiles={jest.fn()}
                 emailInvitationsEnabled={true}
@@ -26,6 +27,7 @@ describe('components/invitation_modal/InvitationModalMembersStep', () => {
         const wrapper = shallowWithIntl(
             <InvitationModalMembersStep
                 teamName='Test Team'
+                currentTeamId='test-team-id'
                 inviteId='123'
                 searchProfiles={jest.fn()}
                 emailInvitationsEnabled={false}

--- a/components/invitation_modal/invitation_modal_members_step.test.jsx
+++ b/components/invitation_modal/invitation_modal_members_step.test.jsx
@@ -37,4 +37,28 @@ describe('components/invitation_modal/InvitationModalMembersStep', () => {
         );
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should send not_in_team_id when search profiles is called', async () => {
+        const searchProfiles = jest.fn().mockImplementation(() => {
+            const data = [];
+
+            return Promise.resolve({data});
+        });
+
+        const wrapper = shallowWithIntl(
+            <InvitationModalMembersStep
+                teamName='Test Team'
+                currentTeamId='test-team-id'
+                inviteId='123'
+                searchProfiles={searchProfiles}
+                emailInvitationsEnabled={false}
+                onSubmit={jest.fn()}
+                onEdit={jest.fn()}
+            />
+        );
+
+        wrapper.instance().usersLoader('@something', jest.fn());
+        jest.runAllTimers();
+        expect(searchProfiles).toHaveBeenCalledWith('@something', {not_in_team_id: 'test-team-id'});
+    });
 });


### PR DESCRIPTION
#### Summary
- This modal is used for inviting users to a team however it was never sending a `not_in_team_id` parameter, and ended up just falling back to `UserStore.Search` on the server. However some server changes made it so that that behaviour would default to `SearchUsersInTeam`.
- This PR ensures now that the invite to team modal sends the `not_in_team_id` and ends up calling the correct store function always 
 
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23977