### PR TITLE
Consitering strings in resolve element. 

### DIFF
--- a/plugins/registry.js
+++ b/plugins/registry.js
@@ -42,7 +42,7 @@ function dispatchPluginComponentAction(name, pluginId, component, id = generateI
 }
 
 const resolveReactElement = (element) => {
-    if (element && !React.isValidElement(element)) {
+    if (element && !React.isValidElement(element) && typeof element !== 'string') {
         // Allow element to be passed as the name of the component, instead of a React element.
         return React.createElement(element);
     }


### PR DESCRIPTION
#### Summary
Strings are used here in plugins and are not valid react elements. But they also can't be turned directly into components as `React.createElement("Not a component name")` thinks you mean `<Not a component name/>`