### PR TITLE
add new-separator class to NewMessageSeparator component

### DIFF
--- a/components/post_view/new_message_separator/__snapshots__/new_message_separator.test.jsx.snap
+++ b/components/post_view/new_message_separator/__snapshots__/new_message_separator.test.jsx.snap
@@ -1,13 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/post_view/new_message_separator should render new_message_separator 1`] = `
-<NotificationSeparator
-  id="1234"
+<div
+  className="new-separator"
 >
-  <FormattedMessage
-    defaultMessage="New Messages"
-    id="posts_view.newMsg"
-    values={Object {}}
-  />
-</NotificationSeparator>
+  <NotificationSeparator
+    id="1234"
+  >
+    <FormattedMessage
+      defaultMessage="New Messages"
+      id="posts_view.newMsg"
+      values={Object {}}
+    />
+  </NotificationSeparator>
+</div>
 `;

--- a/components/post_view/new_message_separator/new_message_separator.jsx
+++ b/components/post_view/new_message_separator/new_message_separator.jsx
@@ -14,13 +14,15 @@ export default class NewMessageSeparator extends React.PureComponent {
 
     render() {
         return (
-            <NotificationSeparator id={this.props.separatorId}>
-                <FormattedMessage
-                    id='posts_view.newMsg'
-                    defaultMessage='New Messages'
-                />
+            <div className='new-separator'>
+                <NotificationSeparator id={this.props.separatorId}>
+                    <FormattedMessage
+                        id='posts_view.newMsg'
+                        defaultMessage='New Messages'
+                    />
 
-            </NotificationSeparator>
+                </NotificationSeparator>
+            </div>
         );
     }
 }


### PR DESCRIPTION
#### Summary
This PR adds add the `new-separator` class to the `NewMessageSeparator` component. 

By wrapping the `NotificationSeparator` component with this class, the css will adjust according to the settings in `Account Settings` > `Display` > `Theme` > `Custom Theme` >  `Center Channel Styles` > `New Message Separator`

Tested the following cases:
* change in color exists after marking message unread (with post menu pulldown option)
* line and message can be seen changing colors (in the background of the account settings modal) as you change the color picker value
* As 2nd user, post message to channel user1 is not viewing, to create new unread messages. User1 switches to channel and sees the new line component with the correct color.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23885

#### Related Pull Requests
Original PR that introduced this issue. https://github.com/mattermost/mattermost-webapp/pull/3727

#### Screenshots
With the color set to blue (as an example for the color picker), the following was still loading the default color
![image](https://user-images.githubusercontent.com/7575921/80647709-899e3200-8a34-11ea-92cd-c91504071e20.png)

After the fix, the color is adjusted to match the user's Account Settings
![image](https://user-images.githubusercontent.com/7575921/80647849-c1a57500-8a34-11ea-83d1-6545a040a192.png)
