### PR TITLE
MM-24381 - Improve channel header button options

### DIFF
--- a/components/channel_header/channel_header.js
+++ b/components/channel_header/channel_header.js
@@ -87,6 +87,7 @@ class ChannelHeader extends React.PureComponent {
         currentRelativeTeamUrl: PropTypes.string.isRequired,
         newSideBarPreference: PropTypes.bool,
         announcementBarCount: PropTypes.number,
+        priorityPluginButtons: PropTypes.array,
     };
 
     constructor(props) {
@@ -280,6 +281,20 @@ class ChannelHeader extends React.PureComponent {
 
     handleFormattedTextClick = (e) => Utils.handleFormattedTextClick(e, this.props.currentRelativeTeamUrl);
 
+    createPriorityPluginButton = (plug) => {
+        return (
+            <HeaderIconWrapper
+                key={'channelHeaderButton' + plug.id}
+                buttonClass='channel-header__icon style--none'
+                iconComponent={plug.icon}
+                onClick={() => plug.action(this.props.channel, this.props.channelMember)}
+                buttonId={plug.id}
+                tooltipKey={'plugin'}
+                tooltipText={plug.tooltipText ? plug.tooltipText : plug.dropdownText}
+            />
+        );
+    }
+
     render() {
         const {
             teamId,
@@ -298,6 +313,7 @@ class ChannelHeader extends React.PureComponent {
         } = this.props;
         const {formatMessage} = this.props.intl;
         const ariaLabelChannelHeader = Utils.localizeMessage('accessibility.sections.channelHeader', 'channel header region');
+        const priorityPluginButtons = this.props.priorityPluginButtons || [];
 
         let hasGuestsText = '';
         if (hasGuests) {
@@ -787,6 +803,9 @@ class ChannelHeader extends React.PureComponent {
                             tooltipKey={'search'}
                         />
                     )}
+
+                    {priorityPluginButtons.map(this.createPriorityPluginButton)}
+
                     <HeaderIconWrapper
                         iconComponent={
                             <MentionsIcon

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -82,7 +82,8 @@ function makeMapStateToProps() {
             teammateNameDisplaySetting: getTeammateNameDisplaySetting(state),
             currentRelativeTeamUrl: getCurrentRelativeTeamUrl(state),
             newSideBarPreference: getNewSidebarPreference(state),
-            announcementBarCount: getAnnouncementBarCount(state)
+            announcementBarCount: getAnnouncementBarCount(state),
+            priorityPluginButtons: state.plugins.components.ChannelHeaderPriorityButton,
         };
     };
 }

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -105,7 +105,9 @@ export default class PluginRegistry {
     // - action - a function called when the button is clicked, passed the channel and channel member as arguments
     // - dropdown_text - string or React element shown for the dropdown button description
     // - tooltip_text - string shown for tooltip appear on hover
-    registerChannelHeaderButtonAction(icon, action, dropdownText, tooltipText) {
+    // - priority - boolean. If true: the icon will appear to the right of the search bar. False or undefined: the icon
+    //              will appear with the rest of the plugin icons.
+    registerChannelHeaderButtonAction(icon, action, dropdownText, tooltipText, priority) {
         const id = generateId();
 
         const data = {
@@ -119,7 +121,7 @@ export default class PluginRegistry {
 
         store.dispatch({
             type: ActionTypes.RECEIVED_PLUGIN_COMPONENT,
-            name: 'ChannelHeaderButton',
+            name: priority ? 'ChannelHeaderPriorityButton' : 'ChannelHeaderButton',
             data,
         });
 


### PR DESCRIPTION
#### Summary
- Plugins can now register their channel header button in `registerChannelHeaderButtonAction` with a priority flag. If set to true, it will put the button in a new array in the store, and those buttons will be rendered to the right of the search box. 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-24381

#### Screenshots
- The incident response plugin (the exclamation point) without the priority set:
![image](https://user-images.githubusercontent.com/1490756/80140668-49433d80-8576-11ea-88f6-a778d4329c99.png)
- With the priority set:
![image](https://user-images.githubusercontent.com/1490756/80140711-59f3b380-8576-11ea-8c91-ecb64816fbe3.png)
