### PR TITLE
MM-22155 Replace usage of React.Component with React.PureComponent 

### DIFF
--- a/actions/views/modals.test.jsx
+++ b/actions/views/modals.test.jsx
@@ -9,7 +9,7 @@ import thunk from 'redux-thunk';
 import {openModal, closeModal} from 'actions/views/modals';
 import {ActionTypes, ModalIdentifiers} from 'utils/constants';
 
-class TestModal extends React.Component {
+class TestModal extends React.PureComponent {
     render() {
         return (
             <Modal

--- a/components/add_groups_to_channel_modal/add_groups_to_channel_modal.jsx
+++ b/components/add_groups_to_channel_modal/add_groups_to_channel_modal.jsx
@@ -18,7 +18,7 @@ import AddIcon from 'components/widgets/icons/fa_add_icon';
 const GROUPS_PER_PAGE = 50;
 const MAX_SELECTABLE_VALUES = 10;
 
-export default class AddGroupsToChannelModal extends React.Component {
+export default class AddGroupsToChannelModal extends React.PureComponent {
     static propTypes = {
         currentChannelName: PropTypes.string.isRequired,
         currentChannelId: PropTypes.string.isRequired,

--- a/components/add_groups_to_team_modal/add_groups_to_team_modal.jsx
+++ b/components/add_groups_to_team_modal/add_groups_to_team_modal.jsx
@@ -18,7 +18,7 @@ import AddIcon from 'components/widgets/icons/fa_add_icon';
 const GROUPS_PER_PAGE = 50;
 const MAX_SELECTABLE_VALUES = 10;
 
-export default class AddGroupsToTeamModal extends React.Component {
+export default class AddGroupsToTeamModal extends React.PureComponent {
     static propTypes = {
         currentTeamName: PropTypes.string.isRequired,
         currentTeamId: PropTypes.string.isRequired,

--- a/components/add_user_to_channel_modal/add_user_to_channel_modal.jsx
+++ b/components/add_user_to_channel_modal/add_user_to_channel_modal.jsx
@@ -14,7 +14,7 @@ import SuggestionList from 'components/suggestion/suggestion_list.jsx';
 
 import {placeCaretAtEnd} from 'utils/utils.jsx';
 
-export default class AddUserToChannelModal extends React.Component {
+export default class AddUserToChannelModal extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/admin_console/admin_button_outline/admin_button_outline.jsx
+++ b/components/admin_console/admin_button_outline/admin_button_outline.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import './admin_button_outline.scss';
 
-export default class AdminButtonOutline extends React.Component {
+export default class AdminButtonOutline extends React.PureComponent {
     static propTypes = {
         onClick: PropTypes.func.isRequired,
         children: PropTypes.string.isRequired,

--- a/components/admin_console/admin_console.tsx
+++ b/components/admin_console/admin_console.tsx
@@ -69,7 +69,7 @@ type Item = {
     url: string;
 }
 
-export default class AdminConsole extends React.Component<Props, State> {
+export default class AdminConsole extends React.PureComponent<Props, State> {
     public constructor(props: Props) {
         super(props);
         this.state = {

--- a/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.tsx
+++ b/components/admin_console/admin_navbar_dropdown/admin_navbar_dropdown.tsx
@@ -29,7 +29,7 @@ type Props = {
     };
 };
 
-class AdminNavbarDropdown extends React.Component<Props, {}> {
+class AdminNavbarDropdown extends React.PureComponent<Props, {}> {
     private handleLogout = (e: React.MouseEvent<HTMLButtonElement>) => {
         if (this.props.navigationBlocked) {
             e.preventDefault();

--- a/components/admin_console/admin_settings.tsx
+++ b/components/admin_console/admin_settings.tsx
@@ -34,7 +34,7 @@ type ClientErrorPlaceholder = {
     server_error_id: string;
 }
 
-export default abstract class AdminSettings extends React.Component<Props, State> {
+export default abstract class AdminSettings extends React.PureComponent<Props, State> {
     public constructor(props: Props) {
         super(props);
         const stateInit = {

--- a/components/admin_console/admin_sidebar/admin_sidebar.jsx
+++ b/components/admin_console/admin_sidebar/admin_sidebar.jsx
@@ -40,7 +40,7 @@ const renderScrollThumbVertical = (props) => (
     />
 );
 
-class AdminSidebar extends React.Component {
+class AdminSidebar extends React.PureComponent {
     static propTypes = {
         license: PropTypes.object.isRequired,
         config: PropTypes.object,

--- a/components/admin_console/admin_sidebar_category.jsx
+++ b/components/admin_console/admin_sidebar_category.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {NavLink, Route} from 'react-router-dom';
 
-export default class AdminSidebarCategory extends React.Component {
+export default class AdminSidebarCategory extends React.PureComponent {
     static get propTypes() {
         return {
             name: PropTypes.string,

--- a/components/admin_console/admin_sidebar_header/admin_sidebar_header.tsx
+++ b/components/admin_console/admin_sidebar_header/admin_sidebar_header.tsx
@@ -17,7 +17,7 @@ type Props = {
     currentUser: UserProfile& {last_picture_update?: number};
 }
 
-export default class SidebarHeader extends React.Component<Props> {
+export default class SidebarHeader extends React.PureComponent<Props> {
     public render() {
         const me = this.props.currentUser;
         let profilePicture = null;

--- a/components/admin_console/admin_sidebar_section.jsx
+++ b/components/admin_console/admin_sidebar_section.jsx
@@ -8,7 +8,7 @@ import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import BlockableLink from 'components/admin_console/blockable_link';
 import * as Utils from 'utils/utils.jsx';
 
-export default class AdminSidebarSection extends React.Component {
+export default class AdminSidebarSection extends React.PureComponent {
     static get propTypes() {
         return {
             name: PropTypes.string.isRequired,

--- a/components/admin_console/boolean_setting.tsx
+++ b/components/admin_console/boolean_setting.tsx
@@ -21,7 +21,7 @@ type Props = {
     helpText: React.ReactNode;
 }
 
-export default class BooleanSetting extends React.Component<Props> {
+export default class BooleanSetting extends React.PureComponent<Props> {
     public static defaultProps = {
         trueText: (
             <FormattedMessage

--- a/components/admin_console/cluster_table.jsx
+++ b/components/admin_console/cluster_table.jsx
@@ -10,7 +10,7 @@ import statusGreen from 'images/status_green.png';
 import statusYellow from 'images/status_yellow.png';
 import ReloadIcon from 'components/widgets/icons/fa_reload_icon';
 
-export default class ClusterTable extends React.Component {
+export default class ClusterTable extends React.PureComponent {
     static propTypes = {
         clusterInfos: PropTypes.array.isRequired,
         reload: PropTypes.func.isRequired,

--- a/components/admin_console/cluster_table_container.jsx
+++ b/components/admin_console/cluster_table_container.jsx
@@ -8,7 +8,7 @@ import LoadingScreen from '../loading_screen';
 
 import ClusterTable from './cluster_table.jsx';
 
-export default class ClusterTableContainer extends React.Component {
+export default class ClusterTableContainer extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
+++ b/components/admin_console/custom_enable_disable_guest_accounts_setting.tsx
@@ -20,7 +20,7 @@ type Props = {
     showConfirm: boolean;
 }
 
-export default class CustomEnableDisableGuestAccountsSetting extends React.Component<Props> {
+export default class CustomEnableDisableGuestAccountsSetting extends React.PureComponent<Props> {
     public handleChange = (id: string, value: boolean, submit = false) => {
         const confirmNeeded = value === false; // Requires confirmation if disabling guest accounts
         let warning: React.ReactNode | string = '';

--- a/components/admin_console/custom_url_schemes_setting.jsx
+++ b/components/admin_console/custom_url_schemes_setting.jsx
@@ -11,7 +11,7 @@ import LocalizedInput from 'components/localized_input/localized_input';
 
 import Setting from './setting';
 
-export default class CustomUrlSchemesSetting extends React.Component {
+export default class CustomUrlSchemesSetting extends React.PureComponent {
     static get propTypes() {
         return {
             id: PropTypes.string.isRequired,

--- a/components/admin_console/dropdown_setting.jsx
+++ b/components/admin_console/dropdown_setting.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import Setting from './setting';
 
-export default class DropdownSetting extends React.Component {
+export default class DropdownSetting extends React.PureComponent {
     static propTypes = {
         id: PropTypes.string.isRequired,
         values: PropTypes.array.isRequired,

--- a/components/admin_console/generated_setting.tsx
+++ b/components/admin_console/generated_setting.tsx
@@ -22,7 +22,7 @@ type Props = {
     regenerateHelpText?: React.ReactNode;
 }
 
-export default class GeneratedSetting extends React.Component<Props> {
+export default class GeneratedSetting extends React.PureComponent<Props> {
     public static get defaultProps() {
         return {
             disabled: false,

--- a/components/admin_console/group_settings/group_row.jsx
+++ b/components/admin_console/group_settings/group_row.jsx
@@ -11,7 +11,7 @@ import {localizeMessage} from 'utils/utils.jsx';
 import CheckboxCheckedIcon from 'components/widgets/icons/checkbox_checked_icon.jsx';
 import LoadingSpinner from 'components/widgets/loading/loading_spinner';
 
-export default class GroupRow extends React.Component {
+export default class GroupRow extends React.PureComponent {
     static propTypes = {
         primary_key: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,

--- a/components/admin_console/highlight.tsx
+++ b/components/admin_console/highlight.tsx
@@ -10,7 +10,7 @@ type Props = {
     children: React.ReactNode;
 }
 
-export default class Highlight extends React.Component<Props> {
+export default class Highlight extends React.PureComponent<Props> {
     private markInstance? : Mark;
     private ref: React.RefObject<HTMLDivElement>;
 

--- a/components/admin_console/license_settings/license_settings.jsx
+++ b/components/admin_console/license_settings/license_settings.jsx
@@ -10,7 +10,7 @@ import * as Utils from 'utils/utils.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 import FormattedAdminHeader from 'components/widgets/admin_console/formatted_admin_header';
 
-export default class LicenseSettings extends React.Component {
+export default class LicenseSettings extends React.PureComponent {
     static propTypes = {
         license: PropTypes.object.isRequired,
         config: PropTypes.object,

--- a/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
+++ b/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
@@ -9,7 +9,7 @@ import Menu from 'components/widgets/menu/menu';
 
 import * as Utils from 'utils/utils.jsx';
 
-export default class ManageTeamsDropdown extends React.Component {
+export default class ManageTeamsDropdown extends React.PureComponent {
     static propTypes = {
         team: PropTypes.object.isRequired,
         user: PropTypes.object.isRequired,

--- a/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
+++ b/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
@@ -15,7 +15,7 @@ import Avatar from 'components/widgets/users/avatar';
 import ManageTeamsDropdown from './manage_teams_dropdown.jsx';
 import RemoveFromTeamButton from './remove_from_team_button.jsx';
 
-export default class ManageTeamsModal extends React.Component {
+export default class ManageTeamsModal extends React.PureComponent {
     static propTypes = {
         locale: PropTypes.string.isRequired,
         onModalDismissed: PropTypes.func.isRequired,

--- a/components/admin_console/multiselect_settings.jsx
+++ b/components/admin_console/multiselect_settings.jsx
@@ -9,7 +9,7 @@ import FormError from 'components/form_error';
 
 import Setting from './setting';
 
-export default class MultiSelectSetting extends React.Component {
+export default class MultiSelectSetting extends React.PureComponent {
     static propTypes = {
         id: PropTypes.string.isRequired,
         values: PropTypes.array.isRequired,

--- a/components/admin_console/permission_schemes_settings/edit_post_time_limit_button/edit_post_time_limit_button.jsx
+++ b/components/admin_console/permission_schemes_settings/edit_post_time_limit_button/edit_post_time_limit_button.jsx
@@ -8,7 +8,7 @@ import {FormattedMessage} from 'react-intl';
 import {Constants} from 'utils/constants';
 import {t} from 'utils/i18n';
 
-export default class EditPostTimeLimitButton extends React.Component {
+export default class EditPostTimeLimitButton extends React.PureComponent {
     static propTypes = {
         timeLimit: PropTypes.number.isRequired,
         onClick: PropTypes.func,

--- a/components/admin_console/permission_schemes_settings/edit_post_time_limit_modal/edit_post_time_limit_modal.jsx
+++ b/components/admin_console/permission_schemes_settings/edit_post_time_limit_modal/edit_post_time_limit_modal.jsx
@@ -12,7 +12,7 @@ import {t} from 'utils/i18n';
 
 const INT32_MAX = 2147483647;
 
-export default class EditPostTimeLimitModal extends React.Component {
+export default class EditPostTimeLimitModal extends React.PureComponent {
     static propTypes = {
         config: PropTypes.object.isRequired,
         show: PropTypes.bool,

--- a/components/admin_console/permission_schemes_settings/guest_permissions_tree/guest_permissions_tree.jsx
+++ b/components/admin_console/permission_schemes_settings/guest_permissions_tree/guest_permissions_tree.jsx
@@ -12,7 +12,7 @@ import PermissionGroup from '../permission_group.jsx';
 import EditPostTimeLimitButton from '../edit_post_time_limit_button';
 import EditPostTimeLimitModal from '../edit_post_time_limit_modal';
 
-export default class GuestPermissionsTree extends React.Component {
+export default class GuestPermissionsTree extends React.PureComponent {
     static propTypes = {
         scope: PropTypes.string.isRequired,
         role: PropTypes.object.isRequired,

--- a/components/admin_console/permission_schemes_settings/permission_description.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_description.jsx
@@ -10,7 +10,7 @@ import {generateId} from 'utils/utils.jsx';
 import {intlShape} from 'utils/react_intl';
 import Constants from 'utils/constants';
 
-export class PermissionDescription extends React.Component {
+export class PermissionDescription extends React.PureComponent {
     static propTypes = {
         intl: intlShape.isRequired,
         id: PropTypes.string.isRequired,

--- a/components/admin_console/permission_schemes_settings/permission_group.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_group.jsx
@@ -23,7 +23,7 @@ const getRecursivePermissions = (permissions) => {
     return result;
 };
 
-export default class PermissionGroup extends React.Component {
+export default class PermissionGroup extends React.PureComponent {
     static propTypes = {
         id: PropTypes.string.isRequired,
         uniqId: PropTypes.string.isRequired,

--- a/components/admin_console/permission_schemes_settings/permission_row.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_row.jsx
@@ -8,7 +8,7 @@ import {FormattedMessage} from 'react-intl';
 import PermissionCheckbox from './permission_checkbox.jsx';
 import PermissionDescription from './permission_description.jsx';
 
-export default class PermissionRow extends React.Component {
+export default class PermissionRow extends React.PureComponent {
     static propTypes = {
         id: PropTypes.string.isRequired,
         uniqId: PropTypes.string.isRequired,

--- a/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.jsx
@@ -24,7 +24,7 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 import PermissionsTree, {EXCLUDED_PERMISSIONS} from '../permissions_tree';
 import GuestPermissionsTree, {GUEST_INCLUDED_PERMISSIONS} from '../guest_permissions_tree';
 
-export default class PermissionSystemSchemeSettings extends React.Component {
+export default class PermissionSystemSchemeSettings extends React.PureComponent {
     static propTypes = {
         config: PropTypes.object.isRequired,
         roles: PropTypes.object.isRequired,

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/permission_team_scheme_settings.jsx
@@ -27,7 +27,7 @@ import LocalizedInput from 'components/localized_input/localized_input';
 
 import TeamInList from './team_in_list';
 
-export default class PermissionTeamSchemeSettings extends React.Component {
+export default class PermissionTeamSchemeSettings extends React.PureComponent {
     static propTypes = {
         schemeId: PropTypes.string,
         scheme: PropTypes.object,

--- a/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/team_in_list.jsx
+++ b/components/admin_console/permission_schemes_settings/permission_team_scheme_settings/team_in_list/team_in_list.jsx
@@ -9,7 +9,7 @@ import TeamIcon from 'components/widgets/team_icon/team_icon';
 
 import {imageURLForTeam} from 'utils/utils';
 
-export default class TeamInList extends React.Component {
+export default class TeamInList extends React.PureComponent {
     static propTypes = {
         team: PropTypes.object.isRequired,
         onRemoveTeam: PropTypes.func,

--- a/components/admin_console/permission_schemes_settings/permissions_scheme_summary/permissions_scheme_summary.jsx
+++ b/components/admin_console/permission_schemes_settings/permissions_scheme_summary/permissions_scheme_summary.jsx
@@ -16,7 +16,7 @@ import Constants from 'utils/constants';
 
 const MAX_TEAMS_PER_SCHEME_SUMMARY = 8;
 
-export default class PermissionsSchemeSummary extends React.Component {
+export default class PermissionsSchemeSummary extends React.PureComponent {
     static propTypes = {
         scheme: PropTypes.object.isRequired,
         teams: PropTypes.array,

--- a/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.jsx
+++ b/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.jsx
@@ -12,7 +12,7 @@ import PermissionGroup from '../permission_group.jsx';
 import EditPostTimeLimitButton from '../edit_post_time_limit_button';
 import EditPostTimeLimitModal from '../edit_post_time_limit_modal';
 
-export default class PermissionsTree extends React.Component {
+export default class PermissionsTree extends React.PureComponent {
     static propTypes = {
         scope: PropTypes.string.isRequired,
         config: PropTypes.object.isRequired,

--- a/components/admin_console/radio_setting.tsx
+++ b/components/admin_console/radio_setting.tsx
@@ -15,7 +15,7 @@ interface Props {
     helpText?: React.ReactNode;
     onChange(id: string, value: any): void;
 }
-export default class RadioSetting extends React.Component<Props> {
+export default class RadioSetting extends React.PureComponent<Props> {
     public static defaultProps: Partial<Props> = {
         disabled: false,
     };

--- a/components/admin_console/request_button/request_button.jsx
+++ b/components/admin_console/request_button/request_button.jsx
@@ -16,7 +16,7 @@ import WarningIcon from 'components/widgets/icons/fa_warning_icon';
  * its outcome as either success, or failure accompanied by the
  * `message` property of the `err` object.
  */
-export default class RequestButton extends React.Component {
+export default class RequestButton extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/admin_console/reset_email_modal/reset_email_modal.jsx
+++ b/components/admin_console/reset_email_modal/reset_email_modal.jsx
@@ -10,7 +10,7 @@ import {isEmail} from 'mattermost-redux/utils/helpers';
 
 import {adminResetEmail} from 'actions/admin_actions.jsx';
 
-export default class ResetEmailModal extends React.Component {
+export default class ResetEmailModal extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object,
         show: PropTypes.bool.isRequired,

--- a/components/admin_console/reset_password_modal/reset_password_modal.tsx
+++ b/components/admin_console/reset_password_modal/reset_password_modal.tsx
@@ -38,7 +38,7 @@ type Props = {
     };
 }
 
-export default class ResetPasswordModal extends React.Component<Props, State> {
+export default class ResetPasswordModal extends React.PureComponent<Props, State> {
     public static defaultProps: Partial<Props> = {
         show: false,
     };

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -37,7 +37,7 @@ import FormattedAdminHeader from 'components/widgets/admin_console/formatted_adm
 
 import Setting from './setting';
 
-export default class SchemaAdminSettings extends React.Component {
+export default class SchemaAdminSettings extends React.PureComponent {
     static propTypes = {
         config: PropTypes.object,
         environmentConfig: PropTypes.object,

--- a/components/admin_console/server_logs/logs.jsx
+++ b/components/admin_console/server_logs/logs.jsx
@@ -11,7 +11,7 @@ import FormattedAdminHeader from 'components/widgets/admin_console/formatted_adm
 
 import LogList from './log_list.jsx';
 
-export default class Logs extends React.Component {
+export default class Logs extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/admin_console/settings_group.jsx
+++ b/components/admin_console/settings_group.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class SettingsGroup extends React.Component {
+export default class SettingsGroup extends React.PureComponent {
     static get propTypes() {
         return {
             show: PropTypes.bool.isRequired,

--- a/components/admin_console/system_user_detail/team_list/team_list.tsx
+++ b/components/admin_console/system_user_detail/team_list/team_list.tsx
@@ -62,7 +62,7 @@ type State = {
     serverError: string | null;
 }
 
-export default class TeamList extends React.Component<Props, State> {
+export default class TeamList extends React.PureComponent<Props, State> {
     public static defaultProps = {
         emptyListTextId: t('admin.team_settings.team_list.no_teams_found'),
         emptyListTextDefaultMessage: 'No teams found',

--- a/components/admin_console/system_user_detail/team_list/team_list_dropdown.tsx
+++ b/components/admin_console/system_user_detail/team_list/team_list_dropdown.tsx
@@ -20,7 +20,7 @@ type State = {
     serverError: string | null;
 }
 
-export default class TeamListDropdown extends React.Component<Props, State> {
+export default class TeamListDropdown extends React.PureComponent<Props, State> {
     public constructor(props: Props) {
         super(props);
 

--- a/components/admin_console/system_user_detail/team_list/team_row.tsx
+++ b/components/admin_console/system_user_detail/team_list/team_row.tsx
@@ -18,7 +18,7 @@ type Props = {
     doMakeUserTeamMember: (teamId: string) => Promise<void>;
 }
 
-export default class TeamRow extends React.Component<Props, {}> {
+export default class TeamRow extends React.PureComponent<Props, {}> {
     private renderTeamType = (team: {[x: string]: string}) => {
         if (team.group_constrained) {
             return (

--- a/components/admin_console/system_users/list/system_users_list.jsx
+++ b/components/admin_console/system_users/list/system_users_list.jsx
@@ -18,7 +18,7 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx'
 
 import SystemUsersDropdown from '../system_users_dropdown';
 
-export default class SystemUsersList extends React.Component {
+export default class SystemUsersList extends React.PureComponent {
     static propTypes = {
         users: PropTypes.arrayOf(PropTypes.object),
         usersPerPage: PropTypes.number,

--- a/components/admin_console/system_users/system_users.jsx
+++ b/components/admin_console/system_users/system_users.jsx
@@ -25,7 +25,7 @@ import SystemUsersList from './list';
 const USER_ID_LENGTH = 26;
 const USERS_PER_PAGE = 50;
 
-export default class SystemUsers extends React.Component {
+export default class SystemUsers extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/admin_console/team_channel_settings/channel/channel_settings.jsx
+++ b/components/admin_console/team_channel_settings/channel/channel_settings.jsx
@@ -9,7 +9,7 @@ import {t} from 'utils/i18n';
 import ChannelsList from 'components/admin_console/team_channel_settings/channel/list';
 import AdminPanel from 'components/widgets/admin_console/admin_panel';
 
-export class ChannelsSettings extends React.Component {
+export class ChannelsSettings extends React.PureComponent {
     static propTypes = {
         siteName: PropTypes.string.isRequired,
     };

--- a/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_details.tsx
@@ -73,7 +73,7 @@ interface ChannelDetailsState {
     teamScheme?: Scheme;
 }
 
-export default class ChannelDetails extends React.Component<ChannelDetailsProps, ChannelDetailsState> {
+export default class ChannelDetails extends React.PureComponent<ChannelDetailsProps, ChannelDetailsState> {
     constructor(props: ChannelDetailsProps) {
         super(props);
         this.state = {

--- a/components/admin_console/team_channel_settings/channel/details/channel_moderation.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_moderation.tsx
@@ -251,7 +251,7 @@ export const ChannelModerationTableRow: React.FunctionComponent<RowProps> = (pro
     );
 };
 
-export default class ChannelModeration extends React.Component<Props> {
+export default class ChannelModeration extends React.PureComponent<Props> {
     private errorMessagesToDisplay = (entry: ChannelPermissions): Array<any> => {
         const errorMessages: Array<any> = [];
         const isGuestsDisabled = !isNil(entry.roles.guests?.enabled) && !entry.roles.guests?.enabled && this.props.guestAccountsEnabled;

--- a/components/admin_console/team_channel_settings/channel/list/channel_row.tsx
+++ b/components/admin_console/team_channel_settings/channel/list/channel_row.tsx
@@ -15,7 +15,7 @@ interface Props {
     onRowClick: (id: string) => void;
 }
 
-export default class ChannelRow extends React.Component<Props> {
+export default class ChannelRow extends React.PureComponent<Props> {
     private handleRowClick = () => {
         const {channel, onRowClick} = this.props;
         onRowClick(channel.id);

--- a/components/admin_console/team_channel_settings/group/group_row.tsx
+++ b/components/admin_console/team_channel_settings/group/group_row.tsx
@@ -17,7 +17,7 @@ interface GroupRowProps {
     type: string;
 }
 
-export default class GroupRow extends React.Component<GroupRowProps> {
+export default class GroupRow extends React.PureComponent<GroupRowProps> {
     removeGroup = () => {
         this.props.removeGroup(this.props.group.id!);
     };

--- a/components/admin_console/team_channel_settings/team/details/team_details.jsx
+++ b/components/admin_console/team_channel_settings/team/details/team_details.jsx
@@ -21,7 +21,7 @@ import {TeamProfile} from './team_profile';
 import {TeamModes} from './team_modes';
 import {TeamGroups} from './team_groups';
 
-export default class TeamDetails extends React.Component {
+export default class TeamDetails extends React.PureComponent {
     static propTypes = {
         teamID: PropTypes.string.isRequired,
         team: PropTypes.object.isRequired,

--- a/components/admin_console/team_channel_settings/team/list/team_row.jsx
+++ b/components/admin_console/team_channel_settings/team/list/team_row.jsx
@@ -9,7 +9,7 @@ import {FormattedMessage} from 'react-intl';
 import * as Utils from 'utils/utils';
 import TeamIcon from 'components/widgets/team_icon/team_icon';
 
-export default class TeamRow extends React.Component {
+export default class TeamRow extends React.PureComponent {
     static propTypes = {
         team: PropTypes.object.isRequired,
         onRowClick: PropTypes.func.isRequired,

--- a/components/admin_console/user_autocomplete_setting/user_autocomplete_setting.jsx
+++ b/components/admin_console/user_autocomplete_setting/user_autocomplete_setting.jsx
@@ -9,7 +9,7 @@ import Setting from 'components/admin_console/setting';
 import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
 import SuggestionList from 'components/suggestion/suggestion_list.jsx';
 
-export default class UserAutocompleteSetting extends React.Component {
+export default class UserAutocompleteSetting extends React.PureComponent {
     static get propTypes() {
         return {
             id: PropTypes.string.isRequired,

--- a/components/analytics/team_analytics/team_analytics.jsx
+++ b/components/analytics/team_analytics/team_analytics.jsx
@@ -24,7 +24,7 @@ import {formatPostsPerDayData, formatUsersWithPostsPerDayData} from '../format';
 
 const LAST_ANALYTICS_TEAM = 'last_analytics_team';
 
-export default class TeamAnalytics extends React.Component {
+export default class TeamAnalytics extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/app.jsx
+++ b/components/app.jsx
@@ -14,7 +14,7 @@ const LazyRoot = React.lazy(() => import('components/root'));
 
 const Root = makeAsyncComponent(LazyRoot);
 
-class App extends React.Component {
+class App extends React.PureComponent {
     render() {
         return (
             <Provider store={store}>

--- a/components/authorize/authorize.jsx
+++ b/components/authorize/authorize.jsx
@@ -11,7 +11,7 @@ import {browserHistory} from 'utils/browser_history';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
-export default class Authorize extends React.Component {
+export default class Authorize extends React.PureComponent {
     static get propTypes() {
         return {
             location: PropTypes.object.isRequired,

--- a/components/autosize_textarea.tsx
+++ b/components/autosize_textarea.tsx
@@ -14,7 +14,7 @@ type Props = {
     placeholder?: string;
 }
 
-export default class AutosizeTextarea extends React.Component<Props> {
+export default class AutosizeTextarea extends React.PureComponent<Props> {
     private height: number;
     constructor(props: Props) {
         super(props);

--- a/components/backstage/backstage_controller.jsx
+++ b/components/backstage/backstage_controller.jsx
@@ -41,7 +41,7 @@ const BackstageRoute = ({component: Component, extraProps, ...rest}) => ( //esli
     />
 );
 
-export default class BackstageController extends React.Component {
+export default class BackstageController extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/backstage/components/backstage_category.jsx
+++ b/components/backstage/components/backstage_category.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Route, NavLink} from 'react-router-dom';
 
-export default class BackstageCategory extends React.Component {
+export default class BackstageCategory extends React.PureComponent {
     static get propTypes() {
         return {
             name: PropTypes.string.isRequired,

--- a/components/backstage/components/backstage_header.jsx
+++ b/components/backstage/components/backstage_header.jsx
@@ -8,7 +8,7 @@ import LocalizedIcon from 'components/localized_icon';
 
 import {t} from 'utils/i18n';
 
-export default class BackstageHeader extends React.Component {
+export default class BackstageHeader extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node,
     };

--- a/components/backstage/components/backstage_list.jsx
+++ b/components/backstage/components/backstage_list.jsx
@@ -9,7 +9,7 @@ import * as Utils from 'utils/utils.jsx';
 import LoadingScreen from 'components/loading_screen';
 import SearchIcon from 'components/widgets/icons/fa_search_icon';
 
-export default class BackstageList extends React.Component {
+export default class BackstageList extends React.PureComponent {
     static propTypes = {
         children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
         header: PropTypes.node.isRequired,

--- a/components/backstage/components/backstage_navbar.jsx
+++ b/components/backstage/components/backstage_navbar.jsx
@@ -8,7 +8,7 @@ import {Link} from 'react-router-dom';
 
 import BackIcon from 'components/widgets/icons/fa_back_icon';
 
-export default class BackstageNavbar extends React.Component {
+export default class BackstageNavbar extends React.PureComponent {
     static get propTypes() {
         return {
             team: PropTypes.object.isRequired,

--- a/components/backstage/components/backstage_section.jsx
+++ b/components/backstage/components/backstage_section.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {NavLink} from 'react-router-dom';
 
-export default class BackstageSection extends React.Component {
+export default class BackstageSection extends React.PureComponent {
     static get propTypes() {
         return {
             name: PropTypes.string.isRequired,

--- a/components/backstage/components/backstage_sidebar.jsx
+++ b/components/backstage/components/backstage_sidebar.jsx
@@ -13,7 +13,7 @@ import TeamPermissionGate from 'components/permissions_gates/team_permission_gat
 import BackstageCategory from './backstage_category.jsx';
 import BackstageSection from './backstage_section.jsx';
 
-export default class BackstageSidebar extends React.Component {
+export default class BackstageSidebar extends React.PureComponent {
     static get propTypes() {
         return {
             team: PropTypes.object.isRequired,

--- a/components/channel_invite_modal/channel_invite_modal.jsx
+++ b/components/channel_invite_modal/channel_invite_modal.jsx
@@ -21,7 +21,7 @@ import Constants from 'utils/constants';
 const USERS_PER_PAGE = 50;
 const MAX_SELECTABLE_VALUES = 20;
 
-export default class ChannelInviteModal extends React.Component {
+export default class ChannelInviteModal extends React.PureComponent {
     static propTypes = {
         profilesNotInCurrentChannel: PropTypes.array.isRequired,
         profilesNotInCurrentTeam: PropTypes.array.isRequired,

--- a/components/channel_members_dropdown/channel_members_dropdown.jsx
+++ b/components/channel_members_dropdown/channel_members_dropdown.jsx
@@ -14,7 +14,7 @@ import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 
 const ROWS_FROM_BOTTOM_TO_OPEN_UP = 3;
 
-export default class ChannelMembersDropdown extends React.Component {
+export default class ChannelMembersDropdown extends React.PureComponent {
     static propTypes = {
         channel: PropTypes.object.isRequired,
         user: PropTypes.object.isRequired,

--- a/components/channel_selector_modal/channel_selector_modal.jsx
+++ b/components/channel_selector_modal/channel_selector_modal.jsx
@@ -15,7 +15,7 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx'
 
 const CHANNELS_PER_PAGE = 50;
 
-export default class ChannelSelectorModal extends React.Component {
+export default class ChannelSelectorModal extends React.PureComponent {
     static propTypes = {
         searchTerm: PropTypes.string.isRequired,
         onModalDismissed: PropTypes.func,

--- a/components/claim/components/email_to_ldap.jsx
+++ b/components/claim/components/email_to_ldap.jsx
@@ -11,7 +11,7 @@ import {t} from 'utils/i18n.jsx';
 import LoginMfa from 'components/login/login_mfa.jsx';
 import LocalizedInput from 'components/localized_input/localized_input';
 
-export default class EmailToLDAP extends React.Component {
+export default class EmailToLDAP extends React.PureComponent {
     static propTypes = {
         email: PropTypes.string,
         siteName: PropTypes.string,

--- a/components/claim/components/ldap_to_email.jsx
+++ b/components/claim/components/ldap_to_email.jsx
@@ -10,7 +10,7 @@ import {t} from 'utils/i18n.jsx';
 import LoginMfa from 'components/login/login_mfa.jsx';
 import LocalizedInput from 'components/localized_input/localized_input';
 
-export default class LDAPToEmail extends React.Component {
+export default class LDAPToEmail extends React.PureComponent {
     static propTypes = {
         email: PropTypes.string,
         passwordConfig: PropTypes.object,

--- a/components/code_preview.jsx
+++ b/components/code_preview.jsx
@@ -11,7 +11,7 @@ import * as SyntaxHighlighting from 'utils/syntax_highlighting';
 import LoadingSpinner from 'components/widgets/loading/loading_spinner';
 import FileInfoPreview from 'components/file_info_preview';
 
-export default class CodePreview extends React.Component {
+export default class CodePreview extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/copy_url_context_menu/copy_url_context_menu.jsx
+++ b/components/copy_url_context_menu/copy_url_context_menu.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {ContextMenu, ContextMenuTrigger, MenuItem} from 'react-contextmenu';
 import {FormattedMessage} from 'react-intl';
 
-export default class CopyUrlContextMenu extends React.Component {
+export default class CopyUrlContextMenu extends React.PureComponent {
     static propTypes = {
 
         // The child component that will be right-clicked on to show the context menu

--- a/components/deferComponentRender.jsx
+++ b/components/deferComponentRender.jsx
@@ -14,7 +14,7 @@ import React from 'react';
  * https://gist.github.com/paularmstrong/cc2ead7e2a0dec37d8b2096fc8d85759#file-defercomponentrender-js
  */
 export default function deferComponentRender(WrappedComponent, PreRenderComponent = null) {
-    class DeferredRenderWrapper extends React.Component {
+    class DeferredRenderWrapper extends React.PureComponent {
         constructor(props, context) {
             super(props, context);
 

--- a/components/discard_changes_modal.tsx
+++ b/components/discard_changes_modal.tsx
@@ -12,7 +12,7 @@ type Props = {
     onCancel: (checked: boolean) => void;
 }
 
-export default class DiscardChangesModal extends React.Component<Props> {
+export default class DiscardChangesModal extends React.PureComponent<Props> {
     public render(): JSX.Element {
         const title: JSX.Element = (
             <FormattedMessage

--- a/components/emoji/add_emoji/add_emoji.jsx
+++ b/components/emoji/add_emoji/add_emoji.jsx
@@ -12,7 +12,7 @@ import SpinnerButton from 'components/spinner_button';
 import {browserHistory} from 'utils/browser_history';
 import {localizeMessage} from 'utils/utils.jsx';
 
-export default class AddEmoji extends React.Component {
+export default class AddEmoji extends React.PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
             createCustomEmoji: PropTypes.func.isRequired,

--- a/components/emoji/emoji_list/emoji_list.jsx
+++ b/components/emoji/emoji_list/emoji_list.jsx
@@ -20,7 +20,7 @@ import {t} from 'utils/i18n.jsx';
 const EMOJI_PER_PAGE = 50;
 const EMOJI_SEARCH_DELAY_MILLISECONDS = 200;
 
-export default class EmojiList extends React.Component {
+export default class EmojiList extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/emoji/emoji_list_item/emoji_list_item.jsx
+++ b/components/emoji/emoji_list_item/emoji_list_item.jsx
@@ -10,7 +10,7 @@ import {Client4} from 'mattermost-redux/client';
 import DeleteEmoji from 'components/emoji/delete_emoji_modal.jsx';
 import AnyTeamPermissionGate from 'components/permissions_gates/any_team_permission_gate';
 
-export default class EmojiListItem extends React.Component {
+export default class EmojiListItem extends React.PureComponent {
     static propTypes = {
         emoji: PropTypes.object.isRequired,
         currentUserId: PropTypes.string.isRequired,

--- a/components/emoji/emoji_page.jsx
+++ b/components/emoji/emoji_page.jsx
@@ -13,7 +13,7 @@ import AnyTeamPermissionGate from 'components/permissions_gates/any_team_permiss
 
 import EmojiList from './emoji_list';
 
-export default class EmojiPage extends React.Component {
+export default class EmojiPage extends React.PureComponent {
     static propTypes = {
         teamId: PropTypes.string.isRequired,
         teamName: PropTypes.string.isRequired,

--- a/components/emoji_picker/components/emoji_picker_preview.jsx
+++ b/components/emoji_picker/components/emoji_picker_preview.jsx
@@ -8,7 +8,7 @@ import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
 
 import imgTrans from 'images/img_trans.gif';
 
-export default class EmojiPickerPreview extends React.Component {
+export default class EmojiPickerPreview extends React.PureComponent {
     static propTypes = {
         emoji: PropTypes.object,
     }

--- a/components/file_attachment_list/file_attachment_list.jsx
+++ b/components/file_attachment_list/file_attachment_list.jsx
@@ -13,7 +13,7 @@ import FileAttachment from 'components/file_attachment';
 import SingleImageView from 'components/single_image_view';
 import ViewImageModal from 'components/view_image';
 
-export default class FileAttachmentList extends React.Component {
+export default class FileAttachmentList extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/form_error.tsx
+++ b/components/form_error.tsx
@@ -13,7 +13,7 @@ type Props = {
     errors?: React.ReactNode[];
 }
 
-export default class FormError extends React.Component<Props> {
+export default class FormError extends React.PureComponent<Props> {
     public static defaultProps = {
         error: null,
         errors: [],

--- a/components/gif_picker/gif_picker.jsx
+++ b/components/gif_picker/gif_picker.jsx
@@ -4,8 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import PureRenderMixin from 'react-addons-pure-render-mixin';
-
 import App from 'components/gif_picker/components/App';
 import Categories from 'components/gif_picker/components/Categories';
 import Search from 'components/gif_picker/components/Search';
@@ -26,9 +24,7 @@ export const appProps = {
     },
 };
 
-// shouldComponentUpdate set in constructor
-// eslint-disable-next-line react/require-optimization
-export default class GifPicker extends React.Component {
+export default class GifPicker extends React.PureComponent {
     static propTypes = {
         onGifClick: PropTypes.func.isRequired,
         defaultSearchText: PropTypes.string,
@@ -37,9 +33,6 @@ export default class GifPicker extends React.Component {
 
     constructor(props) {
         super(props);
-
-        // All props are primitives or treated as immutable
-        this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
 
         const action = props.defaultSearchText ? 'search' : 'trending';
         this.state = {

--- a/components/help/help_controller.tsx
+++ b/components/help/help_controller.tsx
@@ -18,7 +18,7 @@ type Props = {
     };
 }
 
-export default class HelpController extends React.Component<Props> {
+export default class HelpController extends React.PureComponent<Props> {
     public componentDidUpdate(): void {
         // eslint-disable-next-line react/no-find-dom-node
         const helpControllerNode = ReactDOM.findDOMNode(this);

--- a/components/integrations/abstract_incoming_webhook.jsx
+++ b/components/integrations/abstract_incoming_webhook.jsx
@@ -12,7 +12,7 @@ import FormError from 'components/form_error';
 import SpinnerButton from 'components/spinner_button';
 import {localizeMessage} from 'utils/utils.jsx';
 
-export default class AbstractIncomingWebhook extends React.Component {
+export default class AbstractIncomingWebhook extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/integrations/abstract_outgoing_webhook.jsx
+++ b/components/integrations/abstract_outgoing_webhook.jsx
@@ -12,7 +12,7 @@ import ChannelSelect from 'components/channel_select';
 import FormError from 'components/form_error';
 import SpinnerButton from 'components/spinner_button';
 
-export default class AbstractOutgoingWebhook extends React.Component {
+export default class AbstractOutgoingWebhook extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/integrations/bots/add_bot/add_bot.jsx
+++ b/components/integrations/bots/add_bot/add_bot.jsx
@@ -25,7 +25,7 @@ import * as FileUtils from 'utils/file_utils.jsx';
 const roleOptionSystemAdmin = 'System Admin';
 const roleOptionMember = 'Member';
 
-export default class AddBot extends React.Component {
+export default class AddBot extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/integrations/confirm_integration/confirm_integration.jsx
+++ b/components/integrations/confirm_integration/confirm_integration.jsx
@@ -13,7 +13,7 @@ import BackstageHeader from 'components/backstage/components/backstage_header.js
 import {getSiteURL} from 'utils/url';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
 
-export default class ConfirmIntegration extends React.Component {
+export default class ConfirmIntegration extends React.PureComponent {
     static get propTypes() {
         return {
             team: PropTypes.object,

--- a/components/integrations/integration_option.jsx
+++ b/components/integrations/integration_option.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router-dom';
 
-export default class IntegrationOption extends React.Component {
+export default class IntegrationOption extends React.PureComponent {
     static get propTypes() {
         return {
             image: PropTypes.string.isRequired,

--- a/components/integrations/integrations.jsx
+++ b/components/integrations/integrations.jsx
@@ -20,7 +20,7 @@ import TeamPermissionGate from 'components/permissions_gates/team_permission_gat
 
 import IntegrationOption from './integration_option.jsx';
 
-export default class Integrations extends React.Component {
+export default class Integrations extends React.PureComponent {
     static get propTypes() {
         return {
             team: PropTypes.object,

--- a/components/interactive_dialog/interactive_dialog.jsx
+++ b/components/interactive_dialog/interactive_dialog.jsx
@@ -17,7 +17,7 @@ import {localizeMessage} from 'utils/utils.jsx';
 import DialogElement from './dialog_element';
 import DialogIntroductionText from './dialog_introduction_text';
 
-export default class InteractiveDialog extends React.Component {
+export default class InteractiveDialog extends React.PureComponent {
     static propTypes = {
         url: PropTypes.string.isRequired,
         callbackId: PropTypes.string,

--- a/components/invitation_modal/invitation_modal.jsx
+++ b/components/invitation_modal/invitation_modal.jsx
@@ -23,7 +23,7 @@ const STEPS_INVITE_MEMBERS = 'members';
 const STEPS_INVITE_GUESTS = 'guests';
 const STEPS_INVITE_CONFIRM = 'confirm';
 
-export default class InvitationModal extends React.Component {
+export default class InvitationModal extends React.PureComponent {
     static propTypes = {
         show: PropTypes.bool,
         currentTeam: PropTypes.object.isRequired,

--- a/components/invitation_modal/invitation_modal_confirm_step.jsx
+++ b/components/invitation_modal/invitation_modal_confirm_step.jsx
@@ -13,7 +13,7 @@ import {InviteTypes} from 'utils/constants';
 
 import './invitation_modal_confirm_step.scss';
 
-export default class InvitationModalConfirmStep extends React.Component {
+export default class InvitationModalConfirmStep extends React.PureComponent {
     static propTypes = {
         teamName: PropTypes.string.isRequired,
         onDone: PropTypes.func.isRequired,

--- a/components/invitation_modal/invitation_modal_confirm_step_row.jsx
+++ b/components/invitation_modal/invitation_modal_confirm_step_row.jsx
@@ -15,7 +15,7 @@ import {imageURLForUser, isGuest, getLongDisplayName} from 'utils/utils.jsx';
 
 import './invitation_modal_confirm_step_row.scss';
 
-export default class InvitationModalConfirmStepRow extends React.Component {
+export default class InvitationModalConfirmStepRow extends React.PureComponent {
     static propTypes = {
         invitation: PropTypes.object.isRequired,
     }

--- a/components/invitation_modal/invitation_modal_confirm_step_table.jsx
+++ b/components/invitation_modal/invitation_modal_confirm_step_table.jsx
@@ -9,7 +9,7 @@ import InvitationModalConfirmStepRow from 'components/invitation_modal/invitatio
 
 import './invitation_modal_confirm_step_table.scss';
 
-export default class InvitationModalConfirmStepTable extends React.Component {
+export default class InvitationModalConfirmStepTable extends React.PureComponent {
     static propTypes = {
         invites: PropTypes.arrayOf(PropTypes.object).isRequired,
     }

--- a/components/invitation_modal/invitation_modal_guests_step.jsx
+++ b/components/invitation_modal/invitation_modal_guests_step.jsx
@@ -19,7 +19,7 @@ import './invitation_modal_guests_step.scss';
 import {t} from 'utils/i18n.jsx';
 import {localizeMessage} from 'utils/utils.jsx';
 
-export default class InvitationModalGuestsStep extends React.Component {
+export default class InvitationModalGuestsStep extends React.PureComponent {
     static propTypes = {
         teamName: PropTypes.string.isRequired,
         myInvitableChannels: PropTypes.array.isRequired,

--- a/components/invitation_modal/invitation_modal_initial_step.jsx
+++ b/components/invitation_modal/invitation_modal_initial_step.jsx
@@ -11,7 +11,7 @@ import ArrowRightIcon from 'components/widgets/icons/arrow_right_icon';
 
 import './invitation_modal_initial_step.scss';
 
-export default class InvitationModalInitialStep extends React.Component {
+export default class InvitationModalInitialStep extends React.PureComponent {
     static propTypes = {
         teamName: PropTypes.string.isRequired,
         goToMembers: PropTypes.func.isRequired,

--- a/components/invitation_modal/invitation_modal_members_step.jsx
+++ b/components/invitation_modal/invitation_modal_members_step.jsx
@@ -20,7 +20,7 @@ import {localizeMessage} from 'utils/utils.jsx';
 
 import './invitation_modal_members_step.scss';
 
-class InvitationModalMembersStep extends React.Component {
+class InvitationModalMembersStep extends React.PureComponent {
     static propTypes = {
         teamName: PropTypes.string.isRequired,
         currentTeamId: PropTypes.string.isRequired,

--- a/components/latex_block/latex_block.jsx
+++ b/components/latex_block/latex_block.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
 
-export default class LatexBlock extends React.Component {
+export default class LatexBlock extends React.PureComponent {
     static propTypes = {
         content: PropTypes.string.isRequired,
         enableLatex: PropTypes.bool.isRequired,

--- a/components/leave_private_channel_modal/leave_private_channel_modal.tsx
+++ b/components/leave_private_channel_modal/leave_private_channel_modal.tsx
@@ -21,7 +21,7 @@ type Props = {
     };
 }
 
-export default class LeavePrivateChannelModal extends React.Component<Props, State> {
+export default class LeavePrivateChannelModal extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
 

--- a/components/legacy_team_sidebar/components/team_button.jsx
+++ b/components/legacy_team_sidebar/components/team_button.jsx
@@ -19,7 +19,7 @@ import OverlayTrigger from 'components/overlay_trigger';
 import TeamIcon from '../../widgets/team_icon/team_icon';
 
 // eslint-disable-next-line react/require-optimization
-class TeamButton extends React.Component {
+class TeamButton extends React.PureComponent {
     static propTypes = {
         btnClass: PropTypes.string,
         url: PropTypes.string.isRequired,

--- a/components/legacy_team_sidebar/legacy_team_sidebar_controller.jsx
+++ b/components/legacy_team_sidebar/legacy_team_sidebar_controller.jsx
@@ -42,7 +42,7 @@ export function renderThumbVertical(props) {
         />);
 }
 
-export default class LegacyTeamSidebar extends React.Component {
+export default class LegacyTeamSidebar extends React.PureComponent {
     static propTypes = {
         myTeams: PropTypes.array.isRequired,
         currentTeamId: PropTypes.string.isRequired,

--- a/components/loading_screen.tsx
+++ b/components/loading_screen.tsx
@@ -10,7 +10,7 @@ type Props = {
     message?: ReactNode;
 }
 
-export default class LoadingScreen extends React.Component<Props> {
+export default class LoadingScreen extends React.PureComponent<Props> {
     public static defaultProps: Partial<Props> = {
         position: 'relative',
         style: {},

--- a/components/login/login_controller/login_controller.jsx
+++ b/components/login/login_controller/login_controller.jsx
@@ -34,7 +34,7 @@ import Markdown from 'components/markdown';
 
 import LoginMfa from '../login_mfa.jsx';
 
-class LoginController extends React.Component {
+class LoginController extends React.PureComponent {
     static propTypes = {
         intl: intlShape.isRequired,
 

--- a/components/member_list_team/member_list_team.tsx
+++ b/components/member_list_team/member_list_team.tsx
@@ -47,7 +47,7 @@ type State = {
     loading: boolean;
 }
 
-export default class MemberListTeam extends React.Component<Props, State> {
+export default class MemberListTeam extends React.PureComponent<Props, State> {
     private searchTimeoutId: number;
 
     constructor(props: Props) {

--- a/components/mfa/confirm.jsx
+++ b/components/mfa/confirm.jsx
@@ -13,7 +13,7 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx'
 
 const KeyCodes = Constants.KeyCodes;
 
-export default class Confirm extends React.Component {
+export default class Confirm extends React.PureComponent {
     componentDidMount() {
         document.body.addEventListener('keydown', this.onKeyPress);
     }

--- a/components/mfa/mfa_controller/mfa_controller.jsx
+++ b/components/mfa/mfa_controller/mfa_controller.jsx
@@ -14,7 +14,7 @@ import LogoutIcon from 'components/widgets/icons/fa_logout_icon';
 import Setup from '../setup';
 import Confirm from '../confirm';
 
-export default class MFAController extends React.Component {
+export default class MFAController extends React.PureComponent {
     componentDidMount() {
         document.body.classList.add('sticky');
         document.getElementById('root').classList.add('container-fluid');

--- a/components/mfa/setup/setup.jsx
+++ b/components/mfa/setup/setup.jsx
@@ -11,7 +11,7 @@ import {t} from 'utils/i18n.jsx';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 import LocalizedInput from 'components/localized_input/localized_input';
 
-export default class Setup extends React.Component {
+export default class Setup extends React.PureComponent {
     static propTypes = {
         currentUser: PropTypes.object,
         siteName: PropTypes.string,

--- a/components/modal_controller/modal_controller.test.jsx
+++ b/components/modal_controller/modal_controller.test.jsx
@@ -9,7 +9,7 @@ import {mount} from 'enzyme';
 
 import ModalController from 'components/modal_controller';
 
-class TestModal extends React.Component {
+class TestModal extends React.PureComponent {
     render() {
         return (
             <Modal

--- a/components/more_channels/more_channels.jsx
+++ b/components/more_channels/more_channels.jsx
@@ -18,7 +18,7 @@ const CHANNELS_CHUNK_SIZE = 50;
 const CHANNELS_PER_PAGE = 50;
 const SEARCH_TIMEOUT_MILLISECONDS = 100;
 
-export default class MoreChannels extends React.Component {
+export default class MoreChannels extends React.PureComponent {
     static propTypes = {
         channels: PropTypes.array.isRequired,
         archivedChannels: PropTypes.array.isRequired,

--- a/components/more_direct_channels/group_message_option.tsx
+++ b/components/more_direct_channels/group_message_option.tsx
@@ -14,7 +14,7 @@ type Props = {
     onAdd: (users: UserProfile[]) => void;
 }
 
-export default class GroupMessageOption extends React.Component<Props> {
+export default class GroupMessageOption extends React.PureComponent<Props> {
     static propTypes = {
 
     };

--- a/components/more_direct_channels/more_direct_channels.tsx
+++ b/components/more_direct_channels/more_direct_channels.tsx
@@ -84,7 +84,7 @@ type State = {
     loadingUsers: boolean;
 }
 
-export default class MoreDirectChannels extends React.Component<Props, State> {
+export default class MoreDirectChannels extends React.PureComponent<Props, State> {
     searchTimeoutId: any;
     exitToChannel?: string;
     multiselect: React.RefObject<MultiSelect<OptionType>>;

--- a/components/msg_typing/msg_typing.tsx
+++ b/components/msg_typing/msg_typing.tsx
@@ -8,7 +8,7 @@ type Props = {
     typingUsers: string[];
 }
 
-export default class MsgTyping extends React.Component<Props> {
+export default class MsgTyping extends React.PureComponent<Props> {
     private getTypingText = () => {
         let users: string[] = [];
         let numUsers = 0;

--- a/components/multiselect/multiselect.tsx
+++ b/components/multiselect/multiselect.tsx
@@ -60,7 +60,7 @@ export type State = {
 
 const KeyCodes = Constants.KeyCodes;
 
-export default class MultiSelect<T extends Value> extends React.Component<Props<T>, State> {
+export default class MultiSelect<T extends Value> extends React.PureComponent<Props<T>, State> {
     private listRef = React.createRef<MultiSelectList<T>>()
     private reactSelectRef = React.createRef<ReactSelect>()
     private selected: T | null = null

--- a/components/multiselect/multiselect_list.tsx
+++ b/components/multiselect/multiselect_list.tsx
@@ -35,7 +35,7 @@ type State = {
 }
 const KeyCodes = Constants.KeyCodes;
 
-export default class MultiSelectList<T extends Value> extends React.Component<Props<T>, State> {
+export default class MultiSelectList<T extends Value> extends React.PureComponent<Props<T>, State> {
     public static defaultProps = {
         options: [],
         perPage: 50,

--- a/components/new_channel_flow/new_channel_flow.tsx
+++ b/components/new_channel_flow/new_channel_flow.tsx
@@ -85,7 +85,7 @@ type NewChannelData = {
     header: string;
 }
 
-export default class NewChannelFlow extends React.Component<Props, State> {
+export default class NewChannelFlow extends React.PureComponent<Props, State> {
     public static defaultProps = {
         show: false,
         channelType: Constants.OPEN_CHANNEL as ChannelType,

--- a/components/permissions_gates/any_team_permission_gate/any_team_permission_gate.jsx
+++ b/components/permissions_gates/any_team_permission_gate/any_team_permission_gate.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class AnyTeamPermissionGate extends React.Component {
+export default class AnyTeamPermissionGate extends React.PureComponent {
     static defaultProps = {
         invert: false,
     }

--- a/components/permissions_gates/channel_permission_gate/channel_permission_gate.jsx
+++ b/components/permissions_gates/channel_permission_gate/channel_permission_gate.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class ChannelPermissionGate extends React.Component {
+export default class ChannelPermissionGate extends React.PureComponent {
     static defaultProps = {
         invert: false,
     }

--- a/components/permissions_gates/system_permission_gate/system_permission_gate.jsx
+++ b/components/permissions_gates/system_permission_gate/system_permission_gate.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class SystemPermissionGate extends React.Component {
+export default class SystemPermissionGate extends React.PureComponent {
     static defaultProps = {
         invert: false,
     }

--- a/components/permissions_gates/team_permission_gate/team_permission_gate.tsx
+++ b/components/permissions_gates/team_permission_gate/team_permission_gate.tsx
@@ -31,7 +31,7 @@ type Props = {
     children: React.ReactNode;
 };
 
-export default class TeamPermissionGate extends React.Component<Props> {
+export default class TeamPermissionGate extends React.PureComponent<Props> {
     public static defaultProps = {
         invert: false,
     }

--- a/components/plugin_marketplace/marketplace_item/marketplace_item.js
+++ b/components/plugin_marketplace/marketplace_item/marketplace_item.js
@@ -263,7 +263,7 @@ UpdateConfirmationModal.propTypes = {
     onCancel: PropTypes.func.isRequired,
 };
 
-export default class MarketplaceItem extends React.Component {
+export default class MarketplaceItem extends React.PureComponent {
     static propTypes = {
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,

--- a/components/plugin_marketplace/marketplace_modal.js
+++ b/components/plugin_marketplace/marketplace_modal.js
@@ -89,7 +89,7 @@ InstalledPlugins.propTypes = {
 };
 
 // MarketplaceModal is the plugin marketplace.
-export class MarketplaceModal extends React.Component {
+export class MarketplaceModal extends React.PureComponent {
     static propTypes = {
         show: PropTypes.bool,
         plugins: PropTypes.array.isRequired,

--- a/components/popover_list_members/popover_list_members.jsx
+++ b/components/popover_list_members/popover_list_members.jsx
@@ -16,7 +16,7 @@ import Popover from 'components/widgets/popover';
 
 import PopoverListMembersItem from 'components/popover_list_members/popover_list_members_item';
 
-export default class PopoverListMembers extends React.Component {
+export default class PopoverListMembers extends React.PureComponent {
     static propTypes = {
         channel: PropTypes.object.isRequired,
         statuses: PropTypes.object.isRequired,

--- a/components/rhs_card_header/rhs_card_header.jsx
+++ b/components/rhs_card_header/rhs_card_header.jsx
@@ -10,7 +10,7 @@ import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants, {RHSStates} from 'utils/constants';
 
-export default class RhsCardHeader extends React.Component {
+export default class RhsCardHeader extends React.PureComponent {
     static propTypes = {
         previousRhsState: PropTypes.oneOf(Object.values(RHSStates)),
         actions: PropTypes.shape({

--- a/components/rhs_header_post/rhs_header_post.jsx
+++ b/components/rhs_header_post/rhs_header_post.jsx
@@ -12,7 +12,7 @@ import Constants, {RHSStates} from 'utils/constants';
 import {isMobile} from 'utils/utils.jsx';
 import {browserHistory} from 'utils/browser_history';
 
-export default class RhsHeaderPost extends React.Component {
+export default class RhsHeaderPost extends React.PureComponent {
     static propTypes = {
         rootPostId: PropTypes.string.isRequired,
         channel: PropTypes.object.isRequired,

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -82,7 +82,7 @@ const LoggedInRoute = ({component: Component, ...rest}) => (
     />
 );
 
-export default class Root extends React.Component {
+export default class Root extends React.PureComponent {
     static propTypes = {
         diagnosticsEnabled: PropTypes.bool,
         diagnosticId: PropTypes.string,

--- a/components/root_portal.jsx
+++ b/components/root_portal.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
-export default class RootPortal extends React.Component {
+export default class RootPortal extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node,
     }

--- a/components/search_bar/search_bar.jsx
+++ b/components/search_bar/search_bar.jsx
@@ -24,7 +24,7 @@ import Popover from 'components/widgets/popover';
 
 const {KeyCodes} = Constants;
 
-export default class SearchBar extends React.Component {
+export default class SearchBar extends React.PureComponent {
     static propTypes = {
         isSearchingTerm: PropTypes.bool,
         searchTerms: PropTypes.string,

--- a/components/search_results_header/search_results_header.jsx
+++ b/components/search_results_header/search_results_header.jsx
@@ -10,7 +10,7 @@ import OverlayTrigger from 'components/overlay_trigger';
 
 import Constants from 'utils/constants';
 
-export default class SearchResultsHeader extends React.Component {
+export default class SearchResultsHeader extends React.PureComponent {
     static propTypes = {
         children: PropTypes.node,
         actions: PropTypes.shape({

--- a/components/searchable_channel_list.jsx
+++ b/components/searchable_channel_list.jsx
@@ -23,7 +23,7 @@ import Menu from './widgets/menu/menu';
 
 const NEXT_BUTTON_TIMEOUT_MILLISECONDS = 500;
 
-export default class SearchableChannelList extends React.Component {
+export default class SearchableChannelList extends React.PureComponent {
     static getDerivedStateFromProps(props, state) {
         return {isSearch: props.isSearch, page: props.isSearch && !state.isSearch ? 0 : state.page};
     }

--- a/components/searchable_user_list/searchable_user_list.jsx
+++ b/components/searchable_user_list/searchable_user_list.jsx
@@ -15,7 +15,7 @@ import {t} from 'utils/i18n';
 
 const NEXT_BUTTON_TIMEOUT = 500;
 
-class SearchableUserList extends React.Component {
+class SearchableUserList extends React.PureComponent {
     static propTypes = {
         users: PropTypes.arrayOf(PropTypes.object),
         usersPerPage: PropTypes.number,

--- a/components/searchable_user_list/searchable_user_list_container.jsx
+++ b/components/searchable_user_list/searchable_user_list_container.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import SearchableUserList from './searchable_user_list.jsx';
 
-export default class SearchableUserListContainer extends React.Component {
+export default class SearchableUserListContainer extends React.PureComponent {
     static propTypes = {
         users: PropTypes.arrayOf(PropTypes.object),
         usersPerPage: PropTypes.number,

--- a/components/select_team/select_team.jsx
+++ b/components/select_team/select_team.jsx
@@ -34,7 +34,7 @@ import SelectTeamItem from './components/select_team_item.jsx';
 export const TEAMS_PER_PAGE = 30;
 const TEAM_MEMBERSHIP_DENIAL_ERROR_ID = 'api.team.add_members.user_denied';
 
-export default class SelectTeam extends React.Component {
+export default class SelectTeam extends React.PureComponent {
     static propTypes = {
         currentUserId: PropTypes.string.isRequired,
         currentUserRoles: PropTypes.string,

--- a/components/setting_upload.jsx
+++ b/components/setting_upload.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
-export default class SettingsUpload extends React.Component {
+export default class SettingsUpload extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/settings_sidebar.tsx
+++ b/components/settings_sidebar.tsx
@@ -19,7 +19,7 @@ export type Props = {
     updateTab: (name: string) => void;
 }
 
-export default class SettingsSidebar extends React.Component<Props> {
+export default class SettingsSidebar extends React.PureComponent<Props> {
     public handleClick = (tab: Tab, e: React.MouseEvent) => {
         e.preventDefault();
         this.props.updateTab(tab.name);

--- a/components/signup/signup_controller/signup_controller.jsx
+++ b/components/signup/signup_controller/signup_controller.jsx
@@ -19,7 +19,7 @@ import LoadingScreen from 'components/loading_screen';
 import {Constants} from 'utils/constants';
 import {t} from 'utils/i18n';
 
-export default class SignupController extends React.Component {
+export default class SignupController extends React.PureComponent {
     static propTypes = {
         location: PropTypes.object,
         loggedIn: PropTypes.bool.isRequired,

--- a/components/signup/signup_email/signup_email.jsx
+++ b/components/signup/signup_email/signup_email.jsx
@@ -22,7 +22,7 @@ import SiteNameAndDescription from 'components/common/site_name_and_description'
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
-export default class SignupEmail extends React.Component {
+export default class SignupEmail extends React.PureComponent {
     static propTypes = {
         location: PropTypes.object,
         enableSignUpWithEmail: PropTypes.bool.isRequired,

--- a/components/status_dropdown/status_dropdown.jsx
+++ b/components/status_dropdown/status_dropdown.jsx
@@ -14,7 +14,7 @@ import Avatar from 'components/widgets/users/avatar';
 import Menu from 'components/widgets/menu/menu';
 import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 
-export default class StatusDropdown extends React.Component {
+export default class StatusDropdown extends React.PureComponent {
     static propTypes = {
         style: PropTypes.object,
         status: PropTypes.string,

--- a/components/suggestion/suggestion.jsx
+++ b/components/suggestion/suggestion.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class Suggestion extends React.Component {
+export default class Suggestion extends React.PureComponent {
     static get propTypes() {
         return {
             item: PropTypes.oneOfType([

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -13,7 +13,7 @@ import * as Utils from 'utils/utils.jsx';
 
 const KeyCodes = Constants.KeyCodes;
 
-export default class SuggestionBox extends React.Component {
+export default class SuggestionBox extends React.PureComponent {
     static propTypes = {
 
         /**

--- a/components/team_general_tab/team_general_tab.jsx
+++ b/components/team_general_tab/team_general_tab.jsx
@@ -19,7 +19,7 @@ import {t} from 'utils/i18n.jsx';
 
 const ACCEPTED_TEAM_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/bmp'];
 
-export default class GeneralTab extends React.Component {
+export default class GeneralTab extends React.PureComponent {
     static propTypes = {
         updateSection: PropTypes.func.isRequired,
         team: PropTypes.object.isRequired,

--- a/components/team_import_tab.jsx
+++ b/components/team_import_tab.jsx
@@ -22,7 +22,7 @@ const holders = defineMessages({
     },
 });
 
-class TeamImportTab extends React.Component {
+class TeamImportTab extends React.PureComponent {
     static propTypes = {
         closeModal: PropTypes.func.isRequired,
         collapseModal: PropTypes.func.isRequired,

--- a/components/team_members_dropdown/team_members_dropdown.jsx
+++ b/components/team_members_dropdown/team_members_dropdown.jsx
@@ -15,7 +15,7 @@ import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 
 const ROWS_FROM_BOTTOM_TO_OPEN_UP = 3;
 
-export default class TeamMembersDropdown extends React.Component {
+export default class TeamMembersDropdown extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object.isRequired,
         currentUser: PropTypes.object.isRequired,

--- a/components/team_selector_modal/team_selector_modal.jsx
+++ b/components/team_selector_modal/team_selector_modal.jsx
@@ -18,7 +18,7 @@ import {imageURLForTeam} from 'utils/utils';
 
 const TEAMS_PER_PAGE = 50;
 
-export default class TeamSelectorModal extends React.Component {
+export default class TeamSelectorModal extends React.PureComponent {
     static propTypes = {
         currentSchemeId: PropTypes.string,
         alreadySelected: PropTypes.array,

--- a/components/team_settings_modal/team_settings_modal.jsx
+++ b/components/team_settings_modal/team_settings_modal.jsx
@@ -13,7 +13,7 @@ const SettingsSidebar = React.lazy(() => import('components/settings_sidebar.tsx
 
 import TeamSettings from 'components/team_settings';
 
-export default class TeamSettingsModal extends React.Component {
+export default class TeamSettingsModal extends React.PureComponent {
     static propTypes = {
         onHide: PropTypes.func,
     };

--- a/components/toggle_modal_button.jsx
+++ b/components/toggle_modal_button.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class ModalToggleButton extends React.Component {
+export default class ModalToggleButton extends React.PureComponent {
     constructor(props) {
         super(props);
 

--- a/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
+++ b/components/toggle_modal_button_redux/toggle_modal_button_redux.jsx
@@ -7,7 +7,7 @@ import {injectIntl} from 'react-intl';
 
 import {intlShape} from 'utils/react_intl';
 
-class ModalToggleButtonRedux extends React.Component {
+class ModalToggleButtonRedux extends React.PureComponent {
     static propTypes = {
         accessibilityLabel: PropTypes.string,
         children: PropTypes.node.isRequired,

--- a/components/toggle_modal_button_redux/toggle_modal_button_redux.test.jsx
+++ b/components/toggle_modal_button_redux/toggle_modal_button_redux.test.jsx
@@ -9,7 +9,7 @@ import {mountWithIntl} from 'tests/helpers/intl-test-helper';
 import {ModalIdentifiers} from 'utils/constants';
 import ToggleModalButtonRedux from 'components/toggle_modal_button_redux/toggle_modal_button_redux.jsx';
 
-class TestModal extends React.Component {
+class TestModal extends React.PureComponent {
     render() {
         return (
             <Modal

--- a/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
+++ b/components/tutorial/tutorial_intro_screens/tutorial_intro_screens.jsx
@@ -14,7 +14,7 @@ import InvitationModal from 'components/invitation_modal';
 
 const NUM_SCREENS = 3;
 
-export default class TutorialIntroScreens extends React.Component {
+export default class TutorialIntroScreens extends React.PureComponent {
     static propTypes = {
         currentUserId: PropTypes.string.isRequired,
         step: PropTypes.number,

--- a/components/tutorial/tutorial_tip/tutorial_tip.tsx
+++ b/components/tutorial/tutorial_tip/tutorial_tip.tsx
@@ -38,7 +38,7 @@ type State = {
     show: boolean;
 }
 
-export default class TutorialTip extends React.Component<Props, State> {
+export default class TutorialTip extends React.PureComponent<Props, State> {
     public targetRef: React.RefObject<HTMLImageElement>;
 
     public static defaultProps: Partial<Props> = {

--- a/components/tutorial/tutorial_view.jsx
+++ b/components/tutorial/tutorial_view.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import TutorialIntroScreens from './tutorial_intro_screens';
 
-export default class TutorialView extends React.Component {
+export default class TutorialView extends React.PureComponent {
     componentDidMount() {
         if (this.props.isRoot) {
             $('body').addClass('app__body');

--- a/components/user_list.jsx
+++ b/components/user_list.jsx
@@ -10,7 +10,7 @@ import LoadingScreen from 'components/loading_screen';
 
 import UserListRow from './user_list_row';
 
-export default class UserList extends React.Component {
+export default class UserList extends React.PureComponent {
     static propTypes = {
         users: PropTypes.arrayOf(PropTypes.object),
         extraInfo: PropTypes.object,

--- a/components/user_list_row/user_list_row.jsx
+++ b/components/user_list_row/user_list_row.jsx
@@ -11,7 +11,7 @@ import UserProfile from 'components/user_profile';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
-export default class UserListRow extends React.Component {
+export default class UserListRow extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object.isRequired,
         status: PropTypes.string,

--- a/components/user_list_row_with_error/user_list_row_with_error.jsx
+++ b/components/user_list_row_with_error/user_list_row_with_error.jsx
@@ -12,7 +12,7 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 
 import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx';
 
-export default class UserListRowWithError extends React.Component {
+export default class UserListRowWithError extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object.isRequired,
         status: PropTypes.string,

--- a/components/user_settings/display/manage_languages/manage_languages.jsx
+++ b/components/user_settings/display/manage_languages/manage_languages.jsx
@@ -12,7 +12,7 @@ import FormattedMarkdownMessage from 'components/formatted_markdown_message.jsx'
 import {isKeyPressed} from 'utils/utils.jsx';
 import Constants from 'utils/constants';
 
-export default class ManageLanguage extends React.Component {
+export default class ManageLanguage extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object.isRequired,
         locale: PropTypes.string.isRequired,

--- a/components/user_settings/display/user_settings_display.jsx
+++ b/components/user_settings/display/user_settings_display.jsx
@@ -34,7 +34,7 @@ function getDisplayStateFromProps(props) {
     };
 }
 
-export default class UserSettingsDisplay extends React.Component {
+export default class UserSettingsDisplay extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object,
         updateSection: PropTypes.func,

--- a/components/user_settings/display/user_settings_theme/color_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/color_chooser.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 import ColorInput from 'components/color_input';
 
-class ColorChooser extends React.Component {
+class ColorChooser extends React.PureComponent {
     static propTypes = {
 
         /*

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -116,7 +116,7 @@ const messages = defineMessages({
     },
 });
 
-export default class CustomThemeChooser extends React.Component {
+export default class CustomThemeChooser extends React.PureComponent {
     static propTypes = {
         theme: PropTypes.object.isRequired,
         updateTheme: PropTypes.func.isRequired,

--- a/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import Constants from 'utils/constants';
 import * as Utils from 'utils/utils.jsx';
 
-export default class PremadeThemeChooser extends React.Component {
+export default class PremadeThemeChooser extends React.PureComponent {
     render() {
         const theme = this.props.theme;
 

--- a/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
+++ b/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
@@ -16,7 +16,7 @@ import SettingItemMin from 'components/setting_item_min';
 import CustomThemeChooser from './custom_theme_chooser.jsx';
 import PremadeThemeChooser from './premade_theme_chooser';
 
-export default class ThemeSetting extends React.Component {
+export default class ThemeSetting extends React.PureComponent {
     static propTypes = {
         actions: PropTypes.shape({
             saveTheme: PropTypes.func.isRequired,

--- a/components/user_settings/general/user_settings_general.jsx
+++ b/components/user_settings/general/user_settings_general.jsx
@@ -85,7 +85,7 @@ const holders = defineMessages({
     },
 });
 
-class UserSettingsGeneralTab extends React.Component {
+class UserSettingsGeneralTab extends React.PureComponent {
     static propTypes = {
         intl: intlShape.isRequired,
         user: PropTypes.object.isRequired,

--- a/components/user_settings/import_theme_modal.tsx
+++ b/components/user_settings/import_theme_modal.tsx
@@ -20,7 +20,7 @@ type State = {
     callback: ((args: {}) => void) | null;
 }
 
-export default class ImportThemeModal extends React.Component<{}, State> {
+export default class ImportThemeModal extends React.PureComponent<{}, State> {
     public constructor(props: {}) {
         super(props);
 

--- a/components/user_settings/modal/user_settings_modal.tsx
+++ b/components/user_settings/modal/user_settings_modal.tsx
@@ -87,7 +87,7 @@ type State = {
     resendStatus: string;
 }
 
-class UserSettingsModal extends React.Component<Props, State> {
+class UserSettingsModal extends React.PureComponent<Props, State> {
     private requireConfirm: boolean;
     private customConfirmAction: ((handleConfirm: () => void) => void) | null;
     private modalBodyRef: React.RefObject<Modal>;

--- a/components/user_settings/notifications/desktop_notification_settings.jsx
+++ b/components/user_settings/notifications/desktop_notification_settings.jsx
@@ -11,7 +11,7 @@ import {t} from 'utils/i18n.jsx';
 import SettingItemMax from 'components/setting_item_max.jsx';
 import SettingItemMin from 'components/setting_item_min';
 
-export default class DesktopNotificationSettings extends React.Component {
+export default class DesktopNotificationSettings extends React.PureComponent {
     handleMinUpdateSection = (section) => {
         this.props.updateSection(section);
 

--- a/components/user_settings/security/user_access_token_section/user_access_token_section.jsx
+++ b/components/user_settings/security/user_access_token_section/user_access_token_section.jsx
@@ -23,7 +23,7 @@ const TOKEN_CREATING = 'creating';
 const TOKEN_CREATED = 'created';
 const TOKEN_NOT_CREATING = 'not_creating';
 
-export default class UserAccessTokenSection extends React.Component {
+export default class UserAccessTokenSection extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object,
         active: PropTypes.bool,

--- a/components/user_settings/sidebar/user_settings_sidebar.tsx
+++ b/components/user_settings/sidebar/user_settings_sidebar.tsx
@@ -130,7 +130,7 @@ interface UserSettingsSidebarState {
     serverError?: string;
 }
 
-export default class UserSettingsSidebar extends React.Component<UserSettingsSidebarProps, UserSettingsSidebarState> {
+export default class UserSettingsSidebar extends React.PureComponent<UserSettingsSidebarProps, UserSettingsSidebarState> {
     constructor(props: UserSettingsSidebarProps) {
         super(props);
 

--- a/components/widgets/admin_console/admin_header.tsx
+++ b/components/widgets/admin_console/admin_header.tsx
@@ -7,7 +7,7 @@ type Props = {
     children: JSX.Element[] | JSX.Element | string;
 };
 
-export default class AdminHeader extends React.Component<Props> {
+export default class AdminHeader extends React.PureComponent<Props> {
     public render() {
         return (
             <div className={'admin-console__header'}>

--- a/components/widgets/badges/badge.tsx
+++ b/components/widgets/badges/badge.tsx
@@ -11,7 +11,7 @@ type Props = {
     className: string;
 };
 
-export default class Badge extends React.Component<Props> {
+export default class Badge extends React.PureComponent<Props> {
     public static defaultProps = {
         show: true,
         className: '',

--- a/components/widgets/inputs/channels_input.jsx
+++ b/components/widgets/inputs/channels_input.jsx
@@ -20,7 +20,7 @@ import {t} from 'utils/i18n.jsx';
 
 import './channels_input.scss';
 
-export default class ChannelsInput extends React.Component {
+export default class ChannelsInput extends React.PureComponent {
     static propTypes = {
         placeholder: PropTypes.string,
         ariaLabel: PropTypes.string.isRequired,

--- a/components/widgets/inputs/users_emails_input.jsx
+++ b/components/widgets/inputs/users_emails_input.jsx
@@ -24,7 +24,7 @@ import {isGuest} from 'utils/utils';
 
 import './users_emails_input.scss';
 
-export default class UsersEmailsInput extends React.Component {
+export default class UsersEmailsInput extends React.PureComponent {
     static propTypes = {
         placeholder: PropTypes.string,
         ariaLabel: PropTypes.string.isRequired,

--- a/components/widgets/loading/loading_wrapper.tsx
+++ b/components/widgets/loading/loading_wrapper.tsx
@@ -11,7 +11,7 @@ type Props = {
     children: React.ReactNode;
 }
 
-export default class LoadingWrapper extends React.Component<Props> {
+export default class LoadingWrapper extends React.PureComponent<Props> {
     public static defaultProps: Props = {
         loading: true,
         text: null,

--- a/components/widgets/modals/full_screen_modal.tsx
+++ b/components/widgets/modals/full_screen_modal.tsx
@@ -23,7 +23,7 @@ type Props = {
     intl: any; // TODO This needs to be replaced with IntlShape once react-intl is upgraded
 };
 
-class FullScreenModal extends React.Component<Props> {
+class FullScreenModal extends React.PureComponent<Props> {
     private modal = React.createRef<HTMLDivElement>();
 
     public componentDidMount() {

--- a/components/widgets/settings/bool_setting.tsx
+++ b/components/widgets/settings/bool_setting.tsx
@@ -17,7 +17,7 @@ type Props = {
     autoFocus?: boolean;
 }
 
-export default class BoolSetting extends React.Component<Props> {
+export default class BoolSetting extends React.PureComponent<Props> {
     public static defaultProps: Partial<Props> = {
         labelClassName: '',
         inputClassName: '',

--- a/components/widgets/settings/radio_setting.tsx
+++ b/components/widgets/settings/radio_setting.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 }
 
-export default class RadioSetting extends React.Component<Props> {
+export default class RadioSetting extends React.PureComponent<Props> {
     public static defaultProps: Partial<Props> = {
         labelClassName: '',
         inputClassName: '',

--- a/components/widgets/settings/text_setting.tsx
+++ b/components/widgets/settings/text_setting.tsx
@@ -27,7 +27,7 @@ export type WidgetTextSettingProps = {
 // Since handle change is read from input and textarea element
 type HandleChangeTypes = React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>
 
-export default class TextSetting extends React.Component<WidgetTextSettingProps> {
+export default class TextSetting extends React.PureComponent<WidgetTextSettingProps> {
     public static validTypes: string[] = ['input', 'textarea', 'number', 'email', 'tel', 'url', 'password'];
 
     public static defaultProps: Partial<WidgetTextSettingProps> = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3190,8 +3190,7 @@
     "@types/highlight.js": {
       "version": "9.12.3",
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
-      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
-      "dev": true
+      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ=="
     },
     "@types/history": {
       "version": "4.7.3",
@@ -3375,7 +3374,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/react-custom-scrollbars/-/react-custom-scrollbars-4.0.6.tgz",
       "integrity": "sha512-QvQCSMpP59WO2UtGW4alEDRnrhxToPXxws+IzwtboDR2ookcr7z/KE29s3HHYXYwjZpxiQ/ncFhWoQwREor7+Q==",
-      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -3464,7 +3462,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-1.0.1.tgz",
       "integrity": "sha512-1egEnh2/+sRRKImnCo5EMVm0Uxu4fBHeLHk/inhSp/VpE93It8lk3gYeNfehUgXd6OzqP5LLA9kzO9x7o3WfwA==",
-      "dev": true,
       "requires": {
         "redux": "^4.0.0"
       }
@@ -9203,8 +9200,7 @@
     "eventemitter3": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
-      "dev": true
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
     },
     "events": {
       "version": "3.1.0",
@@ -10809,7 +10805,10 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
       "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.63.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -11761,6 +11760,12 @@
       "requires": {
         "postcss": "^7.0.14"
       }
+    },
+    "icu4c-data": {
+      "version": "0.63.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.63.2.tgz",
+      "integrity": "sha512-vT6/47CcBzDemlhRzkL7dZLoNvuUWjjiuKZHMt5T4dbkKAqLBh7ZQ33GU13ecC/aIcMlIdBOqtF4uIYTgWML4Q==",
+      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -15916,8 +15921,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
       "version": "1.1.0",
@@ -17078,15 +17082,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
-      }
-    },
-    "react-addons-pure-render-mixin": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-15.6.2.tgz",
-      "integrity": "sha1-a4P0C2s27kBzXL1hJes/E84c3ck=",
-      "requires": {
-        "fbjs": "^0.8.4",
-        "object-assign": "^4.1.0"
       }
     },
     "react-beautiful-dnd": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "popper.js": "1.16.0",
     "prop-types": "15.7.2",
     "react": "16.8.6",
-    "react-addons-pure-render-mixin": "15.6.2",
     "react-beautiful-dnd": "^11.0.5",
     "react-bootstrap": "github:mattermost/react-bootstrap#c6957962364e0818a51bbfd13e89919903b422d6",
     "react-color": "2.17.3",

--- a/reducers/views/modals.test.jsx
+++ b/reducers/views/modals.test.jsx
@@ -7,7 +7,7 @@ import {Modal} from 'react-bootstrap';
 import modalsReducer from 'reducers/views/modals';
 import {ActionTypes, ModalIdentifiers} from 'utils/constants';
 
-class TestModal extends React.Component {
+class TestModal extends React.PureComponent {
     render() {
         return (
             <Modal


### PR DESCRIPTION
As part of MM-22155 where we want to silence unnecessarily noisy warnings, we decided a while back to prefer `React.PureComponent` unless we had a good reason not to.

I left a few files using `React.Component` since those defined `shouldComponentUpdate` methods, so they weren't causing any unnecessary warnings, but we could also update those as well at some point.

The only other notable thing here is that I removed `react-addons-pure-render-mixin` since it was being used only by the GifPicker, and I replaced that with a `PureComponent`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22155