### PR TITLE
[MM-24035] Fix getDeactivatedChannel selector for DM channel

### DIFF
--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -23,7 +23,7 @@ const getDeactivatedChannel = createSelector(
     (state, channelId) => {
         return getDirectTeammate(state, channelId);
     },
-    (users, channelId, teammate) => {
+    (users, teammate) => {
         return Boolean(teammate && teammate.delete_at);
     }
 );

--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -19,11 +19,10 @@ import ChannelView from './channel_view.jsx';
 
 // Temporary selector until getDirectTeammate is converted to be redux-friendly
 const getDeactivatedChannel = createSelector(
-    (state) => state.entities.users.profiles,
     (state, channelId) => {
         return getDirectTeammate(state, channelId);
     },
-    (users, teammate) => {
+    (teammate) => {
         return Boolean(teammate && teammate.delete_at);
     }
 );


### PR DESCRIPTION
#### Summary
- There was an extra argument so teammate was always undefined resulting in a deactivated DM channel never showing up as deactivated

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-24035

#### Screenshots

![Screen Shot 2020-04-08 at 10 49 49 PM](https://user-images.githubusercontent.com/3207297/78852775-43cceb80-79eb-11ea-9360-9da4eec11104.png)
