### PR TITLE
MM-22917 Allow up to 5 plugin header buttons to be displayed before a menu appears.

### DIFF
--- a/components/channel_header/__snapshots__/channel_header.test.jsx.snap
+++ b/components/channel_header/__snapshots__/channel_header.test.jsx.snap
@@ -106,7 +106,7 @@ exports[`components/ChannelHeader should render active flagged posts 1`] = `
             teamId="team_id"
           >
             <button
-              className="channel-header__description style--none"
+              className="header-placeholder style--none"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -316,7 +316,7 @@ exports[`components/ChannelHeader should render active mentions posts 1`] = `
             teamId="team_id"
           >
             <button
-              className="channel-header__description style--none"
+              className="header-placeholder style--none"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -526,7 +526,7 @@ exports[`components/ChannelHeader should render active pinned posts 1`] = `
             teamId="team_id"
           >
             <button
-              className="channel-header__description style--none"
+              className="header-placeholder style--none"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -920,7 +920,7 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
             teamId="team_id"
           >
             <button
-              className="channel-header__description style--none"
+              className="header-placeholder style--none"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -1136,7 +1136,7 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
             teamId="team_id"
           >
             <button
-              className="channel-header__description style--none"
+              className="header-placeholder style--none"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -1594,7 +1594,7 @@ exports[`components/ChannelHeader should render the pinned icon with the pinned 
             teamId="team_id"
           >
             <button
-              className="channel-header__description style--none"
+              className="header-placeholder style--none"
               onClick={[Function]}
             >
               <FormattedMessage

--- a/components/channel_header/__snapshots__/channel_header.test.jsx.snap
+++ b/components/channel_header/__snapshots__/channel_header.test.jsx.snap
@@ -106,7 +106,7 @@ exports[`components/ChannelHeader should render active flagged posts 1`] = `
             teamId="team_id"
           >
             <button
-              className="style--none"
+              className="channel-header__description style--none"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -316,7 +316,7 @@ exports[`components/ChannelHeader should render active mentions posts 1`] = `
             teamId="team_id"
           >
             <button
-              className="style--none"
+              className="channel-header__description style--none"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -526,7 +526,7 @@ exports[`components/ChannelHeader should render active pinned posts 1`] = `
             teamId="team_id"
           >
             <button
-              className="style--none"
+              className="channel-header__description style--none"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -920,7 +920,7 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
             teamId="team_id"
           >
             <button
-              className="style--none"
+              className="channel-header__description style--none"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -1136,7 +1136,7 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
             teamId="team_id"
           >
             <button
-              className="style--none"
+              className="channel-header__description style--none"
               onClick={[Function]}
             >
               <FormattedMessage
@@ -1594,7 +1594,7 @@ exports[`components/ChannelHeader should render the pinned icon with the pinned 
             teamId="team_id"
           >
             <button
-              className="style--none"
+              className="channel-header__description style--none"
               onClick={[Function]}
             >
               <FormattedMessage

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -504,7 +504,7 @@ class ChannelHeader extends React.PureComponent {
                     if (!isDirect || !dmUser.is_bot) {
                         editMessage = (
                             <button
-                                className='style--none'
+                                className='header-placeholder style--none'
                                 onClick={this.showEditChannelHeaderModal}
                             >
                                 <FormattedMessage
@@ -528,7 +528,7 @@ class ChannelHeader extends React.PureComponent {
                             permissions={[isPrivate ? Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES : Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]}
                         >
                             <button
-                                className='channel-header__description style--none'
+                                className='header-placeholder style--none'
                                 onClick={this.showEditChannelHeaderModal}
                             >
                                 <FormattedMessage

--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -528,7 +528,7 @@ class ChannelHeader extends React.PureComponent {
                             permissions={[isPrivate ? Permissions.MANAGE_PRIVATE_CHANNEL_PROPERTIES : Permissions.MANAGE_PUBLIC_CHANNEL_PROPERTIES]}
                         >
                             <button
-                                className='style--none'
+                                className='channel-header__description style--none'
                                 onClick={this.showEditChannelHeaderModal}
                             >
                                 <FormattedMessage

--- a/plugins/channel_header_plug/__snapshots__/channel_header_plug.test.jsx.snap
+++ b/plugins/channel_header_plug/__snapshots__/channel_header_plug.test.jsx.snap
@@ -37,6 +37,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with one extended compo
         className="fa fa-anchor"
       />
     }
+    key="channelHeaderButtonsomeid"
     onClick={[Function]}
     tooltipKey="plugin"
     tooltipText="some tooltip text"
@@ -107,7 +108,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with one extended compo
 </ChannelHeaderPlug>
 `;
 
-exports[`plugins/ChannelHeaderPlug should match snapshot with two extended components 1`] = `
+exports[`plugins/ChannelHeaderPlug should match snapshot with six extended components 1`] = `
 <ChannelHeaderPlug
   channel={Object {}}
   channelMember={Object {}}
@@ -130,6 +131,46 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with two extended compo
           className="fa fa-anchor"
         />,
         "id": "someid2",
+        "pluginId": "pluginid",
+        "tooltipText": "some tooltip text",
+      },
+      Object {
+        "action": [Function],
+        "dropdownText": "some dropdown text",
+        "icon": <i
+          className="fa fa-anchor"
+        />,
+        "id": "someid3",
+        "pluginId": "pluginid",
+        "tooltipText": "some tooltip text",
+      },
+      Object {
+        "action": [Function],
+        "dropdownText": "some dropdown text",
+        "icon": <i
+          className="fa fa-anchor"
+        />,
+        "id": "someid4",
+        "pluginId": "pluginid",
+        "tooltipText": "some tooltip text",
+      },
+      Object {
+        "action": [Function],
+        "dropdownText": "some dropdown text",
+        "icon": <i
+          className="fa fa-anchor"
+        />,
+        "id": "someid5",
+        "pluginId": "pluginid",
+        "tooltipText": "some tooltip text",
+      },
+      Object {
+        "action": [Function],
+        "dropdownText": "some dropdown text",
+        "icon": <i
+          className="fa fa-anchor"
+        />,
+        "id": "someid6",
         "pluginId": "pluginid",
         "tooltipText": "some tooltip text",
       },
@@ -299,7 +340,7 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with two extended compo
                       className="icon__text"
                       id="pluginCount"
                     >
-                      2
+                      6
                     </span>
                   </OverlayTrigger>
                 </OverlayTrigger>
@@ -345,6 +386,86 @@ exports[`plugins/ChannelHeaderPlug should match snapshot with two extended compo
                   </li>
                   <li
                     key="channelHeaderPlugsomeid2"
+                  >
+                    <a
+                      className="d-flex align-items-center"
+                      href="#"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="d-flex align-items-center overflow--ellipsis"
+                      >
+                        <i
+                          className="fa fa-anchor"
+                        />
+                      </span>
+                      <span>
+                        some dropdown text
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    key="channelHeaderPlugsomeid3"
+                  >
+                    <a
+                      className="d-flex align-items-center"
+                      href="#"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="d-flex align-items-center overflow--ellipsis"
+                      >
+                        <i
+                          className="fa fa-anchor"
+                        />
+                      </span>
+                      <span>
+                        some dropdown text
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    key="channelHeaderPlugsomeid4"
+                  >
+                    <a
+                      className="d-flex align-items-center"
+                      href="#"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="d-flex align-items-center overflow--ellipsis"
+                      >
+                        <i
+                          className="fa fa-anchor"
+                        />
+                      </span>
+                      <span>
+                        some dropdown text
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    key="channelHeaderPlugsomeid5"
+                  >
+                    <a
+                      className="d-flex align-items-center"
+                      href="#"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="d-flex align-items-center overflow--ellipsis"
+                      >
+                        <i
+                          className="fa fa-anchor"
+                        />
+                      </span>
+                      <span>
+                        some dropdown text
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    key="channelHeaderPlugsomeid6"
                   >
                     <a
                       className="d-flex align-items-center"

--- a/plugins/channel_header_plug/channel_header_plug.jsx
+++ b/plugins/channel_header_plug/channel_header_plug.jsx
@@ -122,6 +122,7 @@ export default class ChannelHeaderPlug extends React.PureComponent {
     createButton = (plug) => {
         return (
             <HeaderIconWrapper
+                key={'channelHeaderButton' + plug.id}
                 buttonClass='channel-header__icon style--none'
                 iconComponent={plug.icon}
                 onClick={() => plug.action(this.props.channel, this.props.channelMember)}
@@ -208,8 +209,8 @@ export default class ChannelHeaderPlug extends React.PureComponent {
 
         if (components.length === 0) {
             return null;
-        } else if (components.length === 1) {
-            return this.createButton(components[0]);
+        } else if (components.length <= 5) {
+            return components.map(this.createButton);
         }
 
         return this.createDropdown(components);

--- a/plugins/channel_header_plug/channel_header_plug.test.jsx
+++ b/plugins/channel_header_plug/channel_header_plug.test.jsx
@@ -41,10 +41,17 @@ describe('plugins/ChannelHeaderPlug', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should match snapshot with two extended components', () => {
+    test('should match snapshot with six extended components', () => {
         const wrapper = mountWithIntl(
             <ChannelHeaderPlug
-                components={[testPlug, {...testPlug, id: 'someid2'}]}
+                components={[
+                    testPlug,
+                    {...testPlug, id: 'someid2'},
+                    {...testPlug, id: 'someid3'},
+                    {...testPlug, id: 'someid4'},
+                    {...testPlug, id: 'someid5'},
+                    {...testPlug, id: 'someid6'},
+                ]}
                 channel={{}}
                 channelMember={{}}
                 theme={{}}

--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -275,9 +275,13 @@
             }
         }
 
-        span {
+        .header-placeholder {
+            display: flex;
             overflow: hidden;
-            text-overflow: ellipsis;
+            span {
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
         }
 
         .header-description__text {

--- a/sass/layout/_headers.scss
+++ b/sass/layout/_headers.scss
@@ -275,6 +275,11 @@
             }
         }
 
+        span {
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
         .header-description__text {
             overflow: hidden;
             display: flex;


### PR DESCRIPTION
#### Summary
Allow up to 5 plugin header buttons to be displayed before a menu appears. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22917

#### Screenshots
**Incident response, Zoom, and Webex at the same time!**
![Screenshot_2020-04-20 Cloud Incident 4739 - rrrr Mattermost](https://user-images.githubusercontent.com/3191642/79773436-50ecb300-82e6-11ea-9ac4-6291fe105430.png)


**After 5 the menu returns**
![Screenshot_2020-04-20 Cloud Incident 4739 - rrrr Mattermost(1)](https://user-images.githubusercontent.com/3191642/79773532-6e218180-82e6-11ea-833f-bb27091bbac0.png)
