### PR TITLE
E2E: Fix status dropdown spec

### DIFF
--- a/e2e/cypress/integration/menus/status_dropdown_spec.js
+++ b/e2e/cypress/integration/menus/status_dropdown_spec.js
@@ -19,6 +19,11 @@ describe('Status dropdown menu', () => {
         cy.apiUpdateUserStatus();
     });
 
+    afterEach(() => {
+        // # Reset user status to online to prevent status modal
+        cy.apiUpdateUserStatus();
+    });
+
     it('Displays default menu when status icon is clicked', () => {
         // # Wait for posts to load
         cy.get('#postListContent').should('be.visible');


### PR DESCRIPTION
#### Summary
- This test is currently not failing but causing other tests to fail because the status modal has been left open. This will hopefully at least run the other tests past the modal failures.

#### Ticket Link
NA