### PR TITLE
[MM-24356] Dispatch getChannelMemberCountsByGroup if timezones are enabled when user is updated

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -836,15 +836,22 @@ export async function handleUserUpdatedEvent(msg) {
     const currentUser = getCurrentUser(state);
     const user = msg.data.user;
 
-    if (isGuest(user)) {
+    const config = getConfig(state);
+    const isTimezoneEnabled = config.ExperimentalTimezone === 'true';
+    const userIsGuest = isGuest(user);
+    if (userIsGuest || isTimezoneEnabled) {
         let members = getMembersInCurrentChannel(state);
         const currentChannelId = getCurrentChannelId(state);
-        if (members && members[user.id]) {
-            dispatch(getChannelStats(currentChannelId));
-        } else {
+        if (!members || !members[user.id]) {
             await dispatch(getChannelMember(currentChannelId, user.id));
             members = getMembersInCurrentChannel(getState());
-            if (members && members[user.id]) {
+        }
+
+        if (members && members[user.id]) {
+            if (isTimezoneEnabled) {
+                dispatch(getChannelMemberCountsByGroup(currentChannelId, true));
+            }
+            if (isGuest(user)) {
                 dispatch(getChannelStats(currentChannelId));
             }
         }

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -842,12 +842,14 @@ export async function handleUserUpdatedEvent(msg) {
     if (userIsGuest || isTimezoneEnabled) {
         let members = getMembersInCurrentChannel(state);
         const currentChannelId = getCurrentChannelId(state);
-        if (!members || !members[user.id]) {
+        let memberExists = members && members[user.id];
+        if (!memberExists) {
             await dispatch(getChannelMember(currentChannelId, user.id));
             members = getMembersInCurrentChannel(getState());
+            memberExists = members && members[user.id];
         }
 
-        if (members && members[user.id]) {
+        if (memberExists) {
             if (isTimezoneEnabled) {
                 dispatch(getChannelMemberCountsByGroup(currentChannelId, true));
             }


### PR DESCRIPTION
#### Summary
- Builds off of https://github.com/mattermost/mattermost-webapp/pull/5331 look at latest commit for my changes
- Dispatch `getChannelMemberCountsByGroup` when a user updates is called in order to ensure timezone counts are accurate since a user may change their timezone resulting in the confirmation modal displaying out of date information if the page hasnt been reloaded in a while.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-24356