### PR TITLE
MM-22249 : Add automatic lazy loading of syntax highlighting libraries

### DIFF
--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1304,6 +1304,10 @@ export const Constants = {
         COMPOSING: ['Composing', 229],
     },
     CODE_PREVIEW_MAX_FILE_SIZE: 500000, // 500 KB
+
+    // TODO add support for all languages defined in 
+    // https://github.com/highlightjs/highlight.js/blob/master/SUPPORTED_LANGUAGES.md
+    // since now we are dynamically loading
     HighlightedLanguages: {
         actionscript: {name: 'ActionScript', extensions: ['as'], aliases: ['as', 'as3']},
         applescript: {name: 'AppleScript', extensions: ['applescript', 'osascript', 'scpt']},

--- a/utils/syntax_highlighting.tsx
+++ b/utils/syntax_highlighting.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import hlJS from 'highlight.js';
+import hlJS from 'highlight.js/lib/core';
 
 import Constants from './constants';
 import * as TextFormatting from './text_formatting';
@@ -40,7 +40,11 @@ export function highlight(lang: string, code: string, addLineNumbers = false) {
 
     if (language) {
         try {
+            // Require the language highlight support dynamically and register
+            hlJS.registerLanguage(language, require(`highlight.js/lib/languages/${language}`));
+
             const codeValue = hlJS.highlight(language, code).value;
+
             if (addLineNumbers) {
                 return formatHighLight(codeValue);
             }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Added dynamic require and register of languages in hightlight js

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/14029
JIRA https://mattermost.atlassian.net/browse/MM-22249

#### Related Pull Requests
none

#### Screenshots
none