### PR TITLE
Cypress/E2E: Fix apiAdminLogin return object

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/channel_members_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_members_spec.js
@@ -9,14 +9,6 @@
 
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
-const saveConfig = () => {
-    // # Click save
-    cy.get('#saveSetting').click();
-
-    // # Check that the members block is no longer visible meaning that the save has succeeded and we were redirected out
-    cy.get('#channelMembers').should('not.be.visible');
-};
-
 describe('Channel members test', () => {
     let testChannel;
     let user1;
@@ -26,7 +18,7 @@ describe('Channel members test', () => {
     before(() => {
         // # Login as sysadmin
         cy.apiAdminLogin().then((res) => {
-            sysadmin = res.body;
+            sysadmin = res.user;
         });
 
         // * Check if server has license
@@ -68,8 +60,7 @@ describe('Channel members test', () => {
         cy.get('#channelMembers').scrollIntoView().should('be.visible');
 
         // # Search for user1 that we know is in the team
-        cy.get('#channelMembers .DataGrid_search input').clear().type(user1.email);
-        cy.wait(TIMEOUTS.HALF_SEC); // Timeout required to wait for timeout that happens when search input changes
+        searchFor(user1.email);
 
         // # Wait till loading complete and then remove the only visible user
         cy.get('#channelMembers .DataGrid_loading').should('not.be.visible');
@@ -85,8 +76,7 @@ describe('Channel members test', () => {
         cy.get('#cancelModalButton').click();
 
         // # Search for user2 that we know is in the team
-        cy.get('#channelMembers .DataGrid_search input').clear().type(user2.email);
-        cy.wait(TIMEOUTS.HALF_SEC); // Timeout required to wait for timeout that happens when search input changes
+        searchFor(user2.email);
 
         // # Wait till loading complete and then remove the only visible user
         cy.get('#channelMembers .DataGrid_loading').should('not.be.visible');
@@ -108,15 +98,13 @@ describe('Channel members test', () => {
         cy.visit(`/admin_console/user_management/channels/${testChannel.id}`);
 
         // # Search for user1 that we know is no longer in the team
-        cy.get('#channelMembers .DataGrid_search input').scrollIntoView().clear().type(user1.email);
-        cy.wait(TIMEOUTS.HALF_SEC); // Timeout required to wait for timeout that happens when search input changes
+        searchFor(user1.email);
 
         // * Assert that no matching users found
         cy.get('#channelMembers .DataGrid_rows').should('contain', 'No users found');
 
         // # Search for user2 that we know is no longer in the team
-        cy.get('#channelMembers .DataGrid_search input').clear().type(user2.email);
-        cy.wait(TIMEOUTS.HALF_SEC); // Timeout required to wait for timeout that happens when search input changes
+        searchFor(user2.email);
 
         // * Assert that no matching users found
         cy.get('#channelMembers .DataGrid_rows').should('contain', 'No users found');
@@ -131,8 +119,7 @@ describe('Channel members test', () => {
         cy.get('#addUsersToChannelModal #saveItems').click();
 
         // # Search for user1
-        cy.get('#channelMembers .DataGrid_search input').clear().type(user1.email);
-        cy.wait(TIMEOUTS.HALF_SEC); // Timeout required to wait for timeout that happens when search input changes
+        searchFor(user1.email);
 
         // * Assert that the user is now added to the members block and contains text denoting that they are New
         cy.get('#channelMembers .DataGrid_rows').children(0).should('contain', user1.email).and('contain', 'New');
@@ -148,15 +135,13 @@ describe('Channel members test', () => {
         });
 
         // # Search for user2
-        cy.get('#channelMembers .DataGrid_search input').clear().type(user2.email);
-        cy.wait(TIMEOUTS.HALF_SEC); // Timeout required to wait for timeout that happens when search input changes
+        searchFor(user2.email);
 
         // * Assert that the user is now added to the members block and contains text denoting that they are New
         cy.get('#channelMembers .DataGrid_rows').children(0).should('contain', user2.email).and('contain', 'New');
 
         // # Search for sysadmin
-        cy.get('#channelMembers .DataGrid_search input').clear().type(sysadmin.email);
-        cy.wait(TIMEOUTS.HALF_SEC); // Timeout required to wait for timeout that happens when search input changes
+        searchFor(sysadmin.email);
 
         // * Assert that searching for users after adding users returns only relevant search results
         cy.get('#channelMembers .DataGrid_rows').children(0).should('contain', sysadmin.email);
@@ -168,8 +153,7 @@ describe('Channel members test', () => {
         cy.visit(`/admin_console/user_management/channels/${testChannel.id}`);
 
         // # Search user1 that we know is now in the team again
-        cy.get('#channelMembers .DataGrid_search input').scrollIntoView().clear().type(user1.email);
-        cy.wait(TIMEOUTS.HALF_SEC); // Timeout required to wait for timeout that happens when search input changes
+        searchFor(user1.email);
         cy.get('#channelMembers .DataGrid_loading').should('not.be.visible');
 
         // * Assert that the user is now saved as an admin
@@ -188,8 +172,7 @@ describe('Channel members test', () => {
         cy.get('#channelMembers .DataGrid_rows').children(0).should('contain', user1.email).and('not.contain', 'New').and('contain', 'Channel Member');
 
         // # Search user2 that we know is now in the team again
-        cy.get('#channelMembers .DataGrid_search input').scrollIntoView().clear().type(user2.email);
-        cy.wait(TIMEOUTS.HALF_SEC); // Timeout required to wait for timeout that happens when search input changes
+        searchFor(user2.email);
         cy.get('#channelMembers .DataGrid_loading').should('not.be.visible');
 
         // * Assert user2 is now saved as a regular member
@@ -199,3 +182,16 @@ describe('Channel members test', () => {
         saveConfig();
     });
 });
+
+function saveConfig() {
+    // # Click save
+    cy.get('#saveSetting').click();
+
+    // # Check that the members block is no longer visible meaning that the save has succeeded and we were redirected out
+    cy.get('#channelMembers').should('not.be.visible');
+}
+
+function searchFor(searchTerm) {
+    cy.get('#channelMembers .DataGrid_search input[type="text"]').scrollIntoView().clear().type(searchTerm);
+    cy.wait(TIMEOUTS.HALF_SEC); // Timeout required to wait for timeout that happens when search input changes
+}

--- a/e2e/cypress/integration/enterprise/system_console/team_members_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/team_members_spec.js
@@ -20,7 +20,7 @@ describe('Team members test', () => {
     before(() => {
         // # Login as sysadmin
         cy.apiAdminLogin().then((res) => {
-            sysadmin = res.body;
+            sysadmin = res.user;
         });
 
         // * Check if server has license


### PR DESCRIPTION
#### Summary
- Fixed `apiAdminLogin` return per https://github.com/mattermost/mattermost-webapp/pull/5945#pullrequestreview-452374708
- Applied similar changes to `channel_members_spec`

#### Ticket Link
None - master only
