### PR TITLE
E2E: Quick fix on failing tests in LDAP

### DIFF
--- a/e2e/cypress/integration/enterprise/ldap_group/search_channels_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/search_channels_spec.js
@@ -10,7 +10,7 @@
 // Stage: @prod
 // Group: @enterprise @ldap_group
 
-import uuid from 'uuid/v4';
+import {v4 as uuidv4} from 'uuid';
 const PAGE_SIZE = 10;
 
 describe('Search channels', () => {
@@ -40,7 +40,7 @@ describe('Search channels', () => {
     });
 
     it('returns results', function() {
-        const displayName = uuid();
+        const displayName = uuidv4();
         cy.apiGetTeams().then((response) => {
             const teamID = response.body[0].id;
 
@@ -58,7 +58,7 @@ describe('Search channels', () => {
     });
 
     it('results are paginated', function() {
-        const displayName = uuid();
+        const displayName = uuidv4();
         cy.apiGetTeams().then((response) => {
             const teamID = response.body[0].id;
 
@@ -84,7 +84,7 @@ describe('Search channels', () => {
     });
 
     it('clears the results when "x" is clicked', function() {
-        const displayName = uuid();
+        const displayName = uuidv4();
         cy.apiGetTeams().then((response) => {
             const teamID = response.body[0].id;
 
@@ -111,7 +111,7 @@ describe('Search channels', () => {
     });
 
     it('clears the results when the search term is deleted with backspace', function() {
-        const displayName = uuid();
+        const displayName = uuidv4();
         cy.apiGetTeams().then((response) => {
             const teamID = response.body[0].id;
 

--- a/e2e/cypress/integration/enterprise/teams/search_teams_spec.js
+++ b/e2e/cypress/integration/enterprise/teams/search_teams_spec.js
@@ -10,7 +10,7 @@
 // Stage: @prod
 // Group: @enterprise @system_console
 
-import uuid from 'uuid/v4';
+import {v4 as uuidv4} from 'uuid';
 const PAGE_SIZE = 10;
 
 describe('Search teams', () => {
@@ -37,7 +37,7 @@ describe('Search teams', () => {
     });
 
     it('returns results', function() {
-        const displayName = uuid();
+        const displayName = uuidv4();
 
         // # Create a new team.
         cy.apiCreateTeam('team-search', displayName).then((response) => {
@@ -52,7 +52,7 @@ describe('Search teams', () => {
     });
 
     it('results are paginated', function() {
-        const displayName = uuid();
+        const displayName = uuidv4();
 
         // # Create enough new teams with common name prefixes to get multiple pages of search results.
         for (let i = 0; i < PAGE_SIZE + 2; i++) {
@@ -75,7 +75,7 @@ describe('Search teams', () => {
     });
 
     it('clears the results when "x" is clicked', function() {
-        const displayName = uuid();
+        const displayName = uuidv4();
 
         // # Create a new team.
         cy.apiCreateTeam('team-search', displayName).then((response) => {
@@ -99,7 +99,7 @@ describe('Search teams', () => {
     });
 
     it('clears the results when the search term is deleted with backspace', function() {
-        const displayName = uuid();
+        const displayName = uuidv4();
 
         // # Create a team.
         cy.apiCreateTeam('team-search', displayName).then((response) => {


### PR DESCRIPTION
#### Summary
Fixed on tests in LDAP due to outdated use of `uuid`.

#### Ticket Link
None
