### PR TITLE
MM-26035 Make Cypress test data independent from auto generated sample data (make test-data)

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -8,11 +8,14 @@
     "integrationFolder": "..",
     "testFiles": "**/*_spec.js",
     "env": {
+        "adminUsername": "sysadmin",
+        "adminPassword": "Sys@dmin-sample1",
         "dbClient": "mysql",
         "dbConnection": "mysql://mmuser:mostest@localhost:3306/mattermost_test?charset=utf8mb4&readTimeout=30s&writeTimeout=30s",
         "ldapServer": "localhost",
         "ldapPort": 389,
         "runLDAPSync": true,
+        "resetBeforeTest": false,
         "storybookUrl": "http://localhost:6006/",
         "webhookBaseUrl": "http://localhost:3000"
     }

--- a/e2e/cypress/integration/accessibility/accessibility_account_settings_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_account_settings_spec.js
@@ -31,8 +31,6 @@ function verifySections(sections) {
 
 describe('Verify Accessibility Support in different sections in Account Settings Dialog', () => {
     before(() => {
-        cy.apiLogin('sysadmin');
-
         // # Update Configs
         cy.apiUpdateConfig({
             ServiceSettings: {

--- a/e2e/cypress/integration/accessibility/accessibility_buttons_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_buttons_spec.js
@@ -12,8 +12,6 @@
 
 describe('Verify Accessibility Support in different Buttons', () => {
     before(() => {
-        cy.apiLogin('sysadmin');
-
         // # Visit the Off Topic channel
         cy.visit('/ad-1/channels/off-topic');
         cy.findAllByTestId('postView').should('be.visible');

--- a/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_dropdowns_spec.js
@@ -32,26 +32,22 @@ function verifyMenuItems(menuEl, labels) {
 }
 
 describe('Verify Accessibility Support in Dropdown Menus', () => {
-    before(() => {
-        cy.apiLogin('sysadmin');
+    let testTeam;
 
-        // # Ensure an open team is available to join
-        cy.getCurrentUserId().then((userId) => {
-            cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-                const teamId = response.body.id;
-                cy.removeUserFromTeam(teamId, userId);
-            });
+    before(() => {
+        cy.apiInitSetup().then(({team}) => {
+            testTeam = team;
         });
     });
 
     beforeEach(() => {
         // Visit the Off Topic channel
-        cy.visit('/ad-1/channels/off-topic').wait(TIMEOUTS.SMALL);
+        cy.visit(`/${testTeam.name}/channels/off-topic`).wait(TIMEOUTS.SMALL);
     });
 
     it('MM-22627 Accessibility Support in Channel Menu Dropdown', () => {
         // # Press tab from the Channel Favorite button
-        cy.get('#toggleFavorite').focus().tab({shift: true}).tab().tab();
+        cy.get('#toggleFavorite').focus().wait(500).tab({shift: true}).tab().tab();
 
         // * Verify the aria-label in channel menu button
         cy.get('#channelHeaderDropdownButton button').should('have.attr', 'aria-label', 'channel menu').and('have.class', 'a11y--active a11y--focused').click();
@@ -76,7 +72,7 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
 
     it('MM-22627 Accessibility Support in Main Menu Dropdown', () => {
         // # Press tab from the Set Status button
-        cy.get('.status-wrapper button.status').focus().tab({shift: true}).tab().tab();
+        cy.get('.status-wrapper button.status').focus().wait(500).tab({shift: true}).tab().tab();
 
         // * Verify the aria-label in main menu button
         cy.get('#headerInfo button').should('have.attr', 'aria-label', 'main menu').and('have.class', 'a11y--active a11y--focused').click();
@@ -108,7 +104,7 @@ describe('Verify Accessibility Support in Dropdown Menus', () => {
 
     it('MM-22627 Accessibility Support in Status Dropdown', () => {
         // # Press tab from Add Team button
-        cy.get('#select_teamTeamButton').focus().tab({shift: true}).tab().tab();
+        cy.get('#select_teamTeamButton').focus().wait(500).tab({shift: true}).tab().tab();
 
         // * Verify the aria-label in status menu button
         cy.get('.status-wrapper button.status').should('have.attr', 'aria-label', 'set status').and('have.class', 'a11y--active a11y--focused').click();

--- a/e2e/cypress/integration/accessibility/accessibility_image_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_image_spec.js
@@ -10,18 +10,18 @@
 // Stage: @prod
 // Group: @accessibility
 
-import users from '../../fixtures/users.json';
-
-const otherUser = users['user-1'];
-
 // * Verify the accessibility support in the different images
 
 describe('Verify Accessibility Support in Different Images', () => {
-    before(() => {
-        cy.apiLogin('sysadmin');
+    let otherUser;
 
-        // Visit the Off Topic channel
-        cy.visit('/ad-1/channels/off-topic');
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            otherUser = user;
+
+            // Visit the Off Topic channel
+            cy.visit(`/${team.name}/channels/off-topic`);
+        });
     });
 
     it('MM-24075 Accessibility support in different images', () => {
@@ -43,11 +43,8 @@ describe('Verify Accessibility Support in Different Images', () => {
 
         // # Post a message as a different user
         cy.getCurrentChannelId().then((channelId) => {
-            cy.apiGetUserByEmail(otherUser.email).then((emailResponse) => {
-                cy.apiAddUserToChannel(channelId, emailResponse.body.id);
-                const message = `hello from ${otherUser.username}: ${Date.now()}`;
-                cy.postMessageAs({sender: otherUser, message, channelId});
-            });
+            const message = `hello from ${otherUser.username}: ${Date.now()}`;
+            cy.postMessageAs({sender: otherUser, message, channelId});
         });
 
         // # Open profile popover

--- a/e2e/cypress/integration/accessibility/accessibility_input_fields_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_input_fields_spec.js
@@ -10,10 +10,7 @@
 // Stage: @prod
 // Group: @accessibility
 
-import users from '../../fixtures/users.json';
 import * as TIMEOUTS from '../../fixtures/timeouts';
-
-const user1 = users['user-1'];
 
 function verifySearchAutocomplete(index, type = 'user') {
     cy.get('#search-autocomplete__popover').find('.search-autocomplete__item').eq(index).should('be.visible').and('have.class', 'selected a11y--focused').within((el) => {
@@ -54,38 +51,23 @@ function verifyMessageAutocomplete(index, type = 'user') {
 }
 
 describe('Verify Accessibility Support in different input fields', () => {
+    let testTeam;
     let testChannel;
 
-    beforeEach(() => {
-        testChannel = null;
-
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
+    before(() => {
         // * Check if server has license for Guest Accounts
         cy.requireLicenseForFeature('GuestAccounts');
 
-        // # Enable Guest Accounts
-        cy.apiUpdateConfig({
-            GuestAccountsSettings: {
-                Enable: true,
-            },
-        });
-
-        // # Visit the test channel
-        cy.apiGetTeamByName('ad-1').then((res) => {
-            cy.apiCreateChannel(res.body.id, 'accessibility', 'accessibility').then((response) => {
-                testChannel = response.body;
-                cy.visit(`/ad-1/channels/${testChannel.name}`);
-            });
+        cy.apiInitSetup().then(({team}) => {
+            testTeam = team;
         });
     });
 
-    afterEach(() => {
-        cy.apiLogin('sysadmin');
-        if (testChannel && testChannel.id) {
-            cy.apiDeleteChannel(testChannel.id);
-        }
+    beforeEach(() => {
+        cy.apiCreateChannel(testTeam.id, 'accessibility', 'accessibility').then((response) => {
+            testChannel = response.body;
+            cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+        });
     });
 
     it('MM-22625 Verify Accessibility Support in Input fields in Invite People Flow', () => {
@@ -129,14 +111,13 @@ describe('Verify Accessibility Support in different input fields', () => {
 
     it('MM-22625 Verify Accessibility Support in Search Autocomplete', () => {
         // # Adding at least five other users in the channel
-        const channelId = testChannel.id;
-        cy.apiGetTeamByName('ad-1').then((res) => {
-            for (let i = 0; i < 5; i++) {
-                cy.apiCreateNewUser({}, [res.body.id]).then((user) => {
-                    cy.apiAddUserToChannel(channelId, user.id);
+        for (let i = 0; i < 5; i++) {
+            cy.apiCreateUser().then(({user}) => { // eslint-disable-line
+                cy.apiAddUserToTeam(testTeam.id, user.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, user.id);
                 });
-            }
-        });
+            });
+        }
 
         // * Verify Accessibility support in search input
         cy.get('#searchBox').should('have.attr', 'aria-describedby', 'searchbar-help-popup').and('have.attr', 'aria-label', 'Search').focus();
@@ -175,52 +156,51 @@ describe('Verify Accessibility Support in different input fields', () => {
 
     it('MM-22625 Verify Accessibility Support in Message Autocomplete', () => {
         // # Adding at least one other user in the channel
-        cy.getCurrentChannelId().then((channelId) => {
-            cy.apiGetUserByEmail(user1.email).then((res) => {
-                const user = res.body;
-                cy.apiAddUserToChannel(channelId, user.id);
+        cy.apiCreateUser().then(({user}) => {
+            cy.apiAddUserToTeam(testTeam.id, user.id).then(() => {
+                cy.apiAddUserToChannel(testChannel.id, user.id).then(() => {
+                    // * Verify Accessibility support in post input field
+                    cy.get('#post_textbox').should('have.attr', 'aria-label', `write to ${testChannel.display_name}`).clear().focus();
+
+                    // # Ensure User list is cached once in UI
+                    cy.get('#post_textbox').type('@').wait(TIMEOUTS.SMALL);
+
+                    // # Select the first user in the list
+                    cy.get('#suggestionList').find('.mentions__name').eq(0).within((el) => {
+                        cy.get('.mention--align').invoke('text').then((text) => {
+                            cy.wrap(el).parents('body').find('#post_textbox').clear().type(text);
+                        });
+                    });
+
+                    // # Trigger the user autocomplete again
+                    cy.get('#post_textbox').clear().type('@').wait(TIMEOUTS.SMALL).type('{downarrow}');
+
+                    // * Verify Accessibility Support in message autocomplete
+                    verifyMessageAutocomplete(1);
+
+                    // # Press Up arrow and verify if focus changes
+                    cy.focused().type('{downarrow}{uparrow}{uparrow}');
+
+                    // * Verify Accessibility Support in message autocomplete
+                    verifyMessageAutocomplete(0);
+
+                    // # Trigger the channel autocomplete filter and ensure channel list is cached once
+                    cy.get('#post_textbox').clear().type('~').wait(TIMEOUTS.SMALL);
+
+                    // # Trigger the channel autocomplete again
+                    cy.get('#post_textbox').clear().type('~').wait(TIMEOUTS.SMALL).type('{downarrow}{downarrow}');
+
+                    // * Verify Accessibility Support in message autocomplete
+                    verifyMessageAutocomplete(2, 'channel');
+
+                    // # Press Up arrow and verify if focus changes
+                    cy.focused().type('{downarrow}{uparrow}{uparrow}');
+
+                    // * Verify Accessibility Support in message autocomplete
+                    verifyMessageAutocomplete(1, 'channel');
+                });
             });
         });
-
-        // * Verify Accessibility support in post input field
-        cy.get('#post_textbox').should('have.attr', 'aria-label', `write to ${testChannel.display_name}`).clear().focus();
-
-        // # Ensure User list is cached once in UI
-        cy.get('#post_textbox').type('@').wait(TIMEOUTS.SMALL);
-
-        // # Select the first user in the list
-        cy.get('#suggestionList').find('.mentions__name').eq(0).within((el) => {
-            cy.get('.mention--align').invoke('text').then((text) => {
-                cy.wrap(el).parents('body').find('#post_textbox').clear().type(text);
-            });
-        });
-
-        // # Trigger the user autocomplete again
-        cy.get('#post_textbox').clear().type('@').wait(TIMEOUTS.SMALL).type('{downarrow}');
-
-        // * Verify Accessibility Support in message autocomplete
-        verifyMessageAutocomplete(1);
-
-        // # Press Up arrow and verify if focus changes
-        cy.focused().type('{downarrow}{uparrow}{uparrow}');
-
-        // * Verify Accessibility Support in message autocomplete
-        verifyMessageAutocomplete(0);
-
-        // # Trigger the channel autocomplete filter and ensure channel list is cached once
-        cy.get('#post_textbox').clear().type('~').wait(TIMEOUTS.SMALL);
-
-        // # Trigger the channel autocomplete again
-        cy.get('#post_textbox').clear().type('~').wait(TIMEOUTS.SMALL).type('{downarrow}{downarrow}');
-
-        // * Verify Accessibility Support in message autocomplete
-        verifyMessageAutocomplete(2, 'channel');
-
-        // # Press Up arrow and verify if focus changes
-        cy.focused().type('{downarrow}{uparrow}{uparrow}');
-
-        // * Verify Accessibility Support in message autocomplete
-        verifyMessageAutocomplete(1, 'channel');
     });
 
     it('MM-22625 Verify Accessibility Support in Main Post Input', () => {

--- a/e2e/cypress/integration/accessibility/accessibility_keyboard_usability_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_keyboard_usability_spec.js
@@ -34,8 +34,6 @@ function postMessages(cnt = 1) {
 
 describe('Verify Accessibility keyboard usability across different regions in the app', () => {
     before(() => {
-        cy.apiLogin('sysadmin');
-
         // Visit the Town Square channel
         cy.visit('/ad-1/channels/town-square');
 

--- a/e2e/cypress/integration/accessibility/accessibility_modals_dialogs_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_modals_dialogs_spec.js
@@ -55,7 +55,7 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
     });
 
     beforeEach(() => {
-        // # Visit the Town Square channel
+        // # Login as sysadmin and visit the town-square
         cy.apiAdminLogin();
         cy.visit(`/${testTeam.name}/channels/town-square`);
     });

--- a/e2e/cypress/integration/accessibility/accessibility_modals_dialogs_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_modals_dialogs_spec.js
@@ -9,12 +9,9 @@
 
 // Group: @accessibility
 
-import users from '../../fixtures/users.json';
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
 let selectedRowText;
-const user1 = users['user-1'];
-const user2 = users['user-2'];
 
 function verifyMainMenuModal(modalName, modalId, modalLabel, expectedModalName) {
     cy.get('#headerInfo button').click();
@@ -36,26 +33,31 @@ function verifyChannelMenuModal(menuItem, modalName, modalLabel) {
 }
 
 describe('Verify Accessibility Support in Modals & Dialogs', () => {
-    before(() => {
-        cy.apiLogin('sysadmin');
+    let testTeam;
+    let testChannel;
+    let testUser;
 
+    before(() => {
         // * Check if server has license for Guest Accounts
         cy.requireLicenseForFeature('GuestAccounts');
 
-        // # Enable Guest Account Settings
-        cy.apiUpdateConfig({
-            GuestAccountsSettings: {
-                Enable: true,
-            },
-        });
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            testTeam = team;
+            testChannel = channel;
+            testUser = user;
 
-        // Visit the Town Square channel
-        cy.visit('/ad-1/channels/town-square');
+            cy.apiCreateUser().then(({user: newUser}) => {
+                cy.apiAddUserToTeam(testTeam.id, newUser.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, newUser.id);
+                });
+            });
+        });
     });
 
     beforeEach(() => {
-        // Visit the Town Square channel
-        cy.visit('/ad-1/channels/town-square');
+        // # Visit the Town Square channel
+        cy.apiAdminLogin();
+        cy.visit(`/${testTeam.name}/channels/town-square`);
     });
 
     it('MM-22623 Accessibility Support in Different Modals and Dialog screen', () => {
@@ -69,9 +71,9 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
         verifyMainMenuModal('Team Settings', 'teamSettingsModal', 'teamSettingsModalLabel', 'Team Settings');
 
         // * Verify the accessibility support in Manage Members Dialog
-        verifyMainMenuModal('Manage Members', 'teamMembersModal', 'teamMemberModalLabel', 'eligendi Members');
+        verifyMainMenuModal('Manage Members', 'teamMembersModal', 'teamMemberModalLabel', `${testTeam.display_name} Members`);
 
-        cy.visit('/ad-1/channels/off-topic');
+        cy.visit(`/${testTeam.name}/channels/off-topic`);
 
         // * Verify the accessibility support in Channel Edit Header Dialog
         verifyChannelMenuModal('Edit Channel Header', 'Edit Header for Off-Topic', 'editChannelHeaderModalLabel');
@@ -123,49 +125,65 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
     });
 
     it('MM-22623 Accessibility Support in More Channels Dialog screen', () => {
-        // * Verify the aria-label in more public channels button
-        cy.get('#sidebarPublicChannelsMore').should('have.attr', 'aria-label', 'See more public channels').click();
+        // # Create atleast 2 channels
+        cy.apiCreateChannel(testTeam.id, 'accessibility', 'accessibility');
+        cy.apiCreateChannel(testTeam.id, 'accessibility', 'accessibility').then(() => {
+            cy.apiLogin(testUser.username, testUser.password).then(() => {
+                cy.reload();
 
-        // * Verify the accessibility support in More Channels Dialog`
-        cy.get('#moreChannelsModal').should('have.attr', 'role', 'dialog').and('have.attr', 'aria-labelledby', 'moreChannelsModalLabel').within(() => {
-            cy.get('#moreChannelsModalLabel').should('be.visible').and('contain', 'More Channels');
-            cy.get('.modal-header button.close').should('have.attr', 'aria-label', 'Close');
+                // * Verify the aria-label in more public channels button
+                cy.get('#sidebarPublicChannelsMore').should('have.attr', 'aria-label', 'See more public channels').click();
 
-            // * Verify the accessibility support in search input
-            cy.get('#searchChannelsTextbox').should('have.attr', 'placeholder', 'Search channels');
+                // * Verify the accessibility support in More Channels Dialog`
+                cy.get('#moreChannelsModal').should('have.attr', 'role', 'dialog').and('have.attr', 'aria-labelledby', 'moreChannelsModalLabel').within(() => {
+                    cy.get('#moreChannelsModalLabel').should('be.visible').and('contain', 'More Channels');
+                    cy.get('.modal-header button.close').should('have.attr', 'aria-label', 'Close');
 
-            // # Focus on the Create Channel button and TAB twice
-            cy.get('#createNewChannel').focus().tab().tab();
+                    // * Verify the accessibility support in search input
+                    cy.get('#searchChannelsTextbox').should('have.attr', 'placeholder', 'Search channels');
 
-            // * Verify channel name is highlighted and reader reads the channel name and channel description
-            cy.get('#moreChannelsList').children().eq(0).as('selectedRow');
-            cy.get('@selectedRow').within(() => {
-                cy.get('.more-modal__description').invoke('text').then((description) => {
-                    cy.get('.more-modal__details button').
-                        should('have.class', 'a11y--active a11y--focused').invoke('text').then((channel) => {
-                            selectedRowText = channel.toLowerCase() + ', ' + description.toLowerCase();
-                            cy.get('.more-modal__details button').should('have.attr', 'aria-label', selectedRowText);
+                    // # Focus on the Create Channel button and TAB twice
+                    cy.get('#createNewChannel').focus().tab().tab();
+
+                    // * Verify channel name is highlighted and reader reads the channel name and channel description
+                    cy.get('#moreChannelsList').children().eq(0).as('selectedRow');
+                    cy.get('@selectedRow').within(() => {
+                        cy.get('.more-modal__description').invoke('text').then((description) => {
+                            cy.get('.more-modal__details button').
+                                should('have.class', 'a11y--active a11y--focused').invoke('text').then((channel) => {
+                                    selectedRowText = channel.toLowerCase() + ', ' + description.toLowerCase();
+                                    cy.get('.more-modal__details button').should('have.attr', 'aria-label', selectedRowText);
+                                });
                         });
+
+                        // * Press Tab and verify if focus changes to Join button
+                        cy.focused().tab();
+                        cy.get('.more-modal__actions button').should('have.class', 'a11y--active a11y--focused');
+
+                        // * Verify previous button should no longer be focused
+                        cy.get('.more-modal__details button').should('not.have.class', 'a11y--active a11y--focused');
+                    });
+
+                    // * Press Tab again and verify if focus changes to next row
+                    cy.focused().tab();
+                    cy.get('#moreChannelsList').children().eq(1).as('selectedRow').
+                        get('.more-modal__details button').
+                        should('have.class', 'a11y--active a11y--focused');
                 });
-
-                // * Press Tab and verify if focus changes to Join button
-                cy.focused().tab();
-                cy.get('.more-modal__actions button').should('have.class', 'a11y--active a11y--focused');
-
-                // * Verify previous button should no longer be focused
-                cy.get('.more-modal__details button').should('not.have.class', 'a11y--active a11y--focused');
             });
-
-            // * Press Tab again and verify if focus changes to next row
-            cy.focused().tab();
-            cy.get('#moreChannelsList').children().eq(1).as('selectedRow').
-                get('.more-modal__details button').
-                should('have.class', 'a11y--active a11y--focused');
         });
     });
 
     it('MM-22623 Accessibility Support in Add New Members to Channel Dialog screen', () => {
-        cy.visit('/ad-1/channels/off-topic');
+        // # Add atleast 5 users
+        for (let i = 0; i < 5; i++) {
+            cy.apiCreateUser().then(({user}) => { // eslint-disable-line
+                cy.apiAddUserToTeam(testTeam.id, user.id);
+            });
+        }
+
+        // # Visit the test channel
+        cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
         // # Open Add Members Dialog
         cy.get('#channelHeaderDropdownIcon').click();
@@ -173,14 +191,14 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
 
         // * Verify the accessibility support in Add New Members Dialog`
         cy.get('#addUsersToChannelModal').should('have.attr', 'role', 'dialog').and('have.attr', 'aria-labelledby', 'channelInviteModalLabel').within(() => {
-            cy.get('#channelInviteModalLabel').should('be.visible').and('contain', 'Add New Members to Off-Topic');
+            cy.get('#channelInviteModalLabel').should('be.visible').and('contain', `Add New Members to ${testChannel.display_name}`);
             cy.get('.modal-header button.close').should('have.attr', 'aria-label', 'Close');
 
             // * Verify the accessibility support in search input
             cy.get('#selectItems input').should('have.attr', 'aria-label', 'Search and add members').and('have.attr', 'aria-autocomplete', 'list');
 
             // # Search for a text and then check up and down arrow
-            cy.get('#selectItems input').type('s', {force: true}).wait(TIMEOUTS.TINY).type('{downarrow}{downarrow}{downarrow}{uparrow}', {force: true});
+            cy.get('#selectItems input').type('u', {force: true}).wait(TIMEOUTS.TINY).type('{downarrow}{downarrow}{downarrow}{uparrow}', {force: true});
             cy.get('#multiSelectList').children().eq(2).should('have.class', 'more-modal__row--selected').within(() => {
                 cy.get('.more-modal__name').invoke('text').then((user) => {
                     selectedRowText = user.split(' - ')[0].replace('@', '');
@@ -207,19 +225,8 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
     });
 
     it('MM-22623 Accessibility Support in Manage Channel Members Dialog screen', () => {
-        cy.visit('/ad-1/channels/off-topic');
-
-        // # Adding at least two other users in the channel
-        cy.getCurrentChannelId().then((channelId) => {
-            cy.apiGetUserByEmail(user1.email).then((res) => {
-                const user = res.body;
-                cy.apiAddUserToChannel(channelId, user.id);
-            });
-            cy.apiGetUserByEmail(user2.email).then((res) => {
-                const user = res.body;
-                cy.apiAddUserToChannel(channelId, user.id);
-            });
-        });
+        // # Visit test team and channel
+        cy.visit(`/${testTeam.name}/channels/off-topic`);
 
         // # Open Channel Members Dialog
         cy.get('#channelHeaderDropdownIcon').click();

--- a/e2e/cypress/integration/accessibility/accessibility_nav_diff_regions_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_nav_diff_regions_spec.js
@@ -40,8 +40,6 @@ function verifyNavSupport(element, label, tabOrder) {
 
 describe('Verify Quick Navigation support across different regions in the app', () => {
     before(() => {
-        cy.apiLogin('sysadmin');
-
         // Visit the Town Square channel
         cy.visit('/ad-1/channels/town-square');
 

--- a/e2e/cypress/integration/accessibility/accessibility_popovers_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_popovers_spec.js
@@ -25,9 +25,7 @@ function verifyArrowKeysEmojiNavigation(arrowKey, count) {
 
 describe('Verify Accessibility Support in Popovers', () => {
     before(() => {
-        cy.apiLogin('sysadmin');
-
-        // Visit the Off Topic channel
+        // # Visit the Off Topic channel
         cy.visit('/ad-1/channels/off-topic');
         cy.findAllByTestId('postView').should('be.visible');
 

--- a/e2e/cypress/integration/accessibility/accessibility_post_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_post_spec.js
@@ -71,8 +71,6 @@ function verifyPostLabel(elementId, username, labelSuffix) {
 
 describe('Verify Accessibility Support in Post', () => {
     before(() => {
-        cy.apiLogin('sysadmin');
-
         // # Update Configs
         cy.apiUpdateConfig({
             ServiceSettings: {

--- a/e2e/cypress/integration/accessibility/accessibility_sidebar_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_sidebar_spec.js
@@ -49,7 +49,6 @@ function markNewChannelAsUnread(channelName) {
 
 describe('Verify Accessibility Support in Channel Sidebar Navigation', () => {
     before(() => {
-        cy.apiLogin('sysadmin');
         cy.apiSaveSidebarSettingPreference();
 
         // # Update Configs

--- a/e2e/cypress/integration/account_settings/display/channel_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/channel_display_mode_spec.js
@@ -12,15 +12,11 @@
 
 describe('Account Settings > Display > Channel Display Mode', () => {
     before(() => {
-        cy.apiLogin('user-1');
-
-        // # Set default preference of a user on channel and message display
-        cy.apiSaveChannelDisplayModePreference('centered');
-        cy.apiSaveMessageDisplayPreference();
-
-        // Post a message to a channel
-        cy.visit('/ad-1/channels/town-square');
-        cy.postMessage('Test for channel display mode');
+        // # Login as new user, visit town-square and post a message
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+            cy.postMessage('Test for channel display mode');
+        });
     });
 
     beforeEach(() => {
@@ -45,7 +41,7 @@ describe('Account Settings > Display > Channel Display Mode', () => {
 
         // * Check the min setting view if each element is present and contains expected text values
         cy.get('#channel_display_modeTitle').should('be.visible').should('contain', 'Channel Display');
-        cy.get('#channel_display_modeDesc').should('be.visible').should('contain', 'Fixed width');
+        cy.get('#channel_display_modeDesc').should('be.visible').should('contain', 'Full width');
         cy.get('#channel_display_modeEdit').should('be.visible').should('contain', 'Edit');
         cy.get('#accountSettingsHeader > .close').should('be.visible');
     });

--- a/e2e/cypress/integration/account_settings/display/code_theme_colors_spec.js
+++ b/e2e/cypress/integration/account_settings/display/code_theme_colors_spec.js
@@ -41,27 +41,11 @@ function navigateToThemeSettings() {
 
 describe('AS14319 Theme Colors - Code', () => {
     before(() => {
-        // # Login and navigate to the app
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
-
-        // # Enter in code block for message
-        cy.get('#post_textbox').clear().type('```\ncode\n```{enter}');
-    });
-
-    // reset settings to default mattermost theme
-    after(() => {
-        navigateToThemeSettings();
-
-        // # Select the Theme Colors radio
-        cy.get('#standardThemes').check().should('be.checked');
-
-        // # Select the Mattermost pre-made theme
-        cy.get('#premadeThemeMattermost').first().click();
-
-        // # Save and close settings modal
-        cy.get('#saveSetting').click();
-        cy.get('#accountSettingsHeader > .close').click();
+        // # Login as new user, visit town-square and post a message
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+            cy.get('#post_textbox').clear().type('```\ncode\n```{enter}');
+        });
     });
 
     THEMES.forEach((THEME) => {

--- a/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
@@ -10,53 +10,57 @@
 // Stage: @prod
 // Group: @account_setting
 
+import {getRandomId} from '../../../utils';
+
 describe('Account Settings > Display > Message Display', () => {
     before(() => {
-        // # Change message display setting to compact
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
-        cy.changeMessageDisplaySetting('COMPACT');
+        // # Login as new user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
-    after(() => {
-        // Revert setting so it does not impact other tests
-        cy.apiSaveMessageDisplayPreference('clean');
-    });
+    ['COMPACT', 'STANDARD'].forEach((display) => {
+        it(`M14283 ${display} view: Line breaks remain intact after editing`, () => {
+            cy.uiChangeMessageDisplaySetting(display);
 
-    it('M14283 Compact view: Line breaks remain intact after editing', () => {
-        // # Enter in text
-        cy.get('#post_textbox').
-            clear().
-            type('First line').
-            type('{shift}{enter}{enter}').
-            type('Text after{enter}');
+            const firstLine = `First line ${getRandomId()}`;
+            const secondLine = `Text after ${getRandomId()}`;
 
-        // # Get last postId
-        cy.getLastPostId().then((postId) => {
-            const postMessageTextId = `#postMessageText_${postId}`;
+            // # Enter in text
+            cy.get('#post_textbox').
+                clear().
+                type(firstLine).
+                type('{shift}{enter}{enter}').
+                type(`${secondLine}{enter}`);
 
-            // * Verify HTML still includes new line
-            cy.get(postMessageTextId).should('have.html', '<p>First line</p>\n<p>Text after</p>');
+            // # Get last postId
+            cy.getLastPostId().then((postId) => {
+                const postMessageTextId = `#postMessageText_${postId}`;
 
-            // # click dot menu button
-            cy.clickPostDotMenu(postId);
+                // * Verify HTML still includes new line
+                cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine}</p>`);
 
-            // # click edit post
-            cy.get(`#edit_post_${postId}`).should('be.visible').click();
+                // # click dot menu button
+                cy.clickPostDotMenu(postId);
 
-            // # Add ",edited" to the text
-            cy.get('#edit_textbox').type(',edited');
+                // # click edit post
+                cy.get(`#edit_post_${postId}`).should('be.visible').click();
 
-            // # Save
-            cy.get('#editButton').click();
+                // # Add ",edited" to the text
+                cy.get('#edit_textbox').type(',edited');
 
-            // * Verify HTML includes newline and the edit
-            cy.get(postMessageTextId).should('have.html', '<p>First line</p>\n<p>Text after,edited</p>');
+                // # Save
+                cy.get('#editButton').click();
 
-            // * Post should have (edited)
-            cy.get(`#postEdited_${postId}`).
-                should('be.visible').
-                should('contain', '(edited)');
+                // * Verify HTML includes newline and the edit
+                cy.get(postMessageTextId).should('have.html', `<p>${firstLine}</p>\n<p>${secondLine},edited</p>`);
+
+                // * Post should have (edited)
+                cy.get(`#postEdited_${postId}`).
+                    should('be.visible').
+                    should('contain', '(edited)');
+            });
         });
     });
 });

--- a/e2e/cypress/integration/account_settings/display/theme/custom_theme_color_picker_spec.js
+++ b/e2e/cypress/integration/account_settings/display/theme/custom_theme_color_picker_spec.js
@@ -14,9 +14,10 @@ import * as TIMEOUTS from '../../../../fixtures/timeouts';
 
 describe('AS14318 Theme Colors - Color Picker', () => {
     before(() => {
-        // Login as user-1 and visit town-square channel
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
+        // # Login as new user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     beforeEach(() => {
@@ -25,10 +26,6 @@ describe('AS14318 Theme Colors - Color Picker', () => {
         cy.get('#displayButton').click();
         cy.get('#themeTitle').click();
         cy.get('#customThemes').click();
-    });
-
-    after(() => {
-        cy.apiSaveThemePreference();
     });
 
     afterEach(() => {

--- a/e2e/cypress/integration/account_settings/display/theme/custom_theme_sidebar_styles_spec.js
+++ b/e2e/cypress/integration/account_settings/display/theme/custom_theme_sidebar_styles_spec.js
@@ -30,18 +30,14 @@ const testCases = [
 
 describe('AS14318 Theme Colors - Custom Sidebar Styles input change', () => {
     before(() => {
-        // # Login as user-1, set default theme preference and visit town-square channel
-        cy.apiLogin('user-1');
-        cy.apiSaveThemePreference();
-        cy.visit('/ad-1/channels/town-square');
+        // # Login as new user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
 
-        // # Go to Theme > Custom > Sidebar Styles
-        toThemeDisplaySettings();
-        openSidebarStyles();
-    });
-
-    after(() => {
-        cy.apiSaveThemePreference();
+            // # Go to Theme > Custom > Sidebar Styles
+            toThemeDisplaySettings();
+            openSidebarStyles();
+        });
     });
 
     testCases.forEach((testCase) => {

--- a/e2e/cypress/integration/account_settings/display/theme/settings_view_spec.js
+++ b/e2e/cypress/integration/account_settings/display/theme/settings_view_spec.js
@@ -12,15 +12,10 @@
 
 describe('AS14318 Theme Colors - Settings View', () => {
     before(() => {
-        // # Login as user-1, set default theme preference and visit town-square channel
-        cy.apiLogin('user-1');
-        cy.apiSaveThemePreference();
-        cy.visit('/ad-1/channels/town-square');
-    });
-
-    after(() => {
-        // * Revert to default theme preference
-        cy.apiSaveThemePreference();
+        // # Login as new user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     it('Theme Display should render in min setting view', () => {

--- a/e2e/cypress/integration/account_settings/general/fullname_spec.js
+++ b/e2e/cypress/integration/account_settings/general/fullname_spec.js
@@ -15,14 +15,24 @@ import {getRandomId} from '../../../utils';
 describe('Account Settings > Sidebar > General', () => {
     // # number to identify particular user
     const randomId = getRandomId();
-    before(() => {
-        cy.apiLogin('sysadmin');
-        cy.apiGetTeamByName('ad-1').then((res) => {
-            const team = res.body;
-            cy.apiCreateAndLoginAsNewUser({}, [team.id]).as('newuser');
 
-            // # Go to town-square channel and into the Account Settings
-            cy.visit('/ad-1/channels/town-square');
+    let testTeam;
+    let testUser;
+    let otherUser;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+
+            cy.apiCreateUser().then(({user: user1}) => {
+                otherUser = user1;
+                cy.apiAddUserToTeam(testTeam.id, otherUser.id);
+            });
+
+            // # Login as test user, visit town-square and go to the Account Settings
+            cy.apiLogin(testUser.username, testUser.password);
+            cy.visit(`/${team.name}/channels/town-square`);
             cy.toAccountSettingsModal();
 
             // # Click General button
@@ -40,36 +50,34 @@ describe('Account Settings > Sidebar > General', () => {
     });
 
     it('M17459 - Filtering by first name with Korean characters', () => {
-        cy.apiLogin('user-1');
-        cy.get('@newuser').then((user) => {
-            cy.visit('/ad-1/channels/town-square');
+        cy.apiLogin(otherUser.username, otherUser.password);
+        cy.visit(`/${testTeam.name}/channels/town-square`);
 
-            // # type in user`s firstName substring
-            cy.get('#post_textbox').clear().type(`@정트리나${randomId}`);
+        // # type in user`s firstName substring
+        cy.get('#post_textbox').clear().type(`@정트리나${randomId}`);
 
-            cy.findByTestId(user.username, {exact: false}).within((name) => {
-                cy.wrap(name).prev('.suggestion-list__divider').
-                    should('have.text', 'Channel Members');
-                cy.wrap(name).find('.mention--align').
-                    should('have.text', `@${user.username}`);
-                cy.wrap(name).find('.ml-2').
-                    should('have.text', `정트리나${randomId}/trina.jung/집단사무국(CO) ${user.lastName} (${user.nickname})`);
-            });
-
-            // # Press tab on text input
-            cy.get('#post_textbox').tab();
-
-            // # verify that after enter user`s username match
-            cy.get('#post_textbox').should('have.value', `@${user.username} `);
-
-            // # click enter in post textbox
-            cy.get('#post_textbox').type('{enter}');
-
-            // # verify that message has been post in chat
-            cy.get(`[data-mention="${user.username}"]`).
-                last().
-                scrollIntoView().
-                should('be.visible');
+        cy.findByTestId(testUser.username, {exact: false}).within((name) => {
+            cy.wrap(name).prev('.suggestion-list__divider').
+                should('have.text', 'Channel Members');
+            cy.wrap(name).find('.mention--align').
+                should('have.text', `@${testUser.username}`);
+            cy.wrap(name).find('.ml-2').
+                should('have.text', `정트리나${randomId}/trina.jung/집단사무국(CO) ${testUser.last_name} (${testUser.nickname})`);
         });
+
+        // # Press tab on text input
+        cy.get('#post_textbox').tab();
+
+        // # verify that after enter user`s username match
+        cy.get('#post_textbox').should('have.value', `@${testUser.username} `);
+
+        // # click enter in post textbox
+        cy.get('#post_textbox').type('{enter}');
+
+        // # verify that message has been post in chat
+        cy.get(`[data-mention="${testUser.username}"]`).
+            last().
+            scrollIntoView().
+            should('be.visible');
     });
 });

--- a/e2e/cypress/integration/account_settings/general/nickname_spec.js
+++ b/e2e/cypress/integration/account_settings/general/nickname_spec.js
@@ -11,10 +11,14 @@
 // Group: @account_setting
 
 describe('Account Settings > Sidebar > General', () => {
+    let testUser;
+
     before(() => {
-        // # Login as user-1 and visit town-square channel
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
+        // # Login as new user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
+            testUser = user;
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     beforeEach(() => {
@@ -29,7 +33,7 @@ describe('Account Settings > Sidebar > General', () => {
         // * Check if element is present before nickname is set and contains expected text values
         cy.get('#generalSettingsTitle').should('be.visible').should('contain', 'General Settings');
         cy.get('#nicknameTitle').should('be.visible').should('contain', 'Nickname');
-        cy.get('#nicknameDesc').should('be.visible').should('contain', "Click 'Edit' to add a nickname");
+        cy.get('#nicknameDesc').should('be.visible').should('contain', testUser.nickname);
         cy.get('#nicknameEdit').should('be.visible').should('contain', 'Edit');
         cy.get('#accountSettingsHeader > .close').should('be.visible').click();
     });
@@ -66,9 +70,9 @@ describe('Account Settings > Sidebar > General', () => {
 
         // # Search for username and check that no nickname is present
         cy.get('.modal-title').should('be.visible');
-        cy.get('#searchUsersInput').should('be.visible').type('Victor Welch');
+        cy.get('#searchUsersInput').should('be.visible').type(testUser.first_name);
         cy.get('.more-modal__details > .more-modal__name').should('be.visible').then((el) => {
-            expect(getInnerText(el)).equal('@user-1 - Victor Welch');
+            expect(getInnerText(el)).equal(`@${testUser.username} - ${testUser.first_name} ${testUser.last_name}`);
         });
 
         // # Close Team Members modal
@@ -96,9 +100,9 @@ describe('Account Settings > Sidebar > General', () => {
 
         // # Search for username and check that expected nickname is present
         cy.get('.modal-title').should('be.visible');
-        cy.get('#searchUsersInput').should('be.visible').type('Victor Welch');
+        cy.get('#searchUsersInput').should('be.visible').type(testUser.first_name);
         cy.get('.more-modal__details > .more-modal__name').should('be.visible').then((el) => {
-            expect(getInnerText(el)).equal('@user-1 - Victor Welch (victor_nick)');
+            expect(getInnerText(el)).equal(`@${testUser.username} - ${testUser.first_name} ${testUser.last_name} (victor_nick)`);
         });
 
         // # Close Channel Members modal

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -13,34 +13,26 @@
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('Account Settings > Sidebar > Channel Switcher', () => {
+    let testUser;
     let testChannel;
     let testTeam;
 
     before(() => {
-        // # Login as user-1
-        cy.apiLogin('user-1');
+        // # Login as test user
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel, user}) => {
+            testUser = user;
+            testChannel = channel;
+            testTeam = team;
 
-        // # Create a test team and channels
-        cy.apiCreateTeam('test-team', 'Test Team').then((teamRes) => {
-            testTeam = teamRes.body;
-
+            // # Create more test channels
             const numberOfChannels = 14;
             Cypress._.forEach(Array(numberOfChannels), (_, index) => {
-                cy.apiCreateChannel(testTeam.id, 'channel-switcher', `Channel Switcher ${index.toString()}`).then((response) => {
-                    if (index === 0) {
-                        testChannel = response.body;
-                    }
-                });
+                cy.apiCreateChannel(testTeam.id, 'channel-switcher', `Channel Switcher ${index.toString()}`);
             });
-        });
-    });
 
-    after(() => {
-        // # Delete the test team as sysadmin
-        if (testTeam && testTeam.id) {
-            cy.apiLogin('sysadmin');
-            cy.apiDeleteTeam(testTeam.id, true);
-        }
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     it('set channel switcher setting to On and test on click of sidebar switcher button', () => {
@@ -108,7 +100,7 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
 
     it('Cmd/Ctrl+Shift+M closes Channel Switch modal and sets focus to mentions', () => {
         // # patch user info
-        cy.apiPatchMe({notify_props: {first_name: 'false', mention_keys: 'user-1'}});
+        cy.apiPatchMe({notify_props: {first_name: 'false', mention_keys: testUser.username}});
 
         // # Go to a known team and channel
         cy.visit(`/${testTeam.name}/channels/town-square`);
@@ -127,7 +119,7 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         cy.get('#suggestionList').should('not.be.visible');
 
         // * searchbox should appear
-        cy.get('#searchBox').should('have.attr', 'value', 'user-1 @user-1 ');
+        cy.get('#searchBox').should('have.attr', 'value', `${testUser.username} @${testUser.username} `);
         cy.get('.sidebar--right__title').should('contain', 'Recent Mentions');
     });
 });

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_ui_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_ui_spec.js
@@ -12,8 +12,7 @@
 
 describe('Account Settings > Sidebar > Channel Switcher', () => {
     before(() => {
-        // # Login as user-1 and visit town-square channel
-        cy.apiLogin('sysadmin');
+        // # Update config and visit town-square channel
         cy.apiUpdateConfig({
             ServiceSettings: {
                 ExperimentalChannelSidebarOrganization: 'disabled',

--- a/e2e/cypress/integration/channel/add_users_to_channel_spec.js
+++ b/e2e/cypress/integration/channel/add_users_to_channel_spec.js
@@ -53,15 +53,29 @@ function addNumberOfUsersToChannel(num = 1) {
 }
 
 describe('CS15445 Join/leave messages', () => {
+    let testTeam;
+
     before(() => {
-        cy.apiLogin('user-1');
-        cy.apiSaveTeammateNameDisplayPreference('username');
-        cy.visit('/ad-1/channels/town-square');
+        // # Login as new user and visit town-square
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+
+            // # Add atleast 4 users
+            for (let i = 0; i < 4; i++) {
+                cy.apiCreateUser().then(({user: newUser}) => { // eslint-disable-line
+                    cy.apiAddUserToTeam(testTeam.id, newUser.id);
+                });
+            }
+
+            cy.apiLogin(user.username, user.password);
+        });
     });
 
     it('Single User: Usernames are links, open profile popovers', () => {
         // # Create and visit new channel
-        cy.createAndVisitNewChannel().then(() => {
+        cy.apiCreateChannel(testTeam.id, 'channel-test', 'Channel').then((res) => {
+            cy.visit(`/${testTeam.name}/channels/${res.body.name}`);
+
             // # Add users to channel
             addNumberOfUsersToChannel(1);
 
@@ -77,7 +91,9 @@ describe('CS15445 Join/leave messages', () => {
 
     it('Combined Users: Usernames are links, open profile popovers', () => {
         // # Create and visit new channel
-        cy.createAndVisitNewChannel().then(() => {
+        cy.apiCreateChannel(testTeam.id, 'channel-test', 'Channel').then((res) => {
+            cy.visit(`/${testTeam.name}/channels/${res.body.name}`);
+
             addNumberOfUsersToChannel(3);
 
             cy.getLastPostId().then((id) => {

--- a/e2e/cypress/integration/channel/add_users_to_channel_spec.js
+++ b/e2e/cypress/integration/channel/add_users_to_channel_spec.js
@@ -60,7 +60,7 @@ describe('CS15445 Join/leave messages', () => {
         cy.apiInitSetup().then(({team, user}) => {
             testTeam = team;
 
-            // # Add atleast 4 users
+            // # Add 4 users
             for (let i = 0; i < 4; i++) {
                 cy.apiCreateUser().then(({user: newUser}) => { // eslint-disable-line
                     cy.apiAddUserToTeam(testTeam.id, newUser.id);

--- a/e2e/cypress/integration/channel/archived_channels_spec.js
+++ b/e2e/cypress/integration/channel/archived_channels_spec.js
@@ -11,7 +11,6 @@
 // Group: @channel
 
 import {testWithConfig} from '../../support/hooks';
-
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('Leave an archived channel', () => {
@@ -21,36 +20,40 @@ describe('Leave an archived channel', () => {
         },
     });
 
+    let testTeam;
+    let testChannel;
+
     before(() => {
-        cy.apiLogin('user-1');
-        cy.visit('/');
+        // # Login as test user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            testTeam = team;
+            testChannel = channel;
+
+            cy.visit(`/${team.name}/channels/${testChannel.name}`);
+        });
     });
 
     it('should leave recently archived channel', () => {
-        const channelName = 'archived-channels-spec-' + Date.now().toString();
+        // # Archive the channel
+        cy.get('#channelHeaderDropdownIcon').click();
+        cy.get('#channelArchiveChannel').click();
+        cy.get('#deleteChannelModalDeleteButton').click();
 
-        cy.createAndVisitNewChannel(channelName).then((channel) => {
-            // # Archive the channel
-            cy.get('#channelHeaderDropdownIcon').click();
-            cy.get('#channelArchiveChannel').click();
-            cy.get('#deleteChannelModalDeleteButton').click();
+        // # Switch to another channel
+        cy.visit(`/${testTeam.name}/channels/town-square`);
 
-            // # Switch to another channel
-            cy.visit('/ad-1/channels/town-square');
+        // # Switch back to the archived channel
+        cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
-            // # Switch back to the archived channel
-            cy.visit(`/ad-1/channels/${channel.name}`);
+        // # Leave the channel
+        cy.get('#channelHeaderDropdownIcon').click();
+        cy.get('#channelLeaveChannel').click();
 
-            // # Leave the channel
-            cy.get('#channelHeaderDropdownIcon').click();
-            cy.get('#channelLeaveChannel').click();
+        // # Wait to make sure that the Loading page does not get back
+        cy.wait(TIMEOUTS.SMALL);
 
-            // # Wait to make sure that the Loading page does not get back
-            cy.wait(TIMEOUTS.SMALL);
-
-            // * Verify sure that we have switched channels
-            cy.get('#channelHeaderTitle').should('not.contain', channel.display_name);
-        });
+        // * Verify sure that we have switched channels
+        cy.get('#channelHeaderTitle').should('not.contain', testChannel.display_name);
     });
 });
 

--- a/e2e/cypress/integration/channel/channel_groups_spec.js
+++ b/e2e/cypress/integration/channel/channel_groups_spec.js
@@ -20,8 +20,6 @@ describe('channel groups', () => {
     before(() => {
         cy.requireLicenseForFeature('LDAP');
 
-        cy.apiLogin('sysadmin');
-
         // # Link 2 groups
         cy.apiGetLDAPGroups().then((result) => {
             for (let i = 0; i < 2; i++) {
@@ -53,7 +51,7 @@ describe('channel groups', () => {
     });
 
     after(() => {
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         cy.apiDeleteTeam(teamID, true);
         for (let i = 0; i < 2; i++) {
             cy.apiUnlinkGroup(groups[i].remote_id);
@@ -73,7 +71,7 @@ describe('channel groups', () => {
         cy.get('#addGroupsToChannelModal').find('.more-modal__row').its('length').should('be.gte', 2);
 
         // # Group-constrain the parent team
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         cy.apiPatchTeam(teamID, {group_constrained: true});
         cy.apiLogin('board.one', 'Password1');
         cy.visit(`/${teamName}/channels/off-topic`);

--- a/e2e/cypress/integration/channel/channel_mention_autocomplete_spec.js
+++ b/e2e/cypress/integration/channel/channel_mention_autocomplete_spec.js
@@ -10,31 +10,27 @@
 // Stage: @prod
 // Group: @channel
 
-import users from '../../fixtures/users.json';
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('Channel', () => {
     let testTeam;
-    let testChannel;
+    let ownChannel;
+    let otherChannel;
+    let testUser;
 
     before(() => {
-        // # Build data to test and login as user-1
-        cy.apiLogin('user-1');
-        cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-            testTeam = response.body;
+        // # Login as new user and visit town-square
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            testTeam = team;
+            ownChannel = channel;
+            testUser = user;
 
-            cy.apiGetUserByEmail(users.sysadmin.email).then((eRes) => {
-                const user = eRes.body;
-                cy.apiAddUserToTeam(testTeam.id, user.id);
-
-                cy.apiLogin('sysadmin');
-                cy.apiCreateChannel(testTeam.id, 'test-channel', 'Test Channel').then((cRes) => {
-                    testChannel = cRes.body;
-
-                    cy.apiLogin('user-1');
-                    cy.visit(`/${testTeam.name}/channels/town-square`);
-                });
+            cy.apiCreateChannel(testTeam.id, 'delta-test', 'Delta Channel').then((res) => {
+                otherChannel = res.body;
             });
+
+            cy.apiLogin(testUser.username, testUser.password);
+            cy.visit(`/${team.name}/channels/town-square`);
         });
     });
 
@@ -47,19 +43,20 @@ describe('Channel', () => {
         // * Should match each channel item and group label
         cy.get('#suggestionList').should('be.visible').children().within((el) => {
             cy.wrap(el).eq(0).should('contain', 'My Channels');
-            cy.wrap(el).eq(1).should('contain', 'Off-Topic');
-            cy.wrap(el).eq(2).should('contain', 'Town Square');
-            cy.wrap(el).eq(3).should('contain', 'Other Channels');
-            cy.wrap(el).eq(4).should('contain', testChannel.display_name);
+            cy.wrap(el).eq(1).should('contain', ownChannel.display_name);
+            cy.wrap(el).eq(2).should('contain', 'Off-Topic');
+            cy.wrap(el).eq(3).should('contain', 'Town Square');
+            cy.wrap(el).eq(4).should('contain', 'Other Channels');
+            cy.wrap(el).eq(5).should('contain', otherChannel.display_name);
         });
     });
 
     it('Joining a channel should alter channel mention autocomplete lists accordingly', () => {
         // # Join a channel by /join slash command
-        cy.get('#post_textbox').should('be.visible').clear().wait(TIMEOUTS.TINY).type(`/join ~${testChannel.name}`).type('{enter}').wait(TIMEOUTS.TINY);
+        cy.get('#post_textbox').should('be.visible').clear().wait(TIMEOUTS.TINY).type(`/join ~${otherChannel.name}`).type('{enter}').wait(TIMEOUTS.TINY);
 
         // * Verify that it redirects into the channel
-        cy.url().should('include', `/${testTeam.name}/channels/${testChannel.name}`);
+        cy.url().should('include', `/${testTeam.name}/channels/${otherChannel.name}`);
 
         // # Type "~"
         cy.get('#post_textbox').should('be.visible').type('~').wait(TIMEOUTS.TINY);
@@ -69,22 +66,21 @@ describe('Channel', () => {
         // * Should match each channel item and group label
         cy.get('#suggestionList').should('be.visible').children().within((el) => {
             cy.wrap(el).eq(0).should('contain', 'My Channels');
-            cy.wrap(el).eq(1).should('contain', 'Off-Topic');
-            cy.wrap(el).eq(2).should('contain', testChannel.display_name);
-            cy.wrap(el).eq(3).should('contain', 'Town Square');
+            cy.wrap(el).eq(1).should('contain', ownChannel.display_name);
+            cy.wrap(el).eq(2).should('contain', otherChannel.display_name);
+            cy.wrap(el).eq(3).should('contain', 'Off-Topic');
+            cy.wrap(el).eq(4).should('contain', 'Town Square');
         });
     });
 
     it('Getting removed from a channel should alter channel mention autocomplete lists accordingly', () => {
-        // # Remove user-1 from the test channel
-        cy.apiGetMe().then((res) => {
-            const userId = res.body.id;
-            return cy.removeUserFromChannel(testChannel.id, userId);
-        }).then((res) => {
+        // # Remove test user from the test channel
+        cy.apiAdminLogin();
+        cy.removeUserFromChannel(otherChannel.id, testUser.id).then((res) => {
             expect(res).to.equal(200);
 
-            // # Login as user-1 and visit the test team
-            cy.apiLogin('user-1');
+            // # Login as test user and visit the test team
+            cy.apiLogin(testUser.username, testUser.password);
             cy.visit(`/${testTeam.name}/channels/town-square`);
 
             // # Type "~"
@@ -95,10 +91,11 @@ describe('Channel', () => {
             // * Should match each channel item and group label
             cy.get('#suggestionList').should('be.visible').children().within((el) => {
                 cy.wrap(el).eq(0).should('contain', 'My Channels');
-                cy.wrap(el).eq(1).should('contain', 'Off-Topic');
-                cy.wrap(el).eq(2).should('contain', 'Town Square');
-                cy.wrap(el).eq(3).should('contain', 'Other Channels');
-                cy.wrap(el).eq(4).should('contain', testChannel.display_name);
+                cy.wrap(el).eq(1).should('contain', ownChannel.display_name);
+                cy.wrap(el).eq(2).should('contain', 'Off-Topic');
+                cy.wrap(el).eq(3).should('contain', 'Town Square');
+                cy.wrap(el).eq(4).should('contain', 'Other Channels');
+                cy.wrap(el).eq(5).should('contain', otherChannel.display_name);
             });
         });
     });

--- a/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
+++ b/e2e/cypress/integration/channel/channel_name_tooltips_spec.js
@@ -39,41 +39,28 @@ function verifyChannel(res, verifyExistence = true) {
 describe('channel name tooltips', () => {
     let loggedUser;
     let longUser;
-    let team;
+    let testTeam;
 
     before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+        // # Login as new user and visit town-square
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            loggedUser = user;
 
-        // # Create new test team
-        cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-            team = response.body;
-
-            // # Create test user with long username
-            cy.apiCreateNewUser({
-                email: `longUser${timestamp}@sample.mattermost.com`,
-                username: `thisIsALongUsername${timestamp}`,
-                firstName: `thisIsALongFirst${timestamp}`,
-                lastName: `thisIsALongLast${timestamp}`,
-                nickname: `thisIsALongNickname${timestamp}`,
-                password: 'password123',
-            }, [team.id]).then((user) => {
-                longUser = user;
+            cy.apiCreateUser({prefix: `thisIsALongUsername${timestamp}`}).then(({user: user1}) => {
+                longUser = user1;
+                cy.apiAddUserToTeam(testTeam.id, loggedUser.id);
             });
 
-            cy.apiCreateAndLoginAsNewUser({}, [team.id]).then((user) => {
-                loggedUser = user;
-
-                // # Go to "/"
-                cy.visit(`/${response.body.name}/town-square`);
-            });
+            cy.apiLogin(loggedUser.username, loggedUser.password);
+            cy.visit(`/${testTeam.name}/channels/town-square`);
         });
     });
 
     it('Should show tooltip on hover - open/public channel with long name', () => {
         // # Create new test channel
         cy.apiCreateChannel(
-            team.id,
+            testTeam.id,
             'channel-test',
             `Public channel with a long name-${timestamp}`,
         ).then((res) => {
@@ -84,7 +71,7 @@ describe('channel name tooltips', () => {
     it('Should show tooltip on hover - private channel with long name', () => {
         // # Create new test channel
         cy.apiCreateChannel(
-            team.id,
+            testTeam.id,
             'channel-test',
             `Private channel with a long name-${timestamp}`,
             'P',
@@ -96,7 +83,7 @@ describe('channel name tooltips', () => {
     it('Should not show tooltip on hover - open/public channel with short name', () => {
         // # Create new test channel
         cy.apiCreateChannel(
-            team.id,
+            testTeam.id,
             'channel-test',
             'Public channel',
         ).then((res) => {
@@ -107,7 +94,7 @@ describe('channel name tooltips', () => {
     it('Should not show tooltip on hover - private channel with short name', () => {
         // # Create new test channel
         cy.apiCreateChannel(
-            team.id,
+            testTeam.id,
             'channel-test',
             'Private channel',
             'P',

--- a/e2e/cypress/integration/channel/channel_routing_spec.js
+++ b/e2e/cypress/integration/channel/channel_routing_spec.js
@@ -11,122 +11,134 @@
 // Group: @channel
 
 describe('Channel routing', () => {
+    let testUser;
+    let otherUser1;
+    let otherUser2;
+    let testTeam;
+
     before(() => {
-        cy.apiLogin('user-1');
-        cy.apiSaveTeammateNameDisplayPreference('username');
-        cy.visit('/ad-1/channels/town-square');
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            cy.apiCreateUser().then(({user: newUser}) => {
+                otherUser1 = newUser;
+
+                cy.apiAddUserToTeam(team.id, newUser.id);
+            });
+
+            cy.apiCreateUser().then(({user: newUser}) => {
+                otherUser2 = newUser;
+
+                cy.apiAddUserToTeam(team.id, newUser.id);
+            });
+
+            // # Login as test user and go to town square
+            cy.apiLogin(testUser.username, testUser.password);
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     it('should go to town square channel view', () => {
-        // # Go to town square channel
-        cy.visit('/ad-1/channels/town-square');
-
         // * Check if the channel is loaded correctly
         cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
     });
 
     it('should go to private channel view', () => {
-        cy.getCurrentTeamId().then((teamId) => {
-            // # Create a private channel
-            cy.apiCreateChannel(teamId, 'private-channel', 'Private channel', 'P').then((response) => {
-                // # Go to the newly created channel
-                cy.visit(`/ad-1/channels/${response.body.name}`);
+        // # Create a private channel
+        cy.apiCreateChannel(testTeam.id, 'private-channel', 'Private channel', 'P').then((response) => {
+            // # Go to the newly created channel
+            cy.visit(`/${testTeam.name}/channels/${response.body.name}`);
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Private channel');
+            // * Check you can go to the channel without problem
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Private channel');
 
-                // # Remove the created channel
-                cy.apiDeleteChannel(response.body.id);
-            });
+            // # Remove the created channel
+            cy.apiDeleteChannel(response.body.id);
         });
     });
 
     it('should go to self direct channel using the multiple ways to go', () => {
-        cy.apiGetUsers(['user-1']).then((userResponse) => {
-            const user = userResponse.body[0];
+        // # Create a self direct channel
+        cy.apiCreateDirectChannel([testUser.id, testUser.id]).then((response) => {
+            const ownDMChannel = response.body;
 
-            // # Create a self direct channel
-            cy.apiCreateDirectChannel([user.id, user.id]).then((response) => {
-                // # Visit the channel using the channel name
-                cy.visit(`/ad-1/channels/${user.id}__${user.id}`);
+            // # Visit the channel using the channel name
+            cy.visit(`/${testTeam.name}/channels/${testUser.id}__${testUser.id}`);
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+            // * Check you can go to the channel without problem
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', `${testUser.username} (you)`);
 
-                // # Visit the channel using the channel id
-                cy.visit(`/ad-1/channels/${response.body.id}`);
+            // # Visit the channel using the channel id
+            cy.visit(`/${testTeam.name}/channels/${ownDMChannel.id}`);
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+            // * Check you can go to the channel without problem
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', `${testUser.username} (you)`);
 
-                // # Visit the channel using the username
-                cy.visit(`/ad-1/messages/@${user.username}`);
+            // # Visit the channel using the username
+            cy.visit(`/${testTeam.name}/messages/@${testUser.username}`);
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
+            // * Check you can go to the channel without problem
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', `${testUser.username} (you)`);
 
-                // # Visit the channel using the user email
-                cy.visit(`/ad-1/messages/${user.email}`);
+            // # Visit the channel using the user email
+            cy.visit(`/${testTeam.name}/messages/${testUser.email}`);
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'user-1');
-            });
+            // * Check you can go to the channel without problem
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', `${testUser.username} (you)`);
         });
     });
 
     it('should go to other user direct channel using multiple ways to go', () => {
-        cy.apiGetUsers(['user-1', 'sysadmin']).then((userResponse) => {
-            const user1 = userResponse.body[1];
-            const user2 = userResponse.body[0];
-            const userIds = [user2.id, user1.id];
+        // # Create a direct channel between two users
+        cy.apiCreateDirectChannel([testUser.id, otherUser1.id]).then((response) => {
+            const dmChannel = response.body;
 
-            // # Create a direct channel between two users
-            cy.apiCreateDirectChannel(userIds).then((response) => {
-                // # Visit the channel using the channel name
-                cy.visit(`/ad-1/channels/${user1.id}__${user2.id}`);
+            // # Visit the channel using the channel name
+            cy.visit(`/${testTeam.name}/channels/${testUser.id}__${otherUser1.id}`);
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+            // * Check you can go to the channel without problem
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', otherUser1.username);
 
-                // # Visit the channel using the channel id
-                cy.visit(`/ad-1/channels/${response.body.id}`);
+            // # Visit the channel using the channel id
+            cy.visit(`/${testTeam.name}/channels/${dmChannel.id}`);
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+            // * Check you can go to the channel without problem
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', otherUser1.username);
 
-                // # Visit the channel using the target username
-                cy.visit(`/ad-1/messages/@${user2.username}`);
+            // # Visit the channel using the target username
+            cy.visit(`/${testTeam.name}/messages/@${otherUser1.username}`);
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
+            // * Check you can go to the channel without problem
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', otherUser1.username);
 
-                // # Visit the channel using the target user email
-                cy.visit(`/ad-1/messages/${user2.email}`);
+            // # Visit the channel using the target user email
+            cy.visit(`/${testTeam.name}/messages/${otherUser1.email}`);
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'sysadmin');
-            });
+            // * Check you can go to the channel without problem
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', otherUser1.username);
         });
     });
+
     it('should go group channel using group id', () => {
-        const users = ['user-1', 'aaron.peterson', 'sysadmin'];
-        cy.apiGetUsers(users).then((userResponse) => {
-            const userGroupIds = [userResponse.body[2].id, userResponse.body[1].id, userResponse.body[0].id];
+        const userGroupIds = [testUser.id, otherUser1.id, otherUser2.id];
 
-            // # Create a group channel for 3 users
-            cy.apiCreateGroupChannel(userGroupIds).then((response) => {
-                // # Visit the channel using the name using the channels route
-                cy.visit(`/ad-1/channels/${response.body.name}`);
+        // # Create a group channel for 3 users
+        cy.apiCreateGroupChannel(userGroupIds).then((response) => {
+            const gmChannel = response.body;
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'aaron.peterson, sysadmin');
+            // # Visit the channel using the name using the channels route
+            cy.visit(`/${testTeam.name}/channels/${gmChannel.name}`);
 
-                // # Visit the channel using the name using the messages route
-                cy.visit(`/ad-1/messages/${response.body.name}`);
+            // * Check you can go to the channel without problem
+            const displayName = gmChannel.display_name.split(', ').filter(((username) => username !== testUser.username)).join(', ');
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', displayName);
 
-                // * Check you can go to the channel without problem
-                cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'aaron.peterson, sysadmin');
-            });
+            // # Visit the channel using the name using the messages route
+            cy.visit(`/${testTeam.name}/messages/${gmChannel.name}`);
+
+            // * Check you can go to the channel without problem
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', displayName);
         });
     });
 });

--- a/e2e/cypress/integration/channel/channel_settings_spec.js
+++ b/e2e/cypress/integration/channel/channel_settings_spec.js
@@ -13,8 +13,16 @@
 
 describe('Channel Settings', () => {
     before(() => {
-        // # Go to Main Channel View with "user-1"
-        cy.toMainChannelView('user-1');
+        cy.apiInitSetup().then(({team, user}) => {
+            cy.apiCreateChannel(team.id, 'channel', 'Private Channel', 'P').then((res) => {
+                cy.apiAddUserToChannel(res.body.id, user.id);
+            });
+
+            cy.apiLogin(user.username, user.password);
+
+            // # Visit town-square channel
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     it('C15052 All channel types have appropriate close button', () => {

--- a/e2e/cypress/integration/channel/close_direct_group_spec.js
+++ b/e2e/cypress/integration/channel/close_direct_group_spec.js
@@ -22,13 +22,28 @@ function verifyChannelWasProperlyClosed(channelName) {
 }
 
 describe('Close direct messages', () => {
+    let testUser;
+    let otherUser;
+    let testTeam;
+
     before(() => {
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+
+            cy.apiCreateUser().then(({user: newUser}) => {
+                otherUser = newUser;
+                cy.apiAddUserToTeam(team.id, newUser.id);
+            });
+
+            // # Login as test user and go to town square
+            cy.apiLogin(testUser.username, testUser.password);
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+        });
     });
 
     it('Through channel header dropdown menu', () => {
-        cy.createAndVisitNewDirectMessageWith('sysadmin').then((channel) => {
+        createAndVisitDMChannel([testUser.id, otherUser.id]).then((channel) => {
             // # Open channel header dropdown menu and click on Close Direct Message
             cy.get('#channelHeaderDropdownIcon').click();
             cy.findByText('Close Direct Message').click();
@@ -38,23 +53,58 @@ describe('Close direct messages', () => {
     });
 
     it('Through x button on channel sidebar item', () => {
-        cy.createAndVisitNewDirectMessageWith('sysadmin').then((channel) => {
+        createAndVisitDMChannel([testUser.id, otherUser.id]).then((channel) => {
             // # Click on the x button on the sidebar channel item
             cy.get('#sidebarItem_' + channel.name + '>span.btn-close').click({force: true});
 
             verifyChannelWasProperlyClosed(channel.name);
         });
     });
+
+    function createAndVisitDMChannel(userIds) {
+        return cy.apiCreateDirectChannel(userIds).then((res) => {
+            const channel = res.body;
+
+            // # Visit the new channel
+            cy.visit(`/${testTeam.name}/channels/${channel.name}`);
+
+            // * Verify channel's display name
+            cy.get('#channelHeaderTitle').should('contain', channel.display_name);
+
+            return cy.wrap(channel);
+        });
+    }
 });
 
 describe('Close group messages', () => {
+    let testUser;
+    let otherUser1;
+    let otherUser2;
+    let testTeam;
+
     before(() => {
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
+        cy.apiAdminLogin();
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+
+            cy.apiCreateUser({prefix: 'aaa'}).then(({user: newUser}) => {
+                otherUser1 = newUser;
+                cy.apiAddUserToTeam(team.id, newUser.id);
+            });
+            cy.apiCreateUser({prefix: 'bbb'}).then(({user: newUser}) => {
+                otherUser2 = newUser;
+                cy.apiAddUserToTeam(team.id, newUser.id);
+            });
+
+            // # Login as test user and go to town square
+            cy.apiLogin(testUser.username, testUser.password);
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     it('Through channel header dropdown menu', () => {
-        cy.createAndVisitNewGroupMessageWith(['sysadmin', 'samuel.tucker']).then((channel) => {
+        createAndVisitGMChannel([otherUser1, otherUser2]).then((channel) => {
             // # Open channel header dropdown menu and click on Close Direct Message
             cy.get('#channelHeaderDropdownIcon').click();
             cy.findByText('Close Group Message').click();
@@ -64,11 +114,30 @@ describe('Close group messages', () => {
     });
 
     it('Through x button on channel sidebar item', () => {
-        cy.createAndVisitNewGroupMessageWith(['sysadmin', 'samuel.tucker']).then((channel) => {
+        createAndVisitGMChannel([otherUser1, otherUser2]).then((channel) => {
             // # Click on the x button on the sidebar channel item
             cy.get('#sidebarItem_' + channel.name + '>span.btn-close').click({force: true});
 
             verifyChannelWasProperlyClosed(channel.name);
         });
     });
+
+    function createAndVisitGMChannel(users = []) {
+        const userIds = users.map((user) => user.id);
+        return cy.apiCreateGroupChannel(userIds).then((res) => {
+            const channel = res.body;
+
+            // # Visit the new channel
+            cy.visit(`/${testTeam.name}/channels/${channel.name}`);
+
+            // * Verify channel's display name
+            const displayName = users.
+                map((member) => member.username).
+                sort((a, b) => a.localeCompare(b, 'en', {numeric: true})).
+                join(', ');
+            cy.get('#channelHeaderTitle').should('contain', displayName);
+
+            return cy.wrap(channel);
+        });
+    }
 });

--- a/e2e/cypress/integration/channel/more_channels_spec.js
+++ b/e2e/cypress/integration/channel/more_channels_spec.js
@@ -12,38 +12,51 @@
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
-let channel;
-
 describe('Channels', () => {
-    it('MM-19337 Verify UI of More channels modal with archived selection', () => {
-        // # Login as sysadmin and update config
-        cy.apiLogin('sysadmin');
-        cy.apiGetTeamByName('ad-1').then((teamRes) => {
-            // # Create new test channel
-            cy.apiCreateChannel(teamRes.body.id, 'channel-test', 'Channel Test' + Date.now()).then((channelRes) => {
-                channel = channelRes.body;
+    let testUser;
+    let otherUser;
+    let testTeam;
+    let testChannel;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+
+            cy.apiCreateUser().then(({user: user1}) => {
+                otherUser = user1;
+
+                cy.apiAddUserToTeam(testTeam.id, otherUser.id);
+            });
+
+            cy.apiLogin(testUser.username, testUser.password).then(() => {
+                // # Create new test channel
+                cy.apiCreateChannel(testTeam.id, 'channel-test', 'Channel').then((channelRes) => {
+                    testChannel = channelRes.body;
+                });
+
+                // # Go to town square
+                cy.visit(`/${team.name}/channels/town-square`);
             });
         });
+    });
 
-        cy.visit('/ad-1/channels/town-square');
-
-        verifyMoreChannelsModalWithArchivedSelection(false);
-
-        verifyMoreChannelsModalWithArchivedSelection(true);
+    it('MM-19337 Verify UI of More channels modal with archived selection', () => {
+        verifyMoreChannelsModalWithArchivedSelection(false, testUser, testTeam);
+        verifyMoreChannelsModalWithArchivedSelection(true, testUser, testTeam);
     });
 
     it('MM-19337 Enable users to view archived channels', () => {
-        // # Login as new user and go to "/"
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         cy.apiUpdateConfig({
             TeamSettings: {
                 ExperimentalViewArchivedChannels: true,
             },
         });
-        cy.apiGetTeamByName('ad-1').then((res) => {
-            cy.apiCreateAndLoginAsNewUser({}, [res.body.id]);
-            cy.visit('/ad-1/channels/town-square');
-        });
+
+        // # Login as new user and go to "/"
+        cy.apiLogin(otherUser.username, otherUser.password);
+        cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Go to LHS and click "More..." under Public Channels group
         cy.get('#publicChannelList').should('be.visible').within(() => {
@@ -52,31 +65,31 @@ describe('Channels', () => {
 
         cy.get('#moreChannelsModal').should('be.visible').within(() => {
             // * Dropdown should be visible, defaulting to "Public Channels"
-            cy.get('#channelsMoreDropdown').should('be.visible').and('contain', 'Show: Public Channels');
+            cy.get('#channelsMoreDropdown').should('be.visible').and('contain', 'Show: Public Channels').wait(TIMEOUTS.TINY);
 
-            cy.get('#searchChannelsTextbox').type(channel.display_name).wait(TIMEOUTS.TINY);
-            cy.get('#moreChannelsList').children().should('have.length', 1).within(() => {
-                cy.findByText(channel.display_name).should('be.visible');
+            cy.get('#searchChannelsTextbox').should('be.visible').type(testChannel.display_name).wait(TIMEOUTS.TINY);
+            cy.get('#moreChannelsList').should('be.visible').children().should('have.length', 1).within(() => {
+                cy.findByText(testChannel.display_name).should('be.visible');
             });
             cy.get('#searchChannelsTextbox').clear();
 
             // * Channel test should be visible as a public channel in the list
             cy.get('#moreChannelsList').should('be.visible').within(() => {
                 // # Click to join the channel
-                cy.findByText(channel.display_name).scrollIntoView().should('be.visible').click();
+                cy.findByText(testChannel.display_name).scrollIntoView().should('be.visible').click();
             });
         });
 
         // # Verify that the modal is closed and it's redirected to the selected channel
         cy.get('#moreChannelsModal').should('not.exist');
-        cy.url().should('include', `/ad-1/channels/${channel.name}`);
+        cy.url().should('include', `/${testTeam.name}/channels/${testChannel.name}`);
 
         // # Login as channel admin and go directly to the channel
-        cy.apiLogin('user-1');
-        cy.visit(`/ad-1/channels/${channel.name}`);
+        cy.apiLogin(testUser.username, testUser.password);
+        cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
 
         // # Click channel header to open channel menu
-        cy.get('#channelHeaderTitle').should('contain', channel.display_name).click();
+        cy.get('#channelHeaderTitle').should('contain', testChannel.display_name).click();
 
         // * Verify that the menu is opened
         cy.get('.Menu__content').should('be.visible').within(() => {
@@ -105,16 +118,16 @@ describe('Channels', () => {
                 cy.wrap(el).should('contain', 'Show: Archived Channels');
             });
 
-            cy.get('#searchChannelsTextbox').type(channel.display_name).wait(TIMEOUTS.TINY);
+            cy.get('#searchChannelsTextbox').should('be.visible').type(testChannel.display_name).wait(TIMEOUTS.TINY);
             cy.get('#moreChannelsList').children().should('have.length', 1).within(() => {
-                cy.findByText(channel.display_name).should('be.visible');
+                cy.findByText(testChannel.display_name).should('be.visible');
             });
             cy.get('#searchChannelsTextbox').clear();
 
             // * Test channel should be visible as a archived channel in the list
             cy.get('#moreChannelsList').should('be.visible').within(() => {
                 // # Click to view archived channel
-                cy.findByText(channel.display_name).scrollIntoView().should('be.visible').click();
+                cy.findByText(testChannel.display_name).scrollIntoView().should('be.visible').click();
             });
         });
 
@@ -126,13 +139,13 @@ describe('Channels', () => {
         cy.get('#sidebarItem_town-square').click();
 
         // * Assert that archived channel doesn't show up in LHS list
-        cy.get('#publicChannelList').should('not.contain', channel.display_name);
+        cy.get('#publicChannelList').should('not.contain', testChannel.display_name);
     });
 });
 
-function verifyMoreChannelsModalWithArchivedSelection(isEnabled) {
+function verifyMoreChannelsModalWithArchivedSelection(isEnabled, testUser, testTeam) {
     // # Login as sysadmin and Update config to enable/disable viewing of archived channels
-    cy.apiLogin('sysadmin');
+    cy.apiAdminLogin();
     cy.apiUpdateConfig({
         TeamSettings: {
             ExperimentalViewArchivedChannels: isEnabled,
@@ -140,16 +153,16 @@ function verifyMoreChannelsModalWithArchivedSelection(isEnabled) {
     });
 
     // * Verify more channels modal
+    cy.visit(`/${testTeam.name}/channels/town-square`);
     verifyMoreChannelsModal(isEnabled);
 
     // # Login as regular user and verify more channels modal
-    cy.apiLogin('user-1');
+    cy.apiLogin(testUser.username, testUser.password);
+    cy.visit(`/${testTeam.name}/channels/town-square`);
     verifyMoreChannelsModal(isEnabled);
 }
 
 function verifyMoreChannelsModal(isEnabled) {
-    cy.visit('/ad-1/channels/town-square');
-
     // # Select "More..." on the left hand side menu
     cy.get('#publicChannelList').should('be.visible').within(() => {
         cy.findByText('More...').scrollIntoView().should('be.visible').click({force: true});

--- a/e2e/cypress/integration/channel/user_to_admin_updates_manage_channel_members_modal_spec.js
+++ b/e2e/cypress/integration/channel/user_to_admin_updates_manage_channel_members_modal_spec.js
@@ -12,9 +12,9 @@
 
 import {getAdminAccount} from '../../support/env';
 
-const sysadmin = getAdminAccount();
-
 describe('View Members modal', () => {
+    const sysadmin = getAdminAccount();
+
     it('MM-20164 - Going from a Member to an Admin should update the modal', () => {
         cy.apiInitSetup().then(({team, user}) => {
             cy.apiCreateUser().then(({user: user1}) => {
@@ -24,24 +24,24 @@ describe('View Members modal', () => {
             // # Promote user as a system admin
             // # Visit default channel and verify members modal
             cy.apiLogin(user.username, user.password);
-            promoteToSysAdmin(user);
+            promoteToSysAdmin(user, sysadmin);
             cy.visit(`/${team.name}/channels/town-square`);
             verifyMemberDropdownAction(true);
 
             // # Make user a regular member
             // # Reload and verify members modal
-            demoteToMember(user);
+            demoteToMember(user, sysadmin);
             cy.reload();
             verifyMemberDropdownAction(false);
         });
     });
 });
 
-const demoteToMember = (user) => {
+const demoteToMember = (user, sysadmin) => {
     cy.externalRequest({user: sysadmin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user'}});
 };
 
-const promoteToSysAdmin = (user) => {
+const promoteToSysAdmin = (user, sysadmin) => {
     cy.externalRequest({user: sysadmin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}});
 };
 

--- a/e2e/cypress/integration/channel/user_to_admin_updates_manage_channel_members_modal_spec.js
+++ b/e2e/cypress/integration/channel/user_to_admin_updates_manage_channel_members_modal_spec.js
@@ -10,21 +10,27 @@
 // Stage: @prod
 // Group: @channel
 
-import users from '../../fixtures/users.json';
+import {getAdminAccount} from '../../support/env';
+
+const sysadmin = getAdminAccount();
 
 describe('View Members modal', () => {
     it('MM-20164 - Going from a Member to an Admin should update the modal', () => {
-        cy.apiLogin('user-1');
-        cy.apiGetMe().then((res) => {
-            // # Promote user-1 as a system admin
+        cy.apiInitSetup().then(({team, user}) => {
+            cy.apiCreateUser().then(({user: user1}) => {
+                cy.apiAddUserToTeam(team.id, user1.id);
+            });
+
+            // # Promote user as a system admin
             // # Visit default channel and verify members modal
-            promoteToSysAdmin(res.body);
-            cy.visit('/ad-1/channels/town-square');
+            cy.apiLogin(user.username, user.password);
+            promoteToSysAdmin(user);
+            cy.visit(`/${team.name}/channels/town-square`);
             verifyMemberDropdownAction(true);
 
             // # Make user a regular member
             // # Reload and verify members modal
-            demoteToMember(res.body);
+            demoteToMember(user);
             cy.reload();
             verifyMemberDropdownAction(false);
         });
@@ -32,11 +38,11 @@ describe('View Members modal', () => {
 });
 
 const demoteToMember = (user) => {
-    cy.externalRequest({user: users.sysadmin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user'}});
+    cy.externalRequest({user: sysadmin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user'}});
 };
 
 const promoteToSysAdmin = (user) => {
-    cy.externalRequest({user: users.sysadmin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}});
+    cy.externalRequest({user: sysadmin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}});
 };
 
 function verifyMemberDropdownAction(hasActionItem) {

--- a/e2e/cypress/integration/channel/user_to_channel_admin_member_updates_manage_channel_members_modal_spec.js
+++ b/e2e/cypress/integration/channel/user_to_channel_admin_member_updates_manage_channel_members_modal_spec.js
@@ -12,13 +12,11 @@
 
 import {getAdminAccount} from '../../support/env';
 
-const admin = getAdminAccount();
-
-const demoteToMember = (user) => {
+const demoteToMember = (user, admin) => {
     cy.externalRequest({user: admin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user'}});
 };
 
-const demoteToChannelMember = (user, channelId) => {
+const demoteToChannelMember = (user, channelId, admin) => {
     cy.externalRequest({
         user: admin,
         method: 'put',
@@ -30,7 +28,7 @@ const demoteToChannelMember = (user, channelId) => {
     });
 };
 
-const promoteToChannelAdmin = (user, channelId) => {
+const promoteToChannelAdmin = (user, channelId, admin) => {
     cy.externalRequest({
         user: admin,
         method: 'put',
@@ -43,6 +41,7 @@ const promoteToChannelAdmin = (user, channelId) => {
 };
 
 describe('Change Roles', () => {
+    const admin = getAdminAccount();
     let testUser;
     let townsquareChannelId;
 
@@ -63,8 +62,8 @@ describe('Change Roles', () => {
                 townsquareChannelId = id;
 
                 // # Make user a regular member for channel and system
-                demoteToMember(testUser);
-                demoteToChannelMember(testUser, townsquareChannelId);
+                demoteToMember(testUser, admin);
+                demoteToChannelMember(testUser, townsquareChannelId, admin);
 
                 // # Reload page to ensure no cache or saved information
                 cy.reload(true);
@@ -83,7 +82,7 @@ describe('Change Roles', () => {
         });
 
         // Promote user to a channel admin
-        promoteToChannelAdmin(testUser, townsquareChannelId);
+        promoteToChannelAdmin(testUser, townsquareChannelId, admin);
 
         // * Check to see if a drop now exists now
         cy.get('.filtered-user-list').should('be.visible').within(() => {

--- a/e2e/cypress/integration/channel_sidebar/category_collapsing_unread_filter_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/category_collapsing_unread_filter_spec.js
@@ -14,14 +14,14 @@ import {testWithConfig} from '../../support/hooks';
 import {getAdminAccount} from '../../support/env';
 import {getRandomId} from '../../utils';
 
-const sysadmin = getAdminAccount();
-
 describe('Channel sidebar', () => {
     testWithConfig({
         ServiceSettings: {
             ExperimentalChannelSidebarOrganization: 'default_on',
         },
     });
+
+    const sysadmin = getAdminAccount();
 
     before(() => {
         // # Login as test user and visit town-square

--- a/e2e/cypress/integration/channel_sidebar/category_collapsing_unread_filter_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/category_collapsing_unread_filter_spec.js
@@ -10,13 +10,11 @@
 // Stage: @prod
 // Group: @channel_sidebar
 
-import users from '../../fixtures/users';
-
 import {testWithConfig} from '../../support/hooks';
-
+import {getAdminAccount} from '../../support/env';
 import {getRandomId} from '../../utils';
 
-const sysadmin = users.sysadmin;
+const sysadmin = getAdminAccount();
 
 describe('Channel sidebar', () => {
     testWithConfig({
@@ -26,9 +24,10 @@ describe('Channel sidebar', () => {
     });
 
     before(() => {
-        cy.apiLogin('user-1');
-
-        cy.visit('/');
+        // # Login as test user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     it('should display collapsed state when collapsed', () => {

--- a/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
@@ -10,13 +10,11 @@
 // Stage: @prod
 // Group: @channel_sidebar
 
-import users from '../../fixtures/users';
-
 import {testWithConfig} from '../../support/hooks';
-
+import {getAdminAccount} from '../../support/env';
 import {getRandomId} from '../../utils';
 
-const sysadmin = users.sysadmin;
+const sysadmin = getAdminAccount();
 
 describe('Channel sidebar', () => {
     testWithConfig({
@@ -26,9 +24,10 @@ describe('Channel sidebar', () => {
     });
 
     before(() => {
-        cy.apiLogin('user-1');
-
-        cy.visit('/');
+        // # Login as test user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     it('should switch channels when clicking on a channel in the sidebar', () => {

--- a/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
@@ -14,14 +14,14 @@ import {testWithConfig} from '../../support/hooks';
 import {getAdminAccount} from '../../support/env';
 import {getRandomId} from '../../utils';
 
-const sysadmin = getAdminAccount();
-
 describe('Channel sidebar', () => {
     testWithConfig({
         ServiceSettings: {
             ExperimentalChannelSidebarOrganization: 'default_on',
         },
     });
+
+    const sysadmin = getAdminAccount();
 
     before(() => {
         // # Login as test user and visit town-square

--- a/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
@@ -22,9 +22,10 @@ describe('Channel sidebar', () => {
     });
 
     before(() => {
-        cy.apiLogin('user-1');
-
-        cy.visit('/');
+        // # Login as test user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     it('should not show history arrows on the regular webapp', () => {

--- a/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
@@ -9,13 +9,12 @@
 
 // Group: @channel_sidebar
 
-import users from '../../fixtures/users';
-
 import {testWithConfig} from '../../support/hooks';
 
 import {getRandomId} from '../../utils';
+import {getAdminAccount} from '../../support/env';
 
-const sysadmin = users.sysadmin;
+const sysadmin = getAdminAccount();
 
 describe('Channel switching', () => {
     testWithConfig({
@@ -25,9 +24,10 @@ describe('Channel switching', () => {
     });
 
     before(() => {
-        cy.apiLogin('user-1');
-
-        cy.visit('/');
+        // # Login as test user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     const cmdOrCtrl = Cypress.platform === 'darwin' ? '{cmd}' : '{ctrl}';
@@ -66,7 +66,6 @@ describe('Channel switching', () => {
         cy.getCurrentChannelId().as('townSquareId');
 
         // # Create a new channel
-        // cy.createAndVisitNewChannel().as('testChannel');
         cy.getCurrentTeamId().then((teamId) => {
             cy.apiCreateChannel(teamId, 'test-channel', 'Test Channel').then((response) => {
                 expect(response.status).to.equal(201);

--- a/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
@@ -14,14 +14,14 @@ import {testWithConfig} from '../../support/hooks';
 import {getRandomId} from '../../utils';
 import {getAdminAccount} from '../../support/env';
 
-const sysadmin = getAdminAccount();
-
 describe('Channel switching', () => {
     testWithConfig({
         ServiceSettings: {
             ExperimentalChannelSidebarOrganization: 'default_on',
         },
     });
+
+    const sysadmin = getAdminAccount();
 
     before(() => {
         // # Login as test user and visit town-square

--- a/e2e/cypress/integration/channel_sidebar/new_channel_dropdown_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/new_channel_dropdown_spec.js
@@ -22,9 +22,10 @@ describe('Channel sidebar', () => {
     });
 
     before(() => {
-        cy.apiLogin('user-1');
-
-        cy.visit('/');
+        // # Login as test user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     it('should create a new channel when using the new channel dropdown', () => {

--- a/e2e/cypress/integration/emoji/custom_emoji_spec.js
+++ b/e2e/cypress/integration/emoji/custom_emoji_spec.js
@@ -12,11 +12,19 @@
 
 describe('Custom emojis', () => {
     before(() => {
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableCustomEmoji: true,
+            },
+        });
+
+        // # Visit town-square
+        cy.apiInitSetup().then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
-    it('MM-9777 User cant add custom emoji with the same name as a system one', async () => {
+    it('MM-9777 User cant add custom emoji with the same name as a system one', () => {
         // #Open sidebar
         cy.get('#sidebarHeaderDropdownButton').click();
 

--- a/e2e/cypress/integration/emoji/react_to_last_message_shortcut_spec.js
+++ b/e2e/cypress/integration/emoji/react_to_last_message_shortcut_spec.js
@@ -24,9 +24,6 @@ describe('Keyboard shortcut for adding reactions to last message in channel or t
         testChannel = null;
         isArchived = false;
 
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
         // # Enable Experimental View Archived Channels
         cy.apiUpdateConfig({
             TeamSettings: {
@@ -54,7 +51,7 @@ describe('Keyboard shortcut for adding reactions to last message in channel or t
     });
 
     afterEach(() => {
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         if (testChannel && testChannel.id && !isArchived) {
             cy.apiDeleteChannel(testChannel.id);
         }

--- a/e2e/cypress/integration/emoji/sorted_emojis_spec.js
+++ b/e2e/cypress/integration/emoji/sorted_emojis_spec.js
@@ -12,9 +12,10 @@
 
 describe('M16739 - Filtered emojis are sorted', () => {
     before(() => {
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
-        cy.clearLocalStorage(/recent_emojis/);
+        // # Login as test user and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
     });
 
     it('By recency', () => {

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/channels_spec.js
@@ -25,9 +25,6 @@ describe('Autocomplete with Elasticsearch - Channel', () => {
     let user;
 
     before(() => {
-        // # Execute the before hook based on current config
-        cy.apiLogin('sysadmin');
-
         // * Check if server has license for Elasticsearch
         cy.requireLicenseForFeature('Elasticsearch');
 
@@ -139,7 +136,7 @@ describe('Autocomplete with Elasticsearch - Channel', () => {
 
         before(() => {
             // # Login as admin
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
             cy.visit(`/${team.name}`);
 
             const name = 'hellothere';

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/renaming_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/renaming_spec.js
@@ -22,8 +22,6 @@ describe('Autocomplete with Elasticsearch - Renaming', () => {
     let team;
 
     before(() => {
-        // # Login as admin
-        cy.apiLogin('sysadmin');
         cy.apiSaveTeammateNameDisplayPreference('username');
 
         // * Check if server has license for Elasticsearch

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/system_console_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/system_console_spec.js
@@ -14,9 +14,6 @@ import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('Elasticsearch system console', () => {
     before(() => {
-        // # Login as admin
-        cy.apiLogin('sysadmin');
-
         // * Check if server has license for Elasticsearch
         cy.requireLicenseForFeature('Elasticsearch');
 

--- a/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_spec.js
+++ b/e2e/cypress/integration/enterprise/elasticsearch_autocomplete/users_spec.js
@@ -17,8 +17,6 @@ describe('Autocomplete with Elasticsearch - Users', () => {
     let team;
 
     before(() => {
-        // # Login as admin
-        cy.apiLogin('sysadmin');
         cy.apiSaveTeammateNameDisplayPreference('username');
 
         // * Check if server has license for Elasticsearch

--- a/e2e/cypress/integration/enterprise/extend_session/email_login_activity_spec.js
+++ b/e2e/cypress/integration/enterprise/extend_session/email_login_activity_spec.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import users from '../../../fixtures/users.json';
+import {getAdminAccount} from '../../../support/env';
 
 // ***************************************************************
 // - [#] indicates a test step (e.g. # Go to a page)
@@ -12,23 +12,26 @@ import users from '../../../fixtures/users.json';
 // Group: @enterprise @extend_session
 
 describe('MM-T2575 Extend Session - Email Login', () => {
-    const townSquarePage = '/ad-1/channels/town-square';
+    let townSquarePage;
     const oneDay = 24 * 60 * 60 * 1000;
-    const testUser = 'user-1';
+    const admin = getAdminAccount();
+    let testUser;
 
     before(() => {
-        // # Login as sysadmin and check if with license and has matching database
-        cy.apiLogin('sysadmin');
+        // # Check if with license and has matching database
         cy.requireLicense();
         cy.requireServerDBToMatch();
+
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            townSquarePage = `/${team.name}/channels/town-square`;
+        });
     });
 
     beforeEach(() => {
         // # Login as sysadmin and revoke sessions of the test user
-        cy.apiLogin('sysadmin');
-        cy.dbGetUser({username: testUser}).then(({user}) => {
-            cy.apiRevokeUserSessions(user.id);
-        });
+        cy.apiAdminLogin();
+        cy.apiRevokeUserSessions(testUser.id);
     });
 
     it('should redirect to login page when session expired', () => {
@@ -42,11 +45,11 @@ describe('MM-T2575 Extend Session - Email Login', () => {
         cy.apiUpdateConfig(setting);
 
         // # Login as test user and go to town-square channel
-        cy.apiLogin(testUser);
+        cy.apiLogin(testUser.username, testUser.password);
         cy.visit(townSquarePage);
 
         // # Get active user sessions as baseline reference
-        cy.dbGetActiveUserSessions({username: testUser}).then(({sessions: initialSessions}) => {
+        cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: initialSessions}) => {
             // Post a message to a channel
             cy.postMessage(Date.now());
 
@@ -62,7 +65,7 @@ describe('MM-T2575 Extend Session - Email Login', () => {
                 expect(parseDateTime(updatedSession.expiresat)).to.equal(expiredSession);
 
                 // # Invalidate cache and reload to take effect the expired session
-                cy.externalRequest({user: users.sysadmin, method: 'POST', path: 'caches/invalidate'});
+                cy.externalRequest({user: admin, method: 'POST', path: 'caches/invalidate'});
                 cy.reload();
 
                 // # Try to visit town-square channel
@@ -72,7 +75,7 @@ describe('MM-T2575 Extend Session - Email Login', () => {
                 cy.url().should('include', `/login?redirect_to=${townSquarePage.replace(/\//g, '%2F')}`);
 
                 // * Get user's active session of test user and verify that it remained as expired and is not extended
-                cy.dbGetActiveUserSessions({username: testUser}).then(({sessions: activeSessions}) => {
+                cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: activeSessions}) => {
                     expect(activeSessions.length).to.equal(0);
 
                     cy.dbGetUserSession({sessionId: initialSessions[0].id}).then(({session: unExtendedSession}) => {
@@ -124,11 +127,11 @@ describe('MM-T2575 Extend Session - Email Login', () => {
             cy.apiUpdateConfig(setting);
 
             // # Login as test user and go to town-square channel
-            cy.apiLogin(testUser);
+            cy.apiLogin(testUser.username, testUser.password);
             cy.visit(townSquarePage);
 
             // # Get active user sessions as baseline reference
-            cy.dbGetActiveUserSessions({username: testUser}).then(({sessions: initialSessions}) => {
+            cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: initialSessions}) => {
                 const initialSession = initialSessions[0];
 
                 // Post a message to a channel
@@ -148,7 +151,7 @@ describe('MM-T2575 Extend Session - Email Login', () => {
                     expect(parseDateTime(updatedSession.expiresat)).to.equal(elapsedAboveThreshold);
 
                     // # Invalidate cache and reload to take effect the new session
-                    cy.externalRequest({user: users.sysadmin, method: 'POST', path: 'caches/invalidate'});
+                    cy.externalRequest({user: admin, method: 'POST', path: 'caches/invalidate'});
                     cy.reload();
 
                     // # Visit a channel or post a message
@@ -156,7 +159,7 @@ describe('MM-T2575 Extend Session - Email Login', () => {
                     testCase.fn(now);
 
                     // * Get active session of test user and verify that the session has been extended depending on SessionLengthWebInDays setting
-                    cy.dbGetActiveUserSessions({username: testUser}).then(({sessions: extendedSessions}) => {
+                    cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: extendedSessions}) => {
                         expect(extendedSessions[0].id).to.equal(updatedSession.id);
                         expect(parseDateTime(extendedSessions[0].expiresat)).to.be.greaterThan(parseDateTime(updatedSession.expiresat));
 
@@ -180,11 +183,11 @@ describe('MM-T2575 Extend Session - Email Login', () => {
             cy.apiUpdateConfig(setting);
 
             // # Login as test user and go to town-square channel
-            cy.apiLogin(testUser);
+            cy.apiLogin(testUser.username, testUser.password);
             cy.visit(townSquarePage);
 
             // # Get active user sessions as baseline reference
-            cy.dbGetActiveUserSessions({username: testUser}).then(({sessions: initialSessions}) => {
+            cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: initialSessions}) => {
                 const initialSession = initialSessions[0];
 
                 // Post a message to a channel
@@ -204,7 +207,7 @@ describe('MM-T2575 Extend Session - Email Login', () => {
                     expect(parseDateTime(updatedSession.expiresat)).to.equal(elapsedBelowThreshold);
 
                     // # Invalidate cache and reload to take effect the new session
-                    cy.externalRequest({user: users.sysadmin, method: 'POST', path: 'caches/invalidate'});
+                    cy.externalRequest({user: admin, method: 'POST', path: 'caches/invalidate'});
                     cy.reload();
 
                     // # Visit a channel or post a message
@@ -212,7 +215,7 @@ describe('MM-T2575 Extend Session - Email Login', () => {
                     testCase.fn(now);
 
                     // * Get active session of test user and verify that the session has remained the same and has not extended
-                    cy.dbGetActiveUserSessions({username: testUser}).then(({sessions: unExtendedSessions}) => {
+                    cy.dbGetActiveUserSessions({username: testUser.username}).then(({sessions: unExtendedSessions}) => {
                         const unExtendedSession = unExtendedSessions[0];
                         expect(initialSession.id).to.equal(unExtendedSession.id);
                         expect(elapsedBelowThreshold).to.equal(parseDateTime(unExtendedSession.expiresat));

--- a/e2e/cypress/integration/enterprise/extend_session/session_length_spec.js
+++ b/e2e/cypress/integration/enterprise/extend_session/session_length_spec.js
@@ -12,7 +12,7 @@
 
 // # Goes to the System Scheme page as System Admin
 const goToSessionLengths = () => {
-    cy.apiLogin('sysadmin');
+    cy.apiAdminLogin();
     cy.visit('/admin_console/environment/session_lengths');
 };
 

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
@@ -15,12 +15,11 @@
  */
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
-let guest;
-
 describe('Guest Account - Guest User Experience', () => {
+    let guestUser;
+
     before(() => {
         // * Check if server has license for Guest Accounts
-        cy.apiLogin('sysadmin');
         cy.requireLicenseForFeature('GuestAccounts');
 
         // # Enable Guest Account Settings
@@ -33,15 +32,23 @@ describe('Guest Account - Guest User Experience', () => {
             },
         });
 
-        // # Login as a guest user and go to /
-        cy.loginAsNewGuestUser().then(({user, team}) => {
-            guest = user;
-            cy.visit(`/${team.name}/channels/town-square`);
+        cy.apiInitSetup().then(({team, channel}) => {
+            // # Create new team and visit its URL
+            cy.apiCreateGuestUser().then(({guest}) => {
+                guestUser = guest;
+
+                cy.apiAddUserToTeam(team.id, guestUser.id).then(() => {
+                    cy.apiAddUserToChannel(channel.id, guestUser.id).then(() => {
+                        cy.apiLogin(guestUser.username, guestUser.password);
+                        cy.visit(`/${team.name}/channels/${channel.name}`);
+                    });
+                });
+            });
         });
     });
 
     it('MM-18043 Verify Guest User Restrictions', () => {
-        // *Verify Reduced Options in Main Menu
+        // * Verify Reduced Options in Main Menu
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
         const missingMainOptions = ['#invitePeople', '#teamSettings', '#manageMembers', '#createTeam', '#joinTeam', '#integrations', '#systemConsole'];
         const includeMainOptions = ['#accountSettings', '#viewMembers', '#leaveTeam'];
@@ -52,14 +59,13 @@ describe('Guest Account - Guest User Experience', () => {
             cy.get(includeOption).should('be.visible');
         });
 
-        // *Verify Reduced Options in LHS
+        // * Verify Reduced Options in LHS
         const missingLHSOptions = ['#createPublicChannel', "li[data-testid='morePublicButton']", '#createPrivateChannel'];
         missingLHSOptions.forEach((missingOption) => {
             cy.get(missingOption).should('not.exist');
         });
 
         // * Verify Guest Badge in Channel Header
-        cy.get('#sidebarItem_town-square').click({force: true});
         cy.get('#channelHeaderDescription').within(($el) => {
             cy.wrap($el).find('.has-guest-header').should('be.visible').and('have.text', 'This channel has guests');
         });
@@ -67,28 +73,27 @@ describe('Guest Account - Guest User Experience', () => {
         // * Verify list of Users and Guest Badge in Channel Members List
         cy.get('#member_popover').click();
         cy.get('#member-list-popover').should('be.visible').within(($el) => {
-            cy.wrap($el).findAllByTestId('popoverListMembersItem').should('have.length', 2).each(($elChild) => {
+            cy.wrap($el).findAllByTestId('popoverListMembersItem').should('have.length', 3).each(($elChild) => {
                 cy.wrap($elChild).invoke('attr', 'aria-label').then((username) => {
-                    if (username === guest.username) {
+                    if (username === guestUser.username) {
                         cy.wrap($elChild).find('.Badge').should('be.visible').and('have.text', 'GUEST');
                     }
                 });
             });
         });
 
-        // #Close the Channel Members Popover
+        // # Close the Channel Members Popover
         cy.get('#member_popover').click();
 
         // * Verify list of Users in Direct Messages Dialog
         cy.get('#addDirectChannel').click().wait(TIMEOUTS.SMALL);
         cy.get('#multiSelectList').should('be.visible').within(($el) => {
-            // * Verify only 2 users - Current User and Sysadmin is listed
-            cy.wrap($el).children().should('have.length', 2);
+            // * Verify only 3 users - Guest, regular member and sysadmin is listed
+            cy.wrap($el).children().should('have.length', 3);
         });
         cy.get('.modal-header .close').click();
 
         // * Verify Guest Badge when guest user posts a message
-        cy.get('#sidebarItem_town-square').click({force: true});
         cy.postMessage('testing');
         cy.getLastPostId().then((postId) => {
             cy.get(`#post_${postId}`).within(($el) => {
@@ -105,13 +110,13 @@ describe('Guest Account - Guest User Experience', () => {
         // # Close the profile popover
         cy.get('#channel-header').click();
 
-        // * Verify Guest User can see only 2 channels in LHS
-        cy.get('#publicChannelList').find('a').should('have.length', 2);
+        // * Verify Guest User can see only 1 channel in LHS
+        cy.get('#publicChannelList').find('a').should('have.length', 1);
 
         // * Verify list of Users a Guest User can see in Team Members dialog
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
         cy.get('#viewMembers').click().wait(TIMEOUTS.SMALL);
-        cy.get('#searchableUserListTotal').should('be.visible').and('have.text', '1 - 2 members of 2 total');
+        cy.get('#searchableUserListTotal').should('be.visible').and('have.text', '1 - 3 members of 3 total');
     });
 
     it('MM-18049 Verify Guest User Restrictions is removed when promoted', () => {
@@ -119,9 +124,9 @@ describe('Guest Account - Guest User Experience', () => {
         cy.reload();
 
         // # Promote a Guest user to a member and reload
-        cy.promoteUser(guest.id);
+        cy.promoteUser(guestUser.id);
 
-        // *Verify Options in Main Menu are changed
+        // * Verify Options in Main Menu are changed
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
         const includeMainOptions = ['#accountSettings', '#viewMembers', '#leaveTeam', '#invitePeople', '#createTeam'];
         includeMainOptions.forEach((includeOption) => {
@@ -131,7 +136,7 @@ describe('Guest Account - Guest User Experience', () => {
         // # Close the main menu
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
 
-        // *Verify Options in LHS are changed
+        // * Verify Options in LHS are changed
         const missingLHSOptions = ['#createPublicChannel', "li[data-testid='morePublicButton']", '#createPrivateChannel'];
         missingLHSOptions.forEach((missingOption) => {
             cy.get(missingOption).should('be.visible');
@@ -146,16 +151,16 @@ describe('Guest Account - Guest User Experience', () => {
         // * Verify Guest Badge is removed in Channel Members List
         cy.get('#member_popover').click();
         cy.get('#member-list-popover').should('be.visible').within(($el) => {
-            cy.wrap($el).findAllByTestId('popoverListMembersItem').should('have.length', 2).each(($elChild) => {
+            cy.wrap($el).findAllByTestId('popoverListMembersItem').should('have.length', 3).each(($elChild) => {
                 cy.wrap($elChild).invoke('attr', 'aria-label').then((username) => {
-                    if (username === guest.username) {
+                    if (username === guestUser.username) {
                         cy.wrap($elChild).find('.Badge').should('not.exist');
                     }
                 });
             });
         });
 
-        // #Close the Channel Members Popover
+        // # Close the Channel Members Popover
         cy.get('#member_popover').click();
 
         // * Verify Guest Badge is removed when user posts a message

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_invitation_ui_spec.js
@@ -15,11 +15,10 @@
  */
 import {getRandomId} from '../../../utils';
 import * as TIMEOUTS from '../../../fixtures/timeouts';
-import users from '../../../fixtures/users.json';
 
 let testTeam;
 let newUser;
-const user1 = users['user-1'];
+let regularUser;
 
 function changeGuestFeatureSettings(featureFlag = true, emailInvitation = true, whitelistedDomains = '') {
     // # Update Guest Accounts, Email Invitations, and Whitelisted Domains
@@ -110,37 +109,30 @@ function verifyInvitationSuccess(user, successText, verifyGuestBadge = false) {
 }
 
 describe('Guest Account - Guest User Invitation Flow', () => {
-    beforeEach(() => {
-        testTeam = null;
-
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
+    before(() => {
         // * Check if server has license for Guest Accounts
         cy.requireLicenseForFeature('GuestAccounts');
+    });
+
+    beforeEach(() => {
+        // # Login as sysadmin
+        cy.apiAdminLogin();
 
         // # Reset Guest Feature settings
         changeGuestFeatureSettings();
 
-        // # Create new team and visit its URL
-        cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-            testTeam = response.body;
+        cy.apiInitSetup().then(({team, user}) => {
+            regularUser = user;
+            testTeam = team;
 
-            // # Create a new user and add it to the new team
-            cy.apiCreateNewUser().then((user) => {
-                newUser = user;
-                cy.apiAddUserToTeam(testTeam.id, user.id);
+            cy.apiCreateUser().then(({user: user1}) => {
+                newUser = user1;
+                cy.apiAddUserToTeam(testTeam.id, newUser.id);
             });
 
-            cy.visit(`/${testTeam.name}/channels/town-square`);
+            // # Go to town square
+            cy.visit(`/${team.name}/channels/town-square`);
         });
-    });
-
-    afterEach(() => {
-        cy.apiLogin('sysadmin');
-        if (testTeam && testTeam.id) {
-            cy.apiDeleteTeam(testTeam.id);
-        }
     });
 
     it('MM-18041 Verify UI Elements of Guest User Invitation Flow', () => {
@@ -243,22 +235,22 @@ describe('Guest Account - Guest User Invitation Flow', () => {
         verifyInvitationError(newUser.username, 'This person is already a member.');
 
         // # Search and add an existing member by email who is not part of the team
-        invitePeople(user1.email, 1, user1.username);
+        invitePeople(regularUser.email, 1, regularUser.username);
 
         // * Verify the content and message in next screen
-        verifyInvitationError(user1.username, 'This person is already a member.');
+        verifyInvitationError(regularUser.username, 'This person is already a member.');
 
         // # Demote the user from member to guest
         cy.demoteUser(newUser.id);
 
         // # Search and add an existing guest by first name, who is part of the team but not channel
-        invitePeople(newUser.firstName, 1, newUser.username, 'Off-Topic');
+        invitePeople(newUser.first_name, 1, newUser.username, 'Off-Topic');
 
         // * Verify the content and message in next screen
         verifyInvitationSuccess(newUser.username, 'This guest has been added to the team and channel.');
 
         // # Search and add an existing guest by last name, who is part of the team and channel
-        invitePeople(newUser.lastName, 1, newUser.username);
+        invitePeople(newUser.last_name, 1, newUser.username);
 
         // * Verify the content and message in next screen
         verifyInvitationError(newUser.username, 'This person is already a member of all the channels.', true);

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_removal_ui_spec.js
@@ -15,11 +15,7 @@
  */
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
-let guest;
-let team1;
-let team2;
-
-function removeUserFromAllChannels(verifyAlert) {
+function removeUserFromAllChannels(verifyAlert, user) {
     // # Remove the Guest user from all channels of a team as a sysadmin
     const channels = ['Town Square', 'Off-Topic'];
 
@@ -29,7 +25,7 @@ function removeUserFromAllChannels(verifyAlert) {
     channels.forEach((channel) => {
         // # Remove the Guest User from channel
         cy.getCurrentChannelId().then((channelId) => {
-            cy.removeUserFromChannel(channelId, guest.id);
+            cy.removeUserFromChannel(channelId, user.id);
         });
 
         // * Verify if guest user gets a message when the channel is removed. Does not appears when removed from last channel of the last team
@@ -42,29 +38,27 @@ function removeUserFromAllChannels(verifyAlert) {
 }
 
 describe('Guest Account - Guest User Removal Experience', () => {
+    let team1;
+    let team2;
+    let guest;
+
     before(() => {
         // * Check if server has license for Guest Accounts
         cy.requireLicenseForFeature('GuestAccounts');
 
-        // # Enable Guest Account Settings
-        cy.apiLogin('sysadmin');
-        cy.apiUpdateConfig({
-            GuestAccountsSettings: {
-                Enable: true,
-            },
-        });
+        cy.apiInitSetup().then(({team}) => {
+            team1 = team;
 
-        // # Get ad-1 as team1
-        cy.apiGetTeamByName('ad-1').then((res) => {
-            team1 = res.body;
-
-            cy.apiCreateAndLoginAsNewUser({}, [team1.id]).then((userResponse) => {
-                guest = userResponse;
-
-                // # Create new team and visit its URL
-                cy.apiCreateTeam('test-team2', 'Test Team2').then((response) => {
-                    team2 = {id: response.body.id, name: response.body.name};
-                    cy.visit(`/${team2.name}/channels/town-square`);
+            // # Create new team and visit its URL
+            cy.apiCreateTeam('test-team2', 'Test Team2').then((response) => {
+                cy.apiCreateUser().then(({user}) => {
+                    guest = user;
+                    team2 = response.body;
+                    cy.apiAddUserToTeam(team1.id, guest.id);
+                    cy.apiAddUserToTeam(team2.id, guest.id).then(() => {
+                        cy.apiLogin(guest.username, guest.password);
+                        cy.visit(`/${team2.name}/channels/town-square`);
+                    });
                 });
             });
         });
@@ -78,7 +72,7 @@ describe('Guest Account - Guest User Removal Experience', () => {
         cy.get('#teamSidebarWrapper').should('be.visible');
 
         // # Remove User from all the channels of the team as a sysadmin
-        removeUserFromAllChannels(true);
+        removeUserFromAllChannels(true, guest);
 
         // * Verify if user is automatically redirected to the other team
         cy.url().should('include', team1.name);
@@ -86,15 +80,15 @@ describe('Guest Account - Guest User Removal Experience', () => {
         // * Verify team Sidebar is not present
         cy.get('#teamSidebarWrapper').should('not.exist');
 
-        // # Remove User from all the channels of the team as a sysadmin
-        removeUserFromAllChannels(false);
+        // // # Remove User from all the channels of the team as a sysadmin
+        removeUserFromAllChannels(false, guest);
 
         // * Verify if the user is redirected to the Select Team page
         cy.url().should('include', '/select_team');
         cy.get('.signup__content').should('be.visible').and('have.text', 'Your guest account has no channels assigned. Please contact an administrator.');
 
         // Login as sysadmin and verify test team 2
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         cy.reload().visit(`/${team2.name}/channels/town-square`);
 
         // * Verify if status is displayed indicating guest user is removed from the channel

--- a/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
@@ -15,10 +15,6 @@
 import {getRandomId} from '../../../utils';
 import {getAdminAccount} from '../../../support/env';
 
-let testTeam;
-let testUser;
-const sysadmin = getAdminAccount();
-
 function invitePeople(typeText, resultsCount, verifyText) {
     // # Open Invite People
     cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
@@ -35,10 +31,10 @@ function invitePeople(typeText, resultsCount, verifyText) {
     cy.get('#inviteMembersButton').scrollIntoView().click();
 }
 
-function verifyInvitationError(user, errorText) {
+function verifyInvitationError(user, team, errorText) {
     // * Verify the content and error message in the Invitation Modal
     cy.findByTestId('invitationModal').within(($el) => {
-        cy.wrap($el).find('h1').should('have.text', `Members Invited to ${testTeam.display_name}`);
+        cy.wrap($el).find('h1').should('have.text', `Members Invited to ${team.display_name}`);
         cy.wrap($el).find('h2.subtitle > span').should('have.text', '1 invitation was not sent');
         cy.wrap($el).find('div.invitation-modal-confirm-sent').should('not.exist');
         cy.wrap($el).find('div.invitation-modal-confirm-not-sent').should('be.visible').within(($subel) => {
@@ -55,10 +51,10 @@ function verifyInvitationError(user, errorText) {
     cy.get('.InvitationModal').should('not.exist');
 }
 
-function verifyInvitationSuccess(user, successText) {
+function verifyInvitationSuccess(user, team, successText) {
     // * Verify the content and success message in the Invitation Modal
     cy.findByTestId('invitationModal').within(($el) => {
-        cy.wrap($el).find('h1').should('have.text', `Members Invited to ${testTeam.display_name}`);
+        cy.wrap($el).find('h1').should('have.text', `Members Invited to ${team.display_name}`);
         cy.wrap($el).find('h2.subtitle > span').should('have.text', '1 person has been invited');
         cy.wrap($el).find('div.invitation-modal-confirm-not-sent').should('not.exist');
         cy.wrap($el).find('div.invitation-modal-confirm-sent').should('be.visible').within(($subel) => {
@@ -75,19 +71,23 @@ function verifyInvitationSuccess(user, successText) {
     cy.get('.InvitationModal').should('not.exist');
 }
 
-function loginAsNewUser() {
+function loginAsNewUser(team) {
     // # Login as new user and get the user id
     cy.apiCreateNewUser().then((newUser) => {
-        cy.apiAddUserToTeam(testTeam.id, newUser.id);
+        cy.apiAddUserToTeam(team.id, newUser.id);
 
         // # Logout sysadmin, then login as new user
         cy.apiLogout();
         cy.apiLogin(newUser.username, newUser.password);
-        cy.visit(`/${testTeam.name}`);
+        cy.visit(`/${team.name}`);
     });
 }
 
 describe('Guest Account - Member Invitation Flow', () => {
+    const sysadmin = getAdminAccount();
+    let testTeam;
+    let testUser;
+
     beforeEach(() => {
         // * Check if server has license for Guest Accounts
         cy.requireLicenseForFeature('GuestAccounts');
@@ -189,37 +189,37 @@ describe('Guest Account - Member Invitation Flow', () => {
 
     it('MM-18040 Verify Invite New/Existing Users', () => {
         // # Login as new user
-        loginAsNewUser();
+        loginAsNewUser(testTeam);
 
         // # Search and add an existing member by username who is part of the team
         invitePeople(sysadmin.username, 1, sysadmin.username);
 
         // * Verify the content and message in next screen
-        verifyInvitationError(sysadmin.username, 'This person is already a team member.');
+        verifyInvitationError(sysadmin.username, testTeam, 'This person is already a team member.');
 
         // # Search and add an existing member by email who is not part of the team
         invitePeople(testUser.email, 1, testUser.username);
 
         // * Verify the content and message in next screen
-        verifyInvitationSuccess(testUser.username, 'This member has been added to the team.');
+        verifyInvitationSuccess(testUser.username, testTeam, 'This member has been added to the team.');
 
         // # Search and add a new member by email who is not part of the team
         const email = `temp-${getRandomId()}@mattermost.com`;
         invitePeople(email, 1, email);
 
         // * Verify the content and message in next screen
-        verifyInvitationSuccess(email, 'An invitation email has been sent.');
+        verifyInvitationSuccess(email, testTeam, 'An invitation email has been sent.');
     });
 
     it('MM-22037 Invite Member via Email containing upper case letters', () => {
         // # Login as new user
-        loginAsNewUser();
+        loginAsNewUser(testTeam);
 
         // # Invite a email containing uppercase letters
         const email = `tEMp-${getRandomId()}@mattermost.com`;
         invitePeople(email, 1, email);
 
         // * Verify the content and message in next screen
-        verifyInvitationSuccess(email, 'An invitation email has been sent.');
+        verifyInvitationSuccess(email, testTeam, 'An invitation email has been sent.');
     });
 });

--- a/e2e/cypress/integration/enterprise/guest_accounts/system_console_guest_access_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/system_console_guest_access_ui_spec.js
@@ -19,7 +19,6 @@ let guest;
 describe('Guest Account - Verify Guest Access UI', () => {
     before(() => {
         // * Check if server has license for Guest Accounts
-        cy.apiLogin('sysadmin');
         cy.requireLicenseForFeature('GuestAccounts');
 
         // # Enable Guest Account Settings

--- a/e2e/cypress/integration/enterprise/guest_accounts/system_console_manage_guest_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/system_console_manage_guest_spec.js
@@ -28,7 +28,6 @@ function verifyGuest(userStatus = 'Guest ') {
 describe('Guest Account - Verify Manage Guest Users', () => {
     before(() => {
         // * Check if server has license for Guest Accounts
-        cy.apiLogin('sysadmin');
         cy.requireLicenseForFeature('GuestAccounts');
 
         // # Enable Guest Account Settings

--- a/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
@@ -36,8 +36,6 @@ context('ldap', () => {
             // * Check if server has license for LDAP
             cy.requireLicenseForFeature('LDAP');
 
-            cy.apiLogin('sysadmin');
-
             cy.apiGetConfig().then((response) => {
                 testSettings = setLDAPTestSettings(response.body);
             });
@@ -80,7 +78,7 @@ context('ldap', () => {
                     UserFilter: '(cn=no_users)',
                 },
             };
-            cy.apiLogin('sysadmin').then(() => {
+            cy.cy.apiAdminLogin().then(() => {
                 cy.apiUpdateConfig(ldapSetting).then(() => {
                     cy.doLDAPLogin(testSettings).then(() => {
                         cy.checkLoginFailed(testSettings);
@@ -96,7 +94,7 @@ context('ldap', () => {
                     UserFilter: '(cn=test*)',
                 },
             };
-            cy.apiLogin('sysadmin').then(() => {
+            cy.cy.apiAdminLogin().then(() => {
                 cy.apiUpdateConfig(ldapSetting).then(() => {
                     cy.doLDAPLogin(testSettings).then(() => {
                         cy.doMemberLogout(testSettings);
@@ -114,7 +112,7 @@ context('ldap', () => {
                     GuestFilter: '(cn=no_guests)',
                 },
             };
-            cy.apiLogin('sysadmin').then(() => {
+            cy.cy.apiAdminLogin().then(() => {
                 cy.apiUpdateConfig(ldapSetting).then(() => {
                     cy.doLDAPLogin(testSettings).then(() => {
                         cy.get('#createPublicChannel').should('be.visible');
@@ -131,7 +129,7 @@ context('ldap', () => {
                     GuestFilter: '(cn=board*)',
                 },
             };
-            cy.apiLogin('sysadmin').then(() => {
+            cy.cy.apiAdminLogin().then(() => {
                 cy.apiUpdateConfig(ldapSetting).then(() => {
                     cy.doLDAPLogin(testSettings).then(() => {
                         cy.doGuestLogout(testSettings);
@@ -143,7 +141,7 @@ context('ldap', () => {
 
     describe('LDAP Add Member and Guest to teams and test logins', () => {
         before(() => {
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
 
             cy.apiGetTeamByName(testSettings.teamName).then((r) => {
                 const teamId = r.body.id;

--- a/e2e/cypress/integration/enterprise/ldap_group/channel_modes_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/channel_modes_spec.js
@@ -12,9 +12,6 @@
 
 describe('Test channel public/private toggle', () => {
     before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
         // * Check if server has license for LDAP Groups
         cy.requireLicenseForFeature('LDAPGroups');
 

--- a/e2e/cypress/integration/enterprise/ldap_group/groups_assign_roles_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/groups_assign_roles_spec.js
@@ -47,9 +47,6 @@ const getChannelsAssociatedToGroupAndUnlink = (groupId) => {
 
 describe('System Console', () => {
     before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
         // * Check if server has license for LDAP Groups
         cy.requireLicenseForFeature('LDAPGroups');
 

--- a/e2e/cypress/integration/enterprise/ldap_group/invite_bot_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/invite_bot_spec.js
@@ -18,8 +18,7 @@ describe('Group Synced Team - Bot invitation flow', () => {
         // * Check if server has license for LDAP Groups
         cy.requireLicenseForFeature('LDAPGroups');
 
-        // # Login as sysadmin and enable LDAP
-        cy.apiLogin('sysadmin');
+        // # Enable LDAP
         cy.apiUpdateConfig({LdapSettings: {Enable: true}});
 
         // # Get the first group constrained team available on the server

--- a/e2e/cypress/integration/enterprise/ldap_group/search_channels_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/search_channels_spec.js
@@ -15,8 +15,7 @@ const PAGE_SIZE = 10;
 
 describe('Search channels', () => {
     before(() => {
-        // * Login as sysadmin and check if server has license for LDAP Groups
-        cy.apiLogin('sysadmin');
+        // * Check if server has license for LDAP Groups
         cy.requireLicenseForFeature('LDAPGroups');
 
         // Enable LDAP

--- a/e2e/cypress/integration/enterprise/ldap_group/team_and_channel_assign_roles_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/team_and_channel_assign_roles_spec.js
@@ -29,9 +29,6 @@ describe('System Console', () => {
     let team;
 
     before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
         // * Check if server has license for LDAP Groups
         cy.requireLicenseForFeature('LDAPGroups');
 

--- a/e2e/cypress/integration/enterprise/saml/okta_login_spec.js
+++ b/e2e/cypress/integration/enterprise/saml/okta_login_spec.js
@@ -72,7 +72,6 @@ context('Okta', () => {
     describe('SAML Login flow', () => {
         before(() => {
             // * Check if server has license for SAML
-            cy.apiLogin('sysadmin');
             cy.requireLicenseForFeature('SAML');
 
             // # Get certificates status and upload as necessary
@@ -104,7 +103,7 @@ context('Okta', () => {
         });
 
         it('Saml login new and existing MM regular user', () => {
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
 
             testSettings.user = regular1;
 
@@ -136,7 +135,7 @@ context('Okta', () => {
         });
 
         it('Saml login new and existing MM guest user(userType=Guest)', () => {
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
 
             testSettings.user = guest1;
             newConfig.SamlSettings.GuestAttribute = 'UserType=Guest';
@@ -171,7 +170,7 @@ context('Okta', () => {
         });
 
         it('Saml login new and existing MM guest(isGuest=true)', () => {
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
 
             testSettings.user = guest2;
             newConfig.SamlSettings.GuestAttribute = 'IsGuest=true';
@@ -206,7 +205,7 @@ context('Okta', () => {
         });
 
         it('Saml login new and existing MM admin(userType=Admin)', () => {
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
 
             testSettings.user = admin1;
             newConfig.SamlSettings.EnableAdminAttribute = true;
@@ -242,7 +241,7 @@ context('Okta', () => {
         });
 
         it('Saml login new and existing MM admin(isAdmin=true)', () => {
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
             testSettings.user = admin2;
             newConfig.SamlSettings.EnableAdminAttribute = true;
             newConfig.SamlSettings.AdminAttribute = 'IsAdmin=true';
@@ -276,7 +275,7 @@ context('Okta', () => {
         });
 
         it('Saml login invited Guest user to a team', () => {
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
             testSettings.user = regular1;
 
             //login as a regular user - generate an invite link

--- a/e2e/cypress/integration/enterprise/saml/saml_metadata_spec.js
+++ b/e2e/cypress/integration/enterprise/saml/saml_metadata_spec.js
@@ -23,7 +23,6 @@ let config;
 describe('SystemConsole->SAML 2.0 - Get Metadata from Idp Flow', () => {
     before(() => {
         // * Check if server has license for SAML
-        cy.apiLogin('sysadmin');
         cy.requireLicenseForFeature('SAML');
 
         cy.apiUpdateConfig({

--- a/e2e/cypress/integration/enterprise/system_console/channel_members_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_members_spec.js
@@ -29,11 +29,6 @@ describe('Channel members test', () => {
             sysadmin = res.body;
         });
 
-        // # Login as sysadmin
-        cy.apiAdminLogin().then((res) => {
-            sysadmin = res.body;
-        });
-
         // * Check if server has license
         cy.requireLicense();
 

--- a/e2e/cypress/integration/enterprise/system_console/channel_members_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_members_spec.js
@@ -7,14 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-import users from '../../../fixtures/users.json';
 import * as TIMEOUTS from '../../../fixtures/timeouts';
-
-let team;
-let channel;
-let user1;
-let user2;
-let sysadmin;
 
 const saveConfig = () => {
     // # Click save
@@ -25,63 +18,42 @@ const saveConfig = () => {
 };
 
 describe('Channel members test', () => {
+    let testChannel;
+    let user1;
+    let user2;
+    let sysadmin;
+
     before(() => {
         // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin().then((res) => {
+            sysadmin = res.body;
+        });
+
+        // # Login as sysadmin
+        cy.apiAdminLogin().then((res) => {
+            sysadmin = res.body;
+        });
 
         // * Check if server has license
         cy.requireLicense();
 
-        // # Create a new team and channel that are not group constrained
-        cy.apiCreateTeam('test-team', 'Test Team').then((teamRes) => {
-            team = teamRes.body;
-            cy.apiCreateChannel(team.id, 'channel-members-test-channel', 'Channel members test channel').then((channelRes) => {
-                channel = channelRes.body;
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            user1 = user;
+            testChannel = channel;
 
-                // # Make sure user1 is in the team and channel initially
-                cy.apiGetUserByEmail(users['user-1'].email).then((user1Res) => {
-                    user1 = user1Res.body;
-                    cy.apiAddUserToTeam(team.id, user1.id).then(() => {
-                        cy.apiAddUserToChannel(channel.id, user1.id);
-                    });
-                });
+            cy.apiCreateUser().then(({user: newUser}) => {
+                user2 = newUser;
 
-                // # Make sure user2 is in the team and channel initially
-                cy.apiGetUserByEmail(users['user-2'].email).then((user2Res) => {
-                    user2 = user2Res.body;
-                    cy.apiAddUserToTeam(team.id, user2.id).then(() => {
-                        cy.apiAddUserToChannel(channel.id, user2.id);
-                    });
-                });
-
-                // # Make sure sysadmin is in the team and channel initially
-                cy.apiGetUserByEmail(users.sysadmin.email).then((sysadminRes) => {
-                    sysadmin = sysadminRes.body;
-                    cy.apiAddUserToTeam(team.id, sysadmin.id).then(() => {
-                        cy.apiAddUserToChannel(channel.id, sysadmin.id);
-                    });
+                cy.apiAddUserToTeam(team.id, user2.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, user2.id);
                 });
             });
         });
     });
 
-    after(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
-        // # Reset data after running tests
-        if (channel?.id) {
-            cy.apiDeleteChannel(channel.id).then(() => {
-                if (team?.id) {
-                    cy.apiDeleteTeam(team.id, true);
-                }
-            });
-        }
-    });
-
     it('MM-23938 - Channel members block is only visible when channel is not group synced', () => {
         // # Visit the channel page
-        cy.visit(`/admin_console/user_management/channels/${channel.id}`);
+        cy.visit(`/admin_console/user_management/channels/${testChannel.id}`);
 
         // * Assert that the members block is visible on non group synced channel
         cy.get('#channelMembers').scrollIntoView().should('be.visible');
@@ -95,7 +67,7 @@ describe('Channel members test', () => {
 
     it('MM-23938 - Channel Members block can search for users, remove users, add users and modify their roles', () => {
         // # Visit the channel page
-        cy.visit(`/admin_console/user_management/channels/${channel.id}`);
+        cy.visit(`/admin_console/user_management/channels/${testChannel.id}`);
 
         // * Assert that the members block is visible on non group synced team
         cy.get('#channelMembers').scrollIntoView().should('be.visible');
@@ -138,7 +110,7 @@ describe('Channel members test', () => {
         cy.get('#channelMembers').should('not.be.visible');
 
         // # Visit the channel page
-        cy.visit(`/admin_console/user_management/channels/${channel.id}`);
+        cy.visit(`/admin_console/user_management/channels/${testChannel.id}`);
 
         // # Search for user1 that we know is no longer in the team
         cy.get('#channelMembers .DataGrid_search input').scrollIntoView().clear().type(user1.email);
@@ -198,7 +170,7 @@ describe('Channel members test', () => {
         saveConfig();
 
         // # Visit the channel page
-        cy.visit(`/admin_console/user_management/channels/${channel.id}`);
+        cy.visit(`/admin_console/user_management/channels/${testChannel.id}`);
 
         // # Search user1 that we know is now in the team again
         cy.get('#channelMembers .DataGrid_search input').scrollIntoView().clear().type(user1.email);

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/channel_mentions_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/channel_mentions_spec.js
@@ -1,0 +1,181 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @system_console @channel_moderation
+
+import {checkboxesTitleToIdMap} from './constants';
+
+import {
+    disableChannelModeratedPermission,
+    enableChannelModeratedPermission,
+    postChannelMentionsAndVerifySystemMessageExist,
+    postChannelMentionsAndVerifySystemMessageNotExist,
+    saveConfigForChannel,
+    saveConfigForScheme,
+    visitChannel,
+    visitChannelConfigPage,
+} from './helpers';
+
+describe('MM-23102 - Channel Moderation - Channel Mentions', () => {
+    let regularUser;
+    let guestUser;
+    let testTeam;
+    let testChannel;
+
+    before(() => {
+        // * Check if server has license
+        cy.requireLicense();
+
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            regularUser = user;
+            testTeam = team;
+            testChannel = channel;
+
+            cy.apiCreateGuestUser().then(({guest}) => {
+                guestUser = guest;
+
+                cy.apiAddUserToTeam(testTeam.id, guestUser.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, guestUser.id);
+                });
+
+                // # Activate guest user
+                cy.apiActivateUser(guestUser.id, true);
+            });
+        });
+    });
+
+    it('Channel Mentions option for Guests', () => {
+        // # Uncheck the Channel Mentions option for Guests and save
+        visitChannelConfigPage(testChannel);
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_GUESTS);
+        saveConfigForChannel();
+
+        visitChannel(guestUser, testChannel, testTeam);
+
+        // # Check Guest user has the permission to user special mentions like @all @channel and @here
+        postChannelMentionsAndVerifySystemMessageExist(testChannel.name);
+
+        // # Visit Channel page and Search for the channel.
+        visitChannelConfigPage(testChannel);
+
+        // # check the channel mentions option for guests and save
+        enableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_GUESTS);
+        saveConfigForChannel();
+
+        visitChannel(guestUser, testChannel, testTeam);
+
+        // # Check Guest user has the permission to user special mentions like @all @channel and @here
+        postChannelMentionsAndVerifySystemMessageNotExist(testChannel);
+    });
+
+    it('Channel Mentions option for Members', () => {
+        // # Visit Channel page and Search for the channel.
+        visitChannelConfigPage(testChannel);
+
+        // # Uncheck the channel mentions option for guests and save
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        saveConfigForChannel();
+
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # Check Member user does not has the permission to use special mentions like @all @channel and @here
+        postChannelMentionsAndVerifySystemMessageExist(testChannel.name);
+
+        // # Visit Channel page and Search for the channel.
+        visitChannelConfigPage(testChannel);
+
+        // # check the channel mentions option for guests and save
+        enableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        saveConfigForChannel();
+
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # Check Member user has the permission to user special mentions like @all @channel and @here
+        postChannelMentionsAndVerifySystemMessageNotExist(testChannel);
+    });
+
+    it('Channel Mentions option removed when Create Post is disabled', () => {
+        // # Visit Channel page and Search for the channel.
+        visitChannelConfigPage(testChannel);
+
+        // # Uncheck the create posts option for guests
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
+
+        // * Option to allow Channel Mentions for Guests should also be disabled when Create Post option is disabled.
+        // * A message Guests can not use channel mentions without the ability to create posts should be displayed.
+        cy.findByTestId('admin-channel_settings-channel_moderation-channelMentions-disabledGuestsDueToCreatePosts').
+            should('have.text', 'Guests can not use channel mentions without the ability to create posts.');
+        cy.findByTestId(checkboxesTitleToIdMap.CHANNEL_MENTIONS_GUESTS).should('be.disabled');
+
+        // # check the create posts option for guests and uncheck for members
+        enableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
+
+        // * Option to allow Channel Mentions for Members should also be disabled when Create Post option is disabled.
+        // * A message Members can not use channel mentions without the ability to create posts should be displayed.
+        cy.findByTestId('admin-channel_settings-channel_moderation-channelMentions-disabledMemberDueToCreatePosts').
+            should('have.text', 'Members can not use channel mentions without the ability to create posts.');
+        cy.findByTestId(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS).should('be.disabled');
+
+        // # Uncheck the create posts option for guests
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
+
+        // * Ensure that channel mentions for members and guests is disabled
+        // * Ensure message Guests & Members can not use channel mentions without the ability to create posts
+        cy.findByTestId('admin-channel_settings-channel_moderation-channelMentions-disabledBothDueToCreatePosts').
+            should('have.text', 'Guests and members can not use channel mentions without the ability to create posts.');
+        cy.findByTestId(checkboxesTitleToIdMap.CHANNEL_MENTIONS_GUESTS).should('be.disabled');
+        cy.findByTestId(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS).should('be.disabled');
+    });
+
+    it('Message when user without channel mention permission uses special channel mentions', () => {
+        visitChannelConfigPage(testChannel);
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        saveConfigForChannel();
+
+        visitChannel(regularUser, testChannel, testTeam);
+
+        cy.findByTestId('post_textbox').clear().type('@');
+
+        // * Ensure that @here, @all, and @channel do not show up in the autocomplete list
+        cy.findAllByTestId('mentionSuggestion_here').should('not.exist');
+        cy.findAllByTestId('mentionSuggestion_all').should('not.exist');
+        cy.findAllByTestId('mentionSuggestion_channel').should('not.exist');
+
+        // * When you type @all, @enter, and @channel make sure that a system message shows up notifying you nothing happened.
+        postChannelMentionsAndVerifySystemMessageExist(testChannel.name);
+    });
+
+    it('Confirm sending notifications while using special channel mentions', () => {
+        // # Visit Channel page and Search for the channel.
+        visitChannelConfigPage(testChannel);
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        saveConfigForChannel();
+
+        // # Set @channel and @all confirmation dialog to true
+        cy.visit('admin_console/environment/notifications');
+        cy.findByTestId('TeamSettings.EnableConfirmNotificationsToChanneltrue').check();
+        saveConfigForScheme();
+
+        // # Visit test channel
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // * Type at all and enter that no confirmation dialogue shows up
+        cy.postMessage('@all');
+        cy.get('#confirmModalLabel').should('not.exist');
+
+        // * Type at channel and enter that no confirmation dialogue shows up
+        cy.postMessage('@channel');
+        cy.get('#confirmModalLabel').should('not.exist');
+
+        // * Type at here and enter that no confirmation dialogue shows up
+        cy.postMessage('@here');
+        cy.get('#confirmModalLabel').should('not.exist');
+    });
+});

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/constants.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/constants.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export const checkboxesTitleToIdMap = {
+    CREATE_POSTS_GUESTS: 'create_post-guests',
+    CREATE_POSTS_MEMBERS: 'create_post-members',
+    POST_REACTIONS_GUESTS: 'create_reactions-guests',
+    POST_REACTIONS_MEMBERS: 'create_reactions-members',
+    MANAGE_MEMBERS_GUESTS: 'manage_members-guests',
+    MANAGE_MEMBERS_MEMBERS: 'manage_members-members',
+    CHANNEL_MENTIONS_MEMBERS: 'use_channel_mentions-members',
+    CHANNEL_MENTIONS_GUESTS: 'use_channel_mentions-guests',
+};
+
+export const checkBoxes = [
+    checkboxesTitleToIdMap.CREATE_POSTS_GUESTS,
+    checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS,
+    checkboxesTitleToIdMap.POST_REACTIONS_GUESTS,
+    checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS,
+    checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS,
+    checkboxesTitleToIdMap.CHANNEL_MENTIONS_GUESTS,
+    checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS,
+];

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/create_posts_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/create_posts_spec.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @system_console @channel_moderation
+
+import {checkboxesTitleToIdMap} from './constants';
+
+import {
+    disableChannelModeratedPermission,
+    enableChannelModeratedPermission,
+    saveConfigForChannel,
+    visitChannel,
+    visitChannelConfigPage,
+} from './helpers';
+
+describe('MM-23102 - Channel Moderation - Create Posts', () => {
+    let regularUser;
+    let guestUser;
+    let testTeam;
+    let testChannel;
+
+    before(() => {
+        // * Check if server has license
+        cy.requireLicense();
+
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            regularUser = user;
+            testTeam = team;
+            testChannel = channel;
+
+            cy.apiCreateGuestUser().then(({guest}) => {
+                guestUser = guest;
+
+                cy.apiAddUserToTeam(testTeam.id, guestUser.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, guestUser.id);
+                });
+
+                // # Activate guest user
+                cy.apiActivateUser(guestUser.id, true);
+            });
+        });
+    });
+
+    it('Create Post option for Guests', () => {
+        // # Go to channel configuration page of
+        visitChannelConfigPage(testChannel);
+
+        // # Uncheck the Create Posts option for Guests and Save
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
+        saveConfigForChannel();
+
+        // # Login as a Guest user and visit the same channel
+        visitChannel(guestUser, testChannel, testTeam);
+
+        // # Check Guest user should not have the permission to create a post on a channel when the option is removed
+        // * Guest user should see a message stating that this channel is read-only and the textbox area should be disabled
+        cy.findByTestId('post_textbox_placeholder').should('have.text', 'This channel is read-only. Only members with permission can post here.');
+        cy.findByTestId('post_textbox').should('be.disabled');
+
+        // # As a system admin, check the option to allow Create Posts for Guests and save
+        visitChannelConfigPage(testChannel);
+        enableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
+        saveConfigForChannel();
+
+        // # Login as a Guest user and visit the same channel
+        visitChannel(guestUser, testChannel, testTeam);
+
+        // # Check Guest user should have the permission to create a post on a channel when the option is allowed
+        // * Guest user should see a message stating that this channel is read-only and the textbox area should be disabled
+        cy.findByTestId('post_textbox').clear();
+        cy.findByTestId('post_textbox_placeholder').should('have.text', `Write to ${testChannel.display_name}`);
+        cy.findByTestId('post_textbox').should('not.be.disabled');
+    });
+
+    it('Create Post option for Members', () => {
+        // # Go to system admin page and to channel configuration page of test channel
+        visitChannelConfigPage(testChannel);
+
+        // # Uncheck the Create Posts option for Members and Save
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
+        saveConfigForChannel();
+
+        // # Login as a Guest user and visit test channel
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # Check Member should not have the permission to create a post on a channel when the option is removed.
+        // * User should see a message stating that this channel is read-only and the textbox area should be disabled
+        cy.findByTestId('post_textbox_placeholder').should('have.text', 'This channel is read-only. Only members with permission can post here.');
+        cy.findByTestId('post_textbox').should('be.disabled');
+
+        // # As a system admin, check the option to allow Create Posts for Members and save
+        visitChannelConfigPage(testChannel);
+        enableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
+        saveConfigForChannel();
+
+        // # Login as a Member user and visit the same channel
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # Check Member should have the permission to create a post on a channel when the option is allowed
+        // * Member user should see a message stating that this channel is read-only and the textbox area should be disabled
+        cy.findByTestId('post_textbox').clear();
+        cy.findByTestId('post_textbox_placeholder').should('have.text', `Write to ${testChannel.display_name}`);
+        cy.findByTestId('post_textbox').should('not.be.disabled');
+    });
+});

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
@@ -1,0 +1,289 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
+import {getAdminAccount} from '../../../../support/env';
+
+import {checkBoxes} from './constants';
+
+// # Visits the channel configuration for a channel with channelName
+export const visitChannelConfigPage = (channel) => {
+    cy.apiAdminLogin();
+    cy.visit('/admin_console/user_management/channels');
+    cy.findByTestId('search-input').type(`${channel.name}{enter}`);
+    cy.findByText('Edit').click();
+    cy.wait(TIMEOUTS.TINY * 2);
+};
+
+// # Disable a specific channel moderated permission in the channel moderation widget
+export const disableChannelModeratedPermission = (permission) => {
+    cy.findByTestId(permission).scrollIntoView().should('be.visible').then((btn) => {
+        if (btn.hasClass('checked')) {
+            btn.click();
+        }
+    });
+};
+
+// # Saves channel config and navigates back to the channel config page if specified
+export const saveConfigForChannel = (channelName = false, clickConfirmationButton = false) => {
+    cy.get('#saveSetting').then((btn) => {
+        if (btn.is(':enabled')) {
+            btn.click();
+
+            if (clickConfirmationButton) {
+                cy.get('#confirmModalButton').click();
+            }
+
+            // # Make sure the save is complete by looking for the search input which is only visible on the teams index page
+            cy.findByTestId('search-input').should('be.visible');
+
+            if (channelName) {
+                // # Search for the channel.
+                cy.findByTestId('search-input').type(`${channelName}{enter}`);
+                cy.findByText('Edit').click();
+            }
+        }
+    });
+};
+
+// # Visits a channel as the member specified
+export const visitChannel = (user, channel, team) => {
+    cy.apiLogin(user.username, user.password);
+    cy.visit(`/${team.name}/channels/${channel.name}`);
+    cy.get('#postListContent', {timeout: TIMEOUTS.HUGE}).should('be.visible');
+};
+
+// # Checks to see if we got a system message warning after using @all/@here/@channel
+export const postChannelMentionsAndVerifySystemMessageExist = (channelName) => {
+    function getSystemMessage(text) {
+        return `Channel notifications are disabled in ${channelName}. The ${text} did not trigger any notifications.`;
+    }
+
+    // # Type @all and post it to the channel
+    cy.postMessage('@all');
+
+    // # Get last post message text
+    cy.getLastPostId().then((postId) => {
+        // * Assert that the last message posted is the system message informing us we are not allowed to use channel mentions
+        cy.get(`#postMessageText_${postId}`).should('include.text', getSystemMessage('@all'));
+    });
+
+    // # Type @here and post it to the channel
+    cy.postMessage('@here');
+
+    // # Get last post message text
+    cy.getLastPostId().then((postId) => {
+        // * Assert that the last message posted is the system message informing us we are not allowed to use channel mentions
+        cy.get(`#postMessageText_${postId}`).should('include.text', getSystemMessage('@here'));
+    });
+
+    cy.postMessage('@channel');
+
+    // # Type last post message text
+    cy.getLastPostId().then((postId) => {
+        // * Assert that the last message posted is the system message informing us we are not allowed to use channel mentions
+        cy.get(`#postMessageText_${postId}`).should('include.text', getSystemMessage('@channel'));
+    });
+};
+
+// # Enable a specific channel moderated permission in the channel moderation widget
+export const enableChannelModeratedPermission = (permission) => {
+    cy.findByTestId(permission).scrollIntoView().should('be.visible').then((btn) => {
+        if (!btn.hasClass('checked')) {
+            btn.click();
+        }
+    });
+};
+
+// # Checks to see if we did not get a system message warning after using @all/@here/@channel
+export const postChannelMentionsAndVerifySystemMessageNotExist = (channel) => {
+    function getSystemMessage(text) {
+        return `Channel notifications are disabled in ${channel.name}. The ${text} did not trigger any notifications.`;
+    }
+
+    cy.postMessage('@all');
+
+    // # Get last post message text
+    cy.getLastPostId().then((postId) => {
+        // * Assert that the last message posted is NOT a system message informing us we are not allowed to use channel mentions
+        cy.get(`#postMessageText_${postId}`).should('not.have.text', getSystemMessage('@all'));
+    });
+
+    cy.postMessage('@here');
+
+    // # Get last post message text
+    cy.getLastPostId().then((postId) => {
+        // * Assert that the last message posted is NOT a system message informing us we are not allowed to use channel mentions
+        cy.get(`#postMessageText_${postId}`).should('not.have.text', getSystemMessage('@here'));
+    });
+
+    cy.postMessage('@channel');
+
+    // # Get last post message text
+    cy.getLastPostId().then((postId) => {
+        // * Assert that the last message posted is NOT a system message informing us we are not allowed to use channel mentions
+        cy.get(`#postMessageText_${postId}`).should('not.have.text', getSystemMessage('@channel'));
+    });
+};
+
+// # Wait's until the Saving text becomes Save
+const waitUntilConfigSave = () => {
+    cy.waitUntil(() => cy.get('#saveSetting').then((el) => {
+        return el[0].innerText === 'Save';
+    }));
+};
+
+// Clicks the save button in the system console page.
+// waitUntilConfigSaved: If we need to wait for the save button to go from saving -> save.
+// Usually we need to wait unless we are doing this in team override scheme
+export const saveConfigForScheme = (waitUntilConfigSaved = true, clickConfirmationButton = false) => {
+    // # Save if possible (if previous test ended abruptly all permissions may already be enabled)
+    cy.get('#saveSetting').then((btn) => {
+        if (btn.is(':enabled')) {
+            btn.click();
+        }
+    });
+    if (clickConfirmationButton) {
+        cy.get('#confirmModalButton').click();
+    }
+    if (waitUntilConfigSaved) {
+        waitUntilConfigSave();
+    }
+};
+
+// # Goes to the System Scheme page as System Admin
+export const goToSystemScheme = () => {
+    cy.apiAdminLogin();
+    cy.visit('/admin_console/user_management/permissions/system_scheme');
+};
+
+// # Goes to the permissions page and creates a new team override scheme with schemeName
+export const goToPermissionsAndCreateTeamOverrideScheme = (schemeName, team) => {
+    cy.apiAdminLogin();
+    cy.visit('/admin_console/user_management/permissions');
+    cy.findByTestId('team-override-schemes-link').click();
+    cy.get('#scheme-name').type(schemeName);
+    cy.findByTestId('add-teams').click();
+    cy.get('#selectItems').click().type(team.display_name);
+    cy.get('#multiSelectList').should('be.visible').children().first().click({force: true});
+    cy.get('#saveItems').should('be.visible').click();
+    saveConfigForScheme(false);
+    cy.wait(TIMEOUTS.TINY * 2);
+};
+
+// # Goes to the permissions page and clicks edit or delete for a team override scheme
+export const deleteOrEditTeamScheme = (schemeDisplayName, editOrDelete) => {
+    cy.apiAdminLogin();
+    cy.visit('/admin_console/user_management/permissions');
+    cy.findByTestId(`${schemeDisplayName}-${editOrDelete}`).click();
+    if (editOrDelete === 'delete') {
+        cy.get('#confirmModalButton').click();
+    }
+};
+
+// # Clicks the View/Manage channel members for a channel (Text changes between View and Manage depending on your role in the channel)
+export const viewManageChannelMembersModal = (viewOrManage) => {
+    // # Click member count to open member list popover
+    cy.get('#member_popover').click();
+
+    cy.get('#member-list-popover').should('be.visible').within(() => {
+        // # Click "View/Manage Members"
+        cy.findByText(`${viewOrManage} Members`).click();
+    });
+};
+
+// # Enable (check) all the permissions in the channel moderation widget through the API
+export const enableDisableAllChannelModeratedPermissionsViaAPI = (channel, enable = true) => {
+    cy.externalRequest(
+        {
+            user: getAdminAccount(),
+            method: 'PUT',
+            path: `channels/${channel.id}/moderations/patch`,
+            data:
+                [
+                    {
+                        name: 'create_post',
+                        roles: {
+                            members: enable,
+                            guests: enable,
+                        },
+                    },
+                    {
+                        name: 'create_reactions',
+                        roles: {
+                            members: enable,
+                            guests: enable,
+                        },
+                    },
+                    {
+                        name: 'manage_members',
+                        roles: {
+                            members: enable,
+                        },
+                    },
+                    {
+                        name: 'use_channel_mentions',
+                        roles: {
+                            members: enable,
+                            guests: enable,
+                        },
+                    },
+                ],
+        },
+    );
+};
+
+// # This goes to the system scheme and clicks the reset permissions to default and then saves the setting
+export const resetSystemSchemePermissionsToDefault = () => {
+    cy.apiAdminLogin();
+    cy.visit('/admin_console/user_management/permissions/system_scheme');
+    cy.findByTestId('resetPermissionsToDefault').click();
+    cy.get('#confirmModalButton').click();
+    saveConfigForScheme();
+};
+
+export const demoteToChannelOrTeamMember = (userId, id, channelsOrTeams = 'channels') => {
+    cy.externalRequest({
+        user: getAdminAccount(),
+        method: 'put',
+        path: `${channelsOrTeams}/${id}/members/${userId}/schemeRoles`,
+        data: {
+            scheme_user: true,
+            scheme_admin: false,
+        },
+    });
+};
+
+export const promoteToChannelOrTeamAdmin = (userId, id, channelsOrTeams = 'channels') => {
+    cy.externalRequest({
+        user: getAdminAccount(),
+        method: 'put',
+        path: `${channelsOrTeams}/${id}/members/${userId}/schemeRoles`,
+        data: {
+            scheme_user: true,
+            scheme_admin: true,
+        },
+    });
+};
+
+// # Disable (uncheck) all the permissions in the channel moderation widget
+export const disableAllChannelModeratedPermissions = () => {
+    checkBoxes.forEach((buttonId) => {
+        cy.findByTestId(buttonId).then((btn) => {
+            if (btn.hasClass('checked')) {
+                btn.click();
+            }
+        });
+    });
+};
+
+// # Enable (check) all the permissions in the channel moderation widget
+export const enableAllChannelModeratedPermissions = () => {
+    checkBoxes.forEach((buttonId) => {
+        cy.findByTestId(buttonId).then((btn) => {
+            if (!btn.hasClass('checked')) {
+                btn.click();
+            }
+        });
+    });
+};

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/higher_scoped_scheme_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/higher_scoped_scheme_spec.js
@@ -1,0 +1,329 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @system_console @channel_moderation
+
+import {getRandomId} from '../../../../utils';
+
+import {checkboxesTitleToIdMap} from './constants';
+
+import {
+    deleteOrEditTeamScheme,
+    demoteToChannelOrTeamMember,
+    disableChannelModeratedPermission,
+    enableChannelModeratedPermission,
+    enableDisableAllChannelModeratedPermissionsViaAPI,
+    goToPermissionsAndCreateTeamOverrideScheme,
+    goToSystemScheme,
+    postChannelMentionsAndVerifySystemMessageNotExist,
+    promoteToChannelOrTeamAdmin,
+    saveConfigForChannel,
+    saveConfigForScheme,
+    viewManageChannelMembersModal,
+    visitChannel,
+    visitChannelConfigPage,
+} from './helpers';
+
+describe('MM-23102 - Channel Moderation - Higher Scoped Scheme', () => {
+    let regularUser;
+    let guestUser;
+    let testTeam;
+    let testChannel;
+
+    before(() => {
+        // * Check if server has license
+        cy.requireLicense();
+    });
+
+    beforeEach(() => {
+        cy.apiAdminLogin();
+        cy.apiResetRoles();
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            regularUser = user;
+            testTeam = team;
+            testChannel = channel;
+
+            cy.apiCreateGuestUser().then(({guest}) => {
+                guestUser = guest;
+
+                cy.apiAddUserToTeam(testTeam.id, guestUser.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, guestUser.id);
+                });
+
+                // # Activate guest user
+                cy.apiActivateUser(guestUser.id, true);
+            });
+        });
+    });
+
+    it('Effect of changing System Schemes on a Channel for which Channel Moderation Settings was modified', () => {
+        // # Visit Channel page and Search for the channel.
+        visitChannelConfigPage(testChannel);
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+
+        // # check the channel mentions option for guests and save
+        enableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        saveConfigForChannel();
+
+        goToSystemScheme();
+        cy.get('#all_users-public_channel-manage_public_channel_members').scrollIntoView().should('be.visible').click();
+        cy.findByTestId('all_users-public_channel-manage_public_channel_members-checkbox').should('not.have.class', 'checked');
+        saveConfigForScheme();
+
+        // * Ensure manage members for members is disabled
+        visitChannelConfigPage(testChannel);
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('be.disabled');
+
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # View members modal
+        viewManageChannelMembersModal('View');
+
+        // * Add Members button does not exist
+        cy.get('#showInviteModal').should('not.exist');
+    });
+
+    it('Effect of changing System Schemes on a Channel for which Channel Moderation Settings was never modified', () => {
+        // # Reset system scheme to default and create a new channel to ensure that this channels moderation settings have never been modified
+        cy.apiAdminLogin();
+        cy.apiCreateChannel(testTeam.id, 'never-modified', `Never Modified ${getRandomId()}`).then((response) => {
+            const randomChannel = response.body;
+
+            goToSystemScheme();
+            cy.get('#all_users-public_channel-manage_public_channel_members').click();
+            saveConfigForScheme();
+
+            // # Visit Channel page and Search for the channel.
+            // * ensure manage members for members is disabled
+            visitChannelConfigPage(randomChannel);
+            cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('be.disabled');
+
+            visitChannel(regularUser, randomChannel, testTeam);
+
+            // # View members modal
+            viewManageChannelMembersModal('View');
+
+            // * Add Members button does not exist
+            cy.get('#showInviteModal').should('not.exist');
+        });
+    });
+
+    it('Effect of changing Team Override Schemes on a Channel for which Channel Moderation Settings was never modified', () => {
+        // # Reset system scheme to default and create a new channel to ensure that this channels moderation settings have never been modified
+        cy.apiAdminLogin();
+        cy.apiCreateChannel(testTeam.id, 'never-modified', `Never Modified ${getRandomId()}`).then((response) => {
+            const randomChannel = response.body;
+
+            goToPermissionsAndCreateTeamOverrideScheme(randomChannel.name, testTeam);
+            deleteOrEditTeamScheme(randomChannel.name, 'edit');
+            cy.get('#all_users-public_channel-manage_public_channel_members').click();
+            saveConfigForScheme(false);
+
+            // # Visit Channel page and Search for the channel.
+            // * Assert message for manage member for members appears and that it's disabled
+            visitChannelConfigPage(randomChannel);
+            cy.findByTestId('admin-channel_settings-channel_moderation-manageMembers-disabledMember').
+                should('have.text', `Manage members for members are disabled in ${randomChannel.name} Team Scheme.`);
+            cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('be.disabled');
+
+            visitChannel(regularUser, randomChannel, testTeam);
+
+            // # View members modal
+            viewManageChannelMembersModal('View');
+
+            // * Add Members button does not exist
+            cy.get('#showInviteModal').should('not.exist');
+        });
+    });
+
+    it('Effect of changing Team Override Schemes on a Channel for which Channel Moderation Settings was modified', () => {
+        const teamOverrideSchemeName = testChannel.name + getRandomId();
+
+        // # Reset system scheme to default and create a new channel to ensure that this channels moderation settings have never been modified
+        visitChannelConfigPage(testChannel);
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        saveConfigForChannel();
+
+        visitChannelConfigPage(testChannel);
+        enableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        saveConfigForChannel();
+
+        goToPermissionsAndCreateTeamOverrideScheme(teamOverrideSchemeName, testTeam);
+        deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
+        cy.get('#all_users-public_channel-manage_public_channel_members').click();
+        saveConfigForScheme(false);
+
+        // # Visit Channel page and Search for the channel.
+        // * Assert message shows and manage members for members is disabled
+        visitChannelConfigPage(testChannel);
+        cy.findByTestId('admin-channel_settings-channel_moderation-manageMembers-disabledMember').
+            should('have.text', `Manage members for members are disabled in ${teamOverrideSchemeName} Team Scheme.`);
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('be.disabled');
+
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # View members modal
+        viewManageChannelMembersModal('View');
+
+        // * Add Members button does not exist
+        cy.get('#showInviteModal').should('not.exist');
+    });
+
+    it('Manage Members removed for Public Channels', () => {
+        const teamOverrideSchemeName = testChannel.name + getRandomId();
+
+        // # Create a new team override scheme and remove manage public channel members
+        goToPermissionsAndCreateTeamOverrideScheme(teamOverrideSchemeName, testTeam);
+        deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
+        cy.get('#all_users-public_channel-manage_public_channel_members').click();
+
+        // * Ensure that manage private channel members is checked
+        cy.get('#all_users-private_channel-manage_private_channel_members').children().should('have.class', 'checked');
+        saveConfigForScheme(false);
+
+        // # Visit Channel page and Search for the channel.
+        // * Ensure message is disabled and manage members for members is disabled
+        visitChannelConfigPage(testChannel);
+        cy.findByTestId('allow-all-toggle').should('has.have.text', 'Public');
+        cy.findByTestId('admin-channel_settings-channel_moderation-manageMembers-disabledMember').
+            should('have.text', `Manage members for members are disabled in ${teamOverrideSchemeName} Team Scheme.`);
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('be.disabled');
+
+        // # Turn channel into a private channel
+        cy.findByTestId('allow-all-toggle').click();
+        saveConfigForChannel(testChannel.display_name, true);
+
+        // * Ensure it is private and no error message is shown and that manage members for members is not disabled
+        cy.findByTestId('allow-all-toggle').should('has.have.text', 'Private');
+        cy.findByTestId('admin-channel_settings-channel_moderation-manageMembers-disabledMember').
+            should('not.have.text', `Manage members for members are disabled in ${teamOverrideSchemeName} Team Scheme.`);
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('not.be.disabled');
+
+        // # Turn channel back to public channel
+        cy.findByTestId('allow-all-toggle').click();
+        saveConfigForChannel(testChannel.display_name, true);
+
+        // * ensure it got reverted back to a Public channel
+        cy.findByTestId('allow-all-toggle').should('has.have.text', 'Public');
+    });
+
+    it('Manage Members removed for Private Channels / Permissions inherited when channel converted from Public to Private', () => {
+        const teamOverrideSchemeName = testChannel.name + getRandomId();
+
+        // # Create a new team override scheme and remove manage private channel members from it
+        // * Ensure that manage public channel members is checked
+        goToPermissionsAndCreateTeamOverrideScheme(teamOverrideSchemeName, testTeam);
+        deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
+        cy.get('#all_users-private_channel-manage_private_channel_members').click();
+        cy.get('#all_users-public_channel-manage_public_channel_members').children().should('have.class', 'checked');
+        saveConfigForScheme(false);
+
+        // # Visit Channel page and Search for the channel.
+        visitChannelConfigPage(testChannel);
+
+        // * Ensure that error message is not displayed and manage members for members is not disabled
+        cy.findByTestId('allow-all-toggle').should('has.have.text', 'Public');
+        cy.findByTestId('admin-channel_settings-channel_moderation-manageMembers-disabledMember').
+            should('not.have.text', `Manage members for members are disabled in ${teamOverrideSchemeName} Team Scheme.`);
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('not.be.disabled');
+
+        // # Turn it into a private channel
+        cy.findByTestId('allow-all-toggle').click();
+        saveConfigForChannel(testChannel.display_name, true);
+
+        // * Ensure it is a private channel and that a message is disabled and also manage members for members is disabled
+        cy.findByTestId('allow-all-toggle').should('has.have.text', 'Private');
+        cy.findByTestId('admin-channel_settings-channel_moderation-manageMembers-disabledMember').
+            should('have.text', `Manage members for members are disabled in ${teamOverrideSchemeName} Team Scheme.`);
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('be.disabled');
+
+        // # Turn channel back to public channel
+        cy.findByTestId('allow-all-toggle').click();
+        saveConfigForChannel(testChannel.display_name, true);
+
+        // * Ensure it got reset back to a public channel
+        cy.findByTestId('allow-all-toggle').should('has.have.text', 'Public');
+    });
+
+    it('Check if user is allowed to Edit or Delete their own posts on a Read-Only channel', () => {
+        visitChannel(regularUser, testChannel, testTeam);
+        cy.postMessage(`test message ${Date.now()}`);
+        cy.findByTestId('post_textbox_placeholder').should('not.have.text', 'This channel is read-only. Only members with permission can post here.');
+        cy.findByTestId('post_textbox').should('not.be.disabled');
+
+        visitChannelConfigPage(testChannel);
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
+
+        saveConfigForChannel();
+
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // * user should see a message stating that this channel is read-only and the textbox area should be disabled
+        cy.findByTestId('post_textbox_placeholder').should('have.text', 'This channel is read-only. Only members with permission can post here.');
+        cy.findByTestId('post_textbox').should('be.disabled');
+
+        cy.getLastPostId().then((postId) => {
+            cy.clickPostDotMenu(postId);
+
+            // * As per test case, ensure edit and delete button show up
+            cy.get(`#edit_post_${postId}`).should('exist');
+            cy.get(`#delete_post_${postId}`).should('exist');
+        });
+    });
+
+    it('Channel Moderation Settings should not be applied for Channel Admins', () => {
+        enableDisableAllChannelModeratedPermissionsViaAPI(testChannel, false);
+        visitChannel(regularUser, testChannel, testTeam);
+        promoteToChannelOrTeamAdmin(regularUser.id, testChannel.id);
+
+        // * Assert user can post message and user channel mentions
+        postChannelMentionsAndVerifySystemMessageNotExist(testChannel);
+
+        // # Check Channel Admin have the permission to react to any post on a channel when all channel moderation permissions are off.
+        // * Channel Admin should see the smiley face that allows a user to react to a post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#post_${postId}`).trigger('mouseover');
+            cy.findByTestId('post-reaction-emoji-icon').should('exist');
+        });
+
+        // # View members modal
+        viewManageChannelMembersModal('Manage');
+
+        // * Add Members button does not exist
+        cy.get('#showInviteModal').should('exist');
+
+        demoteToChannelOrTeamMember(regularUser.id, testChannel.id);
+    });
+
+    it('Channel Moderation Settings should not be applied for Team Admins', () => {
+        enableDisableAllChannelModeratedPermissionsViaAPI(testChannel, false);
+        visitChannel(regularUser, testChannel, testTeam);
+        promoteToChannelOrTeamAdmin(regularUser.id, testTeam.id, 'teams');
+
+        // * Assert user can post message and user channel mentions
+        postChannelMentionsAndVerifySystemMessageNotExist(testChannel);
+
+        // # Check Channel Admin have the permission to react to any post on a channel when all channel moderation permissions are off.
+        // * Channel Admin should see the smiley face that allows a user to react to a post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#post_${postId}`).trigger('mouseover');
+            cy.findByTestId('post-reaction-emoji-icon').should('exist');
+        });
+
+        // # View members modal
+        viewManageChannelMembersModal('Manage');
+
+        // * Add Members button does not exist
+        cy.get('#showInviteModal').should('exist');
+
+        demoteToChannelOrTeamMember(regularUser.id, testTeam.id, 'teams');
+    });
+});

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/manage_members_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/manage_members_spec.js
@@ -1,0 +1,192 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @system_console @channel_moderation
+
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
+import {getRandomId} from '../../../../utils';
+
+import {checkboxesTitleToIdMap} from './constants';
+
+import {
+    deleteOrEditTeamScheme,
+    disableChannelModeratedPermission,
+    enableChannelModeratedPermission,
+    goToPermissionsAndCreateTeamOverrideScheme,
+    goToSystemScheme,
+    saveConfigForChannel,
+    saveConfigForScheme,
+    viewManageChannelMembersModal,
+    visitChannel,
+    visitChannelConfigPage,
+} from './helpers';
+
+describe('MM-23102 - Channel Moderation - Manage Members', () => {
+    let regularUser;
+    let guestUser;
+    let testTeam;
+    let testChannel;
+
+    before(() => {
+        // * Check if server has license
+        cy.requireLicense();
+    });
+
+    beforeEach(() => {
+        cy.apiAdminLogin();
+        cy.apiResetRoles();
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            regularUser = user;
+            testTeam = team;
+            testChannel = channel;
+
+            cy.apiCreateGuestUser().then(({guest}) => {
+                guestUser = guest;
+
+                cy.apiAddUserToTeam(testTeam.id, guestUser.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, guestUser.id);
+                });
+
+                // # Activate guest user
+                cy.apiActivateUser(guestUser.id, true);
+            });
+        });
+    });
+
+    it('No option to Manage Members for Guests', () => {
+        visitChannelConfigPage(testChannel);
+
+        // * Assert that Manage Members for Guests does not exist (checkbox is not there)
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_GUESTS).should('not.exist');
+
+        visitChannel(guestUser, testChannel, testTeam);
+
+        // # View members modal
+        viewManageChannelMembersModal('View');
+
+        // * Add Members button does not exist
+        cy.get('#showInviteModal').should('not.exist');
+    });
+
+    it('Manage Members option for Members', () => {
+        // # Visit test channel page and turn off the Manage members for Members and then save
+        visitChannelConfigPage(testChannel);
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        saveConfigForChannel();
+
+        visitChannel(regularUser, testChannel, testTeam);
+        viewManageChannelMembersModal('View');
+
+        // * Add Members button does not exist
+        cy.get('#showInviteModal').should('not.exist');
+
+        // # Visit test channel page and turn off the Manage members for Members and then save
+        visitChannelConfigPage(testChannel);
+        enableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        saveConfigForChannel();
+
+        visitChannel(regularUser, testChannel, testTeam);
+        viewManageChannelMembersModal('Manage');
+
+        // * Add Members button does exist
+        cy.get('#showInviteModal').should('exist');
+    });
+
+    it('Manage Members option removed for Members in System Scheme', () => {
+        // Edit the System Scheme and disable the Manage Members option for Members & Save.
+        goToSystemScheme();
+        cy.get('#all_users-public_channel-manage_public_channel_members').scrollIntoView().should('be.visible').click();
+        cy.findByTestId('all_users-public_channel-manage_public_channel_members-checkbox').should('not.have.class', 'checked');
+        saveConfigForScheme();
+
+        // # Visit test channel page
+        visitChannelConfigPage(testChannel);
+
+        // * Assert that Manage Members option should be disabled for a Members.
+        // * A message Manage members for members are disabled in the System Scheme should be displayed.
+        cy.findByTestId('admin-channel_settings-channel_moderation-manageMembers-disabledMember').
+            should('exist').
+            and('have.text', 'Manage members for members are disabled in System Scheme.');
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('be.disabled');
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_GUESTS).should('not.exist');
+
+        visitChannel(regularUser, testChannel, testTeam);
+        viewManageChannelMembersModal('View');
+
+        // * Add Members button does not exist
+        cy.get('#showInviteModal').should('not.exist');
+
+        // Edit the System Scheme and enable the Manage Members option for Members & Save.
+        goToSystemScheme();
+        cy.get('#all_users-public_channel-manage_public_channel_members').scrollIntoView().should('be.visible').click();
+        cy.findByTestId('all_users-public_channel-manage_public_channel_members-checkbox').should('have.class', 'checked');
+        saveConfigForScheme();
+
+        // # Visit test channel page
+        visitChannelConfigPage(testChannel);
+
+        // * Assert that Manage Members option should be enabled for a Members.
+        // * A message Manage members for members are enabled in the System Scheme should be displayed.
+        cy.findByTestId('admin-channel_settings-channel_moderation-manageMembers-disabledMember').
+            should('not.exist');
+
+        visitChannel(regularUser, testChannel, testTeam);
+        viewManageChannelMembersModal('Manage');
+
+        // * Add Members button does not exist
+        cy.get('#showInviteModal').should('exist');
+    });
+
+    it('Manage Members option removed for Members in Team Override Scheme', () => {
+        const teamOverrideSchemeName = `manage_members_${getRandomId()}`;
+
+        // # Create a new team override scheme and remove manage members option for members
+        goToPermissionsAndCreateTeamOverrideScheme(teamOverrideSchemeName, testTeam);
+
+        // # Disable mange channel members
+        deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
+        cy.get('#all_users-public_channel-manage_public_channel_members').scrollIntoView().should('be.visible').click();
+        cy.findByTestId('all_users-public_channel-manage_public_channel_members-checkbox').should('not.have.class', 'checked');
+        saveConfigForScheme(false);
+        cy.wait(TIMEOUTS.SMALL);
+
+        // * Assert that Manage Members is disabled for members and a message is displayed
+        visitChannelConfigPage(testChannel);
+        cy.findByTestId('admin-channel_settings-channel_moderation-manageMembers-disabledMember').
+            should('exist').
+            and('have.text', `Manage members for members are disabled in ${teamOverrideSchemeName} Team Scheme.`);
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('be.disabled');
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_GUESTS).should('not.exist');
+
+        visitChannel(regularUser, testChannel, testTeam);
+        viewManageChannelMembersModal('View');
+
+        // * Add Members button does not exist in manage channel members modal
+        cy.get('#showInviteModal').should('not.exist');
+
+        // # Enable manage channel members
+        deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
+        cy.get('#all_users-public_channel-manage_public_channel_members').scrollIntoView().should('be.visible').click();
+        cy.findByTestId('all_users-public_channel-manage_public_channel_members-checkbox').should('have.class', 'checked');
+        saveConfigForScheme(false);
+        cy.wait(TIMEOUTS.SMALL);
+
+        visitChannelConfigPage(testChannel);
+        cy.findByTestId('admin-channel_settings-channel_moderation-manageMembers-disabledMember').
+            should('not.exist');
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS).should('have.class', 'checkbox checked');
+        cy.findByTestId(checkboxesTitleToIdMap.MANAGE_MEMBERS_GUESTS).should('not.exist');
+
+        visitChannel(regularUser, testChannel, testTeam);
+        viewManageChannelMembersModal('Manage');
+
+        // * Add Members button does exist in manage channel members modal
+        cy.get('#showInviteModal').should('exist');
+    });
+});

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/post_reactions_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/post_reactions_spec.js
@@ -1,0 +1,230 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @system_console @channel_moderation
+
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
+import {getRandomId} from '../../../../utils';
+import {getAdminAccount} from '../../../../support/env';
+
+import {checkboxesTitleToIdMap} from './constants';
+
+import {
+    deleteOrEditTeamScheme,
+    disableChannelModeratedPermission,
+    enableChannelModeratedPermission,
+    goToPermissionsAndCreateTeamOverrideScheme,
+    goToSystemScheme,
+    saveConfigForChannel,
+    saveConfigForScheme,
+    visitChannel,
+    visitChannelConfigPage,
+} from './helpers';
+
+describe('MM-23102 - Channel Moderation - Post Reactions', () => {
+    let regularUser;
+    let guestUser;
+    let testTeam;
+    let testChannel;
+    const admin = getAdminAccount();
+
+    before(() => {
+        // * Check if server has license
+        cy.requireLicense();
+
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            regularUser = user;
+            testTeam = team;
+            testChannel = channel;
+
+            cy.apiCreateGuestUser().then(({guest}) => {
+                guestUser = guest;
+
+                cy.apiAddUserToTeam(testTeam.id, guestUser.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, guestUser.id);
+                });
+
+                // # Activate guest user
+                cy.apiActivateUser(guestUser.id, true);
+
+                // Post a few messages in the channel
+                visitChannel(admin, testChannel, testTeam);
+                for (let i = 0; i < 3; i++) {
+                    cy.postMessage(`test message ${Date.now()}`);
+                }
+            });
+        });
+    });
+
+    it('Post Reactions option for Guests', () => {
+        visitChannelConfigPage(testChannel);
+
+        // # Uncheck the post reactions option for Guests and save
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.POST_REACTIONS_GUESTS);
+        saveConfigForChannel();
+
+        // # Login as a Guest user and visit the same channel
+        visitChannel(guestUser, testChannel, testTeam);
+
+        // # Check Guest user should not have the permission to react to any post on a channel when the option is removed.
+        // * Guest user should not see the smiley face that allows a user to react to a post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#post_${postId}`).trigger('mouseover');
+            cy.findByTestId('post-reaction-emoji-icon').should('not.exist');
+        });
+
+        // # Visit test channel configuration page and enable post reactions for guest and save
+        visitChannelConfigPage(testChannel);
+        enableChannelModeratedPermission(checkboxesTitleToIdMap.POST_REACTIONS_GUESTS);
+        saveConfigForChannel();
+
+        visitChannel(guestUser, testChannel, testTeam);
+
+        // # Check Guest user should have the permission to react to any post on a channel when the option is allowed.
+        // * Guest user should see the smiley face that allows a user to react to a post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#post_${postId}`).trigger('mouseover');
+            cy.findByTestId('post-reaction-emoji-icon').should('exist');
+        });
+    });
+
+    it('Post Reactions option for Members', () => {
+        visitChannelConfigPage(testChannel);
+
+        // # Uncheck the Create reactions option for Members and save
+        disableChannelModeratedPermission(checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS);
+        saveConfigForChannel();
+
+        // # Login as a Member user and visit the same channel
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # Check Member user should not have the permission to react to any post on a channel when the option is removed.
+        // * Member user should not see the smiley face that allows a user to react to a post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#post_${postId}`).trigger('mouseover');
+            cy.findByTestId('post-reaction-emoji-icon').should('not.exist');
+        });
+
+        // # Visit test Channel configuration page and enable post reactions for members and save
+        visitChannelConfigPage(testChannel);
+        enableChannelModeratedPermission(checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS);
+        saveConfigForChannel();
+
+        // # Login as a Member user and visit the same channel
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # Check Member user should have the permission to react to any post on a channel when the option is allowed.
+        // * Member user should see the smiley face that allows a user to react to a post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#post_${postId}`).trigger('mouseover');
+            cy.findByTestId('post-reaction-emoji-icon').should('exist');
+        });
+    });
+
+    it('Post Reactions option removed for Guests and Members in System Scheme', () => {
+        // # Login as sysadmin and visit the Permissions page in the system console.
+        // # Edit the System Scheme and remove the Post Reaction option for Guests & Save.
+        goToSystemScheme();
+        cy.get('.guest').should('be.visible').within(() => {
+            cy.findByText('Post Reactions').click();
+        });
+        saveConfigForScheme();
+
+        // # Visit the Channels page and click on a channel.
+        visitChannelConfigPage(testChannel);
+
+        // * Assert that post reaction is disabled for guest and not disabled for members and a message is displayed
+        cy.findByTestId('admin-channel_settings-channel_moderation-postReactions-disabledGuest').
+            should('exist').
+            and('have.text', 'Post reactions for guests are disabled in System Scheme.');
+        cy.findByTestId(checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS).should('not.be.disabled');
+        cy.findByTestId(checkboxesTitleToIdMap.POST_REACTIONS_GUESTS).should('be.disabled');
+
+        // # Go to system admin page and then go to the system scheme and remove post reaction option for all members and save
+        goToSystemScheme();
+        cy.get('#all_users-posts-reactions').click();
+        saveConfigForScheme();
+
+        visitChannelConfigPage(testChannel);
+
+        // * Post Reaction option should be disabled for a Members. A message Post reactions for guests & members are disabled in the System Scheme should be displayed.
+        cy.findByTestId('admin-channel_settings-channel_moderation-postReactions-disabledBoth').
+            should('exist').
+            and('have.text', 'Post reactions for members and guests are disabled in System Scheme.');
+        cy.findByTestId(checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS).should('be.disabled');
+        cy.findByTestId(checkboxesTitleToIdMap.POST_REACTIONS_GUESTS).should('be.disabled');
+
+        // # Login as a Guest user and visit the same channel
+        visitChannel(guestUser, testChannel, testTeam);
+
+        // # Check Guest User should not have the permission to react to any post on any channel when the option is removed from the System Scheme.
+        // * Guest user should not see the smiley face that allows a user to react to a post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#post_${postId}`).trigger('mouseover');
+            cy.findByTestId('post-reaction-emoji-icon').should('not.exist');
+        });
+
+        // # Login as a Member user and visit the same channel
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # Check Member should not have the permission to react to any post on any channel when the option is removed from the System Scheme.
+        // * Member user should not see the smiley face that allows a user to react to a post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#post_${postId}`).trigger('mouseover');
+            cy.findByTestId('post-reaction-emoji-icon').should('not.exist');
+        });
+    });
+
+    // GUEST PERMISSIONS DON'T EXIST ON TEAM OVERRIDE SCHEMES SO GUEST PORTION NOT IMPLEMENTED!
+    // ONLY THE MEMBERS PORTION OF THIS TEST IS IMPLEMENTED
+    it('Post Reactions option removed for Guests & Members in Team Override Scheme', () => {
+        const teamOverrideSchemeName = `post_reactions_${getRandomId()}`;
+
+        // # Create a new team override scheme
+        goToPermissionsAndCreateTeamOverrideScheme(teamOverrideSchemeName, testTeam);
+
+        visitChannelConfigPage(testChannel);
+
+        // * Assert that post reaction is disabled for members
+        cy.findByTestId(checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS).should('have.class', 'checkbox checked');
+
+        // # Login as a Member user and visit the same channel
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # Check Member should have the permission to react to any post on any channel in that team
+        // * User should see the smiley face that allows a user to react to a post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#post_${postId}`).trigger('mouseover');
+            cy.findByTestId('post-reaction-emoji-icon').should('exist');
+        });
+
+        // # Go to system admin page and then go to the system scheme and remove post reaction option for all members and save
+        deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
+        cy.get('#all_users-posts-reactions').click();
+        saveConfigForScheme(false);
+
+        // # Wait until the groups have been saved (since it redirects you)
+        cy.wait(TIMEOUTS.TINY * 2);
+
+        visitChannelConfigPage(testChannel);
+
+        // * Assert that post reaction is disabled for members
+        cy.findByTestId(checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS).should('have.class', 'checkbox disabled');
+
+        // # Login as a Member user and visit the same channel
+        visitChannel(regularUser, testChannel, testTeam);
+
+        // # Check Member should not have the permission to react to any post on any channel in that team
+        // * User should not see the smiley face that allows a user to react to a post
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#post_${postId}`).trigger('mouseover');
+            cy.findByTestId('post-reaction-emoji-icon').should('not.exist');
+        });
+    });
+});

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/system_config_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/system_config_spec.js
@@ -1,0 +1,98 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @enterprise @system_console @channel_moderation
+
+import * as TIMEOUTS from '../../../../fixtures/timeouts';
+
+import {checkBoxes} from './constants';
+
+import {
+    disableAllChannelModeratedPermissions,
+    enableAllChannelModeratedPermissions,
+    saveConfigForChannel,
+} from './helpers';
+
+describe('Channel Moderation', () => {
+    let guestUser;
+    let testTeam;
+    let testChannel;
+
+    before(() => {
+        // * Check if server has license
+        cy.requireLicense();
+
+        cy.apiInitSetup().then(({team, channel}) => {
+            testTeam = team;
+            testChannel = channel;
+
+            cy.apiCreateGuestUser().then(({guest}) => {
+                guestUser = guest;
+
+                cy.apiAddUserToTeam(testTeam.id, guestUser.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, guestUser.id);
+                });
+
+                // # Activate guest user
+                cy.apiActivateUser(guestUser.id, true);
+            });
+        });
+    });
+
+    it('MM-22276 - Enable and Disable all channel moderated permissions', () => {
+        // # Go to system admin page and to channel configuration page of test channel
+        cy.apiAdminLogin();
+        cy.visit('/admin_console/user_management/channels');
+
+        // # Search for the channel.
+        cy.findByTestId('search-input').type(`${testChannel.name}{enter}`);
+        cy.findByText('Edit').click();
+
+        // # Wait until the groups retrieved and show up
+        cy.wait(TIMEOUTS.TINY * 2);
+
+        // # Check all the boxes currently unchecked (align with the system scheme permissions)
+        enableAllChannelModeratedPermissions();
+
+        // # Save if possible (if previous test ended abruptly all permissions may already be enabled)
+        saveConfigForChannel(testChannel.display_name);
+
+        // # Wait until the groups retrieved and show up
+        cy.wait(TIMEOUTS.TINY * 2);
+
+        // * Ensure all checkboxes are checked
+        checkBoxes.forEach((buttonId) => {
+            cy.findByTestId(buttonId).should('have.class', 'checked');
+        });
+
+        // # Uncheck all the boxes currently checked
+        disableAllChannelModeratedPermissions();
+
+        // # Save the page and wait till saving is done
+        saveConfigForChannel(testChannel.display_name);
+
+        // # Wait until the groups retrieved and show up
+        cy.wait(TIMEOUTS.TINY * 2);
+
+        // * Ensure all checkboxes have the correct unchecked state
+        checkBoxes.forEach((buttonId) => {
+            // * Ensure all checkboxes are unchecked
+            cy.findByTestId(buttonId).should('not.have.class', 'checked');
+
+            // * Ensure Channel Mentions are disabled due to Create Posts
+            if (buttonId.includes('use_channel_mentions')) {
+                cy.findByTestId(buttonId).should('be.disabled');
+                return;
+            }
+
+            // * Ensure all other check boxes are still enabled
+            cy.findByTestId(buttonId).should('not.be.disabled');
+        });
+    });
+});

--- a/e2e/cypress/integration/enterprise/system_console/sidebar_link_navigation_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/sidebar_link_navigation_spec.js
@@ -97,8 +97,7 @@ describe('System Console - Enterprise', () => {
     ];
 
     before(() => {
-        // * Login as sysadmin and check if server has license
-        cy.apiLogin('sysadmin');
+        // * Check if server has license
         cy.requireLicense();
 
         const newSettings = {

--- a/e2e/cypress/integration/enterprise/system_console/system_scheme_permission_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/system_scheme_permission_spec.js
@@ -10,51 +10,63 @@
 // Stage: @prod
 // Group: @enterprise @system_console
 
-import users from '../../../fixtures/users.json';
+import {getAdminAccount} from '../../../support/env';
 
-const channelUrl = '/ad-1/channels/suscipit-4';
-const setUserTeamAndChannelMemberships = (channelAdmin = false, teamAdmin = false) => {
-    cy.apiLogin('user-1');
-    cy.visit(channelUrl);
+describe('System Scheme Channel Mentions Permissions Test', () => {
+    let testUser;
+    let testTeam;
+    let testChannel;
 
-    cy.apiGetMe().then((res) => {
-        const userId = res.body.id;
+    before(() => {
+        // * Check if server has license
+        cy.requireLicense();
 
-        // # Set user as regular system user
-        cy.externalRequest({user: users.sysadmin, method: 'put', path: `users/${userId}/roles`, data: {roles: 'system_user'}});
-
-        // # Get team membership
-        cy.getCurrentTeamId().then((teamId) => {
-            cy.externalRequest({
-                user: users.sysadmin,
-                method: 'put',
-                path: `teams/${teamId}/members/${userId}/schemeRoles`,
-                data: {
-                    scheme_user: true,
-                    scheme_admin: teamAdmin,
-                },
-            });
-
-            // # Reload page to ensure no cache or saved information
-            cy.reload(true);
-        });
-
-        // # Get channel membership
-        cy.getCurrentChannelId().then((channelId) => {
-            cy.externalRequest({
-                user: users.sysadmin,
-                method: 'put',
-                path: `channels/${channelId}/members/${userId}/schemeRoles`,
-                data: {
-                    scheme_user: true,
-                    scheme_admin: channelAdmin,
-                },
-            });
-
-            // # Reload page to ensure no cache or saved information
-            cy.reload(true);
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            testUser = user;
+            testTeam = team;
+            testChannel = channel;
         });
     });
+
+    beforeEach(() => {
+        cy.apiAdminLogin();
+        cy.apiResetRoles();
+    });
+
+    it('MM-23018 - Enable and Disable Channel Mentions', () => {
+        checkChannelPermission(
+            'use_channel_mentions',
+            () => channelMentionsPermissionCheck(true),
+            () => channelMentionsPermissionCheck(false),
+            testUser,
+            testTeam,
+            testChannel,
+        );
+    });
+
+    it('MM-24379 - Enable and Disable Create Post', () => {
+        checkChannelPermission(
+            'create_post',
+            () => createPostPermissionCheck(true),
+            () => createPostPermissionCheck(false),
+            testUser,
+            testTeam,
+            testChannel,
+        );
+    });
+});
+
+const setUserTeamAndChannelMemberships = (user, team, channel, channelAdmin = false, teamAdmin = false) => {
+    const admin = getAdminAccount();
+
+    // # Set user as regular system user
+    cy.externalRequest({user: admin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user'}});
+
+    // # Get team membership
+    cy.externalRequest({user: admin, method: 'put', path: `teams/${team.id}/members/${user.id}/schemeRoles`, data: {scheme_user: true, scheme_admin: teamAdmin}});
+
+    // # Get channel membership
+    cy.externalRequest({user: admin, method: 'put', path: `channels/${channel.id}/members/${user.id}/schemeRoles`, data: {scheme_user: true, scheme_admin: channelAdmin}});
 };
 
 const saveConfig = () => {
@@ -62,15 +74,6 @@ const saveConfig = () => {
     cy.waitUntil(() => cy.get('#saveSetting').then((el) => {
         return el[0].innerText === 'Save';
     }));
-};
-
-const deleteExistingTeamOverrideSchemes = () => {
-    cy.apiLogin('sysadmin');
-    cy.apiGetSchemes('team').then((res) => {
-        res.body.forEach((scheme) => {
-            cy.apiDeleteScheme(scheme.id);
-        });
-    });
 };
 
 const enablePermission = (permissionCheckBoxTestId) => {
@@ -101,6 +104,8 @@ const channelMentionsPermissionCheck = (enabled) => {
             // * Assert that the last message posted is not a system message informing us we are not allowed to use channel mentions
             cy.get(`#postMessageText_${postId}`).should('not.include.text', 'Channel notifications are disabled');
         } else {
+            cy.uiWaitUntilMessagePostedIncludes('Channel notifications are disabled');
+
             // * Assert that the last message posted is the system message informing us we are not allowed to use channel mentions
             cy.get(`#postMessageText_${postId}`).should('include.text', 'Channel notifications are disabled');
         }
@@ -130,7 +135,7 @@ const createPostPermissionCheck = (enabled) => {
 
 const resetPermissionsToDefault = () => {
     // # Login as sysadmin and navigate to system scheme page
-    cy.apiLogin('sysadmin');
+    cy.apiAdminLogin();
     cy.visit('/admin_console/user_management/permissions/system_scheme');
 
     // # Click reset to defaults and confirm
@@ -141,53 +146,25 @@ const resetPermissionsToDefault = () => {
     saveConfig();
 };
 
-describe('System Scheme Channel Mentions Permissions Test', () => {
-    before(() => {
-        // * Check if server has license
-        cy.requireLicense();
-
-        // Reset permissions in system scheme to defaults.
-        resetPermissionsToDefault();
-
-        deleteExistingTeamOverrideSchemes();
-    });
-
-    after(() => {
-        resetPermissionsToDefault();
-    });
-
-    it('MM-23018 - Enable and Disable Channel Mentions', () => {
-        checkChannelPermission('use_channel_mentions', () => {
-            channelMentionsPermissionCheck(true);
-        }, () => {
-            channelMentionsPermissionCheck(false);
-        });
-    });
-
-    it('MM-24379 - Enable and Disable Create Post', () => {
-        checkChannelPermission('create_post', () => {
-            createPostPermissionCheck(true);
-        }, () => {
-            createPostPermissionCheck(false);
-        });
-    });
-});
-
-const checkChannelPermission = (permissionName, hasChannelPermisisonCheckFunc, notHasChannelPermissionCheckFunc) => {
+const checkChannelPermission = (permissionName, hasChannelPermissionCheckFunc, notHasChannelPermissionCheckFunc, testUser, testTeam, testChannel) => {
     const guestsTestId = `guests-guest_${permissionName}-checkbox`;
     const usersTestId = `all_users-posts-${permissionName}-checkbox`;
     const channelTestId = `channel_admin-posts-${permissionName}-checkbox`;
     const teamTestId = `team_admin-posts-${permissionName}-checkbox`;
     const testIds = [guestsTestId, usersTestId, channelTestId, teamTestId];
 
+    const channelUrl = `/${testTeam.name}/channels/${testChannel.name}`;
+
     // # Setup user as a regular channel member and team member
-    setUserTeamAndChannelMemberships();
+    setUserTeamAndChannelMemberships(testUser, testTeam, testChannel);
 
     // * Ensure user can use channel mentions by default
-    hasChannelPermisisonCheckFunc();
+    cy.apiLogin(testUser.username, testUser.password);
+    cy.visit(channelUrl);
+    hasChannelPermissionCheckFunc();
 
     // # Go to system permissions scheme page as sysadmin
-    cy.apiLogin('sysadmin');
+    cy.apiAdminLogin();
     cy.visit('/admin_console/user_management/permissions/system_scheme');
 
     // * Ensure permission is enabled at each scope by default
@@ -230,44 +207,50 @@ const checkChannelPermission = (permissionName, hasChannelPermisisonCheckFunc, n
     cy.findByTestId(usersTestId).should('not.have.class', 'checked');
 
     // # Setup user as a regular channel member
-    setUserTeamAndChannelMemberships();
+    setUserTeamAndChannelMemberships(testUser, testTeam, testChannel);
 
     // * Ensure user cannot use channel mentions
+    cy.apiLogin(testUser.username, testUser.password);
+    cy.visit(channelUrl);
     notHasChannelPermissionCheckFunc();
 
     // # Setup user as a channel admin
-    setUserTeamAndChannelMemberships(true, false);
+    setUserTeamAndChannelMemberships(testUser, testTeam, testChannel, true, false);
 
     // * Ensure user can use channel mentions as channel admin
-    hasChannelPermisisonCheckFunc();
+    cy.apiLogin(testUser.username, testUser.password);
+    cy.visit(channelUrl);
+    hasChannelPermissionCheckFunc();
 
     // # Navigate back to system scheme as sysadmin and remove permission from channel admins
-    cy.apiLogin('sysadmin');
+    cy.apiAdminLogin();
     cy.visit('/admin_console/user_management/permissions/system_scheme');
     removePermission(channelTestId);
     saveConfig();
 
     // # Log back in as regular user
-    cy.apiLogin('user-1');
+    cy.apiLogin(testUser.username, testUser.password);
     cy.visit(channelUrl);
 
     // * Ensure user cannot use channel mentions as channel admin
     notHasChannelPermissionCheckFunc();
 
     // # Setup user as a team admin
-    setUserTeamAndChannelMemberships(true, true);
+    setUserTeamAndChannelMemberships(testUser, testTeam, testChannel, true, true);
 
     // * Ensure user can use channel mentions as team admin
-    hasChannelPermisisonCheckFunc();
+    cy.apiLogin(testUser.username, testUser.password);
+    cy.visit(channelUrl);
+    hasChannelPermissionCheckFunc();
 
     // # Navigate back to system scheme as sysadmin and remove permission from team admins
-    cy.apiLogin('sysadmin');
+    cy.apiAdminLogin();
     cy.visit('/admin_console/user_management/permissions/system_scheme');
     removePermission(teamTestId);
     saveConfig();
 
     // # Log back in as regular user
-    cy.apiLogin('user-1');
+    cy.apiLogin(testUser.username, testUser.password);
     cy.visit(channelUrl);
 
     // * Ensure user cannot use channel mentions as team admin

--- a/e2e/cypress/integration/enterprise/system_console/team_guest_channel_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/team_guest_channel_spec.js
@@ -52,7 +52,6 @@ describe('Team Scheme Guest Permissions Test', () => {
     before(() => {
         // * Check if server has license
         cy.requireLicense();
-        cy.apiLogin('sysadmin');
     });
 
     it('MM- - Enable and Disable all guest permission', () => {

--- a/e2e/cypress/integration/enterprise/system_console/team_scheme_permission_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/team_scheme_permission_spec.js
@@ -9,51 +9,94 @@
 
 // Stage: @prod
 
-import users from '../../../fixtures/users.json';
+import {getAdminAccount} from '../../../support/env';
 
-const channelUrl = '/ad-1/channels/suscipit-4';
-const setUserTeamAndChannelMemberships = (channelAdmin = false, teamAdmin = false) => {
-    cy.apiLogin('user-1');
-    cy.visit(channelUrl);
+describe('Team Scheme Channel Mentions Permissions Test', () => {
+    let testUser;
+    let testTeam;
+    let testChannel;
 
-    cy.apiGetMe().then((res) => {
-        const userId = res.body.id;
+    before(() => {
+        // * Check if server has license
+        cy.requireLicense();
 
-        // # Set user as regular system user
-        cy.externalRequest({user: users.sysadmin, method: 'put', path: `users/${userId}/roles`, data: {roles: 'system_user'}});
-
-        // # Get team membership
-        cy.getCurrentTeamId().then((teamId) => {
-            cy.externalRequest({
-                user: users.sysadmin,
-                method: 'put',
-                path: `teams/${teamId}/members/${userId}/schemeRoles`,
-                data: {
-                    scheme_user: true,
-                    scheme_admin: teamAdmin,
-                },
-            });
-
-            // # Reload page to ensure no cache or saved information
-            cy.reload(true);
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            testUser = user;
+            testTeam = team;
+            testChannel = channel;
         });
 
-        // # Get channel membership
-        cy.getCurrentChannelId().then((channelId) => {
-            cy.externalRequest({
-                user: users.sysadmin,
-                method: 'put',
-                path: `channels/${channelId}/members/${userId}/schemeRoles`,
-                data: {
-                    scheme_user: true,
-                    scheme_admin: channelAdmin,
-                },
-            });
+        // Delete any existing team override schemes
+        deleteExistingTeamOverrideSchemes();
+    });
 
-            // # Reload page to ensure no cache or saved information
-            cy.reload(true);
+    beforeEach(() => {
+        cy.apiAdminLogin();
+        cy.apiResetRoles();
+    });
+
+    it('MM-23018 - Create a team override scheme', () => {
+        // # Visit the permissions page
+        cy.visit('/admin_console/user_management/permissions/team_override_scheme');
+
+        // # Give the new team scheme a name
+        cy.get('#scheme-name').type('Test Team Scheme');
+
+        // # Assign the new team scheme to the eligendi team using the add teams modal
+        cy.findByTestId('add-teams').click();
+
+        cy.get('#selectItems').type(testTeam.display_name);
+
+        cy.get('.team-info-block').then((el) => {
+            el.click();
+        });
+
+        cy.get('#saveItems').click();
+
+        // # Save config
+        cy.get('#saveSetting').click();
+
+        // * Ensure that the team scheme was created and assigned to the team
+        cy.findByTestId('permissions-scheme-summary').within(() => {
+            cy.get('.permissions-scheme-summary--header').should('include.text', 'Test Team Scheme');
+            cy.get('.permissions-scheme-summary--teams').should('include.text', testTeam.display_name);
         });
     });
+
+    it('MM-23018 - Enable and Disable Channel Mentions for team scheme', () => {
+        checkChannelPermission(
+            'use_channel_mentions',
+            () => channelMentionsPermissionCheck(true),
+            () => channelMentionsPermissionCheck(false),
+            testUser,
+            testTeam,
+            testChannel,
+        );
+    });
+
+    it('MM-24379 - Enable and Disable Create Post for team scheme', () => {
+        checkChannelPermission(
+            'create_post',
+            () => createPostPermissionCheck(true),
+            () => createPostPermissionCheck(false),
+            testUser,
+            testTeam,
+            testChannel,
+        );
+    });
+});
+
+const setUserTeamAndChannelMemberships = (user, team, channel, channelAdmin = false, teamAdmin = false) => {
+    const admin = getAdminAccount();
+
+    // # Set user as regular system user
+    cy.externalRequest({user: admin, method: 'put', path: `users/${user.id}/roles`, data: {roles: 'system_user'}});
+
+    // # Get team membership
+    cy.externalRequest({user: admin, method: 'put', path: `teams/${team.id}/members/${user.id}/schemeRoles`, data: {scheme_user: true, scheme_admin: teamAdmin}});
+
+    // # Get channel membership
+    cy.externalRequest({user: admin, method: 'put', path: `channels/${channel.id}/members/${user.id}/schemeRoles`, data: {scheme_user: true, scheme_admin: channelAdmin}});
 };
 
 const enablePermission = (permissionCheckBoxTestId) => {
@@ -92,6 +135,8 @@ const channelMentionsPermissionCheck = (enabled) => {
             // * Assert that the last message posted is not a system message informing us we are not allowed to use channel mentions
             cy.get(`#postMessageText_${postId}`).should('not.include.text', 'Channel notifications are disabled');
         } else {
+            cy.uiWaitUntilMessagePostedIncludes('Channel notifications are disabled');
+
             // * Assert that the last message posted is the system message informing us we are not allowed to use channel mentions
             cy.get(`#postMessageText_${postId}`).should('include.text', 'Channel notifications are disabled');
         }
@@ -119,99 +164,19 @@ const createPostPermissionCheck = (enabled) => {
     });
 };
 
-const resetPermissionsToDefault = () => {
-    cy.visit('/admin_console/user_management/permissions/system_scheme');
+const checkChannelPermission = (permissionName, hasChannelPermissionCheckFunc, notHasChannelPermissionCheckFunc, testUser, testTeam, testChannel) => {
+    const channelUrl = `/${testTeam.name}/channels/${testChannel.name}`;
 
-    // # Click reset to defaults and confirm
-    cy.findByTestId('resetPermissionsToDefault').click();
-    cy.get('#confirmModalButton').click();
-
-    // # Save
-    cy.get('#saveSetting').click();
-    cy.waitUntil(() => cy.get('#saveSetting').then((el) => {
-        return el[0].innerText === 'Save';
-    }));
-};
-
-describe('Team Scheme Channel Mentions Permissions Test', () => {
-    before(() => {
-        // # Login as sysadmin and navigate to system scheme page
-        cy.apiLogin('sysadmin');
-
-        // * Check if server has license
-        cy.requireLicense();
-
-        // Reset permissions in system scheme to defaults.
-        resetPermissionsToDefault();
-
-        // Delete any existing team override schemes
-        deleteExistingTeamOverrideSchemes();
-
-        // # Visit the permissions page
-        cy.visit('/admin_console/user_management/permissions');
-    });
-
-    after(() => {
-        // # Login as sysadmin and navigate to system scheme page
-        cy.apiLogin('sysadmin');
-        resetPermissionsToDefault();
-        deleteExistingTeamOverrideSchemes();
-    });
-
-    it('MM-23018 - Create a team override scheme', () => {
-        // # Visit the permissions page
-        cy.visit('/admin_console/user_management/permissions/team_override_scheme');
-
-        // # Give the new team scheme a name
-        cy.get('#scheme-name').type('Test Team Scheme');
-
-        // # Assign the new team scheme to the eligendi team using the add teams modal
-        cy.findByTestId('add-teams').click();
-
-        cy.get('#selectItems').type('eligendi');
-
-        cy.get('.team-info-block').then((el) => {
-            el.click();
-        });
-
-        cy.get('#saveItems').click();
-
-        // # Save config
-        cy.get('#saveSetting').click();
-
-        // * Ensure that the team scheme was created and assigned to the team
-        cy.findByTestId('permissions-scheme-summary').within(() => {
-            cy.get('.permissions-scheme-summary--header').should('include.text', 'Test Team Scheme');
-            cy.get('.permissions-scheme-summary--teams').should('include.text', 'eligendi');
-        });
-    });
-
-    it('MM-23018 - Enable and Disable Channel Mentions for team scheme', () => {
-        checkChannelPermission('use_channel_mentions', () => {
-            channelMentionsPermissionCheck(true);
-        }, () => {
-            channelMentionsPermissionCheck(false);
-        });
-    });
-
-    it('MM-24379 - Enable and Disable Create Post for team scheme', () => {
-        checkChannelPermission('create_post', () => {
-            createPostPermissionCheck(true);
-        }, () => {
-            createPostPermissionCheck(false);
-        });
-    });
-});
-
-const checkChannelPermission = (permissionName, hasChannelPermissionCheckFunc, notHasChannelPermissionCheckFunc) => {
     // # Setup user as a regular channel member
-    setUserTeamAndChannelMemberships();
+    setUserTeamAndChannelMemberships(testUser, testTeam, testChannel);
 
     // * Ensure user can use channel mentions by default
+    cy.apiLogin(testUser.username, testUser.password);
+    cy.visit(channelUrl);
     hasChannelPermissionCheckFunc();
 
     // # Login as sysadmin again
-    cy.apiLogin('sysadmin');
+    cy.apiAdminLogin();
 
     // # Get team scheme URL
     cy.apiGetSchemes('team').then((res) => {
@@ -263,19 +228,23 @@ const checkChannelPermission = (permissionName, hasChannelPermissionCheckFunc, n
         cy.findByTestId(usersTestId).should('not.have.class', 'checked');
 
         // # Setup user as a regular channel member
-        setUserTeamAndChannelMemberships();
+        setUserTeamAndChannelMemberships(testUser, testTeam, testChannel);
 
         // * Ensure user cannot use channel mentions
+        cy.apiLogin(testUser.username, testUser.password);
+        cy.visit(channelUrl);
         notHasChannelPermissionCheckFunc();
 
         // # Setup user as a channel admin
-        setUserTeamAndChannelMemberships(true, false);
+        setUserTeamAndChannelMemberships(testUser, testTeam, testChannel, true, false);
 
         // * Ensure user can use channel mentions as channel admin
+        cy.apiLogin(testUser.username, testUser.password);
+        cy.visit(channelUrl);
         hasChannelPermissionCheckFunc();
 
         // # Navigate back to team scheme as sysadmin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         cy.visit(url);
 
         // # Remove permission from channel admins and save
@@ -284,20 +253,22 @@ const checkChannelPermission = (permissionName, hasChannelPermissionCheckFunc, n
         cy.visit(url);
 
         // # Log back in as regular user
-        cy.apiLogin('user-1');
+        cy.apiLogin(testUser.username, testUser.password);
         cy.visit(channelUrl);
 
         // * Ensure user cannot use channel mentions as channel admin
         notHasChannelPermissionCheckFunc();
 
         // # Setup user as a team admin
-        setUserTeamAndChannelMemberships(true, true);
+        setUserTeamAndChannelMemberships(testUser, testTeam, testChannel, true, true);
 
         // * Ensure user can use channel mentions as team admin
+        cy.apiLogin(testUser.username, testUser.password);
+        cy.visit(channelUrl);
         hasChannelPermissionCheckFunc();
 
         // # Navigate back to system scheme as sysadmin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         cy.visit(url);
 
         // # Remove permission from team admins and save
@@ -306,7 +277,7 @@ const checkChannelPermission = (permissionName, hasChannelPermissionCheckFunc, n
         cy.visit(url);
 
         // # Log back in as regular user
-        cy.apiLogin('user-1');
+        cy.apiLogin(testUser.username, testUser.password);
         cy.visit(channelUrl);
 
         // * Ensure user cannot use channel mentions as team admin

--- a/e2e/cypress/integration/enterprise/system_console/ui_and_api/notifications_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/ui_and_api/notifications_spec.js
@@ -12,8 +12,7 @@
 
 describe('System Console', () => {
     before(() => {
-        // * Login as sysadmin and check if server has license for ID Loaded Push Notifications
-        cy.apiLogin('sysadmin');
+        // * Check if server has license for ID Loaded Push Notifications
         cy.requireLicenseForFeature('IDLoadedPushNotifications');
 
         // # Update to default config

--- a/e2e/cypress/integration/enterprise/teams/search_teams_spec.js
+++ b/e2e/cypress/integration/enterprise/teams/search_teams_spec.js
@@ -20,7 +20,7 @@ describe('Search teams', () => {
     });
 
     beforeEach(() => {
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         cy.visit('/admin_console/user_management/teams');
         cy.wrap([]).as('createdTeamIDs');
     });

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -11,14 +11,28 @@
 // Group: @integrations
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
-import users from '../../../fixtures/users.json';
 
 describe('I18456 Built-in slash commands: common', () => {
+    let user1;
+    let user2;
+    let testChannelUrl;
+
     before(() => {
-        loginAndVisitDefaultChannel('user-1');
+        cy.apiInitSetup().then(({team, user}) => {
+            user1 = user;
+            testChannelUrl = `/${team.name}/channels/town-square`;
+
+            cy.apiCreateUser().then(({user: otherUser}) => {
+                user2 = otherUser;
+
+                cy.apiAddUserToTeam(team.id, user2.id);
+            });
+        });
     });
 
     it('/ autocomplete list can scroll', () => {
+        loginAndVisitDefaultChannel(user1, testChannelUrl);
+
         // # Clear post textbox
         cy.get('#post_textbox').clear().type('/');
 
@@ -37,32 +51,30 @@ describe('I18456 Built-in slash commands: common', () => {
     });
 
     it('/shrug test', () => {
-        // # Login as user-2 and post a message
-        loginAndVisitDefaultChannel('user-2');
-        cy.postMessage('hello from user-2');
+        // # Login as user2 and post a message
+        loginAndVisitDefaultChannel(user2, testChannelUrl);
+        cy.postMessage('hello from user2');
 
-        // # Login as user-1 and post "/shrug test"
-        loginAndVisitDefaultChannel('user-1');
+        // # Login as user1 and post "/shrug test"
+        loginAndVisitDefaultChannel(user1, testChannelUrl);
         cy.postMessage('/shrug test');
 
-        // * Verify that it posted message as expected from user-1
+        // * Verify that it posted message as expected from user1
         cy.getLastPostId().then((postId) => {
-            cy.get(`#post_${postId}`).find('.user-popover').should('have.text', 'user-1');
+            cy.get(`#post_${postId}`).find('.user-popover').should('have.text', user1.username);
             cy.get(`#postMessageText_${postId}`).should('have.text', 'test ¯\\_(ツ)_/¯');
         });
 
-        // * Login as user-2 and verify that it read the same message as expected from user-1
-        loginAndVisitDefaultChannel('user-2');
+        // * Login as user2 and verify that it read the same message as expected from user1
+        loginAndVisitDefaultChannel(user2, testChannelUrl);
         cy.getLastPostId().then((postId) => {
-            cy.get(`#post_${postId}`).find('.user-popover').should('have.text', 'user-1');
+            cy.get(`#post_${postId}`).find('.user-popover').should('have.text', user1.username);
             cy.get(`#postMessageText_${postId}`).should('have.text', 'test ¯\\_(ツ)_/¯');
         });
     });
 });
 
-function loginAndVisitDefaultChannel(username) {
-    const user = users[username];
+function loginAndVisitDefaultChannel(user, channelUrl) {
     cy.apiLogin(user.username, user.password);
-    cy.apiSaveTeammateNameDisplayPreference('username');
-    cy.visit('/ad-1/channels/town-square');
+    cy.visit(channelUrl);
 }

--- a/e2e/cypress/integration/integrations/builtin_commands/user_status_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/user_status_commands_spec.js
@@ -18,10 +18,13 @@ const testCases = [
 ];
 
 describe('Integrations', () => {
+    let testChannelUrl;
+
     before(() => {
-        // # Login as user-1, go to "/" and set user status to online
-        cy.apiLogin('user-1');
-        cy.apiUpdateUserStatus('online');
+        // # Login as test user, go to town-square and set user status to online
+        cy.apiInitSetup().then(({team}) => {
+            testChannelUrl = `/${team.name}/channels/town-square`;
+        });
     });
 
     after(() => {
@@ -31,7 +34,7 @@ describe('Integrations', () => {
 
     it('I18456 Built-in slash commands: change user status via post', () => {
         cy.apiSaveMessageDisplayPreference('compact');
-        cy.visit('/ad-1/channels/town-square');
+        cy.visit(testChannelUrl);
 
         testCases.forEach((testCase) => {
             cy.postMessage(testCase.command + ' ');
@@ -42,7 +45,7 @@ describe('Integrations', () => {
 
     it('I18456 Built-in slash commands: change user status via suggestion list', () => {
         cy.apiSaveMessageDisplayPreference('clean');
-        cy.visit('/ad-1/channels/town-square');
+        cy.visit(testChannelUrl);
 
         testCases.forEach((testCase) => {
             // # Type "/" on textbox
@@ -64,6 +67,8 @@ describe('Integrations', () => {
 function verifyUserStatus(testCase, isCompactMode) {
     // * Verify that the user status is as indicated
     cy.get('#lhsHeader').find('svg').should('be.visible').and('have.attr', 'aria-label', testCase.ariaLabel);
+
+    cy.uiWaitUntilMessagePostedIncludes(testCase.message);
 
     // * Verify that ephemeral message is posted as expected
     cy.getLastPostId().then((postId) => {

--- a/e2e/cypress/integration/integrations/integrations_spec.js
+++ b/e2e/cypress/integration/integrations/integrations_spec.js
@@ -14,8 +14,7 @@ import {getRandomId} from '../../utils';
 
 describe('Integrations page', () => {
     before(() => {
-        // # Login as sysadmin and set ServiceSettings to expected values
-        cy.apiLogin('sysadmin');
+        // # Set ServiceSettings to expected values
         const newSettings = {
             ServiceSettings: {
                 EnableOAuthServiceProvider: true,

--- a/e2e/cypress/integration/integrations/message_to_channel_via_slash_command_spec.js
+++ b/e2e/cypress/integration/integrations/message_to_channel_via_slash_command_spec.js
@@ -20,9 +20,6 @@ describe('Integrations', () => {
     before(() => {
         cy.requireWebhookServer();
 
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
         // # Create new team and get off-topic channel
         cy.apiCreateTeam('test-team', 'Test Team').then((teamResponse) => {
             team = teamResponse.body;

--- a/e2e/cypress/integration/interactive_dialog/boolean_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/boolean_spec.js
@@ -21,8 +21,7 @@ let simpleDialog;
 
 describe('Interactive Dialog', () => {
     before(() => {
-        // # Login as sysadmin and ensure that teammate name display setting is set to default 'username'
-        cy.apiLogin('sysadmin');
+        // # Ensure that teammate name display setting is set to default 'username'
         cy.apiSaveTeammateNameDisplayPreference('username');
 
         cy.requireWebhookServer();

--- a/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
@@ -37,8 +37,7 @@ describe('Interactive Dialog', () => {
     before(() => {
         cy.requireWebhookServer();
 
-        // # Login as sysadmin and ensure that teammate name display setting is set to default 'username'
-        cy.apiLogin('sysadmin');
+        // # Ensure that teammate name display setting is set to default 'username'
         cy.apiSaveTeammateNameDisplayPreference('username');
 
         // # Get config

--- a/e2e/cypress/integration/interactive_dialog/scrollable_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/scrollable_spec.js
@@ -23,8 +23,7 @@ describe('Interactive Dialog', () => {
     before(() => {
         cy.requireWebhookServer();
 
-        // # Login as sysadmin and ensure that teammate name display setting is set to default 'username'
-        cy.apiLogin('sysadmin');
+        // # Ensure that teammate name display setting is set to default 'username'
         cy.apiSaveTeammateNameDisplayPreference('username');
 
         // # Create new team and create command on it

--- a/e2e/cypress/integration/interactive_dialog/simple_dialog_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/simple_dialog_spec.js
@@ -26,8 +26,7 @@ describe('Interactive Dialog', () => {
         before(() => {
             cy.requireWebhookServer();
 
-            // # Login as sysadmin and ensure that teammate name display setting is set to default 'username'
-            cy.apiLogin('sysadmin');
+            // # Ensure that teammate name display setting is set to default 'username'
             cy.apiSaveTeammateNameDisplayPreference('username');
 
             // # Create new team and create command on it

--- a/e2e/cypress/integration/interactive_menu/basic_options_spec.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options_spec.js
@@ -14,7 +14,6 @@
 * Note: This test requires webhook server running. Initiate `npm run start:webhook` to start.
 */
 
-import users from '../../fixtures/users.json';
 import messageMenusOptions from '../../fixtures/interactive_message_menus_options.json';
 import {getMessageMenusPayload} from '../../utils';
 import * as TIMEOUTS from '../../fixtures/timeouts';
@@ -25,27 +24,38 @@ const options = [
     {text: 'Option 3', value: 'option3'},
 ];
 
-let channel;
-let incomingWebhook;
-let longUsername;
-
 describe('Interactive Menu', () => {
+    let testUser;
+    let otherUser;
+    let longUser;
+    let testChannel;
+    let incomingWebhook;
+
     before(() => {
         cy.requireWebhookServer();
 
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            testUser = user;
+            testChannel = channel;
 
-        // # Update teammate name display setting is set to default 'username'
-        cy.apiSaveTeammateNameDisplayPreference('username');
-        cy.apiSaveMessageDisplayPreference('clean');
+            cy.apiCreateUser().then(({user: user2}) => {
+                otherUser = user2;
 
-        // # Create and visit new channel and create incoming webhook
-        cy.createAndVisitNewChannel().then((data) => {
-            channel = data;
+                cy.apiAddUserToTeam(team.id, otherUser.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, otherUser.id);
+                });
+            });
+
+            const longUsername = 'with-long-username-abcdefghijklmnopqrstuvwxyz-123456789';
+            cy.apiCreateUser({prefix: longUsername}).then(({user: user3}) => {
+                longUser = user3;
+                cy.apiAddUserToTeam(team.id, longUser.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, longUser.id);
+                });
+            });
 
             const newIncomingHook = {
-                channel_id: channel.id,
+                channel_id: testChannel.id,
                 channel_locked: true,
                 description: 'Incoming webhook interactive menu',
                 display_name: 'menuIn' + Date.now(),
@@ -54,6 +64,9 @@ describe('Interactive Menu', () => {
             cy.apiCreateWebhook(newIncomingHook).then((hook) => {
                 incomingWebhook = hook;
             });
+
+            cy.apiLogin(testUser.username, testUser.password);
+            cy.visit(`/${team.name}/channels/${testChannel.name}`);
         });
     });
 
@@ -113,14 +126,6 @@ describe('Interactive Menu', () => {
     });
 
     it('IM15887 - Reply is displayed in center channel with "commented on [user\'s] message: [text]"', () => {
-        const user1 = users['user-1'];
-
-        // # Add user to channel
-        cy.apiGetUserByEmail(user1.email).then((res) => {
-            const user = res.body;
-            cy.apiAddUserToChannel(channel.id, user.id);
-        });
-
         // # Post an incoming webhook
         const payload = getMessageMenusPayload({options});
         cy.postIncomingWebhook({url: incomingWebhook.url, data: payload});
@@ -128,7 +133,7 @@ describe('Interactive Menu', () => {
         // # Get last post
         cy.getLastPostId().then((parentMessageId) => {
             // # Post another message
-            cy.postMessageAs({sender: user1, message: 'Just another message', channelId: channel.id});
+            cy.postMessageAs({sender: otherUser, message: 'Just another message', channelId: testChannel.id});
 
             // # Click comment icon to open RHS
             cy.clickPostCommentIcon(parentMessageId);
@@ -137,7 +142,7 @@ describe('Interactive Menu', () => {
             cy.get('#rhsContainer').should('be.visible');
 
             // # Have another user reply to the webhook message
-            cy.postMessageAs({sender: user1, message: 'Reply to webhook', channelId: channel.id, rootId: parentMessageId});
+            cy.postMessageAs({sender: otherUser, message: 'Reply to webhook', channelId: testChannel.id, rootId: parentMessageId});
 
             // # Get the latest post
             cy.getLastPostId().then((replyMessageId) => {
@@ -533,51 +538,41 @@ describe('Interactive Menu', () => {
     });
 
     it('IM21038 - Selected options with long usernames are not cut off in the RHS', () => {
-        cy.getCurrentTeamId().then((teamId) => {
-            longUsername = `name-of-64-abcdefghijklmnopqrstuvwxyz-123456789-${Date.now()}`;
+        // # Make webhook request to get list of all the users
+        const userOptions = getMessageMenusPayload({dataSource: 'users'});
+        cy.postIncomingWebhook({url: incomingWebhook.url, data: userOptions});
 
-            // # Create a new user with 64 chars length
-            cy.apiCreateNewUser({username: longUsername}, [teamId]).then((user) => {
-                cy.visit(`/ad-1/channels/${channel.name}`);
-                cy.apiAddUserToChannel(channel.id, user.id);
+        // # Go to last webhook message with users list
+        cy.getLastPostId().then((lastPostId) => {
+            // # Get the last messages attachment container
+            cy.get(`#messageAttachmentList_${lastPostId}`).within(() => {
+                // # Find and select the user, we just added
+                cy.findByPlaceholderText('Select an option...').scrollIntoView().clear({force: true}).type(longUser.username);
 
-                // # Make webhook request to get list of all the users
-                const userOptions = getMessageMenusPayload({dataSource: 'users'});
-                cy.postIncomingWebhook({url: incomingWebhook.url, data: userOptions});
-
-                // # Go to last webhook message with users list
-                cy.getLastPostId().then((lastPostId) => {
-                    // # Get the last messages attachment container
-                    cy.get(`#messageAttachmentList_${lastPostId}`).within(() => {
-                        // # Find and select the user, we just added
-                        cy.findByPlaceholderText('Select an option...').scrollIntoView().clear({force: true}).type(`${longUsername}`);
-
-                        cy.get('#suggestionList').within(() => {
-                            // * Newly added username should be there in the search list
-                            cy.findByText(`@${longUsername}`).should('exist').click();
-                        });
-
-                        // * Verify the input has the complete username value
-                        cy.findByDisplayValue(longUsername).should('exist');
-                    });
-
-                    // # Click on reply icon to open message in RHS
-                    cy.clickPostCommentIcon(lastPostId);
-
-                    // * Verify RHS has opened
-                    cy.get('#rhsContainer').should('exist');
-
-                    // # Same id as parent post in center, only opened in RHS
-                    cy.get(`#rhsPost_${lastPostId}`).within(() => {
-                        // * Verify the input has the selected value same as that of Center
-                        //   and verify that it has truncation css applied
-                        cy.findByDisplayValue(longUsername).should('exist').and('have.css', 'text-overflow', 'ellipsis');
-                    });
-
-                    // # Close RHS
-                    cy.closeRHS();
+                cy.get('#suggestionList').within(() => {
+                    // * Newly added username should be there in the search list
+                    cy.findByText(`@${longUser.username}`).should('exist').click();
                 });
+
+                // * Verify the input has the complete username value
+                cy.findByDisplayValue(longUser.username).should('exist');
             });
+
+            // # Click on reply icon to open message in RHS
+            cy.clickPostCommentIcon(lastPostId);
+
+            // * Verify RHS has opened
+            cy.get('#rhsContainer').should('exist');
+
+            // # Same id as parent post in center, only opened in RHS
+            cy.get(`#rhsPost_${lastPostId}`).within(() => {
+                // * Verify the input has the selected value same as that of Center
+                //   and verify that it has truncation css applied
+                cy.findByDisplayValue(longUser.username).should('exist').and('have.css', 'text-overflow', 'ellipsis');
+            });
+
+            // # Close RHS
+            cy.closeRHS();
         });
     });
 });

--- a/e2e/cypress/integration/interactive_menu/select_with_keys_spec.js
+++ b/e2e/cypress/integration/interactive_menu/select_with_keys_spec.js
@@ -24,24 +24,16 @@ const searchOptions = [
     {text: 'Option 3', value: 'option3'},
 ];
 
-let channelId;
-let incomingWebhook;
-
 describe('Interactive Menu', () => {
+    let incomingWebhook;
+
     before(() => {
         cy.requireWebhookServer();
 
-        // # Login as sysadmin and ensure that teammate name display setting is set to default 'username'
-        cy.apiLogin('sysadmin');
-        cy.apiSaveTeammateNameDisplayPreference('username');
-        cy.apiSaveMessageDisplayPreference('clean');
-
         // # Create and visit new channel and create incoming webhook
-        cy.createAndVisitNewChannel().then((channel) => {
-            channelId = channel.id;
-
+        cy.apiInitSetup().then(({team, channel}) => {
             const newIncomingHook = {
-                channel_id: channelId,
+                channel_id: channel.id,
                 channel_locked: true,
                 description: 'Incoming webhook interactive menu',
                 display_name: 'menuIn' + Date.now(),
@@ -50,6 +42,8 @@ describe('Interactive Menu', () => {
             cy.apiCreateWebhook(newIncomingHook).then((hook) => {
                 incomingWebhook = hook;
             });
+
+            cy.visit(`/${team.name}/channels/${channel.name}`);
         });
     });
 

--- a/e2e/cypress/integration/interactive_menu/slack_parsing_message_button_spec.js
+++ b/e2e/cypress/integration/interactive_menu/slack_parsing_message_button_spec.js
@@ -16,24 +16,14 @@
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
-let channel;
-let incomingWebhook;
-
 describe('Interactive Menu', () => {
+    let incomingWebhook;
+
     before(() => {
         cy.requireWebhookServer();
 
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
-        // # Update teammate name display setting is set to default 'username'
-        cy.apiSaveTeammateNameDisplayPreference('username');
-        cy.apiSaveMessageDisplayPreference('clean');
-
         // # Create and visit new channel and create incoming webhook
-        cy.createAndVisitNewChannel().then((data) => {
-            channel = data;
-
+        cy.apiInitSetup().then(({team, channel}) => {
             const newIncomingHook = {
                 channel_id: channel.id,
                 channel_locked: true,
@@ -44,6 +34,8 @@ describe('Interactive Menu', () => {
             cy.apiCreateWebhook(newIncomingHook).then((hook) => {
                 incomingWebhook = hook;
             });
+
+            cy.visit(`/${team.name}/channels/${channel.name}`);
         });
     });
 

--- a/e2e/cypress/integration/keyboard_shortcuts/alt_option_plus_up_down_spec.js
+++ b/e2e/cypress/integration/keyboard_shortcuts/alt_option_plus_up_down_spec.js
@@ -10,26 +10,18 @@
 // Stage: @prod
 
 describe('Keyboard Shortcuts', () => {
-    let team;
+    let testTeam;
     let publicChannel;
     let privateChannel;
 
     before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
         // # Create and login as new user
-        cy.apiCreateAndLoginAsNewUser();
-        cy.apiSaveTeammateNameDisplayPreference('username');
-
         // # Create a test team and channel, then visit
-        cy.apiCreateTeam('test-team', 'Test Team').then((teamResponse) => {
-            team = teamResponse.body;
-            cy.apiCreateChannel(team.id, 'public-a', 'Public A').then((channelResponse) => {
-                publicChannel = channelResponse.body;
-            });
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            testTeam = team;
+            publicChannel = channel;
 
-            cy.apiCreateChannel(team.id, 'private-a', 'Private B', 'P').then((channelResponse) => {
+            cy.apiCreateChannel(testTeam.id, 'private-a', 'Private B', 'P').then((channelResponse) => {
                 privateChannel = channelResponse.body;
             });
         });
@@ -40,35 +32,35 @@ describe('Keyboard Shortcuts', () => {
     const offTopic = {display_name: 'Off-Topic', name: 'off-topic', type: 'O'};
 
     it('Alt/Option + Up', () => {
-        cy.visit(`/${team.name}/messages/@sysadmin`);
+        cy.visit(`/${testTeam.name}/messages/@sysadmin`);
 
         // * Verify that the channel is loaded
         cy.get('#channelHeaderTitle').should('contain', 'sysadmin');
 
         // * Switch to channels by Alt+Up/Down keypress and verify
-        verifyChannelSwitch(team.name, privateChannel, sysadmin, '{uparrow}');
-        verifyChannelSwitch(team.name, townSquare, privateChannel, '{uparrow}');
-        verifyChannelSwitch(team.name, publicChannel, townSquare, '{uparrow}');
-        verifyChannelSwitch(team.name, offTopic, publicChannel, '{uparrow}');
+        verifyChannelSwitch(testTeam.name, privateChannel, sysadmin, '{uparrow}');
+        verifyChannelSwitch(testTeam.name, townSquare, privateChannel, '{uparrow}');
+        verifyChannelSwitch(testTeam.name, offTopic, townSquare, '{uparrow}');
+        verifyChannelSwitch(testTeam.name, publicChannel, offTopic, '{uparrow}');
 
         // * Should switch to bottom of channel list when current channel is at the very top
-        verifyChannelSwitch(team.name, sysadmin, offTopic, '{uparrow}');
+        verifyChannelSwitch(testTeam.name, sysadmin, publicChannel, '{uparrow}');
     });
 
     it('Alt/Option + Down', () => {
-        cy.visit(`/${team.name}/channels/off-topic`);
+        cy.visit(`/${testTeam.name}/channels/${publicChannel.name}`);
 
         // * Verify that the channel is loaded
-        cy.get('#channelHeaderTitle').should('contain', 'Off-Topic');
+        cy.get('#channelHeaderTitle').should('contain', publicChannel.display_name);
 
         // # Switch to channels by Alt+Up/Down keypress and verify
-        verifyChannelSwitch(team.name, publicChannel, offTopic, '{downarrow}');
-        verifyChannelSwitch(team.name, townSquare, publicChannel, '{downarrow}');
-        verifyChannelSwitch(team.name, privateChannel, townSquare, '{downarrow}');
-        verifyChannelSwitch(team.name, sysadmin, privateChannel, '{downarrow}');
+        verifyChannelSwitch(testTeam.name, offTopic, publicChannel, '{downarrow}');
+        verifyChannelSwitch(testTeam.name, townSquare, offTopic, '{downarrow}');
+        verifyChannelSwitch(testTeam.name, privateChannel, townSquare, '{downarrow}');
+        verifyChannelSwitch(testTeam.name, sysadmin, privateChannel, '{downarrow}');
 
         // * Should switch to top of channel list when current channel is at the very bottom
-        verifyChannelSwitch(team.name, offTopic, sysadmin, '{downarrow}');
+        verifyChannelSwitch(testTeam.name, publicChannel, sysadmin, '{downarrow}');
     });
 });
 

--- a/e2e/cypress/integration/mark_as_unread/mark_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/mark_as_unread_spec.js
@@ -11,14 +11,9 @@
 // Group: @mark_as_unread
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
-import users from '../../fixtures/users.json';
-
-const user1 = users['user-1'];
-const sysadmin = users.sysadmin;
 
 describe('Mark as Unread', () => {
-    let sysadminId;
-    let team;
+    let testUser;
 
     let channelA;
     let channelB;
@@ -27,50 +22,41 @@ describe('Mark as Unread', () => {
     let post2;
     let post3;
 
-    before(() => {
-        cy.apiLogin('user-1');
-
-        // # Create a team and add sysadmin into it
-        cy.apiCreateTeam('test-team', 'Test Team').then((teamRes) => {
-            team = teamRes.body;
-            cy.apiGetUserByEmail(sysadmin.email).then((emailResponse) => {
-                sysadminId = emailResponse.body.id;
-                cy.apiAddUserToTeam(team.id, sysadminId);
-            });
-        });
-    });
-
     beforeEach(() => {
-        cy.apiCreateChannel(team.id, 'channel-a', 'Channel A').then((resp) => {
-            channelA = resp.body;
+        cy.apiAdminLogin();
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            testUser = user;
+            channelA = channel;
 
-            // # Add sysadmin to channel A
-            cy.apiAddUserToChannel(channelA.id, sysadminId);
+            cy.apiCreateChannel(team.id, 'channel-b', 'Channel B').then((resp) => {
+                channelB = resp.body;
+                cy.apiAddUserToChannel(channelB.id, testUser.id);
+            });
 
-            // Another user creates posts in the channel since you can't mark your own posts unread currently
-            cy.postMessageAs({sender: sysadmin, message: 'post1', channelId: channelA.id}).then((p1) => {
-                post1 = p1;
+            cy.apiCreateUser().then(({user: user2}) => {
+                const otherUser = user2;
 
-                cy.postMessageAs({sender: sysadmin, message: 'post2', channelId: channelA.id}).then((p2) => {
-                    post2 = p2;
+                cy.apiAddUserToTeam(team.id, otherUser.id).then(() => {
+                    cy.apiAddUserToChannel(channelA.id, otherUser.id);
 
-                    cy.postMessageAs({sender: sysadmin, message: 'post3', channelId: channelA.id, rootId: post1.id}).then((post) => {
-                        post3 = post;
+                    // Another user creates posts in the channel since you can't mark your own posts unread currently
+                    cy.postMessageAs({sender: otherUser, message: 'post1', channelId: channelA.id}).then((p1) => {
+                        post1 = p1;
+
+                        cy.postMessageAs({sender: otherUser, message: 'post2', channelId: channelA.id}).then((p2) => {
+                            post2 = p2;
+
+                            cy.postMessageAs({sender: otherUser, message: 'post3', channelId: channelA.id, rootId: post1.id}).then((post) => {
+                                post3 = post;
+                            });
+                        });
                     });
                 });
             });
+
+            cy.apiLogin(testUser.username, testUser.password);
+            cy.visit(`/${team.name}/channels/town-square`);
         });
-
-        cy.apiCreateChannel(team.id, 'channel-b', 'Channel B').then((resp) => {
-            channelB = resp.body;
-        });
-
-        cy.visit(`/${team.name}/channels/town-square`);
-    });
-
-    afterEach(() => {
-        cy.apiDeleteChannel(channelA.id);
-        cy.apiDeleteChannel(channelB.id);
     });
 
     it('Channel should appear unread after switching away from channel and be read after switching back', () => {
@@ -245,7 +231,7 @@ describe('Mark as Unread', () => {
 
         cy.get(`#sidebarItem_${channelA.name}`).should(beRead);
 
-        markAsUnreadFromAnotherSession(post2);
+        markAsUnreadFromAnotherSession(post2, testUser);
 
         // The channel should now be unread
         cy.get(`#sidebarItem_${channelA.name}`).should(beUnread);
@@ -273,7 +259,7 @@ describe('Mark as Unread', () => {
 
         cy.get(`#sidebarItem_${channelA.name}`).should(beRead);
 
-        markAsUnreadFromAnotherSession(post2);
+        markAsUnreadFromAnotherSession(post2, testUser);
 
         // The channel should now be unread
         cy.get(`#sidebarItem_${channelA.name}`).should(beUnread);
@@ -319,17 +305,15 @@ function markAsUnreadFromPost(post, rhs = false) {
     const prefix = rhs ? 'rhsPost' : 'post';
 
     cy.get('body').type('{alt}', {release: false});
-    cy.get(`#${prefix}_${post.id}`).click();
+    cy.get(`#${prefix}_${post.id}`).click({force: true});
     cy.get('body').type('{alt}', {release: true});
 }
 
-function markAsUnreadFromAnotherSession(post) {
-    cy.getCurrentUserId().then((userId) => {
-        cy.externalRequest({
-            user: user1,
-            method: 'post',
-            path: `users/${userId}/posts/${post.id}/set_unread`,
-        });
+function markAsUnreadFromAnotherSession(post, user) {
+    cy.externalRequest({
+        user,
+        method: 'post',
+        path: `users/${user.id}/posts/${post.id}/set_unread`,
     });
 }
 

--- a/e2e/cypress/integration/markdown/markdown_image_spec.js
+++ b/e2e/cypress/integration/markdown/markdown_image_spec.js
@@ -12,8 +12,7 @@
 
 describe('Markdown', () => {
     before(() => {
-        // # Login as sysadmin and update config
-        cy.apiLogin('sysadmin');
+        // # Update config
         cy.apiUpdateConfig({
             ImageProxySettings: {
                 Enable: true,
@@ -21,12 +20,9 @@ describe('Markdown', () => {
             },
         });
 
-        // # Login as new user
-        cy.apiCreateAndLoginAsNewUser().then(() => {
-            // # Create new team and visit its URL
-            cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-                cy.visit(`/${response.body.name}`);
-            });
+        // # Login as new user, create new team and visit its URL
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
         });
     });
 
@@ -89,8 +85,8 @@ describe('Markdown', () => {
             cy.get(`#postMessageText_${postId}`).should('be.visible').within(() => {
                 cy.get('.markdown-inline-img').should('be.visible').
                     and((inlineImg) => {
-                        expect(inlineImg.height()).to.be.closeTo(143, 2);
-                        expect(inlineImg.width()).to.be.closeTo(906, 2);
+                        expect(inlineImg.height()).to.be.closeTo(153, 2);
+                        expect(inlineImg.width()).to.be.closeTo(971, 2);
                     }).
                     click();
             });

--- a/e2e/cypress/integration/markdown/markdown_text_spec.js
+++ b/e2e/cypress/integration/markdown/markdown_text_spec.js
@@ -29,8 +29,7 @@ const testCases = [
 
 describe('Markdown message', () => {
     before(() => {
-        // # Login as sysadmin and enable local image proxy so our expected URLs match
-        cy.apiLogin('sysadmin');
+        // # Enable local image proxy so our expected URLs match
         const newSettings = {
             ImageProxySettings: {
                 Enable: true,
@@ -41,12 +40,9 @@ describe('Markdown message', () => {
         };
         cy.apiUpdateConfig(newSettings);
 
-        // # Login as new user
-        cy.apiCreateAndLoginAsNewUser().then(() => {
-            // # Create new team and visit its URL
-            cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-                cy.visit(`/${response.body.name}`);
-            });
+        // # Login as new user, create new team and visit its URL
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
         });
     });
 

--- a/e2e/cypress/integration/menus/main_menu_spec.js
+++ b/e2e/cypress/integration/menus/main_menu_spec.js
@@ -38,7 +38,7 @@ describe('Main menu', () => {
 
     describe('should show integrations option', () => {
         it('for system administrator', () => {
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
             cy.visit('/ad-1/channels/town-square');
 
             cy.get('#lhsHeader').should('be.visible').within(() => {

--- a/e2e/cypress/integration/menus/status_dropdown_spec.js
+++ b/e2e/cypress/integration/menus/status_dropdown_spec.js
@@ -11,13 +11,18 @@
 // Group: @menu
 
 describe('Status dropdown menu', () => {
-    beforeEach(() => {
-        // # Login as "user-1" and go to /
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
+    before(() => {
+        // # Login as test user and visit town-square
+        cy.apiInitSetup().then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
+    });
 
+    afterEach(() => {
         // # Reset user status to online to prevent status modal
-        cy.apiUpdateUserStatus();
+        cy.apiUpdateUserStatus('online');
+
+        cy.reload();
     });
 
     it('Displays default menu when status icon is clicked', () => {
@@ -36,17 +41,17 @@ describe('Status dropdown menu', () => {
         cy.get('#postListContent').should('be.visible');
 
         // # Set user status to away to ensure menu click changes status
-        cy.apiUpdateUserStatus('away');
+        cy.apiUpdateUserStatus('away').then(() => {
+            // # Click status menu
+            cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
 
-        // # Click status menu
-        cy.get('.MenuWrapper .status-wrapper.status-selector button.status').click();
+            // # Wait for status menu to transition in
+            cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
 
-        // # Wait for status menu to transition in
-        cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu').should('be.visible');
+            cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu #status-menu-online').click();
 
-        cy.get('.MenuWrapper.status-dropdown-menu .Menu__content.dropdown-menu #status-menu-online').click();
-
-        cy.get('.MenuWrapper.status-dropdown-menu > .status-wrapper > button.status > span > svg > path.online--icon').should('exist');
+            cy.get('.MenuWrapper.status-dropdown-menu > .status-wrapper > button.status > span > svg > path.online--icon').should('exist');
+        });
     });
 
     it('Changes status icon to away when "Away" menu item is selected', () => {

--- a/e2e/cypress/integration/menus/status_dropdown_spec.js
+++ b/e2e/cypress/integration/menus/status_dropdown_spec.js
@@ -25,11 +25,6 @@ describe('Status dropdown menu', () => {
         cy.reload();
     });
 
-    afterEach(() => {
-        // # Reset user status to online to prevent status modal
-        cy.apiUpdateUserStatus();
-    });
-
     it('Displays default menu when status icon is clicked', () => {
         // # Wait for posts to load
         cy.get('#postListContent').should('be.visible');

--- a/e2e/cypress/integration/messaging/at_mentions_spec.js
+++ b/e2e/cypress/integration/messaging/at_mentions_spec.js
@@ -101,7 +101,6 @@ describe('at-mention', () => {
 
     before(() => {
         // # Update Configs
-        cy.apiLogin('sysadmin');
         cy.apiUpdateConfig({
             ServiceSettings: {
                 ExperimentalChannelOrganization: true,

--- a/e2e/cypress/integration/messaging/channel_menu_spec.js
+++ b/e2e/cypress/integration/messaging/channel_menu_spec.js
@@ -10,73 +10,71 @@
 // Stage: @prod
 // Group: @messaging
 
-import users from '../../fixtures/users.json';
+import {getAdminAccount} from '../../support/env';
+
+const admin = getAdminAccount();
 
 function demoteUserToGuest(user) {
     // # Issue a Request to demote the user to guest
     const baseUrl = Cypress.config('baseUrl');
-    cy.externalRequest({user: users.sysadmin, method: 'post', baseUrl, path: `users/${user.id}/demote`});
+    cy.externalRequest({user: admin, method: 'post', baseUrl, path: `users/${user.id}/demote`});
 }
 
 function promoteGuestToUser(user) {
     // # Issue a Request to promote the guest to user
     const baseUrl = Cypress.config('baseUrl');
-    cy.externalRequest({user: users.sysadmin, method: 'post', baseUrl, path: `users/${user.id}/promote`});
+    cy.externalRequest({user: admin, method: 'post', baseUrl, path: `users/${user.id}/promote`});
 }
 
 describe('Channel header menu', () => {
+    let testUser;
+    let testTeam;
+
     before(() => {
-        cy.apiLogin('sysadmin');
-        cy.apiUpdateConfig({
-            GuestAccountsSettings: {
-                Enable: true,
-            },
+        // # Login as new user, create new team and visit its URL
+        cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+            cy.visit(`/${testTeam.name}/channels/town-square`);
         });
-        cy.apiCreateAndLoginAsNewUser().as('newuser');
     });
 
     it('MM-14490 show/hide properly menu dividers', () => {
         let channel;
 
         // # Go to "/"
-        cy.visit('/ad-1/channels/town-square');
+        cy.visit(`/${testTeam.name}/channels/town-square`);
 
-        cy.getCurrentTeamId().then((teamId) => {
-            // # Create new test channel
-            cy.apiCreateChannel(teamId, 'channel-test', 'Channel Test').then((res) => {
-                channel = res.body;
+        // # Create new test channel
+        cy.apiCreateChannel(testTeam.id, 'channel-test', 'Channel Test').then((res) => {
+            channel = res.body;
 
-                // # Select channel on the left hand side
-                cy.get(`#sidebarItem_${channel.name}`).click();
+            // # Select channel on the left hand side
+            cy.get(`#sidebarItem_${channel.name}`).click();
 
-                // * Channel's display name should be visible at the top of the center pane
-                cy.get('#channelHeaderTitle').should('contain', channel.display_name);
+            // * Channel's display name should be visible at the top of the center pane
+            cy.get('#channelHeaderTitle').should('contain', channel.display_name);
 
-                // # Then click it to access the drop-down menu
-                cy.get('#channelHeaderTitle').click();
+            // # Then click it to access the drop-down menu
+            cy.get('#channelHeaderTitle').click();
 
-                // * The dropdown menu of the channel header should be visible;
-                cy.get('.Menu__content').should('be.visible');
+            // * The dropdown menu of the channel header should be visible;
+            cy.get('.Menu__content').should('be.visible');
 
-                // * The dropdown menu of the channel header should have 3 dividers;
-                cy.get('.Menu__content').find('.menu-divider:visible').should('have.lengthOf', 3);
+            // * The dropdown menu of the channel header should have 3 dividers;
+            cy.get('.Menu__content').find('.menu-divider:visible').should('have.lengthOf', 3);
 
-                // # Demote the user to guest
-                cy.get('@newuser').then((user) => {
-                    demoteUserToGuest(user);
-                });
+            // # Demote the user to guest
+            demoteUserToGuest(testUser);
 
-                // * The dropdown menu of the channel header should have 2 dividers because some options have disappeared;
-                cy.get('.Menu__content').find('.menu-divider:visible').should('have.lengthOf', 2);
+            // * The dropdown menu of the channel header should have 2 dividers because some options have disappeared;
+            cy.get('.Menu__content').find('.menu-divider:visible').should('have.lengthOf', 2);
 
-                // # Promote the guest to user again
-                cy.get('@newuser').then((user) => {
-                    promoteGuestToUser(user);
-                });
+            // # Promote the guest to user again
+            promoteGuestToUser(testUser);
 
-                // * The dropdown menu of the channel header should have 3 dividers again;
-                cy.get('.Menu__content').find('.menu-divider:visible').should('have.lengthOf', 3);
-            });
+            // * The dropdown menu of the channel header should have 3 dividers again;
+            cy.get('.Menu__content').find('.menu-divider:visible').should('have.lengthOf', 3);
         });
     });
 
@@ -84,31 +82,29 @@ describe('Channel header menu', () => {
         let channel;
 
         // # Go to "/"
-        cy.visit('/ad-1/channels/town-square');
+        cy.visit(`/${testTeam.name}/channels/town-square`);
 
-        cy.getCurrentTeamId().then((teamId) => {
-            // # Create new test channel
-            cy.apiCreateChannel(teamId, 'channel-test-leave', 'Channel Test Leave').then((res) => {
-                channel = res.body;
+        // # Create new test channel
+        cy.apiCreateChannel(testTeam.id, 'channel-test-leave', 'Channel Test Leave').then((res) => {
+            channel = res.body;
 
-                // # Select channel on the left hand side
-                cy.get(`#sidebarItem_${channel.name}`).click();
+            // # Select channel on the left hand side
+            cy.get(`#sidebarItem_${channel.name}`).click();
 
-                // * Channel's display name should be visible at the top of the center pane
-                cy.get('#channelHeaderTitle').should('contain', channel.display_name);
+            // * Channel's display name should be visible at the top of the center pane
+            cy.get('#channelHeaderTitle').should('contain', channel.display_name);
 
-                // # Then click it to access the drop-down menu
-                cy.get('#channelHeaderTitle').click();
+            // # Then click it to access the drop-down menu
+            cy.get('#channelHeaderTitle').click();
 
-                // * The dropdown menu of the channel header should be visible;
-                cy.get('.Menu__content').should('be.visible');
+            // * The dropdown menu of the channel header should be visible;
+            cy.get('.Menu__content').should('be.visible');
 
-                // # Click the "Leave Channel" option
-                cy.get('#channelLeaveChannel').click();
+            // # Click the "Leave Channel" option
+            cy.get('#channelLeaveChannel').click();
 
-                // * Should now be in Town Square
-                cy.get('#channelHeaderInfo').should('be.visible').and('contain', 'Town Square');
-            });
+            // * Should now be in Town Square
+            cy.get('#channelHeaderInfo').should('be.visible').and('contain', 'Town Square');
         });
     });
 });

--- a/e2e/cypress/integration/messaging/channel_menu_spec.js
+++ b/e2e/cypress/integration/messaging/channel_menu_spec.js
@@ -12,21 +12,20 @@
 
 import {getAdminAccount} from '../../support/env';
 
-const admin = getAdminAccount();
-
-function demoteUserToGuest(user) {
+function demoteUserToGuest(user, admin) {
     // # Issue a Request to demote the user to guest
     const baseUrl = Cypress.config('baseUrl');
     cy.externalRequest({user: admin, method: 'post', baseUrl, path: `users/${user.id}/demote`});
 }
 
-function promoteGuestToUser(user) {
+function promoteGuestToUser(user, admin) {
     // # Issue a Request to promote the guest to user
     const baseUrl = Cypress.config('baseUrl');
     cy.externalRequest({user: admin, method: 'post', baseUrl, path: `users/${user.id}/promote`});
 }
 
 describe('Channel header menu', () => {
+    const admin = getAdminAccount();
     let testUser;
     let testTeam;
 
@@ -65,13 +64,13 @@ describe('Channel header menu', () => {
             cy.get('.Menu__content').find('.menu-divider:visible').should('have.lengthOf', 3);
 
             // # Demote the user to guest
-            demoteUserToGuest(testUser);
+            demoteUserToGuest(testUser, admin);
 
             // * The dropdown menu of the channel header should have 2 dividers because some options have disappeared;
             cy.get('.Menu__content').find('.menu-divider:visible').should('have.lengthOf', 2);
 
             // # Promote the guest to user again
-            promoteGuestToUser(testUser);
+            promoteGuestToUser(testUser, admin);
 
             // * The dropdown menu of the channel header should have 3 dividers again;
             cy.get('.Menu__content').find('.menu-divider:visible').should('have.lengthOf', 3);

--- a/e2e/cypress/integration/messaging/channel_read_after_permalink_spec.js
+++ b/e2e/cypress/integration/messaging/channel_read_after_permalink_spec.js
@@ -17,9 +17,6 @@ describe('Messaging', () => {
     beforeEach(() => {
         testChannel = null;
 
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
         // # Reset Sidebar Setting Preference
         cy.apiSaveSidebarSettingPreference();
 
@@ -31,7 +28,7 @@ describe('Messaging', () => {
     });
 
     afterEach(() => {
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         if (testChannel && testChannel.id) {
             cy.apiDeleteChannel(testChannel.id);
         }
@@ -86,7 +83,7 @@ describe('Messaging', () => {
                 // # Change user
                 cy.visit('/ad-1/town-square');
                 cy.apiLogout();
-                cy.apiLogin('sysadmin');
+                cy.apiAdminLogin();
                 cy.visit('/ad-1/town-square');
 
                 // # Check Message is in Unread List

--- a/e2e/cypress/integration/messaging/channel_users_interactions_spec.js
+++ b/e2e/cypress/integration/messaging/channel_users_interactions_spec.js
@@ -10,44 +10,60 @@
 // Stage: @prod
 // Group: @messaging
 
-import users from '../../fixtures/users.json';
-
-const receiver = users['user-1'];
-const sender = users['user-2'];
-
-let townsquareChannelId;
-
 describe('Channel users interactions', () => {
-    before(() => {
-        cy.apiLogin(receiver.username);
+    let testTeam;
+    let testChannel;
+    let receiver;
+    let sender;
 
-        cy.visit('/ad-1/channels/town-square');
-        cy.getCurrentChannelId().then((id) => {
-            townsquareChannelId = id;
+    before(() => {
+        // # Login as test user
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            receiver = user;
+            testTeam = team;
+            testChannel = channel;
+
+            cy.apiCreateUser().then(({user: user1}) => {
+                sender = user1;
+                cy.apiAddUserToTeam(testTeam.id, sender.id).then(() => {
+                    cy.apiAddUserToChannel(testChannel.id, sender.id);
+                });
+            });
+
+            cy.apiLogin(receiver.username, receiver.password);
+
+            // # Visit a test channel and post a message
+            cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+            cy.postMessage('Hello');
         });
     });
 
     it('M17454 Scroll to bottom when sending a message', () => {
-        // # Go to test channel A on sidebar
-        cy.visit('/ad-1/channels/off-topic');
+        // # Go to off-topic channel via LHS
+        cy.get('#sidebarItem_off-topic').click({force: true});
 
-        // # post message in channel B by another user
-        const message = 'I\'m messaging!\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2\n2';
-        cy.postMessageAs({sender, message, channelId: townsquareChannelId});
+        // # Post a message in test channel by another user
+        const message = `I\'m messaging!${'\n2'.repeat(30)}`; // eslint-disable-line no-useless-escape
+        cy.postMessageAs({sender, message, channelId: testChannel.id});
 
-        // # return back channel where is a post
-        cy.get('#sidebarItem_town-square').click({force: true});
+        // # Post any message to off-topic channel
+        const hello = 'Hello';
+        cy.postMessage(hello);
+        cy.uiWaitUntilMessagePostedIncludes(hello);
 
-        // * check that separator with message visible
+        // # Go to test channel where the message is posted
+        cy.get(`#sidebarItem_${testChannel.name}`).click({force: true});
+
+        // * Check that the new message separator is visible
         cy.findByTestId('NotificationSeparator').
             find('span').
             should('be.visible').
             and('have.text', 'New Messages');
 
-        // # post message on current channel
+        // # Post a message on current channel
         cy.get('#post_textbox').clear().type('message123{enter}');
 
-        // * verify that last posted message is visible
+        // * Verify that last posted message is visible
         cy.getLastPostId().then((postId) => {
             cy.get(`#postMessageText_${postId}`).should('have.text', 'message123');
         });

--- a/e2e/cypress/integration/messaging/collapse_link_spec.js
+++ b/e2e/cypress/integration/messaging/collapse_link_spec.js
@@ -13,7 +13,7 @@
 describe('Messaging', () => {
     beforeEach(() => {
         // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
 
         // # Enable Link Previews
         cy.apiUpdateConfig({
@@ -54,7 +54,7 @@ describe('Messaging', () => {
             cy.get(`#${postId}_message`).find('.attachment__image').should('exist');
 
             // # Log-in to the other user
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
             cy.visit('/ad-1/channels/town-square');
 
             // * Check the preview is shown
@@ -73,7 +73,7 @@ describe('Messaging', () => {
             cy.get(`#${postId}_message`).find('.attachment__image').should('not.exist');
 
             // # Log-in to the other user
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
             cy.visit('/ad-1/channels/town-square');
 
             // * Check the preview is shown
@@ -94,7 +94,7 @@ describe('Messaging', () => {
             cy.get(`#${postId}_message`).find('.attachment__image').should('not.exist');
 
             // # Log-in to the other user
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
             cy.visit('/ad-1/channels/town-square');
 
             // * Preview should not exist

--- a/e2e/cypress/integration/messaging/date_separator_spec.js
+++ b/e2e/cypress/integration/messaging/date_separator_spec.js
@@ -17,23 +17,16 @@ describe('Messaging', () => {
     let newChannel;
 
     before(() => {
-        // # Login as user-1 and set preferences for locale and timezone
-        cy.apiLogin('user-1');
-        cy.apiPatchMe({
-            locale: 'en',
-            timezone: {automaticTimezone: '', manualTimezone: 'UTC', useAutomaticTimezone: 'false'},
-        });
-
         // # Create and visit new channel
-        cy.createAndVisitNewChannel().then((channel) => {
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
             newChannel = channel;
-        });
-    });
 
-    after(() => {
-        cy.apiPatchMe({
-            locale: 'en',
-            timezone: {automaticTimezone: '', manualTimezone: 'UTC', useAutomaticTimezone: 'false'},
+            cy.apiPatchMe({
+                locale: 'en',
+                timezone: {automaticTimezone: '', manualTimezone: 'UTC', useAutomaticTimezone: 'false'},
+            });
+
+            cy.visit(`/${team.name}/channels/${channel.name}`);
         });
     });
 
@@ -76,7 +69,7 @@ describe('Messaging', () => {
         cy.apiPatchMe({timezone: {automaticTimezone: '', manualTimezone: 'NZ-CHAT', useAutomaticTimezone: 'false'}});
         cy.reload();
 
-        // * Verify that it renders in English as default and in short format of "ddd, MMM D, YYYY"
-        verifyDateSeparator(0, /^(Sun|Mon), Jan (5|6), 2020/);
+        // * Verify that it renders in "es" locale
+        verifyDateSeparator(0, /^(sáb|dom)., (04|05) ene. 2020/);
     });
 });

--- a/e2e/cypress/integration/messaging/focus_move_spec.js
+++ b/e2e/cypress/integration/messaging/focus_move_spec.js
@@ -62,7 +62,7 @@ describe('Messaging', () => {
     });
 
     afterEach(() => {
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         if (testChannel && testChannel.id) {
             cy.apiDeleteChannel(testChannel.id);
         }

--- a/e2e/cypress/integration/messaging/header_spec.js
+++ b/e2e/cypress/integration/messaging/header_spec.js
@@ -28,7 +28,7 @@ describe('Header', () => {
     });
 
     afterEach(() => {
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         if (testTeam && testTeam.id) {
             cy.apiDeleteTeam(testTeam.id);
         }
@@ -50,7 +50,7 @@ describe('Header', () => {
 
     it('M14784 - An ellipsis indicates the channel header is too long - DM', () => {
         // # Open Account Setting and enable Compact View on the Display tab
-        cy.changeMessageDisplaySetting('COMPACT');
+        cy.uiChangeMessageDisplaySetting('COMPACT');
 
         // # Open a DM with user named 'user-2'
         cy.get('#addDirectChannel').click().wait(TIMEOUTS.TINY);

--- a/e2e/cypress/integration/messaging/image_attachment_spec.js
+++ b/e2e/cypress/integration/messaging/image_attachment_spec.js
@@ -24,15 +24,9 @@ function verifyImageInPostFooter(verifyExistence = true) {
 
 describe('Image attachment', () => {
     before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
         // # Login as new user
-        cy.apiCreateAndLoginAsNewUser().then(() => {
-            // # Create new team and visit its URL
-            cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-                cy.visit(`/${response.body.name}`);
-            });
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
         });
     });
 
@@ -149,8 +143,8 @@ describe('Image attachment', () => {
 
                 cy.get('@div').find('img').
                     and((img) => {
-                        expect(img.height()).to.be.closeTo(145, 2.0);
-                        expect(img.width()).to.be.closeTo(913, 2.0);
+                        expect(img.height()).to.be.closeTo(155, 2.0);
+                        expect(img.width()).to.be.closeTo(978, 2.0);
                     });
             });
         });
@@ -174,8 +168,8 @@ describe('Image attachment', () => {
 
                 cy.get('@div').find('img').
                     and((img) => {
-                        expect(img.height()).to.be.closeTo(145, 2.0);
-                        expect(img.width()).to.be.closeTo(913, 2.0);
+                        expect(img.height()).to.be.closeTo(155, 2.0);
+                        expect(img.width()).to.be.closeTo(978, 2.0);
                     }).
                     click();
             });

--- a/e2e/cypress/integration/messaging/input_box_expands_with_rhs_spec.js
+++ b/e2e/cypress/integration/messaging/input_box_expands_with_rhs_spec.js
@@ -11,12 +11,20 @@
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
+import {getAdminAccount} from '../../support/env';
+
+const admin = getAdminAccount();
 
 describe('Messaging', () => {
     before(() => {
-        // # Login and go to sint channel
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/suscipit-4');
+        // # Log in as test user, go to test channel and post several messages
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            cy.visit(`/${team.name}/channels/${channel.name}`);
+
+            Cypress._.times(30, (i) => {
+                cy.postMessageAs({sender: admin, message: `[${i}]`, channelId: channel.id});
+            });
+        });
     });
 
     it('M18709-Input box on main thread can expand with RHS open', () => {
@@ -71,7 +79,7 @@ describe('Messaging', () => {
         cy.get('#post_textbox').should('be.visible').clear();
 
         // # Scroll to a previous post
-        cy.getNthPostId(-20).then((postId) => {
+        cy.getNthPostId(-29).then((postId) => {
             cy.get(`#postMessageText_${postId}`).scrollIntoView();
         });
 
@@ -81,7 +89,7 @@ describe('Messaging', () => {
         }
 
         // * Previous post should be visible
-        cy.getNthPostId(-20).then((postId) => {
+        cy.getNthPostId(-29).then((postId) => {
             cy.get(`#postMessageText_${postId}`).should('be.visible');
         });
     });

--- a/e2e/cypress/integration/messaging/input_box_expands_with_rhs_spec.js
+++ b/e2e/cypress/integration/messaging/input_box_expands_with_rhs_spec.js
@@ -13,9 +13,9 @@
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import {getAdminAccount} from '../../support/env';
 
-const admin = getAdminAccount();
-
 describe('Messaging', () => {
+    const admin = getAdminAccount();
+
     before(() => {
         // # Log in as test user, go to test channel and post several messages
         cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {

--- a/e2e/cypress/integration/messaging/local_date_time_spec.js
+++ b/e2e/cypress/integration/messaging/local_date_time_spec.js
@@ -9,25 +9,23 @@
 
 // Group: @messaging
 
-import users from '../../fixtures/users.json';
+import {getAdminAccount} from '../../support/env';
 
-const sysadmin = users.sysadmin;
+const sysadmin = getAdminAccount();
 
 describe('Messaging', () => {
     before(() => {
-        // # Login sysadmin and enable Timezone
-        cy.apiLogin('sysadmin');
+        // # Enable Timezone
         cy.apiUpdateConfig({
             DisplaySettings: {
                 ExperimentalTimezone: true,
             },
         });
 
-        // # Login as user-1
-        cy.apiLogin('user-1');
-
         // # Create and visit new channel
-        cy.createAndVisitNewChannel().then((channel) => {
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            cy.visit(`/${team.name}/channels/${channel.name}`);
+
             // # Post messages from the past
             [
                 Date.UTC(2020, 0, 5, 4, 30), // Jan 5, 2020 04:30
@@ -46,18 +44,11 @@ describe('Messaging', () => {
         });
     });
 
-    after(() => {
-        cy.apiPatchMe({
-            locale: 'en',
-            timezone: {automaticTimezone: '', manualTimezone: 'UTC', useAutomaticTimezone: 'false'},
-        });
-    });
-
     describe('MM-21342 Post time should render correct format and locale', () => {
         const testCases = [
             {
                 name: 'in English',
-                channelIntro: 'Beginning of Channel Test',
+                publicChannel: 'PUBLIC CHANNELS',
                 locale: 'en',
                 manualTimezone: 'UTC',
                 localTimes: [
@@ -69,7 +60,7 @@ describe('Messaging', () => {
             },
             {
                 name: 'in Spanish',
-                channelIntro: 'Inicio de Channel Test',
+                publicChannel: 'CANALES PÚBLICOS',
                 locale: 'es',
                 manualTimezone: 'UTC',
                 localTimes: [
@@ -81,7 +72,7 @@ describe('Messaging', () => {
             },
             {
                 name: 'in react-intl unsupported timezone',
-                channelIntro: 'Inicio de Channel Test',
+                publicChannel: 'CANALES PÚBLICOS',
                 locale: 'es',
                 manualTimezone: 'NZ-CHAT',
                 localTimes: [
@@ -105,7 +96,7 @@ describe('Messaging', () => {
                             setLocaleAndTimezone(testCase.locale, testCase.manualTimezone);
 
                             // * Verify that the channel is loaded correctly based on locale
-                            cy.findByText(testCase.channelIntro).should('be.visible');
+                            cy.findByText(testCase.publicChannel).should('be.visible');
 
                             // * Verify that the local time of each post is rendered in 12-hour format based on locale
                             cy.findAllByTestId('postView').eq(index).find('.post__time', {timeout: 500}).should('have.text', localTime.standard);
@@ -122,11 +113,8 @@ describe('Messaging', () => {
                             // # Set user locale and timezone
                             setLocaleAndTimezone(testCase.locale, testCase.manualTimezone);
 
-                            // # Increase viewport to ensure channel intro remains in view.
-                            cy.viewport(1300, 800);
-
                             // * Verify that the channel is loaded correctly based on locale
-                            cy.findByText(testCase.channelIntro).should('be.visible');
+                            cy.findByText(testCase.publicChannel).should('be.visible');
 
                             // * Verify that the local time of each post is rendered in 24-hour format based on locale
                             cy.findAllByTestId('postView').eq(index).find('.post__time', {timeout: 500}).should('have.text', localTime.military);

--- a/e2e/cypress/integration/messaging/local_date_time_spec.js
+++ b/e2e/cypress/integration/messaging/local_date_time_spec.js
@@ -11,9 +11,9 @@
 
 import {getAdminAccount} from '../../support/env';
 
-const sysadmin = getAdminAccount();
-
 describe('Messaging', () => {
+    const sysadmin = getAdminAccount();
+
     before(() => {
         // # Enable Timezone
         cy.apiUpdateConfig({

--- a/e2e/cypress/integration/messaging/long_post_attachments_spec.js
+++ b/e2e/cypress/integration/messaging/long_post_attachments_spec.js
@@ -43,24 +43,14 @@ describe('M14322 Long post with multiple attachments', () => {
     let testTeam;
 
     beforeEach(() => {
-        testTeam = null;
-
         // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
 
         // # Create new team and new user and visit Town Square channel
-        cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-            testTeam = response.body;
-            cy.apiCreateAndLoginAsNewUser({}, [testTeam.id]);
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            testTeam = team;
             cy.visit(`/${testTeam.name}/channels/town-square`);
         });
-    });
-
-    afterEach(() => {
-        cy.apiLogin('sysadmin');
-        if (testTeam && testTeam.id) {
-            cy.apiDeleteTeam(testTeam.id);
-        }
     });
 
     it('Attachment previews/thumbnails display as expected, when viewing full or partial post', () => {

--- a/e2e/cypress/integration/messaging/message_channel_draw_spec.js
+++ b/e2e/cypress/integration/messaging/message_channel_draw_spec.js
@@ -22,8 +22,7 @@ describe('Draw plugin : Post message', () => {
     const pluginId = 'com.mattermost.draw-plugin';
 
     before(() => {
-        // # Login as sysadmin and update config
-        cy.apiLogin('sysadmin');
+        // # Update config
         cy.apiUpdateConfig({
             PluginSettings: {
                 Enable: true,
@@ -44,7 +43,7 @@ describe('Draw plugin : Post message', () => {
 
     after(() => {
         // # UnInstall Draw plugin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         cy.apiRemovePluginById(pluginId);
     });
 

--- a/e2e/cypress/integration/messaging/message_deleted_on_reply_spec.js
+++ b/e2e/cypress/integration/messaging/message_deleted_on_reply_spec.js
@@ -75,7 +75,7 @@ describe('Messaging', () => {
         cy.get('#reply_textbox').should('contain', '123');
 
         // # Change to the other user and go to Town Square
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         cy.visit('/ad-1/channels/town-square');
         cy.wait(TIMEOUTS.SMALL);
 

--- a/e2e/cypress/integration/messaging/message_draft_spec.js
+++ b/e2e/cypress/integration/messaging/message_draft_spec.js
@@ -10,20 +10,14 @@
 // Stage: @prod
 // Group: @messaging
 
-let testTeam;
-
 describe('Message Draft', () => {
-    before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+    let testTeam;
 
-        // # Login as new user
-        cy.apiCreateAndLoginAsNewUser().then(() => {
-            // # Create new team and visit its URL
-            cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-                testTeam = response.body;
-                cy.visit(`/${testTeam.name}`);
-            });
+    before(() => {
+        // # Create new team and new user and visit Town Square channel
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            testTeam = team;
+            cy.visit(`/${testTeam.name}/channels/town-square`);
         });
     });
 

--- a/e2e/cypress/integration/messaging/message_draft_then_switch_channel_spec.js
+++ b/e2e/cypress/integration/messaging/message_draft_then_switch_channel_spec.js
@@ -12,20 +12,14 @@
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
-let testTeam;
-
 describe('Message Draft and Switch Channels', () => {
-    before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+    let testTeam;
 
-        // # Login as new user
-        cy.apiCreateAndLoginAsNewUser().then(() => {
-            // # Create new team and visit its URL
-            cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-                testTeam = response.body;
-                cy.visit(`/${testTeam.name}`);
-            });
+    before(() => {
+        // # Create new team and new user and visit Town Square channel
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            testTeam = team;
+            cy.visit(`/${testTeam.name}/channels/town-square`);
         });
     });
 

--- a/e2e/cypress/integration/messaging/message_permalink_spec.js
+++ b/e2e/cypress/integration/messaging/message_permalink_spec.js
@@ -33,7 +33,7 @@ describe('Message permalink', () => {
     });
 
     afterEach(() => {
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         if (testChannel && testChannel.id) {
             cy.apiDeleteChannel(testChannel.id);
         }

--- a/e2e/cypress/integration/messaging/message_reply_bot_post_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_bot_post_spec.js
@@ -10,9 +10,10 @@
 // Stage: @prod
 // Group: @messaging
 
-import users from '../../fixtures/users.json';
+import {getAdminAccount} from '../../support/env';
 
-const sysadmin = users.sysadmin;
+const sysadmin = getAdminAccount();
+
 describe('Messaging', () => {
     let newChannel;
     let botsUserId;
@@ -20,8 +21,7 @@ describe('Messaging', () => {
     let botToken;
     let yesterdaysDate;
     before(() => {
-        // # Login as sysadmin and set ServiceSettings to expected values
-        cy.apiLogin('sysadmin');
+        // # Set ServiceSettings to expected values
         const newSettings = {
             ServiceSettings: {
                 EnableBotAccountCreation: true,
@@ -29,11 +29,10 @@ describe('Messaging', () => {
         };
         cy.apiUpdateConfig(newSettings);
 
-        cy.apiSaveTeammateNameDisplayPreference('username');
-
         // # Create and visit new channel
-        cy.createAndVisitNewChannel().then((channel) => {
+        cy.apiInitSetup().then(({team, channel}) => {
             newChannel = channel;
+            cy.visit(`/${team.name}/channels/${channel.name}`);
         });
     });
 

--- a/e2e/cypress/integration/messaging/message_reply_bot_post_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_bot_post_spec.js
@@ -12,14 +12,14 @@
 
 import {getAdminAccount} from '../../support/env';
 
-const sysadmin = getAdminAccount();
-
 describe('Messaging', () => {
+    const sysadmin = getAdminAccount();
     let newChannel;
     let botsUserId;
     let botName;
     let botToken;
     let yesterdaysDate;
+
     before(() => {
         // # Set ServiceSettings to expected values
         const newSettings = {

--- a/e2e/cypress/integration/messaging/message_reply_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_spec.js
@@ -10,21 +10,18 @@
 // Stage: @prod
 // Group: @messaging
 
-import users from '../../fixtures/users.json';
+import {getAdminAccount} from '../../support/env';
 
-const sysadmin = users.sysadmin;
+const sysadmin = getAdminAccount();
 
 describe('Message Reply', () => {
     let newChannel;
 
     before(() => {
-        // # Login and go to /
-        cy.apiLogin('user-1');
-        cy.apiSaveTeammateNameDisplayPreference('username');
-
         // # Create and visit new channel
-        cy.createAndVisitNewChannel().then((channel) => {
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
             newChannel = channel;
+            cy.visit(`/${team.name}/channels/${channel.name}`);
         });
     });
 

--- a/e2e/cypress/integration/messaging/message_reply_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_spec.js
@@ -12,9 +12,8 @@
 
 import {getAdminAccount} from '../../support/env';
 
-const sysadmin = getAdminAccount();
-
 describe('Message Reply', () => {
+    const sysadmin = getAdminAccount();
     let newChannel;
 
     before(() => {

--- a/e2e/cypress/integration/messaging/message_shortlinking_spec.js
+++ b/e2e/cypress/integration/messaging/message_shortlinking_spec.js
@@ -11,17 +11,23 @@
 // Group: @messaging
 
 describe('Message', () => {
-    beforeEach(() => {
-        // # Login as "user-1" and go to /
-        cy.apiLogin('user-1');
+    let testChannel;
+    let testTeam;
 
-        cy.visit('/ad-1/channels/town-square');
+    before(() => {
+        // # Login as test user and go to town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            testChannel = channel;
+            testTeam = team;
+
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+        });
     });
 
     it('M17451 Channel shortlinking still works when placed in brackets', () => {
         // # Post a shortlink of channel
-        const shortLink = '(~saepe-5)';
-        const longLink = '~doloremque';
+        const shortLink = `(~${testChannel.name})`;
+        const longLink = `~${testChannel.display_name}`;
 
         cy.postMessage(shortLink);
 
@@ -31,10 +37,10 @@ describe('Message', () => {
             cy.get(divPostId).contains(longLink).click();
 
             // * verify that the url is the same as what was just clicked on
-            cy.location('pathname').should('contain', 'ad-1/channels/saepe-5');
+            cy.location('pathname').should('contain', `${testTeam.name}/channels/${testChannel.name}`);
 
             // * verify that the channel title represents the same channel that was clicked on
-            cy.get('#channelHeaderTitle').should('contain', 'doloremque');
+            cy.get('#channelHeaderTitle').should('contain', testChannel.display_name);
         });
     });
 });

--- a/e2e/cypress/integration/messaging/message_spec.js
+++ b/e2e/cypress/integration/messaging/message_spec.js
@@ -12,8 +12,6 @@
 
 import {getAdminAccount} from '../../support/env';
 
-const admin = getAdminAccount();
-
 function shouldHavePostProfileImageVisible(isVisible = true) {
     cy.getLastPostId().then((postID) => {
         const target = `#post_${postID}`;
@@ -37,6 +35,7 @@ function shouldHavePostProfileImageVisible(isVisible = true) {
 }
 
 describe('Message', () => {
+    const admin = getAdminAccount();
     let testTeam;
     let testChannel;
 

--- a/e2e/cypress/integration/messaging/message_spec.js
+++ b/e2e/cypress/integration/messaging/message_spec.js
@@ -10,9 +10,9 @@
 // Stage: @prod
 // Group: @messaging @smoke
 
-import users from '../../fixtures/users.json';
+import {getAdminAccount} from '../../support/env';
 
-const sysadmin = users.sysadmin;
+const admin = getAdminAccount();
 
 function shouldHavePostProfileImageVisible(isVisible = true) {
     cy.getLastPostId().then((postID) => {
@@ -37,10 +37,16 @@ function shouldHavePostProfileImageVisible(isVisible = true) {
 }
 
 describe('Message', () => {
+    let testTeam;
+    let testChannel;
+
     before(() => {
-        // # Login as "user-1" and go to /
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
+        // # Create new team and new user and visit Town Square channel
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            testTeam = team;
+            testChannel = channel;
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+        });
     });
 
     it('M13701 Consecutive message does not repeat profile info', () => {
@@ -48,9 +54,7 @@ describe('Message', () => {
         cy.get('#postListContent').should('be.visible');
 
         // # Post a message to force next user message to display a message
-        cy.getCurrentChannelId().then((channelId) => {
-            cy.postMessageAs({sender: sysadmin, message: 'Hello', channelId});
-        });
+        cy.postMessageAs({sender: admin, message: 'Hello', channelId: testChannel.id});
 
         // # Post message "One"
         cy.postMessage('One');
@@ -97,18 +101,6 @@ describe('Message', () => {
     });
 
     it('M14320 @here, @all and @channel (ending in a period) still highlight', () => {
-        // # Change settings to allow @channel messages
-        cy.apiPatchMe({notify_props: {channel: 'true'}});
-
-        // # Login as sysadmin the create/login as new user
-        cy.apiLogin('sysadmin');
-        cy.apiCreateAndLoginAsNewUser().then(() => {
-            // # Create new team and visit its URL
-            cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-                cy.visit(`/${response.body.name}`);
-            });
-        });
-
         // # Post message
         cy.postMessage('@here. @all. @channel.');
 
@@ -128,7 +120,10 @@ describe('Message', () => {
 
     it('MM-2954 /me message should be formatted like a system message', () => {
         // # Post message
-        cy.postMessage('/me hello there');
+        const message = 'hello there';
+        cy.postMessage(`/me ${message}`);
+
+        cy.uiWaitUntilMessagePostedIncludes(message);
 
         cy.getLastPostId().then((postId) => {
             const divPostId = `#post_${postId}`;

--- a/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
+++ b/e2e/cypress/integration/messaging/permalink_loading_indicator_spec.js
@@ -29,7 +29,7 @@ describe('Messaging', () => {
     });
 
     afterEach(() => {
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         if (testPrivateChannel && testPrivateChannel.id) {
             cy.apiDeleteChannel(testPrivateChannel.id);
         }

--- a/e2e/cypress/integration/messaging/quote_notation_spec.js
+++ b/e2e/cypress/integration/messaging/quote_notation_spec.js
@@ -52,7 +52,7 @@ describe('Compact view: Markdown quotation', () => {
     function resetRoot() {
         // # Write a message from SysAdmin to make sure we have the root on compact mode
         cy.apiLogout();
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
         cy.visit('/ad-1/messages/@user-1');
         cy.postMessage('Hello' + Date.now());
 

--- a/e2e/cypress/integration/messaging/remove_gif_spec.js
+++ b/e2e/cypress/integration/messaging/remove_gif_spec.js
@@ -16,22 +16,24 @@ import users from '../../fixtures/users.json';
 const sysadmin = users.sysadmin;
 
 describe('Messaging', () => {
-    before(() => {
-        // # Login and setup link preferences
-        cy.apiLogin('user-1');
-        cy.apiSaveShowPreviewPreference();
-        cy.apiSavePreviewCollapsedPreference('false');
+    let testUser;
+    let testTeam;
 
-        // # Login as sysadmin and set the configuration on Link Previews
-        cy.apiLogin('sysadmin');
+    before(() => {
+        // # Set the configuration on Link Previews
         cy.apiUpdateConfig({
             ServiceSettings: {
                 EnableLinkPreviews: true,
             },
         });
 
-        // # Go to town-square channel
-        cy.visit('/ad-1/channels/town-square');
+        // # Login as test user and go to town-square
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+        });
     });
 
     it('M18692-Delete a GIF from RHS reply thread, other user viewing in center and RHS sees GIF preview disappear from both', () => {
@@ -45,8 +47,8 @@ describe('Messaging', () => {
         cy.postMessageReplyInRHS('https://media1.giphy.com/media/l41lM6sJvwmZNruLe/giphy.gif');
 
         // # Change user and go to Town Square
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
+        cy.apiLogin(testUser.username, testUser.password);
+        cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Wait for the page to be loaded
         cy.wait(TIMEOUTS.SMALL);
@@ -91,8 +93,8 @@ describe('Messaging', () => {
             cy.get(`#post_${postId}`).should('not.exist');
 
             // # Log in as the other user and go to town square
-            cy.apiLogin('sysadmin');
-            cy.visit('/ad-1/channels/town-square');
+            cy.apiAdminLogin();
+            cy.visit(`/${testTeam.name}/channels/town-square`);
 
             // * The post should not exist
             cy.get(`#post_${postId}`).should('not.exist');
@@ -100,6 +102,8 @@ describe('Messaging', () => {
     });
 
     it('M18692-Delete a GIF from RHS reply thread, other user viewing in center and RHS sees GIF preview disappear from both (mobile view)', () => {
+        cy.apiAdminLogin();
+
         // # Type message to use
         cy.postMessage('123');
 
@@ -110,8 +114,8 @@ describe('Messaging', () => {
         cy.postMessageReplyInRHS('https://media1.giphy.com/media/l41lM6sJvwmZNruLe/giphy.gif');
 
         // # Change user and go to Town Square
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
+        cy.apiLogin(testUser.username, testUser.password);
+        cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // # Change viewport so it has mobile view
         cy.viewport('iphone-6');
@@ -146,8 +150,8 @@ describe('Messaging', () => {
             cy.get(`#rhsPost_${postId}`).find('.attachment__image').should('not.exist');
 
             // # Log in as the other user and go to town square
-            cy.apiLogin('sysadmin');
-            cy.visit('/ad-1/channels/town-square');
+            cy.apiAdminLogin();
+            cy.visit(`/${testTeam.name}/channels/town-square`);
 
             // * The post should not exist
             cy.get(`#post_${postId}`).should('not.exist');

--- a/e2e/cypress/integration/messaging/remove_last_post_in_channel_spec.js
+++ b/e2e/cypress/integration/messaging/remove_last_post_in_channel_spec.js
@@ -19,7 +19,7 @@ const baseUrl = Cypress.config('baseUrl');
 describe('Remove Last Post', () => {
     beforeEach(() => {
         // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
 
         // # Use the API to create a new user
         cy.apiCreateNewUser().then((res) => {

--- a/e2e/cypress/integration/messaging/scroll_channel_messages_spec.js
+++ b/e2e/cypress/integration/messaging/scroll_channel_messages_spec.js
@@ -12,9 +12,8 @@
 
 import {getAdminAccount} from '../../support/env';
 
-const sysadmin = getAdminAccount();
-
 describe('Scroll channel`s messages in mobile view', () => {
+    const sysadmin = getAdminAccount();
     let newChannel;
 
     before(() => {

--- a/e2e/cypress/integration/messaging/scroll_channel_messages_spec.js
+++ b/e2e/cypress/integration/messaging/scroll_channel_messages_spec.js
@@ -10,22 +10,21 @@
 // Stage: @prod
 // Group: @messaging
 
-import users from '../../fixtures/users';
+import {getAdminAccount} from '../../support/env';
 
-const sysadmin = users.sysadmin;
+const sysadmin = getAdminAccount();
 
 describe('Scroll channel`s messages in mobile view', () => {
     let newChannel;
 
     before(() => {
-        cy.apiLogin('user-1');
-
         // # resize browser to phone view
         cy.viewport('iphone-6');
 
-        // # visit channel
-        cy.createAndVisitNewChannel().then((channel) => {
+        // # Create and visit new channel
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
             newChannel = channel;
+            cy.visit(`/${team.name}/channels/${channel.name}`);
         });
     });
 
@@ -34,7 +33,7 @@ describe('Scroll channel`s messages in mobile view', () => {
 
         // # Post a day old message
         for (let j = 2; j >= 0; j--) {
-            date = Cypress.moment().add(j, 'days').valueOf();
+            date = Cypress.moment().subtract(j, 'days').valueOf();
             for (let i = 0; i < 5; i++) {
                 cy.postMessageAs({sender: sysadmin, message: `Hello \n from \n other \n day \n - ${j}`, channelId: newChannel.id, createAt: date});
             }
@@ -43,11 +42,6 @@ describe('Scroll channel`s messages in mobile view', () => {
         // # reload to see correct changes
         cy.reload();
 
-        const twoDaysAgo = Cypress.moment();
-
-        // # set date 3 days fron now because channel created today and scroll not working because of it
-        cy.clock(Cypress.moment().add(2, 'days').valueOf(), ['Date']);
-
         // * check date on scroll and save it
         cy.findAllByTestId('postView').eq(15).scrollIntoView();
 
@@ -55,7 +49,7 @@ describe('Scroll channel`s messages in mobile view', () => {
         cy.findByTestId('floatingTimestamp').should('be.visible').and('have.text', 'Today');
 
         // * check date on scroll and save it
-        cy.findAllByTestId('postView').eq(10).scrollIntoView();
+        cy.findAllByTestId('postView').eq(9).scrollIntoView();
 
         // * check date on scroll is yesterday
         cy.findByTestId('floatingTimestamp').should('be.visible').and('have.text', 'Yesterday');
@@ -64,6 +58,6 @@ describe('Scroll channel`s messages in mobile view', () => {
         cy.findAllByTestId('postView').eq(4).scrollIntoView();
 
         // * check date on scroll is two days ago
-        cy.findByTestId('floatingTimestamp').should('be.visible').and('have.text', twoDaysAgo.format('ddd, MMM DD, YYYY'));
+        cy.findByTestId('floatingTimestamp').should('be.visible').and('have.text', Cypress.moment().subtract(2, 'days').format('ddd, MMM DD, YYYY'));
     });
 });

--- a/e2e/cypress/integration/messaging/send_message_via_profile_popover_spec.js
+++ b/e2e/cypress/integration/messaging/send_message_via_profile_popover_spec.js
@@ -17,7 +17,7 @@ describe('Profile popover', () => {
 
     beforeEach(() => {
         // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
 
         // # Save Teammate Name Display Preference to username
         // # Save Message Display Preference to clean

--- a/e2e/cypress/integration/messaging/system_message_limited_options_spec.js
+++ b/e2e/cypress/integration/messaging/system_message_limited_options_spec.js
@@ -15,7 +15,7 @@ import * as TIMEOUTS from '../../fixtures/timeouts';
 describe('Messaging', () => {
     beforeEach(() => {
         // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
 
         // # Visit the Town Square channel
         cy.visit('/ad-1/channels/town-square');

--- a/e2e/cypress/integration/messaging/tooltip_visual_verification_spec.js
+++ b/e2e/cypress/integration/messaging/tooltip_visual_verification_spec.js
@@ -15,7 +15,7 @@ import * as TIMEOUTS from '../../fixtures/timeouts';
 describe('Messaging', () => {
     beforeEach(() => {
         // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
 
         // # Create new user and DM
         cy.apiCreateNewUser().then((res) => {

--- a/e2e/cypress/integration/onboarding/existing_email_adress_spec.js
+++ b/e2e/cypress/integration/onboarding/existing_email_adress_spec.js
@@ -36,8 +36,7 @@ function signupWithEmail(name, pw) {
 
 describe('Email Address', () => {
     before(() => {
-        // # Login as sysadmin and set EnableOpenServer to true and disable other auth options
-        cy.apiLogin('sysadmin');
+        // # Set EnableOpenServer to true and disable other auth options
         const newSettings = {
             TeamSettings: {EnableOpenServer: true},
             Office365Settings: {Enable: false},

--- a/e2e/cypress/integration/onboarding/tutorial_navigation_and_links_spec.js
+++ b/e2e/cypress/integration/onboarding/tutorial_navigation_and_links_spec.js
@@ -10,26 +10,33 @@
 // Stage: @prod
 // Group: @onboarding @smoke
 
-const appDownloadLink = 'https://about.mattermost.com/downloads/';
-
 describe('Test Tutorial Navigation', () => {
-    let team;
+    let testUser;
+    let otherUser;
+    let testTeam;
+    let config;
 
     before(() => {
-        cy.apiLogin('sysadmin');
-        cy.apiUpdateConfig({
-            NativeAppSettings: {
-                AppDownloadLink: appDownloadLink,
-            },
-            SupportSettings: {
-                SupportEmail: 'feedback@mattermost.com',
-            },
+        cy.apiGetConfig().then((res) => {
+            config = res.body;
         });
-        cy.apiGetTeamByName('ad-1').then((res) => {
-            team = res.body;
 
-            cy.apiCreateAndLoginAsNewUser({}, [team.id], false);
-            cy.visit(`/${team.name}/channels/town-square`);
+        // # Create new team and new user and visit Town Square channel
+        cy.apiInitSetup().then(({team}) => {
+            testTeam = team;
+
+            cy.apiCreateUser({bypassTutorial: false}).then(({user: user2}) => {
+                otherUser = user2;
+                cy.apiAddUserToTeam(testTeam.id, otherUser.id);
+            });
+
+            cy.apiCreateUser({bypassTutorial: false}).then(({user: user1}) => {
+                testUser = user1;
+                cy.apiAddUserToTeam(testTeam.id, testUser.id);
+
+                cy.apiLogin(testUser.username, testUser.password);
+                cy.visit(`/${testTeam.name}/channels/town-square`);
+            });
         });
     });
 
@@ -41,7 +48,7 @@ describe('Test Tutorial Navigation', () => {
         cy.get('#tutorialIntroCircle1').click();
 
         // * Verify the second step displays.
-        checkStepTwo();
+        checkStepTwo(config.NativeAppSettings.AppDownloadLink);
 
         // # Click the third dot.
         cy.get('#tutorialIntroCircle2').click();
@@ -59,7 +66,7 @@ describe('Test Tutorial Navigation', () => {
         cy.get('#tutorialNextButton').click();
 
         // * Verify that the second step displays.
-        checkStepTwo();
+        checkStepTwo(config.NativeAppSettings.AppDownloadLink);
 
         // * Test the App Download Image link to ensure it returns a 200 result.
         cy.get('#appDownloadImage').should('have.attr', 'href').then((href) => {
@@ -76,7 +83,7 @@ describe('Test Tutorial Navigation', () => {
         cy.get('#sidebarItem_off-topic').parent().should('have.class', 'active');
 
         // * Verify that the second step of the tutorial still displays:
-        checkStepTwo();
+        checkStepTwo(config.NativeAppSettings.AppDownloadLink);
 
         // # Click the Next button
         cy.get('#tutorialNextButton').click();
@@ -90,13 +97,9 @@ describe('Test Tutorial Navigation', () => {
         // * Verify that the Off-Topic channel displays.
         checkOffTopicChannel();
 
-        // # Log the current user out.
-        cy.apiLogout();
-
-        // # Create another new user with the tutorial bypass flag set to false.
-        cy.apiLogin('sysadmin');
-        cy.apiCreateAndLoginAsNewUser({}, [team.id], false);
-        cy.visit(`/${team.name}/channels/town-square`);
+        // # Log in as another new user with the tutorial bypass flag set to false.
+        cy.apiLogin(otherUser.username, otherUser.password);
+        cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // * Verify that the first step of the tutorial displays.
         checkStepOne();
@@ -128,7 +131,7 @@ function checkStepOne() {
 *    This function checks the contents of the second step of the tutorial.
 */
 
-function checkStepTwo() {
+function checkStepTwo(appDownloadLink) {
     cy.get('#tutorialIntroTwo').should('be.visible').
         and('contain', 'Communication happens in public discussion channels, private channels and direct messages.').
         and('contain', 'Everything is archived and searchable from any web-enabled desktop, laptop or phone.').

--- a/e2e/cypress/integration/plugins/marketplace/marketplace_spec.js
+++ b/e2e/cypress/integration/plugins/marketplace/marketplace_spec.js
@@ -15,7 +15,7 @@ describe('Plugin Marketplace', () => {
     describe('should not render in main menu', () => {
         it('for non-admin', () => {
             // # Login as sysadmin
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
 
             // # Enable Plugin Marketplace
             cy.apiUpdateConfig({
@@ -33,7 +33,7 @@ describe('Plugin Marketplace', () => {
 
         it('when marketplace disabled', () => {
             // # Login as sysadmin
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
 
             // # Disable Plugin Marketplace
             cy.apiUpdateConfig({
@@ -50,7 +50,7 @@ describe('Plugin Marketplace', () => {
 
         it('when plugins disabled', () => {
             // # Login as sysadmin
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
 
             // # Disable Plugin
             // # Enable Plugin Marketplace
@@ -70,7 +70,7 @@ describe('Plugin Marketplace', () => {
     describe('invalid marketplace, should', () => {
         beforeEach(() => {
             // # Login as sysadmin
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
 
             // # Enable Plugin Marketplace and Remote Marketplace
             cy.apiUpdateConfig({

--- a/e2e/cypress/integration/search/clear_input_spec.js
+++ b/e2e/cypress/integration/search/clear_input_spec.js
@@ -14,8 +14,7 @@ import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('Search', () => {
     before(() => {
-        // # Login as the sysadmin.
-        cy.apiLogin('sysadmin');
+        // # Visit town-square channel
         cy.visit('/ad-1/channels/town-square');
     });
 

--- a/e2e/cypress/integration/search/search_group_message_spec.js
+++ b/e2e/cypress/integration/search/search_group_message_spec.js
@@ -10,56 +10,73 @@
 // Stage: @prod
 // Group: @search
 
-const groupMembers = ['aaron.peterson', 'aaron.ward', 'samuel.tucker'];
-
 describe('Search', () => {
+    let testTeam;
+    let testUser;
+    let userOne;
+    let userTwo;
+    let userThree;
+
     before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
+        // # Create new team and users
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
 
-        // # Create and login as a new user
-        cy.apiCreateAndLoginAsNewUser().then(() => {
-            cy.apiSaveTeammateNameDisplayPreference('username');
-
-            cy.apiGetUsers(groupMembers).then((res) => {
-                const userIds = res.body.map((user) => user.id);
-
-                cy.apiCreateGroupChannel(userIds).then((resp) => {
-                    cy.apiGetTeams().then((response) => {
-                        const team = response.body[0];
-                        cy.visit(`/${team.name}/messages/${resp.body.name}`);
-                    });
-                });
+            cy.apiCreateUser({prefix: 'aaa'}).then(({user: user1}) => {
+                userOne = user1;
+                cy.apiAddUserToTeam(testTeam.id, userOne.id);
             });
+
+            cy.apiCreateUser({prefix: 'bbb'}).then(({user: user2}) => {
+                userTwo = user2;
+                cy.apiAddUserToTeam(testTeam.id, userTwo.id);
+            });
+
+            cy.apiCreateUser({prefix: 'ccc'}).then(({user: user3}) => {
+                userThree = user3;
+                cy.apiAddUserToTeam(testTeam.id, userThree.id);
+            });
+
+            cy.apiLogin(testUser.username, testUser.password);
         });
     });
 
     it('S14673 - Search "in:[username]" returns results in GMs', () => {
-        const message = `hello${Date.now()}`;
+        const groupMembers = [testUser, userOne, userTwo, userThree];
+        cy.apiCreateGroupChannel(groupMembers.map((member) => member.id)).then((resp) => {
+            cy.visit(`/${testTeam.name}/messages/${resp.body.name}`);
 
-        // # Post a message
-        cy.postMessage(message);
+            const message = `hello${Date.now()}`;
 
-        //# Type "in:" text in search input
-        cy.get('#searchBox').type('in:');
+            // # Post a message
+            cy.postMessage(message);
 
-        //# Search group members in the menu
-        cy.get('#search-autocomplete__popover').should('be.visible').within(() => {
-            cy.findAllByTestId('listItem').contains(groupMembers.join(',')).click();
-        });
+            //# Type "in:" text in search input
+            cy.get('#searchBox').type('in:');
 
-        //# Press enter to select
-        cy.get('#searchBox').type('{enter}');
+            const sortedUsernames = groupMembers.
+                map((member) => member.username).
+                sort((a, b) => a.localeCompare(b, 'en', {numeric: true}));
 
-        //# Search for the message
-        cy.get('#searchbarContainer').should('be.visible').within(() => {
-            cy.get('#searchBox').clear().type(`${message}{enter}`);
-        });
+            //# Search group members in the menu
+            cy.get('#search-autocomplete__popover').should('be.visible').within(() => {
+                cy.findAllByTestId('listItem').contains(sortedUsernames.join(',')).click();
+            });
 
-        // * Should return exactly one result from the group channel and matches the message
-        cy.findAllByTestId('search-item-container').should('be.visible').and('have.length', 1).within(() => {
-            cy.get('.search-channel__name').should('be.visible').and('have.text', groupMembers.join(', '));
-            cy.get('.search-highlight').should('be.visible').and('have.text', message);
+            //# Press enter to select
+            cy.get('#searchBox').type('{enter}');
+
+            //# Search for the message
+            cy.get('#searchbarContainer').should('be.visible').within(() => {
+                cy.get('#searchBox').clear().type(`${message}{enter}`);
+            });
+
+            // * Should return exactly one result from the group channel and matches the message
+            cy.findAllByTestId('search-item-container').should('be.visible').and('have.length', 1).within(() => {
+                cy.get('.search-channel__name').should('be.visible').and('have.text', sortedUsernames.filter((username) => username !== testUser.username).join(', '));
+                cy.get('.search-highlight').should('be.visible').and('have.text', message);
+            });
         });
     });
 });

--- a/e2e/cypress/integration/search_autocomplete/channels_spec.js
+++ b/e2e/cypress/integration/search_autocomplete/channels_spec.js
@@ -10,24 +10,20 @@
 // Stage: @prod
 // Group: @autocomplete
 
-import users from '../../fixtures/users.json';
-
 import {
     createPrivateChannel,
-    createEmail,
     searchForChannel,
-    withTimestamp,
 } from '../enterprise/elasticsearch_autocomplete/helpers';
 
+import {getAdminAccount} from '../../support/env';
+
+const admin = getAdminAccount();
+
 describe('Autocomplete without Elasticsearch - Channel', () => {
-    const timestamp = Date.now();
-    let team = {};
-    let user;
+    let testTeam;
+    let testUser;
 
     before(() => {
-        // # Execute the before hook based on current config
-        cy.apiLogin('sysadmin');
-
         // # Disable elastic search via API
         cy.apiUpdateConfig({
             ElasticsearchSettings: {
@@ -38,28 +34,12 @@ describe('Autocomplete without Elasticsearch - Channel', () => {
             },
         });
 
-        // # Create new team to run tests against
-        cy.apiCreateTeam(`search-${timestamp}`, `search-${timestamp}`).then((response) => {
-            team = response.body;
+        // # Login as test user and go to town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
 
-            const daredevil = {
-                username: withTimestamp('daredevil', timestamp),
-                firstName: 'Matt',
-                lastName: 'Murdock',
-                email: createEmail('daredevil', timestamp),
-                nickname: withTimestamp('attorney', timestamp),
-            };
-
-            // # Setup new channel and user
-            cy.apiCreateNewUser(daredevil, [team.id]).as('newUser');
-        });
-        cy.apiLogout();
-
-        // # Login and navigate to team with new user
-        cy.get('@newUser').then((newUser) => {
-            user = newUser;
-            cy.apiLogin(user.username, user.password);
-            cy.visit(`/${team.name}`);
+            cy.visit(`/${testTeam.name}/channels/town-square`);
         });
     });
 
@@ -69,7 +49,7 @@ describe('Autocomplete without Elasticsearch - Channel', () => {
 
     it("private channel I don't belong to does not appear", () => {
         // # Create private channel, do not add new user to it (sets @privateChannel alias)
-        createPrivateChannel(team.id).then((channel) => {
+        createPrivateChannel(testTeam.id).then((channel) => {
             // # Go to off-topic channel to partially reload the page
             cy.get('#sidebarChannelContainer').should('be.visible').within(() => {
                 cy.findAllByText('Off-Topic').should('be.visible').click();
@@ -91,7 +71,7 @@ describe('Autocomplete without Elasticsearch - Channel', () => {
         });
 
         // # Create private channel and add new user to it (sets @privateChannel alias)
-        createPrivateChannel(team.id, user).then((channel) => {
+        createPrivateChannel(testTeam.id, testUser).then((channel) => {
             // # Search for the private channel
             searchForChannel(channel.name);
 
@@ -110,7 +90,7 @@ describe('Autocomplete without Elasticsearch - Channel', () => {
 
         // # As admin, create a new team that the new user is not a member of
         cy.task('externalRequest', {
-            user: users.sysadmin,
+            user: admin,
             path: 'teams',
             baseUrl,
             method: 'post',
@@ -143,16 +123,13 @@ describe('Autocomplete without Elasticsearch - Channel', () => {
         let channelId;
 
         before(() => {
-            cy.apiLogout();
-
-            // # Login as admin
-            cy.apiLogin('sysadmin');
-            cy.visit(`/${team.name}`);
+            // // # Visit town-square
+            cy.visit(`/${testTeam.name}`);
 
             const name = 'hellothere';
 
             // # Create a new channel
-            cy.apiCreateChannel(team.id, name, name).then((channelResponse) => {
+            cy.apiCreateChannel(testTeam.id, name, name).then((channelResponse) => {
                 channelId = channelResponse.body.id;
             });
 

--- a/e2e/cypress/integration/search_autocomplete/channels_spec.js
+++ b/e2e/cypress/integration/search_autocomplete/channels_spec.js
@@ -17,9 +17,8 @@ import {
 
 import {getAdminAccount} from '../../support/env';
 
-const admin = getAdminAccount();
-
 describe('Autocomplete without Elasticsearch - Channel', () => {
+    const admin = getAdminAccount();
     let testTeam;
     let testUser;
 

--- a/e2e/cypress/integration/search_autocomplete/renaming_spec.js
+++ b/e2e/cypress/integration/search_autocomplete/renaming_spec.js
@@ -56,8 +56,6 @@ describe('Autocomplete without Elasticsearch - Renaming', () => {
     let team;
 
     before(() => {
-        // # Login as admin
-        cy.apiLogin('sysadmin');
         cy.apiSaveTeammateNameDisplayPreference('username');
 
         // # Disable elastic search via API

--- a/e2e/cypress/integration/search_autocomplete/users_spec.js
+++ b/e2e/cypress/integration/search_autocomplete/users_spec.js
@@ -18,8 +18,6 @@ describe('Autocomplete without Elasticsearch - Users', () => {
     let team;
 
     before(() => {
-        // # Login as admin
-        cy.apiLogin('sysadmin');
         cy.apiSaveTeammateNameDisplayPreference('username');
 
         // * Check if server has license for Elasticsearch

--- a/e2e/cypress/integration/search_date_filter/date_filter_spec.js
+++ b/e2e/cypress/integration/search_date_filter/date_filter_spec.js
@@ -80,9 +80,6 @@ describe('SF15699 Search Date Filter', () => {
     let newAdmin;
 
     before(() => {
-        // # Login as the sysadmin.
-        cy.apiLogin('sysadmin');
-
         // # Change timezone to UTC so we are in sync with the backend
         changeTimezone('UTC');
 

--- a/e2e/cypress/integration/search_date_filter/negative_filter_spec.js
+++ b/e2e/cypress/integration/search_date_filter/negative_filter_spec.js
@@ -41,21 +41,19 @@ describe('Negative search filters will omit results', () => {
         cy.get('.search-item__container').should('not.exist');
     }
 
+    let testUser;
+
     before(() => {
-        // # Login as the sysadmin.
-        cy.apiLogin('sysadmin');
+        // # Login as test user and go to town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team, user}) => {
+            testUser = user;
 
-        // # Create a new team
-        cy.apiCreateTeam('filter-test', 'filter-test').its('body').as('team');
-
-        // # Get team name and visit that team
-        cy.get('@team').then((team) => {
             cy.visit(`/${team.name}/channels/town-square`);
-        });
 
-        // # Create a post from today
-        cy.get('#postListContent', {timeout: TIMEOUTS.LARGE}).should('be.visible');
-        cy.postMessage(message);
+            // # Create a post from today
+            cy.get('#postListContent', {timeout: TIMEOUTS.LARGE}).should('be.visible');
+            cy.postMessage(message);
+        });
     });
 
     it('just search query', () => {
@@ -86,7 +84,7 @@ describe('Negative search filters will omit results', () => {
     });
 
     it('-from:', () => {
-        const query = `from:sysadmin ${message}`;
+        const query = `from:${testUser.username} ${message}`;
         searchAndVerify(query);
     });
 });

--- a/e2e/cypress/integration/signin_authentication/forgot_password_spec.js
+++ b/e2e/cypress/integration/signin_authentication/forgot_password_spec.js
@@ -10,34 +10,37 @@
 // Stage: @prod
 // Group: @signin_authentication
 
-/*eslint max-nested-callbacks: ["error", 5]*/
-
 import {getEmailUrl, getEmailMessageSeparator, reUrl} from '../../utils';
 
-let config;
-
 describe('Signin/Authentication', () => {
+    let testUser;
+    let testTeam;
+    let testConfig;
+
     before(() => {
         // # Do email test if setup properly
         cy.apiEmailTest();
 
-        // # Login as sysadmin and get config
-        cy.apiLogin('sysadmin');
+        // # Get config
         cy.apiGetConfig().then((response) => {
-            config = response.body;
+            testConfig = response.body;
+        });
+
+        // # Create new team and users
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+
+            cy.apiLogout();
         });
     });
 
     it('SA15008 - Sign In Forgot password - Email address has account on server', () => {
-        cy.apiCreateAndLoginAsNewUser().then((user) => {
-            cy.apiLogout();
-
-            resetPasswordAndLogin(user, config.EmailSettings.FeedbackEmail, config.SupportSettings.SupportEmail);
-        });
+        resetPasswordAndLogin(testUser, testTeam, testConfig);
     });
 });
 
-function verifyForgotPasswordEmail(response, toUser, feedbackEmail, supportEmail, messageSeparator) {
+function verifyForgotPasswordEmail(response, toUser, config, messageSeparator) {
     const isoDate = new Date().toISOString().substring(0, 10);
     const {data, status} = response;
 
@@ -49,7 +52,7 @@ function verifyForgotPasswordEmail(response, toUser, feedbackEmail, supportEmail
     expect(data.to[0]).to.contain(toUser.email);
 
     // * Verify that email is from default feedback email
-    expect(data.from).to.contain(feedbackEmail);
+    expect(data.from).to.contain(config.EmailSettings.FeedbackEmail);
 
     // * Verify that date is current
     expect(data.date).to.contain(isoDate);
@@ -64,17 +67,17 @@ function verifyForgotPasswordEmail(response, toUser, feedbackEmail, supportEmail
     expect(bodyText[4]).to.equal('To change your password, click "Reset Password" below.');
     expect(bodyText[5]).to.contain('If you did not mean to reset your password, please ignore this email and your password will remain the same. The password reset link expires in 24 hours.');
     expect(bodyText[7]).to.contain('Reset Password');
-    expect(bodyText[9]).to.contain(`Any questions at all, mail us any time: ${supportEmail}`);
+    expect(bodyText[9]).to.contain(`Any questions at all, mail us any time: ${config.SupportSettings.SupportEmail}`);
     expect(bodyText[10]).to.equal('Best wishes,');
     expect(bodyText[11]).to.equal(`The ${config.TeamSettings.SiteName} Team`);
     expect(bodyText[13]).to.equal('To change your notification preferences, log in to your team site and go to Account Settings > Notifications.');
 }
 
-function resetPasswordAndLogin(user, feedbackEmail, supportEmail) {
+function resetPasswordAndLogin(user, team, config) {
     const newPassword = 'newpasswd';
 
-    // # Visit '/'
-    cy.visit('/ad-1/channels/town-square');
+    // # Visit town-square
+    cy.visit(`/${team.name}/channels/town-square`);
 
     // * Verify that it redirects to /login
     cy.url().should('contain', '/login');
@@ -107,7 +110,7 @@ function resetPasswordAndLogin(user, feedbackEmail, supportEmail) {
         const separator = getEmailMessageSeparator(baseUrl);
 
         // * Verify contents password reset email
-        verifyForgotPasswordEmail(response, user, feedbackEmail, supportEmail, separator);
+        verifyForgotPasswordEmail(response, user, config, separator);
 
         const bodyText = response.data.body.text.split(separator);
         const passwordResetLink = bodyText[7].match(reUrl)[0];
@@ -139,7 +142,7 @@ function resetPasswordAndLogin(user, feedbackEmail, supportEmail) {
         cy.get('#loginButton').click();
 
         // * Verify that it successfully logged in and redirects to /channels/town-square
-        cy.url().should('contain', '/channels/town-square');
+        cy.url().should('contain', `/${team.name}/channels/town-square`);
 
         // # Logout
         cy.apiLogout();

--- a/e2e/cypress/integration/signin_authentication/login_spec.js
+++ b/e2e/cypress/integration/signin_authentication/login_spec.js
@@ -17,7 +17,6 @@ let config;
 describe('Login page', () => {
     before(() => {
         // Disable other auth options
-        cy.apiLogin('sysadmin');
         const newSettings = {
             Office365Settings: {Enable: false},
             LdapSettings: {Enable: false},

--- a/e2e/cypress/integration/signin_authentication/signup_spec.js
+++ b/e2e/cypress/integration/signin_authentication/signup_spec.js
@@ -15,7 +15,6 @@ let config;
 describe('Signup Email page', () => {
     before(() => {
         // Disable other auth options
-        cy.apiLogin('sysadmin');
         const newSettings = {
             Office365Settings: {Enable: false},
             LdapSettings: {Enable: false},

--- a/e2e/cypress/integration/system_console/cluster_spec.js
+++ b/e2e/cypress/integration/system_console/cluster_spec.js
@@ -10,9 +10,6 @@
 
 describe('Cluster', () => {
     before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
         // # Visit customization system console page
         cy.visit('/admin_console/environment/high_availability');
     });

--- a/e2e/cypress/integration/system_console/demoted_user_spec.js
+++ b/e2e/cypress/integration/system_console/demoted_user_spec.js
@@ -10,25 +10,26 @@
 // Stage: @prod
 // Group: @system_console @smoke
 
-import users from '../../fixtures/users.json';
 import * as TIMEOUTS from '../../fixtures/timeouts';
+import {getAdminAccount} from '../../support/env';
 
-const sysadmin = users.sysadmin;
+const sysadmin = getAdminAccount();
 
 describe('System Console', () => {
+    let testUser;
+
+    before(() => {
+        // # Create new team and login
+        cy.apiInitSetup({loginAfter: true}).then(({user}) => {
+            testUser = user;
+        });
+    });
+
     it('SC14734 Demoted user cannot continue to view System Console', () => {
         const baseUrl = Cypress.config('baseUrl');
 
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
-        // # Login as new user
-        cy.apiCreateAndLoginAsNewUser().as('newuser');
-
         // # Set user to be a sysadmin, so it can access the system console
-        cy.get('@newuser').then((user) => {
-            cy.externalRequest({user: sysadmin, method: 'put', baseUrl, path: `users/${user.id}/roles`, data: {roles: 'system_user system_admin'}});
-        });
+        cy.externalRequest({user: sysadmin, method: 'put', baseUrl, path: `users/${testUser.id}/roles`, data: {roles: 'system_user system_admin'}});
 
         // # Visit a page on the system console
         cy.visit('/admin_console/reporting/system_analytics');
@@ -36,9 +37,7 @@ describe('System Console', () => {
         cy.url().should('include', '/admin_console/reporting/system_analytics');
 
         // # Change the role of the user back to user
-        cy.get('@newuser').then((user) => {
-            cy.externalRequest({user: sysadmin, method: 'put', baseUrl, path: `users/${user.id}/roles`, data: {roles: 'system_user'}});
-        });
+        cy.externalRequest({user: sysadmin, method: 'put', baseUrl, path: `users/${testUser.id}/roles`, data: {roles: 'system_user'}});
 
         // # User should get redirected to town square
         cy.get('#adminConsoleWrapper').should('not.exist');

--- a/e2e/cypress/integration/system_console/demoted_user_spec.js
+++ b/e2e/cypress/integration/system_console/demoted_user_spec.js
@@ -13,9 +13,8 @@
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import {getAdminAccount} from '../../support/env';
 
-const sysadmin = getAdminAccount();
-
 describe('System Console', () => {
+    const sysadmin = getAdminAccount();
     let testUser;
 
     before(() => {

--- a/e2e/cypress/integration/system_console/feature_discovery_spec.js
+++ b/e2e/cypress/integration/system_console/feature_discovery_spec.js
@@ -9,7 +9,6 @@
 
 describe('Feature discovery', () => {
     before(() => {
-        cy.apiLogin('sysadmin');
         cy.visit('/admin_console');
     });
 

--- a/e2e/cypress/integration/system_console/group_configuration_spec.js
+++ b/e2e/cypress/integration/system_console/group_configuration_spec.js
@@ -60,7 +60,7 @@ describe('group configuration', () => {
                 groupID = response.body.id;
 
                 // # Login as sysadmin
-                cy.apiLogin('sysadmin');
+                cy.apiAdminLogin();
 
                 // # Go to the group configuration view of the linked group
                 cy.visit(`/admin_console/user_management/groups/${groupID}`);

--- a/e2e/cypress/integration/system_console/inactive_users_spec.js
+++ b/e2e/cypress/integration/system_console/inactive_users_spec.js
@@ -20,8 +20,7 @@ const perPage = 50;
 
 describe('System Console', () => {
     it('SC18512 List pages of inactive users', () => {
-        // # Login as sysadmin and go to users management page
-        cy.apiLogin('sysadmin');
+        // # Go to users management page
         cy.visit('/admin_console/user_management/users');
 
         // # Select inactive users

--- a/e2e/cypress/integration/system_console/lock_teammate_name_display_spec.js
+++ b/e2e/cypress/integration/system_console/lock_teammate_name_display_spec.js
@@ -12,8 +12,6 @@
 
 describe('System Console', () => {
     it('MM-19309 Allow System Admins to control Teammate Name Display at the system level', () => {
-        cy.apiLogin('sysadmin');
-
         // # Go to system admin page
         cy.visit('/admin_console/site_config/users_and_teams');
 

--- a/e2e/cypress/integration/system_console/plugin_upload_spec.js
+++ b/e2e/cypress/integration/system_console/plugin_upload_spec.js
@@ -23,8 +23,7 @@ describe('Draw Plugin - Upload', () => {
     const fileType = 'application/gzip';
     const pluginId = 'com.mattermost.draw-plugin';
     before(() => {
-        // # Login as sysadmin and update config
-        cy.apiLogin('sysadmin');
+        // # Update config
         cy.apiUpdateConfig({
             PluginSettings: {
                 Enable: true,

--- a/e2e/cypress/integration/system_console/revoke_all_sessions_spec.js
+++ b/e2e/cypress/integration/system_console/revoke_all_sessions_spec.js
@@ -16,7 +16,7 @@ import * as TIMEOUTS from '../../fixtures/timeouts';
 describe('SC17020 - Revoke All Sessions from System Console', () => {
     it('Verify for System Admin', () => {
         // # Login as System Admin
-        cy.apiLogin('sysadmin');
+        cy.apiAdminLogin();
 
         cy.visit('/admin_console/user_management/users');
 

--- a/e2e/cypress/integration/system_console/session_length_spec.js
+++ b/e2e/cypress/integration/system_console/session_length_spec.js
@@ -12,7 +12,7 @@
 
 // # Goes to the System Scheme page as System Admin
 const goToSessionLengths = () => {
-    cy.apiLogin('sysadmin');
+    cy.apiAdminLogin();
     cy.visit('/admin_console/environment/session_lengths');
 };
 

--- a/e2e/cypress/integration/system_console/sidebar_link_navigation_spec.js
+++ b/e2e/cypress/integration/system_console/sidebar_link_navigation_spec.js
@@ -183,8 +183,7 @@ describe('System Console', () => {
     ];
 
     before(() => {
-        // * Login as sysadmin and check if server has license
-        cy.apiLogin('sysadmin');
+        // * Check if server has license
         cy.requireLicense();
 
         const newSettings = {

--- a/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
+++ b/e2e/cypress/integration/system_console/ui_and_api/customization_spec.js
@@ -16,9 +16,6 @@ describe('Customization', () => {
     let origConfig;
 
     before(() => {
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
         // Get config
         cy.apiGetConfig().then((response) => {
             origConfig = response.body;

--- a/e2e/cypress/integration/team_settings/invite_members_spec.js
+++ b/e2e/cypress/integration/team_settings/invite_members_spec.js
@@ -10,12 +10,6 @@
 // Stage: @prod
 // Group: @team_settings
 
-// import users from '../../fixtures/users.json';
-
-// let testTeam;
-// const user1 = users['user-1'];
-// const user2 = users['user-2'];
-
 function openClickInviteMenuItem() {
     // * validating the side bar is visible
     cy.get('#sidebarHeaderDropdownButton').should('be.visible');

--- a/e2e/cypress/integration/team_settings/invite_members_spec.js
+++ b/e2e/cypress/integration/team_settings/invite_members_spec.js
@@ -10,11 +10,11 @@
 // Stage: @prod
 // Group: @team_settings
 
-import users from '../../fixtures/users.json';
+// import users from '../../fixtures/users.json';
 
-let testTeam;
-const user1 = users['user-1'];
-const user2 = users['user-2'];
+// let testTeam;
+// const user1 = users['user-1'];
+// const user2 = users['user-2'];
 
 function openClickInviteMenuItem() {
     // * validating the side bar is visible
@@ -38,10 +38,10 @@ function verifyClickInvitePeopleDialog() {
     cy.get('#inviteMembersSectionDescription').click();
 }
 
-function verifyInvitationSuccess() {
+function verifyInvitationSuccess(team) {
     // * Verify the content and success message in the Invitation Modal
     cy.findByTestId('invitationModal').within(($el) => {
-        cy.wrap($el).find('h1').should('have.text', `Members Invited to ${testTeam.display_name}`);
+        cy.wrap($el).find('h1').should('have.text', `Members Invited to ${team.display_name}`);
         cy.wrap($el).find('h2.subtitle > span').should('have.text', '1 person has been invited');
         cy.wrap($el).find('div.invitation-modal-confirm-not-sent').should('not.exist');
         cy.wrap($el).find('div.invitation-modal-confirm-sent').should('be.visible').within(($subel) => {
@@ -54,10 +54,10 @@ function verifyInvitationSuccess() {
     });
 }
 
-function verifyInviteMembersModal() {
+function verifyInviteMembersModal(team) {
     // * Verify the header has changed in the modal
     cy.findByTestId('invitationModal').within(($el) => {
-        cy.wrap($el).find('h1').should('have.text', `Invite Members to ${testTeam.display_name}`);
+        cy.wrap($el).find('h1').should('have.text', `Invite Members to ${team.display_name}`);
     });
 
     // * Verify Share Link Header and helper text
@@ -88,12 +88,12 @@ function closeAndComplete() {
 }
 
 describe('Invite Members', () => {
-    beforeEach(() => {
-        testTeam = null;
+    let testUser;
+    let userOne;
+    let userTwo;
+    let testTeam;
 
-        // # Login as sysadmin
-        cy.apiLogin('sysadmin');
-
+    before(() => {
         // # Enable API Team Deletion
         // # Disable Require Email Verification
         cy.apiUpdateConfig({
@@ -104,41 +104,47 @@ describe('Invite Members', () => {
                 RequireEmailVerification: false,
             },
         });
-
-        // # Login as new user
-        cy.apiCreateAndLoginAsNewUser().then(() => {
-            // # Create new team and visit its URL
-            cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-                testTeam = response.body;
-                cy.visit(`/${testTeam.name}`);
-            });
-        });
     });
 
-    afterEach(() => {
-        cy.apiLogin('sysadmin');
-        if (testTeam && testTeam.id) {
-            cy.apiDeleteTeam(testTeam.id);
-        }
+    beforeEach(() => {
+        cy.apiAdminLogin();
+
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+
+            cy.apiCreateUser({bypassTutorial: false}).then(({user: user1}) => {
+                userOne = user1;
+                cy.apiAddUserToTeam(testTeam.id, userOne.id);
+            });
+
+            cy.apiCreateUser({bypassTutorial: false}).then(({user: user2}) => {
+                userTwo = user2;
+                cy.apiAddUserToTeam(testTeam.id, userTwo.id);
+            });
+        });
     });
 
     // By default, member don't have "InviteGuest" permission
     // should go directly to "InviteMembers" modal
     it('Invite Members to Team as Member', () => {
+        cy.apiLogin(testUser.username, testUser.password);
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+
         // # function to open and select invite menu item
         openClickInviteMenuItem();
 
         // * verify Invite Members
-        verifyInviteMembersModal();
+        verifyInviteMembersModal(testTeam);
 
         // # invite existing user
-        inviteUser(user1);
+        inviteUser(userOne);
 
         // * verify Invitation was created successfully
-        verifyInvitationSuccess();
+        verifyInvitationSuccess(testTeam);
 
         // * verify returned to "InviteMembers" modal
-        verifyInviteMembersModal();
+        verifyInviteMembersModal(testTeam);
 
         // # close modal
         closeAndComplete();
@@ -147,8 +153,8 @@ describe('Invite Members', () => {
     // By default, sysadmin can Invite Guests, should go to "InvitePeople" modal
     it('Invite Members to Team as SysAdmin', () => {
         // # login and visit
-        cy.apiLogin('sysadmin');
-        cy.visit(`/${testTeam.name}`);
+        cy.apiAdminLogin();
+        cy.visit(`/${testTeam.name}/channels/off-topic`);
 
         // # function to open and select invite menu item
         openClickInviteMenuItem();
@@ -157,13 +163,13 @@ describe('Invite Members', () => {
         verifyClickInvitePeopleDialog();
 
         // * verify Invite Members
-        verifyInviteMembersModal();
+        verifyInviteMembersModal(testTeam);
 
         // # invite existing user
-        inviteUser(user2);
+        inviteUser(userTwo);
 
         // * verify Invitation was created successfully
-        verifyInvitationSuccess();
+        verifyInvitationSuccess(testTeam);
 
         // * verify returned to "InviteMembers" modal
         verifyClickInvitePeopleDialog();

--- a/e2e/cypress/integration/team_settings/remove_team_icon_spec.js
+++ b/e2e/cypress/integration/team_settings/remove_team_icon_spec.js
@@ -10,8 +10,6 @@
 // Stage: @prod
 // Group: @team_settings
 
-let team;
-
 function openTeamSettingsDialog() {
     // validating the side bar is visible
     cy.get('#sidebarHeaderDropdownButton').should('be.visible');
@@ -36,18 +34,16 @@ function openTeamSettingsDialog() {
 }
 
 describe('Teams Settings', () => {
+    let testTeam;
+
     before(() => {
-        // # Login as sysadmin and update config
-        cy.apiLogin('sysadmin');
+        // # Update config
         cy.apiUpdateConfig({EmailSettings: {RequireEmailVerification: false}});
 
-        // # Login as new user
-        cy.apiCreateAndLoginAsNewUser().then(() => {
-            // # Create new team and visit its URL
-            cy.apiCreateTeam('test-team', 'Test Team').then((response) => {
-                team = response.body;
-                cy.visit(`/${team.name}`);
-            });
+        cy.apiInitSetup().then(({team}) => {
+            testTeam = team;
+
+            cy.visit(`/${testTeam.name}/channels/town-square`);
         });
     });
 
@@ -70,7 +66,7 @@ describe('Teams Settings', () => {
         // close the team settings dialog
         cy.get('#teamSettingsModalLabel > .close').click();
 
-        cy.get(`#${team.name}TeamButton`).within(() => {
+        cy.get(`#${testTeam.name}TeamButton`).within(() => {
             cy.findByTestId('teamIconImage').should('be.visible');
             cy.findByTestId('teamIconInitial').should('not.exist');
         });
@@ -88,7 +84,7 @@ describe('Teams Settings', () => {
         cy.get('#teamSettingsModalLabel > .close').click();
 
         // verify the team icon image is visible and initial team holder is not visible
-        cy.get(`#${team.name}TeamButton`).within(() => {
+        cy.get(`#${testTeam.name}TeamButton`).within(() => {
             cy.findByTestId('teamIconImage').should('be.visible');
             cy.findByTestId('teamIconInitial').should('not.exist');
         });
@@ -106,7 +102,7 @@ describe('Teams Settings', () => {
         cy.get('#teamSettingsModalLabel > .close').click();
 
         // after removing the team icon initial team holder is visible but not team icon holder
-        cy.get(`#${team.name}TeamButton`).within(() => {
+        cy.get(`#${testTeam.name}TeamButton`).within(() => {
             cy.findByTestId('teamIconImage').should('not.exist');
             cy.findByTestId('teamIconInitial').should('be.visible');
         });

--- a/e2e/cypress/integration/team_settings/teams_spec.js
+++ b/e2e/cypress/integration/team_settings/teams_spec.js
@@ -10,14 +10,12 @@
 // Stage: @prod
 // Group: @team_settings
 
-import {getRandomId} from '../../utils';
-import users from '../../fixtures/users.json';
 import * as TIMEOUTS from '../../fixtures/timeouts';
+import {getAdminAccount} from '../../support/env';
 
-function removeTeamMember(teamURL, username) {
-    cy.apiLogout();
-    cy.apiLogin('sysadmin');
-    cy.visit(`/${teamURL}`);
+function removeTeamMember(teamName, username) {
+    cy.apiAdminLogin();
+    cy.visit(`/${teamName}`);
     cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
     cy.get('#manageMembers').click();
     cy.get(`#teamMembersDropdown_${username}`).should('be.visible').click();
@@ -26,16 +24,27 @@ function removeTeamMember(teamURL, username) {
 }
 
 describe('Teams Suite', () => {
+    let testTeam;
+    let testUser;
+
+    beforeEach(() => {
+        cy.apiAdminLogin();
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+        });
+    });
+
     it('TS12995 Cancel out of leaving a team', () => {
         // # Login and go to /
-        cy.apiLogin('user-1');
-        cy.visit('/ad-1/channels/town-square');
+        cy.apiLogin(testUser.username, testUser.password);
+        cy.visit(`/${testTeam.name}/channels/town-square`);
 
         // * check the team name
-        cy.get('#headerTeamName').should('contain', 'eligendi');
+        cy.get('#headerTeamName').should('contain', testTeam.display_name);
 
         // * check the initialUrl
-        cy.url().should('include', '/ad-1/channels/town-square');
+        cy.url().should('include', `/${testTeam.name}/channels/town-square`);
 
         // # open the drop down menu
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
@@ -53,123 +62,114 @@ describe('Teams Suite', () => {
         cy.get('#leaveTeamModal').should('not.be.visible');
 
         // * check the team name
-        cy.get('#headerTeamName').should('contain', 'eligendi');
+        cy.get('#headerTeamName').should('contain', testTeam.display_name);
 
         // * check the finalUrl
-        cy.url().should('include', '/ad-1/channels/town-square');
+        cy.url().should('include', `/${testTeam.name}/channels/town-square`);
     });
 
     it('TS13548 Team or System Admin searches and adds new team member', () => {
-        // # Login as sysadmin and update config
-        cy.apiLogin('sysadmin');
+        // # Update config
         cy.apiUpdateConfig({
             GuestAccountsSettings: {
                 Enable: false,
             },
         });
 
-        const user1 = users['user-1'];
-        const sysadmin = users.sysadmin;
-        const letterCount = 3;
-        const nameStartsWith = user1.firstName.slice(0, letterCount);
-        const teamName = 'Stub team';
-        const teamURL = `team-${getRandomId()}`;
+        let otherUser;
+        cy.apiCreateUser().then(({user}) => {
+            otherUser = user;
 
-        // # Login as System Admin, update teammate name display preference to "username" and visit "/"
-        cy.apiLogin(sysadmin.username);
-        cy.apiSaveTeammateNameDisplayPreference('username');
-        cy.visit('/ad-1/channels/town-square');
+            cy.visit(`/${testTeam.name}/channels/town-square`);
 
-        // # Create team
-        cy.createNewTeam(teamName, teamURL);
+            // # Click hamburger menu > Invite People
+            cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
+            cy.get('#invitePeople').should('be.visible').and('contain', 'Invite People').
+                find('.MenuItem__help-text').should('have.text', 'Add or invite people to the team');
 
-        // # Click hamburger menu > Invite People
-        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
-        cy.get('#invitePeople').should('be.visible').and('contain', 'Invite People').
-            find('.MenuItem__help-text').should('have.text', 'Add or invite people to the team');
+            cy.get('#invitePeople').click();
 
-        cy.get('#invitePeople').click();
+            // * Check that the Invitation Modal opened up
+            cy.findByTestId('invitationModal', {timeout: TIMEOUTS.TINY}).should('be.visible');
 
-        // * Check that the Invitation Modal opened up
-        cy.findByTestId('invitationModal', {timeout: TIMEOUTS.TINY}).should('be.visible');
+            cy.findByTestId('inputPlaceholder').should('be.visible').within(($el) => {
+                // # Type the first letters of a user
+                cy.wrap($el).get('input').type(otherUser.first_name, {force: true});
 
-        cy.findByTestId('inputPlaceholder').should('be.visible').within(($el) => {
-            // # Type the first letters of a user
-            cy.wrap($el).get('input').type(nameStartsWith, {force: true});
+                // * Verify user is on the list, then select by clicking on it
+                cy.wrap($el).get('.users-emails-input__menu').
+                    children().should('have.length', 1).
+                    eq(0).should('contain', `@${otherUser.username}`).and('contain', `${otherUser.first_name} ${otherUser.last_name}`).
+                    click();
+            });
 
-            // * Verify user is on the list, then select by clicking on it
-            cy.wrap($el).get('.users-emails-input__menu').
-                children().should('have.length', 1).
-                eq(0).should('contain', `@${user1.username}`).and('contain', `${user1.firstName} ${user1.lastName}`).
-                click();
+            // # Click "Invite Members" button, then "Done" button
+            cy.findByText(/Invite Members/).should('be.visible').click();
+            cy.findByText(/Done/).should('be.visible').click();
+
+            // * As sysadmin, verify system message posts in Town Square and Off-Topic
+            cy.getLastPost().wait(TIMEOUTS.TINY).then(($el) => {
+                cy.wrap($el).get('.user-popover').
+                    should('be.visible').
+                    and('have.text', 'System');
+                cy.wrap($el).get('.post-message__text-container').
+                    should('be.visible').
+                    and('contain', `You and @${testUser.username} joined the team.`).
+                    and('contain', `@${otherUser.username} added to the team by you.`);
+            });
+
+            cy.get('#sidebarItem_off-topic').should('be.visible').click({force: true});
+            cy.getLastPost().wait(TIMEOUTS.TINY).then(($el) => {
+                cy.wrap($el).get('.user-popover').
+                    should('be.visible').
+                    and('have.text', 'System');
+                cy.wrap($el).get('.post-message__text-container').
+                    should('be.visible').
+                    and('contain', `You and @${testUser.username} joined the channel.`).
+                    and('contain', `@${otherUser.username} added to the channel by you.`);
+            });
+
+            // # Login as user added to Team and reload
+            cy.apiLogin(otherUser.username, otherUser.password);
+
+            // # Visit the new team and verify that it's in the correct team view
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+            cy.get('#headerTeamName').should('contain', testTeam.display_name);
+
+            const sysadmin = getAdminAccount();
+
+            // * As other user, verify system message posts in Town Square and Off-Topic
+            cy.getLastPost().wait(TIMEOUTS.TINY).then(($el) => {
+                cy.wrap($el).get('.user-popover').
+                    should('be.visible').
+                    and('have.text', 'System');
+                cy.wrap($el).get('.post-message__text-container').
+                    should('be.visible').
+                    and('contain', `@${sysadmin.username} joined the team.`).
+                    and('contain', `You were added to the team by @${sysadmin.username}.`);
+            });
+
+            cy.get('#sidebarItem_off-topic').should('be.visible').click({force: true});
+            cy.getLastPost().wait(TIMEOUTS.TINY).then(($el) => {
+                cy.wrap($el).get('.user-popover').
+                    should('be.visible').
+                    and('have.text', 'System');
+                cy.wrap($el).get('.post-message__text-container').
+                    should('be.visible').
+                    and('contain', `@${sysadmin.username} joined the channel.`).
+                    and('contain', `You were added to the channel by @${sysadmin.username}.`);
+            });
+
+            // # Remove user from team
+            removeTeamMember(testTeam.name, otherUser.username);
         });
-
-        // # Click "Invite Members" button, then "Done" button
-        cy.findByText(/Invite Members/).should('be.visible').click();
-        cy.findByText(/Done/).should('be.visible').click();
-
-        // * As sysadmin, verify system message posts in Town Square and Off-Topic
-        cy.getLastPost().wait(TIMEOUTS.TINY).then(($el) => {
-            cy.wrap($el).get('.user-popover').
-                should('be.visible').
-                and('have.text', 'System');
-            cy.wrap($el).get('.post-message__text-container').
-                should('be.visible').
-                and('contain', 'You joined the team.').
-                and('contain', `@${user1.username} added to the team by you.`);
-        });
-
-        cy.get('#sidebarItem_off-topic').should('be.visible').click({force: true});
-        cy.getLastPost().wait(TIMEOUTS.TINY).then(($el) => {
-            cy.wrap($el).get('.user-popover').
-                should('be.visible').
-                and('have.text', 'System');
-            cy.wrap($el).get('.post-message__text-container').
-                should('be.visible').
-                and('contain', 'You joined the channel.').
-                and('contain', `@${user1.username} added to the channel by you.`);
-        });
-
-        // # Login as user added to Team, update teammate name display preference to "username" and reload
-        cy.apiLogin(user1.username);
-        cy.apiSaveTeammateNameDisplayPreference('username');
-        cy.reload();
-
-        // # Visit the new team and verify that it's in the correct team view
-        cy.visit(`/${teamURL}/channels/town-square`);
-        cy.get(`#${teamURL}TeamButton`).should('have.attr', 'href').and('contain', teamURL);
-
-        // * As user-1, verify system message posts in Town Square and Off-Topic
-        cy.getLastPost().wait(TIMEOUTS.TINY).then(($el) => {
-            cy.wrap($el).get('.user-popover').
-                should('be.visible').
-                and('have.text', 'System');
-            cy.wrap($el).get('.post-message__text-container').
-                should('be.visible').
-                and('contain', `@${sysadmin.username} joined the team.`).
-                and('contain', `You were added to the team by @${sysadmin.username}.`);
-        });
-
-        cy.get('#sidebarItem_off-topic').should('be.visible').click({force: true});
-        cy.getLastPost().wait(TIMEOUTS.TINY).then(($el) => {
-            cy.wrap($el).get('.user-popover').
-                should('be.visible').
-                and('have.text', 'System');
-            cy.wrap($el).get('.post-message__text-container').
-                should('be.visible').
-                and('contain', `@${sysadmin.username} joined the channel.`).
-                and('contain', `You were added to the channel by @${sysadmin.username}.`);
-        });
-
-        // # Remove user from team
-        removeTeamMember(teamURL, user1.username);
     });
 
     it('TS14633 Leave all teams', () => {
         cy.apiUpdateConfig({EmailSettings: {RequireEmailVerification: false}});
 
-        // # Login as new user
-        cy.apiCreateAndLoginAsNewUser();
+        // // # Login as test user
+        cy.apiLogin(testUser.username, testUser.password);
 
         // # Leave all teams
         cy.apiGetTeams().then((response) => {

--- a/e2e/cypress/integration/websocket/handle_removed_user/helpers.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user/helpers.js
@@ -1,0 +1,99 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+export function createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass) {
+    // # Start with a new team
+    cy.createNewTeam(teamName, teamName);
+
+    // * Verify that we've switched to the new team
+    cy.get('#headerTeamName').should('be.visible').should('be.visible').should('contain', teamName);
+
+    // # Click on Off Topic
+    cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('be.visible').click();
+
+    // * Verify that the channel changed
+    cy.url().should('include', `/${teamName}/channels/off-topic`);
+    cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Off-Topic');
+}
+
+export function removeMeFromCurrentChannel() {
+    // # Remove the Guest User from channel
+    let channelId;
+    return cy.getCurrentChannelId().then((res) => {
+        channelId = res;
+        return cy.apiGetMe();
+    }).then((res) => {
+        const userId = res.body.id;
+        return cy.removeUserFromChannel(channelId, userId);
+    });
+}
+
+export function verifyRHS(teamName, sidebarItemClass, postId) {
+    // # Dismiss the modal informing the user they were kicked out
+    cy.get('#removedChannelBtn').click();
+
+    // * Verify that the channel changed back to Town Square
+    cy.url().should('include', `/${teamName}/channels/town-square`);
+    cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+
+    // * Verify that Off-Topic has been removed
+    cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('not.exist');
+
+    // * Verify that the recently posted message is no longer in the RHS
+    cy.get(`#rhsPostMessageText_${postId}`).should('not.exist');
+}
+
+export function shouldRemoveMentionsInRHS(teamName, sidebarItemClass) {
+    let postId;
+
+    // # Post a unique message with a mention and retrieve its ID
+    cy.apiGetMe().then((res) => {
+        var messageText = `${Date.now()} - mention to @${res.body.username} `;
+        cy.postMessage(messageText);
+
+        return cy.getLastPostId();
+    }).then((lastPostId) => {
+        postId = lastPostId;
+
+        // # Click on the Recent Mentions button to open the RHS
+        cy.get('#channelHeaderMentionButton').click();
+
+        // * Verify that the recently posted message is shown in the RHS
+        cy.get(`#rhsPostMessageText_${postId}`).should('exist');
+
+        return removeMeFromCurrentChannel();
+    }).then(() => {
+        verifyRHS(teamName, sidebarItemClass, postId);
+    });
+}
+
+export function shouldRemoveFlaggedPostsInRHS(teamName, sidebarItemClass) {
+    let postId;
+
+    // # Post a unique message and retrieve its ID
+    var messageText = `${Date.now()} - post to flag`;
+    cy.postMessage(messageText);
+
+    cy.getLastPostId().then((lastPostId) => {
+        postId = lastPostId;
+
+        // # Flag the last post
+        cy.clickPostFlagIcon(postId);
+
+        // # Click on the Flagged Posts button to open the RHS
+        cy.get('#channelHeaderFlagButton').click();
+
+        // * Verify that the recently posted message is shown in the RHS
+        cy.get(`#rhsPostMessageText_${postId}`).should('exist');
+
+        return removeMeFromCurrentChannel();
+    }).then(() => {
+        verifyRHS(teamName, sidebarItemClass, postId);
+    });
+}

--- a/e2e/cypress/integration/websocket/handle_removed_user/new_sidebar_spec.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user/new_sidebar_spec.js
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @websocket
+
+import {testWithConfig} from '../../../support/hooks';
+import {getRandomId} from '../../../utils';
+
+import {
+    createNewTeamAndMoveToOffTopic,
+    removeMeFromCurrentChannel,
+    shouldRemoveFlaggedPostsInRHS,
+    shouldRemoveMentionsInRHS,
+} from './helpers';
+
+describe('Handle removed user - new sidebar', () => {
+    const sidebarItemClass = '.SidebarChannel';
+
+    testWithConfig({
+        ServiceSettings: {
+            ExperimentalChannelSidebarOrganization: 'default_on',
+        },
+    });
+
+    before(() => {
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            cy.visit(`/${team.name}/channels/${channel.name}`);
+        });
+    });
+
+    it('should be redirected to last channel when a user is removed from their current channel', () => {
+        const teamName = `team-${getRandomId()}`;
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
+
+        removeMeFromCurrentChannel().then(() => {
+            // * Verify that the channel changed back to Town Square
+            cy.url().should('include', `/${teamName}/channels/town-square`);
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+        });
+    });
+
+    it('should remove mentions from RHS', () => {
+        const teamName = `team-${getRandomId()}`;
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
+        shouldRemoveMentionsInRHS(teamName, sidebarItemClass);
+    });
+
+    it('should remove flagged posts from RHS', () => {
+        const teamName = `team-${getRandomId()}`;
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
+        shouldRemoveFlaggedPostsInRHS(teamName, sidebarItemClass);
+    });
+});

--- a/e2e/cypress/integration/websocket/handle_removed_user/old_sidebar_spec.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user/old_sidebar_spec.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @websocket
+
+import {getRandomId} from '../../../utils';
+
+import {
+    createNewTeamAndMoveToOffTopic,
+    removeMeFromCurrentChannel,
+    shouldRemoveFlaggedPostsInRHS,
+    shouldRemoveMentionsInRHS,
+} from './helpers';
+
+describe('Handle removed user - old sidebar', () => {
+    const sidebarItemClass = '.sidebar-item';
+
+    before(() => {
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
+            cy.visit(`/${team.name}/channels/${channel.name}`);
+        });
+    });
+
+    it('should be redirected to last channel when a user is removed from their current channel', () => {
+        const teamName = `team-${getRandomId()}`;
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
+
+        removeMeFromCurrentChannel().then(() => {
+            // * Verify that the channel changed back to Town Square and that Off-Topic has been removed
+            cy.url().should('include', `/${teamName}/channels/town-square`);
+            cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+            cy.get(`${sidebarItemClass}:contains(Off-Topic)`).should('not.exist');
+        });
+    });
+
+    it('should remove mentions from RHS', () => {
+        const teamName = `team-${getRandomId()}`;
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
+        shouldRemoveMentionsInRHS(teamName, sidebarItemClass);
+    });
+
+    it('should remove flagged posts from RHS', () => {
+        const teamName = `team-${getRandomId()}`;
+        createNewTeamAndMoveToOffTopic(teamName, sidebarItemClass);
+        shouldRemoveFlaggedPostsInRHS(teamName, sidebarItemClass);
+    });
+});

--- a/e2e/cypress/support/api/index.js
+++ b/e2e/cypress/support/api/index.js
@@ -1,0 +1,5 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import './setup';
+import './user';

--- a/e2e/cypress/support/api/setup.d.ts
+++ b/e2e/cypress/support/api/setup.d.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Meaningful description
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// Custom command should follow naming convention of having `api` prefix, e.g. `apiLogin`.
+// ***************************************************************
+
+declare namespace Cypress {
+    interface Chainable<Subject = any> {
+
+        /**
+         * Creates a new user and make it a member of the new public team and its channels - one public channel, town-square and off-topic.
+         * Created user has an option to log in after all are setup.
+         * @param {boolean} options.loginAfter - false (default) or true if wants to login as the new user after setting up
+         * @returns {Object} `out` Cypress-chainable, yielded with element passed into .wrap().
+         * @returns {UserProfile} `out.user` as `UserProfile` object
+         * @returns {Team} `out.team` as `Team` object
+         * @returns {Channel} `out.channel` as `Channel` object
+         *
+         * @example
+         *   let testUser;
+         *   let testTeam;
+         *   let testChannel;
+         *   cy.apiInitSetup(options).then(({team, channel, user}) => {
+         *       testUser = user;
+         *       testTeam = team;
+         *       testChannel = channel;
+         *   });
+         */
+        apiInitSetup(options: Record<string, any>): Chainable<Record<string, any>>;
+    }
+}

--- a/e2e/cypress/support/api/setup.js
+++ b/e2e/cypress/support/api/setup.js
@@ -1,9 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-Cypress.Commands.add('apiInitSetup', (options = {}) => {
-    const loginAfter = options.loginAfter || false;
-
+Cypress.Commands.add('apiInitSetup', ({loginAfter = false} = {}) => {
     return cy.apiCreateTeam('team', 'Team').then((teamRes) => {
         const team = teamRes.body;
 

--- a/e2e/cypress/support/api/setup.js
+++ b/e2e/cypress/support/api/setup.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+Cypress.Commands.add('apiInitSetup', (options = {}) => {
+    const loginAfter = options.loginAfter || false;
+
+    return cy.apiCreateTeam('team', 'Team').then((teamRes) => {
+        const team = teamRes.body;
+
+        // # Add public channel
+        return cy.apiCreateChannel(team.id, 'channel', 'Channel').then((channelRes) => {
+            const channel = channelRes.body;
+
+            return cy.apiCreateUser().then(({user}) => {
+                return cy.apiAddUserToTeam(team.id, user.id).then(() => {
+                    return cy.apiAddUserToChannel(channel.id, user.id).then(() => {
+                        if (loginAfter) {
+                            return cy.apiLogin(user.username, user.password).then(() => {
+                                return cy.wrap({team, channel, user});
+                            });
+                        }
+
+                        return cy.wrap({team, channel, user});
+                    });
+                });
+            });
+        });
+    });
+});

--- a/e2e/cypress/support/api/user.d.ts
+++ b/e2e/cypress/support/api/user.d.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Meaningful description
+// - Specific link to https://api.mattermost.com
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// Custom command should follow naming convention of having `api` prefix, e.g. `apiLogin`.
+// ***************************************************************
+
+declare namespace Cypress {
+    interface Chainable<Subject = any> {
+
+        /**
+         * Creates an admin account based from the env variables defined in Cypress env
+         * @param {string} options.namePrefix - 'user' (default) or any prefix to easily identify a user
+         * @param {boolean} options.bypassTutorial - true (default) or false for user to go thru tutorial steps
+         * @returns {Object} `out` Cypress-chainable, yielded with element passed into .wrap().
+         * @returns {UserProfile} `out.sysadmin` as `UserProfile` object
+         *
+         * @example
+         *   cy.apiCreateAdmin(options);
+         */
+        apiCreateAdmin(options: Record<string, any>): Chainable<Record<string, any>>;
+
+        /**
+         * Creates a new user with an options to set name prefix and be able to bypass tutorial steps
+         * @param {string} options.user - predefined `user` object instead on random user
+         * @param {string} options.prefix - 'user' (default) or any prefix to easily identify a user
+         * @param {boolean} options.bypassTutorial - true (default) or false for user to go thru tutorial steps
+         * @returns {Object} `out` Cypress-chainable, yielded with element passed into .wrap().
+         * @returns {UserProfile} `out.user` as `UserProfile` object
+         *
+         * @example
+         *   cy.apiCreateUser(options);
+         */
+        apiCreateUser(options: Record<string, any>): Chainable<Record<string, any>>;
+
+        /**
+         * Creates a new guest user with an options to set name prefix and be able to bypass tutorial steps
+         * @param {string} options.prefix - 'guest' (default) or any prefix to easily identify a guest
+         * @param {boolean} options.bypassTutorial - true (default) or false for guest to go thru tutorial steps
+         * @returns {Object} `out` Cypress-chainable, yielded with element passed into .wrap().
+         * @returns {UserProfile} `out.guest` as `UserProfile` object
+         *
+         * @example
+         *   cy.apiCreateGuestUser(options);
+         */
+        apiCreateGuestUser(options: Record<string, any>): Chainable<Record<string, any>>;
+
+        /**
+         * Do not use. To be deprecated soon.
+         */
+        apiCreateNewUser(options: Record<string, any>): Chainable<Record<string, any>>;
+    }
+}

--- a/e2e/cypress/support/api/user.js
+++ b/e2e/cypress/support/api/user.js
@@ -212,6 +212,9 @@ Cypress.Commands.add('apiUpdateUserStatus', (status = 'online') => {
             url: '/api/v4/users/me/status',
             method: 'PUT',
             body: data,
+        }).then((response) => {
+            expect(response.status).to.equal(200);
+            cy.wrap({status: response.body});
         });
     });
 });

--- a/e2e/cypress/support/api/user.js
+++ b/e2e/cypress/support/api/user.js
@@ -165,17 +165,14 @@ function generateRandomUser(prefix = 'user') {
     };
 }
 
-Cypress.Commands.add('apiCreateUser', (options = {}) => {
-    const prefix = options.prefix || 'user';
-    const bypassTutorial = options.hasOwnProperty('bypassTutorial') ? options.bypassTutorial : true;
-
-    const user = options.user || generateRandomUser(prefix);
+Cypress.Commands.add('apiCreateUser', ({prefix = 'user', bypassTutorial = true, user = null} = {}) => {
+    const newUser = user || generateRandomUser(prefix);
 
     const createUserOption = {
         headers: {'X-Requested-With': 'XMLHttpRequest'},
         method: 'POST',
         url: '/api/v4/users',
-        body: user,
+        body: newUser,
     };
 
     return cy.request(createUserOption).then((userRes) => {
@@ -187,7 +184,7 @@ Cypress.Commands.add('apiCreateUser', (options = {}) => {
             cy.apiSaveTutorialStep(createdUser.id, '999');
         }
 
-        return cy.wrap({user: {...createdUser, password: user.password}});
+        return cy.wrap({user: {...createdUser, password: newUser.password}});
     });
 });
 

--- a/e2e/cypress/support/api/user.js
+++ b/e2e/cypress/support/api/user.js
@@ -1,0 +1,235 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getRandomId} from '../../utils';
+import {getAdminAccount} from '../env';
+
+// *****************************************************************************
+// Users
+// https://api.mattermost.com/#tag/users
+// *****************************************************************************
+
+Cypress.Commands.add('apiGetUserByEmail', (email) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/users/email/' + email,
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        cy.wrap(response);
+    });
+});
+
+Cypress.Commands.add('apiGetUsers', (usernames = []) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/users/usernames',
+        method: 'POST',
+        body: usernames,
+    });
+});
+
+Cypress.Commands.add('apiPatchUser', (userId, userData) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        method: 'PUT',
+        url: `/api/v4/users/${userId}/patch`,
+        body: userData,
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        cy.wrap(response);
+    });
+});
+
+Cypress.Commands.add('apiPatchMe', (data) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/users/me/patch',
+        method: 'PUT',
+        body: data,
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        cy.wrap(response);
+    });
+});
+
+/**
+ * Do not use. To be deprecated soon.
+ * Creates a new user via the API, adds them to 3 teams, and sets preference to bypass tutorial.
+ * Then logs in as the user
+ * @param {Object} user - Object of user email, username, and password that you can optionally set.
+ * @param {Array} teamIDs - list of teams to add the new user to
+ * @param {Boolean} bypassTutorial - whether to set user preferences to bypass the tutorial on first login (true) or to show it (false)
+ * Otherwise use default values
+ @returns {Object} Returns object containing email, username, id and password if you need it further in the test
+ */
+
+Cypress.Commands.add('apiCreateNewUser', (user = {}, teamIds = [], bypassTutorial = true) => {
+    const randomId = getRandomId();
+
+    const {
+        email = `user${randomId}@sample.mattermost.com`,
+        username = `user${randomId}`,
+        firstName = `First${randomId}`,
+        lastName = `Last${randomId}`,
+        nickname = `NewE2ENickname${randomId}`,
+        password = 'password123',
+    } = user;
+
+    const createUserOption = {
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        method: 'POST',
+        url: '/api/v4/users',
+        body: {email, username, first_name: firstName, last_name: lastName, password, nickname},
+    };
+
+    // # Create a new user
+    return cy.request(createUserOption).then((userResponse) => {
+        // Safety assertions to make sure we have a valid response
+        expect(userResponse).to.have.property('body').to.have.property('id');
+
+        const userId = userResponse.body.id;
+
+        if (teamIds && teamIds.length > 0) {
+            teamIds.forEach((teamId) => {
+                cy.apiAddUserToTeam(teamId, userId);
+            });
+        } else {
+            // Get teams, select the first three, and add new user to that team
+            cy.request('GET', '/api/v4/teams').then((teamsResponse) => {
+                // Verify we have at least 1 team in the response to add the user to
+                expect(teamsResponse).to.have.property('body').to.have.length.greaterThan(0);
+
+                // Also add the user to the default team ad-1
+                teamsResponse.body.
+                    filter((t) => t.name === 'ad-1').
+                    map((t) => t.id).
+                    forEach((teamId) => {
+                        cy.apiAddUserToTeam(teamId, userId);
+                    });
+            });
+        }
+
+        // # If the bypass flag is true, bypass tutorial
+        if (bypassTutorial === true) {
+            const preferences = [{
+                user_id: userId,
+                category: 'tutorial_step',
+                name: userId,
+                value: '999',
+            }];
+
+            cy.apiSaveUserPreference(preferences, userId);
+        }
+
+        // Wrap our user object so it gets returned from our cypress command
+        cy.wrap({email, username, password, id: userId, firstName, lastName, nickname});
+    });
+});
+
+Cypress.Commands.add('apiCreateAdmin', () => {
+    const {username, password} = getAdminAccount();
+
+    const sysadminUser = {
+        username,
+        password,
+        first_name: 'Kenneth',
+        last_name: 'Moreno',
+        email: 'sysadmin@sample.mattermost.com',
+    };
+
+    const options = {
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        method: 'POST',
+        url: '/api/v4/users',
+        body: sysadminUser,
+    };
+
+    // # Create a new user
+    return cy.request(options).then((res) => {
+        expect(res.status).to.equal(201);
+
+        cy.wrap({sysadmin: res.body});
+    });
+});
+
+function generateRandomUser(prefix = 'user') {
+    const randomId = getRandomId();
+
+    return {
+        email: `${prefix}${randomId}@sample.mattermost.com`,
+        username: `${prefix}${randomId}`,
+        password: 'passwd',
+        first_name: `First${randomId}`,
+        last_name: `Last${randomId}`,
+        nickname: `Nickname${randomId}`,
+    };
+}
+
+Cypress.Commands.add('apiCreateUser', (options = {}) => {
+    const prefix = options.prefix || 'user';
+    const bypassTutorial = options.hasOwnProperty('bypassTutorial') ? options.bypassTutorial : true;
+
+    const user = options.user || generateRandomUser(prefix);
+
+    const createUserOption = {
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        method: 'POST',
+        url: '/api/v4/users',
+        body: user,
+    };
+
+    return cy.request(createUserOption).then((userRes) => {
+        expect(userRes.status).to.equal(201);
+
+        const createdUser = userRes.body;
+
+        if (bypassTutorial) {
+            cy.apiSaveTutorialStep(createdUser.id, '999');
+        }
+
+        return cy.wrap({user: {...createdUser, password: user.password}});
+    });
+});
+
+Cypress.Commands.add('apiCreateGuestUser', (options = {}) => {
+    const prefix = options.prefix || 'guest';
+
+    return cy.apiCreateUser({...options, prefix}).then(({user}) => {
+        cy.demoteUser(user.id);
+
+        return cy.wrap({guest: user});
+    });
+});
+
+/**
+ * Saves channel display mode preference of a user directly via API
+ * This API assume that the user is logged in and has cookie to access
+ * @param {String} status - "online" (default), "offline", "away" or "dnd"
+ */
+Cypress.Commands.add('apiUpdateUserStatus', (status = 'online') => {
+    return cy.getCookie('MMUSERID').then((cookie) => {
+        const data = {user_id: cookie.value, status};
+
+        return cy.request({
+            headers: {'X-Requested-With': 'XMLHttpRequest'},
+            url: '/api/v4/users/me/status',
+            method: 'PUT',
+            body: data,
+        });
+    });
+});
+
+/**
+ * Revoke all active sessions for a user
+ * @param {String} userId - ID of user to revoke sessions
+ */
+Cypress.Commands.add('apiRevokeUserSessions', (userId) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: `/api/v4/users/${userId}/sessions/revoke/all`,
+        method: 'POST',
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        cy.wrap(response);
+    });
+});

--- a/e2e/cypress/support/api_commands.d.ts
+++ b/e2e/cypress/support/api_commands.d.ts
@@ -16,12 +16,6 @@
 // ***************************************************************
 
 declare namespace Cypress {
-    type Bot = import('mattermost-redux/types/bots').Bot;
-    type Channel = import('mattermost-redux/types/channels').Channel;
-    type ChannelMembership = import('mattermost-redux/types/channels').ChannelMembership;
-    type ChannelType = import('mattermost-redux/types/channels').ChannelType;
-    type UserProfile = import('mattermost-redux/types/users').UserProfile;
-
     interface Chainable<Subject = any> {
 
         // *******************************************************************************

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import xor from 'lodash.xor';
 import merge from 'merge-deep';
 
 import {getRandomId} from '../utils';
@@ -9,6 +10,8 @@ import users from '../fixtures/users.json';
 import partialDefaultConfig from '../fixtures/partial_default_config.json';
 
 import theme from '../fixtures/theme.json';
+
+import {getAdminAccount} from './env';
 
 // *****************************************************************************
 // Read more:
@@ -31,6 +34,12 @@ Cypress.Commands.add('apiLogin', (username = 'user-1', password = null) => {
         expect(response.status).to.equal(200);
         return cy.wrap(response);
     });
+});
+
+Cypress.Commands.add('apiAdminLogin', () => {
+    const admin = getAdminAccount();
+
+    return cy.apiLogin(admin.username, admin.password);
 });
 
 Cypress.Commands.add('apiLogout', () => {
@@ -73,8 +82,8 @@ Cypress.Commands.add('apiGetBots', () => {
 // https://api.mattermost.com/#tag/channels
 // *****************************************************************************
 
-Cypress.Commands.add('apiCreateChannel', (teamId, name, displayName, type = 'O', purpose = '', header = '') => {
-    const uniqueName = `${name}-${getRandomId()}`;
+Cypress.Commands.add('apiCreateChannel', (teamId, name, displayName, type = 'O', purpose = '', header = '', unique = true) => {
+    const randomSuffix = getRandomId();
 
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -82,8 +91,8 @@ Cypress.Commands.add('apiCreateChannel', (teamId, name, displayName, type = 'O',
         method: 'POST',
         body: {
             team_id: teamId,
-            name: uniqueName,
-            display_name: displayName,
+            name: unique ? `${name}-${randomSuffix}` : name,
+            display_name: unique ? `${displayName} ${randomSuffix}` : displayName,
             type,
             purpose,
             header,
@@ -176,6 +185,16 @@ Cypress.Commands.add('apiGetChannel', (channelId) => {
     });
 });
 
+Cypress.Commands.add('apiGetAllChannels', () => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/channels',
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        return cy.wrap(response);
+    });
+});
+
 Cypress.Commands.add('apiAddUserToChannel', (channelId, userId) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
@@ -186,6 +205,19 @@ Cypress.Commands.add('apiAddUserToChannel', (channelId, userId) => {
         },
     }).then((response) => {
         expect(response.status).to.equal(201);
+        return cy.wrap(response);
+    });
+});
+
+/**
+ * https://api.mattermost.com/#tag/channels/paths/~1users~1{user_id}~1teams~1{team_id}~1channels/get
+ */
+Cypress.Commands.add('apiGetChannelsForUser', (userId, teamId) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: `/api/v4/users/${userId}/teams/${teamId}/channels`,
+    }).then((response) => {
+        expect(response.status).to.equal(200);
         return cy.wrap(response);
     });
 });
@@ -243,18 +275,19 @@ Cypress.Commands.add('apiEmailTest', () => {
  * @param {String} name - Unique handler for a team, will be present in the team URL
  * @param {String} displayName - Non-unique UI name for the team
  * @param {String} type - 'O' for open (default), 'I' for invite only
+ * @param {Boolean} unique - if true (default), it will create with unique/random team namae.
  * All parameters required
  */
-Cypress.Commands.add('apiCreateTeam', (name, displayName, type = 'O') => {
-    const uniqueName = `${name}-${getRandomId()}`;
+Cypress.Commands.add('apiCreateTeam', (name, displayName, type = 'O', unique = true) => {
+    const randomSuffix = getRandomId();
 
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
         url: '/api/v4/teams',
         method: 'POST',
         body: {
-            name: uniqueName,
-            display_name: displayName,
+            name: unique ? `${name}-${randomSuffix}` : name,
+            display_name: unique ? `${displayName} ${randomSuffix}` : displayName,
             type,
         },
     }).then((response) => {
@@ -576,184 +609,20 @@ Cypress.Commands.add('apiSavePreviewCollapsedPreference', (collapse = 'true') =>
     });
 });
 
-// *****************************************************************************
-// Users
-// https://api.mattermost.com/#tag/users
-// *****************************************************************************
-
-Cypress.Commands.add('apiGetUserByEmail', (email) => {
-    return cy.request({
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/api/v4/users/email/' + email,
-    }).then((response) => {
-        expect(response.status).to.equal(200);
-        cy.wrap(response);
-    });
-});
-
-Cypress.Commands.add('apiGetUsers', (usernames = []) => {
-    return cy.request({
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/api/v4/users/usernames',
-        method: 'POST',
-        body: usernames,
-    });
-});
-
-Cypress.Commands.add('apiPatchUser', (userId, userData) => {
-    return cy.request({
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
-        method: 'PUT',
-        url: `/api/v4/users/${userId}/patch`,
-        body: userData,
-    }).then((response) => {
-        expect(response.status).to.equal(200);
-        cy.wrap(response);
-    });
-});
-
-Cypress.Commands.add('apiPatchMe', (data) => {
-    return cy.request({
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/api/v4/users/me/patch',
-        method: 'PUT',
-        body: data,
-    }).then((response) => {
-        expect(response.status).to.equal(200);
-        cy.wrap(response);
-    });
-});
-
 /**
- * Creates a new user via the API, adds them to 3 teams, and sets preference to bypass tutorial.
- * Then logs in as the user
- * @param {Object} user - Object of user email, username, and password that you can optionally set.
- * @param {Array} teamIDs - list of teams to add the new user to
- * @param {Boolean} bypassTutorial - whether to set user preferences to bypass the tutorial on first login (true) or to show it (false)
- * Otherwise use default values
- @returns {Object} Returns object containing email, username, id and password if you need it further in the test
+ * Saves tutorial step of a user
+ * This API assume that the user is logged in and has cookie to access
+ * @param {string} value - value of tutorial step, e.g. '999' (default, completed tutorial)
  */
-
-Cypress.Commands.add('apiCreateNewUser', (user = {}, teamIds = [], bypassTutorial = true) => {
-    const randomId = getRandomId();
-
-    const {
-        email = `user${randomId}@sample.mattermost.com`,
-        username = `user${randomId}`,
-        firstName = `First${randomId}`,
-        lastName = `Last${randomId}`,
-        nickname = `NewE2ENickname${randomId}`,
-        password = 'password123'} = user;
-
-    const createUserOption = {
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
-        method: 'POST',
-        url: '/api/v4/users',
-        body: {email, username, first_name: firstName, last_name: lastName, password, nickname},
+Cypress.Commands.add('apiSaveTutorialStep', (userId, value = '999') => {
+    const preference = {
+        user_id: userId,
+        category: 'tutorial_step',
+        name: userId,
+        value,
     };
 
-    // # Create a new user
-    return cy.request(createUserOption).then((userResponse) => {
-        // Safety assertions to make sure we have a valid response
-        expect(userResponse).to.have.property('body').to.have.property('id');
-
-        const userId = userResponse.body.id;
-
-        if (teamIds && teamIds.length > 0) {
-            teamIds.forEach((teamId) => {
-                cy.apiAddUserToTeam(teamId, userId);
-            });
-        } else {
-            // Get teams, select the first three, and add new user to that team
-            cy.request('GET', '/api/v4/teams').then((teamsResponse) => {
-                // Verify we have at least 2 teams in the response to add the user to
-                expect(teamsResponse).to.have.property('body').to.have.length.greaterThan(1);
-
-                // Pull out only the first 2 teams
-                teamsResponse.body.
-                    filter((t) => t.delete_at === 0).
-                    slice(0, 2).
-                    map((t) => t.id).
-                    forEach((teamId) => {
-                        cy.apiAddUserToTeam(teamId, userId);
-                    });
-
-                // Also add the user to the default team ad-1
-                teamsResponse.body.
-                    filter((t) => t.name === 'ad-1').
-                    map((t) => t.id).
-                    forEach((teamId) => {
-                        cy.apiAddUserToTeam(teamId, userId);
-                    });
-            });
-        }
-
-        // # If the bypass flag is true, bypass tutorial
-        if (bypassTutorial === true) {
-            const preferences = [{
-                user_id: userId,
-                category: 'tutorial_step',
-                name: userId,
-                value: '999',
-            }];
-
-            cy.apiSaveUserPreference(preferences, userId);
-        }
-
-        // Wrap our user object so it gets returned from our cypress command
-        cy.wrap({email, username, password, id: userId, firstName, lastName, nickname});
-    });
-});
-
-/**
- * Creates a new user via the API , adds them to 3 teams, and sets preference to bypass tutorial.
- * Then logs in as the user
- * @param {Object} user - Object of user email, username, and password that you can optionally set.
- * @param {Boolean} bypassTutorial - Whether to set user preferences to bypass the tutorial (true) or to show it (false)
- * Otherwise use default values
- @returns {Object} Returns object containing email, username, id and password if you need it further in the test
- */
-Cypress.Commands.add('apiCreateAndLoginAsNewUser', (user = {}, teamIds = [], bypassTutorial = true) => {
-    return cy.apiCreateNewUser(user, teamIds, bypassTutorial).then((newUser) => {
-        return cy.apiLogin(newUser.username, newUser.password).then((response) => {
-            expect(response.status).to.equal(200);
-
-            return cy.wrap(newUser);
-        });
-    });
-});
-
-/**
- * Saves channel display mode preference of a user directly via API
- * This API assume that the user is logged in and has cookie to access
- * @param {String} status - "online" (default), "offline", "away" or "dnd"
- */
-Cypress.Commands.add('apiUpdateUserStatus', (status = 'online') => {
-    return cy.getCookie('MMUSERID').then((cookie) => {
-        const data = {user_id: cookie.value, status};
-
-        return cy.request({
-            headers: {'X-Requested-With': 'XMLHttpRequest'},
-            url: '/api/v4/users/me/status',
-            method: 'PUT',
-            body: data,
-        });
-    });
-});
-
-/**
- * Revoke all active sessions for a user
- * @param {String} userId - ID of user to revoke sessions
- */
-Cypress.Commands.add('apiRevokeUserSessions', (userId) => {
-    return cy.request({
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: `/api/v4/users/${userId}/sessions/revoke/all`,
-        method: 'POST',
-    }).then((response) => {
-        expect(response.status).to.equal(200);
-        cy.wrap(response);
-    });
+    return cy.apiSaveUserPreference([preference], userId);
 });
 
 // *****************************************************************************
@@ -853,7 +722,7 @@ Cypress.Commands.add('apiGetConfig', () => {
  * Get some analytics data about the system.
  */
 Cypress.Commands.add('apiGetAnalytics', () => {
-    cy.apiLogin('sysadmin');
+    cy.apiAdminLogin();
 
     return cy.request('/api/v4/analytics/old').then((response) => {
         expect(response.status).to.equal(200);
@@ -913,34 +782,6 @@ Cypress.Commands.add('apiGetTeam', (teamId) => {
 });
 
 /**
- * Creates a new guest user via the API , adds them to 1 team with sysadmin user, and sets preference to bypass tutorial.
- * Then logs in as the user
- * @param {Object} user - Object of user email, username, and password that you can optionally set.
- * @param {Boolean} bypassTutorial - Whether to set user preferences to bypass the tutorial (true) or to show it (false)
- * Otherwise use default values
- @returns {Object} Returns object containing email, username, id and password if you need it further in the test
- */
-Cypress.Commands.add('loginAsNewGuestUser', (user = {}, bypassTutorial = true) => {
-    // # Create a New Team for Guest User
-    return cy.apiCreateTeam('guest-team', 'Guest Team').then((createResponse) => {
-        const team = createResponse.body;
-        cy.getCookie('MMUSERID').then((cookie) => {
-            // #Assign Sysadmin user to the newly created team
-            cy.apiAddUserToTeam(team.id, cookie.value);
-        });
-
-        // #Create New User
-        return cy.apiCreateNewUser(user, [team.id], bypassTutorial).then((newUser) => {
-            // # Demote Regular Member to Guest User
-            cy.demoteUser(newUser.id);
-            cy.apiLogin(newUser.username, newUser.password).then(() => {
-                return cy.wrap({user: newUser, team});
-            });
-        });
-    });
-});
-
-/**
  * Demote a Member to Guest directly via API
  * @param {String} userId - The user ID
  * All parameter required
@@ -948,7 +789,9 @@ Cypress.Commands.add('loginAsNewGuestUser', (user = {}, bypassTutorial = true) =
 Cypress.Commands.add('demoteUser', (userId) => {
     //Demote Regular Member to Guest User
     const baseUrl = Cypress.config('baseUrl');
-    cy.externalRequest({user: users.sysadmin, method: 'post', baseUrl, path: `users/${userId}/demote`});
+    const admin = getAdminAccount();
+
+    cy.externalRequest({user: admin, method: 'post', baseUrl, path: `users/${userId}/demote`});
 });
 
 /**
@@ -960,7 +803,9 @@ Cypress.Commands.add('demoteUser', (userId) => {
 Cypress.Commands.add('removeUserFromChannel', (channelId, userId) => {
     //Remove a User from a Channel
     const baseUrl = Cypress.config('baseUrl');
-    cy.externalRequest({user: users.sysadmin, method: 'delete', baseUrl, path: `channels/${channelId}/members/${userId}`});
+    const admin = getAdminAccount();
+
+    cy.externalRequest({user: admin, method: 'delete', baseUrl, path: `channels/${channelId}/members/${userId}`});
 });
 
 /**
@@ -972,7 +817,9 @@ Cypress.Commands.add('removeUserFromChannel', (channelId, userId) => {
 Cypress.Commands.add('removeUserFromTeam', (teamId, userId) => {
     //Remove a User from a Channel
     const baseUrl = Cypress.config('baseUrl');
-    cy.externalRequest({user: users.sysadmin, method: 'delete', baseUrl, path: `teams/${teamId}/members/${userId}`});
+    const admin = getAdminAccount();
+
+    cy.externalRequest({user: admin, method: 'delete', baseUrl, path: `teams/${teamId}/members/${userId}`});
 });
 
 /**
@@ -983,7 +830,9 @@ Cypress.Commands.add('removeUserFromTeam', (teamId, userId) => {
 Cypress.Commands.add('promoteUser', (userId) => {
     //Promote Regular Member to Guest User
     const baseUrl = Cypress.config('baseUrl');
-    cy.externalRequest({user: users.sysadmin, method: 'post', baseUrl, path: `users/${userId}/promote`});
+    const admin = getAdminAccount();
+
+    cy.externalRequest({user: admin, method: 'post', baseUrl, path: `users/${userId}/promote`});
 });
 
 // *****************************************************************************
@@ -1153,13 +1002,119 @@ Cypress.Commands.add('getRoleByName', (roleName) => {
     });
 });
 
+export const defaultRolesPermissions = {
+    team_admin: [
+        'edit_others_posts',
+        'remove_user_from_team',
+        'manage_team', 'import_team',
+        'manage_team_roles',
+        'manage_channel_roles',
+        'manage_slash_commands',
+        'manage_others_slash_commands',
+        'manage_incoming_webhooks',
+        'manage_outgoing_webhooks',
+        'delete_post',
+        'delete_others_posts',
+        'manage_others_outgoing_webhooks',
+        'add_reaction',
+        'manage_others_incoming_webhooks',
+        'use_channel_mentions',
+        'manage_public_channel_members',
+        'manage_private_channel_members',
+        'create_post',
+        'remove_reaction',
+        'use_group_mentions',
+    ],
+    channel_admin: [
+        'manage_channel_roles',
+        'create_post',
+        'add_reaction',
+        'remove_reaction',
+        'manage_public_channel_members',
+        'manage_private_channel_members',
+        'use_channel_mentions',
+        'use_group_mentions',
+    ],
+    system_user: [
+        'create_direct_channel',
+        'create_group_channel',
+        'permanent_delete_user',
+        'create_team',
+        'get_public_link',
+        'list_public_teams',
+        'join_public_teams',
+        'view_members',
+    ],
+    team_user: [
+        'list_team_channels',
+        'join_public_channels',
+        'read_public_channel',
+        'view_team',
+        'create_public_channel',
+        'create_private_channel',
+        'invite_user',
+        'add_user_to_team',
+    ],
+    channel_user: [
+        'manage_public_channel_properties',
+        'delete_public_channel',
+        'manage_private_channel_properties',
+        'delete_private_channel',
+        'read_channel',
+        'add_reaction',
+        'remove_reaction',
+        'manage_public_channel_members',
+        'upload_file',
+        'create_post',
+        'use_slash_commands',
+        'manage_private_channel_members',
+        'delete_post',
+        'edit_post',
+        'use_channel_mentions',
+        'use_group_mentions',
+    ],
+    system_guest: [
+        'create_direct_channel',
+        'create_group_channel',
+    ],
+    team_guest: [
+        'view_team',
+    ],
+    channel_guest: [
+        'edit_post',
+        'add_reaction',
+        'remove_reaction',
+        'use_channel_mentions',
+        'use_slash_commands',
+        'read_channel',
+        'upload_file',
+        'create_post',
+    ],
+};
+
+/**
+ * Get a list of roles from their names
+ * https://api.mattermost.com/#tag/roles/paths/~1roles~1names/post
+ */
+Cypress.Commands.add('apiGetRolesByNames', (names) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/roles/names',
+        method: 'POST',
+        body: names || Object.keys(defaultRolesPermissions),
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        return cy.wrap(response);
+    });
+});
+
 /**
  * Patch a role.
  *
  * @param {String} roleID - ID of the role to patch
  * @param {String} force - Set to 'true' to overwrite a previously installed plugin with the same ID, if any
  */
-Cypress.Commands.add('patchRole', (roleID, patch) => {
+Cypress.Commands.add('apiPatchRole', (roleID, patch) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
         url: `/api/v4/roles/${roleID}/patch`,
@@ -1169,6 +1124,21 @@ Cypress.Commands.add('patchRole', (roleID, patch) => {
     }).then((response) => {
         expect(response.status).to.equal(200);
         return cy.wrap(response);
+    });
+});
+
+Cypress.Commands.add('apiResetRoles', () => {
+    cy.apiGetRolesByNames().then((res) => {
+        const rolePermissions = res.body;
+
+        rolePermissions.forEach((role) => {
+            const defaultPermissions = defaultRolesPermissions[role.name];
+            const diff = xor(role.permissions, defaultPermissions);
+
+            if (diff.length > 0) {
+                cy.apiPatchRole(role.id, {permissions: defaultPermissions});
+            }
+        });
     });
 });
 
@@ -1208,7 +1178,9 @@ Cypress.Commands.add('apiDeleteScheme', (schemeId) => {
  */
 Cypress.Commands.add('apiActivateUser', (userId, active = true) => {
     const baseUrl = Cypress.config('baseUrl');
-    cy.externalRequest({user: users.sysadmin, method: 'put', baseUrl, path: `users/${userId}/active`, data: {active}});
+    const admin = getAdminAccount();
+
+    cy.externalRequest({user: admin, method: 'put', baseUrl, path: `users/${userId}/active`, data: {active}});
 });
 
 // *****************************************************************************

--- a/e2e/cypress/support/env.js
+++ b/e2e/cypress/support/env.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export function getAdminAccount() {
+    return {
+        username: Cypress.env('adminUsername'),
+        password: Cypress.env('adminPassword'),
+    };
+}
+
+export function getDBConfig() {
+    return {
+        client: Cypress.env('dbClient'),
+        connection: Cypress.env('dbConnection'),
+    };
+}

--- a/e2e/cypress/support/hooks.js
+++ b/e2e/cypress/support/hooks.js
@@ -6,7 +6,6 @@
 export function testWithConfig(config) {
     before(() => {
         let originalConfig;
-        cy.apiLogin('sysadmin');
         cy.apiGetConfig().then((resp) => {
             originalConfig = resp.body;
         });
@@ -15,7 +14,7 @@ export function testWithConfig(config) {
 
         after(() => {
             // # Logging in again since another user session may happen between before and after
-            cy.apiLogin('sysadmin');
+            cy.apiAdminLogin();
             cy.apiUpdateConfig(originalConfig);
         });
     });

--- a/e2e/cypress/support/index.d.ts
+++ b/e2e/cypress/support/index.d.ts
@@ -1,0 +1,12 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+declare namespace Cypress {
+    type Bot = import('mattermost-redux/types/bots').Bot;
+    type Channel = import('mattermost-redux/types/channels').Channel;
+    type ChannelMembership = import('mattermost-redux/types/channels').ChannelMembership;
+    type ChannelType = import('mattermost-redux/types/channels').ChannelType;
+    type UserProfile = import('mattermost-redux/types/users').UserProfile;
+}

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -13,6 +13,7 @@ import 'cypress-wait-until';
 import 'cypress-plugin-tab';
 import addContext from 'mochawesome/addContext';
 
+import './api';
 import './api_commands';
 import './common_login_commands';
 import './db_commands';
@@ -23,6 +24,8 @@ import './saml_commands';
 import './storybook_commands';
 import './task_commands';
 import './ui_commands';
+
+import {getAdminAccount} from './env';
 
 const percentEncoding = {
     ':': '%3A',
@@ -108,11 +111,67 @@ Cypress.on('test:after:run', (test, runnable) => {
     }
 });
 
-// Reset config
 before(() => {
-    cy.apiLogin('sysadmin');
-    cy.apiUpdateConfig();
-    cy.apiInvalidateCache();
+    const admin = getAdminAccount();
+
+    cy.dbGetUser({username: admin.username}).then(({user}) => {
+        if (user.id) {
+            // # Login existing sysadmin
+            cy.apiAdminLogin();
+        } else {
+            // # Create and login a newly created user as sysadmin
+            cy.apiCreateAdmin().then(({sysadmin}) => {
+                cy.apiAdminLogin().then(() => {
+                    cy.apiSaveTutorialStep(sysadmin.id, '999');
+                });
+            });
+        }
+
+        // # Reset config and invalidate cache
+        cy.apiUpdateConfig();
+        cy.apiInvalidateCache();
+
+        // # Reset admin preference
+        cy.apiSaveTeammateNameDisplayPreference('username');
+
+        // # Reset roles
+        cy.apiGetClientLicense().then((res) => {
+            if (res.body.IsLicensed === 'true') {
+                cy.apiResetRoles();
+            }
+        });
+
+        // # Check if default "ad-1" team is present, and
+        // # create if not found.
+        const defaultTeamName = 'ad-1';
+        cy.apiGetTeams().then((teamsRes) => {
+            const teams = teamsRes.body;
+            const defaultTeam = teams && teams.length > 0 && teams.find((team) => team.name === defaultTeamName);
+
+            if (!defaultTeam) {
+                cy.apiCreateTeam(defaultTeamName, 'eligendi', 'O', false);
+            } else if (defaultTeam && Cypress.env('resetBeforeTest')) {
+                teams.forEach((team) => {
+                    if (team.name !== defaultTeamName) {
+                        cy.apiDeleteTeam(team.id);
+                    }
+                });
+
+                cy.apiGetChannelsForUser('me', defaultTeam.id).then((channelsRes) => {
+                    const channels = channelsRes.body;
+
+                    channels.forEach((channel) => {
+                        if (
+                            (channel.team_id === defaultTeam.id || channel.team_name === defaultTeam.name) &&
+                            (channel.name !== 'town-square' && channel.name !== 'off-topic')
+                        ) {
+                            cy.apiDeleteChannel(channel.id);
+                        }
+                    });
+                });
+            }
+        });
+    });
 });
 
 // Add login cookies to whitelist to preserve it

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -131,8 +131,10 @@ before(() => {
         cy.apiUpdateConfig();
         cy.apiInvalidateCache();
 
-        // # Reset admin preference
+        // # Reset admin preference, online status and locale
         cy.apiSaveTeammateNameDisplayPreference('username');
+        cy.apiUpdateUserStatus('online');
+        cy.apiPatchMe({locale: 'en'});
 
         // # Reset roles
         cy.apiGetClientLicense().then((res) => {

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -57,7 +57,7 @@ Cypress.Commands.add('toAccountSettingsModal', () => {
  * Change the message display setting
  * @param {String} setting - as 'STANDARD' or 'COMPACT'
  */
-Cypress.Commands.add('changeMessageDisplaySetting', (setting = 'STANDARD') => {
+Cypress.Commands.add('uiChangeMessageDisplaySetting', (setting = 'STANDARD') => {
     const SETTINGS = {STANDARD: '#message_displayFormatA', COMPACT: '#message_displayFormatB'};
 
     cy.toAccountSettingsModal();
@@ -405,79 +405,6 @@ Cypress.Commands.add('updateChannelHeader', (text) => {
         type(text).
         type('{enter}').
         wait(TIMEOUTS.TINY);
-});
-
-/**
- * On default "ad-1" team, create and visit a new channel
- */
-Cypress.Commands.add('createAndVisitNewChannel', (channelName = 'channel-test') => {
-    cy.visit('/ad-1/channels/town-square');
-
-    cy.getCurrentTeamId().then((teamId) => {
-        cy.apiCreateChannel(teamId, channelName, 'Channel Test').then((res) => {
-            const channel = res.body;
-
-            // # Visit the new channel
-            cy.visit(`/ad-1/channels/${channel.name}`);
-
-            // * Verify channel's display name
-            cy.get('#channelHeaderTitle').should('contain', channel.display_name);
-
-            cy.wrap(channel);
-        });
-    });
-});
-
-/**
- * On default "ad-1" team, create and visit a new direct message between user-1 and the provided user
- * @param {String} user - Username of user to open DM with
- */
-Cypress.Commands.add('createAndVisitNewDirectMessageWith', (user) => {
-    cy.visit('/ad-1/channels/town-square');
-
-    cy.apiGetUsers(['user-1', user]).then((userResponse) => {
-        const userEmailArray = [userResponse.body[1].id, userResponse.body[0].id];
-
-        cy.apiCreateDirectChannel(userEmailArray).then((res) => {
-            const channel = res.body;
-
-            // # Visit the new channel
-            cy.visit(`/ad-1/channels/${channel.name}`);
-
-            // * Verify channel's display name
-            cy.get('#channelHeaderTitle').should('contain', channel.display_name);
-
-            cy.wrap(channel);
-        });
-    });
-});
-
-/**
- * On default "ad-1" team, create and visit a new group message between user-1 and the provided users
- * @param {Array} usernames - Array of usernames of the users to open GM with
- */
-Cypress.Commands.add('createAndVisitNewGroupMessageWith', (usernames) => {
-    cy.visit('/ad-1/channels/town-square');
-
-    cy.apiGetUsers(usernames).then((userResponse) => {
-        const userEmailArray = userResponse.body.map((u) => u.id);
-
-        cy.apiCreateGroupChannel(userEmailArray).then((res) => {
-            const channel = res.body;
-
-            // # Visit the new channel
-            cy.visit(`/ad-1/channels/${channel.name}`);
-
-            // The display name does not contain the logged in user
-            const names = channel.display_name.split(', ');
-            names.splice(names.indexOf('user-1'), 1);
-
-            // * Verify channel's display name
-            cy.get('#channelHeaderTitle').should('contain', names.join(', '));
-
-            cy.wrap(channel);
-        });
-    });
 });
 
 // ***********************************************************

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -3301,6 +3301,12 @@
       "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
       "dev": true
     },
+    "lodash.xor": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.xor/-/lodash.xor-4.5.0.tgz",
+      "integrity": "sha1-TUjtfpgJWwYyWCunFNP/iuj7HbY=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -17,6 +17,7 @@
     "lodash.intersection": "4.4.0",
     "lodash.mapkeys": "4.6.0",
     "lodash.without": "4.4.0",
+    "lodash.xor": "4.5.0",
     "mattermost-redux": "5.23.0",
     "merge-deep": "3.0.2",
     "mime-types": "2.1.27",


### PR DESCRIPTION
#### Summary
This PR changes on how we do Cypress test data preparation. Instead of relying on generated sample data from `make test-data`, we can/should now create test setup on demand. It includes test team, channel and user.

Goals are:
- to be able to run Cypress test against any test server. One use case on short term is running against spinwick - a test server created from PR.
- decrease if not eliminate flaky test in case other test make changes to default user. Like for "sysadmin" or "user-1" that needs to revert changes to user preferences, active status, etc.

This is first installment of hopefully 2 PRs which includes introduction of major changes:
- Cypress env variables of `adminUsername` and `adminPassword` to easily pass sysadmin credential of other test server.  Default values are the ones we're using currently.
- Cypress env variable of `resetBeforeTest` which gives an option to delete teams other than default of "ad-1" and channels before running a test. Default is false; true when running on CI.
- `cy.apiAdminLogin()` - a convenient function to login as admin
- remove redundant admin login at the start of before hook of each spec file since it's already login as admin at `cypress/support/index.js`
-  `cy.apiInitSetup()` for test setup which creates a team, channel and user
- remove other "ui_commands" such as `createAndVisitNewChannel`, `createAndVisitNewDirectMessageWith` and `createAndVisitNewGroupMessageWith`
- remove some "api_commands" such as `apiCreateAndLoginAsNewUser`, `loginAsNewGuestUser`
- rearrange "api_commands" and move similar commands to its own file like `support/api/user.js`. Add some typings for IDE intellisense (this will be on separate campaign to make 100%)

So sorry if this PR changes a lot but it's hard to break into several PRs since they are interconnected. Rest assured that
- it's well tested - [latest run here](https://mm-cypress-report.s3.amazonaws.com/382-master-master/mochawesome.html) and
- will work existing developer workflow which is using generated sample data.

To follow for this ticket is to clean up the use of remaining default data like user-1, ad-1, autem, removal of apiCreateNewUser and removal of `users.json`.

#### Ticket Link
Jira ticket - https://mattermost.atlassian.net/browse/MM-26035
