### PR TITLE
disable button until link shows

### DIFF
--- a/components/__snapshots__/get_link_modal.test.tsx.snap
+++ b/components/__snapshots__/get_link_modal.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`components/GetLinkModal should have called onHide 1`] = `
     <button
       className="btn btn-primary pull-left"
       data-copy-btn="true"
+      disabled={false}
       id="linkModalCopyLink"
       onClick={[Function]}
       type="button"
@@ -168,6 +169,7 @@ exports[`components/GetLinkModal should have called onHide 2`] = `
     <button
       className="btn btn-primary pull-left"
       data-copy-btn="true"
+      disabled={false}
       id="linkModalCopyLink"
       onClick={[Function]}
       type="button"
@@ -259,6 +261,7 @@ exports[`components/GetLinkModal should match snapshot when all props is set 1`]
     <button
       className="btn btn-primary pull-left"
       data-copy-btn="true"
+      disabled={false}
       id="linkModalCopyLink"
       onClick={[Function]}
       type="button"
@@ -345,6 +348,7 @@ exports[`components/GetLinkModal should match snapshot when helpText is not set 
     <button
       className="btn btn-primary pull-left"
       data-copy-btn="true"
+      disabled={false}
       id="linkModalCopyLink"
       onClick={[Function]}
       type="button"

--- a/components/get_link_modal.tsx
+++ b/components/get_link_modal.tsx
@@ -64,6 +64,11 @@ export default class GetLinkModal extends React.PureComponent<Props, State> {
             );
         }
 
+        let disableButton = true;
+        if (this.props.link !== '') {
+            disableButton = false;
+        }
+
         let copyLink = null;
 
         if (document.queryCommandSupported('copy')) {
@@ -73,6 +78,7 @@ export default class GetLinkModal extends React.PureComponent<Props, State> {
                     data-copy-btn='true'
                     type='button'
                     className='btn btn-primary pull-left'
+                    disabled={disableButton}
                     onClick={this.copyLink}
                 >
                     <FormattedMessage


### PR DESCRIPTION
#### Summary
This PR addresses a situation that occurs when users have a slow connection. When this happens, the modal that is used to display a link to a downloaded file is empty.  Also note this only occurs upon a new file upload and immediately trying to retrieve the public link, or after a refresh of the app or browser.  There are is more discussion in the comments section of the Linked Jira ticket.

The current solution disables the `Copy Link` button until the link appears.  There is also a suggestion to add the <LoadingSpinner> component until the text is visible.  The text is currently a <textarea> element and I am not sure how to superimpose the spinner on top of the <textarea>. 

I didn't want to add the spinner element and then replace it with the textarea element because the separation of components would visibly shift, causing a glitchy look.   Any advice?  

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23580

#### Related Pull Requests
N/A

#### Screenshots
Original issue shared by reporter
![image](https://user-images.githubusercontent.com/7575921/81240132-2aa86200-8fcc-11ea-8481-cc060dfba33f.png)

Link to video in Jira. This is the current solution which disables the button until the link shows.
blob:https://mattermost.atlassian.net/1cd4b135-fd0e-4934-8d74-76c05d882119
