### PR TITLE
[MM-25921] Modify admin console index tests to ignore order check in spanish

### DIFF
--- a/utils/admin_console_index.test.jsx
+++ b/utils/admin_console_index.test.jsx
@@ -49,7 +49,7 @@ describe('AdminConsoleIndex.generateIndex', () => {
         const intl = createIntl({locale: 'es', messages: esMessages, defaultLocale: 'es'}, {});
 
         const idx = generateIndex(AdminDefinition, {}, intl);
-        expect(idx.search('ldap')).toEqual([
+        expect(idx.search('ldap').sort()).toEqual([
             'authentication/mfa',
             'authentication/ldap',
             'authentication/saml',
@@ -58,21 +58,21 @@ describe('AdminConsoleIndex.generateIndex', () => {
             'authentication/discover-ldap',
             'environment/session_lengths',
             'authentication/guest_access',
-        ]);
-        expect(idx.search('saml')).toEqual([
+        ].sort());
+        expect(idx.search('saml').sort()).toEqual([
             'authentication/saml',
             'authentication/discover-saml',
             'environment/session_lengths',
             'authentication/email',
             'experimental/features',
-        ]);
+        ].sort());
         expect(idx.search('nginx')).toEqual([
             'environment/rate_limiting',
         ]);
-        expect(idx.search('caracteres')).toEqual([
+        expect(idx.search('caracteres').sort()).toEqual([
             'site_config/customization',
             'authentication/password',
-        ]);
+        ].sort());
         expect(idx.search('characters')).toEqual([]);
         expect(idx.search('notexistingword')).toEqual([]);
     });


### PR DESCRIPTION
#### Summary
- These tests should not check the order of search results in languages other than english since they can change if the community updates translations as seen here https://github.com/mattermost/mattermost-webapp/pull/5688

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25921