### PR TITLE
MM-26008 Fix for suggestions not appearing when opening quick switcher

### DIFF
--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -34,7 +34,7 @@ export default class SuggestionBox extends React.PureComponent {
         /**
          * Array of suggestion providers
          */
-        providers: PropTypes.arrayOf(PropTypes.object),
+        providers: PropTypes.arrayOf(PropTypes.object).isRequired,
 
         /**
          * Where the list will be displayed relative to the input box, defaults to 'top'
@@ -204,6 +204,7 @@ export default class SuggestionBox extends React.PureComponent {
         if (this.props.listenForMentionKeyClick) {
             EventEmitter.addListener('mention_key_click', this.handleMentionKeyClick);
         }
+        this.handlePretextChanged(this.pretext);
     }
 
     componentWillUnmount() {
@@ -322,7 +323,9 @@ export default class SuggestionBox extends React.PureComponent {
                 if (textbox) {
                     const pretext = textbox.value.substring(0, textbox.selectionEnd);
                     if (this.props.openWhenEmpty || pretext.length >= this.props.requiredCharacters) {
-                        this.handlePretextChanged(pretext);
+                        if (this.pretext !== pretext) {
+                            this.handlePretextChanged(pretext);
+                        }
                     }
                 }
             });
@@ -635,10 +638,8 @@ export default class SuggestionBox extends React.PureComponent {
     };
 
     handlePretextChanged = (pretext) => {
-        if (pretext !== this.pretext) {
-            this.pretext = pretext;
-            this.debouncedPretextChanged(pretext);
-        }
+        this.pretext = pretext;
+        this.debouncedPretextChanged(pretext);
     }
 
     blur = () => {

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -316,7 +316,7 @@ export default class SuggestionBox extends React.PureComponent {
 
         this.setState({focused: true});
 
-        if ((this.props.openOnFocus || this.props.openWhenEmpty) && !this.props.forceSuggestionsWhenBlur) {
+        if (this.props.openOnFocus || this.props.openWhenEmpty) {
             setTimeout(() => {
                 const textbox = this.getTextbox();
                 if (textbox) {
@@ -635,8 +635,10 @@ export default class SuggestionBox extends React.PureComponent {
     };
 
     handlePretextChanged = (pretext) => {
-        this.pretext = pretext;
-        this.debouncedPretextChanged(pretext);
+        if (pretext !== this.pretext) {
+            this.pretext = pretext;
+            this.debouncedPretextChanged(pretext);
+        }
     }
 
     blur = () => {

--- a/components/suggestion/suggestion_box.test.jsx
+++ b/components/suggestion/suggestion_box.test.jsx
@@ -22,6 +22,7 @@ describe('components/SuggestionBox', () => {
         value: 'value',
         containerClass: 'test',
         openOnFocus: true,
+        providers: [],
     };
 
     test('findOverlap', () => {
@@ -211,7 +212,7 @@ describe('components/SuggestionBox', () => {
         expect(onBlur).toBeCalledTimes(1);
     });
 
-    test('should call for handlePretextChanged on handleFocusIn', () => {
+    test('should call for handlePretextChanged on handleFocusIn and change of pretext', () => {
         jest.useFakeTimers();
         const onFocus = jest.fn();
         const wrapper = shallow(
@@ -230,20 +231,18 @@ describe('components/SuggestionBox', () => {
         instance.container = {contains};
 
         instance.handleFocusIn({relatedTarget});
-        jest.runAllTimers();
-        expect(instance.handlePretextChanged).toHaveBeenCalled();
+        jest.runOnlyPendingTimers();
+        expect(instance.handlePretextChanged).toHaveBeenCalledTimes(1);
+        instance.handleFocusIn({relatedTarget});
+        expect(instance.handlePretextChanged).toHaveBeenCalledTimes(1);
         expect(onFocus).toHaveBeenCalled();
     });
 
-    test('should call for debouncedPretextChanged only on change of pretext', () => {
+    test('should call for handlePretextChanged on componentDidMount', () => {
         const wrapper = shallow(<SuggestionBox {...baseProps}/>);
         const instance = wrapper.instance();
-        instance.debouncedPretextChanged = jest.fn();
-        instance.handlePretextChanged('value');
-        expect(instance.debouncedPretextChanged).toHaveBeenCalledTimes(1);
-        instance.handlePretextChanged('value');
-        expect(instance.debouncedPretextChanged).toHaveBeenCalledTimes(1);
-        instance.handlePretextChanged('change');
-        expect(instance.debouncedPretextChanged).toHaveBeenCalledTimes(2);
+        instance.handlePretextChanged = jest.fn();
+        instance.componentDidMount();
+        expect(instance.handlePretextChanged).toHaveBeenCalledTimes(1);
     });
 });

--- a/components/suggestion/suggestion_box.test.jsx
+++ b/components/suggestion/suggestion_box.test.jsx
@@ -211,14 +211,13 @@ describe('components/SuggestionBox', () => {
         expect(onBlur).toBeCalledTimes(1);
     });
 
-    test('should not call for pretext change on call of handleFocusIn when forceSuggestionsWhenBlur is true', () => {
+    test('should call for handlePretextChanged on handleFocusIn', () => {
         jest.useFakeTimers();
         const onFocus = jest.fn();
         const wrapper = shallow(
             <SuggestionBox
                 {...baseProps}
                 openOnFocus={true}
-                forceSuggestionsWhenBlur={true}
                 onFocus={onFocus}
             />,
         );
@@ -232,7 +231,19 @@ describe('components/SuggestionBox', () => {
 
         instance.handleFocusIn({relatedTarget});
         jest.runAllTimers();
-        expect(instance.handlePretextChanged).not.toHaveBeenCalled();
+        expect(instance.handlePretextChanged).toHaveBeenCalled();
         expect(onFocus).toHaveBeenCalled();
+    });
+
+    test('should call for debouncedPretextChanged only on change of pretext', () => {
+        const wrapper = shallow(<SuggestionBox {...baseProps}/>);
+        const instance = wrapper.instance();
+        instance.debouncedPretextChanged = jest.fn();
+        instance.handlePretextChanged('value');
+        expect(instance.debouncedPretextChanged).toHaveBeenCalledTimes(1);
+        instance.handlePretextChanged('value');
+        expect(instance.debouncedPretextChanged).toHaveBeenCalledTimes(1);
+        instance.handlePretextChanged('change');
+        expect(instance.debouncedPretextChanged).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
#### Summary
This is a regression caused by https://github.com/mattermost/mattermost-webapp/pull/5702. The linked PR prevents results change on focus to remove a flicker of results disappearing and reappearing on focus change. This caused this issue where quick switcher opens but it does not populate results because it was based on focus in. Instead of changing to a logic where only pretext change causes the computation of results change. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26008
