### PR TITLE
[MM-25771] Dont show deleted profiles on team and channel members block

### DIFF
--- a/components/admin_console/team_channel_settings/channel/details/channel_members/channel_members.tsx
+++ b/components/admin_console/team_channel_settings/channel/details/channel_members/channel_members.tsx
@@ -95,7 +95,7 @@ export default class ChannelMembers extends React.PureComponent<Props, State> {
 
             const searchTimeoutId = window.setTimeout(
                 async () => {
-                    await prevProps.actions.searchProfilesAndChannelMembers(searchTerm, {in_channel_id: this.props.channelId});
+                    await prevProps.actions.searchProfilesAndChannelMembers(searchTerm, {in_channel_id: this.props.channelId, allow_inactive: false});
 
                     if (searchTimeoutId !== this.searchTimeoutId) {
                         return;

--- a/components/admin_console/team_channel_settings/channel/details/channel_members/index.ts
+++ b/components/admin_console/team_channel_settings/channel/details/channel_members/index.ts
@@ -66,15 +66,16 @@ function makeMapStateToProps() {
             member_count: 0,
             channel_id: channelId,
             pinnedpost_count: 0,
+            guest_count: 0,
         };
 
         const searchTerm = state.views.search.modalSearch;
         let users = [];
         if (searchTerm) {
-            users = searchProfilesInChannel(state, channelId, searchTerm);
+            users = searchProfilesInChannel(state, channelId, searchTerm, {skipInactive: false});
             usersToAdd = searchUsersToAdd(usersToAdd, searchTerm);
         } else {
-            users = doGetProfilesInChannel(state, channelId, false);
+            users = doGetProfilesInChannel(state, channelId, true);
         }
 
         return {

--- a/components/admin_console/team_channel_settings/team/details/team_members/index.ts
+++ b/components/admin_console/team_channel_settings/team/details/team_members/index.ts
@@ -55,15 +55,15 @@ function mapStateToProps(state: GlobalState, props: Props) {
 
     const teamMembers = getMembersInTeams(state)[teamId] || {};
     const team = getTeam(state, teamId) || {};
-    const stats = getTeamStats(state)[teamId] || {total_member_count: 0};
+    const stats = getTeamStats(state)[teamId] || {active_member_count: 0};
 
     const searchTerm = state.views.search.modalSearch;
     let users = [];
     if (searchTerm) {
-        users = searchProfilesInTeam(state, teamId, searchTerm, false);
+        users = searchProfilesInTeam(state, teamId, searchTerm, false, {skipInactive: true});
         usersToAdd = searchUsersToAdd(usersToAdd, searchTerm);
     } else {
-        users = getProfilesInTeam(state, teamId);
+        users = getProfilesInTeam(state, teamId, {skipInactive: true});
     }
 
     return {
@@ -73,7 +73,7 @@ function mapStateToProps(state: GlobalState, props: Props) {
         teamMembers,
         usersToAdd,
         usersToRemove,
-        totalCount: stats.total_member_count,
+        totalCount: stats.active_member_count,
         searchTerm,
     };
 }

--- a/components/admin_console/team_channel_settings/team/details/team_members/team_members.tsx
+++ b/components/admin_console/team_channel_settings/team/details/team_members/team_members.tsx
@@ -92,7 +92,7 @@ export default class TeamMembers extends React.PureComponent<Props, State> {
 
             const searchTimeoutId = window.setTimeout(
                 async () => {
-                    await prevProps.actions.searchProfilesAndTeamMembers(searchTerm, {team_id: this.props.teamId});
+                    await prevProps.actions.searchProfilesAndTeamMembers(searchTerm, {team_id: this.props.teamId, allow_inactive: false});
 
                     if (searchTimeoutId !== this.searchTimeoutId) {
                         return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14311,8 +14311,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#fd1d5b800c555e5507f7c3c978cd5fb02c1d59de",
-      "from": "github:mattermost/mattermost-redux#fd1d5b800c555e5507f7c3c978cd5fb02c1d59de",
+      "version": "github:mattermost/mattermost-redux#92a21e92552d3e60c1d641438d4fa2b3ad35f3de",
+      "from": "github:mattermost/mattermost-redux#92a21e92552d3e60c1d641438d4fa2b3ad35f3de",
       "requires": {
         "core-js": "3.6.4",
         "form-data": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "localforage-observable": "2.0.0",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#87769262aa02e1784570f61f4f962050e07cc335",
-    "mattermost-redux": "github:mattermost/mattermost-redux#fd1d5b800c555e5507f7c3c978cd5fb02c1d59de",
+    "mattermost-redux": "github:mattermost/mattermost-redux#92a21e92552d3e60c1d641438d4fa2b3ad35f3de",
     "moment-timezone": "0.5.27",
     "p-queue": "^6.4.0",
     "pdfjs-dist": "2.0.489",


### PR DESCRIPTION
#### Summary
- The team members block in the system console displays deleted users since the getProfiles selectors return deleted users by default.
- This applies the fix by creating a new filter at the redux level instead of filtering the users in the component that was how the team members modal does it on the app side does it but I felt that was not optimal. I think eventually we should add a flag to the backend to exclude deleted users too but for now this will suffice.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25771

#### Related PRs
- Has redux: