### PR TITLE
[MM23361] Focus remains in the RHS text box

### DIFF
--- a/e2e/cypress/integration/messaging/message_spec.js
+++ b/e2e/cypress/integration/messaging/message_spec.js
@@ -10,6 +10,7 @@
 // Stage: @prod
 // Group: @messaging @smoke
 
+import * as MESSAGES from '../../fixtures/messages';
 import users from '../../fixtures/users.json';
 
 const sysadmin = users.sysadmin;
@@ -165,5 +166,26 @@ describe('Message', () => {
             cy.get(divPostId).find('span.emoticon').should('not.exist');
             cy.get(divPostId).find('span.codespan__pre-wrap code').should('have.text', '😉');
         });
+    });
+
+    it('M23361 Focus remains in the RHS text box', () => {
+        cy.apiSaveShowMarkdownPreviewPreference();
+
+        cy.postMessage(MESSAGES.MEDIUM);
+
+        // # Open reply thread (RHS)
+        cy.clickPostCommentIcon();
+
+        // # Add some text to RHS text box
+        cy.get('#reply_textbox').type(MESSAGES.TINY);
+
+        // # Click on Preview
+        cy.get('#previewLink').click();
+
+        // # Click on Add Comment
+        cy.get('#addCommentButton').click();
+
+        // * Focus to remain in the RHS text box
+        cy.get('#reply_textbox').should('be.focused');
     });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->



#### Summary
<!--
A description of what this pull request does.
-->

This test ensures that the replies to a conversation focuses on the "Add a comment" textbox by default.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-server/issues/14081

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes - N/A
- Has redux changes - N/A
- Has mobile changes - N/A

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

Here is the screenshot at the end of the test:
![Screen Shot 2020-04-08 at 9 48 40 PM](https://user-images.githubusercontent.com/1740517/78849544-bdaca700-79e2-11ea-9313-b869cc69a527.png)
