### PR TITLE
Highlight hovered items when searching with "in:"

### DIFF
--- a/components/suggestion/search_channel_suggestion/search_channel_suggestion.jsx
+++ b/components/suggestion/search_channel_suggestion/search_channel_suggestion.jsx
@@ -91,6 +91,7 @@ export default class SearchChannelSuggestion extends Suggestion {
         return (
             <div
                 onClick={this.handleClick}
+                onMouseMove={this.handleMouseMove}
                 className={className}
                 ref={(node) => {
                     this.node = node;


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-webapp/pull/4402 introduced a minor regression on the search popover when using the `in:` keyword, as the `onMouseMove` event was not registered in the `SearchChannelSuggestion` component. This PR just adds it back.

I have tried to add a test for this using Cypress, but I have no luck hovering over the item to check that the CSS class is added. Looks like this is a well-known pain point in Cypress; it even has [a dedicated documentation page](https://docs.cypress.io/api/commands/hover.html#Workarounds), but none of the workarounds worked for me. I'd love to hear other ideas for testing this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24296 (this PR only solves the first issue described in the ticket, I think we should discuss the CSS one separately)

#### Screenshots
Before:
![image](https://user-images.githubusercontent.com/3924815/80394308-f210d600-88b1-11ea-917b-06b19c116359.png)

After:
![image](https://user-images.githubusercontent.com/3924815/80394321-f89f4d80-88b1-11ea-8b78-57643b83f044.png)
