### PR TITLE
[MM-23384] Readded div to wrap around contents of OverlayTrigger

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
 <OverlayTrigger
   defaultOverlayShown={false}
   delayShow={400}
+  onEntering={[Function]}
   overlay={
     <Tooltip
       bsClass="tooltip"
@@ -153,69 +154,71 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
     ]
   }
 >
-  <Link
-    aria-label="channel_label"
-    className="SidebarLink"
-    id="sidebarItem_"
-    onClick={[Function]}
-    to="http://a.fake.link"
-  >
-    <Connect(SidebarChannelIcon)
-      channel={
-        Object {
-          "create_at": 0,
-          "creator_id": "",
-          "delete_at": 0,
-          "display_name": "channel_display_name",
-          "extra_update_at": 0,
-          "group_constrained": false,
-          "header": "",
-          "id": "channel_id",
-          "last_post_at": 0,
-          "name": "",
-          "purpose": "",
-          "scheme_id": "",
-          "team_id": "",
-          "total_msg_count": 0,
-          "type": "O",
-          "update_at": 0,
-        }
-      }
-      icon={null}
-    />
-    <span
-      className="SidebarChannelLinkLabel"
+  <div>
+    <Link
+      aria-label="channel_label"
+      className="SidebarLink"
+      id="sidebarItem_"
+      onClick={[Function]}
+      to="http://a.fake.link"
     >
-      channel_label
-    </span>
-    <ChannelMentionBadge
-      channelId="channel_id"
-      unreadMentions={0}
-    />
-    <SidebarChannelClose
-      channel={
-        Object {
-          "create_at": 0,
-          "creator_id": "",
-          "delete_at": 0,
-          "display_name": "channel_display_name",
-          "extra_update_at": 0,
-          "group_constrained": false,
-          "header": "",
-          "id": "channel_id",
-          "last_post_at": 0,
-          "name": "",
-          "purpose": "",
-          "scheme_id": "",
-          "team_id": "",
-          "total_msg_count": 0,
-          "type": "O",
-          "update_at": 0,
+      <Connect(SidebarChannelIcon)
+        channel={
+          Object {
+            "create_at": 0,
+            "creator_id": "",
+            "delete_at": 0,
+            "display_name": "channel_display_name",
+            "extra_update_at": 0,
+            "group_constrained": false,
+            "header": "",
+            "id": "channel_id",
+            "last_post_at": 0,
+            "name": "",
+            "purpose": "",
+            "scheme_id": "",
+            "team_id": "",
+            "total_msg_count": 0,
+            "type": "O",
+            "update_at": 0,
+          }
         }
-      }
-      show={true}
-    />
-  </Link>
+        icon={null}
+      />
+      <span
+        className="SidebarChannelLinkLabel"
+      >
+        channel_label
+      </span>
+      <ChannelMentionBadge
+        channelId="channel_id"
+        unreadMentions={0}
+      />
+      <SidebarChannelClose
+        channel={
+          Object {
+            "create_at": 0,
+            "creator_id": "",
+            "delete_at": 0,
+            "display_name": "channel_display_name",
+            "extra_update_at": 0,
+            "group_constrained": false,
+            "header": "",
+            "id": "channel_id",
+            "last_post_at": 0,
+            "name": "",
+            "purpose": "",
+            "scheme_id": "",
+            "team_id": "",
+            "total_msg_count": 0,
+            "type": "O",
+            "update_at": 0,
+          }
+        }
+        show={true}
+      />
+    </Link>
+  </div>
 </OverlayTrigger>
 `;
 

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -56,11 +56,14 @@ type State = {
 
 export default class SidebarChannelLink extends React.PureComponent<Props, State> {
     labelRef: React.RefObject<HTMLSpanElement>;
+    gmItemRef: React.RefObject<HTMLDivElement>;
 
     constructor(props: Props) {
         super(props);
 
         this.labelRef = React.createRef();
+        this.gmItemRef = React.createRef();
+
         this.state = {
             showTooltip: false,
         };
@@ -106,6 +109,13 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         }
 
         return ariaLabel.toLowerCase();
+    }
+
+    removeTooltipLink = () => {
+        // Bootstrap adds the attr dynamically, removing it to prevent a11y readout
+        if (this.gmItemRef.current) {
+            this.gmItemRef.current.removeAttribute('aria-describedby');
+        }
     }
 
     trackChannelSelectedEvent = () => {
@@ -196,8 +206,11 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
                     delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='top'
                     overlay={displayNameToolTip}
+                    onEntering={this.removeTooltipLink}
                 >
-                    {element}
+                    <div ref={this.gmItemRef}>
+                        {element}
+                    </div>
                 </OverlayTrigger>
             );
         }


### PR DESCRIPTION
#### Summary
When a channel name is too long for the sidebar, there should be a tooltip that pops up when hovering over the channel to show the full name. This was broken on Desktop with the new sidebar.

This PR re-adds a `div` element needed for the `OverlayTrigger`, and also re-inserts code to remove the extra `aria` tag.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23384
