### PR TITLE
Use inline images for gif picker

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -441,7 +441,7 @@ class CreateComment extends React.PureComponent {
 
         let newMessage = '';
         if (draft.message === '') {
-            newMessage = `![](${gif})`;;
+            newMessage = `![](${gif}) `;
         } else if ((/\s+$/).test(draft.message)) {
             // Check whether there is already a blank at the end of the current message
             newMessage = `${draft.message}![](${gif}) `;

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -441,12 +441,12 @@ class CreateComment extends React.PureComponent {
 
         let newMessage = '';
         if (draft.message === '') {
-            newMessage = gif;
+            newMessage = `![](${gif})`;;
         } else if ((/\s+$/).test(draft.message)) {
             // Check whether there is already a blank at the end of the current message
-            newMessage = `${draft.message}${gif} `;
+            newMessage = `${draft.message}![](${gif}) `;
         } else {
-            newMessage = `${draft.message} ${gif} `;
+            newMessage = `${draft.message} ![](${gif}) `;
         }
 
         const modifiedDraft = {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Move to use inline images for gif picker. Inserting the raw link is ugly and not user friendly.

Needs further testing from someone else.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.

- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)
-->
#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->