### PR TITLE
[MM-25828] Fix incorrect globe / lock icon for private and public channels

### DIFF
--- a/components/channel_selector_modal/channel_selector_modal.jsx
+++ b/components/channel_selector_modal/channel_selector_modal.jsx
@@ -157,10 +157,10 @@ export default class ChannelSelectorModal extends React.PureComponent {
                 <div
                     className='more-modal__details'
                 >
-                    {option.type === 'P' &&
-                        <i className='icon icon-globe'/>}
-                    {option.type === 'O' &&
+                    {option.type === Constants.PRIVATE_CHANNEL &&
                         <i className='icon icon-lock-outline'/>}
+                    {option.type === Constants.OPEN_CHANNEL &&
+                        <i className='icon icon-globe'/>}
                     <span className='channel-name'>{option.display_name}</span>
                     <span className='team-name'>{'(' + option.team_display_name + ')'}</span>
                 </div>


### PR DESCRIPTION
#### Summary
- Fixes a small bug rendering the wrong icon introduced in https://github.com/mattermost/mattermost-webapp/pull/5264

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25828

![Screen Shot 2020-06-05 at 11 37 53 AM](https://user-images.githubusercontent.com/3207297/83895656-00f46f00-a721-11ea-82b9-d3ccb1514f54.png)
