### PR TITLE
[MM-25409] Switch to css variable for search options hover state

### DIFF
--- a/sass/components/_search.scss
+++ b/sass/components/_search.scss
@@ -267,7 +267,7 @@
     box-sizing: border-box;
 
     &.highlighted {
-        background: var(--center-channel-color-06);
+        background: var(--center-channel-color-08);
     }
 }
 
@@ -302,6 +302,6 @@
     }
 
     .search-hint__suggestions-list__option:hover {
-        background: var(--center-channel-color-06);
+        background: var(--center-channel-color-08);
     }
 }

--- a/sass/components/_search.scss
+++ b/sass/components/_search.scss
@@ -267,7 +267,7 @@
     box-sizing: border-box;
 
     &.highlighted {
-        background: rgba(61, 60, 64, 0.06);
+        background: var(--center-channel-color-06);
     }
 }
 
@@ -299,9 +299,9 @@
 
     .search-hint__suggestions-list__option:first-child {
         padding-top: 10px;
-    }    
+    }
 
     .search-hint__suggestions-list__option:hover {
-        background: rgba(61, 60, 64, 0.06);
+        background: var(--center-channel-color-06);
     }
 }

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -897,7 +897,6 @@ export function applyTheme(theme) {
             'center-channel-color-16': changeOpacity(theme.centerChannelColor, 0.16),
             'center-channel-bg-08': changeOpacity(theme.centerChannelBg, 0.08),
             'center-channel-color-08': changeOpacity(theme.centerChannelColor, 0.08),
-            'center-channel-color-06': changeOpacity(theme.centerChannelColor, 0.06),
             'center-channel-color-04': changeOpacity(theme.centerChannelColor, 0.04),
             'new-message-separator': theme.newMessageSeparator,
             'link-color': theme.linkColor,

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -897,6 +897,7 @@ export function applyTheme(theme) {
             'center-channel-color-16': changeOpacity(theme.centerChannelColor, 0.16),
             'center-channel-bg-08': changeOpacity(theme.centerChannelBg, 0.08),
             'center-channel-color-08': changeOpacity(theme.centerChannelColor, 0.08),
+            'center-channel-color-06': changeOpacity(theme.centerChannelColor, 0.06),
             'center-channel-color-04': changeOpacity(theme.centerChannelColor, 0.04),
             'new-message-separator': theme.newMessageSeparator,
             'link-color': theme.linkColor,


### PR DESCRIPTION
#### Summary
The new Search Options popout was using a static colour for the hover state.
This PR switches to using a dimmed version of the center channel colour, which works on all themes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25409