### PR TITLE
MM-25426 Continue to scroll RHS when scrolled to bottom of thread

### DIFF
--- a/components/rhs_thread/rhs_thread.test.tsx
+++ b/components/rhs_thread/rhs_thread.test.tsx
@@ -119,35 +119,23 @@ describe('components/RhsThread', () => {
     };
 
     test('should match snapshot', () => {
-        const wrapper = shallow(
-            <RhsThread {...baseProps}/>,
-            {disableLifecycleMethods: true},
-        );
+        const wrapper = shallow(<RhsThread {...baseProps}/>);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should make api call to get thread posts on socket reconnect', () => {
-        const wrapper = shallow(
-            <RhsThread {...baseProps}/>,
-            {disableLifecycleMethods: true},
-        );
-        const prevProps = {
+        const wrapper = shallow(<RhsThread {...baseProps}/>);
+        wrapper.setProps({
             ...baseProps,
             socketConnectionStatus: false,
-        };
+        });
         wrapper.setProps({socketConnectionStatus: true});
-        const instance = wrapper.instance() as RhsThread;
-        instance.componentDidUpdate(prevProps);
-
         expect(actions.getPostThread).toHaveBeenCalledWith(post.id);
     });
 
     test('should update openTime state when selected prop updated', async () => {
         jest.useRealTimers();
-        const wrapper = shallow(
-            <RhsThread {...baseProps}/>,
-            {disableLifecycleMethods: true},
-        );
+        const wrapper = shallow(<RhsThread {...baseProps}/>);
 
         const waitMilliseconds = 100;
         const originalOpenTimeState = wrapper.state('openTime');
@@ -159,17 +147,10 @@ describe('components/RhsThread', () => {
     });
 
     test('should scroll to the bottom when the current user makes a new post in the thread', () => {
-        const scrollToBottom = jest.fn();
-
-        const wrapper = shallow(
-            <RhsThread {...baseProps}/>,
-            {disableLifecycleMethods: true},
-        );
+        const wrapper = shallow(<RhsThread {...baseProps}/>);
         const instance = wrapper.instance() as RhsThread;
-        instance.scrollToBottom = scrollToBottom;
-        instance.componentDidUpdate(baseProps);
-
-        expect(scrollToBottom).not.toHaveBeenCalled();
+        instance.scrollToBottom = jest.fn();
+        expect(instance.scrollToBottom).not.toHaveBeenCalled();
         wrapper.setProps({
             posts: [
                 {
@@ -180,36 +161,50 @@ describe('components/RhsThread', () => {
                 post,
             ],
         });
-        instance.componentDidUpdate(baseProps);
-
-        expect(scrollToBottom).toHaveBeenCalled();
+        expect(instance.scrollToBottom).toHaveBeenCalled();
     });
 
-    test('should not scroll to the bottom when another user makes a new post in the thread', () => {
-        const scrollToBottom = jest.fn();
-
-        const wrapper = shallow(
-            <RhsThread {...baseProps}/>,
-            {disableLifecycleMethods: true},
-        );
+    test('should not continue scrolling to show next post when thread is scrolled away from the bottom', () => {
+        const wrapper = shallow(<RhsThread {...baseProps}/>);
         const instance = wrapper.instance() as RhsThread;
-        instance.scrollToBottom = scrollToBottom;
-        instance.componentDidUpdate(baseProps);
+        instance.scrollToBottom = jest.fn();
 
-        expect(scrollToBottom).not.toHaveBeenCalled();
-
+        wrapper.setState({
+            isAtBottom: false,
+        });
         wrapper.setProps({
             posts: [
                 {
-                    id: 'newpost',
+                    id: '5kkodt8t4brcugytq4kniu7w1o',
                     root_id: post.id,
-                    user_id: 'other_user_id',
+                    user_id: 'hari5n3xdtybik415jjz4p36qc',
                 },
                 post,
             ],
         });
-        instance.componentDidUpdate(baseProps);
 
-        expect(scrollToBottom).not.toHaveBeenCalled();
+        expect(instance.scrollToBottom).not.toHaveBeenCalled();
+    });
+
+    test('should continue scrolling to show next post when thread is currently scrolled to the bottom', () => {
+        const wrapper = shallow(<RhsThread {...baseProps}/>);
+        const instance = wrapper.instance() as RhsThread;
+
+        //console.log(instance.state);
+
+        instance.scrollToBottom = jest.fn();
+        wrapper.setProps({
+            posts: [
+                {
+                    id: '5kkodt8t4brcugytq4kniu7w1o',
+                    root_id: post.id,
+                    user_id: 'hari5n3xdtybik415jjz4p36qc',
+                },
+                post,
+            ],
+        });
+
+        expect(instance.state.isAtBottom).toBeTruthy();
+        expect(instance.scrollToBottom).toHaveBeenCalled();
     });
 });

--- a/components/rhs_thread/rhs_thread.test.tsx
+++ b/components/rhs_thread/rhs_thread.test.tsx
@@ -167,11 +167,11 @@ describe('components/RhsThread', () => {
     test('should not continue scrolling to show next post when thread is scrolled away from the bottom', () => {
         const wrapper = shallow(<RhsThread {...baseProps}/>);
         const instance = wrapper.instance() as RhsThread;
-        instance.scrollToBottom = jest.fn();
 
         wrapper.setState({
-            isAtBottom: false,
+            isNearBottom: false,
         });
+        instance.scrollToBottom = jest.fn();
         wrapper.setProps({
             posts: [
                 {
@@ -190,8 +190,6 @@ describe('components/RhsThread', () => {
         const wrapper = shallow(<RhsThread {...baseProps}/>);
         const instance = wrapper.instance() as RhsThread;
 
-        //console.log(instance.state);
-
         instance.scrollToBottom = jest.fn();
         wrapper.setProps({
             posts: [
@@ -204,7 +202,7 @@ describe('components/RhsThread', () => {
             ],
         });
 
-        expect(instance.state.isAtBottom).toBeTruthy();
+        expect(instance.state.isNearBottom).toBeTruthy();
         expect(instance.scrollToBottom).toHaveBeenCalled();
     });
 });

--- a/components/rhs_thread/rhs_thread.tsx
+++ b/components/rhs_thread/rhs_thread.tsx
@@ -120,8 +120,10 @@ export default class RhsThread extends React.Component<Props, State> {
 
         // if snapshot value, new posts have been added
         // if at bottom of thread, continue to scroll after adding new post
-        if (snapshot) {
-            this.scrollToBottom();
+        if (!Utils.areObjectsEqual(prevPostsArray, curPostsArray)) {
+            if (snapshot) {
+                this.scrollToBottom();
+            }
         }
 
         if (prevPostsArray.length >= curPostsArray.length) {
@@ -153,6 +155,10 @@ export default class RhsThread extends React.Component<Props, State> {
         }
 
         if (nextState.isScrolling !== this.state.isScrolling) {
+            return true;
+        }
+
+        if (nextState.isNearBottom !== this.state.isNearBottom) {
             return true;
         }
 

--- a/components/rhs_thread/rhs_thread.tsx
+++ b/components/rhs_thread/rhs_thread.tsx
@@ -102,7 +102,7 @@ export default class RhsThread extends React.Component<Props, State> {
         window.removeEventListener('resize', this.handleResize);
     }
 
-    public componentDidUpdate(prevProps: Props, prevState: State, snapshot?: boolean) {
+    public componentDidUpdate(prevProps: Props, prevState: State) {
         const prevPostsArray = prevProps.posts || [];
         const curPostsArray = this.props.posts || [];
 
@@ -118,10 +118,9 @@ export default class RhsThread extends React.Component<Props, State> {
             this.props.actions.getPostThread(this.props.selected.id);
         }
 
-        // if snapshot value, new posts have been added
-        // if at bottom of thread, continue to scroll after adding new post
+        // if near bottom of thread, continue to scroll after adding new post
         if (!Utils.areObjectsEqual(prevPostsArray, curPostsArray)) {
-            if (snapshot) {
+            if (prevState.isNearBottom) {
                 this.scrollToBottom();
             }
         }
@@ -173,14 +172,6 @@ export default class RhsThread extends React.Component<Props, State> {
         }
 
         return false;
-    }
-
-    public getSnapshotBeforeUpdate(prevProps: Props, prevState: State) {
-        // if adding posts to thread, capture state of rhs to determine if scrolled to botttom
-        if (!Utils.areObjectsEqual(prevState.postsArray, this.props.posts)) {
-            return prevState.isNearBottom;
-        }
-        return null;
     }
 
     private handleResize = (): void => {

--- a/components/rhs_thread/rhs_thread.tsx
+++ b/components/rhs_thread/rhs_thread.tsx
@@ -100,7 +100,7 @@ export default class RhsThread extends React.Component<Props, State> {
         window.removeEventListener('resize', this.handleResize);
     }
 
-    public componentDidUpdate(prevProps: Props, snapshot?: any) {
+    public componentDidUpdate(prevProps: Props, prevState: State, snapshot?: any) {
         const prevPostsArray = prevProps.posts || [];
         const curPostsArray = this.props.posts || [];
 
@@ -120,9 +120,7 @@ export default class RhsThread extends React.Component<Props, State> {
         // if at bottom of thread, continue to scroll after adding new post
         if (curPostsArray.length > prevPostsArray.length) {
             if (snapshot) {
-                if (snapshot.isAtBottom) {
-                    this.scrollToBottom();
-                }
+                this.scrollToBottom();
             }
         }
 

--- a/components/rhs_thread/rhs_thread.tsx
+++ b/components/rhs_thread/rhs_thread.tsx
@@ -100,7 +100,7 @@ export default class RhsThread extends React.Component<Props, State> {
         window.removeEventListener('resize', this.handleResize);
     }
 
-    public componentDidUpdate(prevProps: Props, prevState: State, snapshot?: any) {
+    public componentDidUpdate(prevProps: Props, prevState: State, snapshot?: boolean) {
         const prevPostsArray = prevProps.posts || [];
         const curPostsArray = this.props.posts || [];
 


### PR DESCRIPTION
#### Summary
Captures the scrolled state of the thread prior to adding the new post to the DOM. If the thread was scrolled to the bottom, the thread will continue to scroll to expose the next incoming message.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25426

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/5470

#### Screenshots
![thread-scrolling-rhs](https://user-images.githubusercontent.com/44858354/82617732-de415280-9b85-11ea-9172-03f09e31c6fa.gif)
