### PR TITLE
MM-25768 Add typings to Cypress custom commands for quick reference via IDE intellisense

### DIFF
--- a/e2e/cypress/support/api_commands.d.ts
+++ b/e2e/cypress/support/api_commands.d.ts
@@ -1,0 +1,219 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Description
+// - Specific link to https://api.mattermost.com
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// ***************************************************************
+
+declare namespace Cypress {
+  type Bot = import('mattermost-redux/types/bots').Bot;
+  type Channel = import('mattermost-redux/types/channels').Channel;
+  type ChannelMembership = import('mattermost-redux/types/channels').ChannelMembership;
+  type ChannelType = import('mattermost-redux/types/channels').ChannelType;
+  type UserProfile = import('mattermost-redux/types/users').UserProfile;
+
+  interface Chainable<Subject = any> {
+    // *******************************************************************************
+    // Bots
+    // https://api.mattermost.com/#tag/bots
+    // *******************************************************************************
+
+    /**
+     * Get a page of a list of bots via API.
+     * See https://api.mattermost.com/#tag/bots/paths/~1bots/get
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+     * @returns {Bot} response.body: `Bot` object
+     * 
+     * @example
+     *   cy.apiGetBots().then((response) => {
+     *       const bots = response.body;
+     *   });
+     */
+    apiGetBots(): Chainable<Response>;
+
+    // *******************************************************************************
+    // Channels
+    // https://api.mattermost.com/#tag/channels
+    // *******************************************************************************
+
+    /**
+     * Create a new direct message channel between two users via API.
+     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1direct/post
+     * @param {string} teamId - The team ID of the team to create the channel on
+     * @param {string} name - The unique handle for the channel, will be present in the channel URL
+     * @param {string} displayName - The non-unique UI name for the channel
+     * @param {ChannelType} type - 'O' for a public channel (default), 'P' for a private channel
+     * @param {string} purpose - A short description of the purpose of the channel
+     * @param {string} header - Markdown-formatted text to display in the header of the channel
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 201 CREATED to continue or pass.
+     * @returns {Channel} response.body: `Channel` object
+     * 
+     * @example
+     *   cy.apiCreateChannel('team-id', 'channel-name', 'channel-display-name').then((response) => {
+     *     const newChannel = response.body;
+     *   });
+     */
+    apiCreateChannel(
+      teamId: string,
+      name: string,
+      displayName: string,
+      type: ChannelType,
+      purpose?: string,
+      header?: string
+    ): Chainable<Response>;
+
+    /**
+     * Create a new direct message channel between two users.
+     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1direct/post
+     * @param {string[]} userIds - The two user ids to be in the direct message
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 201 CREATED to continue or pass.
+     * @returns {Channel} response.body: `Channel` object
+     * 
+     * @example
+     *   cy.apiCreateDirectChannel('user-1-id', 'user-2-id').then((response) => {
+     *     const newDMChannel = response.body;
+     *   });
+     */
+    apiCreateDirectChannel(userIds: Array<string>): Chainable<Response>;
+
+    /**
+     * Create a new group message channel to group of users via API. If the logged in user's id is not included in the list, it will be appended to the end.
+     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1group/post
+     * @param {string[]} userIds - User ids to be in the group message channel
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 201 CREATED to continue or pass.
+     * @returns {Channel} response.body: `Channel` object
+     * @example
+     *   cy.apiCreateGroupChannel('user-1-id', 'user-2-id', 'current-user-id').then((response) => {
+     *     const newGroupChannel = response.body;
+     *   });
+     */
+    apiCreateGroupChannel(userIds: Array<string>): Chainable<Response>;
+
+    /**
+     * Soft deletes a channel, by marking the channel as deleted in the database.
+     * Soft deleted channels will not be accessible in the user interface.
+     * Direct and group message channels cannot be deleted.
+     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}/delete
+     * @param {string} channelId - The channel ID to be deleted
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+     * @example
+     *   cy.apiDeleteChannel('channel-id');
+     */
+    apiDeleteChannel(channelId: string): Chainable<Response>;
+
+    /**
+     * Update a channel.
+     * The fields that can be updated are listed as parameters. Omitted fields will be treated as blanks.
+     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}/put
+     * @param {string} channelId - The channel ID to be updated
+     * @param {Channel} channel - Channel object to be updated
+     * @param {string} channel.name - The unique handle for the channel, will be present in the channel URL
+     * @param {string} channel.display_name - The non-unique UI name for the channel
+     * @param {string} channel.purpose - A short description of the purpose of the channel
+     * @param {string} channel.header - Markdown-formatted text to display in the header of the channel
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+     * @returns {Channel} response.body: `Channel` object
+     * @example
+     *   cy.apiUpdateChannel('channel-id', {name: 'new-name', display_name: 'New Display Name'. 'purpose': 'Updated purpose', 'header': 'Updated header'});
+     */
+    apiUpdateChannel(channelId: string, channel: Channel): Chainable<Response>;
+
+    /**
+     * Partially update a channel by providing only the fields you want to update.
+     * Omitted fields will not be updated.
+     * The fields that can be updated are defined in the request body, all other provided fields will be ignored.
+     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}~1patch/put
+     * @param {string} channelId - The channel ID to be patched
+     * @param {Channel} channel - Channel object to be patched
+     * @param {string} channel.name - The unique handle for the channel, will be present in the channel URL
+     * @param {string} channel.display_name - The non-unique UI name for the channel
+     * @param {string} channel.purpose - A short description of the purpose of the channel
+     * @param {string} channel.header - Markdown-formatted text to display in the header of the channel
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+     * @returns {Channel} response.body: `Channel` object
+     * @example
+     *   cy.apiPatchChannel('channel-id', {name: 'new-name', display_name: 'New Display Name'});
+     */
+    apiPatchChannel(channelId: string, channel: Channel): Chainable<Response>;
+
+    /**
+     * Gets a channel from the provided team name and channel name strings.
+     * See https://api.mattermost.com/#tag/channels/paths/~1teams~1name~1{team_name}~1channels~1name~1{channel_name}/get
+     * @param {string} teamName - Team name
+     * @param {string} channelName - Channel name
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+     * @returns {Channel} response.body: `Channel` object
+     * @example
+     *   cy.apiGetChannelByName('team-name', 'channel-name').then((response) => {
+     *     const channel = response.body;
+     *   });
+     */
+    apiGetChannelByName(
+      teamName: string,
+      channelName: string
+    ): Chainable<Response>;
+
+    /**
+     * Get channel from the provided channel id string.
+     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}/get
+     * @param {string} channelId - Channel ID
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+     * @returns {Channel} response.body: `Channel` object
+     * @example
+     *   cy.apiGetChannel('channel-id').then((response) => {
+     *     const channel = response.body;
+     *   });
+     */
+    apiGetChannel(channelId: string): Chainable<Response>;
+
+    /**
+     * Add a user to a channel by creating a channel member object.
+     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}~1members/post
+     * @param {string} channelId - Channel ID
+     * @param {string} userId - User ID to add to the channel
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+     * @returns {ChannelMembership} response.body: `ChannelMembership` object
+     * @example
+     *   cy.apiAddUserToChannel('channel-id', 'user-id').then((response) => {
+     *     const channelMember = response.body;
+     *   });
+     */
+    apiAddUserToChannel(channelId: string, userId: string): Chainable<Response>;
+
+
+    // *******************************************************************************
+    // Users
+    // https://api.mattermost.com/#tag/users
+    // *******************************************************************************
+
+    /**
+     * Login to server via API.
+     * See https://api.mattermost.com/#tag/users/paths/~1users~1login/post
+     * @param {string} username
+     * @param {string} password
+     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+     * @returns {UserProfile} response.body: `UserProfile` object
+     * @example
+     *   cy.apiLogin('sysadmin');
+     */
+    apiLogin(username: string, password?: string): Chainable<Response>;
+
+    /**
+     * Logout a user's active session from server via API
+     * https://api.mattermost.com/#tag/users/paths/~1users~1logout/post
+     * Clears all cookies espececially `MMAUTHTOKEN`, `MMUSERID` and `MMCSRF`.
+     * @example
+     *   cy.apiLogout();
+     */
+    apiLogout();
+  }
+}

--- a/e2e/cypress/support/api_commands.d.ts
+++ b/e2e/cypress/support/api_commands.d.ts
@@ -15,205 +15,210 @@
 // ***************************************************************
 
 declare namespace Cypress {
-  type Bot = import('mattermost-redux/types/bots').Bot;
-  type Channel = import('mattermost-redux/types/channels').Channel;
-  type ChannelMembership = import('mattermost-redux/types/channels').ChannelMembership;
-  type ChannelType = import('mattermost-redux/types/channels').ChannelType;
-  type UserProfile = import('mattermost-redux/types/users').UserProfile;
+    type Bot = import('mattermost-redux/types/bots').Bot;
+    type Channel = import('mattermost-redux/types/channels').Channel;
+    type ChannelMembership = import('mattermost-redux/types/channels').ChannelMembership;
+    type ChannelType = import('mattermost-redux/types/channels').ChannelType;
+    type UserProfile = import('mattermost-redux/types/users').UserProfile;
 
-  interface Chainable<Subject = any> {
-    // *******************************************************************************
-    // Bots
-    // https://api.mattermost.com/#tag/bots
-    // *******************************************************************************
+    interface Chainable<Subject = any> {
 
-    /**
-     * Get a page of a list of bots via API.
-     * See https://api.mattermost.com/#tag/bots/paths/~1bots/get
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
-     * @returns {Bot} response.body: `Bot` object
-     * 
-     * @example
-     *   cy.apiGetBots().then((response) => {
-     *       const bots = response.body;
-     *   });
-     */
-    apiGetBots(): Chainable<Response>;
+        // *******************************************************************************
+        // Bots
+        // https://api.mattermost.com/#tag/bots
+        // *******************************************************************************
 
-    // *******************************************************************************
-    // Channels
-    // https://api.mattermost.com/#tag/channels
-    // *******************************************************************************
+        /**
+         * Get a page of a list of bots via API.
+         * See https://api.mattermost.com/#tag/bots/paths/~1bots/get
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+         * @returns {Bot} response.body: `Bot` object
+         *
+         * @example
+         *   cy.apiGetBots().then((response) => {
+         *       const bots = response.body;
+         *   });
+         */
+        apiGetBots(): Chainable<Response>;
 
-    /**
-     * Create a new direct message channel between two users via API.
-     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1direct/post
-     * @param {string} teamId - The team ID of the team to create the channel on
-     * @param {string} name - The unique handle for the channel, will be present in the channel URL
-     * @param {string} displayName - The non-unique UI name for the channel
-     * @param {ChannelType} type - 'O' for a public channel (default), 'P' for a private channel
-     * @param {string} purpose - A short description of the purpose of the channel
-     * @param {string} header - Markdown-formatted text to display in the header of the channel
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 201 CREATED to continue or pass.
-     * @returns {Channel} response.body: `Channel` object
-     * 
-     * @example
-     *   cy.apiCreateChannel('team-id', 'channel-name', 'channel-display-name').then((response) => {
-     *     const newChannel = response.body;
-     *   });
-     */
-    apiCreateChannel(
-      teamId: string,
-      name: string,
-      displayName: string,
-      type: ChannelType,
-      purpose?: string,
-      header?: string
-    ): Chainable<Response>;
+        // *******************************************************************************
+        // Channels
+        // https://api.mattermost.com/#tag/channels
+        // *******************************************************************************
 
-    /**
-     * Create a new direct message channel between two users.
-     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1direct/post
-     * @param {string[]} userIds - The two user ids to be in the direct message
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 201 CREATED to continue or pass.
-     * @returns {Channel} response.body: `Channel` object
-     * 
-     * @example
-     *   cy.apiCreateDirectChannel('user-1-id', 'user-2-id').then((response) => {
-     *     const newDMChannel = response.body;
-     *   });
-     */
-    apiCreateDirectChannel(userIds: Array<string>): Chainable<Response>;
+        /**
+         * Create a new direct message channel between two users via API.
+         * See https://api.mattermost.com/#tag/channels/paths/~1channels~1direct/post
+         * @param {string} teamId - The team ID of the team to create the channel on
+         * @param {string} name - The unique handle for the channel, will be present in the channel URL
+         * @param {string} displayName - The non-unique UI name for the channel
+         * @param {ChannelType} type - 'O' for a public channel (default), 'P' for a private channel
+         * @param {string} purpose - A short description of the purpose of the channel
+         * @param {string} header - Markdown-formatted text to display in the header of the channel
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 201 CREATED to continue or pass.
+         * @returns {Channel} response.body: `Channel` object
+         *
+         * @example
+         *   cy.apiCreateChannel('team-id', 'channel-name', 'channel-display-name').then((response) => {
+         *     const newChannel = response.body;
+         *   });
+         */
+        apiCreateChannel(
+            teamId: string,
+            name: string,
+            displayName: string,
+            type: ChannelType,
+            purpose?: string,
+            header?: string
+        ): Chainable<Response>;
 
-    /**
-     * Create a new group message channel to group of users via API. If the logged in user's id is not included in the list, it will be appended to the end.
-     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1group/post
-     * @param {string[]} userIds - User ids to be in the group message channel
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 201 CREATED to continue or pass.
-     * @returns {Channel} response.body: `Channel` object
-     * @example
-     *   cy.apiCreateGroupChannel('user-1-id', 'user-2-id', 'current-user-id').then((response) => {
-     *     const newGroupChannel = response.body;
-     *   });
-     */
-    apiCreateGroupChannel(userIds: Array<string>): Chainable<Response>;
+        /**
+         * Create a new direct message channel between two users.
+         * See https://api.mattermost.com/#tag/channels/paths/~1channels~1direct/post
+         * @param {string[]} userIds - The two user ids to be in the direct message
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 201 CREATED to continue or pass.
+         * @returns {Channel} response.body: `Channel` object
+         *
+         * @example
+         *   cy.apiCreateDirectChannel('user-1-id', 'user-2-id').then((response) => {
+         *     const newDMChannel = response.body;
+         *   });
+         */
+        apiCreateDirectChannel(userIds: Array<string>): Chainable<Response>;
 
-    /**
-     * Soft deletes a channel, by marking the channel as deleted in the database.
-     * Soft deleted channels will not be accessible in the user interface.
-     * Direct and group message channels cannot be deleted.
-     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}/delete
-     * @param {string} channelId - The channel ID to be deleted
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
-     * @example
-     *   cy.apiDeleteChannel('channel-id');
-     */
-    apiDeleteChannel(channelId: string): Chainable<Response>;
+        /**
+         * Create a new group message channel to group of users via API. If the logged in user's id is not included in the list, it will be appended to the end.
+         * See https://api.mattermost.com/#tag/channels/paths/~1channels~1group/post
+         * @param {string[]} userIds - User ids to be in the group message channel
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 201 CREATED to continue or pass.
+         * @returns {Channel} response.body: `Channel` object
+         * @example
+         *   cy.apiCreateGroupChannel('user-1-id', 'user-2-id', 'current-user-id').then((response) => {
+         *     const newGroupChannel = response.body;
+         *   });
+         */
+        apiCreateGroupChannel(userIds: Array<string>): Chainable<Response>;
 
-    /**
-     * Update a channel.
-     * The fields that can be updated are listed as parameters. Omitted fields will be treated as blanks.
-     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}/put
-     * @param {string} channelId - The channel ID to be updated
-     * @param {Channel} channel - Channel object to be updated
-     * @param {string} channel.name - The unique handle for the channel, will be present in the channel URL
-     * @param {string} channel.display_name - The non-unique UI name for the channel
-     * @param {string} channel.purpose - A short description of the purpose of the channel
-     * @param {string} channel.header - Markdown-formatted text to display in the header of the channel
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
-     * @returns {Channel} response.body: `Channel` object
-     * @example
-     *   cy.apiUpdateChannel('channel-id', {name: 'new-name', display_name: 'New Display Name'. 'purpose': 'Updated purpose', 'header': 'Updated header'});
-     */
-    apiUpdateChannel(channelId: string, channel: Channel): Chainable<Response>;
+        /**
+         * Soft deletes a channel, by marking the channel as deleted in the database.
+         * Soft deleted channels will not be accessible in the user interface.
+         * Direct and group message channels cannot be deleted.
+         * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}/delete
+         * @param {string} channelId - The channel ID to be deleted
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+         *
+         * @example
+         *   cy.apiDeleteChannel('channel-id');
+         */
+        apiDeleteChannel(channelId: string): Chainable<Response>;
 
-    /**
-     * Partially update a channel by providing only the fields you want to update.
-     * Omitted fields will not be updated.
-     * The fields that can be updated are defined in the request body, all other provided fields will be ignored.
-     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}~1patch/put
-     * @param {string} channelId - The channel ID to be patched
-     * @param {Channel} channel - Channel object to be patched
-     * @param {string} channel.name - The unique handle for the channel, will be present in the channel URL
-     * @param {string} channel.display_name - The non-unique UI name for the channel
-     * @param {string} channel.purpose - A short description of the purpose of the channel
-     * @param {string} channel.header - Markdown-formatted text to display in the header of the channel
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
-     * @returns {Channel} response.body: `Channel` object
-     * @example
-     *   cy.apiPatchChannel('channel-id', {name: 'new-name', display_name: 'New Display Name'});
-     */
-    apiPatchChannel(channelId: string, channel: Channel): Chainable<Response>;
+        /**
+         * Update a channel.
+         * The fields that can be updated are listed as parameters. Omitted fields will be treated as blanks.
+         * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}/put
+         * @param {string} channelId - The channel ID to be updated
+         * @param {Channel} channel - Channel object to be updated
+         * @param {string} channel.name - The unique handle for the channel, will be present in the channel URL
+         * @param {string} channel.display_name - The non-unique UI name for the channel
+         * @param {string} channel.purpose - A short description of the purpose of the channel
+         * @param {string} channel.header - Markdown-formatted text to display in the header of the channel
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+         * @returns {Channel} response.body: `Channel` object
+         *
+         * @example
+         *   cy.apiUpdateChannel('channel-id', {name: 'new-name', display_name: 'New Display Name'. 'purpose': 'Updated purpose', 'header': 'Updated header'});
+         */
+        apiUpdateChannel(channelId: string, channel: Channel): Chainable<Response>;
 
-    /**
-     * Gets a channel from the provided team name and channel name strings.
-     * See https://api.mattermost.com/#tag/channels/paths/~1teams~1name~1{team_name}~1channels~1name~1{channel_name}/get
-     * @param {string} teamName - Team name
-     * @param {string} channelName - Channel name
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
-     * @returns {Channel} response.body: `Channel` object
-     * @example
-     *   cy.apiGetChannelByName('team-name', 'channel-name').then((response) => {
-     *     const channel = response.body;
-     *   });
-     */
-    apiGetChannelByName(
-      teamName: string,
-      channelName: string
-    ): Chainable<Response>;
+        /**
+         * Partially update a channel by providing only the fields you want to update.
+         * Omitted fields will not be updated.
+         * The fields that can be updated are defined in the request body, all other provided fields will be ignored.
+         * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}~1patch/put
+         * @param {string} channelId - The channel ID to be patched
+         * @param {Channel} channel - Channel object to be patched
+         * @param {string} channel.name - The unique handle for the channel, will be present in the channel URL
+         * @param {string} channel.display_name - The non-unique UI name for the channel
+         * @param {string} channel.purpose - A short description of the purpose of the channel
+         * @param {string} channel.header - Markdown-formatted text to display in the header of the channel
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+         * @returns {Channel} response.body: `Channel` object
+         *
+         * @example
+         *   cy.apiPatchChannel('channel-id', {name: 'new-name', display_name: 'New Display Name'});
+         */
+        apiPatchChannel(channelId: string, channel: Channel): Chainable<Response>;
 
-    /**
-     * Get channel from the provided channel id string.
-     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}/get
-     * @param {string} channelId - Channel ID
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
-     * @returns {Channel} response.body: `Channel` object
-     * @example
-     *   cy.apiGetChannel('channel-id').then((response) => {
-     *     const channel = response.body;
-     *   });
-     */
-    apiGetChannel(channelId: string): Chainable<Response>;
+        /**
+         * Gets a channel from the provided team name and channel name strings.
+         * See https://api.mattermost.com/#tag/channels/paths/~1teams~1name~1{team_name}~1channels~1name~1{channel_name}/get
+         * @param {string} teamName - Team name
+         * @param {string} channelName - Channel name
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+         * @returns {Channel} response.body: `Channel` object
+         *
+         * @example
+         *   cy.apiGetChannelByName('team-name', 'channel-name').then((response) => {
+         *     const channel = response.body;
+         *   });
+         */
+        apiGetChannelByName(teamName: string, channelName: string): Chainable<Response>;
 
-    /**
-     * Add a user to a channel by creating a channel member object.
-     * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}~1members/post
-     * @param {string} channelId - Channel ID
-     * @param {string} userId - User ID to add to the channel
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
-     * @returns {ChannelMembership} response.body: `ChannelMembership` object
-     * @example
-     *   cy.apiAddUserToChannel('channel-id', 'user-id').then((response) => {
-     *     const channelMember = response.body;
-     *   });
-     */
-    apiAddUserToChannel(channelId: string, userId: string): Chainable<Response>;
+        /**
+         * Get channel from the provided channel id string.
+         * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}/get
+         * @param {string} channelId - Channel ID
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+         * @returns {Channel} response.body: `Channel` object
+         *
+         * @example
+         *   cy.apiGetChannel('channel-id').then((response) => {
+         *     const channel = response.body;
+         *   });
+         */
+        apiGetChannel(channelId: string): Chainable<Response>;
 
+        /**
+         * Add a user to a channel by creating a channel member object.
+         * See https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}~1members/post
+         * @param {string} channelId - Channel ID
+         * @param {string} userId - User ID to add to the channel
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+         * @returns {ChannelMembership} response.body: `ChannelMembership` object
+         *
+         * @example
+         *   cy.apiAddUserToChannel('channel-id', 'user-id').then((response) => {
+         *     const channelMember = response.body;
+         *   });
+         */
+        apiAddUserToChannel(channelId: string, userId: string): Chainable<Response>;
 
-    // *******************************************************************************
-    // Users
-    // https://api.mattermost.com/#tag/users
-    // *******************************************************************************
+        // *******************************************************************************
+        // Users
+        // https://api.mattermost.com/#tag/users
+        // *******************************************************************************
 
-    /**
-     * Login to server via API.
-     * See https://api.mattermost.com/#tag/users/paths/~1users~1login/post
-     * @param {string} username
-     * @param {string} password
-     * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
-     * @returns {UserProfile} response.body: `UserProfile` object
-     * @example
-     *   cy.apiLogin('sysadmin');
-     */
-    apiLogin(username: string, password?: string): Chainable<Response>;
+        /**
+         * Login to server via API.
+         * See https://api.mattermost.com/#tag/users/paths/~1users~1login/post
+         * @param {string} username
+         * @param {string} password
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+         * @returns {UserProfile} response.body: `UserProfile` object
+         *
+         * @example
+         *   cy.apiLogin('sysadmin');
+         */
+        apiLogin(username: string, password?: string): Chainable<Response>;
 
-    /**
-     * Logout a user's active session from server via API
-     * https://api.mattermost.com/#tag/users/paths/~1users~1logout/post
-     * Clears all cookies espececially `MMAUTHTOKEN`, `MMUSERID` and `MMCSRF`.
-     * @example
-     *   cy.apiLogout();
-     */
-    apiLogout();
-  }
+        /**
+         * Logout a user's active session from server via API
+         * https://api.mattermost.com/#tag/users/paths/~1users~1logout/post
+         * Clears all cookies espececially `MMAUTHTOKEN`, `MMUSERID` and `MMCSRF`.
+         *
+         * @example
+         *   cy.apiLogout();
+         */
+        apiLogout();
+    }
 }

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -21,10 +21,6 @@ import theme from '../fixtures/theme.json';
 // https://api.mattermost.com/#tag/authentication
 // *****************************************************************************
 
-/**
- * Login a user directly via API
- * @param {String} username - e.g. "user-1" (default)
- */
 Cypress.Commands.add('apiLogin', (username = 'user-1', password = null) => {
     cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -37,9 +33,6 @@ Cypress.Commands.add('apiLogin', (username = 'user-1', password = null) => {
     });
 });
 
-/**
- * Logout a user directly via API
- */
 Cypress.Commands.add('apiLogout', () => {
     cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -59,16 +52,19 @@ Cypress.Commands.add('apiLogout', () => {
     cy.getCookies({log: false}).should('be.empty');
 });
 
-/**
- * Get a list of all the bots
- * This API assumes that the user logged in has permission to read bots
- */
+// *******************************************************************************
+// Bots
+// https://api.mattermost.com/#tag/bots
+// *******************************************************************************
 
 Cypress.Commands.add('apiGetBots', () => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
         url: '/api/v4/bots',
         method: 'GET',
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        return cy.wrap(response);
     });
 });
 
@@ -77,17 +73,6 @@ Cypress.Commands.add('apiGetBots', () => {
 // https://api.mattermost.com/#tag/channels
 // *****************************************************************************
 
-/**
- * Creates a channel directly via API
- * This API assume that the user is logged in and has cookie to access
- * @param {String} teamId - The team ID of the team to create the channel on
- * @param {String} name - The unique handle for the channel, will be present in the channel URL
- * @param {String} displayName - The non-unique UI name for the channel
- * @param {String} type - 'O' for a public channel (default), 'P' for a private channel
- * @param {String} purpose - A short description of the purpose of the channel
- * @param {String} header - Markdown-formatted text to display in the header of the channel
- * All parameters required except purpose and header
- */
 Cypress.Commands.add('apiCreateChannel', (teamId, name, displayName, type = 'O', purpose = '', header = '') => {
     const uniqueName = `${name}-${getRandomId()}`;
 
@@ -109,27 +94,18 @@ Cypress.Commands.add('apiCreateChannel', (teamId, name, displayName, type = 'O',
     });
 });
 
-/**
- * Creates a new Direct channel directly via API
- * This API assume that the user is logged in and has cookie to access
- * @param {String} userids - array of userids
- * All parameters required
- */
 Cypress.Commands.add('apiCreateDirectChannel', (userids) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
         url: '/api/v4/channels/direct',
         method: 'POST',
         body: userids,
+    }).then((response) => {
+        expect(response.status).to.equal(201);
+        return cy.wrap(response);
     });
 });
 
-/**
- * Creates a group channel directly via API
- * This API assume that the user is logged in and has cookie to access
- * @param {String} userIds - IDs of users as member of the group
- * All parameters required except purpose and header
- */
 Cypress.Commands.add('apiCreateGroupChannel', (userIds = []) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -142,12 +118,6 @@ Cypress.Commands.add('apiCreateGroupChannel', (userIds = []) => {
     });
 });
 
-/**
- * Deletes a channel directly via API
- * This API assume that the user is logged in and has cookie to access
- * @param {String} channelId - The channel ID to be deleted
- * All parameter required
- */
 Cypress.Commands.add('apiDeleteChannel', (channelId) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -159,18 +129,6 @@ Cypress.Commands.add('apiDeleteChannel', (channelId) => {
     });
 });
 
-/**
- * Updates a channel directly via API
- * This API assume that the user is logged in and has cookie to access
- * @param {String} channelId - The channel's id, not updatable
- * @param {Object} channelData
- *   {String} name - The unique handle for the channel, will be present in the channel URL
- *   {String} display_name - The non-unique UI name for the channel
- *   {String} type - 'O' for a public channel (default), 'P' for a private channel
- *   {String} purpose - A short description of the purpose of the channel
- *   {String} header - Markdown-formatted text to display in the header of the channel
- * Only channelId is required
- */
 Cypress.Commands.add('apiUpdateChannel', (channelId, channelData) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -186,17 +144,6 @@ Cypress.Commands.add('apiUpdateChannel', (channelId, channelData) => {
     });
 });
 
-/**
- * Partially update a channel directly via API
- * This API assume that the user is logged in and has cookie to access
- * @param {String} channelId - The channel's id, not updatable
- * @param {Object} channelData
- *   {String} name - The unique handle for the channel, will be present in the channel URL
- *   {String} display_name - The non-unique UI name for the channel
- *   {String} purpose - A short description of the purpose of the channel
- *   {String} header - Markdown-formatted text to display in the header of the channel
- * Only channelId is required
- */
 Cypress.Commands.add('apiPatchChannel', (channelId, channelData) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -153,6 +153,12 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@react-native-community/netinfo": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-4.7.0.tgz",
+      "integrity": "sha512-a/sDB+AsLEUNmhAUlAaTYeXKyQdFGBUfatqKkX5jluBo2CB3OAuTHfm7rSjcaLB9EmG5iSq3fOTpync2E7EYTA==",
+      "dev": true
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -474,6 +480,12 @@
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
       "dev": true
     },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -549,6 +561,30 @@
       "dev": true,
       "requires": {
         "is-retry-allowed": "^1.1.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
       }
     },
     "balanced-match": {
@@ -996,6 +1032,12 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "dev": true
+    },
     "clone-deep": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -1058,6 +1100,12 @@
       "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
       "dev": true
     },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1101,6 +1149,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
       "dev": true
     },
     "core-util-is": {
@@ -1395,6 +1449,15 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -1800,6 +1863,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-params": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/get-params/-/get-params-0.1.2.tgz",
+      "integrity": "sha1-uuDfq6WIoMYNeDTA2Nwv9g7u8v4=",
+      "dev": true
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -1825,6 +1894,15 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "gfycat-sdk": {
+      "version": "1.4.18",
+      "resolved": "https://registry.npmjs.org/gfycat-sdk/-/gfycat-sdk-1.4.18.tgz",
+      "integrity": "sha512-BrINtO6rj8Nr0pm38Qr3epayOuvlKcEFcDCw6yL9T4SrsWTECct6FS/isli766kdij2GGG6bWU6bRp+fDS2Cbg==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.23.0"
       }
     },
     "glob": {
@@ -1982,6 +2060,12 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
@@ -2196,6 +2280,16 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -2223,6 +2317,12 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsan": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/jsan/-/jsan-3.1.13.tgz",
+      "integrity": "sha512-9kGpCsGHifmw6oJet+y8HaCl14y7qgAsxVdV3pCHDySNR3BfDC30zgkssd7x5LRVAT22dnpbe9JdzzmXZnq9/g==",
+      "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
@@ -2296,6 +2396,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
+    },
+    "linked-list": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/linked-list/-/linked-list-0.1.0.tgz",
+      "integrity": "sha1-eYsP+X0bkqT9CEgPVa6k6dSdN78=",
       "dev": true
     },
     "listr": {
@@ -2460,6 +2566,12 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
+      "dev": true
+    },
     "lodash.intersection": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
@@ -2588,6 +2700,42 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
+    },
+    "mattermost-redux": {
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/mattermost-redux/-/mattermost-redux-5.23.0.tgz",
+      "integrity": "sha512-X/7eirk6QXDn6LUbBvixfyuABkWti8VocnpK5kWvTbBRv3ODI4gm2H94iWQk3bkjyozf58EogGYR9mEdkyJH/w==",
+      "dev": true,
+      "requires": {
+        "core-js": "3.1.4",
+        "form-data": "2.5.1",
+        "gfycat-sdk": "1.4.18",
+        "isomorphic-fetch": "2.2.1",
+        "moment-timezone": "0.5.26",
+        "redux": "4.0.4",
+        "redux-action-buffer": "1.2.0",
+        "redux-offline": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
+        "redux-persist": "4.9.1",
+        "redux-persist-node-storage": "2.0.0",
+        "redux-thunk": "2.3.0",
+        "remote-redux-devtools": "0.5.16",
+        "reselect": "4.0.0",
+        "serialize-error": "5.0.0",
+        "shallow-equals": "1.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "md5": {
       "version": "2.2.1",
@@ -3118,10 +3266,25 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
       "dev": true
     },
+    "moment-timezone": {
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
+      "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
+      "dev": true,
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
       "dev": true
     },
     "negotiator": {
@@ -3144,6 +3307,25 @@
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node-localstorage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
+      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
+      "dev": true,
+      "requires": {
+        "write-file-atomic": "^1.1.4"
       }
     },
     "normalize-path": {
@@ -3542,11 +3724,108 @@
         "minimatch": "3.0.4"
       }
     },
+    "redux": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
+      "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-action-buffer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redux-action-buffer/-/redux-action-buffer-1.2.0.tgz",
+      "integrity": "sha1-LsCh2JnMn29EzN60Me5SrUHdl1U=",
+      "dev": true
+    },
+    "redux-devtools-core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/redux-devtools-core/-/redux-devtools-core-0.2.1.tgz",
+      "integrity": "sha512-RAGOxtUFdr/1USAvxrWd+Gq/Euzgw7quCZlO5TgFpDfG7rB5tMhZUrNyBjpzgzL2yMk0eHnPYIGm7NkIfRzHxQ==",
+      "dev": true,
+      "requires": {
+        "get-params": "^0.1.2",
+        "jsan": "^3.1.13",
+        "lodash": "^4.17.11",
+        "nanoid": "^2.0.0",
+        "remotedev-serialize": "^0.1.8"
+      }
+    },
+    "redux-devtools-instrument": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.9.6.tgz",
+      "integrity": "sha512-MwvY4cLEB2tIfWWBzrUR02UM9qRG2i7daNzywRvabOSVdvAY7s9BxSwMmVRH1Y/7QWjplNtOwgT0apKhHg2Qew==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.2.0",
+        "symbol-observable": "^1.0.2"
+      }
+    },
+    "redux-offline": {
+      "version": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
+      "from": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
+      "dev": true,
+      "requires": {
+        "@react-native-community/netinfo": "^4.1.3",
+        "redux-persist": "^4.5.0"
+      }
+    },
+    "redux-persist": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-4.9.1.tgz",
+      "integrity": "sha512-XoOmfPyo9GEU/WLH9FgB47dNIN9l5ArjHes4o7vUWx9nxZoPxnVodhuHdyc4Ot+fMkdj3L2LTqSHhwrkr0QFUg==",
+      "dev": true,
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.4",
+        "lodash-es": "^4.17.4"
+      }
+    },
+    "redux-persist-node-storage": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist-node-storage/-/redux-persist-node-storage-2.0.0.tgz",
+      "integrity": "sha1-QAHjK4tDxzgH7y2pujAfSxxmr3k=",
+      "dev": true,
+      "requires": {
+        "node-localstorage": "^1.3.0"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==",
+      "dev": true
+    },
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
       "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
       "dev": true
+    },
+    "remote-redux-devtools": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.16.tgz",
+      "integrity": "sha512-xZ2D1VRIWzat5nsvcraT6fKEX9Cfi+HbQBCwzNnUAM8Uicm/anOc60XGalcaDPrVmLug7nhDl2nimEa3bL3K9w==",
+      "dev": true,
+      "requires": {
+        "jsan": "^3.1.13",
+        "querystring": "^0.2.0",
+        "redux-devtools-core": "^0.2.1",
+        "redux-devtools-instrument": "^1.9.4",
+        "rn-host-detect": "^1.1.5",
+        "socketcluster-client": "^14.2.1"
+      }
+    },
+    "remotedev-serialize": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.8.tgz",
+      "integrity": "sha512-3YG/FDcOmiK22bl5oMRM8RRnbGrFEuPGjbcDG+z2xi5aQaNQNZ8lqoRnZTwXVfaZtutXuiAQOgPRrogzQk8edg==",
+      "dev": true,
+      "requires": {
+        "jsan": "^3.1.13"
+      }
     },
     "reportportal-client": {
       "version": "5.5.0",
@@ -3649,6 +3928,12 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
@@ -3677,6 +3962,12 @@
         "glob": "^7.1.3"
       }
     },
+    "rn-host-detect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.2.0.tgz",
+      "integrity": "sha512-btNg5kzHcjZZ7t7mvvV/4wNJ9e3MPgrWivkRgWURzXL0JJ0pwWlU4zrbmdlz3HHzHOxhBhHB4D+/dbMFfu4/4A==",
+      "dev": true
+    },
     "rxjs": {
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
@@ -3702,6 +3993,27 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
+    },
+    "sc-channel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
+      "integrity": "sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1"
+      }
+    },
+    "sc-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-2.0.1.tgz",
+      "integrity": "sha512-JoVhq3Ud+3Ujv2SIG7W0XtjRHsrNgl6iXuHHsh0s+Kdt5NwI6N2EGAZD4iteitdDv68ENBkpjtSvN597/wxPSQ==",
+      "dev": true
+    },
+    "sc-formatter": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sc-formatter/-/sc-formatter-3.0.2.tgz",
+      "integrity": "sha512-9PbqYBpCq+OoEeRQ3QfFIGE6qwjjBcd2j7UjgDlhnZbtSnuGgHdcRklPKYGuYFH82V/dwd+AIpu8XvA1zqTd+A==",
       "dev": true
     },
     "semver": {
@@ -3754,6 +4066,15 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
+      }
+    },
+    "serialize-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
+      "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.0"
       }
     },
     "serve-static": {
@@ -3815,6 +4136,12 @@
         }
       }
     },
+    "shallow-equals": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shallow-equals/-/shallow-equals-1.0.0.tgz",
+      "integrity": "sha1-JLdL8cY0wR7Uxxgqbfb7MA3OQ5A=",
+      "dev": true
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -3852,6 +4179,48 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
+    "socketcluster-client": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-14.3.1.tgz",
+      "integrity": "sha512-Sd/T0K/9UlqTfz+HUuFq90dshA5OBJPQbdkRzGtcKIOm52fkdsBTt0FYpiuzzxv5VrU7PWpRm6KIfNXyPwlLpw==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1",
+        "clone": "2.1.1",
+        "component-emitter": "1.2.1",
+        "linked-list": "0.1.0",
+        "querystring": "0.2.0",
+        "sc-channel": "^1.2.0",
+        "sc-errors": "^2.0.1",
+        "sc-formatter": "^3.0.1",
+        "uuid": "3.2.1",
+        "ws": "7.1.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+          "dev": true
+        }
+      }
     },
     "split": {
       "version": "0.3.3",
@@ -4260,6 +4629,12 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -4405,6 +4780,12 @@
         "rxjs": "^6.5.4"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -4461,6 +4842,26 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
+    },
+    "ws": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.0.tgz",
+      "integrity": "sha512-Swie2C4fs7CkwlHu1glMePLYJJsWjzhl1vm3ZaLplD0h7OMkZyZ6kLTB/OagiU923bZrPFXuDTeEqaEN4NWG4g==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "^1.0.0"
+      }
     },
     "xml": {
       "version": "1.0.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -16,6 +16,7 @@
     "lodash": "4.17.15",
     "lodash.intersection": "4.4.0",
     "lodash.without": "4.4.0",
+    "mattermost-redux": "5.23.0",
     "merge-deep": "3.0.2",
     "mime-types": "2.1.27",
     "mocha": "7.1.1",


### PR DESCRIPTION
#### Summary
This PR documents Cypress custom commands by declaring types under Cypress namespace. This will help contributors for quick reference via IDE intellisense and to easily find samples, params, etc of each custom command.
Changes include:
- adding mattermost-redux for typings of models
- moving of command's comments from the function to typings under Cypress namespace.

PR will be submitted in partial per group of models/endpoints.

#### Ticket Link
Jira ticket - https://mattermost.atlassian.net/browse/MM-25768

#### Screenshots
<img width="913" alt="Screen Shot 2020-06-04 at 8 18 55 PM" src="https://user-images.githubusercontent.com/5334504/83758505-c5b45a80-a6a4-11ea-80af-c6edc4e49f3e.png">
