### PR TITLE
Cypress/E2E: Fix accessibility modals dialogs

### DIFF
--- a/e2e/cypress/integration/accessibility/accessibility_modals_dialogs_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_modals_dialogs_spec.js
@@ -238,10 +238,11 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
             cy.get('.modal-header button.close').should('have.attr', 'aria-label', 'Close');
 
             // * Verify the accessibility support in search input
-            cy.get('#searchUsersInput').should('have.attr', 'placeholder', 'Search users').focus().type(' {backspace}').wait(TIMEOUTS.HALF_SEC).tab({shift: true}).tab().tab();
+            cy.get('#searchUsersInput').should('have.attr', 'placeholder', 'Search users').focus().type(' {backspace}').wait(TIMEOUTS.HALF_SEC).tab({shift: true}).tab().tab().tab();
+            cy.wait(TIMEOUTS.HALF_SEC);
 
             // * Verify channel name is highlighted and reader reads the channel name
-            cy.get('.more-modal__list>div').children().eq(0).as('selectedRow');
+            cy.get('.more-modal__list>div').children().eq(1).as('selectedRow');
             cy.get('@selectedRow').within(() => {
                 cy.get('button.user-popover').
                     should('have.class', 'a11y--active a11y--focused');
@@ -344,5 +345,6 @@ describe('Verify Accessibility Support in Modals & Dialogs', () => {
         cy.get('#confirmModal').should('be.visible').and('have.attr', 'aria-modal', 'true').and('have.attr', 'aria-labelledby', 'confirmModalLabel').and('have.attr', 'aria-describedby', 'confirmModalBody');
         cy.get('#confirmModalLabel').should('be.visible').and('have.text', 'Discard Changes');
         cy.get('#confirmModalBody').should('be.visible').and('have.text', 'You have unsent invitations, are you sure you want to discard them?');
+        cy.get('#confirmModalButton').should('be.visible').click();
     });
 });


### PR DESCRIPTION
#### Summary
- Added delay after tab to allow for css class to propagate
- Make sure row tested has drop-down actions (logged in user does not display drop-down, has to be a different user highlighted)
- Close popup modal

#### Ticket Link
None - master only

![Screen Shot 2020-07-22 at 9 08 33 AM](https://user-images.githubusercontent.com/487991/88200487-0cc9c100-cbfb-11ea-84de-a541b4d47ef1.png)
