### PR TITLE
Fix failing tests on handle removed user

### DIFF
--- a/e2e/cypress/integration/websocket/handle_removed_user/helpers.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user/helpers.js
@@ -28,9 +28,8 @@ export function removeMeFromCurrentChannel() {
     return cy.getCurrentChannelId().then((res) => {
         channelId = res;
         return cy.apiGetMe();
-    }).then((res) => {
-        const userId = res.body.id;
-        return cy.removeUserFromChannel(channelId, userId);
+    }).then(({user}) => {
+        return cy.removeUserFromChannel(channelId, user.id);
     });
 }
 
@@ -53,8 +52,8 @@ export function shouldRemoveMentionsInRHS(teamName, sidebarItemClass) {
     let postId;
 
     // # Post a unique message with a mention and retrieve its ID
-    cy.apiGetMe().then((res) => {
-        var messageText = `${Date.now()} - mention to @${res.body.username} `;
+    cy.apiGetMe().then(({user}) => {
+        var messageText = `${Date.now()} - mention to @${user.username} `;
         cy.postMessage(messageText);
 
         return cy.getLastPostId();


### PR DESCRIPTION
#### Summary
Fixes the failing tests on removing user - both for old and new sidebar.
This was introduced by my latest change to cy.apiGetMe.

#### Ticket Link
none, failing on daily Cypress test
