### PR TITLE
Cypress/E2E: Try to fix timezone display mode flakiness

### DIFF
--- a/e2e/cypress/integration/account_settings/display/timezone_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/timezone_display_mode_spec.js
@@ -41,13 +41,15 @@ describe('Account Settings > Display > Timezone Mode', () => {
             },
         });
 
-        // # Create and visit new channel
-        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
-            cy.visit(`/${team.name}/channels/${channel.name}`);
+        // # Create and visit town-square
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
 
             // # Post messages from the past
             [date1, date2, date3, date4].forEach((createAt, index) => {
-                cy.postMessageAs({sender: sysadmin, message: `Hello from ${index}`, channelId: channel.id, createAt});
+                cy.getCurrentChannelId().then((channelId) => {
+                    cy.postMessageAs({sender: sysadmin, message: `Hello from ${index}`, channelId, createAt});
+                });
             });
 
             // # Post messages from now

--- a/e2e/cypress/integration/account_settings/display/timezone_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/timezone_display_mode_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @account_setting
 
 import moment from 'moment-timezone';


### PR DESCRIPTION
#### Summary
- Try to fix timezone flakiness
- Load town-square instead of new channel
- Removed `@prod` since it's unstable for now

Note: new channel is passing for me locally so not really sure why it's failing on cypress.

#### Ticket Link
None - both on master and release-5.26

![Screen Shot 2020-07-21 at 7 49 08 AM](https://user-images.githubusercontent.com/487991/88069695-ad01e600-cb26-11ea-9bfe-9ca081659265.png)
