### PR TITLE
Cypress/E2E: Fix Cypress tests for admin-console search in User Management > Channel

### DIFF
--- a/e2e/cypress/integration/enterprise/ldap_group/search_channels_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/search_channels_spec.js
@@ -34,7 +34,9 @@ describe('Search channels', () => {
 
     it('loads with no search text', () => {
         // * Check that text input loads empty.
-        cy.findByPlaceholderText('Search').should('be.visible').and('have.text', '');
+        cy.get('.DataGrid_searchBar').within(() => {
+            cy.findByPlaceholderText('Search').should('be.visible').and('have.text', '');
+        });
     });
 
     it('returns results', () => {
@@ -43,7 +45,9 @@ describe('Search channels', () => {
         cy.apiCreateChannel(testTeamId, 'channel-search', displayName);
 
         // # Search for the channel.
-        cy.findByPlaceholderText('Search').type(displayName + '{enter}');
+        cy.get('.DataGrid_searchBar').within(() => {
+            cy.findByPlaceholderText('Search').type(displayName + '{enter}');
+        });
 
         // * Check that channel is in search results.
         cy.findAllByTestId('channel-display-name').contains(displayName);
@@ -57,7 +61,9 @@ describe('Search channels', () => {
         }
 
         // # Search using the common channel name prefix.
-        cy.findByPlaceholderText('Search').type(displayName + '{enter}');
+        cy.get('.DataGrid_searchBar').within(() => {
+            cy.findByPlaceholderText('Search').type(displayName + '{enter}');
+        });
 
         // * Check that the first page of results is full.
         cy.findAllByTestId('channel-display-name').should('have.length', PAGE_SIZE);
@@ -77,7 +83,9 @@ describe('Search channels', () => {
         cy.apiCreateChannel(testTeamId, 'channel-search', displayName);
 
         // # Search for the channel.
-        cy.findByPlaceholderText('Search').as('searchInput').type(displayName + '{enter}');
+        cy.get('.DataGrid_searchBar').within(() => {
+            cy.findByPlaceholderText('Search').as('searchInput').type(displayName + '{enter}');
+        });
 
         // * Check that the list of channels is in search results mode.
         cy.findAllByTestId('channel-display-name').should('have.length', 1);
@@ -98,7 +106,9 @@ describe('Search channels', () => {
         cy.apiCreateChannel(testTeamId, 'channel-search', displayName);
 
         // # Search for the channel.
-        cy.findByPlaceholderText('Search').as('searchInput').type(displayName + '{enter}');
+        cy.get('.DataGrid_searchBar').within(() => {
+            cy.findByPlaceholderText('Search').as('searchInput').type(displayName + '{enter}');
+        });
 
         // * Check that the list of teams is in search results mode.
         cy.findAllByTestId('channel-display-name').should('have.length', 1);

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
@@ -10,7 +10,9 @@ import {checkBoxes} from './constants';
 export const visitChannelConfigPage = (channel) => {
     cy.apiAdminLogin();
     cy.visit('/admin_console/user_management/channels');
-    cy.findByPlaceholderText('Search').type(`${channel.name}{enter}`);
+    cy.get('.DataGrid_searchBar').within(() => {
+        cy.findByPlaceholderText('Search').type(`${channel.name}{enter}`);
+    });
     cy.findByText('Edit').click();
     cy.wait(TIMEOUTS.ONE_SEC);
 };
@@ -34,12 +36,16 @@ export const saveConfigForChannel = (channelName = false, clickConfirmationButto
                 cy.get('#confirmModalButton').click();
             }
 
-            // # Make sure the save is complete by looking for the search input which is only visible on the teams index page
-            cy.findByPlaceholderText('Search').should('be.visible');
+            // # Make sure the save is complete by looking for the search input which is only visible on the team's index page
+            cy.get('.DataGrid_searchBar').should('be.visible').within(() => {
+                cy.findByPlaceholderText('Search').should('be.visible');
+            });
 
             if (channelName) {
                 // # Search for the channel.
-                cy.findByPlaceholderText('Search').type(`${channelName}{enter}`);
+                cy.get('.DataGrid_searchBar').within(() => {
+                    cy.findByPlaceholderText('Search').type(`${channelName}{enter}`);
+                });
                 cy.findByText('Edit').click();
             }
         }

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/system_config_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/system_config_spec.js
@@ -49,7 +49,9 @@ describe('Channel Moderation', () => {
         cy.visit('/admin_console/user_management/channels');
 
         // # Search for the channel.
-        cy.findByPlaceholderText('Search').type(`${testChannel.name}{enter}`);
+        cy.get('.DataGrid_searchBar').within(() => {
+            cy.findByPlaceholderText('Search').type(`${testChannel.name}{enter}`);
+        });
         cy.findByText('Edit').click();
 
         // # Wait until the groups retrieved and show up


### PR DESCRIPTION
#### Summary
Added fix for tests failing in the following spec files by scoping the search input within the `DataGrid_searchBar`:

- enterprise/ldap_group/search_channels_spec (5 tests)
- enterprise/system_console/channel_moderation/create_posts_spec(2 tests)
- enterprise/system_console/channel_moderation/manage_members_spec(4 tests)
- enterprise/system_console/channel_moderation/system_config_spec (1 test)

#### Ticket Link
None

#### Screenshots
![Screen Shot 2020-07-27 at 1 50 48 PM](https://user-images.githubusercontent.com/691331/88598535-53198880-d01e-11ea-8706-91406696fccc.png)
![Screen Shot 2020-07-27 at 3 09 58 PM](https://user-images.githubusercontent.com/691331/88598537-56ad0f80-d01e-11ea-9e30-ebe5c39edc82.png)
![Screen Shot 2020-07-27 at 3 13 44 PM](https://user-images.githubusercontent.com/691331/88598542-590f6980-d01e-11ea-91f5-d85936b684f7.png)
![Screen Shot 2020-07-27 at 3 16 24 PM](https://user-images.githubusercontent.com/691331/88598545-5b71c380-d01e-11ea-92d9-223c9c77fe57.png)
