### PR TITLE
MM-23832: Permission SystemConsole by three new System roles.

### DIFF
--- a/components/admin_console/admin_console.tsx
+++ b/components/admin_console/admin_console.tsx
@@ -9,6 +9,8 @@ import {Route, Switch, Redirect} from 'react-router-dom';
 import {ActionFunc} from 'mattermost-redux/types/actions';
 import {Role} from 'mattermost-redux/types/roles';
 
+import {haveINoPermissionOnSysConsoleItem, haveINoWritePermissionOnSysConsoleItem} from 'mattermost-redux/selectors/entities/roles';
+
 import AnnouncementBar from 'components/announcement_bar';
 import SystemNotice from 'components/system_notice';
 import ModalController from 'components/modal_controller';
@@ -32,6 +34,8 @@ type Props = {
     match: { url: string };
     showNavigationPrompt: boolean;
     isCurrentUserSystemAdmin: boolean;
+    isCurrentUserInSystemAdminsRole: boolean;
+    globalstate: any;
     actions: {
         getConfig: () => ActionFunc;
         getEnvironmentConfig: () => ActionFunc;
@@ -64,7 +68,8 @@ type ExtraProps = {
 }
 
 type Item = {
-    isHidden?: (config?: Record<string, any>, state?: Record<string, any>, license?: Record<string, any>, buildEnterpriseReady?: boolean) => void;
+    isHidden?: (config?: Record<string, any>, state?: Record<string, any>, license?: Record<string, any>, buildEnterpriseReady?: boolean, globalstate?: any, func?: ActionFunc) => boolean;
+    isDisabled?: (config?: Record<string, any>, state?: Record<string, any>, license?: Record<string, any>, globalstate?: any, func?: ActionFunc) => boolean;
     schema: Record<string, any>;
     url: string;
 }
@@ -80,7 +85,7 @@ export default class AdminConsole extends React.Component<Props, State> {
     public componentDidMount(): void {
         this.props.actions.getConfig();
         this.props.actions.getEnvironmentConfig();
-        this.props.actions.loadRolesIfNeeded(['channel_user', 'team_user', 'system_user', 'channel_admin', 'team_admin', 'system_admin']);
+        this.props.actions.loadRolesIfNeeded(['channel_user', 'team_user', 'system_user', 'channel_admin', 'team_admin', 'system_admin', 'system_user_manager', 'system_console_viewer', 'system_junior_admin']);
         this.props.actions.selectChannel('');
         this.props.actions.selectTeam('');
     }
@@ -97,24 +102,31 @@ export default class AdminConsole extends React.Component<Props, State> {
             roles.team_admin &&
             roles.team_user &&
             roles.system_admin &&
-            roles.system_user
+            roles.system_user &&
+            roles.system_user_manager &&
+            roles.system_console_viewer &&
+            roles.system_junior_admin
         );
     }
 
     private renderRoutes = (extraProps: ExtraProps) => {
         const schemas = Object.values(this.props.adminDefinition).reduce((acc, section: Item[]) => {
-            const items = Object.values(section).filter((item: Item) => {
-                if (item.isHidden && item.isHidden(this.props.config, {}, this.props.license, this.props.buildEnterpriseReady)) {
-                    return false;
-                }
-                if (!item.schema) {
-                    return false;
-                }
-                return true;
-            });
+            let items = [];
+            const isSectionHidden = section.isHidden && section.isHidden(this.props.config, {}, this.props.license, this.props.buildEnterpriseReady, this.props.globalstate, haveINoPermissionOnSysConsoleItem);
+
+            if (!isSectionHidden) {
+                items = Object.values(section).filter((item: Item) => {
+                    if (!item.schema) {
+                        return false;
+                    }
+                    return true;
+                });
+            }
             return acc.concat(items);
         }, []);
         const schemaRoutes = schemas.map((item: Item) => {
+            const isItemDisabled = item.isDisabled && item.isDisabled(this.props.config, {}, this.props.license, this.props.globalstate, haveINoWritePermissionOnSysConsoleItem);
+
             return (
                 <Route
                     key={item.url}
@@ -124,6 +136,8 @@ export default class AdminConsole extends React.Component<Props, State> {
                             {...extraProps}
                             {...props}
                             schema={item.schema}
+                            globalstate={this.props.globalstate}
+                            isDisabled={isItemDisabled}
                         />
                     )}
                 />
@@ -149,7 +163,7 @@ export default class AdminConsole extends React.Component<Props, State> {
         } = this.props;
         const {setNavigationBlocked, cancelNavigation, confirmNavigation, editRole, updateConfig} = this.props.actions;
 
-        if (!this.props.isCurrentUserSystemAdmin) {
+        if (!this.props.isCurrentUserInSystemAdminsRole) {
             return (
                 <Redirect to={this.props.unauthorizedRoute}/>
             );

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -270,16 +270,6 @@ const AdminDefinition = {
         sectionTitle: t('admin.sidebar.userManagement'),
         sectionTitleDefault: 'User Management',
         isHidden: it.userHasNoPermissionOnResource('user_management'),
-
-        //TODO (temporarily disabled until issue is figured)
-        // system_user_detail: {
-        //     url: 'user_management/user/:user_id',
-        //     isDisabled: it.userHasNoWritePermissionOnResource('user_management.users'),
-        //     schema: {
-        //         id: 'SystemUserDetail',
-        //         component: SystemUserDetail,
-        //     },
-        // },
         system_users: {
             url: 'user_management/users',
             title: t('admin.sidebar.users'),
@@ -291,6 +281,14 @@ const AdminDefinition = {
             schema: {
                 id: 'SystemUsers',
                 component: SystemUsers,
+            },
+        },
+        system_user_detail: {
+            url: 'user_management/user/:user_id',
+            isDisabled: it.userHasNoWritePermissionOnResource('user_management.users'),
+            schema: {
+                id: 'SystemUserDetail',
+                component: SystemUserDetail,
             },
         },
         group_detail: {

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -270,14 +270,16 @@ const AdminDefinition = {
         sectionTitle: t('admin.sidebar.userManagement'),
         sectionTitleDefault: 'User Management',
         isHidden: it.userHasNoPermissionOnResource('user_management'),
-        system_user_detail: {
-            url: 'user_management/user/:user_id',
-            isDisabled: it.userHasNoWritePermissionOnResource('user_management.users'),
-            schema: {
-                id: 'SystemUserDetail',
-                component: SystemUserDetail,
-            },
-        },
+
+        //TODO (temporarily disabled until issue is figured)
+        // system_user_detail: {
+        //     url: 'user_management/user/:user_id',
+        //     isDisabled: it.userHasNoWritePermissionOnResource('user_management.users'),
+        //     schema: {
+        //         id: 'SystemUserDetail',
+        //         component: SystemUserDetail,
+        //     },
+        // },
         system_users: {
             url: 'user_management/users',
             title: t('admin.sidebar.users'),

--- a/components/admin_console/admin_settings.tsx
+++ b/components/admin_console/admin_settings.tsx
@@ -15,6 +15,7 @@ type Props = {
     environmentConfig?: object;
     setNavigationBlocked?: (blocked: boolean) => void;
     updateConfig?: (config: object) => {data: object; error: ClientErrorPlaceholder};
+    isDisabled?: boolean;
 }
 
 type State = {
@@ -229,7 +230,7 @@ export default abstract class AdminSettings extends React.Component<Props, State
                     <div className='admin-console-save'>
                         <SaveButton
                             saving={this.state.saving}
-                            disabled={!this.state.saveNeeded || (this.canSave && !this.canSave())}
+                            disabled={this.props.isDisabled || !this.state.saveNeeded || (this.canSave && !this.canSave())}
                             onClick={this.handleSubmit}
                             savingMessage={localizeMessage('admin.saving', 'Saving Config...')}
                         />

--- a/components/admin_console/admin_sidebar/index.js
+++ b/components/admin_console/admin_sidebar/index.js
@@ -26,6 +26,7 @@ function mapStateToProps(state) {
         buildEnterpriseReady,
         siteName,
         adminDefinition,
+        globalstate: state,
     };
 }
 

--- a/components/admin_console/cluster_settings.jsx
+++ b/components/admin_console/cluster_settings.jsx
@@ -136,6 +136,7 @@ export default class ClusterSettings extends AdminSettings {
                     value={this.state.Enable}
                     onChange={this.overrideHandleChange}
                     setByEnv={this.isSetByEnv('ClusterSettings.Enable')}
+                    disabled={this.props.isDisabled}
                 />
                 <TextSetting
                     id='ClusterName'
@@ -155,6 +156,7 @@ export default class ClusterSettings extends AdminSettings {
                     value={this.state.ClusterName}
                     onChange={this.overrideHandleChange}
                     setByEnv={this.isSetByEnv('ClusterSettings.ClusterName')}
+                    disabled={this.props.isDisabled}
                 />
                 <TextSetting
                     id='OverrideHostname'
@@ -174,6 +176,7 @@ export default class ClusterSettings extends AdminSettings {
                     value={this.state.OverrideHostname}
                     onChange={this.overrideHandleChange}
                     setByEnv={this.isSetByEnv('ClusterSettings.OverrideHostname')}
+                    disabled={this.props.isDisabled}
                 />
                 <BooleanSetting
                     id='UseIpAddress'
@@ -192,6 +195,7 @@ export default class ClusterSettings extends AdminSettings {
                     value={this.state.UseIpAddress}
                     onChange={this.overrideHandleChange}
                     setByEnv={this.isSetByEnv('ClusterSettings.UseIpAddress')}
+                    disabled={this.props.isDisabled}
                 />
                 <BooleanSetting
                     id='UseExperimentalGossip'
@@ -210,6 +214,7 @@ export default class ClusterSettings extends AdminSettings {
                     value={this.state.UseExperimentalGossip}
                     onChange={this.overrideHandleChange}
                     setByEnv={this.isSetByEnv('ClusterSettings.UseExperimentalGossip')}
+                    disabled={this.props.isDisabled}
                 />
                 <TextSetting
                     id='GossipPort'
@@ -229,6 +234,7 @@ export default class ClusterSettings extends AdminSettings {
                     value={this.state.GossipPort}
                     onChange={this.overrideHandleChange}
                     setByEnv={this.isSetByEnv('ClusterSettings.GossipPort')}
+                    disabled={this.props.isDisabled}
                 />
                 <TextSetting
                     id='StreamingPort'
@@ -248,6 +254,7 @@ export default class ClusterSettings extends AdminSettings {
                     value={this.state.StreamingPort}
                     onChange={this.overrideHandleChange}
                     setByEnv={this.isSetByEnv('ClusterSettings.StreamingPort')}
+                    disabled={this.props.isDisabled}
                 />
             </SettingsGroup>
         );

--- a/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
+++ b/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
@@ -58,6 +58,7 @@ export default class CustomEnableDisableGuestAccountsSetting extends React.Compo
                     helpText={helpText}
                     setByEnv={this.props.setByEnv}
                     onChange={this.handleChange}
+                    disabled={this.props.disabled}
                 />
                 <ConfirmModal
                     show={this.props.showConfirm && (this.props.value === false)}

--- a/components/admin_console/custom_terms_of_service_settings/custom_terms_of_service_settings.jsx
+++ b/components/admin_console/custom_terms_of_service_settings/custom_terms_of_service_settings.jsx
@@ -180,9 +180,9 @@ export default class CustomTermsOfServiceSettings extends AdminSettings {
                         />
                     }
                     value={this.state.termsEnabled}
-                    disabled={!(this.props.license.IsLicensed && this.props.license.CustomTermsOfService === 'true')}
                     onChange={this.handleTermsEnabledChange}
                     setByEnv={this.isSetByEnv('SupportSettings.CustomTermsOfServiceEnabled')}
+                    disabled={this.props.isDisabled || !(this.props.license.IsLicensed && this.props.license.CustomTermsOfService === 'true')}
                 />
                 <TextSetting
                     key={'customTermsOfServiceText'}
@@ -200,11 +200,11 @@ export default class CustomTermsOfServiceSettings extends AdminSettings {
                             defaultMessage='Text that will appear in your custom Terms of Service. Supports Markdown-formatted text.'
                         />
                     }
-                    disabled={!this.state.termsEnabled}
                     onChange={this.handleTermsTextChange}
                     setByEnv={this.isSetByEnv('SupportSettings.CustomTermsOfServiceText')}
                     value={this.state.termsText}
                     maxLength={Constants.MAX_TERMS_OF_SERVICE_TEXT_LENGTH}
+                    disabled={this.props.isDisabled || !this.state.termsEnabled}
                 />
                 <TextSetting
                     key={'customTermsOfServiceReAcceptancePeriod'}
@@ -222,10 +222,10 @@ export default class CustomTermsOfServiceSettings extends AdminSettings {
                             defaultMessage='The number of days before Terms of Service acceptance expires, and the terms must be re-accepted.'
                         />
                     }
-                    disabled={!this.state.termsEnabled}
                     value={this.state.reAcceptancePeriod}
                     onChange={this.handleReAcceptancePeriodChange}
                     setByEnv={this.isSetByEnv('SupportSettings.CustomTermsOfServiceReAcceptancePeriod')}
+                    disabled={this.props.isDisabled || !this.state.termsEnabled}
                 />
             </SettingsGroup>
         );

--- a/components/admin_console/data_retention_settings.jsx
+++ b/components/admin_console/data_retention_settings.jsx
@@ -185,6 +185,7 @@ export default class DataRetentionSettings extends AdminSettings {
                     value={this.state.messageRetentionDays}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.MessageRetentionDays')}
+                    disabled={this.props.isDisabled}
                 />
             );
         }
@@ -205,6 +206,7 @@ export default class DataRetentionSettings extends AdminSettings {
                     value={this.state.fileRetentionDays}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.FileRetentionDays')}
+                    disabled={this.props.isDisabled}
                 />
             );
         }
@@ -254,6 +256,7 @@ export default class DataRetentionSettings extends AdminSettings {
                     value={this.state.enableMessageDeletion}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.EnableMessageDeletion')}
+                    disabled={this.props.isDisabled}
                 />
                 {messageRetentionDaysSetting}
                 <DropdownSetting
@@ -274,6 +277,7 @@ export default class DataRetentionSettings extends AdminSettings {
                     value={this.state.enableFileDeletion}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.EnableFileDeletion')}
+                    disabled={this.props.isDisabled}
                 />
                 {fileRetentionDaysSetting}
                 <TextSetting
@@ -294,6 +298,7 @@ export default class DataRetentionSettings extends AdminSettings {
                     value={this.state.deletionJobStartTime}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.DeletionJobStartTime')}
+                    disabled={this.props.isDisabled}
                 />
                 <JobsTable
                     jobType={JobTypes.DATA_RETENTION}

--- a/components/admin_console/database_settings.jsx
+++ b/components/admin_console/database_settings.jsx
@@ -97,6 +97,7 @@ export default class DatabaseSettings extends AdminSettings {
                         defaultMessage: 'Recycling unsuccessful: {error}',
                     }}
                     includeDetailedError={true}
+                    disabled={this.props.isDisabled}
                 />
             );
         }
@@ -177,6 +178,7 @@ export default class DatabaseSettings extends AdminSettings {
                     value={this.state.maxIdleConns}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('SqlSettings.MaxIdleConns')}
+                    disabled={this.props.isDisabled}
                 />
                 <TextSetting
                     id='maxOpenConns'
@@ -196,6 +198,7 @@ export default class DatabaseSettings extends AdminSettings {
                     value={this.state.maxOpenConns}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('SqlSettings.MaxOpenConns')}
+                    disabled={this.props.isDisabled}
                 />
                 <TextSetting
                     id='queryTimeout'
@@ -215,6 +218,7 @@ export default class DatabaseSettings extends AdminSettings {
                     value={this.state.queryTimeout}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('SqlSettings.QueryTimeout')}
+                    disabled={this.props.isDisabled}
                 />
                 <TextSetting
                     id='connMaxLifetimeMilliseconds'
@@ -234,6 +238,7 @@ export default class DatabaseSettings extends AdminSettings {
                     value={this.state.connMaxLifetimeMilliseconds}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('SqlSettings.ConnMaxLifetimeMilliseconds')}
+                    disabled={this.props.isDisabled}
                 />
                 <TextSetting
                     id='minimumHashtagLength'
@@ -253,6 +258,7 @@ export default class DatabaseSettings extends AdminSettings {
                     value={this.state.minimumHashtagLength}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('ServiceSettings.MinimumHashtagLength')}
+                    disabled={this.props.isDisabled}
                 />
                 <BooleanSetting
                     id='trace'
@@ -271,6 +277,7 @@ export default class DatabaseSettings extends AdminSettings {
                     value={this.state.trace}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('SqlSettings.Trace')}
+                    disabled={this.props.isDisabled}
                 />
                 {recycleDbButton}
             </SettingsGroup>

--- a/components/admin_console/elasticsearch_settings.jsx
+++ b/components/admin_console/elasticsearch_settings.jsx
@@ -168,6 +168,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                     value={this.state.enableIndexing}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.EnableIndexing')}
+                    disabled={this.props.isDisabled}
                 />
                 <TextSetting
                     id='connectionUrl'
@@ -199,7 +200,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                         />
                     }
                     value={this.state.connectionUrl}
-                    disabled={!this.state.enableIndexing}
+                    disabled={this.props.isDisabled || !this.state.enableIndexing}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.ConnectionUrl')}
                 />
@@ -218,7 +219,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                         />
                     }
                     value={this.state.skipTLSVerification}
-                    disabled={!this.state.enableIndexing}
+                    disabled={this.props.isDisabled || !this.state.enableIndexing}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.SkipTLSVerification')}
                 />
@@ -238,7 +239,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                         />
                     }
                     value={this.state.username}
-                    disabled={!this.state.enableIndexing}
+                    disabled={this.props.isDisabled || !this.state.enableIndexing}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.Username')}
                 />
@@ -258,7 +259,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                         />
                     }
                     value={this.state.password}
-                    disabled={!this.state.enableIndexing}
+                    disabled={this.props.isDisabled || !this.state.enableIndexing}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.Password')}
                 />
@@ -277,7 +278,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                         />
                     }
                     value={this.state.sniff}
-                    disabled={!this.state.enableIndexing}
+                    disabled={this.props.isDisabled || !this.state.enableIndexing}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.Sniff')}
                 />
@@ -356,7 +357,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                         id: t('admin.elasticsearch.purgeIndexesButton.error'),
                         defaultMessage: 'Failed to purge indexes: {error}',
                     }}
-                    disabled={!this.state.canPurgeAndIndex}
+                    disabled={this.props.isDisabled || !this.state.canPurgeAndIndex}
                     label={(
                         <FormattedMessage
                             id='admin.elasticsearch.purgeIndexesButton.label'
@@ -379,7 +380,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                         />
                     }
                     value={this.state.enableSearching}
-                    disabled={!this.state.enableIndexing || !this.state.configTested}
+                    disabled={this.props.isDisabled || !this.state.enableIndexing || !this.state.configTested}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.EnableSearching')}
                 />
@@ -398,7 +399,7 @@ export default class ElasticsearchSettings extends AdminSettings {
                         />
                     }
                     value={this.state.enableAutocomplete}
-                    disabled={!this.state.enableIndexing || !this.state.configTested}
+                    disabled={this.props.isDisabled || !this.state.enableIndexing || !this.state.configTested}
                     onChange={this.handleSettingChanged}
                     setByEnv={this.isSetByEnv('ElasticsearchSettings.EnableAutocomplete')}
                 />

--- a/components/admin_console/group_settings/group_details/group_profile_and_settings.jsx
+++ b/components/admin_console/group_settings/group_details/group_profile_and_settings.jsx
@@ -13,9 +13,9 @@ import {t} from 'utils/i18n';
 
 import LineSwitch from 'components/admin_console/team_channel_settings/line_switch.jsx';
 
-const GroupSettingsToggle = ({isDefault, allowReference, onToggle}) => (
+const GroupSettingsToggle = ({isDefault, allowReference, onToggle, isDisabled}) => (
     <LineSwitch
-        disabled={isDefault}
+        disabled={isDisabled || isDefault}
         toggled={allowReference}
         last={true}
         onToggle={() => {
@@ -43,6 +43,7 @@ GroupSettingsToggle.propTypes = {
     isDefault: PropTypes.bool.isRequired,
     allowReference: PropTypes.bool.isRequired,
     onToggle: PropTypes.func.isRequired,
+    isDisabled: PropTypes.bool,
 };
 
 export const GroupProfileAndSettings = ({displayname, name, allowReference, onToggle}) => (

--- a/components/admin_console/index.ts
+++ b/components/admin_console/index.ts
@@ -11,7 +11,7 @@ import {getConfig as getGeneralConfig, getLicense} from 'mattermost-redux/select
 import {getRoles} from 'mattermost-redux/selectors/entities/roles';
 import {selectChannel} from 'mattermost-redux/actions/channels';
 import {selectTeam} from 'mattermost-redux/actions/teams';
-import {isCurrentUserSystemAdmin, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {isCurrentUserSystemAdmin, isCurrentUserInSystemAdminsRole, getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import {General} from 'mattermost-redux/constants';
@@ -44,8 +44,10 @@ function mapStateToProps(state: GlobalState) {
         navigationBlocked: getNavigationBlocked(state),
         showNavigationPrompt: showNavigationPrompt(state),
         isCurrentUserSystemAdmin: isCurrentUserSystemAdmin(state),
+        isCurrentUserInSystemAdminsRole: isCurrentUserInSystemAdminsRole(state),
         roles: getRoles(state),
         adminDefinition,
+        globalstate: state,
     };
 }
 

--- a/components/admin_console/license_settings/license_settings.jsx
+++ b/components/admin_console/license_settings/license_settings.jsx
@@ -14,6 +14,7 @@ export default class LicenseSettings extends React.Component {
     static propTypes = {
         license: PropTypes.object.isRequired,
         config: PropTypes.object,
+        isDisabled: PropTypes.bool,
         actions: PropTypes.shape({
             getLicenseConfig: PropTypes.func.isRequired,
             uploadLicense: PropTypes.func.isRequired,
@@ -161,6 +162,7 @@ export default class LicenseSettings extends React.Component {
                         className='btn btn-danger'
                         onClick={this.handleRemove}
                         id='remove-button'
+                        disabled={this.props.isDisabled}
                     >
                         {removeButtonText}
                     </button>
@@ -218,7 +220,10 @@ export default class LicenseSettings extends React.Component {
             licenseKey = (
                 <div className='col-sm-8'>
                     <div className='file__upload'>
-                        <button className='btn btn-primary'>
+                        <button
+                            className='btn btn-primary'
+                            disabled={this.props.isDisabled}
+                        >
                             <FormattedMessage
                                 id='admin.license.choose'
                                 defaultMessage='Choose File'
@@ -229,13 +234,14 @@ export default class LicenseSettings extends React.Component {
                             type='file'
                             accept='.mattermost-license'
                             onChange={this.handleChange}
+                            disabled={this.props.isDisabled}
                         />
                     </div>
                     <button
                         className={btnClass}
-                        disabled={!this.state.fileSelected}
                         onClick={this.handleSubmit}
                         id='upload-button'
+                        disabled={this.props.isDisabled || !this.state.fileSelected}
                     >
                         {uploadButtonText}
                     </button>

--- a/components/admin_console/message_export_settings.jsx
+++ b/components/admin_console/message_export_settings.jsx
@@ -110,9 +110,9 @@ export default class MessageExportSettings extends AdminSettings {
                         />
                     }
                     value={this.state.globalRelayCustomerType ? this.state.globalRelayCustomerType : ''}
-                    disabled={!this.state.enableComplianceExport}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.GlobalRelaySettings.CustomerType')}
+                    disabled={this.props.isDisabled || !this.state.enableComplianceExport}
                 />
             );
 
@@ -133,9 +133,9 @@ export default class MessageExportSettings extends AdminSettings {
                         />
                     }
                     value={this.state.globalRelaySmtpUsername ? this.state.globalRelaySmtpUsername : ''}
-                    disabled={!this.state.enableComplianceExport}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.GlobalRelaySettings.SmtpUsername')}
+                    disabled={this.props.isDisabled || !this.state.enableComplianceExport}
                 />
             );
 
@@ -156,9 +156,9 @@ export default class MessageExportSettings extends AdminSettings {
                         />
                     }
                     value={this.state.globalRelaySmtpPassword ? this.state.globalRelaySmtpPassword : ''}
-                    disabled={!this.state.enableComplianceExport}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.GlobalRelaySettings.SmtpPassword')}
+                    disabled={this.props.isDisabled || !this.state.enableComplianceExport}
                 />
             );
 
@@ -179,9 +179,9 @@ export default class MessageExportSettings extends AdminSettings {
                         />
                     }
                     value={this.state.globalRelayEmailAddress ? this.state.globalRelayEmailAddress : ''}
-                    disabled={!this.state.enableComplianceExport}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.GlobalRelaySettings.EmailAddress')}
+                    disabled={this.props.isDisabled || !this.state.enableComplianceExport}
                 />
             );
 
@@ -222,6 +222,7 @@ export default class MessageExportSettings extends AdminSettings {
                     value={this.state.enableComplianceExport}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.EnableExport')}
+                    disabled={this.props.isDisabled}
                 />
 
                 <TextSetting
@@ -240,9 +241,9 @@ export default class MessageExportSettings extends AdminSettings {
                         />
                     }
                     value={this.state.exportJobStartTime}
-                    disabled={!this.state.enableComplianceExport}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.DailyRunTime')}
+                    disabled={this.props.isDisabled || !this.state.enableComplianceExport}
                 />
 
                 <DropdownSetting
@@ -256,16 +257,15 @@ export default class MessageExportSettings extends AdminSettings {
                     }
                     helpText={dropdownHelpText}
                     value={this.state.exportFormat}
-                    disabled={!this.state.enableComplianceExport}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('DataRetentionSettings.ExportFormat')}
+                    disabled={this.props.isDisabled || !this.state.enableComplianceExport}
                 />
 
                 {globalRelaySettings}
 
                 <JobsTable
                     jobType={JobTypes.MESSAGE_EXPORT}
-                    disabled={!this.state.enableComplianceExport}
                     createJobButtonText={
                         <FormattedMessage
                             id='admin.complianceExport.createJob.title'
@@ -279,6 +279,7 @@ export default class MessageExportSettings extends AdminSettings {
                         />
                     }
                     getExtraInfoText={this.getJobDetails}
+                    disabled={this.props.isDisabled || !this.state.enableComplianceExport}
                 />
             </SettingsGroup>
         );

--- a/components/admin_console/password_settings.jsx
+++ b/components/admin_console/password_settings.jsx
@@ -170,6 +170,7 @@ export default class PasswordSettings extends AdminSettings {
                         value={this.state.passwordMinimumLength}
                         onChange={this.handlePasswordLengthChange}
                         setByEnv={this.isSetByEnv('PasswordSettings.MinimumLength')}
+                        disabled={this.props.isDisabled}
                     />
                     <Setting
                         label={
@@ -187,6 +188,7 @@ export default class PasswordSettings extends AdminSettings {
                                     defaultChecked={this.state.passwordLowercase}
                                     name='admin.password.lowercase'
                                     onChange={this.handleCheckboxChange}
+                                    disabled={this.props.isDisabled}
                                 />
                                 <FormattedMessage
                                     id='admin.password.lowercase'
@@ -202,6 +204,7 @@ export default class PasswordSettings extends AdminSettings {
                                     defaultChecked={this.state.passwordUppercase}
                                     name='admin.password.uppercase'
                                     onChange={this.handleCheckboxChange}
+                                    disabled={this.props.isDisabled}
                                 />
                                 <FormattedMessage
                                     id='admin.password.uppercase'
@@ -217,6 +220,7 @@ export default class PasswordSettings extends AdminSettings {
                                     defaultChecked={this.state.passwordNumber}
                                     name='admin.password.number'
                                     onChange={this.handleCheckboxChange}
+                                    disabled={this.props.isDisabled}
                                 />
                                 <FormattedMessage
                                     id='admin.password.number'
@@ -232,6 +236,7 @@ export default class PasswordSettings extends AdminSettings {
                                     defaultChecked={this.state.passwordSymbol}
                                     name='admin.password.symbol'
                                     onChange={this.handleCheckboxChange}
+                                    disabled={this.props.isDisabled}
                                 />
                                 <FormattedMessage
                                     id='admin.password.symbol'
@@ -270,6 +275,7 @@ export default class PasswordSettings extends AdminSettings {
                     value={this.state.maximumLoginAttempts}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('ServiceSettings.MaximumLoginAttempts')}
+                    disabled={this.props.isDisabled}
                 />
             </SettingsGroup>
         );

--- a/components/admin_console/permission_schemes_settings/permission_schemes_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_schemes_settings.jsx
@@ -33,6 +33,7 @@ export default class PermissionSchemesSettings extends React.PureComponent {
             loadSchemes: PropTypes.func.isRequired,
             loadSchemeTeams: PropTypes.func.isRequired,
         }),
+        isDisabled: PropTypes.bool,
     };
 
     constructor(props) {
@@ -167,7 +168,7 @@ export default class PermissionSchemesSettings extends React.PureComponent {
                         <button
                             className='more-schemes theme style--none color--link'
                             onClick={this.loadMoreSchemes}
-                            disabled={this.state.loadingMore}
+                            disabled={this.props.isDisabled || this.state.loadingMore}
                         >
                             <LoadingWrapper
                                 loading={this.state.loadingMore}

--- a/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.jsx
@@ -29,6 +29,7 @@ export default class PermissionSystemSchemeSettings extends React.Component {
         config: PropTypes.object.isRequired,
         roles: PropTypes.object.isRequired,
         license: PropTypes.object.isRequired,
+        isDisabled: PropTypes.bool,
         actions: PropTypes.shape({
             loadRolesIfNeeded: PropTypes.func.isRequired,
             editRole: PropTypes.func.isRequired,
@@ -327,7 +328,7 @@ export default class PermissionSystemSchemeSettings extends React.Component {
                                     scope={'system_scope'}
                                     onToggle={this.togglePermission}
                                     selectRow={this.selectRow}
-                                    readOnly={!this.haveGuestAccountsPermissions()}
+                                    readOnly={this.props.isDisabled || !this.haveGuestAccountsPermissions()}
                                 />
                             </AdminPanelTogglable>}
 
@@ -347,6 +348,7 @@ export default class PermissionSystemSchemeSettings extends React.Component {
                                 scope={'system_scope'}
                                 onToggle={this.togglePermission}
                                 selectRow={this.selectRow}
+                                readOnly={this.props.isDisabled}
                             />
                         </AdminPanelTogglable>
 
@@ -365,6 +367,7 @@ export default class PermissionSystemSchemeSettings extends React.Component {
                                 scope={'channel_scope'}
                                 onToggle={this.togglePermission}
                                 selectRow={this.selectRow}
+                                readOnly={this.props.isDisabled}
                             />
                         </AdminPanelTogglable>
 
@@ -383,6 +386,7 @@ export default class PermissionSystemSchemeSettings extends React.Component {
                                 scope={'team_scope'}
                                 onToggle={this.togglePermission}
                                 selectRow={this.selectRow}
+                                readOnly={this.props.isDisabled}
                             />
                         </AdminPanelTogglable>
 
@@ -409,7 +413,7 @@ export default class PermissionSystemSchemeSettings extends React.Component {
                 <div className='admin-console-save'>
                     <SaveButton
                         saving={this.state.saving}
-                        disabled={!this.state.saveNeeded || (this.canSave && !this.canSave())}
+                        disabled={this.props.isDisabled || !this.state.saveNeeded || (this.canSave && !this.canSave())}
                         onClick={this.handleSubmit}
                         savingMessage={localizeMessage('admin.saving', 'Saving Config...')}
                     />

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.jsx
@@ -35,6 +35,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
         roles: PropTypes.object.isRequired,
         license: PropTypes.object.isRequired,
         teams: PropTypes.array,
+        isDisabled: PropTypes.bool,
         actions: PropTypes.shape({
             loadRolesIfNeeded: PropTypes.func.isRequired,
             loadScheme: PropTypes.func.isRequired,
@@ -520,6 +521,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                                         value={schemeName}
                                         placeholder={{id: t('admin.permissions.teamScheme.schemeNamePlaceholder'), defaultMessage: 'Scheme Name'}}
                                         onChange={this.handleNameChange}
+                                        disabled={this.props.isDisabled}
                                     />
                                 </div>
                                 <div className='form-group'>
@@ -539,6 +541,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                                         value={schemeDescription}
                                         placeholder={localizeMessage('admin.permissions.teamScheme.schemeDescriptionPlaceholder', 'Scheme Description')}
                                         onChange={this.handleDescriptionChange}
+                                        disabled={this.props.isDisabled}
                                     />
                                 </div>
                             </div>
@@ -553,6 +556,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                             onButtonClick={this.openAddTeam}
                             buttonTextId={t('admin.permissions.teamScheme.addTeams')}
                             buttonTextDefault='Add Teams'
+                            disabled={this.props.isDisabled}
                         >
                             <div className='teams-list'>
                                 {teams.length === 0 &&
@@ -582,6 +586,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                                 titleDefault='Guests'
                                 subtitleId={t('admin.permissions.systemScheme.GuestsDescription')}
                                 subtitleDefault='Permissions granted to guest users.'
+                                disabled={this.props.isDisabled}
                             >
                                 <GuestPermissionsTree
                                     selected={this.state.selectedPermission}
@@ -589,7 +594,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                                     scope={'team_scope'}
                                     onToggle={this.togglePermission}
                                     selectRow={this.selectRow}
-                                    readOnly={!this.haveGuestAccountsPermissions()}
+                                    readOnly={this.props.isDisabled || !this.haveGuestAccountsPermissions()}
                                 />
                             </AdminPanelTogglable>
                         }
@@ -603,6 +608,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                             titleDefault='All Members'
                             subtitleId={t('admin.permissions.systemScheme.allMembersDescription')}
                             subtitleDefault='Permissions granted to all members, including administrators and newly created users.'
+                            disabled={this.props.isDisabled}
                         >
                             <PermissionsTree
                                 selected={this.state.selectedPermission}
@@ -610,6 +616,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                                 scope={'team_scope'}
                                 onToggle={this.togglePermission}
                                 selectRow={this.selectRow}
+                                readOnly={this.props.isDisabled}
                             />
                         </AdminPanelTogglable>
 
@@ -621,6 +628,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                             titleDefault='Channel Administrators'
                             subtitleId={t('admin.permissions.systemScheme.channelAdminsDescription')}
                             subtitleDefault='Permissions granted to channel creators and any users promoted to Channel Administrator.'
+                            disabled={this.props.isDisabled}
                         >
                             <PermissionsTree
                                 parentRole={roles.all_users}
@@ -628,6 +636,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                                 scope={'channel_scope'}
                                 onToggle={this.togglePermission}
                                 selectRow={this.selectRow}
+                                readOnly={this.props.isDisabled}
                             />
                         </AdminPanelTogglable>
 
@@ -639,6 +648,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                             titleDefault='Team Administrators'
                             subtitleId={t('admin.permissions.systemScheme.teamAdminsDescription')}
                             subtitleDefault='Permissions granted to team creators and any users promoted to Team Administrator.'
+                            disabled={this.props.isDisabled}
                         >
                             <PermissionsTree
                                 parentRole={roles.all_users}
@@ -646,6 +656,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                                 scope={'team_scope'}
                                 onToggle={this.togglePermission}
                                 selectRow={this.selectRow}
+                                readOnly={this.props.isDisabled}
                             />
                         </AdminPanelTogglable>
                     </div>
@@ -654,7 +665,7 @@ export default class PermissionTeamSchemeSettings extends React.Component {
                 <div className='admin-console-save'>
                     <SaveButton
                         saving={this.state.saving}
-                        disabled={!this.state.saveNeeded || (this.canSave && !this.canSave())}
+                        disabled={this.props.isDisabled || !this.state.saveNeeded || (this.canSave && !this.canSave())}
                         onClick={this.handleSubmit}
                         savingMessage={localizeMessage('admin.saving', 'Saving Config...')}
                     />

--- a/components/admin_console/plugin_management/plugin_management.jsx
+++ b/components/admin_console/plugin_management/plugin_management.jsx
@@ -778,6 +778,7 @@ export default class PluginManagement extends AdminSettings {
                     value={this.state.enable}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('PluginSettings.Enable')}
+                    disabled={this.props.isDisabled}
                 />
             );
         }
@@ -962,7 +963,7 @@ export default class PluginManagement extends AdminSettings {
                                 />
                             }
                             value={this.state.requirePluginSignature}
-                            disabled={!this.state.enable}
+                            disabled={this.props.isDisabled || !this.state.enable}
                             onChange={this.handleChange}
                             setByEnv={this.isSetByEnv('PluginSettings.RequirePluginSignature')}
                         />
@@ -981,7 +982,7 @@ export default class PluginManagement extends AdminSettings {
                                 />
                             }
                             value={this.state.automaticPrepackagedPlugins}
-                            disabled={!this.state.enable}
+                            disabled={this.props.isDisabled || !this.state.enable}
                             onChange={this.handleChange}
                             setByEnv={this.isSetByEnv('PluginSettings.AutomaticPrepackagedPlugins')}
                         />
@@ -1046,7 +1047,7 @@ export default class PluginManagement extends AdminSettings {
                                 />
                             }
                             value={this.state.enableMarketplace}
-                            disabled={!this.state.enable}
+                            disabled={this.props.isDisabled || !this.state.enable}
                             onChange={this.handleChange}
                             setByEnv={this.isSetByEnv('PluginSettings.EnableMarketplace')}
                         />
@@ -1065,7 +1066,7 @@ export default class PluginManagement extends AdminSettings {
                                 />
                             }
                             value={this.state.enableRemoteMarketplace}
-                            disabled={!this.state.enable || !this.state.enableMarketplace}
+                            disabled={this.props.isDisabled || !this.state.enable || !this.state.enableMarketplace}
                             onChange={this.handleChange}
                             setByEnv={this.isSetByEnv('PluginSettings.EnableRemoteMarketplace')}
                         />
@@ -1080,7 +1081,7 @@ export default class PluginManagement extends AdminSettings {
                             }
                             helpText={this.getMarketplaceUrlHelpText(this.state.marketplaceUrl)}
                             value={this.state.marketplaceUrl}
-                            disabled={!this.state.enable || !this.state.enableMarketplace || !this.state.enableRemoteMarketplace}
+                            disabled={this.props.isDisabled || !this.state.enable || !this.state.enableMarketplace || !this.state.enableRemoteMarketplace}
                             onChange={this.handleChange}
                             setByEnv={this.isSetByEnv('PluginSettings.MarketplaceUrl')}
                         />

--- a/components/admin_console/push_settings.jsx
+++ b/components/admin_console/push_settings.jsx
@@ -162,6 +162,7 @@ export default class PushSettings extends AdminSettings {
                             ref='agree'
                             checked={this.state.agree}
                             onChange={this.handleAgreeChange}
+                            disabled={this.props.isDisabled}
                         />
                         <FormattedMarkdownMessage
                             id='admin.email.agreeHPNS'
@@ -187,6 +188,7 @@ export default class PushSettings extends AdminSettings {
                     onChange={this.handleDropdownChange}
                     helpText={sendHelpText}
                     setByEnv={this.isPushNotificationServerSetByEnv()}
+                    disabled={this.props.isDisabled}
                 />
                 {tosCheckbox}
                 <TextSetting
@@ -201,7 +203,7 @@ export default class PushSettings extends AdminSettings {
                     helpText={pushServerHelpText}
                     value={this.state.pushNotificationServer}
                     onChange={this.handleChange}
-                    disabled={this.state.pushNotificationServerType !== PUSH_NOTIFICATIONS_CUSTOM}
+                    disabled={this.props.isDisabled || this.state.pushNotificationServerType !== PUSH_NOTIFICATIONS_CUSTOM}
                     setByEnv={this.isSetByEnv('EmailSettings.PushNotificationServer')}
                 />
                 <TextSetting
@@ -223,6 +225,7 @@ export default class PushSettings extends AdminSettings {
                     value={this.state.maxNotificationsPerChannel}
                     onChange={this.handleChange}
                     setByEnv={this.isSetByEnv('TeamSettings.MaxNotificationsPerChannel')}
+                    disabled={this.props.isDisabled}
                 />
             </SettingsGroup>
         );

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -7,6 +7,8 @@ import {FormattedMessage} from 'react-intl';
 import {Overlay, Tooltip} from 'react-bootstrap';
 import {Link} from 'react-router-dom';
 
+import {haveINoWritePermissionOnSysConsoleItem} from 'mattermost-redux/selectors/entities/roles';
+
 import * as I18n from 'i18n/i18n.jsx';
 
 import Constants from 'utils/constants';
@@ -47,6 +49,8 @@ export default class SchemaAdminSettings extends React.Component {
         license: PropTypes.object,
         editRole: PropTypes.func,
         updateConfig: PropTypes.func.isRequired,
+        globalstate: PropTypes.object,
+        isDisabled: PropTypes.bool,
     }
 
     constructor(props) {
@@ -346,7 +350,8 @@ export default class SchemaAdminSettings extends React.Component {
 
     isDisabled = (setting) => {
         if (typeof setting.isDisabled === 'function') {
-            return setting.isDisabled(this.props.config, this.state, this.props.license);
+            var result = setting.isDisabled(this.props.config, this.state, this.props.license, this.props.globalstate, haveINoWritePermissionOnSysConsoleItem);
+            return result;
         }
         return Boolean(setting.isDisabled);
     }
@@ -984,7 +989,10 @@ export default class SchemaAdminSettings extends React.Component {
         if (schema && schema.component && schema.settings) {
             const CustomComponent = schema.component;
             return (
-                <CustomComponent {...this.props}/>
+                <CustomComponent
+                    {...this.props}
+                    disabled={this.props.isDisabled}
+                />
             );
         }
         return null;
@@ -995,7 +1003,10 @@ export default class SchemaAdminSettings extends React.Component {
         if (schema && schema.component && !schema.settings) {
             const CustomComponent = schema.component;
             return (
-                <CustomComponent {...this.props}/>
+                <CustomComponent
+                    {...this.props}
+                    disabled={this.props.isDisabled}
+                />
             );
         }
 

--- a/components/admin_console/server_logs/logs.jsx
+++ b/components/admin_console/server_logs/logs.jsx
@@ -19,7 +19,7 @@ export default class Logs extends React.Component {
          */
         logs: PropTypes.arrayOf(PropTypes.string).isRequired,
         nextPage: PropTypes.func,
-
+        isDisabled: PropTypes.bool,
         actions: PropTypes.shape({
 
             /*
@@ -105,6 +105,7 @@ export default class Logs extends React.Component {
                             type='submit'
                             className='btn btn-primary'
                             onClick={this.reload}
+                            disabled={this.props.isDisabled}
                         >
                             <FormattedMessage
                                 id='admin.logs.reload'

--- a/components/admin_console/system_users/list/system_users_list.jsx
+++ b/components/admin_console/system_users/list/system_users_list.jsx
@@ -32,6 +32,7 @@ export default class SystemUsersList extends React.Component {
         filter: PropTypes.string.isRequired,
         term: PropTypes.string.isRequired,
         onTermChange: PropTypes.func.isRequired,
+        isDisabled: PropTypes.bool,
 
         /**
          * Whether MFA is licensed and enabled.
@@ -322,6 +323,7 @@ export default class SystemUsersList extends React.Component {
                         doManageTeams: this.doManageTeams,
                         doManageRoles: this.doManageRoles,
                         doManageTokens: this.doManageTokens,
+                        isDisabled: this.props.isDisabled,
                     }}
                     nextPage={this.nextPage}
                     previousPage={this.previousPage}

--- a/components/admin_console/system_users/system_users.jsx
+++ b/components/admin_console/system_users/system_users.jsx
@@ -57,6 +57,7 @@ export default class SystemUsers extends React.Component {
         teamId: PropTypes.string.isRequired,
         filter: PropTypes.string.isRequired,
         users: PropTypes.object.isRequired,
+        isDisabled: PropTypes.bool,
 
         actions: PropTypes.shape({
 
@@ -377,6 +378,7 @@ export default class SystemUsers extends React.Component {
                                 mfaEnabled={this.props.mfaEnabled}
                                 enableUserAccessTokens={this.props.enableUserAccessTokens}
                                 experimentalEnableAuthenticationTransfer={this.props.experimentalEnableAuthenticationTransfer}
+                                isDisabled={this.props.isDisabled}
                             />
                         </div>
                         <SystemPermissionGate permissions={[Permissions.REVOKE_USER_ACCESS_TOKEN]}>

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.tsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.tsx
@@ -37,6 +37,7 @@ type Props = {
     config: any;
     bots: Dictionary<Bot>;
     isLicensed: boolean;
+    isDisabled: boolean;
     actions: {
         updateUserActive: (id: string, active: boolean) => Promise<{error: Error}>;
         revokeAllSessionsForUser: (id: string) => Promise<{error: Error; data: any}>;
@@ -520,7 +521,9 @@ export default class SystemUsersDropdown extends React.PureComponent<Props, Stat
                 {revokeSessionsModal}
                 {promoteToUserModal}
                 {demoteToGuestModal}
-                <MenuWrapper>
+                <MenuWrapper
+                    isDisabled={this.props.isDisabled}
+                >
                     <div className='text-right'>
                         <a>
                             <span>{currentRoles} </span>

--- a/components/admin_console/team_channel_settings/channel/channel_settings.jsx
+++ b/components/admin_console/team_channel_settings/channel/channel_settings.jsx
@@ -48,7 +48,9 @@ export class ChannelsSettings extends React.Component {
                             subtitleDefault={'Manage channel settings.'}
                             subtitleValues={{...this.state}}
                         >
-                            <ChannelsList onPageChangedCallback={this.onPageChangedCallback}/>
+                            <ChannelsList
+                                onPageChangedCallback={this.onPageChangedCallback}
+                            />
                         </AdminPanel>
                     </div>
                 </div>

--- a/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
@@ -38,6 +38,7 @@ interface ChannelDetailsProps {
     allGroups: {[gid: string]: Group}; // hashmap of groups
     teamScheme?: Scheme;
     guestAccountsEnabled: boolean;
+    isDisabled: boolean;
     actions: {
         getGroups: (channelID: string, q?: string, page?: number, perPage?: number) => Promise<Partial<Group>[]>;
         linkGroupSyncable: (groupID: string, syncableID: string, syncableType: string, patch: Partial<SyncablePatch>) => ActionFunc|ActionResult;
@@ -496,6 +497,7 @@ export default class ChannelDetails extends React.Component<ChannelDetailsProps,
                             isSynced={isSynced}
                             isDefault={isDefault}
                             onToggle={this.setToggles}
+                            isDisabled={this.props.isDisabled}
                         />
 
                         <ChannelModeration
@@ -504,6 +506,7 @@ export default class ChannelDetails extends React.Component<ChannelDetailsProps,
                             teamSchemeID={teamScheme?.id}
                             teamSchemeDisplayName={teamScheme?.['display_name']}
                             guestAccountsEnabled={this.props.guestAccountsEnabled}
+                            isDisabled={this.props.isDisabled}
                         />
 
                         <ChannelGroups
@@ -515,6 +518,7 @@ export default class ChannelDetails extends React.Component<ChannelDetailsProps,
                             onAddCallback={this.handleGroupChange}
                             onGroupRemoved={this.handleGroupRemoved}
                             setNewGroupRole={this.setNewGroupRole}
+                            isDisabled={this.props.isDisabled}
                         />
                     </div>
                 </div>
@@ -525,6 +529,7 @@ export default class ChannelDetails extends React.Component<ChannelDetailsProps,
                     onClick={this.onSave}
                     serverError={serverError}
                     cancelLink='/admin_console/user_management/channels'
+                    isDisabled={this.props.isDisabled}
                 />
             </div>
         );

--- a/components/admin_console/team_channel_settings/channel/details/channel_groups.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_groups.tsx
@@ -23,10 +23,11 @@ interface ChannelGroupsProps {
     removedGroups: object[];
     onGroupRemoved: (gid: string) => void;
     setNewGroupRole: (gid: string) => void;
+    isDisabled: boolean;
 }
 
 export const ChannelGroups: React.SFC<ChannelGroupsProps> = (props: ChannelGroupsProps): JSX.Element => {
-    const {onGroupRemoved, onAddCallback, totalGroups, groups, removedGroups, channel, synced, setNewGroupRole} = props;
+    const {onGroupRemoved, onAddCallback, totalGroups, groups, removedGroups, channel, synced, setNewGroupRole, isDisabled} = props;
     return (
         <AdminPanel
             id='channel_groups'
@@ -45,6 +46,7 @@ export const ChannelGroups: React.SFC<ChannelGroupsProps> = (props: ChannelGroup
                         includeGroups: removedGroups,
                         excludeGroups: groups,
                     }}
+                    isDisabled={isDisabled}
                 >
                     <FormattedMessage
                         id='admin.channel_settings.channel_details.add_group'

--- a/components/admin_console/team_channel_settings/channel/details/channel_moderation.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_moderation.tsx
@@ -168,6 +168,7 @@ interface Props {
     teamSchemeID?: string;
     teamSchemeDisplayName?: string;
     guestAccountsEnabled: boolean;
+    isDisabled: boolean;
 }
 
 interface RowProps {

--- a/components/admin_console/team_channel_settings/channel/details/channel_modes.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_modes.tsx
@@ -15,13 +15,14 @@ interface Props {
     isSynced: boolean;
     isDefault: boolean;
     onToggle: (isSynced: boolean, isPublic: boolean) => void;
+    isDisabled: boolean;
 }
 
 const SyncGroupsToggle: React.SFC<Props> = (props: Props): JSX.Element => {
-    const {isPublic, isSynced, isDefault, onToggle} = props;
+    const {isPublic, isSynced, isDefault, onToggle, isDisabled} = props;
     return (
         <LineSwitch
-            disabled={isDefault}
+            disabled={isDisabled || isDefault}
             toggled={isSynced}
             last={isSynced}
             onToggle={() => {
@@ -47,14 +48,14 @@ const SyncGroupsToggle: React.SFC<Props> = (props: Props): JSX.Element => {
 };
 
 const AllowAllToggle: React.SFC<Props> = (props: Props): JSX.Element | null => {
-    const {isPublic, isSynced, isDefault, onToggle} = props;
+    const {isPublic, isSynced, isDefault, onToggle, isDisabled} = props;
     if (isSynced) {
         return null;
     }
     return (
         <LineSwitch
             id='allow-all-toggle'
-            disabled={isDefault}
+            disabled={isDisabled || isDefault}
             toggled={isPublic}
             last={true}
             onToggle={() => {
@@ -99,7 +100,7 @@ const AllowAllToggle: React.SFC<Props> = (props: Props): JSX.Element | null => {
 };
 
 export const ChannelModes: React.SFC<Props> = (props: Props): JSX.Element => {
-    const {isPublic, isSynced, isDefault, onToggle} = props;
+    const {isPublic, isSynced, isDefault, onToggle, isDisabled} = props;
     return (
         <AdminPanel
             id='channel_manage'
@@ -115,12 +116,14 @@ export const ChannelModes: React.SFC<Props> = (props: Props): JSX.Element => {
                         isSynced={isSynced}
                         isDefault={isDefault}
                         onToggle={onToggle}
+                        isDisabled={isDisabled}
                     />
                     <AllowAllToggle
                         isPublic={isPublic}
                         isSynced={isSynced}
                         isDefault={isDefault}
                         onToggle={onToggle}
+                        isDisabled={isDisabled}
                     />
                 </div>
             </div>

--- a/components/admin_console/team_channel_settings/channel/list/channel_list.tsx
+++ b/components/admin_console/team_channel_settings/channel/list/channel_list.tsx
@@ -28,6 +28,7 @@ interface ChannelListProps {
     onPageChangedCallback?: () => void;
     emptyListTextId?: string;
     emptyListTextDefaultMessage?: string;
+    isDisabled?: boolean;
 }
 
 interface ChannelListState {
@@ -61,6 +62,7 @@ export default class ChannelList extends React.PureComponent<ChannelListProps, C
                         onChange={this.searchBarChangeHandler}
                         value={this.state.searchString}
                         data-testid='search-input'
+                        disabled={this.props.isDisabled}
                     />
                     <SearchIcon
                         id='searchIcon'
@@ -170,6 +172,7 @@ export default class ChannelList extends React.PureComponent<ChannelListProps, C
                 key={item.id}
                 channel={item}
                 onRowClick={this.onChannelClick}
+                isDisabled={this.props.isDisabled}
             />
         );
     };

--- a/components/admin_console/team_channel_settings/channel/list/channel_row.tsx
+++ b/components/admin_console/team_channel_settings/channel/list/channel_row.tsx
@@ -13,6 +13,7 @@ import LockIcon from 'components/widgets/icons/lock_icon';
 interface Props {
     channel: ChannelWithTeamData;
     onRowClick: (id: string) => void;
+    isDisabled? : boolean;
 }
 
 export default class ChannelRow extends React.Component<Props> {
@@ -53,7 +54,9 @@ export default class ChannelRow extends React.Component<Props> {
                         className='group-actions'
                         data-testid={`${channel.display_name}edit`}
                     >
-                        <Link to={`/admin_console/user_management/channels/${channel.id}`} >
+                        <Link
+                            to={`/admin_console/user_management/channels/${channel.id}`}
+                        >
                             <FormattedMessage
                                 id='admin.channel_settings.channel_row.configure'
                                 defaultMessage='Edit'

--- a/components/admin_console/team_channel_settings/save_changes_panel.jsx
+++ b/components/admin_console/team_channel_settings/save_changes_panel.jsx
@@ -10,12 +10,12 @@ import SaveButton from 'components/save_button';
 import {localizeMessage} from 'utils/utils';
 import BlockableLink from 'components/admin_console/blockable_link';
 
-export default function SaveChangesPanel({saveNeeded, onClick, saving, serverError, cancelLink}) {
+export default function SaveChangesPanel({saveNeeded, onClick, saving, serverError, cancelLink, isDisabled}) {
     return (
         <div className='admin-console-save'>
             <SaveButton
                 saving={saving}
-                disabled={!saveNeeded}
+                disabled={isDisabled || !saveNeeded}
                 onClick={onClick}
                 savingMessage={localizeMessage('admin.team_channel_settings.saving', 'Saving Config...')}
             />
@@ -42,4 +42,5 @@ SaveChangesPanel.propTypes = {
     onClick: PropTypes.func.isRequired,
     cancelLink: PropTypes.string.isRequired,
     serverError: PropTypes.node,
+    isDisabled: PropTypes.bool,
 };

--- a/components/admin_console/team_channel_settings/team/details/team_details.jsx
+++ b/components/admin_console/team_channel_settings/team/details/team_details.jsx
@@ -28,6 +28,7 @@ export default class TeamDetails extends React.Component {
         totalGroups: PropTypes.number.isRequired,
         groups: PropTypes.arrayOf(PropTypes.object),
         allGroups: PropTypes.object.isRequired,
+        isDisabled: PropTypes.bool,
         actions: PropTypes.shape({
             setNavigationBlocked: PropTypes.func.isRequired,
             getTeam: PropTypes.func.isRequired,
@@ -245,6 +246,7 @@ export default class TeamDetails extends React.Component {
                             allowedDomains={allowedDomains}
                             syncChecked={syncChecked}
                             onToggle={this.setToggles}
+                            isDisabled={this.props.isDisabled}
                         />
 
                         <TeamGroups
@@ -256,6 +258,7 @@ export default class TeamDetails extends React.Component {
                             onAddCallback={this.handleGroupChange}
                             onGroupRemoved={this.handleGroupRemoved}
                             setNewGroupRole={this.setNewGroupRole}
+                            isDisabled={this.props.isDisabled}
                         />
 
                     </div>
@@ -267,6 +270,7 @@ export default class TeamDetails extends React.Component {
                     saveNeeded={saveNeeded}
                     onClick={this.showRemoveUsersModal}
                     serverError={serverError}
+                    isDisabled={this.props.isDisabled}
                 />
             </div>
         );

--- a/components/admin_console/team_channel_settings/team/details/team_groups.jsx
+++ b/components/admin_console/team_channel_settings/team/details/team_groups.jsx
@@ -14,7 +14,7 @@ import AddGroupsToTeamModal from 'components/add_groups_to_team_modal';
 
 import GroupList from '../../group';
 
-export const TeamGroups = ({onGroupRemoved, syncChecked, team, onAddCallback, totalGroups, groups, removedGroups, setNewGroupRole}) => (
+export const TeamGroups = ({onGroupRemoved, syncChecked, team, onAddCallback, totalGroups, groups, removedGroups, setNewGroupRole, isDisabled}) => (
     <AdminPanel
         id='team_groups'
         titleId={syncChecked ? t('admin.team_settings.team_detail.syncedGroupsTitle') : t('admin.team_settings.team_detail.groupsTitle')}
@@ -32,6 +32,7 @@ export const TeamGroups = ({onGroupRemoved, syncChecked, team, onAddCallback, to
                     excludeGroups: groups,
                     includeGroups: removedGroups,
                 }}
+                isDisabled={isDisabled}
             >
                 <FormattedMessage
                     id='admin.team_settings.team_details.add_group'
@@ -59,4 +60,5 @@ TeamGroups.propTypes = {
     onAddCallback: PropTypes.func.isRequired,
     onGroupRemoved: PropTypes.func.isRequired,
     setNewGroupRole: PropTypes.func.isRequired,
+    isDisabled: PropTypes.bool,
 };

--- a/components/admin_console/team_channel_settings/team/details/team_modes.jsx
+++ b/components/admin_console/team_channel_settings/team/details/team_modes.jsx
@@ -11,8 +11,9 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx'
 
 import LineSwitch from '../../line_switch.jsx';
 
-const SyncGroupsToggle = ({syncChecked, allAllowedChecked, allowedDomainsChecked, allowedDomains, onToggle}) => (
+const SyncGroupsToggle = ({syncChecked, allAllowedChecked, allowedDomainsChecked, allowedDomains, onToggle, isDisabled}) => (
     <LineSwitch
+        disabled={isDisabled}
         toggled={syncChecked}
         last={syncChecked}
         onToggle={() => onToggle(!syncChecked, allAllowedChecked, allowedDomainsChecked, allowedDomains)}
@@ -36,11 +37,13 @@ SyncGroupsToggle.propTypes = {
     allowedDomainsChecked: PropTypes.bool.isRequired,
     allowedDomains: PropTypes.string.isRequired,
     onToggle: PropTypes.func.isRequired,
+    isDisabled: PropTypes.bool,
 };
 
-const AllowAllToggle = ({syncChecked, allAllowedChecked, allowedDomainsChecked, allowedDomains, onToggle}) =>
+const AllowAllToggle = ({syncChecked, allAllowedChecked, allowedDomainsChecked, allowedDomains, onToggle, isDisabled}) =>
     !syncChecked && (
         <LineSwitch
+            disabled={isDisabled}
             toggled={allAllowedChecked}
             singleLine={true}
             onToggle={() => onToggle(syncChecked, !allAllowedChecked, allowedDomainsChecked, allowedDomains)}
@@ -64,11 +67,13 @@ AllowAllToggle.propTypes = {
     allowedDomainsChecked: PropTypes.bool.isRequired,
     allowedDomains: PropTypes.string.isRequired,
     onToggle: PropTypes.func.isRequired,
+    isDisabled: PropTypes.bool,
 };
 
-const AllowedDomainsToggle = ({syncChecked, allAllowedChecked, allowedDomainsChecked, allowedDomains, onToggle}) =>
+const AllowedDomainsToggle = ({syncChecked, allAllowedChecked, allowedDomainsChecked, allowedDomains, onToggle, isDisabled}) =>
     !syncChecked && (
         <LineSwitch
+            disabled={isDisabled}
             toggled={allowedDomainsChecked}
             last={true}
             onToggle={() => onToggle(syncChecked, allAllowedChecked, !allowedDomainsChecked, allowedDomains)}
@@ -107,9 +112,10 @@ AllowedDomainsToggle.propTypes = {
     allowedDomainsChecked: PropTypes.bool.isRequired,
     allowedDomains: PropTypes.string.isRequired,
     onToggle: PropTypes.func.isRequired,
+    isDisabled: PropTypes.bool,
 };
 
-export const TeamModes = ({allAllowedChecked, syncChecked, allowedDomains, allowedDomainsChecked, onToggle}) => (
+export const TeamModes = ({allAllowedChecked, syncChecked, allowedDomains, allowedDomainsChecked, onToggle, isDisabled}) => (
     <AdminPanel
         id='team_manage'
         titleId={t('admin.team_settings.team_detail.manageTitle')}
@@ -125,6 +131,7 @@ export const TeamModes = ({allAllowedChecked, syncChecked, allowedDomains, allow
                     allowedDomains={allowedDomains}
                     syncChecked={syncChecked}
                     onToggle={onToggle}
+                    isDisabled={isDisabled}
                 />
                 <AllowAllToggle
                     allAllowedChecked={allAllowedChecked}
@@ -132,6 +139,7 @@ export const TeamModes = ({allAllowedChecked, syncChecked, allowedDomains, allow
                     allowedDomains={allowedDomains}
                     syncChecked={syncChecked}
                     onToggle={onToggle}
+                    isDisabled={isDisabled}
                 />
                 <AllowedDomainsToggle
                     allAllowedChecked={allAllowedChecked}
@@ -139,6 +147,7 @@ export const TeamModes = ({allAllowedChecked, syncChecked, allowedDomains, allow
                     allowedDomains={allowedDomains}
                     syncChecked={syncChecked}
                     onToggle={onToggle}
+                    isDisabled={isDisabled}
                 />
             </div>
         </div>
@@ -150,4 +159,5 @@ TeamModes.propTypes = {
     allowedDomainsChecked: PropTypes.bool.isRequired,
     onToggle: PropTypes.func.isRequired,
     allowedDomains: PropTypes.string.isRequired,
+    isDisabled: PropTypes.bool,
 };

--- a/components/admin_console/team_channel_settings/team/details/team_modes.jsx
+++ b/components/admin_console/team_channel_settings/team/details/team_modes.jsx
@@ -103,6 +103,7 @@ const AllowedDomainsToggle = ({syncChecked, allAllowedChecked, allowedDomainsChe
                 placeholder='mattermost.org'
                 className='form-control'
                 onChange={(e) => onToggle(syncChecked, allAllowedChecked, allowedDomainsChecked, e.currentTarget.value)}
+                disabled={isDisabled}
             />
         </LineSwitch>);
 

--- a/components/localized_input/localized_input.tsx
+++ b/components/localized_input/localized_input.tsx
@@ -11,6 +11,7 @@ type Props = {
         values?: {string: any};
     };
     value?: string;
+    disabled?: boolean;
 };
 
 const LocalizedInput = React.forwardRef((props: Props, ref?: React.Ref<HTMLInputElement>) => {

--- a/components/main_menu/main_menu.jsx
+++ b/components/main_menu/main_menu.jsx
@@ -312,7 +312,7 @@ class MainMenu extends React.PureComponent {
                     />
                 </Menu.Group>
                 <Menu.Group>
-                    <SystemPermissionGate permissions={[Permissions.MANAGE_SYSTEM]}>
+                    <SystemPermissionGate permissions={[Permissions.READ_SETTINGS]}>
                         <Menu.ItemLink
                             id='systemConsole'
                             show={!this.props.mobile}

--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -35,6 +35,7 @@ class SearchableUserList extends React.Component {
         term: PropTypes.string.isRequired,
         onTermChange: PropTypes.func.isRequired,
         intl: PropTypes.any,
+        isDisabled: PropTypes.bool,
 
         // the type of user list row to render
         rowComponentType: PropTypes.func,
@@ -259,6 +260,7 @@ class SearchableUserList extends React.Component {
                         actionProps={this.props.actionProps}
                         actionUserProps={this.props.actionUserProps}
                         rowComponentType={this.props.rowComponentType}
+                        isDisabled={this.props.isDisabled}
                     />
                 </div>
                 <div className='filter-controls'>

--- a/components/toggle.tsx
+++ b/components/toggle.tsx
@@ -19,6 +19,7 @@ const Toggle: React.FC<Props> = (props: Props) => {
             onClick={onToggle}
             className={`btn btn-lg btn-toggle ${toggled && 'active'} ${disabled && 'disabled'}`}
             aria-pressed={toggled ? 'true' : 'false'}
+            disabled={disabled}
         >
             <div className='handle'/>
             {text(toggled, onText, offText)}

--- a/components/toggle_modal_button.jsx
+++ b/components/toggle_modal_button.jsx
@@ -25,7 +25,7 @@ export default class ModalToggleButton extends React.Component {
     }
 
     render() {
-        const {children, dialogType, dialogProps, onClick, ...props} = this.props;
+        const {children, dialogType, dialogProps, onClick, isDisabled, ...props} = this.props;
 
         // allow callers to provide an onClick which will be called before the modal is shown
         let clickHandler = this.show;
@@ -59,6 +59,7 @@ export default class ModalToggleButton extends React.Component {
                 className={'style--none ' + props.className}
                 onClick={clickHandler}
                 data-testid='add-group'
+                disabled={isDisabled}
             >
                 {children}
                 {dialog}
@@ -73,6 +74,7 @@ ModalToggleButton.propTypes = {
     dialogProps: PropTypes.object,
     onClick: PropTypes.func,
     className: PropTypes.string,
+    isDisabled: PropTypes.bool,
 };
 
 ModalToggleButton.defaultProps = {

--- a/components/user_list.jsx
+++ b/components/user_list.jsx
@@ -17,6 +17,7 @@ export default class UserList extends React.Component {
         actions: PropTypes.arrayOf(PropTypes.func),
         actionProps: PropTypes.object,
         actionUserProps: PropTypes.object,
+        isDisabled: PropTypes.bool,
 
         // the type of user list row to render
         rowComponentType: PropTypes.func,
@@ -56,6 +57,7 @@ export default class UserList extends React.Component {
                         index={index}
                         totalUsers={users.length}
                         userCount={(index >= 0 && index < Constants.TEST_ID_COUNT) ? index : -1}
+                        isDisabled={this.props.isDisabled}
                     />
                 );
             });

--- a/components/user_list_row_with_error/user_list_row_with_error.jsx
+++ b/components/user_list_row_with_error/user_list_row_with_error.jsx
@@ -23,6 +23,7 @@ export default class UserListRowWithError extends React.Component {
         index: PropTypes.number,
         totalUsers: PropTypes.number,
         userCount: PropTypes.number,
+        isDisabled: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -121,8 +122,11 @@ export default class UserListRowWithError extends React.Component {
                             <div
                                 id={userCountID}
                                 className='more-modal__name'
+                                disabled={this.props.isDisabled}
                             >
-                                <Link to={'/admin_console/user_management/user/' + this.props.user.id}>{Utils.displayEntireNameForUser(this.props.user)}</Link>
+                                <Link to={'/admin_console/user_management/user/' + this.props.user.id}>
+                                    {Utils.displayEntireNameForUser(this.props.user)}
+                                </Link>
                                 <BotBadge
                                     className='badge-admin'
                                     show={Boolean(this.props.user.is_bot)}

--- a/components/widgets/admin_console/admin_panel_togglable.tsx
+++ b/components/widgets/admin_console/admin_panel_togglable.tsx
@@ -17,6 +17,7 @@ type Props = {
     subtitleId: string;
     subtitleDefault: string;
     onToggle?: React.EventHandler<React.MouseEvent>;
+    isDisabled?: boolean;
 };
 
 const AdminPanelTogglable: React.FC<Props> = (props: Props) => {

--- a/components/widgets/menu/menu_wrapper.scss
+++ b/components/widgets/menu/menu_wrapper.scss
@@ -11,3 +11,9 @@
         cursor: pointer;
     }
 }
+
+div[disabled]
+{
+  pointer-events: none;
+  opacity: 0.7;
+}

--- a/components/widgets/menu/menu_wrapper.tsx
+++ b/components/widgets/menu/menu_wrapper.tsx
@@ -15,7 +15,7 @@ type Props = {
     onToggle?: (open: boolean) => void;
     animationComponent: any;
     id?: string;
-    isDisabled: boolean;
+    isDisabled?: boolean;
 }
 
 type State = {
@@ -97,7 +97,7 @@ export default class MenuWrapper extends React.PureComponent<Props, State> {
                 className={'MenuWrapper ' + this.props.className}
                 onClick={this.toggle}
                 ref={this.node}
-                disabled={this.props.isDisabled}
+                disabled={Boolean(this.props.isDisabled)}
             >
                 {children ? Object.values(children)[0] : {}}
                 <Animation show={this.state.open}>

--- a/components/widgets/menu/menu_wrapper.tsx
+++ b/components/widgets/menu/menu_wrapper.tsx
@@ -15,6 +15,7 @@ type Props = {
     onToggle?: (open: boolean) => void;
     animationComponent: any;
     id?: string;
+    isDisabled: boolean;
 }
 
 type State = {
@@ -96,6 +97,7 @@ export default class MenuWrapper extends React.PureComponent<Props, State> {
                 className={'MenuWrapper ' + this.props.className}
                 onClick={this.toggle}
                 ref={this.node}
+                disabled={this.props.isDisabled}
             >
                 {children ? Object.values(children)[0] : {}}
                 <Animation show={this.state.open}>

--- a/components/widgets/menu/menu_wrapper.tsx
+++ b/components/widgets/menu/menu_wrapper.tsx
@@ -9,6 +9,11 @@ import MenuWrapperAnimation from './menu_wrapper_animation';
 
 import './menu_wrapper.scss';
 
+declare module 'react' {
+    interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+        disabled?: boolean;
+    }
+}
 type Props = {
     children?: React.ReactNode;
     className: string;
@@ -97,7 +102,7 @@ export default class MenuWrapper extends React.PureComponent<Props, State> {
                 className={'MenuWrapper ' + this.props.className}
                 onClick={this.toggle}
                 ref={this.node}
-                disabled={Boolean(this.props.isDisabled)}
+                disabled={this.props.isDisabled}
             >
                 {children ? Object.values(children)[0] : {}}
                 <Animation show={this.state.open}>

--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -937,3 +937,9 @@
         max-width: none;
     }
 }
+
+div[disabled]
+{
+  pointer-events: none;
+  opacity: 0.7;
+}


### PR DESCRIPTION
POC code for https://mattermost.atlassian.net/browse/MM-23832

#### Summary
- adds three new roles: ConsoleViewer, User Manager and Junior Admin
- adds new set of permissions to the SystemConsole
- hides or disables specific sections/subsections of the SystemConsole based on the current user permissions
- permissions the setting through the API of various config.json settings base on their mapping to the SystemConsole permissions.

TODO
- further refine the permission model
- further permission API functionality for users. groups, teams and channels

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23832

#### Related Pull Requests
redux: https://github.com/mattermost/mattermost-redux/pull/1134
server: https://github.com/mattermost/mattermost-server/pull/14336