### PR TITLE
MM-24506: Fix closing DM/GM from header dropdown menu

### DIFF
--- a/components/channel_header_dropdown/menu_items/close_message/close_message.js
+++ b/components/channel_header_dropdown/menu_items/close_message/close_message.js
@@ -46,6 +46,11 @@ export default class CloseMessage extends React.PureComponent {
              * Action creator to update user preferences
              */
             savePreferences: PropTypes.func.isRequired,
+
+            /**
+             * Action creator to leave DM/GM
+             */
+            leaveDirectChannel: PropTypes.func.isRequired,
         }).isRequired,
     };
 
@@ -59,6 +64,7 @@ export default class CloseMessage extends React.PureComponent {
             redirectChannel,
             actions: {
                 savePreferences,
+                leaveDirectChannel,
             },
         } = this.props;
 
@@ -72,6 +78,7 @@ export default class CloseMessage extends React.PureComponent {
             name = channel.id;
         }
 
+        leaveDirectChannel(channel.name);
         savePreferences(currentUser.id, [{user_id: currentUser.id, category, name, value: 'false'}]);
 
         browserHistory.push(`/${currentTeam.name}/channels/${redirectChannel}`);

--- a/components/channel_header_dropdown/menu_items/close_message/close_message.test.js
+++ b/components/channel_header_dropdown/menu_items/close_message/close_message.test.js
@@ -25,6 +25,7 @@ describe('components/ChannelHeaderDropdown/MenuItem.CloseMessage', () => {
         },
         actions: {
             savePreferences: jest.fn(() => Promise.resolve()),
+            leaveDirectChannel: jest.fn(() => Promise.resolve()),
         },
     };
 

--- a/components/channel_header_dropdown/menu_items/close_message/index.js
+++ b/components/channel_header_dropdown/menu_items/close_message/index.js
@@ -8,6 +8,8 @@ import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getCurrentTeam, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getRedirectChannelNameForTeam} from 'mattermost-redux/selectors/entities/channels';
 
+import {leaveDirectChannel} from 'actions/views/channel';
+
 import CloseMessage from './close_message';
 
 const mapStateToProps = (state) => {
@@ -18,7 +20,7 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-    actions: bindActionCreators({savePreferences}, dispatch),
+    actions: bindActionCreators({savePreferences, leaveDirectChannel}, dispatch),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(CloseMessage);

--- a/e2e/cypress/integration/channel/close_direct_group_spec.js
+++ b/e2e/cypress/integration/channel/close_direct_group_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod @smoke
 // Group: @channel @channel_settings
 
 // Make sure that the current channel is Town Square and that the

--- a/e2e/cypress/integration/channel/close_direct_group_spec.js
+++ b/e2e/cypress/integration/channel/close_direct_group_spec.js
@@ -1,0 +1,74 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod @smoke
+// Group: @channel @channel_settings
+
+// Make sure that the current channel is Town Square and that the
+// channel identified by the passed name is no longer in the channel
+// sidebar
+function verifyChannelWasProperlyClosed(channelName) {
+    // * Make sure that we have switched channels
+    cy.get('#channelHeaderTitle').should('contain', 'Town Square');
+
+    // * Make sure the old DM no longer exists
+    cy.get('#sidebarItem_' + channelName).should('not.exist');
+}
+
+describe('Close direct messages', () => {
+    before(() => {
+        cy.apiLogin('user-1');
+        cy.visit('/ad-1/channels/town-square');
+    });
+
+    it('Through channel header dropdown menu', () => {
+        cy.createAndVisitNewDirectMessageWith('sysadmin').then((channel) => {
+            // # Open channel header dropdown menu and click on Close Direct Message
+            cy.get('#channelHeaderDropdownIcon').click();
+            cy.findByText('Close Direct Message').click();
+
+            verifyChannelWasProperlyClosed(channel.name);
+        });
+    });
+
+    it('Through x button on channel sidebar item', () => {
+        cy.createAndVisitNewDirectMessageWith('sysadmin').then((channel) => {
+            // # Click on the x button on the sidebar channel item
+            cy.get('#sidebarItem_' + channel.name + '>span.btn-close').click({force: true});
+
+            verifyChannelWasProperlyClosed(channel.name);
+        });
+    });
+});
+
+describe('Close group messages', () => {
+    before(() => {
+        cy.apiLogin('user-1');
+        cy.visit('/ad-1/channels/town-square');
+    });
+
+    it('Through channel header dropdown menu', () => {
+        cy.createAndVisitNewGroupMessageWith(['sysadmin', 'samuel.tucker']).then((channel) => {
+            // # Open channel header dropdown menu and click on Close Direct Message
+            cy.get('#channelHeaderDropdownIcon').click();
+            cy.findByText('Close Group Message').click();
+
+            verifyChannelWasProperlyClosed(channel.name);
+        });
+    });
+
+    it('Through x button on channel sidebar item', () => {
+        cy.createAndVisitNewGroupMessageWith(['sysadmin', 'samuel.tucker']).then((channel) => {
+            // # Click on the x button on the sidebar channel item
+            cy.get('#sidebarItem_' + channel.name + '>span.btn-close').click({force: true});
+
+            verifyChannelWasProperlyClosed(channel.name);
+        });
+    });
+});

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -404,6 +404,58 @@ Cypress.Commands.add('createAndVisitNewChannel', () => {
     });
 });
 
+/**
+ * On default "ad-1" team, create and visit a new direct message between user-1 and the provided user
+ * @param {String} user - Username of user to open DM with
+ */
+Cypress.Commands.add('createAndVisitNewDirectMessageWith', (user) => {
+    cy.visit('/ad-1/channels/town-square');
+
+    cy.apiGetUsers(['user-1', user]).then((userResponse) => {
+        const userEmailArray = [userResponse.body[1].id, userResponse.body[0].id];
+
+        cy.apiCreateDirectChannel(userEmailArray).then((res) => {
+            const channel = res.body;
+
+            // # Visit the new channel
+            cy.visit(`/ad-1/channels/${channel.name}`);
+
+            // * Verify channel's display name
+            cy.get('#channelHeaderTitle').should('contain', channel.display_name);
+
+            cy.wrap(channel);
+        });
+    });
+});
+
+/**
+ * On default "ad-1" team, create and visit a new group message between user-1 and the provided users
+ * @param {Array} usernames - Array of usernames of the users to open GM with
+ */
+Cypress.Commands.add('createAndVisitNewGroupMessageWith', (usernames) => {
+    cy.visit('/ad-1/channels/town-square');
+
+    cy.apiGetUsers(usernames).then((userResponse) => {
+        const userEmailArray = userResponse.body.map((u) => u.id);
+
+        cy.apiCreateGroupChannel(userEmailArray).then((res) => {
+            const channel = res.body;
+
+            // # Visit the new channel
+            cy.visit(`/ad-1/channels/${channel.name}`);
+
+            // The display name does not contain the logged in user
+            const names = channel.display_name.split(', ');
+            names.splice(names.indexOf('user-1'), 1);
+
+            // * Verify channel's display name
+            cy.get('#channelHeaderTitle').should('contain', names.join(', '));
+
+            cy.wrap(channel);
+        });
+    });
+});
+
 // ***********************************************************
 // File Upload
 // ************************************************************


### PR DESCRIPTION
#### Summary

PR #4791 fixed an issue with redirecting the user to direct or group messages when they were the last ones to be visited. But a collateral regression was introduced: closing DMs or GMs stopped working, as the user was returned to the closed channel immediately after leaving it.

That commit was reverted (#4995), and then applied again in PR #5224, which also introduced the new `leaveDirectChannel` function to correctly handle the new issue with closing DMs or GMs. But this function was only applied to the case where the user closed the channel through the `x` button on the sidebar channel item.

However, the bug remained in place when the user closed the channel using the "Close {Direct, Group} Message" option in the channel header dropdown menu.

This PR just fixes this second use case by calling the `leaveDirectChannel` function from the right place.

I have also added a couple of E2E tests to make sure that we don't lose this functionality again in the future.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24506