### PR TITLE
[MM-26782] Webapp/Admin console: Next page of Teams does not respect search results

### DIFF
--- a/components/admin_console/team_channel_settings/team/list/team_list.jsx
+++ b/components/admin_console/team_channel_settings/team/list/team_list.jsx
@@ -85,7 +85,7 @@ export default class TeamList extends React.PureComponent {
     searchTeamsDebounced = debounce((page, term) => this.searchTeams(page, term), 300);
 
     nextPage = () => {
-        this.loadPage(this.state.page + 1);
+        this.loadPage(this.state.page + 1, this.state.term);
     }
 
     previousPage = () => {


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Fixes `next page of Teams does not respect search results`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-26782

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![image](https://user-images.githubusercontent.com/17804942/87236676-08f79c80-c3ba-11ea-8d89-3ac7d02e0973.png)
