### PR TITLE
[MM-25952] Fix license banner hiding revoke sessions

### DIFF
--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -70,7 +70,11 @@
     }
 
     .filtered-user-list {
-        height: calc(100vh - 160px);
+        height: calc(100vh - 175px);
+
+        .announcement-bar--fixed & {
+            height: calc(100vh - 205px);
+        }
     }
 
     .Select-value-label {


### PR DESCRIPTION
#### Summary
- Decreases filtered user list height when announcement banner is present
- Also reduces the filtered user list height by a bit when the banner is not present to prevent a scrollbar from appearing on the side

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25952

#### Screenshots
Before: 
![Screen Shot 2020-06-11 at 3 05 45 PM](https://user-images.githubusercontent.com/3207297/84428787-1112bf80-abf5-11ea-9ab0-efb28659d9d0.png)

After: 

![Screen Shot 2020-06-11 at 3 05 21 PM](https://user-images.githubusercontent.com/3207297/84428795-13751980-abf5-11ea-8789-5c03eff85645.png)
