### PR TITLE
MM-26075 Standardized Cypress API commands - apiGetTeamsForUser, apiAddUserToTeam and apiGetUsersNotInTeam

### DIFF
--- a/e2e/cypress/integration/enterprise/ldap_group/search_channels_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/search_channels_spec.js
@@ -40,8 +40,8 @@ describe('Search channels', () => {
 
     it('returns results', function() {
         const displayName = uuidv4();
-        cy.apiGetTeams().then((response) => {
-            const teamID = response.body[0].id;
+        cy.apiGetTeamsForUser().then(({teams}) => {
+            const teamID = teams[0].id;
 
             // # Create a channel.
             cy.apiCreateChannel(teamID, 'channel-search', displayName).then((cResponse) => {
@@ -58,8 +58,8 @@ describe('Search channels', () => {
 
     it('results are paginated', function() {
         const displayName = uuidv4();
-        cy.apiGetTeams().then((response) => {
-            const teamID = response.body[0].id;
+        cy.apiGetTeamsForUser().then(({teams}) => {
+            const teamID = teams[0].id;
 
             // # Create enough new channels with common name prefixes to get multiple pages of search results.
             for (let i = 0; i < PAGE_SIZE + 2; i++) {
@@ -84,8 +84,8 @@ describe('Search channels', () => {
 
     it('clears the results when "x" is clicked', function() {
         const displayName = uuidv4();
-        cy.apiGetTeams().then((response) => {
-            const teamID = response.body[0].id;
+        cy.apiGetTeamsForUser().then(({teams}) => {
+            const teamID = teams[0].id;
 
             // # Create a new channel.
             cy.apiCreateChannel(teamID, 'channel-search', displayName).then((cResponse) => {
@@ -111,8 +111,8 @@ describe('Search channels', () => {
 
     it('clears the results when the search term is deleted with backspace', function() {
         const displayName = uuidv4();
-        cy.apiGetTeams().then((response) => {
-            const teamID = response.body[0].id;
+        cy.apiGetTeamsForUser().then(({teams}) => {
+            const teamID = teams[0].id;
 
             // # Create a channel.
             cy.apiCreateChannel(teamID, 'channel-search', displayName).then((cResponse) => {

--- a/e2e/cypress/integration/system_console/group_configuration_spec.js
+++ b/e2e/cypress/integration/system_console/group_configuration_spec.js
@@ -175,9 +175,9 @@ describe('group configuration', () => {
 
     describe('removing a team', () => {
         it('does not remove a team without saving', () => {
-            cy.apiGetTeams().then((response) => {
+            cy.apiGetTeamsForUser().then(({teams}) => {
                 // # Link a team
-                const team = response.body[0];
+                const team = teams[0];
                 cy.apiLinkGroupTeam(groupID, team.id);
 
                 // # Reload the page
@@ -207,9 +207,9 @@ describe('group configuration', () => {
         });
 
         it('does remove a team when saved', () => {
-            cy.apiGetTeams().then((response) => {
+            cy.apiGetTeamsForUser().then(({teams}) => {
                 // # Link a team
-                const team = response.body[0];
+                const team = teams[0];
                 cy.apiLinkGroupTeam(groupID, team.id);
 
                 // # Reload the page

--- a/e2e/cypress/integration/team_settings/teammates_pagination_spec.js
+++ b/e2e/cypress/integration/team_settings/teammates_pagination_spec.js
@@ -17,8 +17,7 @@ describe('Teams Suite', () => {
             const requiredMembersCount = 60;
 
             // # Get users not in team and add into the team
-            cy.apiGetUsersNotInTeam(team.id, 0, 200).then((res) => {
-                const users = res.body;
+            cy.apiGetUsersNotInTeam({teamId: team.id, page: 0, perPage: 200}).then(({users}) => {
                 const usersToAdd = users.
                     filter((u) => u.delete_at === 0).
                     slice(0, requiredMembersCount - 3).

--- a/e2e/cypress/integration/team_settings/teams_spec.js
+++ b/e2e/cypress/integration/team_settings/teams_spec.js
@@ -172,8 +172,8 @@ describe('Teams Suite', () => {
         cy.apiLogin(testUser);
 
         // # Leave all teams
-        cy.apiGetTeams().then((response) => {
-            response.body.forEach((team) => {
+        cy.apiGetTeamsForUser().then(({teams}) => {
+            teams.forEach((team) => {
                 cy.visit(`/${team.name}/channels/town-square`);
                 cy.get('#headerTeamName').should('be.visible').and('have.text', team.display_name);
                 cy.leaveTeam();

--- a/e2e/cypress/support/api/team.d.ts
+++ b/e2e/cypress/support/api/team.d.ts
@@ -141,6 +141,20 @@ declare namespace Cypress {
         apiGetTeamMembers(teamId: string): Chainable<TeamMembership[]>;
 
         /**
+         * Add a number of users to the team.
+         * See https://api.mattermost.com/#tag/teams/paths/~1teams~1{team_id}~1members~1batch/post
+         * @param {string} teamId - team ID
+         * @param {TeamMembership[]} teamMembers - users to add
+         * @returns {TeamMembership[]} `out.members` as `TeamMembership[]`
+         *
+         * @example
+         *   cy.apiAddUsersToTeam(teamId, [{team_id: 'team-id', user_id: 'user-id'}]).then(({members}) => {
+         *       // do something with members
+         *   });
+         */
+        apiAddUsersToTeam(teamId: string, teamMembers: TeamMembership[]): Chainable<TeamMembership[]>;
+
+        /**
          * Update the scheme-derived roles of a team member.
          * Requires sysadmin session to initiate this command.
          * See https://api.mattermost.com/#tag/teams/paths/~1teams~1{team_id}~1members~1{user_id}~1schemeRoles/put

--- a/e2e/cypress/support/api/team.d.ts
+++ b/e2e/cypress/support/api/team.d.ts
@@ -101,6 +101,33 @@ declare namespace Cypress {
         apiGetAllTeams(queryParams: Record<string, any>): Chainable<Team[]>;
 
         /**
+         * Get a list of teams that a user is on.
+         * See https://api.mattermost.com/#tag/teams/paths/~1users~1{user_id}~1teams/get
+         * @param {String} userId - User ID to get teams, or 'me' (default)
+         * @returns {Team[]} `out.teams` as `Team[]`
+         *
+         * @example
+         *   cy.apiGetTeamsForUser().then(({teams}) => {
+         *       // do something with teams
+         *   });
+         */
+        apiGetTeamsForUser(userId: string): Chainable<Team[]>;
+
+        /**
+         * Add user to the team by user_id.
+         * See https://api.mattermost.com/#tag/teams/paths/~1teams~1{team_id}~1members/post
+         * @param {String} teamId - Team ID
+         * @param {String} userId - User ID to be added into a team
+         * @returns {TeamMembership} `out.member` as `TeamMembership`
+         *
+         * @example
+         *   cy.apiAddUserToTeam('team-id', 'user-id').then(({member}) => {
+         *       // do something with member
+         *   });
+         */
+        apiAddUserToTeam(teamId: string, userId: string): Chainable<TeamMembership>;
+
+        /**
          * Get team members.
          * See https://api.mattermost.com/#tag/teams/paths/~1teams~1{team_id}~1members/get
          * @param {string} teamId - team ID

--- a/e2e/cypress/support/api/team.js
+++ b/e2e/cypress/support/api/team.js
@@ -56,7 +56,7 @@ Cypress.Commands.add('apiGetTeamByName', (name) => {
         method: 'GET',
     }).then((response) => {
         expect(response.status).to.equal(200);
-        cy.wrap(response);
+        cy.wrap({team: response.body});
     });
 });
 
@@ -71,26 +71,17 @@ Cypress.Commands.add('apiGetAllTeams', ({page = 0, perPage = 60} = {}) => {
     });
 });
 
-/**
- * Gets a list of the current user's teams
- * This API assume that the user is logged
- * no params required because we are using /me to refer to current user
- */
-Cypress.Commands.add('apiGetTeams', () => {
+Cypress.Commands.add('apiGetTeamsForUser', (userId = 'me') => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: 'api/v4/users/me/teams',
+        url: `api/v4/users/${userId}/teams`,
         method: 'GET',
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        cy.wrap({teams: response.body});
     });
 });
 
-/**
- * Add user into a team directly via API
- * This API assume that the user is logged in and has cookie to access
- * @param {String} teamId - The team ID
- * @param {String} userId - ID of user to be added into a team
- * All parameter required
- */
 Cypress.Commands.add('apiAddUserToTeam', (teamId, userId) => {
     cy.request({
         method: 'POST',
@@ -100,25 +91,7 @@ Cypress.Commands.add('apiAddUserToTeam', (teamId, userId) => {
         qs: {team_id: teamId},
     }).then((response) => {
         expect(response.status).to.equal(201);
-        return cy.wrap(response);
-    });
-});
-
-/**
- * List users that are not team members
- * @param {String} teamId - The team GUID
- * @param {Integer} page - The desired page of the paginated list
- * @param {Integer} perPage - The number of users per page
- * All parameter required
- */
-Cypress.Commands.add('apiGetUsersNotInTeam', (teamId, page = 0, perPage = 60) => {
-    return cy.request({
-        method: 'GET',
-        url: `/api/v4/users?not_in_team=${teamId}&page=${page}&per_page=${perPage}`,
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
-    }).then((response) => {
-        expect(response.status).to.equal(200);
-        cy.wrap(response);
+        return cy.wrap({member: response.body});
     });
 });
 

--- a/e2e/cypress/support/api/team.js
+++ b/e2e/cypress/support/api/team.js
@@ -95,12 +95,6 @@ Cypress.Commands.add('apiAddUserToTeam', (teamId, userId) => {
     });
 });
 
-/**
- * Join teammates directly via API
- * @param {String} teamId - The team GUID
- * @param {Array} teamMembers - The user IDs to join
- * All parameter required
- */
 Cypress.Commands.add('apiAddUsersToTeam', (teamId, teamMembers) => {
     return cy.request({
         method: 'POST',
@@ -109,7 +103,7 @@ Cypress.Commands.add('apiAddUsersToTeam', (teamId, teamMembers) => {
         body: teamMembers,
     }).then((response) => {
         expect(response.status).to.equal(201);
-        cy.wrap(response);
+        cy.wrap({members: response.body});
     });
 });
 

--- a/e2e/cypress/support/api/user.d.ts
+++ b/e2e/cypress/support/api/user.d.ts
@@ -78,5 +78,21 @@ declare namespace Cypress {
          *   cy.apiCreateGuestUser(options);
          */
         apiCreateGuestUser(options: Record<string, any>): Chainable<Record<string, any>>;
+
+        /**
+         * Get list of users that are not team members
+         * See https://api.mattermost.com/#tag/users/paths/~1users/post
+         * @param {String} queryParams.teamId - Team ID
+         * @param {String} queryParams.page - Page to select, 0 (default)
+         * @param {String} queryParams.perPage - The number of users per page, 60 (default)
+         * @returns {Object} `out` Cypress-chainable, yielded with element passed into .wrap().
+         * @returns {UserProfile[]} `out.users` as `UserProfile[]` object
+         *
+         * @example
+         *   cy.apiGetUsersNotInTeam({teamId: 'team-id'}).then(({users}) => {
+         *       // do something with users
+         *   });
+         */
+        apiGetUsersNotInTeam(queryParams: Record<string, any>): Chainable<UserProfile[]>;
     }
 }

--- a/e2e/cypress/support/api/user.js
+++ b/e2e/cypress/support/api/user.js
@@ -186,3 +186,14 @@ Cypress.Commands.add('apiActivateUser', (userId, active = true) => {
 
     cy.externalRequest({user: admin, method: 'put', baseUrl, path: `users/${userId}/active`, data: {active}});
 });
+
+Cypress.Commands.add('apiGetUsersNotInTeam', ({teamId, page = 0, perPage = 60} = {}) => {
+    return cy.request({
+        method: 'GET',
+        url: `/api/v4/users?not_in_team=${teamId}&page=${page}&per_page=${perPage}`,
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        cy.wrap({users: response.body});
+    });
+});

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -128,13 +128,12 @@ before(() => {
         });
 
         // # Check if default team is present; create if not found.
-        cy.apiGetTeams().then((teamsRes) => {
+        cy.apiGetTeamsForUser().then(({teams}) => {
             // Default team is meant for sysadmin's primary team,
             // selected for compatibility with existing local development.
             // It is not exported since it should not be used for testing.
             const DEFAULT_TEAM = {name: 'ad-1', display_name: 'eligendi', type: 'O'};
 
-            const teams = teamsRes.body;
             const defaultTeam = teams && teams.length > 0 && teams.find((team) => team.name === DEFAULT_TEAM.name);
 
             if (!defaultTeam) {


### PR DESCRIPTION
#### Summary
Standardize returned data and add typings for intellisense of the ff custom API commands:
- apiGetTeamsForUser
- apiAddUserToTeam
- apiGetUsersNotInTeam
- apiAddUsersToTeam

#### Ticket Link
 JIRA ticket: https://mattermost.atlassian.net/browse/MM-26075