### PR TITLE
Fix hotkeys, user status commands, leave channel specs

### DIFF
--- a/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
@@ -104,12 +104,12 @@ describe('Channel switching', () => {
         cy.get('body').type(cmdOrCtrl, {release: false}).type('k').type(cmdOrCtrl, {release: true});
 
         // * Verify that the modal has been opened
-        cy.get('.channel-switch__modal').should('be.visible');
+        cy.get('.channel-switcher').should('be.visible');
 
         // # Press ctrl/cmd + k
         cy.get('body').type(cmdOrCtrl, {release: false}).type('k').type(cmdOrCtrl, {release: true});
 
         // * Verify that the modal has been closed
-        cy.get('.channel-switch__modal').should('not.be.visible');
+        cy.get('.channel-switcher').should('not.be.visible');
     });
 });

--- a/e2e/cypress/integration/integrations/builtin_commands/user_status_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/user_status_commands_spec.js
@@ -50,7 +50,7 @@ describe('Integrations', () => {
             // # Verify that the suggestion list is visible
             cy.get('#suggestionList').should('be.visible').then((container) => {
                 // # Find command and click
-                cy.findByText(new RegExp(testCase.command), {container}).click({force: true});
+                cy.contains(new RegExp(testCase.command), {container}).click({force: true});
             });
 
             // # Hit enter and verify user status

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -105,7 +105,7 @@ function isMac() {
 // ***********************************************************
 
 Cypress.Commands.add('postMessage', (message) => {
-    cy.get('#post_textbox', {timeout: TIMEOUTS.LARGE}).clear().type(message).type('{enter}');
+    cy.get('#post_textbox', {timeout: TIMEOUTS.LARGE}).clear().type(`${message}{enter}`);
     cy.waitUntil(() => {
         return cy.get('#post_textbox').then((el) => {
             return el[0].textContent === '';
@@ -114,7 +114,7 @@ Cypress.Commands.add('postMessage', (message) => {
 });
 
 Cypress.Commands.add('postMessageReplyInRHS', (message) => {
-    cy.get('#reply_textbox').should('be.visible').clear().type(message).type('{enter}');
+    cy.get('#reply_textbox').should('be.visible').clear().type(`${message}{enter}`);
     cy.wait(TIMEOUTS.TINY);
 });
 


### PR DESCRIPTION
#### Summary
- hotkeys - fix class selector
- user status commands - replace `findByText` with `contains` since text is broken up with tags
- leave channel - made sure `{enter}` is part of message and not a separate command; a slash command message without immediate `{enter}` brings up autocomplete which brings focus out of post text box, hence, the test failure

#### Ticket Link
NA