### PR TITLE
E2E: Fix error on import statement in master-unstable tests

### DIFF
--- a/e2e/cypress/plugins/db_request.js
+++ b/e2e/cypress/plugins/db_request.js
@@ -8,7 +8,13 @@
  * in MySQL, first letter is capitalized.
  */
 
-import {convertKeysToLowercase} from '../utils';
+const mapKeys = require('lodash.mapkeys');
+
+function convertKeysToLowercase(obj) {
+    return mapKeys(obj, (_, k) => {
+        return k.toLowerCase();
+    });
+}
 
 function getKnexClient({client, connection}) {
     return require('knex')({client, connection}); // eslint-disable-line global-require

--- a/e2e/cypress/utils/index.js
+++ b/e2e/cypress/utils/index.js
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import mapKeys from 'lodash.mapkeys';
 import {v4 as uuidv4} from 'uuid';
 
 import messageMenusData from '../fixtures/hooks/message_menus.json';
@@ -67,9 +66,3 @@ export function titleCase(str) {
 }
 
 export const reUrl = /(https?:\/\/[^ ]*)/;
-
-export function convertKeysToLowercase(obj) {
-    return mapKeys(obj, (_, k) => {
-        return k.toLowerCase();
-    });
-}


### PR DESCRIPTION
#### Summary
On master-unstable, there's an error with:
```bash
 /home/circleci/mattermost-cypress-docker/e2e/cypress/plugins/db_request.js:11
import {convertKeysToLowercase} from '../utils';
^^^^^^
SyntaxError: Cannot use import statement outside a module
    at Module._compile (internal/modules/cjs/loader.js:896:18)
```

#### Ticket Link
- none, error on daily master-unstable
- introduced by my recent PR - https://github.com/mattermost/mattermost-webapp/pull/5630
