### PR TITLE
MM-24754 - Incident icon on the header closes RHS if clicked while viewing reply thread

### DIFF
--- a/reducers/views/rhs.js
+++ b/reducers/views/rhs.js
@@ -115,6 +115,8 @@ function searchTerms(state = '', action) {
 function pluggableId(state = '', action) {
     switch (action.type) {
     case ActionTypes.UPDATE_RHS_STATE:
+    case ActionTypes.SELECT_POST:
+    case ActionTypes.SELECT_POST_CARD:
         if (action.state === RHSStates.PLUGIN) {
             return action.pluggableId;
         }

--- a/reducers/views/rhs.test.js
+++ b/reducers/views/rhs.test.js
@@ -107,6 +107,50 @@ describe('Reducers.RHS', () => {
         });
     });
 
+    test(`should wipe pluggableId on ${ActionTypes.SELECT_POST}`, () => {
+        const nextState = rhsReducer(
+            {
+                pluggableId: 'pluggableId',
+            },
+            {
+                type: ActionTypes.SELECT_POST,
+                postId: '123',
+                channelId: '321',
+                timestamp: 1234,
+            },
+        );
+
+        expect(nextState).toEqual({
+            ...initialState,
+            pluggableId: '',
+            selectedPostId: '123',
+            selectedPostFocussedAt: 1234,
+            selectedChannelId: '321',
+            isSidebarOpen: true,
+        });
+    });
+
+    test(`should wipe pluggableId on ${ActionTypes.SELECT_POST_CARD}`, () => {
+        const nextState = rhsReducer(
+            {
+                pluggableId: 'pluggableId',
+            },
+            {
+                type: ActionTypes.SELECT_POST_CARD,
+                postId: '123',
+                channelId: '321',
+            },
+        );
+
+        expect(nextState).toEqual({
+            ...initialState,
+            pluggableId: '',
+            selectedPostCardId: '123',
+            selectedChannelId: '321',
+            isSidebarOpen: true,
+        });
+    });
+
     test('should match isSearchingFlaggedPost state to true', () => {
         const nextState = rhsReducer(
             {},


### PR DESCRIPTION
#### Summary
* Clearing out `pluggableId` state on `rhsReducer` when `SELECT_POST_CARD` or `SELECT_POST` dispatched.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-24754

#### Screenshots
![Jun-03-2020 15-53-20](https://user-images.githubusercontent.com/25732808/83682782-670eb400-a5b2-11ea-9d0d-dee9b81b618e.gif)