### PR TITLE
[MM-25947] Removed font-weight: 300 for muted channels

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -903,7 +903,6 @@
         &.muted {
             div.SidebarChannelLinkLabel_wrapper, > i, .status.status--group {
                 opacity: 0.4;
-                font-weight: 300;
             }
         }
 


### PR DESCRIPTION
#### Summary
This changed the `font-weight` on muted channels back to 400.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25947