### PR TITLE
MM-24918: Make sure flagged posts and recent mentions from old channel are excluded in RHS

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -769,6 +769,11 @@ export async function handleUserRemovedEvent(msg) {
         if (msg.data.channel_id === currentChannel.id) {
             if (msg.data.remover_id === msg.broadcast.user_id) {
                 browserHistory.push(getCurrentRelativeTeamUrl(state));
+
+                await dispatch({
+                    type: ChannelTypes.LEAVE_CHANNEL,
+                    data: {id: msg.data.channel_id, user_id: msg.broadcast.user_id},
+                });
             } else {
                 const user = getUser(state, msg.data.remover_id);
                 if (!user) {
@@ -783,6 +788,12 @@ export async function handleUserRemovedEvent(msg) {
                         removerId: msg.data.remover_id,
                     },
                 }));
+
+                await dispatch({
+                    type: ChannelTypes.LEAVE_CHANNEL,
+                    data: {id: msg.data.channel_id, user_id: msg.broadcast.user_id},
+                });
+
                 redirectUserToDefaultTeam();
             }
         }

--- a/e2e/cypress/integration/websocket/handle_removed_user_spec.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user_spec.js
@@ -11,9 +11,8 @@ import {testWithConfig} from '../../support/hooks';
 
 import {getRandomInt} from '../../utils';
 
-function shouldRemoveMentionsInRHS(sidebarItemClass) {
+function createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass) {
     // # Start with a new team
-    const teamName = `team-${getRandomInt(999999)}`;
     cy.createNewTeam(teamName, teamName);
 
     // * Verify that we've switched to the new team
@@ -25,17 +24,40 @@ function shouldRemoveMentionsInRHS(sidebarItemClass) {
     // * Verify that the channel changed
     cy.url().should('include', `/${teamName}/channels/off-topic`);
     cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Off-Topic');
+}
 
+function removeMeFromCurrentChannel() {
+    // # Remove the Guest User from channel
     let channelId;
-    let userId;
-    let postId;
-    cy.getCurrentChannelId().then((res) => {
+    return cy.getCurrentChannelId().then((res) => {
         channelId = res;
         return cy.apiGetMe();
     }).then((res) => {
-        userId = res.body.id;
+        const userId = res.body.id;
+        return cy.removeUserFromChannel(channelId, userId);
+    });
+}
 
-        // # Post a unique message with a mention and retrieve its ID
+function verifyRHS(teamName, sidebarItemClass, postId) {
+    // # Dismiss the modal informing the user they were kicked out
+    cy.get('#removedChannelBtn').click();
+
+    // * Verify that the channel changed back to Town Square
+    cy.url().should('include', `/${teamName}/channels/town-square`);
+    cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+
+    // * Verify that Off-Topic has been removed
+    cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('not.exist');
+
+    // * Verify that the recently posted message is no longer in the RHS
+    cy.get(`#rhsPostMessageText_${postId}`).should('not.exist');
+}
+
+function shouldRemoveMentionsInRHS(teamName, sidebarItemClass) {
+    let postId;
+
+    // # Post a unique message with a mention and retrieve its ID
+    cy.apiGetMe().then((res) => {
         var messageText = `${Date.now()} - mention to @${res.body.username} `;
         cy.postMessage(messageText);
 
@@ -49,53 +71,20 @@ function shouldRemoveMentionsInRHS(sidebarItemClass) {
         // * Verify that the recently posted message is shown in the RHS
         cy.get(`#rhsPostMessageText_${postId}`).should('exist');
 
-        return cy.removeUserFromChannel(channelId, userId);
+        return removeMeFromCurrentChannel();
     }).then(() => {
-        // # Dismiss the modal informing the user they were kicked out
-        cy.get('#removedChannelBtn').click();
-
-        // * Verify that the channel changed back to Town Square
-        cy.url().should('include', `/${teamName}/channels/town-square`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
-
-        // * Verify that Off-Topic has been removed
-        cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('not.exist');
-
-        // * Verify that the recently posted message is no longer in the RHS
-        cy.get(`#rhsPostMessageText_${postId}`).should('not.exist');
+        verifyRHS(teamName, sidebarItemClass, postId);
     });
 }
 
-function shouldRemoveFlaggedPostsInRHS(sidebarItemClass) {
-    // # Start with a new team
-    const teamName = `team-${getRandomInt(999999)}`;
-    cy.createNewTeam(teamName, teamName);
-
-    // * Verify that we've switched to the new team
-    cy.get('#headerTeamName').should('be.visible').should('be.visible').should('contain', teamName);
-
-    // # Click on Off Topic
-    cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('be.visible').click();
-
-    // * Verify that the channel changed
-    cy.url().should('include', `/${teamName}/channels/off-topic`);
-    cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Off-Topic');
-
-    let channelId;
-    let userId;
+function shouldRemoveFlaggedPostsInRHS(teamName, sidebarItemClass) {
     let postId;
-    cy.getCurrentChannelId().then((res) => {
-        channelId = res;
-        return cy.apiGetMe();
-    }).then((res) => {
-        userId = res.body.id;
 
-        // # Post a unique message and retrieve its ID
-        var messageText = `${Date.now()} - post to flag`;
-        cy.postMessage(messageText);
+    // # Post a unique message and retrieve its ID
+    var messageText = `${Date.now()} - post to flag`;
+    cy.postMessage(messageText);
 
-        return cy.getLastPostId();
-    }).then((lastPostId) => {
+    cy.getLastPostId().then((lastPostId) => {
         postId = lastPostId;
 
         // # Flag the last post
@@ -107,24 +96,15 @@ function shouldRemoveFlaggedPostsInRHS(sidebarItemClass) {
         // * Verify that the recently posted message is shown in the RHS
         cy.get(`#rhsPostMessageText_${postId}`).should('exist');
 
-        return cy.removeUserFromChannel(channelId, userId);
+        return removeMeFromCurrentChannel();
     }).then(() => {
-        // # Dismiss the modal informing the user they were kicked out
-        cy.get('#removedChannelBtn').click();
-
-        // * Verify that the channel changed back to Town Square
-        cy.url().should('include', `/${teamName}/channels/town-square`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
-
-        // * Verify that Off-Topic has been removed
-        cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('not.exist');
-
-        // * Verify that the recently posted message is no longer in the RHS
-        cy.get(`#rhsPostMessageText_${postId}`).should('not.exist');
+        verifyRHS(teamName, sidebarItemClass, postId);
     });
 }
 
 describe('Handle removed user - old sidebar', () => {
+    const sidebarItemClass = '.sidebar-item';
+
     before(() => {
         cy.apiLogin('user-1');
 
@@ -132,46 +112,33 @@ describe('Handle removed user - old sidebar', () => {
     });
 
     it('should be redirected to last channel when a user is removed from their current channel', () => {
-        // # Start with a new team
         const teamName = `team-${getRandomInt(999999)}`;
-        cy.createNewTeam(teamName, teamName);
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
 
-        // * Verify that we've switched to the new team
-        cy.get('#headerTeamName').should('be.visible').should('be.visible').should('contain', teamName);
-
-        // # Click on Off Topic
-        cy.get('.sidebar-item:contains(Off-Topic)').should('be.visible').click();
-
-        // * Verify that the channel changed
-        cy.url().should('include', `/${teamName}/channels/off-topic`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Off-Topic');
-
-        // # Remove the Guest User from channel
-        let channelId;
-        cy.getCurrentChannelId().then((res) => {
-            channelId = res;
-            return cy.apiGetMe();
-        }).then((res) => {
-            const userId = res.body.id;
-            return cy.removeUserFromChannel(channelId, userId);
-        }).then(() => {
+        removeMeFromCurrentChannel().then(() => {
             // * Verify that the channel changed back to Town Square and that Off-Topic has been removed
             cy.url().should('include', `/${teamName}/channels/town-square`);
             cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
-            cy.get('.sidebar-item:contains(Off-Topic)').should('not.exist');
+            cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('not.exist');
         });
     });
 
     it('should remove mentions from RHS', () => {
-        shouldRemoveMentionsInRHS('.sidebar-item');
+        const teamName = `team-${getRandomInt(999999)}`;
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
+        shouldRemoveMentionsInRHS(teamName, sidebarItemClass);
     });
 
     it('should remove flagged posts from RHS', () => {
-        shouldRemoveFlaggedPostsInRHS('.sidebar-item');
+        const teamName = `team-${getRandomInt(999999)}`;
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
+        shouldRemoveFlaggedPostsInRHS(teamName, sidebarItemClass);
     });
 });
 
 describe('Handle removed user - new sidebar', () => {
+    const sidebarItemClass = '.SidebarChannel';
+
     testWithConfig({
         ServiceSettings: {
             ExperimentalChannelSidebarOrganization: 'default_on',
@@ -185,29 +152,10 @@ describe('Handle removed user - new sidebar', () => {
     });
 
     it('should be redirected to last channel when a user is removed from their current channel', () => {
-        // # Start with a new team
         const teamName = `team-${getRandomInt(999999)}`;
-        cy.createNewTeam(teamName, teamName);
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
 
-        // * Verify that we've switched to the new team
-        cy.get('#headerTeamName').should('be.visible').should('be.visible').should('contain', teamName);
-
-        // # Click on Off Topic
-        cy.get('.SidebarChannel:contains(Off-Topic)').should('be.visible').click();
-
-        // * Verify that the channel changed
-        cy.url().should('include', `/${teamName}/channels/off-topic`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Off-Topic');
-
-        // # Remove the Guest User from channel
-        let channelId;
-        cy.getCurrentChannelId().then((res) => {
-            channelId = res;
-            return cy.apiGetMe();
-        }).then((res) => {
-            const userId = res.body.id;
-            return cy.removeUserFromChannel(channelId, userId);
-        }).then(() => {
+        removeMeFromCurrentChannel().then(() => {
             // * Verify that the channel changed back to Town Square
             cy.url().should('include', `/${teamName}/channels/town-square`);
             cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
@@ -215,10 +163,14 @@ describe('Handle removed user - new sidebar', () => {
     });
 
     it('should remove mentions from RHS', () => {
-        shouldRemoveMentionsInRHS('.SidebarChannel');
+        const teamName = `team-${getRandomInt(999999)}`;
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
+        shouldRemoveMentionsInRHS(teamName, sidebarItemClass);
     });
 
     it('should remove flagged posts from RHS', () => {
-        shouldRemoveFlaggedPostsInRHS('.SidebarChannel');
+        const teamName = `team-${getRandomInt(999999)}`;
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
+        shouldRemoveFlaggedPostsInRHS(teamName, sidebarItemClass);
     });
 });

--- a/e2e/cypress/integration/websocket/handle_removed_user_spec.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user_spec.js
@@ -11,6 +11,119 @@ import {testWithConfig} from '../../support/hooks';
 
 import {getRandomInt} from '../../utils';
 
+function shouldRemoveMentionsInRHS(sidebarItemClass) {
+    // # Start with a new team
+    const teamName = `team-${getRandomInt(999999)}`;
+    cy.createNewTeam(teamName, teamName);
+
+    // * Verify that we've switched to the new team
+    cy.get('#headerTeamName').should('be.visible').should('be.visible').should('contain', teamName);
+
+    // # Click on Off Topic
+    cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('be.visible').click();
+
+    // * Verify that the channel changed
+    cy.url().should('include', `/${teamName}/channels/off-topic`);
+    cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Off-Topic');
+
+    let channelId;
+    let userId;
+    let postId;
+    cy.getCurrentChannelId().then((res) => {
+        channelId = res;
+        return cy.apiGetMe();
+    }).then((res) => {
+        userId = res.body.id;
+
+        // # Post a unique message with a mention and retrieve its ID
+        var messageText = `${Date.now()} - mention to @${res.body.username} `;
+        cy.postMessage(messageText);
+
+        return cy.getLastPostId();
+    }).then((lastPostId) => {
+        postId = lastPostId;
+
+        // # Click on the Recent Mentions button to open the RHS
+        cy.get('#channelHeaderMentionButton').click();
+
+        // * Verify that the recently posted message is shown in the RHS
+        cy.get(`#rhsPostMessageText_${postId}`).should('exist');
+
+        return cy.removeUserFromChannel(channelId, userId);
+    }).then(() => {
+        // # Dismiss the modal informing the user they were kicked out
+        cy.get('#removedChannelBtn').click();
+
+        // * Verify that the channel changed back to Town Square
+        cy.url().should('include', `/${teamName}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+
+        // * Verify that Off-Topic has been removed
+        cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('not.exist');
+
+        // * Verify that the recently posted message is no longer in the RHS
+        cy.get(`#rhsPostMessageText_${postId}`).should('not.exist');
+    });
+}
+
+function shouldRemoveFlaggedPostsInRHS(sidebarItemClass) {
+    // # Start with a new team
+    const teamName = `team-${getRandomInt(999999)}`;
+    cy.createNewTeam(teamName, teamName);
+
+    // * Verify that we've switched to the new team
+    cy.get('#headerTeamName').should('be.visible').should('be.visible').should('contain', teamName);
+
+    // # Click on Off Topic
+    cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('be.visible').click();
+
+    // * Verify that the channel changed
+    cy.url().should('include', `/${teamName}/channels/off-topic`);
+    cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Off-Topic');
+
+    let channelId;
+    let userId;
+    let postId;
+    cy.getCurrentChannelId().then((res) => {
+        channelId = res;
+        return cy.apiGetMe();
+    }).then((res) => {
+        userId = res.body.id;
+
+        // # Post a unique message and retrieve its ID
+        var messageText = `${Date.now()} - post to flag`;
+        cy.postMessage(messageText);
+
+        return cy.getLastPostId();
+    }).then((lastPostId) => {
+        postId = lastPostId;
+
+        // # Flag the last post
+        cy.clickPostFlagIcon(postId);
+
+        // # Click on the Flagged Posts button to open the RHS
+        cy.get('#channelHeaderFlagButton').click();
+
+        // * Verify that the recently posted message is shown in the RHS
+        cy.get(`#rhsPostMessageText_${postId}`).should('exist');
+
+        return cy.removeUserFromChannel(channelId, userId);
+    }).then(() => {
+        // # Dismiss the modal informing the user they were kicked out
+        cy.get('#removedChannelBtn').click();
+
+        // * Verify that the channel changed back to Town Square
+        cy.url().should('include', `/${teamName}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+
+        // * Verify that Off-Topic has been removed
+        cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('not.exist');
+
+        // * Verify that the recently posted message is no longer in the RHS
+        cy.get(`#rhsPostMessageText_${postId}`).should('not.exist');
+    });
+}
+
 describe('Handle removed user - old sidebar', () => {
     before(() => {
         cy.apiLogin('user-1');
@@ -47,6 +160,14 @@ describe('Handle removed user - old sidebar', () => {
             cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
             cy.get('.sidebar-item:contains(Off-Topic)').should('not.exist');
         });
+    });
+
+    it('should remove mentions from RHS', () => {
+        shouldRemoveMentionsInRHS('.sidebar-item');
+    });
+
+    it('should remove flagged posts from RHS', () => {
+        shouldRemoveFlaggedPostsInRHS('.sidebar-item');
     });
 });
 
@@ -91,5 +212,13 @@ describe('Handle removed user - new sidebar', () => {
             cy.url().should('include', `/${teamName}/channels/town-square`);
             cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
         });
+    });
+
+    it('should remove mentions from RHS', () => {
+        shouldRemoveMentionsInRHS('.SidebarChannel');
+    });
+
+    it('should remove flagged posts from RHS', () => {
+        shouldRemoveFlaggedPostsInRHS('.SidebarChannel');
     });
 });


### PR DESCRIPTION
#### Summary
This PR fixes an issue with the RHS: when a user has the Recent Mentions RHS or the Flagged Posts RHS open and they are kicked out of a channel, the messages from that channel should disappear. This was introduced in https://github.com/mattermost/mattermost-webapp/pull/5320, that removed the dispatching of the `LEAVE_CHANNEL` event when a user was removed from a channel, as its position was causing race conditions when using the `/leave` command.

The thing is that we need to:
1. dispatch the `LEAVE_CHANNEL` event in order to fix https://mattermost.atlassian.net/browse/MM-24918.
2. in case the user is leaving a channel, make sure that we dispatch this event after we have pushed the new URL to the browser history in order to fix https://mattermost.atlassian.net/browse/MM-23994
3. in case the user is being kicked out of the channel, make sure that we dispatch this event before calling `redirectUserToDefaultTeam` in order to fix https://mattermost.atlassian.net/browse/MM-23589

The changes in this PR accomplish that by just dispatching the event when we need it. It's not the most elegant solution, but we want to have this in v5.23 and, given the time constraints, I thought this was the safest way to do it without breaking anything else.

I have also added e2e tests to make sure we don't lose this functionality again in the future.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24918