### PR TITLE
Cypress/E2E: fix failing tests due to search-input test ID change

### DIFF
--- a/e2e/cypress/integration/enterprise/ldap_group/team_and_channel_assign_roles_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/team_and_channel_assign_roles_spec.js
@@ -12,16 +12,19 @@
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 // # Save setting and get back to the resource page
-const saveAndNavigateBackTo = (name) => {
+const saveAndNavigateBackTo = (name, page) => {
     cy.get('#saveSetting').should('be.enabled').click({force: true});
 
-    cy.findByTestId('search-input').should('be.visible').type(`${name}{enter}`).wait(TIMEOUTS.HALF_SEC);
+    // * Verify that it redirects to teams page and wait for a while to load
+    cy.url().should('include', `/admin_console/user_management/${page}`).wait(TIMEOUTS.TWO_SEC);
+
+    cy.findByPlaceholderText('Search').should('be.visible').type(`${name}{enter}`).wait(TIMEOUTS.HALF_SEC);
     cy.findByTestId(`${name}edit`).should('be.visible').click();
 };
 
 const changeRoleTo = (role) => {
     cy.get('#role-to-be > button').should('be.visible').and('have.text', role).click();
-    cy.findByTestId('current-role').should('have.text', role).wait(TIMEOUTS.HALF_SEC);
+    cy.findByTestId('current-role').should('have.text', role).wait(TIMEOUTS.ONE_SEC);
 };
 
 describe('System Console', () => {
@@ -34,7 +37,10 @@ describe('System Console', () => {
         // * Check if server has license for LDAP Groups
         cy.requireLicenseForFeature('LDAPGroups');
 
-        cy.apiInitSetup().then(({team, channel}) => {
+        cy.apiInitSetup({
+            teamPrefix: {name: 'a-team', displayName: 'A Team'},
+            channelPrefix: {name: 'a-channel', displayName: 'A Channel'},
+        }).then(({team, channel}) => {
             testTeam = team;
             teamName = team.display_name;
             channelName = channel.display_name;
@@ -64,7 +70,7 @@ describe('System Console', () => {
         cy.visit('/admin_console/user_management/teams');
 
         // # Search for the team.
-        cy.findByTestId('search-input').type(`${teamName}{enter}`);
+        cy.findByPlaceholderText('Search').should('be.visible').type(`${teamName}{enter}`);
         cy.findByTestId(`${teamName}edit`).click();
 
         // # Add the first group in the group list then save
@@ -85,7 +91,7 @@ describe('System Console', () => {
         changeRoleTo('Team Admin');
 
         // # Save the setting and navigate back to page
-        saveAndNavigateBackTo(teamName);
+        saveAndNavigateBackTo(teamName, 'teams');
 
         // * Check to make the the current role text is displayed as Team Admin
         cy.findByTestId('current-role').should('have.text', 'Team Admin');
@@ -102,7 +108,7 @@ describe('System Console', () => {
         changeRoleTo('Member');
 
         // # Save the setting and navigate back to page
-        saveAndNavigateBackTo(teamName);
+        saveAndNavigateBackTo(teamName, 'teams');
 
         // * Check to make the the current role text is displayed as Member
         cy.findByTestId('current-role').should('have.text', 'Member');
@@ -119,7 +125,7 @@ describe('System Console', () => {
         });
 
         // # Save the setting and navigate back to page
-        saveAndNavigateBackTo(teamName);
+        saveAndNavigateBackTo(teamName, 'teams');
 
         // * Assert that the group was removed successfully
         cy.get('#groups-list--body').then((el) => {
@@ -132,7 +138,7 @@ describe('System Console', () => {
         cy.visit('/admin_console/user_management/teams');
 
         // # Search for the team.
-        cy.findByTestId('search-input').type(`${teamName}{enter}`);
+        cy.findByPlaceholderText('Search').should('be.visible').type(`${teamName}{enter}`);
         cy.findByTestId(`${teamName}edit`).click();
 
         // # Add the first group in the group list then save
@@ -153,7 +159,7 @@ describe('System Console', () => {
         changeRoleTo('Team Admin');
 
         // # Save the setting and navigate back to page
-        saveAndNavigateBackTo(teamName);
+        saveAndNavigateBackTo(teamName, 'teams');
 
         // * Check to make the the current role text is displayed as Team Admin
         cy.findByTestId('current-role').should('have.text', 'Team Admin');
@@ -164,7 +170,7 @@ describe('System Console', () => {
         cy.visit('/admin_console/user_management/channels');
 
         // # Search for the channel.
-        cy.findByTestId('search-input').type(`${channelName}{enter}`);
+        cy.findByPlaceholderText('Search').should('be.visible').type(`${channelName}{enter}`);
         cy.findByTestId(`${channelName}edit`).click();
 
         // # Add the first group in the group list then save
@@ -172,7 +178,7 @@ describe('System Console', () => {
         cy.get('#multiSelectList').should('be.visible');
         cy.get('#multiSelectList>div').children().eq(0).click();
         cy.get('#saveItems').click();
-        saveAndNavigateBackTo(channelName);
+        saveAndNavigateBackTo(channelName, 'channels');
 
         // * Ensure default role is Member
         cy.findByTestId('current-role').scrollIntoView().should('have.text', 'Member').click();
@@ -186,7 +192,7 @@ describe('System Console', () => {
         changeRoleTo('Channel Admin');
 
         // # Save the setting and navigate back to page
-        saveAndNavigateBackTo(channelName);
+        saveAndNavigateBackTo(channelName, 'channels');
 
         // * Check to make the the current role text is displayed as Channel Admin
         cy.findByTestId('current-role').should('have.text', 'Channel Admin');
@@ -203,7 +209,7 @@ describe('System Console', () => {
         changeRoleTo('Member');
 
         // # Save the setting and navigate back to page
-        saveAndNavigateBackTo(channelName);
+        saveAndNavigateBackTo(channelName, 'channels');
 
         // * Check to make the the current role text is displayed as Member
         cy.findByTestId('current-role').should('have.text', 'Member');
@@ -214,7 +220,7 @@ describe('System Console', () => {
         cy.visit('/admin_console/user_management/channels');
 
         // # Search for the channel.
-        cy.findByTestId('search-input').type(`${channelName}{enter}`);
+        cy.findByPlaceholderText('Search').should('be.visible').type(`${channelName}{enter}`);
         cy.findByTestId(`${channelName}edit`).click();
 
         // # Add the first group in the group list then save
@@ -235,7 +241,7 @@ describe('System Console', () => {
         changeRoleTo('Channel Admin');
 
         // # Save the setting and navigate back to page
-        saveAndNavigateBackTo(channelName);
+        saveAndNavigateBackTo(channelName, 'channels');
 
         // * Check to make the the current role text is displayed as Channel Admin
         cy.findByTestId('current-role').should('have.text', 'Channel Admin');

--- a/e2e/cypress/integration/enterprise/system_console/archived_channels_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/archived_channels_spec.js
@@ -13,13 +13,13 @@ describe('Archived channels', () => {
     before(() => {
         cy.requireLicense();
 
-        cy.apiInitSetup().then(({team}) => {
-            cy.apiCreateChannel(team.id, `aaa-archive-${Date.now()}`, 'AAA Archive Test').then((response) => {
-                testChannel = response.body;
+        cy.apiInitSetup({
+            channelPrefix: {name: 'aaa-archive', displayName: 'AAA Archive Test'},
+        }).then(({channel}) => {
+            testChannel = channel;
 
-                // # Archive the channel
-                cy.apiDeleteChannel(testChannel.id);
-            });
+            // # Archive the channel
+            cy.apiDeleteChannel(testChannel.id);
         });
     });
 
@@ -37,7 +37,7 @@ describe('Archived channels', () => {
         cy.visit('/admin_console/user_management/channels');
 
         // # Search for the archived channel
-        cy.get('[data-testid=search-input]').type(`${testChannel.display_name}{enter}`);
+        cy.findByPlaceholderText('Search').type(`${testChannel.display_name}{enter}`);
 
         // * Confirm that the archived channel is in the results
         cy.findByText(testChannel.display_name).should('be.visible');

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
@@ -10,7 +10,7 @@ import {checkBoxes} from './constants';
 export const visitChannelConfigPage = (channel) => {
     cy.apiAdminLogin();
     cy.visit('/admin_console/user_management/channels');
-    cy.findByTestId('search-input').type(`${channel.name}{enter}`);
+    cy.findByPlaceholderText('Search').type(`${channel.name}{enter}`);
     cy.findByText('Edit').click();
     cy.wait(TIMEOUTS.ONE_SEC);
 };
@@ -35,11 +35,11 @@ export const saveConfigForChannel = (channelName = false, clickConfirmationButto
             }
 
             // # Make sure the save is complete by looking for the search input which is only visible on the teams index page
-            cy.findByTestId('search-input').should('be.visible');
+            cy.findByPlaceholderText('Search').should('be.visible');
 
             if (channelName) {
                 // # Search for the channel.
-                cy.findByTestId('search-input').type(`${channelName}{enter}`);
+                cy.findByPlaceholderText('Search').type(`${channelName}{enter}`);
                 cy.findByText('Edit').click();
             }
         }

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/system_config_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/system_config_spec.js
@@ -48,7 +48,7 @@ describe('Channel Moderation', () => {
         cy.visit('/admin_console/user_management/channels');
 
         // # Search for the channel.
-        cy.findByTestId('search-input').type(`${testChannel.name}{enter}`);
+        cy.findByPlaceholderText('Search').type(`${testChannel.name}{enter}`);
         cy.findByText('Edit').click();
 
         // # Wait until the groups retrieved and show up

--- a/e2e/cypress/integration/enterprise/teams/search_teams_spec.js
+++ b/e2e/cypress/integration/enterprise/teams/search_teams_spec.js
@@ -22,68 +22,55 @@ describe('Search teams', () => {
     beforeEach(() => {
         cy.apiAdminLogin();
         cy.visit('/admin_console/user_management/teams');
-        cy.wrap([]).as('createdTeamIDs');
-    });
-
-    afterEach(function() {
-        this.createdTeamIDs.forEach((teamID) => {
-            cy.apiDeleteTeam(teamID);
-        });
     });
 
     it('loads with no search text', () => {
         // * Check the search input is empty.
-        cy.findByTestId('search-input').should('be.visible').and('have.text', '');
+        cy.findByPlaceholderText('Search').should('be.visible').and('have.text', '');
     });
 
-    it('returns results', function() {
+    it('returns results', () => {
         const displayName = uuidv4();
 
         // # Create a new team.
-        cy.apiCreateTeam('team-search', displayName).then(({team}) => {
-            this.createdTeamIDs.push(team.id);
-        });
+        cy.apiCreateTeam('team-search', displayName);
 
         // # Search for the new team.
-        cy.findByTestId('search-input').type(displayName + '{enter}');
+        cy.findByPlaceholderText('Search').type(displayName + '{enter}');
 
         // * Check that the search results contain the team.
         cy.findAllByTestId('team-display-name').contains(displayName);
     });
 
-    it('results are paginated', function() {
+    it('results are paginated', () => {
         const displayName = uuidv4();
 
         // # Create enough new teams with common name prefixes to get multiple pages of search results.
-        for (let i = 0; i < PAGE_SIZE + 2; i++) {
-            cy.apiCreateTeam('team-search-paged-' + i, displayName + ' ' + i).then(({team}) => {
-                this.createdTeamIDs.push(team.id);
-            });
-        }
+        Cypress._.times(PAGE_SIZE + 2, (i) => {
+            cy.apiCreateTeam('team-search-paged-' + i, displayName + ' ' + i);
+        });
 
         // # Search using the common team name prefix.
-        cy.findByTestId('search-input').type(displayName + '{enter}');
+        cy.findByPlaceholderText('Search').type(displayName + '{enter}');
 
         // * Check that the first page of results is full.
         cy.findAllByTestId('team-display-name').should('have.length', PAGE_SIZE);
 
         // # Click the next pagination arrow.
-        cy.findByTestId('page-link-next').should('be.enabled').click();
+        cy.findByTitle('Next Icon').parent().should('be.enabled').click();
 
         // * Check that the 2nd page of results has the expected amount.
         cy.findAllByTestId('team-display-name').should('have.length', 2);
     });
 
-    it('clears the results when "x" is clicked', function() {
+    it('clears the results when "x" is clicked', () => {
         const displayName = uuidv4();
 
         // # Create a new team.
-        cy.apiCreateTeam('team-search', displayName).then(({team}) => {
-            this.createdTeamIDs.push(team.id);
-        });
+        cy.apiCreateTeam('team-search', displayName);
 
         // # Search for the team.
-        cy.get('[data-testid=search-input]').as('searchInput').type(displayName + '{enter}');
+        cy.findByPlaceholderText('Search').as('searchInput').type(displayName + '{enter}');
 
         // * Check that the list of teams is in search results mode.
         cy.findAllByTestId('team-display-name').should('have.length', 1);
@@ -98,16 +85,14 @@ describe('Search teams', () => {
         cy.findAllByTestId('team-display-name').should('have.length', PAGE_SIZE);
     });
 
-    it('clears the results when the search term is deleted with backspace', function() {
+    it('clears the results when the search term is deleted with backspace', () => {
         const displayName = uuidv4();
 
         // # Create a team.
-        cy.apiCreateTeam('team-search', displayName).then(({team}) => {
-            this.createdTeamIDs.push(team.id);
-        });
+        cy.apiCreateTeam('team-search', displayName);
 
         // # Search for the team.
-        cy.get('[data-testid=search-input]').as('searchInput').type(displayName + '{enter}');
+        cy.findByPlaceholderText('Search').as('searchInput').type(displayName + '{enter}');
 
         // * Check that the list of teams is in search results mode.
         cy.findAllByTestId('team-display-name').should('have.length', 1);


### PR DESCRIPTION
#### Summary
Cypress/E2E: fix failing tests due to search-input test ID change.

There are valid bugs on archived channels and search teams specs - https://mattermost.atlassian.net/browse/MM-26762 and https://mattermost.atlassian.net/browse/MM-26782 

#### Ticket Link
none, failing on daily Cypress run
