### PR TITLE
MM-24965 Fix issue of search results stuck loading in mobile web view

### DIFF
--- a/components/search_results/search_results.jsx
+++ b/components/search_results/search_results.jsx
@@ -184,7 +184,7 @@ class SearchResults extends React.Component {
             this.props.isSearchingTerm ||
             this.props.isSearchingFlaggedPost ||
             this.props.isSearchingPinnedPost ||
-            !this.props.isOpened
+            (!this.props.isOpened && !Utils.isMobile())
         ) {
             ctls = (
                 <div className='sidebar--right__subheader a11y__section'>


### PR DESCRIPTION
#### Summary
In mobile web view, search results is stuck showing a loading indicator when the search (or viewing pinned or flagged posts) is initiated while in the mobile view. Works fine If the search is initiated in desktop view before switching to mobile view.

https://community-daily.mattermost.com/core/pl/akk618tnmfgt88ucd948tyn6sy

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24965

#### Related Pull Requests
None

#### Screenshots

**Before**
![search-1](https://user-images.githubusercontent.com/25670682/81402983-b805c680-9132-11ea-8c3f-40fad4515a48.gif)

**After**
![search-2](https://user-images.githubusercontent.com/25670682/81403001-c3f18880-9132-11ea-8cef-8c827d12fffc.gif)
