### PR TITLE
Cypress/E2E: Fix failing tests due to read-only config after HA cluster is enabled

### DIFF
--- a/e2e/cypress/fixtures/partial_default_config.json
+++ b/e2e/cypress/fixtures/partial_default_config.json
@@ -390,7 +390,7 @@
         "AdvertiseAddress": "",
         "UseIpAddress": true,
         "UseExperimentalGossip": false,
-        "ReadOnlyConfig": true,
+        "ReadOnlyConfig": false,
         "GossipPort": 8074,
         "StreamingPort": 8075,
         "MaxIdleConns": 100,


### PR DESCRIPTION
#### Summary
Fix failing tests due to read-only config after HA cluster is enabled

#### Ticket Link
none, failing on daily
