### PR TITLE
Switch mattermost-redux back to master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18109,8 +18109,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#e0703ea564c61caf83183a7c5625ee2241d374b1",
-      "from": "github:mattermost/mattermost-redux#e0703ea564c61caf83183a7c5625ee2241d374b1",
+      "version": "github:mattermost/mattermost-redux#1d05add51585c91543bb1e6ffa11868f4264e78d",
+      "from": "github:mattermost/mattermost-redux#1d05add51585c91543bb1e6ffa11868f4264e78d",
       "requires": {
         "core-js": "3.6.4",
         "form-data": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "localforage-observable": "2.0.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#87769262aa02e1784570f61f4f962050e07cc335",
-    "mattermost-redux": "github:mattermost/mattermost-redux#e0703ea564c61caf83183a7c5625ee2241d374b1",
+    "mattermost-redux": "github:mattermost/mattermost-redux#1d05add51585c91543bb1e6ffa11868f4264e78d",
     "moment-timezone": "0.5.31",
     "p-queue": "^6.4.0",
     "pdfjs-dist": "2.0.489",


### PR DESCRIPTION
https://github.com/mattermost/mattermost-webapp/pull/5447 accidentally left mattermost-redux on a PR branch (with the latest master changes included) instead of master itself, so this is just some cleanup.