### PR TITLE
MM-26628 Fix for empty space for new category in mobile view

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -789,6 +789,10 @@
         padding: 0;
     }
 
+    .SidebarChannelGroup .SidebarChannel.newChannelSpacer {
+        height: 0px;
+    }
+
     /* Channels */
     .SidebarChannel {
         display: block;
@@ -822,10 +826,6 @@
 
         &.noFloat {
             transform: none !important;
-        }
-
-        &.newChannelSpacer {
-            height: 0;
         }
 
         .btn-close {


### PR DESCRIPTION

#### Summary
  * Override height for small screens new category

There is a specificity override for height for smaller screens making the `height:0` in effective

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26628


#### Screenshots
<img width="685" alt="Untitled" src="https://user-images.githubusercontent.com/4973621/87326568-89500600-c550-11ea-895c-74c0edacfc76.png">
