### PR TITLE
MM-26733 - Export Textbox so plugins can use it

### DIFF
--- a/components/quick_input.jsx
+++ b/components/quick_input.jsx
@@ -7,8 +7,9 @@ import {FormattedMessage} from 'react-intl';
 import {Tooltip} from 'react-bootstrap';
 
 import OverlayTrigger from 'components/overlay_trigger';
-
 import Constants from 'utils/constants.jsx';
+
+import AutosizeTextarea from './autosize_textarea';
 
 // A component that can be used to make controlled inputs that function properly in certain
 // environments (ie. IE11) where typing quickly would sometimes miss inputs
@@ -128,6 +129,11 @@ export default class QuickInput extends React.PureComponent {
         Reflect.deleteProperty(props, 'delayInputUpdate');
         Reflect.deleteProperty(props, 'onClear');
         Reflect.deleteProperty(props, 'clearableTooltipText');
+        Reflect.deleteProperty(props, 'channelId');
+
+        if (inputComponent !== AutosizeTextarea) {
+            Reflect.deleteProperty(props, 'onHeightChange');
+        }
 
         const inputElement = React.createElement(
             inputComponent || 'input',

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -22,6 +22,11 @@ export default class SuggestionBox extends React.PureComponent {
         listComponent: PropTypes.func.isRequired,
 
         /**
+         * The input component to render (it is passed through props to the QuickInput)
+         */
+        inputComponent: PropTypes.elementType,
+
+        /**
          * The date component to render
          */
         dateComponent: PropTypes.func,

--- a/components/textbox/index.ts
+++ b/components/textbox/index.ts
@@ -52,5 +52,7 @@ const connectedTextbox = connect(makeMapStateToProps, mapDispatchToProps, null, 
 export default connectedTextbox;
 
 // Attach the Textbox to the window object so that plugins can use it.
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
 window.Textbox = connectedTextbox;
 

--- a/components/textbox/index.ts
+++ b/components/textbox/index.ts
@@ -48,11 +48,5 @@ const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
     }, dispatch),
 });
 
-const connectedTextbox = connect(makeMapStateToProps, mapDispatchToProps, null, {forwardRef: true})(Textbox);
-export default connectedTextbox;
-
-// Attach the Textbox to the window object so that plugins can use it.
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-window.Textbox = connectedTextbox;
+export default connect(makeMapStateToProps, mapDispatchToProps, null, {forwardRef: true})(Textbox);
 

--- a/components/textbox/index.ts
+++ b/components/textbox/index.ts
@@ -48,4 +48,9 @@ const mapDispatchToProps = (dispatch: Dispatch<GenericAction>) => ({
     }, dispatch),
 });
 
-export default connect(makeMapStateToProps, mapDispatchToProps, null, {forwardRef: true})(Textbox);
+const connectedTextbox = connect(makeMapStateToProps, mapDispatchToProps, null, {forwardRef: true})(Textbox);
+export default connectedTextbox;
+
+// Attach the Textbox to the window object so that plugins can use it.
+window.Textbox = connectedTextbox;
+

--- a/components/textbox/textbox.tsx
+++ b/components/textbox/textbox.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 /* eslint-disable react/no-string-refs */
 
-import React, {ChangeEvent, FocusEvent, KeyboardEvent, MouseEvent, ReactElement} from 'react';
+import React, {ChangeEvent, ElementType, FocusEvent, KeyboardEvent, MouseEvent} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {Channel} from 'mattermost-redux/types/channels';
@@ -54,7 +54,7 @@ type Props = {
         searchAssociatedGroupsForReference: (prefix: string, teamId: string, channelId: string | undefined) => (dispatch: any, getState: any) => Promise<{ data: any }>;
     };
     useChannelMentions: boolean;
-    inputComponent?: ReactElement | string;
+    inputComponent?: ElementType;
 };
 
 export default class Textbox extends React.PureComponent<Props> {

--- a/components/textbox/textbox.tsx
+++ b/components/textbox/textbox.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 /* eslint-disable react/no-string-refs */
 
-import React, {ChangeEvent, FocusEvent, KeyboardEvent, MouseEvent} from 'react';
+import React, {ChangeEvent, FocusEvent, KeyboardEvent, MouseEvent, ReactElement} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {Channel} from 'mattermost-redux/types/channels';
@@ -54,6 +54,7 @@ type Props = {
         searchAssociatedGroupsForReference: (prefix: string, teamId: string, channelId: string | undefined) => (dispatch: any, getState: any) => Promise<{ data: any }>;
     };
     useChannelMentions: boolean;
+    inputComponent?: ReactElement | string | null;
 };
 
 export default class Textbox extends React.PureComponent<Props> {
@@ -234,6 +235,7 @@ export default class Textbox extends React.PureComponent<Props> {
                 </div>
             );
         }
+        const inputComponent = this.props.inputComponent || AutosizeTextarea;
 
         return (
             <div
@@ -255,7 +257,7 @@ export default class Textbox extends React.PureComponent<Props> {
                     onBlur={this.handleBlur}
                     onHeightChange={this.handleHeightChange}
                     style={{visibility: this.props.preview ? 'hidden' : 'visible'}}
-                    inputComponent={AutosizeTextarea}
+                    inputComponent={inputComponent}
                     listComponent={SuggestionList}
                     listStyle={this.props.suggestionListStyle}
                     providers={this.suggestionProviders}

--- a/components/textbox/textbox.tsx
+++ b/components/textbox/textbox.tsx
@@ -54,7 +54,7 @@ type Props = {
         searchAssociatedGroupsForReference: (prefix: string, teamId: string, channelId: string | undefined) => (dispatch: any, getState: any) => Promise<{ data: any }>;
     };
     useChannelMentions: boolean;
-    inputComponent?: ReactElement | string | null;
+    inputComponent?: ReactElement | string;
 };
 
 export default class Textbox extends React.PureComponent<Props> {
@@ -67,6 +67,7 @@ export default class Textbox extends React.PureComponent<Props> {
         supportsCommands: true,
         isRHS: false,
         listenForMentionKeyClick: false,
+        inputComponent: AutosizeTextarea,
     };
 
     constructor(props: Props) {
@@ -235,7 +236,6 @@ export default class Textbox extends React.PureComponent<Props> {
                 </div>
             );
         }
-        const inputComponent = this.props.inputComponent || AutosizeTextarea;
 
         return (
             <div
@@ -257,7 +257,7 @@ export default class Textbox extends React.PureComponent<Props> {
                     onBlur={this.handleBlur}
                     onHeightChange={this.handleHeightChange}
                     style={{visibility: this.props.preview ? 'hidden' : 'visible'}}
-                    inputComponent={inputComponent}
+                    inputComponent={this.props.inputComponent}
                     listComponent={SuggestionList}
                     listStyle={this.props.suggestionListStyle}
                     providers={this.suggestionProviders}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8236,7 +8236,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true,
           "optional": true
@@ -10634,14 +10634,14 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true,
           "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "optional": true,
@@ -19760,7 +19760,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true

--- a/plugins/export.js
+++ b/plugins/export.js
@@ -23,4 +23,4 @@ window.PDFJS = require('pdfjs-dist');
 window.PostUtils = {formatText, messageHtmlToComponent};
 window.openInteractiveDialog = openInteractiveDialog;
 window.WebappUtils = {browserHistory};
-window.Textbox = Textbox;
+window.Components = {Textbox};

--- a/plugins/export.js
+++ b/plugins/export.js
@@ -16,9 +16,11 @@ window.Redux = require('redux');
 window.ReactRedux = require('react-redux');
 window.ReactBootstrap = require('react-bootstrap');
 window.ReactRouterDom = require('react-router-dom');
-window.PostUtils = {formatText, messageHtmlToComponent};
 window.PropTypes = require('prop-types');
 window.PDFJS = require('pdfjs-dist');
+
+// Functions and components exposed on window for plugins to use.
+window.PostUtils = {formatText, messageHtmlToComponent};
 window.openInteractiveDialog = openInteractiveDialog;
 window.WebappUtils = {browserHistory};
 window.Textbox = Textbox;

--- a/plugins/export.js
+++ b/plugins/export.js
@@ -4,6 +4,7 @@
 import messageHtmlToComponent from 'utils/message_html_to_component';
 import {formatText} from 'utils/text_formatting';
 import {browserHistory} from 'utils/browser_history';
+import Textbox from 'components/textbox';
 
 // The following import has intentional side effects. Do not remove without research.
 import {openInteractiveDialog} from './interactive_dialog';
@@ -20,3 +21,4 @@ window.PropTypes = require('prop-types');
 window.PDFJS = require('pdfjs-dist');
 window.openInteractiveDialog = openInteractiveDialog;
 window.WebappUtils = {browserHistory};
+window.Textbox = Textbox;


### PR DESCRIPTION
#### Summary
- Tried to compile the Textbox from a plugin, and that was a mess.
- Instead, export the connected component into the window object.
- Now we're able to send in a custom input component to override `Textbox`'s `AutosizeTextArea`.
- In `QuickInput` we don't need the `channelId` so remove it, and if we're not using an `AutosizeTextArea` we don't need to pass in the `onHeightChange` prop (these were causing warnings went sent to a plain input, and I wanted to clean them up).
- Open to a better organization for the exported component. Maybe `window.components.Textbox`? -- done

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-26733