### PR TITLE
MM-27358 Change how we hide unread badges on hover

### DIFF
--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -924,7 +924,13 @@
         }
 
         .badge {
-            display: none;
+            // Hide the badge by giving it 0 width instead of using `display: none` since the desktop app only counts
+            // badges with a non-zero offsetHeight when counting notifications
+            margin: 0px;
+            min-width: 0px;
+            overflow: hidden;
+            padding: 0px;
+            width: 0px;
         }
     }
     .SidebarChannel.active .SidebarLink {

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -924,13 +924,10 @@
         }
 
         .badge {
-            // Hide the badge by giving it 0 width instead of using `display: none` since the desktop app only counts
+            // Hide the badge by hiding it instead of using `display: none` since the desktop app only counts
             // badges with a non-zero offsetHeight when counting notifications
-            margin: 0px;
-            min-width: 0px;
-            overflow: hidden;
-            padding: 0px;
-            width: 0px;
+            position: absolute;
+            visibility: hidden;
         }
     }
     .SidebarChannel.active .SidebarLink {
@@ -1060,4 +1057,3 @@
         }
     }
 }
-


### PR DESCRIPTION
There's a bug in the current web app where the notification badge on the tabs in the desktop app changes its value when you hover over a channel. This is happening because we hide the badge and when that happens [the desktop app stops counting it](https://github.com/mattermost/desktop/blob/c2102bb25734a8c33fec635e0445873a23fd6559/src/browser/webview/mattermost.js#L146). I don't remember why we check this (it might be because we had multiple instances of the sidebar mounted at some point for some reason), but I've fixed it by hacking in a version of `display: none` that keeps the badge's height while still making it invisible

![image](https://user-images.githubusercontent.com/3277310/88961886-a46e8580-d273-11ea-9467-524ae07e2b4b.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27358