### PR TITLE
Fix build failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10766,10 +10766,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
       "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "^0.64.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -11714,12 +11711,6 @@
       "requires": {
         "postcss": "^7.0.14"
       }
-    },
-    "icu4c-data": {
-      "version": "0.64.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
-      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",


### PR DESCRIPTION
#### Summary
Seems like the package-lock is broken and since the npm ci is installing from the package-lock.json file this is breaking the build. I tried the same step which is run from the CI locally and npm install is fixing automagically the package-lock.json with the below code which makes the build not break.  

#### Ticket Link
