### PR TITLE
Adding label for PR smoke tests

### DIFF
--- a/e2e/cypress/integration/messaging/message_spec.js
+++ b/e2e/cypress/integration/messaging/message_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
+// Stage: @prod @smoke
 // Group: @messaging
 
 import users from '../../fixtures/users.json';

--- a/e2e/cypress/integration/plugins/marketplace/marketplace_spec.js
+++ b/e2e/cypress/integration/plugins/marketplace/marketplace_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @smoke
 // Group: @plugin_marketplace @plugin
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';

--- a/e2e/cypress/integration/search/search_user_post_spec.js
+++ b/e2e/cypress/integration/search/search_user_post_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
+// Stage: @prod @smoke
 // Group: @search
 
 import users from '../../fixtures/users.json';

--- a/e2e/cypress/integration/system_console/cluster_spec.js
+++ b/e2e/cypress/integration/system_console/cluster_spec.js
@@ -1,5 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
 
 // Group: @system_console
 

--- a/e2e/cypress/integration/team_settings/create_a_team_spec.js
+++ b/e2e/cypress/integration/team_settings/create_a_team_spec.js
@@ -7,7 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
+// Stage: @prod @smoke
 // Group: @team_settings
 
 import {getRandomId} from '../../utils';


### PR DESCRIPTION
Adding `@smoke` labels for tests to be considered in PR smoke test.
This PR covers smoke tests in the following E2E test files. Some test files already had the `@smoke` label and thus cover the smoke test criteria as such. Only some that needed according to the `Smoke Tests` doc have been added.
- User can create a new team -- `create_a_team_spec`
- User can create a channel -- `accessibility_sidebar_spec`
- Users can join an existing channel -- `add_users_to_channel_spec`
- User can post in a channel -- `messsge_spec`
- Basic search function -- `search_user_post`
- System administrator can access system console -- `ui_and_api > cluster_spec`
- User can install a plugin -- `marketplace_spec`
- User can log out -- `tutorial_navigation_and_links_spec`