### PR TITLE
E2E: Fix tests failing on URL check

### DIFF
--- a/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
@@ -50,8 +50,7 @@ describe('Channel sidebar', () => {
         cy.get('.SidebarChannel:contains(Town Square)').should('be.visible').click();
 
         // * Verify that the channel changed
-        cy.url().should('include', `/${teamName}/channels/town-square`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+        verifyChannelSwitch('Town Square', `/${teamName}/channels/town-square`);
     });
 
     it('should mark channel as read and unread in sidebar', () => {
@@ -98,8 +97,7 @@ describe('Channel sidebar', () => {
         cy.get('#channelLeaveChannel').should('be.visible').click();
 
         // * Verify that we've switched to Town Square
-        cy.url().should('include', `/${teamName}/channels/town-square`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+        verifyChannelSwitch('Town Square', `/${teamName}/channels/town-square`);
 
         // * Verify that Off Topic has disappeared from the sidebar
         cy.get('.SidebarChannel:contains(Off-Topic)').should('not.exist');
@@ -125,10 +123,14 @@ describe('Channel sidebar', () => {
         cy.get('#deleteChannelModalDeleteButton').should('be.visible').click();
 
         // * Verify that we've switched to Town Square
-        cy.url().should('include', `/${teamName}/channels/town-square`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+        verifyChannelSwitch('Town Square', `/${teamName}/channels/town-square`);
 
         // * Verify that Off Topic has disappeared from the sidebar
         cy.get('.SidebarChannel:contains(Off-Topic)').should('not.exist');
     });
+
+    function verifyChannelSwitch(displayName, url) {
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', displayName);
+        cy.url().should('include', url);
+    }
 });

--- a/e2e/cypress/integration/channel_sidebar/new_channel_dropdown_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/new_channel_dropdown_spec.js
@@ -71,8 +71,8 @@ describe('Channel sidebar', () => {
         cy.get('#channelLeaveChannel').click();
 
         // * Verify that we've switched to Town Square
-        cy.url().should('include', `/${teamName}/channels/town-square`);
         cy.get('#channelHeaderTitle').should('contain', 'Town Square');
+        cy.url().should('include', `/${teamName}/channels/town-square`);
 
         // # Click the New Channel Dropdown button
         cy.get('.AddChannelDropdown_dropdownButton').should('be.visible').click();


### PR DESCRIPTION
#### Summary
Fix tests failing on URL check.
- Test on URL failed since the URL on address bar resolved immediately before loading a page. Workaround is to check for element in a page first before URL.

#### Ticket Link
none, failing on Cypress daily test
