### PR TITLE
Fix unstable messaging specs

### DIFF
--- a/e2e/cypress/integration/messaging/at_mentions_spec.js
+++ b/e2e/cypress/integration/messaging/at_mentions_spec.js
@@ -122,7 +122,7 @@ describe('at-mention', () => {
             townsquareChannelId = id;
         });
 
-        cy.get('#sidebarItem_off-topic').click({force: true});
+        cy.visit('/ad-1/channels/off-topic');
         cy.getCurrentChannelId().then((id) => {
             offTopicChannelId = id;
         });

--- a/e2e/cypress/integration/messaging/date_separator_spec.js
+++ b/e2e/cypress/integration/messaging/date_separator_spec.js
@@ -30,6 +30,13 @@ describe('Messaging', () => {
         });
     });
 
+    after(() => {
+        cy.apiPatchMe({
+            locale: 'en',
+            timezone: {automaticTimezone: '', manualTimezone: 'UTC', useAutomaticTimezone: 'false'},
+        });
+    });
+
     it('MM-21482 Date separators should translate correctly', () => {
         function verifyDateSeparator(index, match) {
             cy.findAllByTestId('basicSeparator').eq(index).within(() => {

--- a/e2e/cypress/integration/messaging/header_spec.js
+++ b/e2e/cypress/integration/messaging/header_spec.js
@@ -79,6 +79,8 @@ describe('Header', () => {
             type('London{enter}').
             wait(1000).
             clear();
+        cy.get('#searchbar-help-popup').should('be.visible');
+        cy.get('#searchFormContainer').type('{esc}');
 
         // # Verify the Search side bar opens up
         cy.get('#sidebar-right').should('be.visible').and('contain', 'Search Results');
@@ -93,7 +95,7 @@ describe('Header', () => {
 
         // # Click the pin icon to open the pinned posts RHS
         cy.get('#channelHeaderPinButton').should('be.visible').click();
-        cy.get('#sidebar-right').should('be.visible').and('contain', 'Pinned Posts in');
+        cy.get('#sidebar-right').should('be.visible').and('contain', 'Pinned posts');
 
         // # Verify that the Search term input box is still cleared and search term does not reappear when RHS opens
         cy.get('#searchBox').should('have.attr', 'value', '').and('be.empty');

--- a/e2e/cypress/integration/messaging/message_draft_then_switch_channel_spec.js
+++ b/e2e/cypress/integration/messaging/message_draft_then_switch_channel_spec.js
@@ -64,7 +64,7 @@ describe('Message Draft and Switch Channels', () => {
 
         // * Validate if the draft icon is visible to left of the channel name in the filtered list
         cy.get('#publicChannel').scrollIntoView();
-        cy.get('#switchChannel_town-square #draftIcon').should('be.visible');
+        cy.get('#switchChannel_town-square .icon-pencil-outline').should('be.visible');
 
         // * Escape channel switcher and reset post textbox for test channel
         cy.get('.close').click();

--- a/e2e/cypress/integration/search/post_search_display_spec.js
+++ b/e2e/cypress/integration/search/post_search_display_spec.js
@@ -25,6 +25,8 @@ describe('Post search display', () => {
         // # click on "x" displayed on searchbox
         cy.get('#searchbarContainer').should('be.visible').within(() => {
             cy.get('#searchFormContainer').find('.input-clear-x').click({force: true});
+            cy.get('#searchbar-help-popup').should('be.visible');
+            cy.get('#searchFormContainer').type('{esc}');
         });
 
         // # RHS should be visible with search results
@@ -36,15 +38,15 @@ describe('Post search display', () => {
         });
 
         // # check the contents in search options
-        cy.get('#searchbar-help-popup').within(() => {
+        cy.get('#searchbar-help-popup').should('be.visible').within(() => {
             cy.get('h4 span').first().should('have.text', 'Search Options');
-            cy.get('span ul li').first().should('have.text', 'Use "quotation marks" to search for phrases');
-            cy.get('span ul li').eq(1).should('have.text', 'Use from: to find posts from specific users');
-            cy.get('span ul li').eq(2).should('have.text', 'Use in: to find posts in specific channels');
-            cy.get('span ul li').eq(3).should('have.text', 'Use on: to find posts on a specific date');
-            cy.get('span ul li').eq(4).should('have.text', 'Use before: to find posts before a specific date');
-            cy.get('span ul li').eq(5).should('have.text', 'Use after: to find posts after a specific date');
-            cy.get('span ul li').last().should('have.text', 'Use dash "-" to exclude search terms and modifiers');
+            cy.get('div ul li').first().should('have.text', 'From:Messages from a user');
+            cy.get('div ul li').eq(1).should('have.text', 'In:Messages in a channel');
+            cy.get('div ul li').eq(2).should('have.text', 'On:Messages on a date');
+            cy.get('div ul li').eq(3).should('have.text', 'Before:Messages before a date');
+            cy.get('div ul li').eq(4).should('have.text', 'After:Messages after a date');
+            cy.get('div ul li').eq(5).should('have.text', '—Exclude search terms');
+            cy.get('div ul li').last().should('have.text', '""Messages with phrases');
         });
     });
 });


### PR DESCRIPTION
#### Summary
Minor changes only
- at_mentions_spec - visit off-topic channel directly
- header_spec - updated pinned posts text verification
- message_draft_then_switch_channel_spec - updated draft icon selector
- post_search_display_spec - updated help popup verification
- data_separator_spec - not fixing the issue but resetting locale so that other tests are not affected

#### Ticket Link
NA