### PR TITLE
MM-24380 Allowing plugins to hide the RHS header when displaying a custom RHS.

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "test": "cross-env NODE_ICU_DATA=node_modules/full-icu TZ=Etc/UTC jest --forceExit --detectOpenHandles",
     "test-ci": "cross-env NODE_ICU_DATA=node_modules/full-icu TZ=Etc/UTC jest --forceExit --detectOpenHandles --maxWorkers=2",
     "stats": "cross-env NODE_ENV=production webpack --profile --json > webpack_stats.json",
-    "updatesnapshot": "jest --updateSnapshot",
+    "updatesnapshot": "cross-env NODE_ICU_DATA=node_modules/full-icu TZ=Etc/UTC jest --updateSnapshot",
     "test:watch": "cross-env NODE_ICU_DATA=node_modules/full-icu TZ=Etc/UTC jest --watch",
     "test:coverage": "cross-env NODE_ICU_DATA=node_modules/full-icu TZ=Etc/UTC jest --coverage",
     "mmjstool": "mmjstool",

--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -561,7 +561,8 @@ export default class PluginRegistry {
 
     // Register a Right-Hand Sidebar component by providing a title for the right hand component.
     // Accepts the following:
-    // - title - A string or JSX element to display as a title for the RHS.
+    // - title - A string or JSX element to display as a title for the RHS. Passing null will
+    //           cause the default header not to be shown allowing you to customize its appearance.
     // - component - A react component to display in the Right-Hand Sidebar.
     // Returns:
     // - id: a unique identifier

--- a/plugins/rhs_plugin/rhs_plugin.jsx
+++ b/plugins/rhs_plugin/rhs_plugin.jsx
@@ -18,14 +18,21 @@ export default class RhsPlugin extends React.PureComponent {
     }
 
     render() {
+        let header = null;
+        if (this.props.title !== null) {
+            header = (
+                <SearchResultsHeader>
+                    {this.props.title}
+                </SearchResultsHeader>
+            );
+        }
+
         return (
             <div
                 id='rhsContainer'
                 className='sidebar-right__body'
             >
-                <SearchResultsHeader>
-                    {this.props.title}
-                </SearchResultsHeader>
+                {header}
                 <Pluggable
                     pluggableName='RightHandSidebarComponent'
                     pluggableId={this.props.pluggableId}


### PR DESCRIPTION
#### Summary
Allows plugins to suppress the default RHS header by passing `null` as the second parameter to the registration function instead of a title. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22917