### PR TITLE
MM-26074 Cypress test for MM-T270 and MM-T269 - No Matches for Autocomplete

### DIFF
--- a/e2e/cypress/integration/account_settings/display/channel_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/channel_display_mode_spec.js
@@ -62,7 +62,7 @@ describe('Account Settings > Display > Channel Display Mode', () => {
         cy.get('#accountSettingsHeader > .close').should('be.visible');
     });
 
-    it('change channel display mode setting to "Full width"', () => {
+    it('MM-T296 change channel display mode setting to "Full width"', () => {
         // # Click the radio button for "Full width"
         cy.get('#channel_display_modeFormatA').click();
 
@@ -85,7 +85,7 @@ describe('Account Settings > Display > Channel Display Mode', () => {
         cy.get("div[data-testid='postContent']").first().invoke('attr', 'class').should('contain', 'post__content').should('not.contain', 'center');
     });
 
-    it('AS13225 Channel display mode setting to "Fixed width, centered"', () => {
+    it('MM-T295 Channel display mode setting to "Fixed width, centered"', () => {
         cy.toAccountSettingsModal();
 
         // * Check that the Sidebar tab is loaded

--- a/e2e/cypress/integration/messaging/no_matches_for_autocomplete_spec.js
+++ b/e2e/cypress/integration/messaging/no_matches_for_autocomplete_spec.js
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @messaging
+
+describe('No Matches for Autocomplete', () => {
+    before(() => {
+        cy.apiInitSetup().then(({team}) => {
+            // # Visit town-square
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
+    });
+
+    it('MM-T270 No matches for user autocomplete', () => {
+        // # Type non-existent user name
+        const nonExistentUser = 'nonExistentUser';
+        cy.get('#post_textbox').clear().type(`@${nonExistentUser}`);
+
+        // * Verify suggestion list does not exist
+        cy.get('#suggestionList').should('not.exist');
+
+        // # Hit enter to post non-existent user name
+        cy.get('#post_textbox').type('{enter}');
+
+        // * Verify that the last message posted contains the user name and is not linked
+        cy.getLastPost().within(() => {
+            cy.get(`[data-mention=${nonExistentUser}]`).should('include.text', `@${nonExistentUser}`);
+            cy.get('.mention-link').should('not.exist');
+        });
+    });
+
+    it('MM-T269 No matches for channel autocomplete', () => {
+        // # Type non-existent channel name
+        const nonExistentChannel = 'nonExistentChannel';
+        cy.get('#post_textbox').clear().clear().type(`~${nonExistentChannel}`);
+
+        // * Verify suggestion list does not exist
+        cy.get('#suggestionList').should('not.exist');
+
+        // # Hit enter to post non-existent channel name
+        cy.get('#post_textbox').type('{enter}');
+
+        // * Verify that the last message posted contains the channel name and is not linked
+        cy.getLastPost().should('include.text', `~${nonExistentChannel}`).within(() => {
+            cy.get(`[data-channel-mention=${nonExistentChannel}]`).should('not.exist');
+            cy.get('.mention-link').should('not.exist');
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
Cypress/E2E on no matches for user and channel autocomplete

#### Ticket Link
Jira ticket: https://mattermost.atlassian.net/browse/MM-26074
TM4J tickets: [MM-T270](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T270) and [MM-T269](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T269)