### PR TITLE
MM-24032: Make settings' textarea only vertically resizable

### DIFF
--- a/sass/routes/_settings.scss
+++ b/sass/routes/_settings.scss
@@ -42,6 +42,10 @@
             margin: 5px 0;
         }
     }
+
+    textarea {
+        resize: vertical;
+    }
 }
 
 .modal {


### PR DESCRIPTION
#### Summary
The text box under Custom Theme in the Account Settings > Display > Theme section cannot be horizontally resized, as it expands beyond the visible area of the Settings modal.

I have styled all `textarea` elements under the user settings with `resize: vertical`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24032

#### Screenshots
Before:
![bug](https://user-images.githubusercontent.com/3924815/80959329-e61f9980-8e06-11ea-8860-b9df00955b20.gif)

After:
![resolved](https://user-images.githubusercontent.com/3924815/80959336-ecae1100-8e06-11ea-801b-6c61e47ba3c6.gif)
