### PR TITLE
[MM-24222] - Set mentions to true in header change message

### DIFF
--- a/components/post_markdown/__snapshots__/post_markdown.test.jsx.snap
+++ b/components/post_markdown/__snapshots__/post_markdown.test.jsx.snap
@@ -69,7 +69,7 @@ exports[`components/PostMarkdown should render header change properly 1`] = `
                   "display_name": "Test",
                 },
               },
-              "mentionHighlight": false,
+              "mentionHighlight": true,
               "singleline": true,
             }
           }
@@ -85,7 +85,7 @@ exports[`components/PostMarkdown should render header change properly 1`] = `
                   "display_name": "Test",
                 },
               },
-              "mentionHighlight": false,
+              "mentionHighlight": true,
               "singleline": true,
             }
           }

--- a/components/post_markdown/system_message_helpers.jsx
+++ b/components/post_markdown/system_message_helpers.jsx
@@ -177,7 +177,7 @@ function renderHeaderChangeMessage(post) {
     const headerOptions = {
         singleline: true,
         channelNamesMap: post.props && post.props.channel_mentions,
-        mentionHighlight: false,
+        mentionHighlight: true,
     };
 
     const username = renderUsername(post.props.username);


### PR DESCRIPTION
#### Summary
Mentions were set to false in change header message. This updates it to true as per ticket requirements.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24222

Fix v5.23.0