### PR TITLE
[MM-25785] allow pasting tables into edit post, keep caret position

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -382,7 +382,10 @@ class CreateComment extends React.PureComponent {
             message = formattedMessage;
             this.setCaretPosition(newCaretPosition);
         } else {
-            message = formatMarkdownTableMessage(table, draft.message.trim());
+            const originalSize = draft.message.length;
+            message = formatMarkdownTableMessage(table, draft.message.trim(), this.state.caretPosition);
+            const newCaretPosition = message.length - (originalSize - this.state.caretPosition);
+            this.setCaretPosition(newCaretPosition);
         }
 
         const updatedDraft = {...draft, message};

--- a/components/create_comment/create_comment.test.jsx
+++ b/components/create_comment/create_comment.test.jsx
@@ -1263,6 +1263,20 @@ describe('components/CreateComment', () => {
             />,
         );
 
+        const mockTop = () => {
+            return document.createElement('div');
+        };
+
+        const mockImpl = () => {
+            return {
+                setSelectionRange: jest.fn(),
+                getBoundingClientRect: jest.fn(mockTop),
+                focus: jest.fn(),
+            };
+        };
+
+        wrapper.instance().refs = {textbox: {getWrappedInstance: () => ({getInputBox: jest.fn(mockImpl), focus: jest.fn(), blur: jest.fn()})}};
+
         const event = {
             target: {
                 id: 'reply_textbox',

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -824,11 +824,14 @@ class CreatePost extends React.PureComponent {
         if (isGitHubCodeBlock(table.className)) {
             const {formattedMessage, formattedCodeBlock} = formatGithubCodePaste(this.state.caretPosition, message, clipboardData);
             const newCaretPosition = this.state.caretPosition + formattedCodeBlock.length;
-            this.setMessageAndCaretPostion(formattedMessage, newCaretPosition, clipboardData);
+            this.setMessageAndCaretPostion(formattedMessage, newCaretPosition);
             return;
         }
-        message = formatMarkdownTableMessage(table, message.trim());
-        this.setState({message});
+
+        const originalSize = message.length;
+        message = formatMarkdownTableMessage(table, message.trim(), this.state.caretPosition);
+        const newCaretPosition = message.length - (originalSize - this.state.caretPosition);
+        this.setMessageAndCaretPostion(message, newCaretPosition);
     }
 
     handleFileUploadChange = () => {

--- a/components/create_post/create_post.test.jsx
+++ b/components/create_post/create_post.test.jsx
@@ -1168,7 +1168,10 @@ describe('components/create_post', () => {
         const wrapper = shallowWithIntl(createPost());
 
         const message = 'original message';
-        wrapper.setState({message});
+        wrapper.setState({
+            message,
+            caretPosition: message.length,
+        });
 
         const event = {
             target: {
@@ -1184,8 +1187,22 @@ describe('components/create_post', () => {
             },
         };
 
-        const markdownTable = '|test | test|\n|--- | ---|\n|test | test|\n';
-        const expectedMessage = `${message}\n\n${markdownTable}`;
+        const markdownTable = '|test | test|\n|--- | ---|\n|test | test|\n\n';
+        const expectedMessage = `${message}\n${markdownTable}`;
+
+        const mockTop = () => {
+            return document.createElement('div');
+        };
+
+        const mockImpl = () => {
+            return {
+                setSelectionRange: jest.fn(),
+                getBoundingClientRect: jest.fn(mockTop),
+                focus: jest.fn(),
+            };
+        };
+
+        wrapper.instance().refs = {textbox: {getWrappedInstance: () => ({getInputBox: jest.fn(mockImpl), focus: jest.fn(), blur: jest.fn()})}};
 
         wrapper.instance().pasteHandler(event);
         expect(wrapper.state('message')).toBe(expectedMessage);

--- a/utils/paste.tsx
+++ b/utils/paste.tsx
@@ -53,7 +53,7 @@ function tableHeaders(row: HTMLTableRowElement): string[] {
     return Array.from(row.querySelectorAll('td, th')).map(columnText);
 }
 
-export function formatMarkdownTableMessage(table: HTMLTableElement, message?: string): string {
+export function formatMarkdownTableMessage(table: HTMLTableElement, message?: string, caretPosition?: number): string {
     const rows = Array.from(table.querySelectorAll('tr'));
 
     const headerRow = rows.shift();
@@ -66,8 +66,14 @@ export function formatMarkdownTableMessage(table: HTMLTableElement, message?: st
     }).join('\n');
 
     const formattedTable = `${header}${body}\n`;
-
-    return message ? `${message}\n\n${formattedTable}` : formattedTable;
+    if (!message) {
+        return formattedTable;
+    }
+    if (typeof caretPosition === 'undefined') {
+        return message ? `${message}\n\n${formattedTable}` : formattedTable;
+    }
+    const newMessage = [message.slice(0, caretPosition), formattedTable, message.slice(caretPosition)];
+    return newMessage.join('\n');
 }
 
 export function formatGithubCodePaste(caretPosition: number, message: string, clipboardData: DataTransfer): {formattedMessage: string; formattedCodeBlock: string} {

--- a/utils/paste.tsx
+++ b/utils/paste.tsx
@@ -70,7 +70,7 @@ export function formatMarkdownTableMessage(table: HTMLTableElement, message?: st
         return formattedTable;
     }
     if (typeof caretPosition === 'undefined') {
-        return ${message}\n\n${formattedTable}`;
+        return `${message}\n\n${formattedTable}`;
     }
     const newMessage = [message.slice(0, caretPosition), formattedTable, message.slice(caretPosition)];
     return newMessage.join('\n');

--- a/utils/paste.tsx
+++ b/utils/paste.tsx
@@ -70,7 +70,7 @@ export function formatMarkdownTableMessage(table: HTMLTableElement, message?: st
         return formattedTable;
     }
     if (typeof caretPosition === 'undefined') {
-        return message ? `${message}\n\n${formattedTable}` : formattedTable;
+        return ${message}\n\n${formattedTable}`;
     }
     const newMessage = [message.slice(0, caretPosition), formattedTable, message.slice(caretPosition)];
     return newMessage.join('\n');


### PR DESCRIPTION
#### Summary
fix adding tables into post edits
while working on it, i found it wasn't keeping caretposition when pasting tables from google docs spreadhseets, so I changed that as well

#### Ticket Link

[MM-25785](https://mattermost.atlassian.net/browse/MM-25785)
