### PR TITLE
[MM-25685] Change out of channel msg to show X others when >3 users

### DIFF
--- a/components/post_view/post_add_channel_member/__snapshots__/post_add_channel_member.test.jsx.snap
+++ b/components/post_view/post_add_channel_member/__snapshots__/post_add_channel_member.test.jsx.snap
@@ -4,6 +4,131 @@ exports[`components/post_view/PostAddChannelMember should match snapshot, empty 
 
 exports[`components/post_view/PostAddChannelMember should match snapshot, empty postId 1`] = `""`;
 
+exports[`components/post_view/PostAddChannelMember should match snapshot, more than 3 users 1`] = `
+<Fragment>
+  <p>
+    <span>
+      <Connect(AtMention)
+        key="username_1"
+        mentionName="username_1"
+      />
+      <span
+        key="1"
+      >
+        , 
+      </span>
+      <a
+        id="post_body_other_users_link"
+        onClick={[Function]}
+      >
+        <FormattedMessage
+          defaultMessage="{numOthers} others"
+          id="post_body.check_for_out_of_channel_mentions.others"
+          values={
+            Object {
+              "numOthers": 2,
+            }
+          }
+        />
+      </a>
+      <FormattedMessage
+        defaultMessage=" and "
+        id="post_body.check_for_out_of_channel_mentions.link.and"
+        key="1"
+        values={Object {}}
+      />
+      <Connect(AtMention)
+        key="username_4"
+        mentionName="username_4"
+      />
+    </span>
+     
+    <FormattedMessage
+      defaultMessage="did not get notified by this mention because they are not in the channel. Would you like to "
+      id="post_body.check_for_out_of_channel_mentions.message.multiple"
+      values={Object {}}
+    />
+    <a
+      id="add_channel_member_link"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="add them to the channel"
+        id="post_body.check_for_out_of_channel_mentions.link.public"
+        values={Object {}}
+      />
+    </a>
+    <FormattedMessage
+      defaultMessage="? They will have access to all message history."
+      id="post_body.check_for_out_of_channel_mentions.message_last"
+      values={Object {}}
+    />
+  </p>
+</Fragment>
+`;
+
+exports[`components/post_view/PostAddChannelMember should match snapshot, more than 3 users 2`] = `
+<Fragment>
+  <p>
+    <span>
+      <Connect(AtMention)
+        key="username_1"
+        mentionName="username_1"
+      />
+      <span
+        key="1"
+      >
+        , 
+      </span>
+      <Connect(AtMention)
+        key="username_2"
+        mentionName="username_2"
+      />
+      <span
+        key="2"
+      >
+        , 
+      </span>
+      <Connect(AtMention)
+        key="username_3"
+        mentionName="username_3"
+      />
+      <FormattedMessage
+        defaultMessage=" and "
+        id="post_body.check_for_out_of_channel_mentions.link.and"
+        key="3"
+        values={Object {}}
+      />
+      <Connect(AtMention)
+        key="username_4"
+        mentionName="username_4"
+      />
+    </span>
+     
+    <FormattedMessage
+      defaultMessage="did not get notified by this mention because they are not in the channel. Would you like to "
+      id="post_body.check_for_out_of_channel_mentions.message.multiple"
+      values={Object {}}
+    />
+    <a
+      id="add_channel_member_link"
+      onClick={[Function]}
+    >
+      <FormattedMessage
+        defaultMessage="add them to the channel"
+        id="post_body.check_for_out_of_channel_mentions.link.public"
+        values={Object {}}
+      />
+    </a>
+    <FormattedMessage
+      defaultMessage="? They will have access to all message history."
+      id="post_body.check_for_out_of_channel_mentions.message_last"
+      values={Object {}}
+    />
+  </p>
+</Fragment>
+`;
+
 exports[`components/post_view/PostAddChannelMember should match snapshot, private channel 1`] = `
 <Fragment>
   <p>

--- a/components/post_view/post_add_channel_member/__snapshots__/post_add_channel_member.test.jsx.snap
+++ b/components/post_view/post_add_channel_member/__snapshots__/post_add_channel_member.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`components/post_view/PostAddChannelMember should match snapshot, more t
         , 
       </span>
       <a
-        id="post_body_other_users_link"
+        className="PostBody_otherUsersLink"
         onClick={[Function]}
       >
         <FormattedMessage
@@ -49,7 +49,7 @@ exports[`components/post_view/PostAddChannelMember should match snapshot, more t
       values={Object {}}
     />
     <a
-      id="add_channel_member_link"
+      className="PostBody_addChannelMemberLink"
       onClick={[Function]}
     >
       <FormattedMessage
@@ -111,7 +111,7 @@ exports[`components/post_view/PostAddChannelMember should match snapshot, more t
       values={Object {}}
     />
     <a
-      id="add_channel_member_link"
+      className="PostBody_addChannelMemberLink"
       onClick={[Function]}
     >
       <FormattedMessage
@@ -142,7 +142,7 @@ exports[`components/post_view/PostAddChannelMember should match snapshot, privat
       values={Object {}}
     />
     <a
-      id="add_channel_member_link"
+      className="PostBody_addChannelMemberLink"
       onClick={[Function]}
     >
       <FormattedMessage
@@ -173,7 +173,7 @@ exports[`components/post_view/PostAddChannelMember should match snapshot, public
       values={Object {}}
     />
     <a
-      id="add_channel_member_link"
+      className="PostBody_addChannelMemberLink"
       onClick={[Function]}
     >
       <FormattedMessage
@@ -204,7 +204,7 @@ exports[`components/post_view/PostAddChannelMember should match snapshot, with n
       values={Object {}}
     />
     <a
-      id="add_channel_member_link"
+      className="PostBody_addChannelMemberLink"
       onClick={[Function]}
     >
       <FormattedMessage

--- a/components/post_view/post_add_channel_member/post_add_channel_member.jsx
+++ b/components/post_view/post_add_channel_member/post_add_channel_member.jsx
@@ -141,7 +141,7 @@ export default class PostAddChannelMember extends React.PureComponent {
                     />
                     {commaSeparator(1)}
                     <a
-                        id='post_body_other_users_link'
+                        className='PostBody_otherUsersLink'
                         onClick={this.expand}
                     >
                         <FormattedMessage
@@ -212,7 +212,7 @@ export default class PostAddChannelMember extends React.PureComponent {
                         defaultMessage={outOfChannelMessageText}
                     />
                     <a
-                        id='add_channel_member_link'
+                        className='PostBody_addChannelMemberLink'
                         onClick={this.handleAddChannelMember}
                     >
                         <FormattedMessage

--- a/components/post_view/post_add_channel_member/post_add_channel_member.jsx
+++ b/components/post_view/post_add_channel_member/post_add_channel_member.jsx
@@ -11,6 +11,14 @@ import {t} from 'utils/i18n';
 import AtMention from 'components/at_mention';
 
 export default class PostAddChannelMember extends React.PureComponent {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            expanded: false,
+        };
+    }
+
     static propTypes = {
 
         /*
@@ -74,6 +82,10 @@ export default class PostAddChannelMember extends React.PureComponent {
         }
     }
 
+    expand = () => {
+        this.setState({expanded: true});
+    }
+
     generateAtMentions(usernames = []) {
         if (usernames.length === 1) {
             return (
@@ -94,26 +106,57 @@ export default class PostAddChannelMember extends React.PureComponent {
                 return <span key={key}>{', '}</span>;
             }
 
+            if (this.state.expanded || usernames.length <= 3) {
+                return (
+                    <span>
+                        {
+                            usernames.map((username) => {
+                                return (
+                                    <AtMention
+                                        key={username}
+                                        mentionName={username}
+                                    />
+                                );
+                            }).reduce((acc, el, idx, arr) => {
+                                if (idx === 0) {
+                                    return [el];
+                                } else if (idx === arr.length - 1) {
+                                    return [...acc, andSeparator(idx), el];
+                                }
+
+                                return [...acc, commaSeparator(idx), el];
+                            }, [])
+                        }
+                    </span>
+                );
+            }
+            const otherUsers = [...usernames];
+            const firstUserName = otherUsers.shift();
+            const lastUserName = otherUsers.pop();
             return (
                 <span>
-                    {
-                        usernames.map((username) => {
-                            return (
-                                <AtMention
-                                    key={username}
-                                    mentionName={username}
-                                />
-                            );
-                        }).reduce((acc, el, idx, arr) => {
-                            if (idx === 0) {
-                                return [el];
-                            } else if (idx === arr.length - 1) {
-                                return [...acc, andSeparator(idx), el];
-                            }
-
-                            return [...acc, commaSeparator(idx), el];
-                        }, [])
-                    }
+                    <AtMention
+                        key={firstUserName}
+                        mentionName={firstUserName}
+                    />
+                    {commaSeparator(1)}
+                    <a
+                        id='post_body_other_users_link'
+                        onClick={this.expand}
+                    >
+                        <FormattedMessage
+                            id={'post_body.check_for_out_of_channel_mentions.others'}
+                            defaultMessage={'{numOthers} others'}
+                            values={{
+                                numOthers: otherUsers.length,
+                            }}
+                        />
+                    </a>
+                    {andSeparator(1)}
+                    <AtMention
+                        key={lastUserName}
+                        mentionName={lastUserName}
+                    />
                 </span>
             );
         }

--- a/components/post_view/post_add_channel_member/post_add_channel_member.test.jsx
+++ b/components/post_view/post_add_channel_member/post_add_channel_member.test.jsx
@@ -68,6 +68,24 @@ describe('components/post_view/PostAddChannelMember', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should match snapshot, more than 3 users', () => {
+        const userIds = ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4'];
+        const usernames = ['username_1', 'username_2', 'username_3', 'username_4'];
+        const props = {
+            ...requiredProps,
+            userIds,
+            usernames,
+        };
+
+        const wrapper = shallow(<PostAddChannelMember {...props}/>);
+        expect(wrapper.state('expanded')).toEqual(false);
+        expect(wrapper).toMatchSnapshot();
+
+        wrapper.find('#post_body_other_users_link').simulate('click');
+        expect(wrapper.state('expanded')).toEqual(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('actions should have been called', () => {
         const actions = {
             removePost: jest.fn(),
@@ -78,7 +96,7 @@ describe('components/post_view/PostAddChannelMember', () => {
             <PostAddChannelMember {...props}/>,
         );
 
-        wrapper.find('a').simulate('click');
+        wrapper.find('#add_channel_member_link').simulate('click');
 
         expect(actions.addChannelMember).toHaveBeenCalledTimes(1);
         expect(actions.addChannelMember).toHaveBeenCalledWith(post.channel_id, requiredProps.userIds[0]);
@@ -100,7 +118,7 @@ describe('components/post_view/PostAddChannelMember', () => {
             <PostAddChannelMember {...props}/>,
         );
 
-        wrapper.find('a').simulate('click');
+        wrapper.find('#add_channel_member_link').simulate('click');
         expect(actions.addChannelMember).toHaveBeenCalledTimes(4);
     });
 

--- a/components/post_view/post_add_channel_member/post_add_channel_member.test.jsx
+++ b/components/post_view/post_add_channel_member/post_add_channel_member.test.jsx
@@ -81,7 +81,7 @@ describe('components/post_view/PostAddChannelMember', () => {
         expect(wrapper.state('expanded')).toEqual(false);
         expect(wrapper).toMatchSnapshot();
 
-        wrapper.find('#post_body_other_users_link').simulate('click');
+        wrapper.find('.PostBody_otherUsersLink').simulate('click');
         expect(wrapper.state('expanded')).toEqual(true);
         expect(wrapper).toMatchSnapshot();
     });
@@ -96,7 +96,7 @@ describe('components/post_view/PostAddChannelMember', () => {
             <PostAddChannelMember {...props}/>,
         );
 
-        wrapper.find('#add_channel_member_link').simulate('click');
+        wrapper.find('.PostBody_addChannelMemberLink').simulate('click');
 
         expect(actions.addChannelMember).toHaveBeenCalledTimes(1);
         expect(actions.addChannelMember).toHaveBeenCalledWith(post.channel_id, requiredProps.userIds[0]);
@@ -118,7 +118,7 @@ describe('components/post_view/PostAddChannelMember', () => {
             <PostAddChannelMember {...props}/>,
         );
 
-        wrapper.find('#add_channel_member_link').simulate('click');
+        wrapper.find('.PostBody_addChannelMemberLink').simulate('click');
         expect(actions.addChannelMember).toHaveBeenCalledTimes(4);
     });
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3061,6 +3061,7 @@
   "post_body.check_for_out_of_channel_mentions.message_last": "? They will have access to all message history.",
   "post_body.check_for_out_of_channel_mentions.message.multiple": "did not get notified by this mention because they are not in the channel. Would you like to ",
   "post_body.check_for_out_of_channel_mentions.message.one": "did not get notified by this mention because they are not in the channel. Would you like to ",
+  "post_body.check_for_out_of_channel_mentions.others": "{numOthers} others",
   "post_body.commentedOn": "Commented on {name}'s message: ",
   "post_body.deleted": "(message deleted)",
   "post_body.plusMore": " plus {count, number} other {count, plural, one {file} other {files}}",


### PR DESCRIPTION
#### Summary
- When a large number of out of channel group members is mentioned it should not show the text as expanded by default, this fixes that.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25685

#### Screenshots
![Screen Shot 2020-06-01 at 4 12 25 PM](https://user-images.githubusercontent.com/3207297/83451107-73fd9d00-a424-11ea-8591-dec3aca7f7fd.png)