### PR TITLE
[MM-25903] fix avatar for dms in search

### DIFF
--- a/components/suggestion/search_channel_suggestion/index.js
+++ b/components/suggestion/search_channel_suggestion/index.js
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 import {connect} from 'react-redux';
 
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+
 import {getDirectTeammate} from 'utils/utils';
 
 import SearchChannelSuggestion from './search_channel_suggestion';
@@ -9,6 +11,7 @@ import SearchChannelSuggestion from './search_channel_suggestion';
 const mapStateToProps = (state, ownProps) => {
     return {
         teammate: getDirectTeammate(state, ownProps.item.id),
+        currentUser: getCurrentUserId(state),
     };
 };
 

--- a/components/suggestion/search_channel_suggestion/search_channel_suggestion.jsx
+++ b/components/suggestion/search_channel_suggestion/search_channel_suggestion.jsx
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 import React from 'react';
 
+import {getUserIdFromChannelName} from 'mattermost-redux/utils/channel_utils';
+
 import {imageURLForUser} from 'utils/utils.jsx';
 import Constants from 'utils/constants';
 import Avatar from 'components/widgets/users/avatar';
@@ -9,14 +11,14 @@ import BotBadge from 'components/widgets/badges/bot_badge';
 
 import Suggestion from '../suggestion.jsx';
 
-function itemToName(item) {
+function itemToName(item, currentUser) {
     let itemMarkup = (item);
 
     if (item.type === Constants.DM_CHANNEL) {
         const profilePicture = (
             <Avatar
                 username={item.username}
-                url={imageURLForUser(item.name.substr(0, item.name.indexOf('_')), item.last_picture_update)}
+                url={imageURLForUser(getUserIdFromChannelName(currentUser, item.name), item.last_picture_update)}
                 size='sm'
             />
         );
@@ -69,14 +71,14 @@ function itemToName(item) {
 
 export default class SearchChannelSuggestion extends Suggestion {
     render() {
-        const {item, isSelection, teammate} = this.props;
+        const {item, isSelection, teammate, currentUser} = this.props;
 
         let className = 'search-autocomplete__item';
         if (isSelection) {
             className += ' selected a11y--focused';
         }
 
-        const name = itemToName(item);
+        const name = itemToName(item, currentUser);
 
         let tag = null;
         if (item.type === Constants.DM_CHANNEL) {


### PR DESCRIPTION
#### Summary

searching with the `in:` modifier would display the wrong avatar for the user in the dm.

#### Ticket Link

[MM-25903](https://mattermost.atlassian.net/browse/MM-25903)