### PR TITLE
MM-24791: Fix invisible border in interactive dialog's dropdown

### DIFF
--- a/sass/components/_select.scss
+++ b/sass/components/_select.scss
@@ -35,7 +35,6 @@
         padding-right: 3rem;
         @include border-radius(3px);
         @include box-shadow(unset);
-        border-color: rgba(61, 60, 64, 0.3);
     }
 
     .suggestion-list__content {


### PR DESCRIPTION
#### Summary
The interactive dialog's dropdown component did not render the border properly in dark themes.

Solving it was a matter of removing a hardcoded value that was overwriting the color defined in https://github.com/mattermost/mattermost-webapp/blob/master/sass/components/_forms.scss#L165, which uses a theme-aware variable.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24791

#### Related Pull Requests
--

#### Screenshots
![image](https://user-images.githubusercontent.com/3924815/85281655-af6f1280-b48a-11ea-9d2d-c7fe857f2d66.png)
![image](https://user-images.githubusercontent.com/3924815/85281664-b3029980-b48a-11ea-8924-c19f1e5a3f6d.png)
