### PR TITLE
MM-24590: fix roles check on leave

### DIFF
--- a/components/channel_view/index.js
+++ b/components/channel_view/index.js
@@ -40,12 +40,15 @@ function mapStateToProps(state) {
     let channelRolesLoading = true;
     if (channel && channel.id) {
         const roles = getRoles(state);
-        const channelRoles = getMyChannelRoles(state)[channel.id];
-        for (const roleName of channelRoles.values()) {
-            if (roles[roleName]) {
-                channelRolesLoading = false;
+        const myChannelRoles = getMyChannelRoles(state);
+        if (myChannelRoles[channel.id]) {
+            const channelRoles = myChannelRoles[channel.id].values();
+            for (const roleName of channelRoles) {
+                if (roles[roleName]) {
+                    channelRolesLoading = false;
+                }
+                break;
             }
-            break;
         }
     }
 

--- a/e2e/cypress/integration/messaging/channel_menu_spec.js
+++ b/e2e/cypress/integration/messaging/channel_menu_spec.js
@@ -79,4 +79,36 @@ describe('Channel header menu', () => {
             });
         });
     });
+
+    it('MM-24590 should leave channel successfully', () => {
+        let channel;
+
+        // # Go to "/"
+        cy.visit('/ad-1/channels/town-square');
+
+        cy.getCurrentTeamId().then((teamId) => {
+            // # Create new test channel
+            cy.apiCreateChannel(teamId, 'channel-test-leave', 'Channel Test Leave').then((res) => {
+                channel = res.body;
+
+                // # Select channel on the left hand side
+                cy.get(`#sidebarItem_${channel.name}`).click();
+
+                // * Channel's display name should be visible at the top of the center pane
+                cy.get('#channelHeaderTitle').should('contain', channel.display_name);
+
+                // # Then click it to access the drop-down menu
+                cy.get('#channelHeaderTitle').click();
+
+                // * The dropdown menu of the channel header should be visible;
+                cy.get('.Menu__content').should('be.visible');
+
+                // # Click the "Leave Channel" option
+                cy.get('#channelLeaveChannel').click();
+
+                // * Should now be in Town Square
+                cy.get('#channelHeaderInfo').should('be.visible').and('contain', 'Town Square');
+            });
+        });
+    });
 });


### PR DESCRIPTION
#### Summary
As part of https://github.com/mattermost/mattermost-webapp/pull/5337, a check was added to avoid showing `createPost` until after channel roles are loaded. Unfortunately, when leaving a channel, the state is such that the channel exists but the channel membership does not, resulting in attempting to dereference undefined.

Fix the check not to assume channel memberships exist, and add an e2e test for leaving the channel via the header menu.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-24590