### PR TITLE
Cypress/E2E: Fix specs failing due to dropdown menu

### DIFF
--- a/e2e/cypress/support/ui/post_dropdown_menu.js
+++ b/e2e/cypress/support/ui/post_dropdown_menu.js
@@ -16,7 +16,7 @@ Cypress.Commands.add('uiClickCopyLink', (permalink) => {
 
     // # Click on "Copy Link"
     cy.get('.dropdown-menu').should('be.visible').within(() => {
-        cy.findByText('Copy Link').should('be.visible').click();
+        cy.findByText('Copy Link').scrollIntoView().should('be.visible').click();
 
         // * Verify if it's called with correct link value
         cy.wrap(clipboard).its('wasCalled').should('eq', true);

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -267,7 +267,7 @@ Cypress.Commands.add('getPostMenu', (postId, menuItem, location = 'CENTER') => {
     cy.clickPostDotMenu(postId, location).then(() => {
         cy.get(`#post_${postId}`).should('be.visible').within(() => {
             cy.get('.dropdown-menu').should('be.visible').within(() => {
-                return cy.findByText(menuItem).should('be.visible');
+                return cy.findByText(menuItem).scrollIntoView().should('be.visible');
             });
         });
     });


### PR DESCRIPTION
#### Summary
- Added scrollIntoView as cypress workaround 

#### Ticket Link
None - master only

![Screen Shot 2020-07-28 at 1 49 58 PM](https://user-images.githubusercontent.com/487991/88721064-b23cd300-d0da-11ea-8b56-e8ac38b82730.png)
![Screen Shot 2020-07-28 at 1 52 07 PM](https://user-images.githubusercontent.com/487991/88721069-b49f2d00-d0da-11ea-9cc3-546dce2015ce.png)
![Screen Shot 2020-07-28 at 1 53 10 PM](https://user-images.githubusercontent.com/487991/88721072-b7018700-d0da-11ea-99a8-163129f51ee9.png)
