### PR TITLE
Fix release-5.19 build by tying jest to a specific verison 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14283,8 +14283,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#cba0bcff3515d15d1277da0d562b635a53bba12c",
-      "from": "github:mattermost/mattermost-redux#cba0bcff3515d15d1277da0d562b635a53bba12c",
+      "version": "github:mattermost/mattermost-redux#cf8d3889cd236919eb41379c4e6e8e3b058f4ebf",
+      "from": "github:mattermost/mattermost-redux#cf8d3889cd236919eb41379c4e6e8e3b058f4ebf",
       "requires": {
         "form-data": "2.5.1",
         "gfycat-sdk": "1.4.18",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#8214e10918264fb88cec474196023949f7cb4b30",
-    "mattermost-redux": "github:mattermost/mattermost-redux#cba0bcff3515d15d1277da0d562b635a53bba12c",
+    "mattermost-redux": "github:mattermost/mattermost-redux#cf8d3889cd236919eb41379c4e6e8e3b058f4ebf",
     "moment-timezone": "0.5.27",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
- Changes are in redux - https://github.com/mattermost/mattermost-redux/pull/1155
- Redux PR has to go in first and then package needs to be updated here

