### PR TITLE
[MM-25533] Restored scrolling to autocomplete popover in search bar

### DIFF
--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -307,11 +307,10 @@
             padding: 0 0 12px;
             position: relative;
             -webkit-overflow-scrolling: touch;
-            overflow: hidden;
+            overflow-x: hidden;
 
             &::-webkit-scrollbar-track {
                 width: 0;
-                background: transparent;
             }
 
             &::-webkit-scrollbar-thumb {


### PR DESCRIPTION
#### Summary
The autocomplete popover in the search bar wasn't scrollable using a mouse, it only worked with its own keyboard navigation.

This PR brings back the scrolling to that area.

@asaadmahmood @nevyangelova Let me know if this UX is acceptable, as I wasn't sure if there was a visual reason the scrollbar was removed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25533