### PR TITLE
Cypress/E2E: promote/demote specs for v5.26

### DIFF
--- a/e2e/cypress/integration/account_settings/display/clock_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/clock_display_mode_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 import moment from 'moment-timezone';

--- a/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @account_setting
 
 import {getRandomId} from '../../../utils';

--- a/e2e/cypress/integration/account_settings/display/timezone_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/timezone_display_mode_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 import moment from 'moment-timezone';

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_ui_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_ui_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @account_setting
 
 describe('Account Settings > Sidebar > Channel Switcher', () => {

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @guest_account
 
 /**

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @guest_account
 
 /**

--- a/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @guest_account
 
 /**

--- a/e2e/cypress/integration/enterprise/ldap_group/group_mentions_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/group_mentions_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @enterprise @ldap_group
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';

--- a/e2e/cypress/integration/enterprise/ldap_group/search_channels_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/search_channels_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @ldap_group
 
 import {getRandomId} from '../../../utils';

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/create_posts_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/create_posts_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console @channel_moderation
 
 import {checkboxesTitleToIdMap} from './constants';

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/manage_members_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/manage_members_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console @channel_moderation
 
 import * as TIMEOUTS from '../../../../fixtures/timeouts';

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/system_config_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/system_config_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @enterprise @system_console @channel_moderation
 
 import * as TIMEOUTS from '../../../../fixtures/timeouts';

--- a/e2e/cypress/integration/integrations/incoming_webhook/basic_formatting_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/basic_formatting_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @incoming_webhook
 
 describe('Incoming webhook', () => {

--- a/e2e/cypress/integration/integrations/incoming_webhook/disallow_username_profile_override_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/disallow_username_profile_override_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @incoming_webhook
 
 import {getRandomId} from '../../../utils';

--- a/e2e/cypress/integration/integrations/incoming_webhook/inapp_username_profile_override_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/inapp_username_profile_override_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @incoming_webhook
 
 import {getRandomId} from '../../../utils';

--- a/e2e/cypress/integration/integrations/incoming_webhook/setting_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/setting_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @incoming_webhook
 
 import {getRandomId} from '../../../utils';

--- a/e2e/cypress/integration/messaging/channel_read_after_permalink_spec.js
+++ b/e2e/cypress/integration/messaging/channel_read_after_permalink_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/channel_users_interactions_spec.js
+++ b/e2e/cypress/integration/messaging/channel_users_interactions_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 describe('Channel users interactions', () => {

--- a/e2e/cypress/integration/messaging/date_separator_spec.js
+++ b/e2e/cypress/integration/messaging/date_separator_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 import {getAdminAccount} from '../../support/env';

--- a/e2e/cypress/integration/messaging/mention_autocomplete_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/mention_autocomplete_overlap_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/message_permalink_spec.js
+++ b/e2e/cypress/integration/messaging/message_permalink_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/post_header_spec.js
+++ b/e2e/cypress/integration/messaging/post_header_spec.js
@@ -8,7 +8,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/messaging/post_textbox_height_spec.js
+++ b/e2e/cypress/integration/messaging/post_textbox_height_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 describe('Messaging', () => {

--- a/e2e/cypress/integration/messaging/private_channel_open_spec.js
+++ b/e2e/cypress/integration/messaging/private_channel_open_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @messaging
 
 describe('Messaging - Opening a private channel using keyboard shortcuts', () => {

--- a/e2e/cypress/integration/search/search_user_post_spec.js
+++ b/e2e/cypress/integration/search/search_user_post_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @search @smoke
 
 /**

--- a/e2e/cypress/integration/signin_authentication/forgot_password_spec.js
+++ b/e2e/cypress/integration/signin_authentication/forgot_password_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @signin_authentication
 
 import {getEmailUrl, getEmailMessageSeparator, reUrl} from '../../utils';

--- a/e2e/cypress/integration/system_console/plugin_upload_spec.js
+++ b/e2e/cypress/integration/system_console/plugin_upload_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @system_console @plugin
 
 /**


### PR DESCRIPTION
#### Summary
Promoted tests:
- most came from the recent SDETs campaign on automating those test cases from the backlogs.

Demoted tests are found to be automation bugs like those flaky tests:
- due to post menu being rendered at the bottom for newly created channel
- pixel difference
- uncaught error on `scrollTo`

Other demoted tests need to be investigated further. Unfortunately, those can't make into v5.26.

Test run - https://mm-cypress-report.s3.amazonaws.com/603-for-release-5-26-master/mochawesome.html
However, let's closely monitor once other PR gets merged for 5.26 like this [one](https://github.com/mattermost/mattermost-webapp/pull/5498). I'll try to run the test on that PR too.

#### Ticket Link
none, based on daily Cypress run
