### PR TITLE
[MM-23690] Not showing updated / correct roles when searching for user in the team members modal after their role has been updated

### DIFF
--- a/components/member_list_team/index.ts
+++ b/components/member_list_team/index.ts
@@ -36,7 +36,7 @@ type Actions = {
     loadStatusesForProfilesList: (users: Array<UserProfile>) => Promise<{
         data: boolean;
     }>;
-    loadTeamMembersForProfilesList: (profiles: any, teamId: string) => Promise<{
+    loadTeamMembersForProfilesList: (profiles: any, teamId: string, reloadAllMembers: boolean) => Promise<{
         data: boolean;
     }>;
     setModalSearchTerm: (term: string) => Promise<{

--- a/components/member_list_team/member_list_team.tsx
+++ b/components/member_list_team/member_list_team.tsx
@@ -34,7 +34,7 @@ type Props = {
         loadStatusesForProfilesList: (users: Array<UserProfile>) => Promise<{
             data: boolean;
         }>;
-        loadTeamMembersForProfilesList: (profiles: any, teamId: string) => Promise<{
+        loadTeamMembersForProfilesList: (profiles: any, teamId: string, reloadAllMembers: boolean) => Promise<{
             data: boolean;
         }>;
         setModalSearchTerm: (term: string) => Promise<{
@@ -105,7 +105,7 @@ export default class MemberListTeam extends React.Component<Props, State> {
                     this.setState({loading: true});
 
                     loadStatusesForProfilesList(data);
-                    loadTeamMembersForProfilesList(data, this.props.currentTeamId).then(({data: membersLoaded}) => {
+                    loadTeamMembersForProfilesList(data, this.props.currentTeamId, true).then(({data: membersLoaded}) => {
                         if (membersLoaded) {
                             this.loadComplete();
                         }
@@ -134,14 +134,7 @@ export default class MemberListTeam extends React.Component<Props, State> {
         this.loadComplete();
     }
 
-    search = async (term: string) => {
-        await this.props.actions.getTeamMembers(this.props.currentTeamId, 0, this.props.users.length,
-            {
-                sort: Teams.SORT_USERNAME_OPTION,
-                exclude_deleted_users: true,
-                term,
-            } as GetTeamMembersOpts
-        );
+    search = (term: string) => {
         this.props.actions.setModalSearchTerm(term);
     }
 

--- a/components/member_list_team/member_list_team.tsx
+++ b/components/member_list_team/member_list_team.tsx
@@ -134,7 +134,14 @@ export default class MemberListTeam extends React.Component<Props, State> {
         this.loadComplete();
     }
 
-    search = (term: string) => {
+    search = async (term: string) => {
+        await this.props.actions.getTeamMembers(this.props.currentTeamId, 0, this.props.users.length,
+            {
+                sort: Teams.SORT_USERNAME_OPTION,
+                exclude_deleted_users: true,
+                term,
+            } as GetTeamMembersOpts
+        );
         this.props.actions.setModalSearchTerm(term);
     }
 


### PR DESCRIPTION


#### Summary
<!--
A description of what this pull request does.
-->
If you search for a particular member in the team members modal on chat facing side after a user has had their role updated, it will show an incorrect / out of date role. This PR aims to fix this problem.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23690

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- ~~Has server changes https://github.com/mattermost/mattermost-server/pull/14615~~
- ~~Has Redux changes https://github.com/mattermost/mattermost-redux/pull/1160~~


![MM-23690](https://user-images.githubusercontent.com/17804942/82495603-5726a880-9ab9-11ea-8ef0-3f36848931ac.gif)
