### PR TITLE
MM-24942 Clean up setting AllowedUntrustedInternalConnections on test specs

### DIFF
--- a/e2e/cypress/integration/interactive_dialog/boolean_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/boolean_spec.js
@@ -27,16 +27,6 @@ describe('Interactive Dialog', () => {
 
         cy.requireWebhookServer();
 
-        // Set required ServiceSettings
-        const newSettings = {
-            ServiceSettings: {
-                AllowedUntrustedInternalConnections: 'localhost',
-                EnablePostUsernameOverride: true,
-                EnablePostIconOverride: true,
-            },
-        };
-        cy.apiUpdateConfig(newSettings);
-
         // # Create new team and create command on it
         cy.apiCreateTeam('test-team', 'Test Team').then((teamResponse) => {
             const team = teamResponse.body;

--- a/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
@@ -42,15 +42,8 @@ describe('Interactive Dialog', () => {
         cy.apiLogin('sysadmin');
         cy.apiSaveTeammateNameDisplayPreference('username');
 
-        // Set required ServiceSettings
-        const newSettings = {
-            ServiceSettings: {
-                AllowedUntrustedInternalConnections: 'localhost',
-                EnablePostUsernameOverride: true,
-                EnablePostIconOverride: true,
-            },
-        };
-        cy.apiUpdateConfig(newSettings).then((res) => {
+        // # Get config
+        cy.apiGetConfig().then((res) => {
             config = res.body;
         });
 

--- a/e2e/cypress/integration/interactive_dialog/scrollable_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/scrollable_spec.js
@@ -27,16 +27,6 @@ describe('Interactive Dialog', () => {
         cy.apiLogin('sysadmin');
         cy.apiSaveTeammateNameDisplayPreference('username');
 
-        // Set required ServiceSettings
-        const newSettings = {
-            ServiceSettings: {
-                AllowedUntrustedInternalConnections: 'localhost',
-                EnablePostUsernameOverride: true,
-                EnablePostIconOverride: true,
-            },
-        };
-        cy.apiUpdateConfig(newSettings);
-
         // # Create new team and create command on it
         cy.apiCreateTeam('test-team', 'Test Team').then((teamResponse) => {
             const team = teamResponse.body;

--- a/e2e/cypress/integration/interactive_dialog/simple_dialog_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/simple_dialog_spec.js
@@ -30,16 +30,6 @@ describe('Interactive Dialog', () => {
             cy.apiLogin('sysadmin');
             cy.apiSaveTeammateNameDisplayPreference('username');
 
-            // Set required ServiceSettings
-            const newSettings = {
-                ServiceSettings: {
-                    AllowedUntrustedInternalConnections: 'localhost',
-                    EnablePostUsernameOverride: true,
-                    EnablePostIconOverride: true,
-                },
-            };
-            cy.apiUpdateConfig(newSettings);
-
             // # Create new team and create command on it
             cy.apiCreateTeam('test-team', 'Test Team').then((teamResponse) => {
                 const team = teamResponse.body;

--- a/e2e/cypress/integration/interactive_menu/basic_options_spec.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options_spec.js
@@ -36,16 +36,6 @@ describe('Interactive Menu', () => {
         // # Login as sysadmin
         cy.apiLogin('sysadmin');
 
-        // Set required ServiceSettings
-        const newSettings = {
-            ServiceSettings: {
-                AllowedUntrustedInternalConnections: 'localhost',
-                EnablePostUsernameOverride: true,
-                EnablePostIconOverride: true,
-            },
-        };
-        cy.apiUpdateConfig(newSettings);
-
         // # Update teammate name display setting is set to default 'username'
         cy.apiSaveTeammateNameDisplayPreference('username');
         cy.apiSaveMessageDisplayPreference('clean');

--- a/e2e/cypress/integration/interactive_menu/select_with_keys_spec.js
+++ b/e2e/cypress/integration/interactive_menu/select_with_keys_spec.js
@@ -36,16 +36,6 @@ describe('Interactive Menu', () => {
         cy.apiSaveTeammateNameDisplayPreference('username');
         cy.apiSaveMessageDisplayPreference('clean');
 
-        // Set required ServiceSettings
-        const newSettings = {
-            ServiceSettings: {
-                AllowedUntrustedInternalConnections: 'localhost',
-                EnablePostUsernameOverride: true,
-                EnablePostIconOverride: true,
-            },
-        };
-        cy.apiUpdateConfig(newSettings);
-
         // # Create and visit new channel and create incoming webhook
         cy.createAndVisitNewChannel().then((channel) => {
             channelId = channel.id;

--- a/e2e/cypress/integration/interactive_menu/slack_parsing_message_button_spec.js
+++ b/e2e/cypress/integration/interactive_menu/slack_parsing_message_button_spec.js
@@ -23,16 +23,6 @@ describe('Interactive Menu', () => {
         // # Login as sysadmin
         cy.apiLogin('sysadmin');
 
-        // Set required ServiceSettings
-        const newSettings = {
-            ServiceSettings: {
-                AllowedUntrustedInternalConnections: 'localhost',
-                EnablePostUsernameOverride: true,
-                EnablePostIconOverride: true,
-            },
-        };
-        cy.apiUpdateConfig(newSettings);
-
         // # Update teammate name display setting is set to default 'username'
         cy.apiSaveTeammateNameDisplayPreference('username');
         cy.apiSaveMessageDisplayPreference('clean');


### PR DESCRIPTION
#### Summary
Clean up unnecessary update to config as it's already defined as default, especially in setting AllowedUntrustedInternalConnections on test specs.  This will allow CI server to communicate with custom webhook server by a predefined network's subnet address in docker-compose [see [link](https://github.com/saturninoabril/mattermost-cypress-docker/blob/master/mattermost-e2e/docker-compose.yml#L78)].  I remain as is the value on partial_default_config.json for local dev, and will only replace in CI ([link](https://github.com/saturninoabril/mattermost-cypress-docker/blob/master/Makefile#L59))

Note: Reference repo will eventually move to our org.

#### Ticket Link
JIRA ticket - https://mattermost.atlassian.net/browse/MM-24942
