### PR TITLE
MM-24857 console.log plugin versions

### DIFF
--- a/plugins/index.js
+++ b/plugins/index.js
@@ -72,6 +72,11 @@ export function getPlugins() {
 // loadedPlugins tracks which plugins have been added as script tags to the page
 const loadedPlugins = {};
 
+// describePlugin takes a manifest and spits out a string suitable for console.log messages.
+const describePlugin = (manifest) => (
+    'plugin ' + manifest.id + ', version ' + manifest.version
+);
+
 // loadPlugin fetches the web app bundle described by the given manifest, waits for the bundle to
 // load, and then ensures the plugin has been initialized.
 export function loadPlugin(manifest) {
@@ -90,12 +95,12 @@ export function loadPlugin(manifest) {
 
         function onLoad() {
             initializePlugin(manifest);
-            console.log('Loaded ' + manifest.id + ' plugin'); //eslint-disable-line no-console
+            console.log('Loaded ' + describePlugin(manifest)); //eslint-disable-line no-console
             resolve();
         }
 
         function onError() {
-            reject(new Error('Unable to load bundle for plugin ' + manifest.id));
+            reject(new Error('Unable to load bundle for ' + describePlugin(manifest)));
         }
 
         // Backwards compatibility for old plugins
@@ -104,7 +109,7 @@ export function loadPlugin(manifest) {
             bundlePath = bundlePath.replace('/static/', '/static/plugins/');
         }
 
-        console.log('Loading ' + manifest.id + ' plugin'); //eslint-disable-line no-console
+        console.log('Loading ' + describePlugin(manifest)); //eslint-disable-line no-console
 
         const script = document.createElement('script');
         script.id = 'plugin_' + manifest.id;
@@ -136,7 +141,7 @@ export function removePlugin(manifest) {
     if (!loadedPlugins[manifest.id]) {
         return;
     }
-    console.log('Removing ' + manifest.id + ' plugin'); //eslint-disable-line no-console
+    console.log('Removing ' + describePlugin(manifest)); //eslint-disable-line no-console
 
     delete loadedPlugins[manifest.id];
 
@@ -159,7 +164,7 @@ export function removePlugin(manifest) {
         return;
     }
     script.parentNode.removeChild(script);
-    console.log('Removed ' + manifest.id + ' plugin'); //eslint-disable-line no-console
+    console.log('Removed ' + describePlugin(manifest)); //eslint-disable-line no-console
 }
 
 // loadPluginsIfNecessary synchronizes the current state of loaded plugins with that of the server,


### PR DESCRIPTION
#### Summary
When a plugin is loaded or removed, we log the plugin id, but not the version. Customers often send us screenshots of this loading, and it would be helpful to identify the versions at play, so let's include those.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-24857

#### Screenshots
Note that the duplicate "loading/loaded" is present before and after. Haven't investigated that yet.

Before:
![image](https://user-images.githubusercontent.com/1023171/81072918-42dd8b80-8ebd-11ea-996b-7a0f197a76cf.png)

After:
![image](https://user-images.githubusercontent.com/1023171/81072737-f6924b80-8ebc-11ea-83b1-664f5774ce4e.png)
