### PR TITLE
[MM-20775] Fix: Highlighting is not updated correctly when Group Mention is modified/enabled/disabled until user reloads the page

### DIFF
--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -1159,7 +1159,7 @@ function handleGroupUpdatedEvent(msg) {
         {
             type: GroupTypes.RECEIVED_MY_GROUPS,
             data: [data],
-        }
+        },
     ]));
 }
 

--- a/actions/websocket_actions.jsx
+++ b/actions/websocket_actions.jsx
@@ -1151,10 +1151,16 @@ function handleOpenDialogEvent(msg) {
 
 function handleGroupUpdatedEvent(msg) {
     const data = JSON.parse(msg.data.group);
-    store.dispatch({
-        type: GroupTypes.RECEIVED_GROUP,
-        data,
-    });
+    dispatch(batchActions([
+        {
+            type: GroupTypes.RECEIVED_GROUP,
+            data,
+        },
+        {
+            type: GroupTypes.RECEIVED_MY_GROUPS,
+            data: [data],
+        }
+    ]));
 }
 
 function handleGroupAssociatedToTeamEvent(msg) {


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Fixes group highlighting not getting updated when a group is updated via system console

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-25448


#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![MM-20775](https://user-images.githubusercontent.com/17804942/82835194-5020e100-9e91-11ea-8642-435bec7498a4.gif)
