### PR TITLE
MM-26074 Cypress Test for MM-T305 - Account Settings are not autosaved

### DIFF
--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -29,19 +29,18 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
             Cypress._.forEach(Array(numberOfChannels), (_, index) => {
                 cy.apiCreateChannel(testTeam.id, 'channel-switcher', `Channel Switcher ${index.toString()}`);
             });
-
-            // # Visit town-square
-            cy.visit(`/${team.name}/channels/town-square`);
         });
     });
 
-    it('set channel switcher setting to On and test on click of sidebar switcher button', () => {
-        // # Go to a known team and channel
+    beforeEach(() => {
+        // # Visit town-square
         cy.visit(`/${testTeam.name}/channels/town-square`);
         cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+    })
 
+    it('set channel switcher setting to On and test on click of sidebar switcher button', () => {
         // # Go to Account Settings modal > Sidebar > Channel Switcher and set setting to On
-        enableChannelSwitcher(true);
+        enableOrDisableChannelSwitcher(true);
 
         // # Click the sidebar switcher button
         cy.get('#sidebarSwitcherButton').click();
@@ -50,12 +49,8 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
     });
 
     it('set channel switcher setting to On and test on press of Ctrl/Cmd+K', () => {
-        // # Go to a known team and channel
-        cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
-
         // # Go to Account Settings modal > Sidebar > Channel Switcher and set setting to On
-        enableChannelSwitcher(true);
+        enableOrDisableChannelSwitcher(true);
 
         // # Type CTRL/CMD+K
         cy.typeCmdOrCtrl().type('K', {release: true});
@@ -64,12 +59,8 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
     });
 
     it('AS13216 Using CTRL/CMD+K if Channel Switcher is hidden in the LHS', () => {
-        // # Go to a known team and channel
-        cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
-
         // # Go to Account Settings modal > Sidebar > Channel Switcher and set setting to Off
-        enableChannelSwitcher(false);
+        enableOrDisableChannelSwitcher(false);
 
         // # Type CTRL/CMD+K
         cy.typeCmdOrCtrl().type('K', {release: true});
@@ -78,10 +69,6 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
     });
 
     it('Cmd/Ctrl+Shift+L closes Channel Switch modal and sets focus to post textbox', () => {
-        // # Go to a known team and channel
-        cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
-
         // # Type CTRL/CMD+K
         cy.get('#post_textbox').cmdOrCtrlShortcut('K');
 
@@ -102,10 +89,6 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // # patch user info
         cy.apiPatchMe({notify_props: {first_name: 'false', mention_keys: testUser.username}});
 
-        // # Go to a known team and channel
-        cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
-
         // # Type CTRL/CMD+K
         cy.get('#post_textbox').cmdOrCtrlShortcut('K');
 
@@ -121,6 +104,30 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // * searchbox should appear
         cy.get('#searchBox').should('have.attr', 'value', `${testUser.username} @${testUser.username} `);
         cy.get('.sidebar--right__title').should('contain', 'Recent Mentions');
+    });
+
+    it('MM-T305 Changes to Account Settings are not saved when user does not click on Save button', () => {
+        // # Go to a known team and channel
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
+
+        // # Go to Account Settings modal > Sidebar > Channel Switcher and set setting to Off
+        enableOrDisableChannelSwitcher(false);
+
+        // # Toggle On Channel Switcher without saving
+        toggleOnOrOffChannelSwitcher(true);
+
+        // # Click away from Channel Switcher
+        cy.get('#displayButton').click();
+        cy.get('#displaySettingsTitle.tab-header').should('have.text', 'Display Settings');
+        cy.get('#accountSettingsHeader > .close').click();
+
+        // # Navigate back to Sidebar Settings
+        navigateToSidebarSettings();
+
+        // * Verify Channel Switcher is still Off
+        cy.get('#channelSwitcherDesc').should('have.text', 'Off');
+        cy.get('#accountSettingsHeader > .close').click();
     });
 });
 
@@ -146,7 +153,7 @@ function verifyChannelSwitch(team, channel) {
     cy.get(`#sidebarItem_${channel.name}`).scrollIntoView().should('be.visible');
 }
 
-function enableChannelSwitcher(setToOn = true) {
+function navigateToSidebarSettings() {
     cy.get('#channel_view').should('be.visible');
     cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
     cy.get('#accountSettings').should('be.visible').click();
@@ -155,21 +162,30 @@ function enableChannelSwitcher(setToOn = true) {
     cy.get('#sidebarButton').should('be.visible');
     cy.get('#sidebarButton').click();
 
-    let isOn;
-    cy.get('#channelSwitcherDesc').should((desc) => {
-        if (desc.length > 0) {
-            isOn = Cypress.$(desc[0]).text() === 'On';
-        }
-    });
+    cy.get('#sidebarLi.active').should('be.visible');
+    cy.get('#sidebarTitle > .tab-header').should('have.text', 'Sidebar Settings');
+}
+
+function toggleOnOrOffChannelSwitcher(toggleOn = true) {
+    navigateToSidebarSettings();
 
     cy.get('#channelSwitcherEdit').click();
 
-    if (isOn && !setToOn) {
-        cy.get('#channelSwitcherSectionOff').click();
-    } else if (!isOn && setToOn) {
+    if (toggleOn) {
         cy.get('#channelSwitcherSectionEnabled').click();
+    } else {
+        cy.get('#channelSwitcherSectionOff').click();
     }
+}
+
+function enableOrDisableChannelSwitcher(enable = true) {
+    toggleOnOrOffChannelSwitcher(enable);
 
     cy.get('#saveSetting').click();
+    if (enable) {
+        cy.get('#channelSwitcherDesc').should('have.text', 'On');
+    } else {
+        cy.get('#channelSwitcherDesc').should('have.text', 'Off');
+    }
     cy.get('#accountSettingsHeader > .close').click();
 }

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -107,10 +107,6 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
     });
 
     it('MM-T305 Changes to Account Settings are not saved when user does not click on Save button', () => {
-        // # Go to a known team and channel
-        cy.visit(`/${testTeam.name}/channels/town-square`);
-        cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
-
         // # Go to Account Settings modal > Sidebar > Channel Switcher and set setting to Off
         enableOrDisableChannelSwitcher(false);
 

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_spec.js
@@ -36,7 +36,7 @@ describe('Account Settings > Sidebar > Channel Switcher', () => {
         // # Visit town-square
         cy.visit(`/${testTeam.name}/channels/town-square`);
         cy.get('#channelHeaderTitle').should('be.visible').should('contain', 'Town Square');
-    })
+    });
 
     it('set channel switcher setting to On and test on click of sidebar switcher button', () => {
         // # Go to Account Settings modal > Sidebar > Channel Switcher and set setting to On


### PR DESCRIPTION
#### Summary
Cypress/E2E on Changes to Account Settings are not saved when user does not click on Save button
- added test case
- fixed channel switcher toggling; original implementation did not really toggle the switch and was giving false positives
- minor refactor

#### Ticket Link
Jira ticket: https://mattermost.atlassian.net/browse/MM-26074
TM4J tickets: [MM-T305](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T305)