### PR TITLE
MM-25557 Fix &nbsp; appearing in the View Members modal

### DIFF
--- a/components/user_list_row/user_list_row.jsx
+++ b/components/user_list_row/user_list_row.jsx
@@ -106,10 +106,10 @@ export default class UserListRow extends React.PureComponent {
                             hasMention={true}
                             displayUsername={true}
                         />
-                        {'&nbsp;'}
+                        &nbsp;
                         {this.props.user.first_name || this.props.user.last_name || this.props.user.nickname ?
                             '-' : null}
-                        {'&nbsp;'}
+                        &nbsp;
                         {Utils.displayFullAndNicknameForUser(this.props.user)}
                     </div>
                     <div


### PR DESCRIPTION
I forget why I wrapped those in a string during the ESLint changes, but that was clearly the wrong thing to do since React automatically escapes HTML entities appearing in strings.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25557