### PR TITLE
Cypress/E2E: Fix channel sidebar specs

### DIFF
--- a/e2e/cypress/integration/channel_sidebar/category_collapsing_unread_filter_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/category_collapsing_unread_filter_spec.js
@@ -39,7 +39,7 @@ describe('Channel sidebar', () => {
     it('should display collapsed state when collapsed', () => {
         // # Close "What's new" modal
         cy.uiCloseWhatsNewModal();
-        
+
         // # Check that the CHANNELS group header is visible
         cy.get('.SidebarChannelGroupHeader:contains(CHANNELS)').should('be.visible').as('channelsGroup');
 

--- a/e2e/cypress/integration/channel_sidebar/category_collapsing_unread_filter_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/category_collapsing_unread_filter_spec.js
@@ -37,6 +37,9 @@ describe('Channel sidebar', () => {
     });
 
     it('should display collapsed state when collapsed', () => {
+        // # Close "What's new" modal
+        cy.uiCloseWhatsNewModal();
+        
         // # Check that the CHANNELS group header is visible
         cy.get('.SidebarChannelGroupHeader:contains(CHANNELS)').should('be.visible').as('channelsGroup');
 

--- a/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/channel_sidebar_spec.js
@@ -28,6 +28,9 @@ describe('Channel sidebar', () => {
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);
         });
+
+        // # Close "What's new" modal
+        cy.uiCloseWhatsNewModal();
     });
 
     it('should switch channels when clicking on a channel in the sidebar', () => {

--- a/e2e/cypress/integration/channel_sidebar/drag_and_drop_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/drag_and_drop_spec.js
@@ -36,13 +36,16 @@ describe('Channel sidebar', () => {
                 channelName = response.body.display_name;
             });
             cy.visit(`/${team.name}/channels/town-square`);
-
-            // * Verify that we've switched to the new team
-            cy.get('#headerTeamName', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').should('contain', teamName);
         });
     });
 
     it('should move channel to correct place when dragging channel within category', () => {
+        // # Close "What's new" modal
+        cy.uiCloseWhatsNewModal();
+
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').should('contain', teamName);
+
         // * Verify the order is correct to begin with
         cy.get('.SidebarChannel > .SidebarLink').should('be.visible').as('fromChannelSidebarLink');
         cy.get('@fromChannelSidebarLink').eq(0).should('contain', channelName);
@@ -63,6 +66,9 @@ describe('Channel sidebar', () => {
     });
 
     it('should move category to correct place', () => {
+        // * Verify that we've switched to the new team
+        cy.get('#headerTeamName', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').should('contain', teamName);
+        
         // # Get channel group button and wait for Channels to be visible since for some reason it shows up later...
         cy.get('.SidebarChannelGroupHeader_groupButton > div[data-rbd-drag-handle-draggable-id]').should('be.visible').as('fromChannelGroup');
         cy.get('@fromChannelGroup').should('contain', 'CHANNELS');

--- a/e2e/cypress/integration/channel_sidebar/drag_and_drop_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/drag_and_drop_spec.js
@@ -68,7 +68,7 @@ describe('Channel sidebar', () => {
     it('should move category to correct place', () => {
         // * Verify that we've switched to the new team
         cy.get('#headerTeamName', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').should('contain', teamName);
-        
+
         // # Get channel group button and wait for Channels to be visible since for some reason it shows up later...
         cy.get('.SidebarChannelGroupHeader_groupButton > div[data-rbd-drag-handle-draggable-id]').should('be.visible').as('fromChannelGroup');
         cy.get('@fromChannelGroup').should('contain', 'CHANNELS');

--- a/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/history_channel_switcher_spec.js
@@ -26,6 +26,9 @@ describe('Channel sidebar', () => {
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);
         });
+
+        // # Close "What's new" modal
+        cy.uiCloseWhatsNewModal();
     });
 
     it('should not show history arrows on the regular webapp', () => {

--- a/e2e/cypress/integration/channel_sidebar/new_channel_dropdown_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/new_channel_dropdown_spec.js
@@ -26,6 +26,9 @@ describe('Channel sidebar', () => {
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);
         });
+
+        // # Close "What's new" modal
+        cy.uiCloseWhatsNewModal();
     });
 
     it('should create a new channel when using the new channel dropdown', () => {

--- a/e2e/cypress/integration/websocket/handle_removed_user/new_sidebar_spec.js
+++ b/e2e/cypress/integration/websocket/handle_removed_user/new_sidebar_spec.js
@@ -33,6 +33,9 @@ describe('Handle removed user - new sidebar', () => {
         cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
             cy.visit(`/${team.name}/channels/${channel.name}`);
         });
+
+        // # Close "What's new" modal
+        cy.uiCloseWhatsNewModal();
     });
 
     it('should be redirected to last channel when a user is removed from their current channel', () => {

--- a/e2e/cypress/support/ui/index.js
+++ b/e2e/cypress/support/ui/index.js
@@ -1,4 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import './modal';
 import './post_dropdown_menu';

--- a/e2e/cypress/support/ui/modal.d.ts
+++ b/e2e/cypress/support/ui/modal.d.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Meaningful description
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// Custom command should follow naming convention of having `ui` prefix, e.g. `uiCloseModal`.
+// ***************************************************************
+
+declare namespace Cypress {
+    interface Chainable<Subject = any> {
+
+        /**
+         * Close modal with header label
+         * @param {string} headerLabel - the header label
+         *
+         * @example
+         *   const headerLabel = 'What\'s New';
+         *   cy.uiCloseModal(headerLabel);
+         */
+        uiCloseModal(headerLabel: string): Chainable;
+
+        /**
+         * Close "What's new" modal
+         *
+         * @example
+         *   cy.uiCloseWhatsNewModal();
+         */
+        uiCloseWhatsNewModal(): Chainable;
+    }
+}

--- a/e2e/cypress/support/ui/modal.js
+++ b/e2e/cypress/support/ui/modal.js
@@ -1,0 +1,12 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+Cypress.Commands.add('uiCloseModal', (headerLabel) => {
+    // # Close modal with modal label
+    cy.get('#genericModalLabel').should('have.text', headerLabel).parents().find('.modal-dialog').findByLabelText('Close').click();
+});
+
+Cypress.Commands.add('uiCloseWhatsNewModal', () => {
+    // # Close "What's new" modal
+    cy.uiCloseModal('What\'s new');
+});


### PR DESCRIPTION
#### Summary
- Added `ui/modal.js` and `ui/modal.d.ts`
- Added `uiCloseModal` and `uiCloseWhatsNewModal` commands
- Closed "What's new" modal on affected tests

#### Ticket Link
None - both on master and release-5.26

![Screen Shot 2020-07-23 at 1 35 03 PM](https://user-images.githubusercontent.com/487991/88336899-a4f2a380-ccea-11ea-9f0d-12159a33dc66.png)
![Screen Shot 2020-07-23 at 1 36 20 PM](https://user-images.githubusercontent.com/487991/88336900-a623d080-ccea-11ea-9dfc-0347d9d8b976.png)
![Screen Shot 2020-07-23 at 1 37 02 PM](https://user-images.githubusercontent.com/487991/88336902-a623d080-ccea-11ea-875e-2a0794f4c57e.png)
![Screen Shot 2020-07-23 at 1 37 46 PM](https://user-images.githubusercontent.com/487991/88336904-a6bc6700-ccea-11ea-89b9-d513c74d9874.png)
![Screen Shot 2020-07-23 at 1 38 44 PM](https://user-images.githubusercontent.com/487991/88336906-a754fd80-ccea-11ea-9fd8-96ff47914152.png)
![Screen Shot 2020-07-23 at 1 40 09 PM](https://user-images.githubusercontent.com/487991/88336907-a754fd80-ccea-11ea-9816-71a1e8c22a9a.png)
