### PR TITLE
MM-25904 - Updating link tooltips z-index for plugins

### DIFF
--- a/components/link_tooltip/__snapshots__/link_tooltip.test.tsx.snap
+++ b/components/link_tooltip/__snapshots__/link_tooltip.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`components/link_tooltip/link_tooltip should match snapshot 1`] = `
         "alignItems": "center",
         "display": "flex",
         "flexDirection": "column",
-        "zIndex": 10,
+        "zIndex": 1070,
       }
     }
   >

--- a/components/link_tooltip/__snapshots__/link_tooltip.test.tsx.snap
+++ b/components/link_tooltip/__snapshots__/link_tooltip.test.tsx.snap
@@ -8,6 +8,9 @@ exports[`components/link_tooltip/link_tooltip should match snapshot 1`] = `
         "alignItems": "center",
         "display": "flex",
         "flexDirection": "column",
+        "left": -1000,
+        "position": "absolute",
+        "top": -1000,
         "zIndex": 1070,
       }
     }

--- a/components/link_tooltip/link_tooltip.tsx
+++ b/components/link_tooltip/link_tooltip.tsx
@@ -13,6 +13,9 @@ const tooltipContainerStyles: CSSProperties = {
     flexDirection: 'column',
     alignItems: 'center',
     zIndex: 1070,
+    position: 'absolute',
+    top: -1000,
+    left: -1000
 };
 
 type Props = {

--- a/components/link_tooltip/link_tooltip.tsx
+++ b/components/link_tooltip/link_tooltip.tsx
@@ -12,7 +12,7 @@ const tooltipContainerStyles: CSSProperties = {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    zIndex: 10,
+    zIndex: 1070,
 };
 
 type Props = {


### PR DESCRIPTION
#### Summary
MM-25904 - Updating link tooltips z-index for plugins

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25904

#### Screenshots
![Screenshot 2020-06-12 at 12 54 52 PM](https://user-images.githubusercontent.com/11034289/84479260-1252f380-acac-11ea-9980-69db91e7c7d9.png)
