### PR TITLE
MM-25138: CircleCI caching improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ jobs:
     working_directory: ~/mattermost/mattermost-webapp
     steps:
       - checkout
-      - *restore_cache
       - run: |
           npm ci
           cd node_modules/mattermost-redux && npm i && npm run build
@@ -148,7 +147,7 @@ jobs:
       - persist_to_workspace:
           root: ~/mattermost
           paths:
-            - mattermost-webapp
+            - mattermost-webapp/mattermost-webapp.tar.gz
 
   build-storybook:
     executor:
@@ -163,7 +162,7 @@ jobs:
       - persist_to_workspace:
           root: ~/mattermost
           paths:
-            - mattermost-webapp
+            - mattermost-webapp/storybook-static
 
   upload-storybook:
     docker:


### PR DESCRIPTION
#### Summary
Skip `restore_cache` on the `install` step, since we use `npm ci` which only turns around and throws away the restored `node_modules`. This saves time both from the restore, and the the recursive directory removal. (We still `save_cache` since we use the resulting `node_modules` in other jobs.)

Also tweak the use of the workspace persistence in the `build` and `build-storybook` to only persist the newly generated artifacts instead of the entire workspace a second time. This dramatically shortens the `Persisting to Workspace` step.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-25138