### PR TITLE
[] - Fix preloading of icons for really slow connections

### DIFF
--- a/root.html
+++ b/root.html
@@ -17,6 +17,9 @@
     <link rel="icon" type="image/png" href="/static/images/favicon/favicon-32x32.png" sizes="32x32">
     <link rel="icon" type="image/png" href="/static/images/favicon/favicon-96x96.png" sizes="96x96">
 
+    <link rel="preload" as="font" href="/fonts/mattermosticons/mattermosticons.eot?16343536" type="font" crossorigin="anonymous">
+    <link rel="preload" as="font" href="/fonts/mattermosticons/mattermosticons.eot?16343536#iefix" type="font/embedded-opentype" crossorigin="anonymous">
+
     <!-- CSS Should always go first -->
     <link rel='stylesheet' class='code_theme'>
     <style>


### PR DESCRIPTION

#### Summary
 On very slow connections there is a glitch in the search icon when the initial fonts haven't been loaded. this fixes the issue for me. 

#### Test case
 1. Load webapp with a very slow connection (slow 3g), you can find that in the inspector, network tab, dropdown usually says 'online'
 2. Verify that the icon is present immediately when you click on the search field.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25534
