### PR TITLE
MM-26597/MM-26672/MM-26616/MM-26605 Properly forward ref to Textbox

### DIFF
--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -337,9 +337,7 @@ class EditPostModal extends React.PureComponent {
     }
 
     setEditboxRef = (ref) => {
-        if (ref && ref.getWrappedInstance) {
-            this.editbox = ref;
-        }
+        this.editbox = ref;
 
         if (this.editbox) {
             this.editbox.focus();

--- a/components/rhs_comment/index.js
+++ b/components/rhs_comment/index.js
@@ -84,4 +84,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(RhsComment);
+export default connect(mapStateToProps, mapDispatchToProps, {forwardRef: true})(RhsComment);

--- a/components/rhs_comment/index.js
+++ b/components/rhs_comment/index.js
@@ -84,4 +84,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps, {forwardRef: true})(RhsComment);
+export default connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(RhsComment);

--- a/components/rhs_root_post/index.js
+++ b/components/rhs_root_post/index.js
@@ -59,4 +59,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(RhsRootPost);
+export default connect(mapStateToProps, mapDispatchToProps, {forwardRef: true})(RhsRootPost);

--- a/components/rhs_root_post/index.js
+++ b/components/rhs_root_post/index.js
@@ -59,4 +59,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps, {forwardRef: true})(RhsRootPost);
+export default connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(RhsRootPost);

--- a/components/textbox/index.ts
+++ b/components/textbox/index.ts
@@ -48,4 +48,4 @@ const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
     }, dispatch),
 });
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(Textbox);
+export default connect(makeMapStateToProps, mapDispatchToProps, null, {forwardRef: true})(Textbox);


### PR DESCRIPTION
Previously, we could attach a ref to any `connect`-based component fine, but that's no longer possible since the new version of `react-redux` changed `connect` to generate a functional component, so we have to forward the ref to the underlying component to be able to do anything with it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26616
https://mattermost.atlassian.net/browse/MM-26597
https://mattermost.atlassian.net/browse/MM-26672
https://mattermost.atlassian.net/browse/MM-26605