### PR TITLE
Promoting consistently passing unstable tests to prod stage

### DIFF
--- a/e2e/cypress/integration/accessibility/accessibility_account_settings_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_account_settings_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @accessibility
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/account_settings/general/nickname_spec.js
+++ b/e2e/cypress/integration/account_settings/general/nickname_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 describe('Account Settings > Sidebar > General', () => {

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';

--- a/e2e/cypress/integration/channel/channel_groups_spec.js
+++ b/e2e/cypress/integration/channel/channel_groups_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @ldap_group
 
 import {getRandomId} from '../../utils';

--- a/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @channel_sidebar
 
 import {testWithConfig} from '../../support/hooks';

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @integrations
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';

--- a/e2e/cypress/integration/integrations/builtin_commands/user_status_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/user_status_commands_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @integrations
 
 const testCases = [

--- a/e2e/cypress/integration/menus/main_menu_spec.js
+++ b/e2e/cypress/integration/menus/main_menu_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @menu
 
 describe('Main menu', () => {

--- a/e2e/cypress/integration/menus/status_dropdown_spec.js
+++ b/e2e/cypress/integration/menus/status_dropdown_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @menu
 
 describe('Status dropdown menu', () => {

--- a/e2e/cypress/integration/messaging/message_draft_then_switch_channel_spec.js
+++ b/e2e/cypress/integration/messaging/message_draft_then_switch_channel_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/system_message_limited_options_spec.js
+++ b/e2e/cypress/integration/messaging/system_message_limited_options_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';


### PR DESCRIPTION
#### Summary
Promoting consistently passing unstable tests to prod stage. 
- These tests have consistently passed in the last 4 runs and hence have been identified to be moved to prod stage. 

#### Ticket Link
NA