### PR TITLE
Revert "[MM-26605] Forward references into SearchChannelSuggestion and SwitchChannelSuggestion to allow scrolling during arrow navigation"

### DIFF
--- a/components/suggestion/search_channel_suggestion/index.js
+++ b/components/suggestion/search_channel_suggestion/index.js
@@ -15,4 +15,4 @@ const mapStateToProps = (state, ownProps) => {
     };
 };
 
-export default connect(mapStateToProps, null, null, {forwardRef: true})(SearchChannelSuggestion);
+export default connect(mapStateToProps)(SearchChannelSuggestion);

--- a/components/suggestion/suggestion_box.jsx
+++ b/components/suggestion/suggestion_box.jsx
@@ -681,7 +681,6 @@ export default class SuggestionBox extends React.PureComponent {
             dateComponent,
             listStyle,
             renderNoResults,
-            suppressLoadingSpinner,
             ...props
         } = this.props;
 
@@ -706,7 +705,6 @@ export default class SuggestionBox extends React.PureComponent {
         Reflect.deleteProperty(props, 'listenForMentionKeyClick');
         Reflect.deleteProperty(props, 'wrapperHeight');
         Reflect.deleteProperty(props, 'forceSuggestionsWhenBlur');
-        Reflect.deleteProperty(props, 'onSuggestionsReceived');
 
         // This needs to be upper case so React doesn't think it's an html tag
         const SuggestionListComponent = listComponent;
@@ -754,7 +752,7 @@ export default class SuggestionBox extends React.PureComponent {
                             wrapperHeight={this.props.wrapperHeight}
                             inputRef={this.inputRef}
                             onLoseVisibility={this.blur}
-                            suppressLoadingSpinner={suppressLoadingSpinner}
+                            suppressLoadingSpinner={this.props.suppressLoadingSpinner}
                         />
                     </div>
                 }

--- a/components/suggestion/switch_channel_provider.jsx
+++ b/components/suggestion/switch_channel_provider.jsx
@@ -177,7 +177,7 @@ function mapStateToPropsForSwitchChannelSuggestion(state, ownProps) {
     };
 }
 
-const ConnectedSwitchChannelSuggestion = connect(mapStateToPropsForSwitchChannelSuggestion, null, null, {forwardRef: true})(SwitchChannelSuggestion);
+const ConnectedSwitchChannelSuggestion = connect(mapStateToPropsForSwitchChannelSuggestion)(SwitchChannelSuggestion);
 
 let prefix = '';
 


### PR DESCRIPTION
Looks like mattermost/mattermost-webapp#5845 broke interactive dialog's `select` option. Reverting the change to fix the issue.

Fixes: https://mattermost.atlassian.net/browse/MM-26868

#### Steps to reproduce:
1. Install [demo plugin](https://github.com/mattermost/mattermost-plugin-demo/releases/download/v07.0/com.mattermost.demo-plugin-0.7.0.tar.gz)
2. Run `/dialog` command
3. Click `Option Selector` 
4. Select an option
5. Attempt to select the same option again (it will not open)

![2020-07-15 at 4 01 PM](https://user-images.githubusercontent.com/25732808/87590511-e5cc3600-c6b4-11ea-919c-bb21bf5c06a2.gif)
