### PR TITLE
MM-26075 Add type definitions and standard return to user/status/external api commands

### DIFF
--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_identification_ui_spec.js
@@ -239,7 +239,7 @@ describe('MM-18045 Verify Guest User Identification in different screens', () =>
         });
 
         // # Deactivate Guest user
-        cy.apiActivateUser(guest.id, false).wait(TIMEOUTS.FIVE_SEC);
+        cy.externalActivateUser(guest.id, false).wait(TIMEOUTS.FIVE_SEC);
 
         // * Verify the text 'This channel has guests' is removed from the header
         cy.get('#channelHeaderDescription').within(($el) => {

--- a/e2e/cypress/support/api/index.js
+++ b/e2e/cypress/support/api/index.js
@@ -3,6 +3,7 @@
 
 import './setup';
 import './preference';
+import './status';
 import './system';
 import './team';
 import './user';

--- a/e2e/cypress/support/api/status.d.ts
+++ b/e2e/cypress/support/api/status.d.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Meaningful description
+// - Specific link to https://api.mattermost.com
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// Custom command should follow naming convention of having `api` prefix, e.g. `apiLogin`.
+// ***************************************************************
+
+declare namespace Cypress {
+    interface Chainable<Subject = any> {
+
+        /**
+         * Update status of a current user.
+         * See https://api.mattermost.com/#tag/status/paths/~1users~1{user_id}~1status/put
+         * @param {String} status - "online" (default), "offline", "away" or "dnd"
+         * @returns {UserStatus} `out.status` as `UserStatus`
+         *
+         * @example
+         *   cy.apiUpdateUserStatus('offline').then(({status}) => {
+         *       // do something with status
+         *   });
+         */
+        apiUpdateUserStatus(status: string): Chainable<UserStatus>;
+    }
+}

--- a/e2e/cypress/support/api/status.js
+++ b/e2e/cypress/support/api/status.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *****************************************************************************
+// Status
+// https://api.mattermost.com/#tag/status
+// *****************************************************************************
+
+Cypress.Commands.add('apiUpdateUserStatus', (status = 'online') => {
+    return cy.getCookie('MMUSERID').then((cookie) => {
+        const data = {user_id: cookie.value, status};
+
+        return cy.request({
+            headers: {'X-Requested-With': 'XMLHttpRequest'},
+            url: '/api/v4/users/me/status',
+            method: 'PUT',
+            body: data,
+        }).then((response) => {
+            expect(response.status).to.equal(200);
+            cy.wrap({status: response.body});
+        });
+    });
+});

--- a/e2e/cypress/support/api/user.d.ts
+++ b/e2e/cypress/support/api/user.d.ts
@@ -23,7 +23,7 @@ declare namespace Cypress {
          * See https://api.mattermost.com/#tag/users/paths/~1users~1login/post
          * @param {string} user.username - username of a user
          * @param {string} user.password - password of  user
-         * @returns {UserProfile} response.body: `UserProfile` object
+         * @returns {UserProfile} out.user: `UserProfile` object
          *
          * @example
          *   cy.apiLogin({username: 'sysadmin', password: 'secret'});
@@ -33,7 +33,7 @@ declare namespace Cypress {
         /**
          * Login as admin via API.
          * See https://api.mattermost.com/#tag/users/paths/~1users~1login/post
-         * @returns {UserProfile} response.body: `UserProfile` object
+         * @returns {UserProfile} out.user: `UserProfile` object
          *
          * @example
          *   cy.apiAdminLogin();
@@ -53,7 +53,7 @@ declare namespace Cypress {
         /**
          * Gets current user
          * See https://api.mattermost.com/#tag/users/paths/~1users~1{user_id}/get
-         * @returns {UserProfile} response.body: `UserProfile` object
+         * @returns {UserProfile} out.user: `UserProfile` object
          *
          * @example
          *   cy.apiGetMe().then(({user}) => {
@@ -66,7 +66,7 @@ declare namespace Cypress {
          * Get a user by email
          * See https://api.mattermost.com/#tag/users/paths/~1users~1email~1{email}/get
          * @param {String} email - email address of a user to get profile
-         * @returns {UserProfile} response.body: `UserProfile` object
+         * @returns {UserProfile} out.user: `UserProfile` object
          *
          * @example
          *   cy.apiGetUserByEmail().then(({user}) => {
@@ -79,7 +79,7 @@ declare namespace Cypress {
          * Get users by usernames
          * See https://api.mattermost.com/#tag/users/paths/~1users~1usernames/post
          * @param {String[]} usernames - list of usernames to get profiles
-         * @returns {UserProfile[]} response.body: list of `UserProfile` objects
+         * @returns {UserProfile[]} out.users: list of `UserProfile` objects
          *
          * @example
          *   cy.apiGetUsersByUsernames().then(({users}) => {
@@ -89,42 +89,97 @@ declare namespace Cypress {
         apiGetUsersByUsernames(usernames: string[]): Chainable<UserProfile[]>;
 
         /**
+         * Patch a user.
+         * See https://api.mattermost.com/#tag/users/paths/~1users~1{user_id}~1patch/put
+         * @param {String} userId - ID of user to patch
+         * @param {UserProfile} userData - user profile to be updated
+         * @param {string} userData.email
+         * @param {string} userData.username
+         * @param {string} userData.first_name
+         * @param {string} userData.last_name
+         * @param {string} userData.nickname
+         * @param {string} userData.locale
+         * @param {Object} userData.timezone
+         * @param {string} userData.position
+         * @param {Object} userData.props
+         * @param {Object} userData.notify_props
+         * @returns {UserProfile} out.user: `UserProfile` object
+         *
+         * @example
+         *   cy.apiPatchUser('user-id', {locale: 'en'}).then(({user}) => {
+         *       // do something with user
+         *   });
+         */
+        apiPatchUser(userId: string, userData: UserProfile): Chainable<UserProfile>;
+
+        /**
+         * Convenient command to patch a current user.
+         * See https://api.mattermost.com/#tag/users/paths/~1users~1{user_id}~1patch/put
+         * @param {UserProfile} userData - user profile to be updated
+         * @param {string} userData.email
+         * @param {string} userData.username
+         * @param {string} userData.first_name
+         * @param {string} userData.last_name
+         * @param {string} userData.nickname
+         * @param {string} userData.locale
+         * @param {Object} userData.timezone
+         * @param {string} userData.position
+         * @param {Object} userData.props
+         * @param {Object} userData.notify_props
+         * @returns {UserProfile} out.user: `UserProfile` object
+         *
+         * @example
+         *   cy.apiPatchMe({locale: 'en'}).then(({user}) => {
+         *       // do something with user
+         *   });
+         */
+        apiPatchMe(userData: UserProfile): Chainable<UserProfile>;
+
+        /**
          * Creates an admin account based from the env variables defined in Cypress env
          * @param {string} options.namePrefix - 'user' (default) or any prefix to easily identify a user
          * @param {boolean} options.bypassTutorial - true (default) or false for user to go thru tutorial steps
-         * @returns {Object} `out` Cypress-chainable, yielded with element passed into .wrap().
          * @returns {UserProfile} `out.sysadmin` as `UserProfile` object
          *
          * @example
          *   cy.apiCreateAdmin(options);
          */
-        apiCreateAdmin(options: Record<string, any>): Chainable<Record<string, any>>;
+        apiCreateAdmin(options: Record<string, any>): Chainable<UserProfile>;
 
         /**
          * Creates a new user with an options to set name prefix and be able to bypass tutorial steps
          * @param {string} options.user - predefined `user` object instead on random user
          * @param {string} options.prefix - 'user' (default) or any prefix to easily identify a user
          * @param {boolean} options.bypassTutorial - true (default) or false for user to go thru tutorial steps
-         * @returns {Object} `out` Cypress-chainable, yielded with element passed into .wrap().
          * @returns {UserProfile} `out.user` as `UserProfile` object
          *
          * @example
          *   cy.apiCreateUser(options);
          */
-        apiCreateUser(options: Record<string, any>): Chainable<Record<string, any>>;
+        apiCreateUser(options: Record<string, any>): Chainable<UserProfile>;
 
         /**
          * Creates a new guest user with an options to set name prefix and be able to bypass tutorial steps
          * @param {string} options.prefix - 'guest' (default) or any prefix to easily identify a guest
          * @param {string} options.activate - true (default) to activate guest user
          * @param {boolean} options.bypassTutorial - true (default) or false for guest to go thru tutorial steps
-         * @returns {Object} `out` Cypress-chainable, yielded with element passed into .wrap().
          * @returns {UserProfile} `out.guest` as `UserProfile` object
          *
          * @example
          *   cy.apiCreateGuestUser(options);
          */
-        apiCreateGuestUser(options: Record<string, any>): Chainable<Record<string, any>>;
+        apiCreateGuestUser(options: Record<string, any>): Chainable<UserProfile>;
+
+        /**
+         * Revoke all active sessions for a user.
+         * See https://api.mattermost.com/#tag/users/paths/~1users~1{user_id}~1sessions~1revoke~1all/post
+         * @param {String} userId - ID of a user
+         * @returns {Object} `out.data` as response status
+         *
+         * @example
+         *   cy.apiRevokeUserSessions('user-id');
+         */
+        apiRevokeUserSessions(userId: string): Chainable<Record<string, any>>;
 
         /**
          * Get list of users that are not team members
@@ -132,7 +187,6 @@ declare namespace Cypress {
          * @param {String} queryParams.teamId - Team ID
          * @param {String} queryParams.page - Page to select, 0 (default)
          * @param {String} queryParams.perPage - The number of users per page, 60 (default)
-         * @returns {Object} `out` Cypress-chainable, yielded with element passed into .wrap().
          * @returns {UserProfile[]} `out.users` as `UserProfile[]` object
          *
          * @example

--- a/e2e/cypress/support/api/user.js
+++ b/e2e/cypress/support/api/user.js
@@ -87,7 +87,7 @@ Cypress.Commands.add('apiPatchUser', (userId, userData) => {
         body: userData,
     }).then((response) => {
         expect(response.status).to.equal(200);
-        cy.wrap(response);
+        cy.wrap({user: response.body});
     });
 });
 
@@ -99,7 +99,7 @@ Cypress.Commands.add('apiPatchMe', (data) => {
         body: data,
     }).then((response) => {
         expect(response.status).to.equal(200);
-        cy.wrap(response);
+        cy.wrap({user: response.body});
     });
 });
 
@@ -168,30 +168,9 @@ Cypress.Commands.add('apiCreateUser', ({prefix = 'user', bypassTutorial = true, 
 Cypress.Commands.add('apiCreateGuestUser', ({prefix = 'guest', activate = true} = {}) => {
     return cy.apiCreateUser({prefix}).then(({user}) => {
         cy.demoteUser(user.id);
-        cy.apiActivateUser(user.id, activate);
+        cy.externalActivateUser(user.id, activate);
 
         return cy.wrap({guest: user});
-    });
-});
-
-/**
- * Saves channel display mode preference of a user directly via API
- * This API assume that the user is logged in and has cookie to access
- * @param {String} status - "online" (default), "offline", "away" or "dnd"
- */
-Cypress.Commands.add('apiUpdateUserStatus', (status = 'online') => {
-    return cy.getCookie('MMUSERID').then((cookie) => {
-        const data = {user_id: cookie.value, status};
-
-        return cy.request({
-            headers: {'X-Requested-With': 'XMLHttpRequest'},
-            url: '/api/v4/users/me/status',
-            method: 'PUT',
-            body: data,
-        }).then((response) => {
-            expect(response.status).to.equal(200);
-            cy.wrap({status: response.body});
-        });
     });
 });
 
@@ -206,20 +185,8 @@ Cypress.Commands.add('apiRevokeUserSessions', (userId) => {
         method: 'POST',
     }).then((response) => {
         expect(response.status).to.equal(200);
-        cy.wrap(response);
+        cy.wrap({data: response.body});
     });
-});
-
-/**
- * Activate/Deactivate a User directly via API
- * @param {String} userId - The user ID
- * @param {Boolean} active - Whether to activate or deactivate - true/false
- */
-Cypress.Commands.add('apiActivateUser', (userId, active = true) => {
-    const baseUrl = Cypress.config('baseUrl');
-    const admin = getAdminAccount();
-
-    cy.externalRequest({user: admin, method: 'put', baseUrl, path: `users/${userId}/active`, data: {active}});
 });
 
 Cypress.Commands.add('apiGetUsersNotInTeam', ({teamId, page = 0, perPage = 60} = {}) => {

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -661,18 +661,6 @@ Cypress.Commands.add('apiDeleteScheme', (schemeId) => {
     });
 });
 
-/**
- * Activate/Deactivate a User directly via API
- * @param {String} userId - The user ID
- * @param {Boolean} active - Whether to activate or deactivate - true/false
- */
-Cypress.Commands.add('apiActivateUser', (userId, active = true) => {
-    const baseUrl = Cypress.config('baseUrl');
-    const admin = getAdminAccount();
-
-    cy.externalRequest({user: admin, method: 'put', baseUrl, path: `users/${userId}/active`, data: {active}});
-});
-
 // *****************************************************************************
 // Groups
 // https://api.mattermost.com/#tag/groups

--- a/e2e/cypress/support/external_commands.d.ts
+++ b/e2e/cypress/support/external_commands.d.ts
@@ -21,11 +21,20 @@ declare namespace Cypress {
          * Makes an external request as a sysadmin and adds a user to a team directly via API
          * @param {String} teamId - The team ID
          * @param {String} userId - The user ID
-         * All parameter required
          *
          * @example
          *   cy.externalAddUserToTeam('team-id', 'user-id');
          */
         externalAddUserToTeam(teamId: string, userId: string): Chainable;
+
+        /**
+         * Makes an external request as a sysadmin and activate/deactivate a user directly via API
+         * @param {String} userId - The user ID
+         * @param {Boolean} active - Whether to activate or deactivate - true/false
+         *
+         * @example
+         *   cy.externalActivateUser('user-id', false);
+         */
+        externalActivateUser(userId: string, activate: boolean): Chainable;
     }
 }

--- a/e2e/cypress/support/external_commands.js
+++ b/e2e/cypress/support/external_commands.js
@@ -3,16 +3,16 @@
 
 import {getAdminAccount} from './env';
 
-/**
- * Add a user to a team directly via API
- * @param {String} teamId - The team ID
- * @param {String} userId - The user ID
- * All parameter required
- */
-
 Cypress.Commands.add('externalAddUserToTeam', (teamId, userId) => {
     const baseUrl = Cypress.config('baseUrl');
     const admin = getAdminAccount();
 
     cy.externalRequest({user: admin, method: 'post', baseUrl, path: `teams/${teamId}/members`, data: {team_id: teamId, user_id: userId}});
+});
+
+Cypress.Commands.add('externalActivateUser', (userId, active = true) => {
+    const baseUrl = Cypress.config('baseUrl');
+    const admin = getAdminAccount();
+
+    cy.externalRequest({user: admin, method: 'put', baseUrl, path: `users/${userId}/active`, data: {active}});
 });

--- a/e2e/cypress/support/index.d.ts
+++ b/e2e/cypress/support/index.d.ts
@@ -15,4 +15,5 @@ declare namespace Cypress {
     type Team = import('mattermost-redux/types/teams').Team;
     type TeamMembership = import('mattermost-redux/types/teams').TeamMembership;
     type UserProfile = import('mattermost-redux/types/users').UserProfile;
+    type UserStatus = import('mattermost-redux/types/users').UserStatus;
 }


### PR DESCRIPTION
#### Summary
Add type definitions and standard return to user/status/external api commands
- apiUpdateUserStatus
- apiPatchUser
- apiPatchMe
- apiRevokeUserSessions
- externalActivateUser

#### Ticket Link
Jira ticket - https://mattermost.atlassian.net/browse/MM-26075
