### PR TITLE
MM-25369: Disable Brotli in 'dev' mode.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -339,12 +339,15 @@ var config = {
                 sizes: '96x96',
             }],
         }),
-        new BrotliPlugin({
-            asset: '[file].br',
-            test: /\.(js|css)$/
-        }),
     ],
 };
+
+if (!DEV) {
+    config.plugins.push(new BrotliPlugin({
+        asset: '[file].br',
+        test: /\.(js|css)$/
+    }));
+}
 
 if (!targetIsStats) {
     config.stats = MYSTATS;


### PR DESCRIPTION
#### Summary

Disables Brotli encoding in "dev" mode to speed up the save-to-reload time during front-end development.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-25369

#### Related Pull Requests

https://github.com/mattermost/mattermost-server/pull/14608