### PR TITLE
Add .npmrc file to enforce save-exact

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+


### PR DESCRIPTION
#### Summary

With this file in the root dir, npm will always use exact versions when updating `package.json`. This [file](https://github.com/mattermost/mattermost-mobile/blob/master/.npmrc) already exists in the mattermost-mobile repo.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-25856