### PR TITLE
Fix common commands

### DIFF
--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -9,6 +9,7 @@
 
 // Group: @integrations
 
+import * as TIMEOUTS from '../../../fixtures/timeouts';
 import users from '../../../fixtures/users.json';
 
 describe('I18456 Built-in slash commands: common', () => {
@@ -22,15 +23,15 @@ describe('I18456 Built-in slash commands: common', () => {
 
         // * Suggestion list should be visible
         // # Scroll to bottom and verify that the last command "/shrug" is visible
-        cy.get('#suggestionList').should('be.visible').scrollTo('bottom').then((container) => {
-            cy.findByText(/\/away/, {container}).should('not.be.visible');
-            cy.findByText(/\/shrug/, {container}).should('be.visible');
+        cy.get('#suggestionList', {timeout: TIMEOUTS.SMALL}).should('be.visible').scrollTo('bottom').then((container) => {
+            cy.contains('/away', {container}).should('not.be.visible');
+            cy.contains('/shrug [message]', {container}).should('be.visible');
         });
 
         // # Scroll to top and verify that the first command "/away" is visible
         cy.get('#suggestionList').scrollTo('top').then((container) => {
-            cy.findByText(/\/away/, {container}).should('be.visible');
-            cy.findByText(/\/shrug/, {container}).should('not.be.visible');
+            cy.contains('/away', {container}).should('be.visible');
+            cy.contains('/shrug [message]', {container}).should('not.be.visible');
         });
     });
 


### PR DESCRIPTION
#### Summary
Fix cypress command. Use `contains` instead of `findByText` because `findByText` cannot query text that's broken up by tags

#### Ticket Link
NA