### PR TITLE
Fixed accessibility dropdowns spec and added file path to report

### DIFF
--- a/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
@@ -10,6 +10,8 @@
 // Stage: @prod
 // Group: @accessibility
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
 // * Verify the accessibility support in the menu items
 function verifyMenuItems(menuEl, labels) {
     cy.get(`${menuEl} .MenuItem`).each((child, index) => {
@@ -44,7 +46,7 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
 
     beforeEach(() => {
         // Visit the Off Topic channel
-        cy.visit('/ad-1/channels/off-topic');
+        cy.visit('/ad-1/channels/off-topic').wait(TIMEOUTS.SMALL);
     });
 
     it('MM-22627 Accessibility Support in Channel Menu Dropdown', () => {

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -101,7 +101,7 @@ Cypress.on('test:after:run', (test, runnable) => {
 
         // Add context to the mochawesome report which includes the screenshot
         addContext({test}, {
-            title: 'Failing Screenshot',
+            title: 'Failing Screenshot: >> screenshots/' + filename,
             value: 'screenshots/' + Cypress.spec.name + '/' + filename,
         });
     }


### PR DESCRIPTION
#### Summary
- added timeout after visiting url, for some reason, page is partially loaded and test start and then page refreshes so the hamburger menu is closed during verification
- added file path back to report for easier tracking failing tests

#### Ticket Link
NA