### PR TITLE
MM-26751: Fix highlighting of at-mentions of self

### DIFF
--- a/components/post_markdown/__snapshots__/post_markdown.test.jsx.snap
+++ b/components/post_markdown/__snapshots__/post_markdown.test.jsx.snap
@@ -22,6 +22,7 @@ exports[`components/PostMarkdown plugin hooks can build upon other hook message 
   options={
     Object {
       "disableGroupHighlight": false,
+      "mentionHighlight": true,
     }
   }
   proxyImages={true}
@@ -50,6 +51,7 @@ exports[`components/PostMarkdown plugin hooks can overwrite other hooks messages
   options={
     Object {
       "disableGroupHighlight": false,
+      "mentionHighlight": true,
     }
   }
   proxyImages={true}
@@ -153,6 +155,7 @@ exports[`components/PostMarkdown should render properly with a post 1`] = `
   options={
     Object {
       "disableGroupHighlight": false,
+      "mentionHighlight": true,
     }
   }
   proxyImages={true}
@@ -195,6 +198,7 @@ exports[`components/PostMarkdown should render properly without group highlight 
   options={
     Object {
       "disableGroupHighlight": true,
+      "mentionHighlight": true,
     }
   }
   proxyImages={true}

--- a/components/post_markdown/post_markdown.jsx
+++ b/components/post_markdown/post_markdown.jsx
@@ -76,6 +76,10 @@ export default class PostMarkdown extends React.PureComponent {
             }
         });
 
+        if (post && post.props) {
+            options.mentionHighlight = !post.props.mentionHighlightDisabled;
+        }
+
         return (
             <Markdown
                 imageProps={this.props.imageProps}

--- a/e2e/cypress/integration/messaging/at_mentions_user_spec.js
+++ b/e2e/cypress/integration/messaging/at_mentions_user_spec.js
@@ -27,7 +27,7 @@ describe('Mention user', () => {
     let testUser;
 
     before(() => {
-        // # Login as test user and visit town-square
+        // # Login as admin and visit town-square
         cy.apiInitSetup().then(({team, user}) => {
             testUser = user;
 
@@ -49,6 +49,36 @@ describe('Mention user', () => {
             {input: `@${testUser.first_name} ${testUser.last_name} `, expected: fullname, withoutSuggestion: true, case: 'should not match on @fullname with trailing space'},
         ].forEach((testCase) => {
             verifySuggestionList(testCase);
+        });
+    });
+});
+
+describe('Mention self', () => {
+    let testUser;
+
+    before(() => {
+        // # Login as test user and visit town-square
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+
+            cy.apiLogin(testUser);
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
+    });
+
+    it('should be always highlighted', () => {
+        [
+            `@${testUser.username}`,
+            `@${testUser.username}.`,
+            `@${testUser.username}_`,
+            `@${testUser.username}-`,
+            `@${testUser.username},`,
+        ].forEach((message) => {
+            cy.postMessage(message);
+
+            cy.getLastPostId().then((postId) => {
+                cy.get(`#postMessageText_${postId}`).find('.mention--highlight');
+            });
         });
     });
 });


### PR DESCRIPTION
#### Summary
With https://github.com/mattermost/mattermost-webapp/pull/5372, we reintroduced a bug that prevented self mentions to be highlighted with certain punctuation.

This PR just brings back the fix from https://github.com/mattermost/mattermost-webapp/pull/4994, which solved this same bug back in the day.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26751

#### Screenshots
Highlights are back :tada: 
![image](https://user-images.githubusercontent.com/3924815/87556685-3b094700-c6b7-11ea-88da-2c3972b2456d.png)
