### PR TITLE
Refactor: move @types/* to devDeps and update stale package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3190,7 +3190,8 @@
     "@types/highlight.js": {
       "version": "9.12.3",
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
-      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ=="
+      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
+      "dev": true
     },
     "@types/history": {
       "version": "4.7.3",
@@ -3463,6 +3464,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-1.0.1.tgz",
       "integrity": "sha512-1egEnh2/+sRRKImnCo5EMVm0Uxu4fBHeLHk/inhSp/VpE93It8lk3gYeNfehUgXd6OzqP5LLA9kzO9x7o3WfwA==",
+      "dev": true,
       "requires": {
         "redux": "^4.0.0"
       }
@@ -10765,8 +10767,12 @@
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
       "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
       "dev": true,
-      "requires": {
-        "icu4c-data": "^0.62.2"
+      "dependencies": {
+        "icu4c-data": {
+          "version": "0.62.2",
+          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.62.2.tgz",
+          "integrity": "sha512-XeGQzD3LAFprTRJ+IJZky7gUEk330neU8oo+xUT7LH08JFLTC1Eh22LiyrKIJPiZKV3w5Nq/cj8QyFWe18VDtw=="
+        }
       }
     },
     "function-bind": {
@@ -11712,12 +11718,6 @@
       "requires": {
         "postcss": "^7.0.14"
       }
-    },
-    "icu4c-data": {
-      "version": "0.64.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
-      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
   "dependencies": {
     "@formatjs/intl-pluralrules": "1.3.9",
     "@formatjs/intl-relativetimeformat": "4.5.1",
-    "@types/highlight.js": "9.12.3",
-    "@types/redux-mock-store": "1.0.1",
     "@typescript-eslint/parser": "2.7.0",
     "bootstrap": "3.4.1",
     "bootstrap-colorpicker": "2.5.2",
@@ -115,6 +113,7 @@
     "@types/react-router-dom": "5.1.2",
     "@types/react-select": "3.0.10",
     "@types/react-transition-group": "4.2.3",
+    "@types/redux-mock-store": "1.0.1",
     "@types/xregexp": "3.0.30",
     "@typescript-eslint/eslint-plugin": "2.7.0",
     "babel-eslint": "10.0.3",


### PR DESCRIPTION
#### Summary

This maintenance PR 
- updates `package-lock` to fix the issue that it is stale (has changes on clean `npm install`)
- moves `@types/redux-mock-store` to devDependencies
- removes duplicated `@types/highlight.js` from dependencies

No package version or other code changes.