### PR TITLE
E2E: Minor refactor on post message

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/system_scheme_permission_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/system_scheme_permission_spec.js
@@ -93,10 +93,7 @@ const removePermission = (permissionCheckBoxTestId) => {
 // # If enabled is true assumes the user has the permission enabled and checks for no system message
 const channelMentionsPermissionCheck = (enabled) => {
     // # Type @here and post it to the channel
-    cy.get('#post_textbox').clear().type('@here{enter}');
-
-    // # Wait for system message to appear
-    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.postMessage('@here');
 
     // # Get last post message text
     cy.getLastPostId().then((postId) => {
@@ -116,14 +113,11 @@ const createPostPermissionCheck = (enabled) => {
     if (enabled) {
         // # Try post it to the channel
         cy.get('#post_textbox').should('not.be.disabled');
-        cy.get('#post_textbox').clear().type('test{enter}');
+        cy.postMessage('test');
     } else {
         // # Ensure the input is disabled
         cy.get('#post_textbox').should('be.disabled');
     }
-
-    // # Wait for system message to appear
-    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
 
     // # Get last post message text
     cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/integration/enterprise/system_console/team_scheme_permission_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/team_scheme_permission_spec.js
@@ -84,10 +84,7 @@ const deleteExistingTeamOverrideSchemes = () => {
 // # If enabled is true assumes the user has the permission enabled and checks for no system message
 const channelMentionsPermissionCheck = (enabled) => {
     // # Type @here and post it to the channel
-    cy.get('#post_textbox').clear().type('@here{enter}');
-
-    // # Wait for system message to appear
-    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.postMessage('@here');
 
     // # Get last post message text
     cy.getLastPostId().then((postId) => {
@@ -107,14 +104,11 @@ const createPostPermissionCheck = (enabled) => {
     if (enabled) {
         // # Try post it to the channel
         cy.get('#post_textbox').should('not.be.disabled');
-        cy.get('#post_textbox').clear().type('test{enter}');
+        cy.postMessage('test');
     } else {
         // # Ensure the input is disabled
         cy.get('#post_textbox').should('be.disabled');
     }
-
-    // # Wait for system message to appear
-    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
 
     // # Get last post message text
     cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -42,7 +42,7 @@ describe('I18456 Built-in slash commands: common', () => {
 
         // # Login as user-1 and post "/shrug test"
         loginAndVisitDefaultChannel('user-1');
-        cy.postMessage('/shrug test{enter}');
+        cy.postMessage('/shrug test');
 
         // * Verify that it posted message as expected from user-1
         cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/integration/messaging/emoji_to_markdown_spec.js
+++ b/e2e/cypress/integration/messaging/emoji_to_markdown_spec.js
@@ -17,7 +17,7 @@ function createMessages(message, aliases) {
         cy.clickPostCommentIcon(postId);
     });
 
-    cy.postMessageReplyInRHS(message + '{enter}');
+    cy.postMessageReplyInRHS(message);
     cy.getLastPostId().then((postId) => {
         cy.get(`#postMessageText_${postId}`).as(aliases[1]);
     });

--- a/e2e/cypress/integration/messaging/message_deletion_spec.js
+++ b/e2e/cypress/integration/messaging/message_deletion_spec.js
@@ -28,7 +28,7 @@ describe('Message deletion', () => {
             cy.get('#rhsContainer').should('be.visible');
 
             // # Post a reply in RHS.
-            cy.postMessageReplyInRHS('test message reply in RHS {enter}');
+            cy.postMessageReplyInRHS('test message reply in RHS');
 
             cy.getLastPostId().then((replyMessageId) => {
                 // # Click post dot menu in center.

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -105,18 +105,21 @@ function isMac() {
 // ***********************************************************
 
 Cypress.Commands.add('postMessage', (message) => {
-    cy.get('#post_textbox', {timeout: TIMEOUTS.LARGE}).clear().type(`${message}{enter}`);
-    cy.waitUntil(() => {
-        return cy.get('#post_textbox').then((el) => {
-            return el[0].textContent === '';
-        });
-    });
+    postMessageAndWait('#post_textbox', message);
 });
 
 Cypress.Commands.add('postMessageReplyInRHS', (message) => {
-    cy.get('#reply_textbox').should('be.visible').clear().type(`${message}{enter}`);
-    cy.wait(TIMEOUTS.TINY);
+    postMessageAndWait('#reply_textbox', message);
 });
+
+function postMessageAndWait(textboxSelector, message) {
+    cy.get(textboxSelector, {timeout: TIMEOUTS.LARGE}).should('be.visible').clear().type(`${message}{enter}`);
+    cy.waitUntil(() => {
+        return cy.get(textboxSelector).then((el) => {
+            return el[0].textContent === '';
+        });
+    });
+}
 
 function waitUntilPermanentPost() {
     cy.get('#postListContent').should('be.visible');


### PR DESCRIPTION
#### Summary
- minor refactor on `postMessage` and `postMessageReplyInRHS`
- team and system scheme permission specs to use `postMessage`
- removed redundant `{enter}`

Note: for master and release-5.24

#### Ticket Link
NA