### PR TITLE
[MM-27402] sync en message with defaultMessage

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3057,7 +3057,7 @@
   "multiselect.loading": "Loading...",
   "multiselect.numGroupsRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {group} other {groups}}. ",
   "multiselect.numMembers": "{memberOptions, number} of {totalCount, number} members",
-  "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add up to {num, number} more {num, plural, one {person} {people}} at a time. ",
+  "multiselect.numPeopleRemaining": "Use ↑↓ to browse, ↵ to select. You can add {num, number} more {num, plural, one {person} other {people}}. ",
   "multiselect.numRemaining": "You can add {num, number} more",
   "multiselect.placeholder": "Search and add members",
   "multiselect.selectChannels": "Use ↑↓ to browse, ↵ to select.",


### PR DESCRIPTION
#### Summary
Sync message with its corresponding defaultMessage to prevent react-intl console errors in dev environments.

#### Ticket Links

- https://mattermost.atlassian.net/browse/MM-27402
