### PR TITLE
[MM-27168]  Set -webkit-fill-available when on iOS Safari and 100vh otherwise

### DIFF
--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -10,10 +10,21 @@
     height: 100%;
     padding-left: 220px;
 
+    & > div:first-child {
+        height: 100%;
+    }
+
     .wrapper--fixed {
         display: flex;
         flex-direction: column;
         height: 100vh;
+
+        // Fix for Safari on iOS MM-24361
+        @supports (-webkit-touch-callout: none) {
+            & {
+                height: -webkit-fill-available;
+            }
+        }
 
         .announcement-bar--fixed & {
             height: calc(100vh - 32px);

--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -21,9 +21,7 @@
 
         // Fix for Safari on iOS MM-24361
         @supports (-webkit-touch-callout: none) {
-            & {
-                height: -webkit-fill-available;
-            }
+            height: -webkit-fill-available;
         }
 
         .announcement-bar--fixed & {

--- a/sass/routes/_admin-console.scss
+++ b/sass/routes/_admin-console.scss
@@ -10,10 +10,6 @@
     height: 100%;
     padding-left: 220px;
 
-    & > div:first-child {
-        height: 100%;
-    }
-
     .wrapper--fixed {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
#### Summary
- Since webkit-touch-callout is only supported on iOS Safari (see https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-touch-callout) this will make the original fix of `height: -webkit-fill-available;` apply when its needed and leave desktop chrome / other browsers unchanged.

- I dont have an iOS device to test this on so I havent actually confirmed that this works on iOS safari but I _can_ confirm that it doesnt break anything on chrome / any other desktop browsers 

- Milestone labeled as 5.26 but will also cherry-pick this to 5.25 when tested 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-27168