### PR TITLE
Remove non-project-related items from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,9 @@
-dist
+dist/
 .npminstall
 .yarninstall
 node_modules
-*.swp
-.idea
 *.tar.gz
 tests/reports
-.DS_Store
-mattermost-webapp.iml
-.vscode/
 junit.xml
 coverage
 
@@ -24,11 +19,5 @@ e2e/cypress/videos
 e2e/results
 storybook-static
 
-# Vim temporary files
-[._]*.s[a-w][a-z]
-[._]s[a-w][a-z]
-*.un~
-Session.vim
 .netrwhist
-*~
 .eslintcache


### PR DESCRIPTION
IDE-specific and OS-specific files should be in global gitignores.
The project gitignore should be for files created by the project.

See discussion on https://github.com/mattermost/mattermost-plugin-starter-template/pull/98