### PR TITLE
[E2E] Fix test M18679 - Mobile view: Post options menu (3-dots) is present on a reply post in RHS

### DIFF
--- a/e2e/cypress/integration/messaging/post_options_menu_spec.js
+++ b/e2e/cypress/integration/messaging/post_options_menu_spec.js
@@ -45,14 +45,14 @@ describe('Messaging', () => {
 
             // * Check if modal for post options have opened
             cy.get(dropDownMenuOfPostOptionsID).should('be.visible').within(() => {
-                // * Check if atleast 1 item is present
+                // * Check if at least 1 item is present
                 cy.get('li').should('have.length.greaterThan', 0);
 
                 // * Check if one of the options are as follows
                 cy.findByText('Add Reaction').should('be.visible');
                 cy.findByText('Mark as Unread').should('be.visible');
                 cy.findByText('Copy Link').should('be.visible');
-                cy.findByText('Flag').should('be.visible');
+                cy.findByText('Save').should('be.visible');
                 cy.findByText('Pin to Channel').should('be.visible');
                 cy.findByText('Edit').should('be.visible');
                 cy.findByText('Delete').should('be.visible');


### PR DESCRIPTION
#### Summary
Fixes a failing check in test "M18679 - Mobile view: Post options menu (3-dots) is present on a reply post in RHS", was looking for "Flag" instead of "Save" in the mobile menu. 

This is a follow-up on https://github.com/mattermost/mattermost-webapp/pull/5498

You may also refer to [this thread on MM](https://community-daily.mattermost.com/core/pl/wu4afpaiobgd3ey8sudqcmn5tw).

#### Ticket Link
NA