### PR TITLE
[MM25816] invitation_modal: revert to existing behavior for inviting existing ones

### DIFF
--- a/components/invitation_modal/invitation_modal_members_step.jsx
+++ b/components/invitation_modal/invitation_modal_members_step.jsx
@@ -71,7 +71,7 @@ class InvitationModalMembersStep extends React.PureComponent {
     }
 
     debouncedSearchProfiles = debounce((term, callback) => {
-        this.props.searchProfiles(term, {not_in_team_id: this.props.currentTeamId}).then(({data}) => {
+        this.props.searchProfiles(term).then(({data}) => {
             callback(data);
             if (data.length === 0) {
                 this.setState({termWithoutResults: term});

--- a/components/invitation_modal/invitation_modal_members_step.test.jsx
+++ b/components/invitation_modal/invitation_modal_members_step.test.jsx
@@ -37,28 +37,4 @@ describe('components/invitation_modal/InvitationModalMembersStep', () => {
         );
         expect(wrapper).toMatchSnapshot();
     });
-
-    test('should send not_in_team_id when search profiles is called', async () => {
-        const searchProfiles = jest.fn().mockImplementation(() => {
-            const data = [];
-
-            return Promise.resolve({data});
-        });
-
-        const wrapper = shallowWithIntl(
-            <InvitationModalMembersStep
-                teamName='Test Team'
-                currentTeamId='test-team-id'
-                inviteId='123'
-                searchProfiles={searchProfiles}
-                emailInvitationsEnabled={false}
-                onSubmit={jest.fn()}
-                onEdit={jest.fn()}
-            />,
-        );
-
-        wrapper.instance().usersLoader('@something', jest.fn());
-        jest.runAllTimers();
-        expect(searchProfiles).toHaveBeenCalledWith('@something', {not_in_team_id: 'test-team-id'});
-    });
 });


### PR DESCRIPTION
#### Summary
This PR reverts to existing behavior for inviting team members that are already member of the target team.

#### Ticket Link
<https://mattermost.atlassian.net/browse/MM-25816