### PR TITLE
[MM-24929] Force red background on mobile view header mention badge

### DIFF
--- a/sass/layout/_navigation.scss
+++ b/sass/layout/_navigation.scss
@@ -195,12 +195,10 @@
             width: 110px;
         }
     }
+
+    .badge-notify {
+        background: $red;
+    }
 }
 
-.badge-notify {
-    background: $red !important;
-    left: 4px;
-    position: absolute;
-    top: 3px;
-    z-index: 100;
-}
+

--- a/sass/layout/_navigation.scss
+++ b/sass/layout/_navigation.scss
@@ -198,7 +198,7 @@
 }
 
 .badge-notify {
-    background: $red;
+    background: $red !important;
     left: 4px;
     position: absolute;
     top: 3px;


### PR DESCRIPTION
#### Summary
At some point during v5.24 development, the CSS style sheet stopped using the `background-color` for the `badge-notify` class on the mobile view header mention badge, and started using the `background` provided by the `badge` class.

This PR changes the order of the classes in the CSS file such that the `.badge-notify` class has a higher specificity that will override the `background-color` of the default `badge` class.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24929