### PR TITLE
npminstall: skip if up-to-date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,15 @@ test: node_modules ## Runs tests
 i18n-extract: ## Extract strings for translation from the source code
 	npm run mmjstool -- i18n extract-webapp
 
-node_modules: package.json package-lock.json
+.PHONY: node_modules
+node_modules: .npminstall
+
+.npminstall: package.json package-lock.json
 	@echo Getting dependencies using npm
 
 	npm install
+	touch $@
+
 
 package: build ## Packages app
 	@echo Packaging webapp


### PR DESCRIPTION
#### Summary
Tweak the `make node_modules` directive to skip the expensive `npm install` step if `package.json` and `package-lock.json` haven't changed since the last such invocation. 

This is accomplished using an `.npminstall` file (already part of `.gitignore`) that is touched after a successful `make node_modules`. If the file is missing or older than either `package.json` or `package-lock.json`, `npm install` proceeds normally. Otherwise, the unnecessary `npm install` step is skipped.

Credit to @crspeller for the idea here while iterating on the incident response plugin.

Note that the experience here would be so much better if `npm install` would stop rewriting `package-lock.json` all the time, but I understand we're iterating on that separately.

#### Ticket Link
N/A