### PR TITLE
Rename Error type to ServerError

### DIFF
--- a/components/admin_console/system_users/system_users_dropdown/index.ts
+++ b/components/admin_console/system_users/system_users_dropdown/index.ts
@@ -3,7 +3,7 @@
 
 import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
-import {Error} from 'mattermost-redux/types/errors';
+import {ServerError} from 'mattermost-redux/types/errors';
 import {ActionFunc} from 'mattermost-redux/types/actions';
 
 import {updateUserActive, revokeAllSessionsForUser, promoteGuestToUser, demoteUserToGuest} from 'mattermost-redux/actions/users';
@@ -19,10 +19,10 @@ import {GlobalState} from 'types/store';
 import SystemUsersDropdown from './system_users_dropdown';
 
 type Actions = {
-    updateUserActive: (id: string, active: boolean) => Promise<{error: Error}>;
-    revokeAllSessionsForUser: (id: string) => Promise<{error: Error; data: any}>;
-    promoteGuestToUser: (id: string) => Promise<{error: Error}>;
-    demoteUserToGuest: (id: string) => Promise<{error: Error}>;
+    updateUserActive: (id: string, active: boolean) => Promise<{error: ServerError}>;
+    revokeAllSessionsForUser: (id: string) => Promise<{error: ServerError; data: any}>;
+    promoteGuestToUser: (id: string) => Promise<{error: ServerError}>;
+    demoteUserToGuest: (id: string) => Promise<{error: ServerError}>;
     loadBots: (page?: number, size?: number) => Promise<{}>;
 }
 

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.tsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.tsx
@@ -6,7 +6,7 @@ import {FormattedMessage} from 'react-intl';
 import * as UserUtils from 'mattermost-redux/utils/user_utils';
 import {Permissions} from 'mattermost-redux/constants';
 import {UserProfile} from 'mattermost-redux/types/users';
-import {Error} from 'mattermost-redux/types/errors';
+import {ServerError} from 'mattermost-redux/types/errors';
 import {Dictionary} from 'mattermost-redux/types/utilities';
 import {Bot} from 'mattermost-redux/types/bots';
 
@@ -38,10 +38,10 @@ type Props = {
     bots: Dictionary<Bot>;
     isLicensed: boolean;
     actions: {
-        updateUserActive: (id: string, active: boolean) => Promise<{error: Error}>;
-        revokeAllSessionsForUser: (id: string) => Promise<{error: Error; data: any}>;
-        promoteGuestToUser: (id: string) => Promise<{error: Error}>;
-        demoteUserToGuest: (id: string) => Promise<{error: Error}>;
+        updateUserActive: (id: string, active: boolean) => Promise<{error: ServerError}>;
+        revokeAllSessionsForUser: (id: string) => Promise<{error: ServerError; data: any}>;
+        promoteGuestToUser: (id: string) => Promise<{error: ServerError}>;
+        demoteUserToGuest: (id: string) => Promise<{error: ServerError}>;
         loadBots: (page?: number, size?: number) => Promise<{}>;
     };
     doPasswordReset: (user: UserProfile) => void;
@@ -49,7 +49,7 @@ type Props = {
     doManageTeams: (user: UserProfile) => void;
     doManageRoles: (user: UserProfile) => void;
     doManageTokens: (user: UserProfile) => void;
-    onError: (error: Error | {id: string}) => void;
+    onError: (error: ServerError | {id: string}) => void;
 }
 
 type State = {
@@ -131,7 +131,7 @@ export default class SystemUsersDropdown extends React.PureComponent<Props, Stat
         this.setState({showDeactivateMemberModal: false});
     }
 
-    onUpdateActiveResult = ({error}: {error: Error}) => {
+    onUpdateActiveResult = ({error}: {error: ServerError}) => {
         if (error) {
             this.props.onError({id: error.server_error_id, ...error});
         }

--- a/components/do_verify_email/do_verify_email.tsx
+++ b/components/do_verify_email/do_verify_email.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import {Error} from 'mattermost-redux/types/errors';
+import {ServerError} from 'mattermost-redux/types/errors';
 
 import {UserProfile} from 'mattermost-redux/types/users';
 
@@ -27,7 +27,7 @@ type Props = {
     actions: {
         verifyUserEmail: (token: string) => ActionFunc | ActionResult;
         getMe: () => ActionFunc | ActionResult;
-        logError: (error: Error, displayable: boolean) => void;
+        logError: (error: ServerError, displayable: boolean) => void;
         clearErrors: () => void;
     };
     isLoggedIn: boolean;

--- a/components/new_channel_flow/index.ts
+++ b/components/new_channel_flow/index.ts
@@ -6,7 +6,7 @@ import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
 
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
 import {Channel} from 'mattermost-redux/types/channels';
-import {Error} from 'mattermost-redux/types/errors';
+import {ServerError} from 'mattermost-redux/types/errors';
 import {createChannel} from 'mattermost-redux/actions/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {GlobalState} from 'mattermost-redux/types/store';
@@ -16,7 +16,7 @@ import {switchToChannel} from 'actions/views/channel';
 import NewChannelFlow from './new_channel_flow';
 
 type Actions = {
-    createChannel: (channel: Channel) => Promise<{data: Channel; error?: Error}>;
+    createChannel: (channel: Channel) => Promise<{data: Channel; error?: ServerError}>;
     switchToChannel: (channel: Channel) => Promise<{}>;
 }
 

--- a/components/new_channel_flow/new_channel_flow.tsx
+++ b/components/new_channel_flow/new_channel_flow.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {ChannelType, Channel} from 'mattermost-redux/types/channels';
-import {Error} from 'mattermost-redux/types/errors';
+import {ServerError} from 'mattermost-redux/types/errors';
 
 import Constants from 'utils/constants';
 import * as Utils from 'utils/utils';
@@ -62,7 +62,7 @@ export type Props = {
     canCreatePrivateChannel: boolean;
 
     actions: {
-        createChannel: (channel: Channel) => Promise<{data: Channel; error?: Error}>;
+        createChannel: (channel: Channel) => Promise<{data: Channel; error?: ServerError}>;
         switchToChannel: (channel: Channel) => Promise<{}>;
     };
 };
@@ -157,7 +157,7 @@ export default class NewChannelFlow extends React.PureComponent<Props, State> {
             update_at: 0,
         };
 
-        actions.createChannel(channel).then((result: {data: Channel; error?: Error}) => {
+        actions.createChannel(channel).then((result: {data: Channel; error?: ServerError}) => {
             if (result.error) {
                 this.onCreateChannelError(result.error);
                 return;
@@ -168,7 +168,7 @@ export default class NewChannelFlow extends React.PureComponent<Props, State> {
         });
     };
 
-    onCreateChannelError = (err: Error) => {
+    onCreateChannelError = (err: ServerError) => {
         if (err.server_error_id === 'model.channel.is_valid.2_or_more.app_error') {
             this.setState({
                 flowState: SHOW_EDIT_URL_THEN_COMPLETE,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5444,7 +5444,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true,
           "optional": true
@@ -7531,14 +7531,14 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true,
           "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "optional": true,
@@ -12449,7 +12449,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "optional": true,
@@ -14320,8 +14320,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#7f167309942240f2152eeed4b497dae71f84d6cb",
-      "from": "github:mattermost/mattermost-redux#7f167309942240f2152eeed4b497dae71f84d6cb",
+      "version": "github:mattermost/mattermost-redux#dfaf2e7420dc63cf34d243d4acabadc14624032a",
+      "from": "github:mattermost/mattermost-redux#dfaf2e7420dc63cf34d243d4acabadc14624032a",
       "requires": {
         "core-js": "3.6.4",
         "form-data": "3.0.0",
@@ -15925,7 +15925,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -5444,7 +5444,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true,
           "optional": true
@@ -7531,14 +7531,14 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true,
           "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "optional": true,
@@ -12449,7 +12449,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "optional": true,
@@ -15925,7 +15925,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#5a06d1af25ca48927b9efe0d9c42c01c84e7839b",
-    "mattermost-redux": "github:mattermost/mattermost-redux#7f167309942240f2152eeed4b497dae71f84d6cb",
+    "mattermost-redux": "github:mattermost/mattermost-redux#dfaf2e7420dc63cf34d243d4acabadc14624032a",
     "moment-timezone": "0.5.27",
     "p-queue": "^6.4.0",
     "pdfjs-dist": "2.0.489",


### PR DESCRIPTION
In https://github.com/mattermost/mattermost-redux/pull/1162, I renamed the `Error` type we were using to `ServerError` since it conflicted with the built-in `Error` type, but I forgot to do that on the webapp side as well. This fixes that.

#### Related Pull Requests
https://github.com/mattermost/mattermost-redux/pull/1162