### PR TITLE
MM-27409 Remove references to bootstrap-colorpicker

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -56,17 +56,17 @@ This product contains '@types/highlight' by DefinitelyTyped.
 
 The repository for high quality TypeScript type definitions.
 
-* HOMEPAGE:	
-  * https://github.com/DefinitelyTyped/DefinitelyTyped	
+* HOMEPAGE:
+  * https://github.com/DefinitelyTyped/DefinitelyTyped
 
-* LICENSE: MIT	
+* LICENSE: MIT
 
-This project is licensed under the MIT license.	
-Copyrights are respective of each contributor listed at the beginning of each definition file.	
+This project is licensed under the MIT license.
+Copyrights are respective of each contributor listed at the beginning of each definition file.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:	
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.	
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
@@ -74,11 +74,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ## @types/react-custom-scrollbars
 
-This product contains '@types/react-custom-scrollbars' by Malte Wessel.	
+This product contains '@types/react-custom-scrollbars' by Malte Wessel.
 
 React scrollbars component
 
-* HOMEPAGE:	
+* HOMEPAGE:
   * https://github.com/malte-wessel/react-custom-scrollbars
 
 * LICENSE: The MIT License (MIT)
@@ -91,26 +91,26 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
----	
+---
 
-## @types/redux-mock-store	
+## @types/redux-mock-store
 
-This product contains '@types/redux-mock-store' by Dmitry Zaets.	
+This product contains '@types/redux-mock-store' by Dmitry Zaets.
 
-A mock store for testing Redux async action creators and middleware.	
+A mock store for testing Redux async action creators and middleware.
 
-* HOMEPAGE:	
-  * https://github.com/dmitry-zaets/redux-mock-store	
+* HOMEPAGE:
+  * https://github.com/dmitry-zaets/redux-mock-store
 
-* LICENSE: MIT	
+* LICENSE: MIT
 
-The MIT License (MIT)	
+The MIT License (MIT)
 
-Copyright (c) 2017 Arnaud Benard	
+Copyright (c) 2017 Arnaud Benard
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:	
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.	
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
@@ -187,41 +187,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
----
-
-## bootstrap-colorpicker
-
-This product contains 'bootstrap-colorpicker' by Javi Aguilar.
-
-Bootstrap Colorpicker is a modular color picker plugin for Bootstrap 4.
-
-* HOMEPAGE:
-  * https://farbelous.github.io/bootstrap-colorpicker/
-
-* LICENSE: MIT
-
-MIT License
-
-Copyright (c) 2017 Javi Aguilar
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ---
 

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -9,7 +9,6 @@ import {defineMessages, FormattedMessage} from 'react-intl';
 import {setThemeDefaults} from 'mattermost-redux/utils/theme_utils';
 
 import {t} from 'utils/i18n';
-import 'bootstrap-colorpicker';
 
 import Constants from 'utils/constants';
 import * as UserAgent from 'utils/user_agent';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8429,14 +8429,6 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
       "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
     },
-    "bootstrap-colorpicker": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/bootstrap-colorpicker/-/bootstrap-colorpicker-2.5.2.tgz",
-      "integrity": "sha512-krzBno9AMUwI2+IDwMvjnpqpa2f8womW0CCKmEcxGzVkolCFrt22jjMjzx1NZqB8C1DUdNgZP4LfyCsgpHRiYA==",
-      "requires": {
-        "jquery": ">=1.10"
-      }
-    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@types/react-custom-scrollbars": "^4.0.6",
     "@typescript-eslint/parser": "2.7.0",
     "bootstrap": "3.4.1",
-    "bootstrap-colorpicker": "2.5.2",
     "chart.js": "2.9.3",
     "compass-mixins": "0.12.10",
     "core-js": "3.6.5",

--- a/root.jsx
+++ b/root.jsx
@@ -9,7 +9,6 @@ import {logError} from 'mattermost-redux/actions/errors';
 import PDFJS from 'pdfjs-dist';
 
 // Import our styles
-import 'bootstrap-colorpicker/dist/css/bootstrap-colorpicker.css';
 import 'sass/styles.scss';
 import 'katex/dist/katex.min.css';
 

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -7,7 +7,6 @@
 @import '~bootstrap/dist/css/bootstrap.css';
 @import '~jasny-bootstrap/dist/css/jasny-bootstrap.css';
 @import '~font-awesome/css/font-awesome.css';
-@import '~bootstrap-colorpicker/dist/css/bootstrap-colorpicker.css';
 
 // styles.scss
 @import 'utils/module';


### PR DESCRIPTION
bootstrap-colorpicker was actually removed from the webapp back in https://github.com/mattermost/mattermost-webapp/pull/108, but it wasn't completely removed from package.json. Then, references to the JS code got re-added after a bad merge in https://github.com/mattermost/mattermost-webapp/pull/87.

This removes any dangling references to the library, and almost as importantly, it removes the only library that we include that depends on jQuery.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27409

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/6026