### PR TITLE
[MM-24767] autocomplete icons

### DIFF
--- a/components/suggestion/command_provider.jsx
+++ b/components/suggestion/command_provider.jsx
@@ -21,9 +21,15 @@ export class CommandSuggestion extends Suggestion {
         if (isSelection) {
             className += ' suggestion--selected';
         }
-        let icon = <span>{'/'}</span>;
+        let icon = <div className='slash-command__icon'><span>{'/'}</span></div>;
         if (item.iconData !== '') {
-            icon = <img src={item.iconData}/>;
+            icon = (
+                <div
+                    className='slash-command__icon'
+                    style={{backgroundColor: 'transparent'}}
+                >
+                    <img src={item.iconData}/>
+                </div>);
         }
 
         return (
@@ -33,9 +39,7 @@ export class CommandSuggestion extends Suggestion {
                 onMouseMove={this.handleMouseMove}
                 {...Suggestion.baseProps}
             >
-                <div className='slash-command__icon'>
-                    {icon}
-                </div>
+                {icon}
                 <div className='slash-command__info'>
                     <div className='slash-command__title'>
                         {item.suggestion.substring(1) + ' ' + item.hint}

--- a/components/suggestion/command_provider.jsx
+++ b/components/suggestion/command_provider.jsx
@@ -21,6 +21,10 @@ export class CommandSuggestion extends Suggestion {
         if (isSelection) {
             className += ' suggestion--selected';
         }
+        let icon = <span>{'/'}</span>;
+        if (item.iconData !== '') {
+            icon = <img src={item.iconData}/>;
+        }
 
         return (
             <div
@@ -30,7 +34,7 @@ export class CommandSuggestion extends Suggestion {
                 {...Suggestion.baseProps}
             >
                 <div className='slash-command__icon'>
-                    <span>{'/'}</span>
+                    {icon}
                 </div>
                 <div className='slash-command__info'>
                     <div className='slash-command__title'>
@@ -117,6 +121,7 @@ export default class CommandProvider extends Provider {
                             suggestion: '/' + sug.Suggestion,
                             hint: sug.Hint,
                             description: sug.Description,
+                            iconData: sug.IconData,
                         });
                     });
 

--- a/components/suggestion/command_provider.test.js
+++ b/components/suggestion/command_provider.test.js
@@ -12,6 +12,7 @@ describe('CommandSuggestion', () => {
             suggestion: '/invite',
             hint: '@[username] ~[channel]',
             description: 'Invite a user to a channel',
+            iconData: '',
         },
         isSelection: true,
         term: '/',


### PR DESCRIPTION
#### Summary
This PR will add support of the icons in slash command autocomplete


#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-24767

#### Related Pull Requests
- Has server changes (https://github.com/mattermost/mattermost-server/pull/14489)
- demo plugin (https://github.com/mattermost/mattermost-plugin-demo/pull/104)

#### Screenshots
<img width="570" alt="Screen Shot 2020-05-06 at 15 29 47" src="https://user-images.githubusercontent.com/2340127/81172017-7f3ce480-8fae-11ea-871c-59ca5ab75b03.png">
