### PR TITLE
[MM-25561] Added extra padding on admin console sidebar when announcement bar is visible

### DIFF
--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -569,6 +569,7 @@
 
     body.announcement-bar--fixed & {
         top: $announcement-bar-height;
+        padding-bottom: $announcement-bar-height;
     }
 
     .dropdown-menu {


### PR DESCRIPTION
#### Summary
When the announcement bar is visible in the System Console, the sidebar is pushed down by 32px, thus cutting off the bottom-most sidebar item.

This PR adds 32px of padding to the bottom of the sidebar so that nothing can be cutoff.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25661