### PR TITLE
E2E: fix tests for sidebar link in system console

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/sidebar_link_navigation_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/sidebar_link_navigation_spec.js
@@ -10,7 +10,92 @@
 // Stage: @prod
 // Group: @enterprise @system_console
 
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+
 describe('System Console - Enterprise', () => {
+    const testCases = [
+        {
+            header: 'Groups (Beta)',
+            sidebar: 'Groups (Beta)',
+            url: 'admin_console/user_management/groups',
+        },
+        {
+            header: 'Mattermost Teams',
+            sidebar: 'Teams',
+            url: 'admin_console/user_management/teams',
+        },
+        {
+            header: 'Mattermost Channels',
+            sidebar: 'Channels',
+            url: 'admin_console/user_management/channels',
+        },
+        {
+            header: 'Permission Schemes',
+            sidebar: 'Permissions',
+            url: 'admin_console/user_management/permissions',
+        },
+        {
+            header: 'Elasticsearch',
+            sidebar: 'Elasticsearch',
+            url: 'admin_console/environment/elasticsearch',
+        },
+        {
+            header: 'High Availability',
+            sidebar: 'High Availability',
+            url: 'admin_console/environment/high_availability',
+        },
+        {
+            header: 'Performance Monitoring',
+            sidebar: 'Performance Monitoring',
+            url: 'admin_console/environment/performance_monitoring',
+        },
+        {
+            header: 'Announcement Banner',
+            sidebar: 'Announcement Banner',
+            url: 'admin_console/site_config/announcement_banner',
+        },
+        {
+            header: 'AD/LDAP',
+            sidebar: 'AD/LDAP',
+            url: 'admin_console/authentication/ldap',
+        },
+        {
+            header: 'SAML 2.0',
+            sidebar: 'SAML 2.0',
+            url: 'admin_console/authentication/saml',
+        },
+        {
+            header: 'OAuth 2.0',
+            sidebar: 'OAuth 2.0',
+            url: 'admin_console/authentication/oauth',
+        },
+        {
+            header: 'Guest Access (Beta)',
+            sidebar: 'Guest Access (Beta)',
+            url: 'admin_console/authentication/guest_access',
+        },
+        {
+            header: 'Data Retention Policy',
+            sidebar: 'Data Retention Policy',
+            url: 'admin_console/compliance/data_retention',
+        },
+        {
+            header: 'Compliance Export (Beta)',
+            sidebar: 'Compliance Export (Beta)',
+            url: 'admin_console/compliance/export',
+        },
+        {
+            header: 'Compliance Monitoring',
+            sidebar: 'Compliance Monitoring',
+            url: 'admin_console/compliance/monitoring',
+        },
+        {
+            header: 'Custom Terms of Service (Beta)',
+            sidebar: 'Custom Terms of Service (Beta)',
+            url: 'admin_console/compliance/custom_terms_of_service',
+        },
+    ];
+
     before(() => {
         // * Login as sysadmin and check if server has license
         cy.apiLogin('sysadmin');
@@ -21,120 +106,30 @@ describe('System Console - Enterprise', () => {
         };
         cy.apiUpdateConfig(newSettings);
 
-        cy.visit('/ad-1/channels/town-square');
+        // # Go to system admin then verify admin console URL and header
+        cy.visit('/admin_console/about/license');
+        cy.url().should('include', '/admin_console/about/license');
+        cy.get('.admin-console', {timeout: TIMEOUTS.LARGE}).should('be.visible').within(() => {
+            cy.get('.admin-console__header').should('be.visible').and('have.text', 'Edition and License');
+        });
     });
 
-    const testCases = [
-        {
-            header: 'Groups (Beta)',
-            sidebar: 'Groups (Beta)',
-            url: 'admin_console/user_management/groups',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Mattermost Teams',
-            sidebar: 'Teams',
-            url: 'admin_console/user_management/teams',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Mattermost Channels',
-            sidebar: 'Channels',
-            url: 'admin_console/user_management/channels',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Permission Schemes',
-            sidebar: 'Permissions',
-            url: 'admin_console/user_management/permissions',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Elasticsearch',
-            sidebar: 'Elasticsearch',
-            url: 'admin_console/environment/elasticsearch',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'High Availability',
-            sidebar: 'High Availability',
-            url: 'admin_console/environment/high_availability',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Performance Monitoring',
-            sidebar: 'Performance Monitoring',
-            url: 'admin_console/environment/performance_monitoring',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Announcement Banner',
-            sidebar: 'Announcement Banner',
-            url: 'admin_console/site_config/announcement_banner',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'AD/LDAP',
-            sidebar: 'AD/LDAP',
-            url: 'admin_console/authentication/ldap',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'SAML 2.0',
-            sidebar: 'SAML 2.0',
-            url: 'admin_console/authentication/saml',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'OAuth 2.0',
-            sidebar: 'OAuth 2.0',
-            url: 'admin_console/authentication/oauth',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Guest Access (Beta)',
-            sidebar: 'Guest Access (Beta)',
-            url: 'admin_console/authentication/guest_access',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Data Retention Policy',
-            sidebar: 'Data Retention Policy',
-            url: 'admin_console/compliance/data_retention',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Compliance Export (Beta)',
-            sidebar: 'Compliance Export (Beta)',
-            url: 'admin_console/compliance/export',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Compliance Monitoring',
-            sidebar: 'Compliance Monitoring',
-            url: 'admin_console/compliance/monitoring',
-            otherUrl: 'admin_console/about/license',
-        },
-        {
-            header: 'Custom Terms of Service (Beta)',
-            sidebar: 'Custom Terms of Service (Beta)',
-            url: 'admin_console/compliance/custom_terms_of_service',
-            otherUrl: 'admin_console/about/license',
-        },
-    ];
+    beforeEach(() => {
+        // # Click on "Edition and License"
+        cy.get('.admin-sidebar').should('be.visible').within(() => {
+            cy.findByText('Edition and License').scrollIntoView().should('be.visible').click();
+        });
+
+        // * Verify that it redirects to the URL and matches with the header
+        cy.url().should('include', '/admin_console/about/license');
+        cy.get('.admin-console').should('be.visible').within(() => {
+            cy.get('.admin-console__header').should('be.visible').and('have.text', 'Edition and License');
+        });
+    });
 
     testCases.forEach((testCase) => {
         it(`can navigate to ${testCase.header}`, () => {
-            // # Visit the URL directly
-            cy.visit(testCase.url);
-
-            // * Verify that the header is correct
-            cy.get('.admin-console').should('be.visible').within(() => {
-                cy.get('.admin-console__header').should('be.visible').and('have.text', testCase.header);
-            });
-
-            // # Visit other URL and click the link on the sidebar
-            cy.visit(testCase.otherUrl);
+            // # Click the link on the sidebar
             cy.get('.admin-sidebar').should('be.visible').within(() => {
                 cy.findByText(testCase.sidebar).scrollIntoView().should('be.visible').click();
             });

--- a/e2e/cypress/integration/system_console/sidebar_link_navigation_spec.js
+++ b/e2e/cypress/integration/system_console/sidebar_link_navigation_spec.js
@@ -10,241 +10,212 @@
 // Stage: @prod
 // Group: @system_console
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
 describe('System Console', () => {
-    before(() => {
-        // # Login as sysadmin, update config and visit town-square channel
-        cy.apiLogin('sysadmin');
-        const newSettings = {
-            TeamSettings: {SiteName: 'Mattermost'},
-        };
-        cy.apiUpdateConfig(newSettings);
-        cy.visit('/ad-1/channels/town-square');
-    });
-
-    it('can go to admin console by clicking System Console', () => {
-        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-
-        cy.get('.Menu__content').should('be.visible').within(() => {
-            cy.findByText('System Console').should('be.visible').click();
-        });
-
-        cy.url().should('include', '/admin_console/about/license');
-    });
-
     const testCases = [
         {
             header: 'Edition and License',
             sidebar: 'Edition and License',
             url: 'admin_console/about/license',
-            otherUrl: 'admin_console/reporting/system_analytics',
         },
         {
             header: 'System Statistics',
             sidebar: 'Site Statistics',
             url: '/admin_console/reporting/system_analytics',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Team Statistics',
             sidebar: 'Team Statistics',
             url: '/admin_console/reporting/team_statistics',
-            otherUrl: 'admin_console/about/license',
             headerContains: true,
         },
         {
             header: 'Server Logs',
             sidebar: 'Server Logs',
             url: 'admin_console/reporting/server_logs',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Mattermost Users',
             sidebar: 'Users',
             url: 'admin_console/user_management/users',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Web Server',
             sidebar: 'Web Server',
             url: 'admin_console/environment/web_server',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Database',
             sidebar: 'Database',
             url: 'admin_console/environment/database',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'File Storage',
             sidebar: 'File Storage',
             url: 'admin_console/environment/file_storage',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Image Proxy',
             sidebar: 'Image Proxy',
             url: 'admin_console/environment/image_proxy',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'SMTP',
             sidebar: 'SMTP',
             url: 'admin_console/environment/smtp',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Push Notification Server',
             sidebar: 'Push Notification Server',
             url: 'admin_console/environment/push_notification_server',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Rate Limiting',
             sidebar: 'Rate Limiting',
             url: 'admin_console/environment/rate_limiting',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Logging',
             sidebar: 'Logging',
             url: 'admin_console/environment/logging',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Session Lengths',
             sidebar: 'Session Lengths',
             url: 'admin_console/environment/session_lengths',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Developer Settings',
             sidebar: 'Developer',
             url: 'admin_console/environment/developer',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Customization',
             sidebar: 'Customization',
             url: 'admin_console/site_config/customization',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Localization',
             sidebar: 'Localization',
             url: 'admin_console/site_config/localization',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Users and Teams',
             sidebar: 'Users and Teams',
             url: 'admin_console/site_config/users_and_teams',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Notifications',
             sidebar: 'Notifications',
             url: 'admin_console/environment/notifications',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Emoji',
             sidebar: 'Emoji',
             url: 'admin_console/site_config/emoji',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Posts',
             sidebar: 'Posts',
             url: 'admin_console/site_config/posts',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'File Sharing and Downloads',
             sidebar: 'File Sharing and Downloads',
             url: 'admin_console/site_config/file_sharing_downloads',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Public Links',
             sidebar: 'Public Links',
             url: 'admin_console/site_config/public_links',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Signup',
             sidebar: 'Signup',
             url: 'admin_console/authentication/signup',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Email Authentication',
             sidebar: 'Email',
             url: 'admin_console/authentication/email',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Password',
             sidebar: 'Password',
             url: 'admin_console/authentication/password',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Multi-factor Authentication',
             sidebar: 'MFA',
             url: 'admin_console/authentication/mfa',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Plugin Management',
             sidebar: 'Plugin Management',
             url: 'admin_console/plugins/plugin_management',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Integration Management',
             sidebar: 'Integration Management',
             url: 'admin_console/integrations/integration_management',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Bot Accounts',
             sidebar: 'Bot Accounts',
             url: 'admin_console/integrations/bot_accounts',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'GIF (Beta)',
             sidebar: 'GIF (Beta)',
             url: 'admin_console/integrations/gif',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'CORS',
             sidebar: 'CORS',
             url: 'admin_console/integrations/cors',
-            otherUrl: 'admin_console/about/license',
         },
         {
             header: 'Experimental Features',
             sidebar: 'Features',
             url: 'admin_console/experimental/features',
-            otherUrl: 'admin_console/about/license',
         },
     ];
 
+    before(() => {
+        // * Login as sysadmin and check if server has license
+        cy.apiLogin('sysadmin');
+        cy.requireLicense();
+
+        const newSettings = {
+            TeamSettings: {SiteName: 'Mattermost'},
+        };
+        cy.apiUpdateConfig(newSettings);
+
+        // # Go to system admin then verify admin console URL and header
+        cy.visit('/admin_console/about/license');
+        cy.url().should('include', '/admin_console/about/license');
+        cy.get('.admin-console', {timeout: TIMEOUTS.LARGE}).should('be.visible').within(() => {
+            cy.get('.admin-console__header').should('be.visible').and('have.text', 'Edition and License');
+        });
+    });
+
+    beforeEach(() => {
+        // # Click on "Edition and License"
+        cy.get('.admin-sidebar').should('be.visible').within(() => {
+            cy.findByText('Edition and License').scrollIntoView().should('be.visible').click();
+        });
+
+        // * Verify that it redirects to the URL and matches with the header
+        cy.url().should('include', '/admin_console/about/license');
+        cy.get('.admin-console').should('be.visible').within(() => {
+            cy.get('.admin-console__header').should('be.visible').and('have.text', 'Edition and License');
+        });
+    });
+
     testCases.forEach((testCase) => {
         it(`can navigate to ${testCase.header}`, () => {
-            // # Visit the URL directly
-            cy.visit(testCase.url);
-
-            // * Verify that the header is correct
-            cy.get('.admin-console').should('be.visible').within(() => {
-                cy.get('.admin-console__header').should('be.visible').and(testCase.headerContains ? 'contain' : 'have.text', testCase.header);
-            });
-
-            // # Visit other URL and click the link on the sidebar
-            cy.visit(testCase.otherUrl);
+            // # Click the link on the sidebar
             cy.get('.admin-sidebar').should('be.visible').within(() => {
                 cy.findByText(testCase.sidebar).scrollIntoView().should('be.visible').click();
             });
@@ -254,6 +225,25 @@ describe('System Console', () => {
             cy.get('.admin-console').should('be.visible').within(() => {
                 cy.get('.admin-console__header').should('be.visible').and(testCase.headerContains ? 'contain' : 'have.text', testCase.header);
             });
+        });
+    });
+
+    it('can go to admin console by clicking System Console', () => {
+        // # Go to default team/channel
+        cy.visit('/');
+
+        // # Click on "Main Menu"
+        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
+
+        // # Click on "System Console"
+        cy.get('.Menu__content').should('be.visible').within(() => {
+            cy.findByText('System Console').should('be.visible').click();
+        });
+
+        // * Verify that it redirects to "Edition and License" system console page
+        cy.url().should('include', '/admin_console/about/license');
+        cy.get('.admin-console').should('be.visible').within(() => {
+            cy.get('.admin-console__header').should('be.visible').and('have.text', 'Edition and License');
         });
     });
 });


### PR DESCRIPTION
#### Summary
Fix tests for sidebar link in system console.  Instead of navigating on each section in system console, simply click on the sidebar and verify the corresponding URL is correct.

#### Ticket Link
none, failing on daily Cypress tests.
