### PR TITLE
fix missing dash between tos/pp

### DIFF
--- a/components/about_build_modal/__snapshots__/about_build_modal.test.jsx.snap
+++ b/components/about_build_modal/__snapshots__/about_build_modal.test.jsx.snap
@@ -181,9 +181,7 @@ exports[`components/AboutBuildModal should match snapshot for enterprise edition
               values={Object {}}
             />
           </a>
-          <span>
-             - 
-          </span>
+           - 
           <a
             href="https://about.mattermost.com/default-privacy-policy/"
             id="privacyLink"
@@ -421,9 +419,7 @@ exports[`components/AboutBuildModal should match snapshot for team edition 1`] =
               values={Object {}}
             />
           </a>
-          <span>
-             - 
-          </span>
+           - 
           <a
             href="https://about.mattermost.com/default-privacy-policy/"
             id="privacyLink"
@@ -672,9 +668,7 @@ exports[`components/AboutBuildModal should show ci if a ci build 1`] = `
               values={Object {}}
             />
           </a>
-          <span>
-             - 
-          </span>
+           - 
           <a
             href="https://about.mattermost.com/default-privacy-policy/"
             id="privacyLink"
@@ -911,9 +905,7 @@ exports[`components/AboutBuildModal should show dev if this is a dev build 1`] =
               values={Object {}}
             />
           </a>
-          <span>
-             - 
-          </span>
+           - 
           <a
             href="https://about.mattermost.com/default-privacy-policy/"
             id="privacyLink"

--- a/components/about_build_modal/about_build_modal.jsx
+++ b/components/about_build_modal/about_build_modal.jsx
@@ -168,15 +168,6 @@ export default class AboutBuildModal extends React.PureComponent {
             </a>
         );
 
-        let tosPrivacyHyphen;
-        if (config.TermsOfServiceLink && config.PrivacyPolicyLink) {
-            tosPrivacyHyphen = (
-                <span>
-                    {' - '}
-                </span>
-            );
-        }
-
         // Only show build number if it's a number (so only builds from Jenkins)
         let buildnumber = (
             <div>
@@ -266,7 +257,7 @@ export default class AboutBuildModal extends React.PureComponent {
                             </div>
                             <div className='about-modal__links'>
                                 {termsOfService}
-                                {tosPrivacyHyphen}
+                                {' - '}
                                 {privacyPolicy}
                             </div>
                         </div>


### PR DESCRIPTION
#### Summary
While the TOS/PP links are hard-coded on the about modal, the code still checked for an (empty) configured value (so as to hide on other screens) when rendering the dash between them. Fix this to make the dash equally hard-coded.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-24856

#### Screenshots
Before:
![image](https://user-images.githubusercontent.com/1023171/81070780-1aa05d80-8eba-11ea-9c27-242b183da051.png)

After:
![image](https://user-images.githubusercontent.com/1023171/81070800-22f89880-8eba-11ea-8e51-122cc3c22c11.png)
