### PR TITLE
E2E: Fix failing tests related to LDAP

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -12,6 +12,7 @@
         "webhookBaseUrl": "http://localhost:3000",
         "setChromeWebSecurity": true,
         "ldapServer": "localhost",
-        "ldapPort": 389
+        "ldapPort": 389,
+        "runLDAPSync": true
     }
 }

--- a/e2e/cypress/integration/enterprise/ldap_group/channel_modes_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/channel_modes_spec.js
@@ -24,7 +24,9 @@ describe('Test channel public/private toggle', () => {
         });
 
         // # Check and run LDAP Sync job
-        cy.checkRunLDAPSync();
+        if (Cypress.env('runLDAPSync')) {
+            cy.checkRunLDAPSync();
+        }
     });
 
     it('Verify that System Admin can change channel privacy using toggle', () => {

--- a/e2e/cypress/integration/enterprise/ldap_group/groups_assign_roles_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/groups_assign_roles_spec.js
@@ -58,7 +58,9 @@ describe('System Console', () => {
         cy.apiUpdateConfig({LdapSettings: {Enable: true}});
 
         // # Check and run LDAP Sync job
-        cy.checkRunLDAPSync();
+        if (Cypress.env('runLDAPSync')) {
+            cy.checkRunLDAPSync();
+        }
     });
 
     it('MM-20058 - System Admin can map roles to teams and channels via group configuration page', () => {

--- a/e2e/cypress/integration/enterprise/ldap_group/team_and_channel_assign_roles_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/team_and_channel_assign_roles_spec.js
@@ -28,7 +28,9 @@ describe('System Console', () => {
         cy.apiUpdateConfig({LdapSettings: {Enable: true}});
 
         // # Check and run LDAP Sync job
-        cy.checkRunLDAPSync();
+        if (Cypress.env('runLDAPSync')) {
+            cy.checkRunLDAPSync();
+        }
     });
 
     it('MM-20059 - System Admin can map roles to groups from Team Configuration screen', () => {


### PR DESCRIPTION
#### Summary
Fix failing tests related to LDAP by adding flag whenever we're running tests on CI (see [instruction](https://github.com/mattermost/mattermost-webapp/blob/master/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js#L27)). On CI, we're not doing pre-seed both in PostgreSQL DB and OpenLDAP, that's why related LDAP tests failed.

No change on local development.

#### Ticket Link
none, failing on daily Cypress
