### PR TITLE
[MM-24205] Remove tabability from collapsed channel menus

### DIFF
--- a/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
       }
     }
     channelLink="http://a.fake.link"
+    isCollapsed={false}
     isUnread={false}
   />
 </Link>
@@ -139,6 +140,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
       }
     }
     channelLink="http://a.fake.link"
+    isCollapsed={false}
     isUnread={false}
   />
 </Link>
@@ -235,6 +237,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
       }
     }
     channelLink="http://a.fake.link"
+    isCollapsed={false}
     isUnread={false}
   />
 </Link>
@@ -307,6 +310,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
       }
     }
     channelLink="http://a.fake.link"
+    isCollapsed={false}
     isUnread={true}
   />
 </Link>

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -184,6 +184,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
                 <SidebarChannelMenu
                     channel={channel}
                     isUnread={this.showChannelAsUnread()}
+                    isCollapsed={this.props.isCollapsed}
                     closeHandler={this.props.closeHandler}
                     channelLink={link}
                 />

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     id="SidebarChannelMenu-channel_id"
     onToggle={[Function]}
     refCallback={[Function]}
+    tabIndex={0}
     tooltipText="Channel options"
   >
     <MenuGroup>
@@ -117,6 +118,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     id="SidebarChannelMenu-channel_id"
     onToggle={[Function]}
     refCallback={[Function]}
+    tabIndex={0}
     tooltipText="Channel options"
   >
     <MenuGroup>
@@ -203,6 +205,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     id="SidebarChannelMenu-channel_id"
     onToggle={[Function]}
     refCallback={[Function]}
+    tabIndex={0}
     tooltipText="Channel options"
   >
     <MenuGroup>
@@ -299,6 +302,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     id="SidebarChannelMenu-channel_id"
     onToggle={[Function]}
     refCallback={[Function]}
+    tabIndex={0}
     tooltipText="Channel options"
   >
     <MenuGroup>
@@ -408,6 +412,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     id="SidebarChannelMenu-channel_id"
     onToggle={[Function]}
     refCallback={[Function]}
+    tabIndex={0}
     tooltipText="Channel options"
   >
     <MenuGroup>
@@ -517,6 +522,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     id="SidebarChannelMenu-channel_id"
     onToggle={[Function]}
     refCallback={[Function]}
+    tabIndex={0}
     tooltipText="Channel options"
   >
     <MenuGroup>
@@ -615,6 +621,7 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match sn
     id="SidebarChannelMenu-channel_id"
     onToggle={[Function]}
     refCallback={[Function]}
+    tabIndex={0}
     tooltipText="Channel options"
   >
     <MenuGroup>

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
@@ -58,6 +58,7 @@ describe('components/sidebar/sidebar_channel/sidebar_channel_menu', () => {
         managePublicChannelMembers: true,
         managePrivateChannelMembers: true,
         closeHandler: jest.fn(),
+        isCollapsed: false,
         actions: {
             markChannelAsRead: jest.fn(),
             favoriteChannel: jest.fn(),

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
@@ -31,6 +31,7 @@ type Props = {
     managePublicChannelMembers: boolean;
     managePrivateChannelMembers: boolean;
     closeHandler?: (callback: () => void) => void;
+    isCollapsed: boolean;
     actions: {
         markChannelAsRead: (channelId: string) => void;
         favoriteChannel: (channelId: string) => void;
@@ -336,6 +337,7 @@ export class SidebarChannelMenu extends React.PureComponent<Props, State> {
                     buttonAriaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
                     tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Channel options'})}
                     onToggle={this.onToggle}
+                    tabIndex={this.props.isCollapsed ? -1 : 0}
                 >
                     {this.renderDropdownItems()}
                 </SidebarMenu>

--- a/components/sidebar/sidebar_menu/sidebar_menu.tsx
+++ b/components/sidebar/sidebar_menu/sidebar_menu.tsx
@@ -22,6 +22,7 @@ type Props = {
     refCallback?: (ref: SidebarMenu) => void;
     onToggle?: (open: boolean) => void;
     draggingState: DraggingState;
+    tabIndex?: number;
 };
 
 type State = {
@@ -168,6 +169,7 @@ export default class SidebarMenu extends React.PureComponent<Props, State> {
                     ref={this.menuButtonRef}
                     className='SidebarMenu_menuButton'
                     aria-label={buttonAriaLabel}
+                    tabIndex={this.props.tabIndex}
                 >
                     {buttonContents}
                 </button>


### PR DESCRIPTION
#### Summary
When a category is collapsed, and you use keyboard navigation to navigate through the channels, the channel menu icon was still focusable on collapsed channels.

This PR adds a `tabIndex=-1` to those channels when collapsed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24205