### PR TITLE
MM-18457 E2E for sending message to other channel via custom slash command

### DIFF
--- a/e2e/cypress/integration/integrations/message_to_channel_via_slash_command_spec.js
+++ b/e2e/cypress/integration/integrations/message_to_channel_via_slash_command_spec.js
@@ -1,0 +1,115 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @integrations
+
+/**
+* Note: This test requires webhook server running. Initiate `npm run start:webhook` to start.
+*/
+
+describe('Integrations', () => {
+    let team;
+    let offTopicChannel;
+
+    before(() => {
+        cy.requireWebhookServer();
+
+        // # Login as sysadmin
+        cy.apiLogin('sysadmin');
+
+        // # Create new team and get off-topic channel
+        cy.apiCreateTeam('test-team', 'Test Team').then((teamResponse) => {
+            team = teamResponse.body;
+
+            cy.apiGetChannelByName(team.name, 'off-topic').then((res) => {
+                offTopicChannel = res.body;
+            });
+        });
+    });
+
+    beforeEach(() => {
+        // # Visit town-square
+        cy.visit(`/${team.name}/town-square`);
+    });
+
+    it('MM-T706 Error Handling for Slash Commands', () => {
+        const command = {
+            auto_complete: false,
+            description: 'Test for Slash Command',
+            display_name: 'Send message to different channel via slash command',
+            icon_url: '',
+            method: 'P',
+            team_id: team.id,
+            trigger: 'send_message' + Date.now(),
+            url: `${Cypress.env().webhookBaseUrl}/send_message_to_channel?type=system_message&channel_id=${offTopicChannel.id}`,
+            username: '',
+        };
+
+        // # Create a slash command
+        cy.apiCreateCommand(command).then(({data: slashCommand}) => {
+            // * Verify that off-topic channel is read
+            cy.findByLabelText('off-topic public channel').should('exist');
+
+            // # Post a slash command that sends message to off-topic channel
+            cy.postMessage(`/${slashCommand.trigger}`);
+
+            // * Verify slash command error
+            cy.findByText(`Command '${slashCommand.trigger}' failed to post response. Please contact your System Administrator.`).should('be.visible');
+
+            // * Verify that off-topic channel is unread and then click
+            cy.findByLabelText('off-topic public channel unread').
+                should('exist').
+                click();
+
+            // * Verify that only "Hello World" is posted in off-topic channel
+            cy.getLastPostId().then((postId) => {
+                cy.get(`#postMessageText_${postId}`).should('be.visible').and('have.text', 'Hello World');
+            });
+            cy.getNthPostId(-2).then((postId) => {
+                cy.get(`#postMessageText_${postId}`).should('be.visible').and('not.have.text', 'Extra response 2');
+            });
+        });
+    });
+
+    it('MM-T707 Send a message to a different channel than where the slash command was issued from', () => {
+        const command = {
+            auto_complete: false,
+            description: 'Test for Slash Command',
+            display_name: 'Send message to different channel via slash command',
+            icon_url: '',
+            method: 'P',
+            team_id: team.id,
+            trigger: 'send_message' + Date.now(),
+            url: `${Cypress.env().webhookBaseUrl}/send_message_to_channel?channel_id=${offTopicChannel.id}`,
+            username: '',
+        };
+
+        // # Create a slash command
+        cy.apiCreateCommand(command).then(({data: slashCommand}) => {
+            // * Verify that off-topic channel is read
+            cy.findByLabelText('off-topic public channel').should('exist');
+
+            // # Post a slash command that sends message to off-topic channel
+            cy.postMessage(`/${slashCommand.trigger}`);
+
+            // * Verify that off-topic channel is unread and then click
+            cy.findByLabelText('off-topic public channel unread').
+                should('exist').
+                click();
+
+            // * Verify that both messages are posted in off-topic channel
+            cy.getLastPostId().then((postId) => {
+                cy.get(`#postMessageText_${postId}`).should('be.visible').and('have.text', 'Hello World');
+            });
+            cy.getNthPostId(-2).then((postId) => {
+                cy.get(`#postMessageText_${postId}`).should('be.visible').and('have.text', 'Extra response 2');
+            });
+        });
+    });
+});

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,7 +2,6 @@
   "devDependencies": {
     "@testing-library/cypress": "5.3.0",
     "axios": "0.19.2",
-    "body-parser": "1.19.0",
     "chalk": "3.0.0",
     "clipboardy": "2.2.0",
     "cypress": "4.0.2",

--- a/e2e/webhook_serve.js
+++ b/e2e/webhook_serve.js
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 const express = require('express');
-const bodyParser = require('body-parser');
 const axios = require('axios');
 
 const webhookUtils = require('./utils/webhook_utils');
@@ -13,8 +12,8 @@ const users = require('./cypress/fixtures/users.json');
 const port = 3000;
 
 const server = express();
-server.use(bodyParser.json());
-server.use(bodyParser.urlencoded({extended: true}));
+server.use(express.json());
+server.use(express.urlencoded({extended: true}));
 
 process.title = process.argv[2];
 
@@ -26,6 +25,7 @@ server.post('/user_and_channel_dialog_request', onUserAndChannelDialogRequest);
 server.post('/dialog_submit', onDialogSubmit);
 server.post('/boolean_dialog_request', onBooleanDialogRequest);
 server.post('/slack_compatible_message_response', postSlackCompatibleMessageResponse);
+server.post('/send_message_to_channel', postSendMessageToChannel);
 
 server.listen(port, () => console.log(`Webhook test server listening on port ${port}!`)); // eslint-disable-line no-console
 
@@ -124,6 +124,31 @@ function onDialogSubmit(req, res) {
     }
 
     return res.json({text: message});
+}
+
+/**
+ * @route "POST /send_message_to_channel?type={messageType}&channel_id={channelId}"
+ * @query type - message type of empty string for regular message if not provided (default), "system_message", etc
+ * @query channel_id - channel where to send the message
+ */
+function postSendMessageToChannel(req, res) {
+    const channelId = req.query.channel_id;
+    const response = {
+        response_type: 'in_channel',
+        text: 'Extra response 2',
+        channel_id: channelId,
+        extra_responses: [{
+            response_type: 'in_channel',
+            text: 'Hello World',
+            channel_id: channelId,
+        }],
+    };
+
+    if (req.query.type) {
+        response.type = req.query.type;
+    }
+
+    res.json(response);
 }
 
 function getWebhookBaseUrl() {


### PR DESCRIPTION
#### Summary
E2E for sending message to other channel via custom slash command.  Cypress test for the ff:
1. [MM-T706 Error Handling for Slash Commands](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/3969606)
2. [MM-T707 Send a message to a different channel than where the slash command was issued from](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/3969607)

#### Ticket Link
JIRA ticket: https://mattermost.atlassian.net/browse/MM-18457
