### PR TITLE
MM-24033: Compute suggestion list width

### DIFF
--- a/components/add_user_to_channel_modal/__snapshots__/add_user_to_channel_modal.test.jsx.snap
+++ b/components/add_user_to_channel_modal/__snapshots__/add_user_to_channel_modal.test.jsx.snap
@@ -71,7 +71,7 @@ exports[`components/AddUserToChannelModal should match snapshot 1`] = `
       <SuggestionBox
         className="form-control focused"
         completeOnTab={false}
-        containerClass=""
+        containerClass="add-user-to-channel-modal__suggestion-box"
         delayInputUpdate={true}
         isRHS={false}
         listComponent={[Function]}

--- a/components/add_user_to_channel_modal/__snapshots__/add_user_to_channel_modal.test.jsx.snap
+++ b/components/add_user_to_channel_modal/__snapshots__/add_user_to_channel_modal.test.jsx.snap
@@ -68,37 +68,41 @@ exports[`components/AddUserToChannelModal should match snapshot 1`] = `
           values={Object {}}
         />
       </div>
-      <SuggestionBox
-        className="form-control focused"
-        completeOnTab={false}
-        containerClass="add-user-to-channel-modal__suggestion-box"
-        delayInputUpdate={true}
-        isRHS={false}
-        listComponent={[Function]}
-        listStyle="bottom"
-        listenForMentionKeyClick={false}
-        maxLength="64"
-        onChange={[Function]}
-        onItemSelected={[Function]}
-        openOnFocus={false}
-        openWhenEmpty={true}
-        providers={
-          Array [
-            SearchChannelWithPermissionsProvider {
-              "autocompleteChannelsForSearch": [MockFunction],
-              "disableDispatches": false,
-              "latestComplete": true,
-              "latestPrefix": "",
-              "requestStarted": false,
-            },
-          ]
-        }
-        renderDividers={false}
-        renderNoResults={false}
-        replaceAllInputOnSelect={false}
-        requiredCharacters={1}
-        value=""
-      />
+      <div
+        className="pos-relative"
+      >
+        <SuggestionBox
+          className="form-control focused"
+          completeOnTab={false}
+          containerClass=""
+          delayInputUpdate={true}
+          isRHS={false}
+          listComponent={[Function]}
+          listStyle="bottom"
+          listenForMentionKeyClick={false}
+          maxLength="64"
+          onChange={[Function]}
+          onItemSelected={[Function]}
+          openOnFocus={false}
+          openWhenEmpty={true}
+          providers={
+            Array [
+              SearchChannelWithPermissionsProvider {
+                "autocompleteChannelsForSearch": [MockFunction],
+                "disableDispatches": false,
+                "latestComplete": true,
+                "latestPrefix": "",
+                "requestStarted": false,
+              },
+            ]
+          }
+          renderDividers={false}
+          renderNoResults={false}
+          replaceAllInputOnSelect={false}
+          requiredCharacters={1}
+          value=""
+        />
+      </div>
       <div>
         <br />
       </div>

--- a/components/add_user_to_channel_modal/add_user_to_channel_modal.jsx
+++ b/components/add_user_to_channel_modal/add_user_to_channel_modal.jsx
@@ -236,6 +236,7 @@ export default class AddUserToChannelModal extends React.Component {
 
         const content = (
             <SuggestionBox
+                containerClass='add-user-to-channel-modal__suggestion-box'
                 ref={this.setSearchBoxRef}
                 className='form-control focused'
                 onChange={this.onInputChange}

--- a/components/add_user_to_channel_modal/add_user_to_channel_modal.jsx
+++ b/components/add_user_to_channel_modal/add_user_to_channel_modal.jsx
@@ -236,7 +236,6 @@ export default class AddUserToChannelModal extends React.Component {
 
         const content = (
             <SuggestionBox
-                containerClass='add-user-to-channel-modal__suggestion-box'
                 ref={this.setSearchBoxRef}
                 className='form-control focused'
                 onChange={this.onInputChange}
@@ -292,7 +291,9 @@ export default class AddUserToChannelModal extends React.Component {
                         <div className='modal__hint'>
                             {help}
                         </div>
-                        {content}
+                        <div className='pos-relative'>
+                            {content}
+                        </div>
                         <div>
                             {errorMsg}
                             <br/>

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -53,10 +53,6 @@
             }
         }
 
-        .suggestion-list__content {
-            max-height: 150px;
-        }
-
         .edit-post-footer {
             display: inline-block;
             font-size: 13px;

--- a/sass/components/_suggestion-list.scss
+++ b/sass/components/_suggestion-list.scss
@@ -80,6 +80,7 @@
     overflow-y: auto;
     padding-bottom: 12px;
     max-width: 100%;
+    width: 496px;
 
     &::-webkit-scrollbar-track {
         width: 0;
@@ -205,11 +206,5 @@
         padding: 0 10px 0 5px;
         position: relative;
         z-index: 5;
-    }
-}
-
-.add-user-to-channel-modal__suggestion-box {
-    .suggestion-list {
-        width: calc(100% - 30px);
     }
 }

--- a/sass/components/_suggestion-list.scss
+++ b/sass/components/_suggestion-list.scss
@@ -116,6 +116,7 @@
 
     .modal & {
         max-height: 205px;
+        width: 100%;
     }
 }
 

--- a/sass/components/_suggestion-list.scss
+++ b/sass/components/_suggestion-list.scss
@@ -80,7 +80,6 @@
     overflow-y: auto;
     padding-bottom: 12px;
     max-width: 100%;
-    width: 496px;
 
     &::-webkit-scrollbar-track {
         width: 0;
@@ -205,5 +204,11 @@
         padding: 0 10px 0 5px;
         position: relative;
         z-index: 5;
+    }
+}
+
+.add-user-to-channel-modal__suggestion-box {
+    .suggestion-list {
+        width: calc(100% - 30px);
     }
 }

--- a/sass/utils/_modifiers.scss
+++ b/sass/utils/_modifiers.scss
@@ -44,6 +44,10 @@ $positions: 't'top,
     box-shadow: 0 0 0 1px 2px $primary-color;
 }
 
+.pos-relative {
+    position: relative;
+}
+
 .hidden-label {
     position: absolute;
     overflow: hidden;


### PR DESCRIPTION
## Summary
The `SuggestionList` inside the `AddUserToChannelModel` component had a fixed width that rendered smaller than the modal input box width. This PR computes the width of the `SuggestionList` as the parent div width minus two times the padding in the parent div.

This is *very* hacky, and that is why I have narrowed the change to a specific class inside the component. But we have plans to rework this modal in the near future, so we should get rid of this code hopefully sooner than later.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24033


#### Screenshots
![image](https://user-images.githubusercontent.com/3924815/81206589-a1ddf600-8fcc-11ea-91dc-763b8f8b9c19.png)
![image](https://user-images.githubusercontent.com/3924815/81206612-aa363100-8fcc-11ea-83e1-b8e026e403a2.png)
