### PR TITLE
MM-25527 Improve Cypress reporting to accommodate master/release/PR in partial/full view

### DIFF
--- a/e2e/save_report.js
+++ b/e2e/save_report.js
@@ -15,9 +15,9 @@
  *   For saving reports to Automation dashboard
  *      - DASHBOARD_ENABLE, DASHBOARD_ENDPOINT and DASHBOARD_TOKEN
  *   For sending hooks to Mattermost channels
- *      - WEBHOOK_URL and DIAGNOSTIC_WEBHOOK_URL
+ *      - FULL_REPORT, WEBHOOK_URL and DIAGNOSTIC_WEBHOOK_URL
  *   Test type
- *      - TYPE=[type], e.g. "DAILY", "PR", "RELEASE"
+ *      - TYPE=[type], e.g. "MASTER", "PR", "RELEASE"
  */
 
 const {merge} = require('mochawesome-merge');
@@ -82,8 +82,8 @@ const saveReport = async () => {
     }
 
     // Send diagnostic report via webhook
-    // Send on "DAILY" type only
-    if (TYPE === 'DAILY' && DIAGNOSTIC_WEBHOOK_URL && DIAGNOSTIC_USER_ID && DIAGNOSTIC_TEAM_ID) {
+    // Send on "RELEASE" type only
+    if (TYPE === 'RELEASE' && DIAGNOSTIC_WEBHOOK_URL && DIAGNOSTIC_USER_ID && DIAGNOSTIC_TEAM_ID) {
         const data = generateDiagnosticReport(summary, {userId: DIAGNOSTIC_USER_ID, teamId: DIAGNOSTIC_TEAM_ID});
         await sendReport('test info for diagnostic analysis', DIAGNOSTIC_WEBHOOK_URL, data);
     }

--- a/e2e/utils/report.js
+++ b/e2e/utils/report.js
@@ -127,7 +127,7 @@ function generateTestReport(summary, isUploadedToS3, reportLink) {
     }
 
     let title;
-    
+
     switch (TYPE) {
     case 'PR':
         title = `E2E for Pull Request Build: [${BRANCH}](${PULL_REQUEST}) with ${BUILD_TAG ? dockerImageLink : ''}`;
@@ -139,8 +139,8 @@ function generateTestReport(summary, isUploadedToS3, reportLink) {
         title = `E2E for Master Nightly Build (Prod tests) with ${BUILD_TAG ? dockerImageLink : ''}`;
         break;
     case 'MASTER_UNSTABLE':
-            title = `E2E for Master Nightly Build (Unstable tests) with ${BUILD_TAG ? dockerImageLink : ''}`;
-            break;
+        title = `E2E for Master Nightly Build (Unstable tests) with ${BUILD_TAG ? dockerImageLink : ''}`;
+        break;
     default:
         title = 'Cypress UI Test';
     }
@@ -170,25 +170,25 @@ function generateTestReport(summary, isUploadedToS3, reportLink) {
                 ],
             }],
         };
-    } else {
-        let summary = `${stats.passPercent.toFixed(2)}% (${stats.passes}/${stats.tests}) in ${stats.suites} suites`;
-        if (isUploadedToS3) {
-            summary = `[${summary}](${reportLink})`;
-        }
-
-        return {
-            username: 'Cypress UI Test',
-            icon_url: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
-            attachments: [{
-                color: testResult.color,
-                author_name: 'Webapp End-to-end Testing',
-                author_icon: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
-                author_link: 'https://www.mattermost.com/',
-                title,
-                text: `${summary} | ${(stats.duration / (60 * 1000)).toFixed(2)} mins | ${os.type()} ${BROWSER} (${HEADLESS === 'false', 'headed', 'headless'})`,
-            }],
-        }
     }
+
+    let quickSummary = `${stats.passPercent.toFixed(2)}% (${stats.passes}/${stats.tests}) in ${stats.suites} suites`;
+    if (isUploadedToS3) {
+        quickSummary = `[${quickSummary}](${reportLink})`;
+    }
+
+    return {
+        username: 'Cypress UI Test',
+        icon_url: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
+        attachments: [{
+            color: testResult.color,
+            author_name: 'Webapp End-to-end Testing',
+            author_icon: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
+            author_link: 'https://www.mattermost.com/',
+            title,
+            text: `${quickSummary} | ${(stats.duration / (60 * 1000)).toFixed(2)} mins | ${os.type()} ${BROWSER} (${HEADLESS === 'false' ? 'headed' : 'headless'})`,
+        }],
+    };
 }
 
 function generateDiagnosticReport(summary, serverInfo) {

--- a/e2e/utils/report.js
+++ b/e2e/utils/report.js
@@ -3,6 +3,7 @@
 
 /* eslint-disable no-console */
 
+const os = require('os');
 const axios = require('axios');
 const fse = require('fs-extra');
 
@@ -92,7 +93,15 @@ const result = [
 ];
 
 function generateTestReport(summary, isUploadedToS3, reportLink) {
-    const {BRANCH, BROWSER} = process.env;
+    const {
+        BRANCH,
+        BROWSER,
+        BUILD_TAG,
+        FULL_REPORT,
+        HEADLESS,
+        PULL_REQUEST,
+        TYPE,
+    } = process.env;
     const {statsFieldValue, stats} = summary;
 
     let testResult;
@@ -112,31 +121,74 @@ function generateTestReport(summary, isUploadedToS3, reportLink) {
         };
     }
 
-    return {
-        username: 'Cypress UI Test',
-        icon_url: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
-        attachments: [{
-            color: testResult.color,
-            author_name: 'Cypress UI Test',
-            author_icon: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
-            author_link: 'https://www.mattermost.com',
-            title: `Cypress UI Test Automation ${testResult.status}!`,
-            fields: [
-                {
-                    short: false,
-                    title: 'Environment',
-                    value: `Branch: **${BRANCH}**, Browser: **${BROWSER}**`,
-                },
-                awsS3Fields,
-                {
-                    short: false,
-                    title: `Key metrics (required support: ${testResult.priority})`,
-                    value: statsFieldValue,
-                },
-            ],
-            image_url: 'https://pbs.twimg.com/profile_images/1044345247440896001/pXI1GDHW_bigger.jpg',
-        }],
-    };
+    let dockerImageLink;
+    if (BUILD_TAG) {
+        dockerImageLink = `[mattermost-enterprise-edition:${BUILD_TAG}](https://hub.docker.com/r/mattermost/mattermost-enterprise-edition/tags?name=${BUILD_TAG})`;
+    }
+
+    let title;
+    
+    switch (TYPE) {
+    case 'PR':
+        title = `E2E for Pull Request Build: [${BRANCH}](${PULL_REQUEST}) with ${BUILD_TAG ? dockerImageLink : ''}`;
+        break;
+    case 'RELEASE':
+        title = `E2E for Release Build with ${BUILD_TAG ? dockerImageLink : ''}`;
+        break;
+    case 'MASTER':
+        title = `E2E for Master Nightly Build (Prod tests) with ${BUILD_TAG ? dockerImageLink : ''}`;
+        break;
+    case 'MASTER_UNSTABLE':
+            title = `E2E for Master Nightly Build (Unstable tests) with ${BUILD_TAG ? dockerImageLink : ''}`;
+            break;
+    default:
+        title = 'Cypress UI Test';
+    }
+
+    if (FULL_REPORT) {
+        return {
+            username: 'Cypress UI Test',
+            icon_url: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
+            attachments: [{
+                color: testResult.color,
+                author_name: 'Cypress UI Test',
+                author_icon: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
+                author_link: 'https://www.mattermost.com',
+                title,
+                fields: [
+                    {
+                        short: false,
+                        title: 'Environment',
+                        value: `Branch: **${BRANCH}**, Browser: **${BROWSER}**`,
+                    },
+                    awsS3Fields,
+                    {
+                        short: false,
+                        title: `Key metrics (required support: ${testResult.priority})`,
+                        value: statsFieldValue,
+                    },
+                ],
+            }],
+        };
+    } else {
+        let summary = `${stats.passPercent.toFixed(2)}% (${stats.passes}/${stats.tests}) in ${stats.suites} suites`;
+        if (isUploadedToS3) {
+            summary = `[${summary}](${reportLink})`;
+        }
+
+        return {
+            username: 'Cypress UI Test',
+            icon_url: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
+            attachments: [{
+                color: testResult.color,
+                author_name: 'Webapp End-to-end Testing',
+                author_icon: 'https://www.mattermost.org/wp-content/uploads/2016/04/icon.png',
+                author_link: 'https://www.mattermost.com/',
+                title,
+                text: `${summary} | ${(stats.duration / (60 * 1000)).toFixed(2)} mins | ${os.type()} ${BROWSER} (${HEADLESS === 'false', 'headed', 'headless'})`,
+            }],
+        }
+    }
 }
 
 function generateDiagnosticReport(summary, serverInfo) {


### PR DESCRIPTION
#### Summary
Improve Cypress reporting to accommodate master/release/PR in partial/full view.  This is to improve visibility/highlighting priorities over other test results when everything is posted in a channel.

#### Ticket Link
Jira ticket - https://mattermost.atlassian.net/browse/MM-25527

#### Screenshots:
__Partial View:__
<img width="785" alt="Screen Shot 2020-05-26 at 6 19 19 PM" src="https://user-images.githubusercontent.com/5334504/82889596-905d8d80-9f7d-11ea-96fb-3b784b228f01.png">

__Full View:__
<img width="783" alt="Screen Shot 2020-05-26 at 6 19 38 PM" src="https://user-images.githubusercontent.com/5334504/82889623-9a7f8c00-9f7d-11ea-86c2-fe0c7812c68e.png">
