### PR TITLE
[MM-25771] Ensure users displayed in add users to team modal are not inactive

### DIFF
--- a/components/add_users_to_team_modal/index.ts
+++ b/components/add_users_to_team_modal/index.ts
@@ -28,9 +28,9 @@ type Actions = {
 function mapStateToProps(state: GlobalState, props: Props) {
     const {id: teamId} = props.team;
 
-    let filterOptions: {} = {};
+    let filterOptions: {} = {skipInactive: true};
     if (props.filterExcludeGuests) {
-        filterOptions = {role: 'system_user'};
+        filterOptions = {role: 'system_user', ...filterOptions};
     }
 
     const users: UserProfile[] = selectProfilesNotInTeam(state, teamId, filterOptions);


### PR DESCRIPTION
#### Summary
- Ensures that inactive (deleted) users do not show up in the add users to team modal

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25771