### PR TITLE
Fix "rending > rendering" typo in Latex help text

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -1983,7 +1983,7 @@ const AdminDefinition = {
                         label: t('admin.customization.enableLatexTitle'),
                         label_default: 'Enable Latex Rendering:',
                         help_text: t('admin.customization.enableLatexDesc'),
-                        help_text_default: 'Enable rending of Latex code. If false, Latex code will be highlighted only.',
+                        help_text_default: 'Enable rendering of Latex code. If false, Latex code will be highlighted only.',
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_CUSTOM,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -394,7 +394,7 @@
   "admin.customization.enableEmojiPickerTitle": "Enable Emoji Picker:",
   "admin.customization.enableGifPickerDesc": "Allow users to select GIFs from the emoji picker via a Gfycat integration.",
   "admin.customization.enableGifPickerTitle": "Enable GIF Picker:",
-  "admin.customization.enableLatexDesc": "Enable rending of Latex code. If false, Latex code will be highlighted only.",
+  "admin.customization.enableLatexDesc": "Enable rendering of Latex code. If false, Latex code will be highlighted only.",
   "admin.customization.enableLatexTitle": "Enable Latex Rendering:",
   "admin.customization.enableLinkPreviewsDesc": "Display a preview of website content, image links and YouTube links below the message when available. The server must be connected to the internet and have access through the firewall (if applicable) to the websites from which previews are expected. Users can disable these previews from Account Settings > Display > Website Link Previews.",
   "admin.customization.enableLinkPreviewsTitle": "Enable Link Previews:",


### PR DESCRIPTION
#### Summary

First introduced in Mattermost 5.17

#### Ticket Link
N/A

#### Related Pull Requests

#### Screenshots
