### PR TITLE
Remove event listener when modal is closed

### DIFF
--- a/components/view_image/view_image.jsx
+++ b/components/view_image/view_image.jsx
@@ -110,7 +110,7 @@ export default class ViewImageModal extends React.PureComponent {
     }
 
     onModalHidden = () => {
-        document.addEventListener('keyup', this.handleKeyPress);
+        document.removeEventListener('keyup', this.handleKeyPress);
 
         if (this.refs.video) {
             this.refs.video.stop();


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR Removes 'keyup' event listener when `ViewImageModal` is closed. 
The arrow keys were being used to navigate through images displayed on the modal, and they kept firing even after the modal was closed. Hanging on to the listener is a source of memory leaks.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23804