### PR TITLE
Cypress/E2E: fix tests on timezone display

### DIFF
--- a/e2e/cypress/integration/account_settings/display/timezone_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/timezone_display_mode_spec.js
@@ -253,7 +253,9 @@ function setTimezoneDisplayToManual(timezone) {
 function verifyLocalTimeIsTimezoneFormatted(localTime, timeFormat) {
     // * Verify that the local time of each post is in timezone format
     const formattedTime = localTime.dateInTimezone.format(timeFormat);
-    cy.findAllByTestId('postView').eq(localTime.postIndex).find('time', {timeout: TIMEOUTS.HALF_SEC}).should('have.text', formattedTime);
+    cy.findAllByTestId('postView', {timeout: TIMEOUTS.ONE_MIN}).
+        eq(localTime.postIndex).find('time', {timeout: TIMEOUTS.HALF_SEC}).
+        should('have.text', formattedTime);
 }
 
 function verifyLocalTimeIsTimezoneFormatted12Hour(localTime) {

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -26,7 +26,7 @@ Cypress.Commands.add('getCurrentUserId', () => {
 
 // Go to Account Settings modal
 Cypress.Commands.add('toAccountSettingsModal', () => {
-    cy.get('#channel_view').should('be.visible');
+    cy.get('#channel_view', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
     cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
     cy.get('#accountSettings').should('be.visible').click();
     cy.get('#accountSettingsModal').should('be.visible');


### PR DESCRIPTION
#### Summary
Fix tests on timezone display by adding longer timeouts waiting for an element to show up.

#### Ticket Link
None, (randomly) failing on daily Cypress run - both on master and release-5.26
