### PR TITLE
Remove stringRefs from CreatePost/CreateComment

### DIFF
--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-/* eslint-disable react/no-string-refs */
 
 import $ from 'jquery';
 import PropTypes from 'prop-types';
@@ -271,6 +270,10 @@ class CreateComment extends React.PureComponent {
         this.lastBlurAt = 0;
         this.draftsForPost = {};
         this.doInitialScrollToBottom = false;
+
+        this.createCommentControlsRef = React.createRef();
+        this.fileUploadRef = React.createRef();
+        this.textboxRef = React.createRef();
     }
 
     componentDidMount() {
@@ -351,7 +354,7 @@ class CreateComment extends React.PureComponent {
     }
 
     setCaretPosition = (newCaretPosition) => {
-        const textbox = this.refs.textbox.getInputBox();
+        const textbox = this.textboxRef.current.getInputBox();
 
         this.setState({
             caretPosition: newCaretPosition,
@@ -643,8 +646,8 @@ class CreateComment extends React.PureComponent {
 
         if (allowSending) {
             e.persist();
-            if (this.refs.textbox) {
-                this.refs.textbox.blur();
+            if (this.textboxRef.current) {
+                this.textboxRef.current.blur();
             }
 
             if (withClosedCodeBlock && message) {
@@ -742,8 +745,8 @@ class CreateComment extends React.PureComponent {
 
         if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && Utils.isKeyPressed(e, Constants.KeyCodes.UP) && message === '') {
             e.preventDefault();
-            if (this.refs.textbox) {
-                this.refs.textbox.blur();
+            if (this.textboxRef.current) {
+                this.textboxRef.current.blur();
             }
 
             const {data: canEditNow} = this.props.onEditLatestPost();
@@ -868,8 +871,8 @@ class CreateComment extends React.PureComponent {
             if (index !== -1) {
                 uploadsInProgress.splice(index, 1);
 
-                if (this.refs.fileUpload && this.refs.fileUpload) {
-                    this.refs.fileUpload.cancelUpload(id);
+                if (this.fileUploadRef.current) {
+                    this.fileUploadRef.current.cancelUpload(id);
                 }
             }
         } else {
@@ -900,16 +903,16 @@ class CreateComment extends React.PureComponent {
     }
 
     getFileUploadTarget = () => {
-        return this.refs.textbox;
+        return this.textboxRef.current;
     }
 
     getCreateCommentControls = () => {
-        return this.refs.createCommentControls;
+        return this.createCommentControlsRef.current;
     }
 
     focusTextbox = (keepFocus = false) => {
-        if (this.refs.textbox && (keepFocus || !UserAgent.isMobile())) {
-            this.refs.textbox.focus();
+        if (this.textboxRef.current && (keepFocus || !UserAgent.isMobile())) {
+            this.textboxRef.current.focus();
         }
     }
 
@@ -1075,7 +1078,6 @@ class CreateComment extends React.PureComponent {
                     onRemove={this.removePreview}
                     uploadsInProgress={draft.uploadsInProgress}
                     uploadsProgressPercent={this.state.uploadsProgressPercent}
-                    ref='preview'
                 />
             );
         }
@@ -1108,7 +1110,7 @@ class CreateComment extends React.PureComponent {
         if (!readOnlyChannel && !this.props.shouldShowPreview) {
             fileUpload = (
                 <FileUpload
-                    ref='fileUpload'
+                    ref={this.fileUploadRef}
                     fileCount={this.getFileCount()}
                     getTarget={this.getFileUploadTarget}
                     onFileUploadChange={this.handleFileUploadChange}
@@ -1164,7 +1166,7 @@ class CreateComment extends React.PureComponent {
             scrollbarClass = ' scroll';
         }
 
-        const textboxRef = this.refs.textbox;
+        const textboxRef = this.textboxRef.current;
         if (textboxRef) {
             const textboxPosTop = textboxRef.getInputBox().getBoundingClientRect().top;
             if (textboxPosTop < Constants.SUGGESTION_LIST_SPACE_RHS) {
@@ -1208,7 +1210,7 @@ class CreateComment extends React.PureComponent {
                                 isRHS={true}
                                 popoverMentionKeyClick={true}
                                 id='reply_textbox'
-                                ref='textbox'
+                                ref={this.textboxRef}
                                 disabled={readOnlyChannel}
                                 characterLimit={this.props.maxPostSize}
                                 preview={this.props.shouldShowPreview}
@@ -1218,7 +1220,7 @@ class CreateComment extends React.PureComponent {
                                 useChannelMentions={this.props.useChannelMentions}
                             />
                             <span
-                                ref='createCommentControls'
+                                ref={this.createCommentControlsRef}
                                 className='post-body__actions'
                             >
                                 {fileUpload}
@@ -1280,4 +1282,3 @@ class CreateComment extends React.PureComponent {
 }
 
 export default injectIntl(CreateComment);
-/* eslint-enable react/no-string-refs */

--- a/components/create_post/create_post.jsx
+++ b/components/create_post/create_post.jsx
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-/* eslint-disable react/no-string-refs */
 
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -325,6 +324,10 @@ class CreatePost extends React.PureComponent {
         this.lastChannelSwitchAt = 0;
         this.draftsForChannel = {};
         this.lastOrientation = null;
+
+        this.createPostControlsRef = React.createRef();
+        this.fileUploadRef = React.createRef();
+        this.textboxRef = React.createRef();
     }
 
     componentDidMount() {
@@ -414,7 +417,7 @@ class CreatePost extends React.PureComponent {
         }
 
         if (this.lastOrientation && orientation !== this.lastOrientation && (document.activeElement || {}).id === 'post_textbox') {
-            this.refs.textbox.blur();
+            this.textboxRef.current.blur();
         }
 
         this.lastOrientation = orientation;
@@ -739,12 +742,12 @@ class CreatePost extends React.PureComponent {
 
     focusTextbox = (keepFocus = false) => {
         const postTextboxDisabled = this.props.readOnlyChannel || !this.props.canPost;
-        if (this.refs.textbox && postTextboxDisabled) {
-            this.refs.textbox.blur(); // Fixes Firefox bug which causes keyboard shortcuts to be ignored (MM-22482)
+        if (this.textboxRef.current && postTextboxDisabled) {
+            this.textboxRef.current.blur(); // Fixes Firefox bug which causes keyboard shortcuts to be ignored (MM-22482)
             return;
         }
-        if (this.refs.textbox && (keepFocus || !UserAgent.isMobile())) {
-            this.refs.textbox.focus();
+        if (this.textboxRef.current && (keepFocus || !UserAgent.isMobile())) {
+            this.textboxRef.current.focus();
         }
     }
 
@@ -761,8 +764,8 @@ class CreatePost extends React.PureComponent {
 
         if (allowSending) {
             e.persist();
-            if (this.refs.textbox) {
-                this.refs.textbox.blur();
+            if (this.textboxRef.current) {
+                this.textboxRef.current.blur();
             }
 
             if (withClosedCodeBlock && message) {
@@ -930,8 +933,8 @@ class CreatePost extends React.PureComponent {
                     uploadsInProgress,
                 };
 
-                if (this.refs.fileUpload && this.refs.fileUpload) {
-                    this.refs.fileUpload.cancelUpload(id);
+                if (this.fileUploadRef.current) {
+                    this.fileUploadRef.current.cancelUpload(id);
                 }
             }
         } else {
@@ -991,15 +994,15 @@ class CreatePost extends React.PureComponent {
     }
 
     getFileUploadTarget = () => {
-        if (this.refs.textbox) {
-            return this.refs.textbox;
+        if (this.textboxRef.current) {
+            return this.textboxRef.current;
         }
 
         return null;
     }
 
     getCreatePostControls = () => {
-        return this.refs.createPostControls;
+        return this.createPostControlsRef.current;
     }
 
     fillMessageFromHistory() {
@@ -1057,8 +1060,8 @@ class CreatePost extends React.PureComponent {
         } else {
             type = Utils.localizeMessage('create_post.post', Posts.MESSAGE_TYPES.POST);
         }
-        if (this.refs.textbox) {
-            this.refs.textbox.blur();
+        if (this.textboxRef.current) {
+            this.textboxRef.current.blur();
         }
         this.props.actions.setEditingPost(lastPost.id, this.props.commentCountForPost, 'post_textbox', type);
     }
@@ -1122,7 +1125,7 @@ class CreatePost extends React.PureComponent {
     }
 
     setMessageAndCaretPostion = (newMessage, newCaretPosition) => {
-        const textbox = this.refs.textbox.getInputBox();
+        const textbox = this.textboxRef.current.getInputBox();
 
         this.setState({
             message: newMessage,
@@ -1381,7 +1384,7 @@ class CreatePost extends React.PureComponent {
         if (!readOnlyChannel && !this.props.shouldShowPreview) {
             fileUpload = (
                 <FileUpload
-                    ref='fileUpload'
+                    ref={this.fileUploadRef}
                     fileCount={this.getFileCount()}
                     getTarget={this.getFileUploadTarget}
                     onFileUploadChange={this.handleFileUploadChange}
@@ -1445,7 +1448,6 @@ class CreatePost extends React.PureComponent {
         return (
             <form
                 id='create_post'
-                ref='topDiv'
                 className={centerClass}
                 onSubmit={this.handleSubmit}
             >
@@ -1474,7 +1476,7 @@ class CreatePost extends React.PureComponent {
                                 createMessage={createMessage}
                                 channelId={currentChannel.id}
                                 id='post_textbox'
-                                ref='textbox'
+                                ref={this.textboxRef}
                                 disabled={readOnlyChannel}
                                 characterLimit={this.props.maxPostSize}
                                 preview={this.props.shouldShowPreview}
@@ -1483,7 +1485,7 @@ class CreatePost extends React.PureComponent {
                                 useChannelMentions={this.props.useChannelMentions}
                             />
                             <span
-                                ref='createPostControls'
+                                ref={this.createPostControlsRef}
                                 className='post-body__actions'
                             >
                                 {fileUpload}
@@ -1552,4 +1554,3 @@ class CreatePost extends React.PureComponent {
 }
 
 export default injectIntl(CreatePost);
-/* eslint-enable react/no-string-refs */


### PR DESCRIPTION
I was having issues with running master branch locally, and I thought it was caused by trying to use string refs with `React.forwardRef`, but it turns out that was just because I needed to rebuild the web app from scratch after updating to the latest master.

Even though this didn't solve my error, it still cleans up the code.