### PR TITLE
E2E: fix failing tests on image attachment and markdown

### DIFF
--- a/e2e/cypress/integration/markdown/markdown_image_spec.js
+++ b/e2e/cypress/integration/markdown/markdown_image_spec.js
@@ -90,7 +90,7 @@ describe('Markdown', () => {
                 cy.get('.markdown-inline-img').should('be.visible').
                     and((inlineImg) => {
                         expect(inlineImg.height()).to.be.closeTo(143, 2);
-                        expect(inlineImg.width()).to.be.closeTo(893, 2);
+                        expect(inlineImg.width()).to.be.closeTo(906, 2);
                     }).
                     click();
             });

--- a/e2e/cypress/integration/messaging/image_attachment_spec.js
+++ b/e2e/cypress/integration/messaging/image_attachment_spec.js
@@ -149,8 +149,8 @@ describe('Image attachment', () => {
 
                 cy.get('@div').find('img').
                     and((img) => {
-                        expect(img.height()).to.be.closeTo(142, 0.9);
-                        expect(img.width()).to.be.closeTo(899, 0.9);
+                        expect(img.height()).to.be.closeTo(145, 2.0);
+                        expect(img.width()).to.be.closeTo(913, 2.0);
                     });
             });
         });
@@ -174,8 +174,8 @@ describe('Image attachment', () => {
 
                 cy.get('@div').find('img').
                     and((img) => {
-                        expect(img.height()).to.be.closeTo(142, 0.9);
-                        expect(img.width()).to.be.closeTo(899, 0.9);
+                        expect(img.height()).to.be.closeTo(145, 2.0);
+                        expect(img.width()).to.be.closeTo(913, 2.0);
                     }).
                     click();
             });


### PR DESCRIPTION
#### Summary
Fix failing tests on image attachment and markdown.  Updates on dimensions were due to recent CSS changes. These are some of the pain points in which visual regression testing could help us a lot.

Note: Other failing tests on `markdown_image_spec` were fixed by the other PR on default config, specifically on setting up `SiteURL `, `EnableSVGs` and `ImageProxySettings` - https://github.com/mattermost/mattermost-webapp/pull/5477

#### Ticket Link
none, failing on daily Cypress test.
