### PR TITLE
MM-27346 Fix for excessive analytic events on scroll of LHS

### DIFF
--- a/components/sidebar/sidebar_menu/sidebar_menu.test.tsx
+++ b/components/sidebar/sidebar_menu/sidebar_menu.test.tsx
@@ -54,6 +54,19 @@ describe('components/sidebar/sidebar_menu', () => {
         expect(baseProps.onToggle).toHaveBeenCalledWith(false);
     });
 
+    test('should not call external onToggle when menu state hasnt changed', () => {
+        const wrapper = shallow<SidebarMenu>(
+            <SidebarMenu {...baseProps}/>,
+        );
+
+        wrapper.instance().handleMenuToggle(true);
+        expect(baseProps.onToggle).toHaveBeenCalledWith(true);
+        expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
+
+        wrapper.instance().handleMenuToggle(true);
+        expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
+    });
+
     test('should set the openUp and width properties correctly based on window and ref information', () => {
         const windowSpy = jest.spyOn(global, 'window' as any, 'get');
         windowSpy.mockImplementation(() => ({

--- a/components/sidebar/sidebar_menu/sidebar_menu.tsx
+++ b/components/sidebar/sidebar_menu/sidebar_menu.tsx
@@ -119,7 +119,7 @@ export default class SidebarMenu extends React.PureComponent<Props, State> {
     }
 
     handleMenuToggle = (isMenuOpen: boolean) => {
-        if(this.state.isMenuOpen !== isMenuOpen) {
+        if (this.state.isMenuOpen !== isMenuOpen) {
             this.setState({isMenuOpen}, () => {
                 if (this.props.onToggle) {
                     this.props.onToggle(isMenuOpen);

--- a/components/sidebar/sidebar_menu/sidebar_menu.tsx
+++ b/components/sidebar/sidebar_menu/sidebar_menu.tsx
@@ -119,13 +119,15 @@ export default class SidebarMenu extends React.PureComponent<Props, State> {
     }
 
     handleMenuToggle = (isMenuOpen: boolean) => {
-        this.setState({isMenuOpen}, () => {
-            if (this.props.onToggle) {
-                this.props.onToggle(isMenuOpen);
-            }
-            this.setMenuPosition();
-            this.disableScrollbar();
-        });
+        if(this.state.isMenuOpen !== isMenuOpen) {
+            this.setState({isMenuOpen}, () => {
+                if (this.props.onToggle) {
+                    this.props.onToggle(isMenuOpen);
+                }
+                this.setMenuPosition();
+                this.disableScrollbar();
+            });
+        }
     }
 
     render() {

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1470,8 +1470,8 @@ export const Constants = {
     AUTOCOMPLETE_SPLIT_CHARACTERS: ['.', '-', '_'],
     ANIMATION_TIMEOUT: 1000,
     SEARCH_TIMEOUT_MILLISECONDS: 100,
-    DIAGNOSTICS_RUDDER_KEY: 'placeholder_rudder_key',
-    DIAGNOSTICS_RUDDER_DATAPLANE_URL: 'placeholder_rudder_dataplane_url',
+    DIAGNOSTICS_RUDDER_KEY: '1dodSrnEWiacrD76jx0nVToHNGu',
+    DIAGNOSTICS_RUDDER_DATAPLANE_URL: 'https://pdat.matterlytics.com',
     TEAMMATE_NAME_DISPLAY: {
         SHOW_USERNAME: 'username',
         SHOW_NICKNAME_FULLNAME: 'nickname_full_name',

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1470,8 +1470,8 @@ export const Constants = {
     AUTOCOMPLETE_SPLIT_CHARACTERS: ['.', '-', '_'],
     ANIMATION_TIMEOUT: 1000,
     SEARCH_TIMEOUT_MILLISECONDS: 100,
-    DIAGNOSTICS_RUDDER_KEY: '1dodSrnEWiacrD76jx0nVToHNGu',
-    DIAGNOSTICS_RUDDER_DATAPLANE_URL: 'https://pdat.matterlytics.com',
+    DIAGNOSTICS_RUDDER_KEY: 'placeholder_rudder_key',
+    DIAGNOSTICS_RUDDER_DATAPLANE_URL: 'placeholder_rudder_dataplane_url',
     TEAMMATE_NAME_DISPLAY: {
         SHOW_USERNAME: 'username',
         SHOW_NICKNAME_FULLNAME: 'nickname_full_name',


### PR DESCRIPTION
#### Summary

We have a scroll listener https://github.com/mattermost/mattermost-webapp/blob/f5d93686ed6798813a6d1eb20182a1b6532a46ee/components/sidebar/sidebar_menu/sidebar_menu.tsx#L63 which is triggering `handleMenuToggle` call
https://github.com/mattermost/mattermost-webapp/blob/f5d93686ed6798813a6d1eb20182a1b6532a46ee/components/sidebar/sidebar_menu/sidebar_menu.tsx#L74-L79

Preventing the call if state hasn't changed to fix this

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27346
