### PR TITLE
Fix LinkTooltip with uncommon link format

### DIFF
--- a/components/link_tooltip/__snapshots__/link_tooltip.test.tsx.snap
+++ b/components/link_tooltip/__snapshots__/link_tooltip.test.tsx.snap
@@ -28,3 +28,43 @@ exports[`components/link_tooltip/link_tooltip should match snapshot 1`] = `
   </span>
 </Fragment>
 `;
+
+exports[`components/link_tooltip/link_tooltip should match snapshot with uncommon link structure 1`] = `
+<Fragment>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexDirection": "column",
+        "zIndex": 10,
+      }
+    }
+  >
+    <Connect(Pluggable)
+      href="https://www.google.com"
+      pluggableName="LinkTooltip"
+    />
+  </div>
+  <span
+    onMouseLeave={[Function]}
+    onMouseOver={[Function]}
+  >
+    <span
+      className="codespan__pre-wrap"
+    >
+      <code>
+        foo
+      </code>
+    </span>
+     and 
+    <span
+      className="codespan__pre-wrap"
+    >
+      <code>
+        bar
+      </code>
+    </span>
+  </span>
+</Fragment>
+`;

--- a/components/link_tooltip/link_tooltip.test.tsx
+++ b/components/link_tooltip/link_tooltip.test.tsx
@@ -38,7 +38,7 @@ describe('components/link_tooltip/link_tooltip', () => {
                 <span className='codespan__pre-wrap'>
                     <code>{'foo'}</code>
                 </span>
-                    {' and '}
+                {' and '}
                 <span className='codespan__pre-wrap'>
                     <code>{'bar'}</code>
                 </span>
@@ -48,6 +48,4 @@ describe('components/link_tooltip/link_tooltip', () => {
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find('span').at(0).text()).toBe('foo and bar');
     });
-
-
 });

--- a/components/link_tooltip/link_tooltip.test.tsx
+++ b/components/link_tooltip/link_tooltip.test.tsx
@@ -13,17 +13,41 @@ describe('components/link_tooltip/link_tooltip', () => {
         const wrapper: ShallowWrapper<{}, {}, LinkTooltip> = shallow(
             <LinkTooltip
                 href={'www.test.com'}
-                title={'test title'}
                 attributes={{
                     class: 'mention-highlight',
                     'data-hashtag': '#somehashtag',
                     'data-link': 'somelink',
                     'data-channel-mention': 'somechannel',
                 }}
-            />,
+            >
+                {'test title'}
+            </LinkTooltip>
         );
 
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.find('span').text()).toBe('test title');
     });
+
+    test('should match snapshot with uncommon link structure', () => {
+        ReactDOM.createPortal = (node) => node as ReactPortal;
+        const wrapper: ShallowWrapper<{}, {}, LinkTooltip> = shallow(
+            <LinkTooltip
+                href={'https://www.google.com'}
+                attributes={{}}
+            >
+                <span className='codespan__pre-wrap'>
+                    <code>{'foo'}</code>
+                </span>
+                    {' and '}
+                <span className='codespan__pre-wrap'>
+                    <code>{'bar'}</code>
+                </span>
+            </LinkTooltip>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('span').at(0).text()).toBe('foo and bar');
+    });
+
+
 });

--- a/components/link_tooltip/link_tooltip.tsx
+++ b/components/link_tooltip/link_tooltip.tsx
@@ -17,7 +17,6 @@ const tooltipContainerStyles: CSSProperties = {
 
 type Props = {
     href: string;
-    title: string;
     attributes: {[attribute: string]: string};
 }
 
@@ -87,7 +86,7 @@ export default class LinkTooltip extends React.PureComponent<Props> {
     };
 
     public render() {
-        const {href, title, attributes} = this.props;
+        const {href, children, attributes} = this.props;
 
         const dataAttributes = {
             'data-hashtag': attributes['data-hashtag'],
@@ -113,7 +112,7 @@ export default class LinkTooltip extends React.PureComponent<Props> {
                     onMouseLeave={this.hideTooltip}
                     {...dataAttributes}
                 >
-                    {title}
+                    {children}
                 </span>
             </React.Fragment>
         );

--- a/utils/__snapshots__/message_html_to_component.test.jsx.snap
+++ b/utils/__snapshots__/message_html_to_component.test.jsx.snap
@@ -162,8 +162,9 @@ exports[`messageHtmlToComponent link with enabled a tooltip plugin 1`] = `
         }
       }
       href="http://www.dolor.com"
-      title="www.dolor.com"
-    />
+    >
+      www.dolor.com
+    </LinkTooltip>
   </a>
    sit amet
 </p>

--- a/utils/message_html_to_component.jsx
+++ b/utils/message_html_to_component.jsx
@@ -59,9 +59,10 @@ export function messageHtmlToComponent(html, isRHS, options = {}) {
                 return (
                     <LinkTooltip
                         href={node.attribs[hrefAttrib]}
-                        title={children[0]}
                         attributes={node.attribs}
-                    />
+                    >
+                        {children}
+                    </LinkTooltip>
                 );
             },
         });


### PR DESCRIPTION
#### Summary

When a hyperlink is generated, depending on the structure of the text, there can be several components on the top level of its React children. When `messageHtmlToComponent` renders the `LinkTooltip` component, it is only passing the first child of its `children` array.

This PR makes sure all children are passed, so the `LinkTooltip` component can render all of them.

```[`foo` and `bar`](https://www.google.com)``` was being rendered as [`foo`](https://www.google.com), instead of [`foo` and `bar`](https://www.google.com)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-25808

#### Screenshots

Before

![image](https://user-images.githubusercontent.com/6913320/84957583-838a1080-b0c9-11ea-8801-2856e5f9b8d8.png)

After

![image](https://user-images.githubusercontent.com/6913320/84957701-bdf3ad80-b0c9-11ea-8d94-3f816cdc8a23.png)

