### PR TITLE
[MM-24968] Fixed add channel dropdown on mobile to pop out correctly

### DIFF
--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -236,7 +236,7 @@
         }
     }
 
-    .SidebarMenu {
+    .SidebarMenu, .AddChannelDropdown {
         display: block !important;
 
         .Menu {
@@ -245,7 +245,7 @@
     }
 
     .app__body {
-        .post, .SidebarMenu {
+        .post, .SidebarMenu, .AddChannelDropdown {
             .Menu {
                 @include border-radius(0);
                 border: 0px;


### PR DESCRIPTION
#### Summary
The Add Channel Dropdown class was missing in the mobile CSS file, so the menu wasn't popping out correctly like the sidebar ones were. This PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24968