### PR TITLE
MM-16998 Add eslint-plugin-jquery to block explicit usage of jquery

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,14 @@
 {
   "extends": [
     "plugin:mattermost/react",
-    "plugin:cypress/recommended"
+    "plugin:cypress/recommended",
+    "plugin:jquery/deprecated"
   ],
   "plugins": [
     "mattermost",
     "import",
-    "cypress"
+    "cypress",
+    "jquery"
   ],
   "env": {
     "jest": true,

--- a/components/activity_log_modal/activity_log_modal.jsx
+++ b/components/activity_log_modal/activity_log_modal.jsx
@@ -59,7 +59,7 @@ export default class ActivityLogModal extends React.PureComponent {
 
     submitRevoke = (altId, e) => {
         e.preventDefault();
-        var modalContent = $(e.target).closest('.modal-content');
+        var modalContent = $(e.target).closest('.modal-content'); // eslint-disable-line jquery/no-closest
         modalContent.addClass('animation--highlight');
         setTimeout(() => {
             modalContent.removeClass('animation--highlight');

--- a/components/admin_console/brand_image_setting/brand_image_setting.jsx
+++ b/components/admin_console/brand_image_setting/brand_image_setting.jsx
@@ -81,7 +81,7 @@ export default class BrandImageSetting extends React.PureComponent {
 
             const img = this.refs.image;
             reader.onload = (e) => {
-                $(img).attr('src', e.target.result);
+                $(img).attr('src', e.target.result); // eslint-disable-line jquery/no-attr
             };
 
             reader.readAsDataURL(this.state.brandImage);

--- a/components/code_preview.jsx
+++ b/components/code_preview.jsx
@@ -61,7 +61,7 @@ export default class CodePreview extends React.PureComponent {
         if (!this.state.lang || this.props.fileInfo.size > Constants.CODE_PREVIEW_MAX_FILE_SIZE) {
             return;
         }
-        $.ajax({
+        $.ajax({ // eslint-disable-line jquery/no-ajax
             async: true,
             url: this.props.fileUrl,
             type: 'GET',

--- a/components/create_comment/create_comment.jsx
+++ b/components/create_comment/create_comment.jsx
@@ -681,7 +681,7 @@ class CreateComment extends React.PureComponent {
     scrollToBottom = () => {
         const $el = $('.post-right__scroll');
         if ($el[0]) {
-            $el.parent().scrollTop($el[0].scrollHeight);
+            $el.parent().scrollTop($el[0].scrollHeight); // eslint-disable-line jquery/no-parent
         }
     }
 

--- a/components/link_tooltip/link_tooltip.tsx
+++ b/components/link_tooltip/link_tooltip.tsx
@@ -55,7 +55,7 @@ export default class LinkTooltip extends React.PureComponent<Props> {
             this.showTimeout = window.setTimeout(() => {
                 this.show = true;
 
-                $tooltipContainer.show();
+                $tooltipContainer.show(); // eslint-disable-line jquery/no-show
                 $tooltipContainer.children().on('mouseover', () => clearTimeout(this.hideTimeout));
                 $tooltipContainer.children().on('mouseleave', (event: JQueryEventObject) => {
                     if (event.relatedTarget !== null) {
@@ -84,7 +84,7 @@ export default class LinkTooltip extends React.PureComponent<Props> {
             //prevent executing the showTimeout after the hideTooltip
             clearTimeout(this.showTimeout);
 
-            $(this.tooltipContainerRef.current).hide();
+            $(this.tooltipContainerRef.current).hide(); // eslint-disable-line jquery/no-hide
         }, Constants.OVERLAY_TIME_DELAY_SMALL);
     };
 

--- a/components/logged_in/logged_in.jsx
+++ b/components/logged_in/logged_in.jsx
@@ -87,49 +87,49 @@ export default class LoggedIn extends React.PureComponent {
 
         // Device tracking setup
         if (UserAgent.isIos()) {
-            $('body').addClass('ios');
+            $('body').addClass('ios'); // eslint-disable-line jquery/no-class
         } else if (UserAgent.isAndroid()) {
-            $('body').addClass('android');
+            $('body').addClass('android'); // eslint-disable-line jquery/no-class
         }
 
         if (!this.props.currentUser) {
-            $('#root').attr('class', '');
+            $('#root').attr('class', ''); // eslint-disable-line jquery/no-attr
             GlobalActions.emitUserLoggedOutEvent('/login?redirect_to=' + encodeURIComponent(this.props.location.pathname), true, false);
         }
 
         $('body').on('mouseenter mouseleave', ':not(.post-list__dynamic) .post', function mouseOver(ev) {
             if (ev.type === 'mouseenter') {
-                $(this).prev('.date-separator, .new-separator').addClass('hovered--after');
-                $(this).next('.date-separator, .new-separator').addClass('hovered--before');
+                $(this).prev('.date-separator, .new-separator').addClass('hovered--after'); // eslint-disable-line jquery/no-find, jquery/no-class
+                $(this).next('.date-separator, .new-separator').addClass('hovered--before'); // eslint-disable-line jquery/no-find, jquery/no-class
             } else {
-                $(this).prev('.date-separator, .new-separator').removeClass('hovered--after');
-                $(this).next('.date-separator, .new-separator').removeClass('hovered--before');
+                $(this).prev('.date-separator, .new-separator').removeClass('hovered--after'); // eslint-disable-line jquery/no-find, jquery/no-class
+                $(this).next('.date-separator, .new-separator').removeClass('hovered--before'); // eslint-disable-line jquery/no-find, jquery/no-class
             }
         });
 
         $('body').on('mouseenter mouseleave', '.search-item__container .post', function mouseOver(ev) {
             if (ev.type === 'mouseenter') {
-                $(this).closest('.search-item__container').find('.date-separator').addClass('hovered--after');
-                $(this).closest('.search-item__container').next('div').find('.date-separator').addClass('hovered--before');
+                $(this).closest('.search-item__container').find('.date-separator').addClass('hovered--after'); // eslint-disable-line jquery/no-closest, jquery/no-find, jquery/no-class
+                $(this).closest('.search-item__container').next('div').find('.date-separator').addClass('hovered--before'); // eslint-disable-line jquery/no-closest, jquery/no-find, jquery/no-class
             } else {
-                $(this).closest('.search-item__container').find('.date-separator').removeClass('hovered--after');
-                $(this).closest('.search-item__container').next('div').find('.date-separator').removeClass('hovered--before');
+                $(this).closest('.search-item__container').find('.date-separator').removeClass('hovered--after'); // eslint-disable-line jquery/no-closest, jquery/no-find, jquery/no-class
+                $(this).closest('.search-item__container').next('div').find('.date-separator').removeClass('hovered--before'); // eslint-disable-line jquery/no-closest, jquery/no-find, jquery/no-class
             }
         });
 
         $('body').on('mouseenter mouseleave', ':not(.post-list__dynamic) .post.post--comment.same--root', function mouseOver(ev) {
             if (ev.type === 'mouseenter') {
-                $(this).prev('.date-separator, .new-separator').addClass('hovered--comment');
-                $(this).next('.date-separator, .new-separator').addClass('hovered--comment');
+                $(this).prev('.date-separator, .new-separator').addClass('hovered--comment'); // eslint-disable-line jquery/no-find, jquery/no-class
+                $(this).next('.date-separator, .new-separator').addClass('hovered--comment'); // eslint-disable-line jquery/no-find, jquery/no-class
             } else {
-                $(this).prev('.date-separator, .new-separator').removeClass('hovered--comment');
-                $(this).next('.date-separator, .new-separator').removeClass('hovered--comment');
+                $(this).prev('.date-separator, .new-separator').removeClass('hovered--comment'); // eslint-disable-line jquery/no-find, jquery/no-class
+                $(this).next('.date-separator, .new-separator').removeClass('hovered--comment'); // eslint-disable-line jquery/no-find, jquery/no-class
             }
         });
 
         // Prevent backspace from navigating back a page
         $(window).on('keydown.preventBackspace', (e) => {
-            if (e.which === BACKSPACE_CHAR && !$(e.target).is('input, textarea')) {
+            if (e.which === BACKSPACE_CHAR && !$(e.target).is('input, textarea')) { // eslint-disable-line jquery/no-is
                 e.preventDefault();
             }
         });

--- a/components/new_channel_modal/new_channel_modal.jsx
+++ b/components/new_channel_modal/new_channel_modal.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal} from 'react-bootstrap';
@@ -12,7 +11,6 @@ import LockIcon from 'components/widgets/icons/lock_icon';
 import LocalizedInput from 'components/localized_input/localized_input';
 import Constants from 'utils/constants.jsx';
 import {getShortenedURL} from 'utils/url';
-import * as UserAgent from 'utils/user_agent';
 import * as Utils from 'utils/utils.jsx';
 import {t} from 'utils/i18n.jsx';
 
@@ -108,13 +106,6 @@ export default class NewChannelModal extends React.PureComponent {
         this.channelHeaderInput = React.createRef();
         this.channelPurposeInput = React.createRef();
         this.displayNameInput = React.createRef();
-    }
-
-    componentDidMount() {
-        // ???
-        if (UserAgent.isInternetExplorer() || UserAgent.isEdge()) {
-            $('body').addClass('browser--ie');
-        }
     }
 
     onEnterKeyDown = (e) => {

--- a/components/rhs_thread/rhs_thread.tsx
+++ b/components/rhs_thread/rhs_thread.tsx
@@ -208,7 +208,7 @@ export default class RhsThread extends React.Component<Props, State> {
 
     public scrollToBottom = (): void => {
         if ($('.post-right__scroll')[0]) {
-            $('.post-right__scroll').parent().scrollTop($('.post-right__scroll')[0].scrollHeight);
+            $('.post-right__scroll').parent().scrollTop($('.post-right__scroll')[0].scrollHeight); // eslint-disable-line jquery/no-parent
         }
     }
 

--- a/components/root/root.jsx
+++ b/components/root/root.jsx
@@ -107,7 +107,7 @@ export default class Root extends React.PureComponent {
         setSystemEmojis(EmojiIndicesByAlias);
 
         // Force logout of all tabs if one tab is logged out
-        $(window).bind('storage', (e) => {
+        $(window).bind('storage', (e) => { // eslint-disable-line jquery/no-bind
             // when one tab on a browser logs out, it sets __logout__ in localStorage to trigger other tabs to log out
             if (e.originalEvent.key === StoragePrefixes.LOGOUT && e.originalEvent.storageArea === localStorage && e.originalEvent.newValue) {
                 // make sure it isn't this tab that is sending the logout signal (only necessary for IE11)

--- a/components/setting_upload.jsx
+++ b/components/setting_upload.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -22,10 +21,12 @@ export default class SettingsUpload extends React.PureComponent {
 
     doFileSelect = (e) => {
         e.preventDefault();
-        var filename = $(e.target).val();
+
+        let filename = e.target.value;
         if (filename.substring(3, 11) === 'fakepath') {
             filename = filename.substring(12);
         }
+
         this.setState({
             clientError: '',
             serverError: '',

--- a/components/settings_sidebar.tsx
+++ b/components/settings_sidebar.tsx
@@ -23,13 +23,15 @@ export default class SettingsSidebar extends React.PureComponent<Props> {
     public handleClick = (tab: Tab, e: React.MouseEvent) => {
         e.preventDefault();
         this.props.updateTab(tab.name);
-        $(e.target).closest('.settings-modal').addClass('display--content');
+        $(e.target).closest('.settings-modal').addClass('display--content'); // eslint-disable-line jquery/no-closest, jquery/no-class
     }
+
     public componentDidMount() {
         if (UserAgent.isFirefox()) {
-            $('.settings-modal .settings-table .nav').addClass('position--top');
+            $('.settings-modal .settings-table .nav').addClass('position--top'); // eslint-disable-line jquery/no-closest, jquery/no-class
         }
     }
+
     public render() {
         const tabList = this.props.tabs.map((tab) => {
             const key = `${tab.name}_li`;

--- a/components/suggestion/search_suggestion_list.jsx
+++ b/components/suggestion/search_suggestion_list.jsx
@@ -49,7 +49,7 @@ export default class SearchSuggestionList extends SuggestionList {
     }
 
     getContent = () => {
-        return $(ReactDOM.findDOMNode(this.popoverRef.current)).find('.popover-content');
+        return $(ReactDOM.findDOMNode(this.popoverRef.current)).find('.popover-content'); // eslint-disable-line jquery/no-find
     }
 
     renderChannelDivider(type) {

--- a/components/team_settings_modal/team_settings_modal.jsx
+++ b/components/team_settings_modal/team_settings_modal.jsx
@@ -42,7 +42,7 @@ export default class TeamSettingsModal extends React.PureComponent {
     }
 
     collapseModal = () => {
-        $(ReactDOM.findDOMNode(this.modalBodyRef.current)).closest('.modal-dialog').removeClass('display--content');
+        $(ReactDOM.findDOMNode(this.modalBodyRef.current)).closest('.modal-dialog').removeClass('display--content'); // eslint-disable-line jquery/no-closest, jquery/no-class
 
         this.setState({
             active_tab: '',

--- a/components/tutorial/tutorial_view.jsx
+++ b/components/tutorial/tutorial_view.jsx
@@ -10,13 +10,13 @@ import TutorialIntroScreens from './tutorial_intro_screens';
 export default class TutorialView extends React.PureComponent {
     componentDidMount() {
         if (this.props.isRoot) {
-            $('body').addClass('app__body');
+            $('body').addClass('app__body'); // eslint-disable-line jquery/no-class
         }
     }
 
     componentWillUnmount() {
         if (this.props.isRoot) {
-            $('body').removeClass('app__body');
+            $('body').removeClass('app__body'); // eslint-disable-line jquery/no-class
         }
     }
 

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -215,30 +215,30 @@ export default class CustomThemeChooser extends React.PureComponent {
     toggleSidebarStyles = (e) => {
         e.preventDefault();
 
-        $(this.refs.sidebarStylesHeader).toggleClass('open');
+        $(this.refs.sidebarStylesHeader).toggleClass('open'); // eslint-disable-line jquery/no-class
         this.toggleSection(this.refs.sidebarStyles);
     }
 
     toggleCenterChannelStyles = (e) => {
         e.preventDefault();
 
-        $(this.refs.centerChannelStylesHeader).toggleClass('open');
+        $(this.refs.centerChannelStylesHeader).toggleClass('open'); // eslint-disable-line jquery/no-class
         this.toggleSection(this.refs.centerChannelStyles);
     }
 
     toggleLinkAndButtonStyles = (e) => {
         e.preventDefault();
 
-        $(this.refs.linkAndButtonStylesHeader).toggleClass('open');
+        $(this.refs.linkAndButtonStylesHeader).toggleClass('open'); // eslint-disable-line jquery/no-class
         this.toggleSection(this.refs.linkAndButtonStyles);
     }
 
     toggleSection(node) {
         if (UserAgent.isIos()) {
             // iOS doesn't support jQuery animations
-            $(node).toggleClass('open');
+            $(node).toggleClass('open'); // eslint-disable-line jquery/no-class
         } else {
-            $(node).slideToggle();
+            $(node).slideToggle(); // eslint-disable-line jquery/no-slide
         }
     }
 

--- a/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/premade_theme_chooser/premade_theme_chooser.jsx
@@ -22,7 +22,7 @@ export default class PremadeThemeChooser extends React.PureComponent {
                     continue;
                 }
 
-                const premadeTheme = $.extend(true, {}, Constants.THEMES[k]);
+                const premadeTheme = $.extend(true, {}, Constants.THEMES[k]); // eslint-disable-line jquery/no-extend
 
                 let activeClass = '';
                 if (premadeTheme.type === theme.type) {

--- a/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
+++ b/components/user_settings/display/user_settings_theme/user_settings_theme.jsx
@@ -46,7 +46,7 @@ export default class ThemeSetting extends React.PureComponent {
 
     componentDidMount() {
         if (this.props.selected) {
-            $(ReactDOM.findDOMNode(this.refs[this.state.theme])).addClass('active-border');
+            $(ReactDOM.findDOMNode(this.refs[this.state.theme])).addClass('active-border'); // eslint-disable-line jquery/no-class
         }
     }
 
@@ -56,8 +56,8 @@ export default class ThemeSetting extends React.PureComponent {
         }
 
         if (this.props.selected) {
-            $('.color-btn').removeClass('active-border');
-            $(ReactDOM.findDOMNode(this.refs[this.state.theme])).addClass('active-border');
+            $('.color-btn').removeClass('active-border'); // eslint-disable-line jquery/no-class
+            $(ReactDOM.findDOMNode(this.refs[this.state.theme])).addClass('active-border'); // eslint-disable-line jquery/no-class
         }
     }
 

--- a/e2e/cypress/integration/accessibility/accessibility_account_settings_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_account_settings_spec.js
@@ -122,7 +122,7 @@ describe('Verify Accessibility Support in different sections in Account Settings
             if (section.type === 'text') {
                 cy.get(`#${section.key}Edit`).click();
                 cy.get('.setting-list-item .form-group').each(($el) => {
-                    if ($el.find('input').length) {
+                    if ($el.find('input').length) { // eslint-disable-line jquery/no-find
                         cy.wrap($el).find('.control-label').invoke('text').then((label) => {
                             cy.wrap($el).find('input').should('have.attr', 'aria-label', label);
                         });

--- a/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
+++ b/e2e/cypress/integration/emoji/recently_used_emoji_spec.js
@@ -53,12 +53,12 @@ describe('Recent Emoji', () => {
 
         // * Assert first emoji should equal with second recent emoji
         cy.get('.emoji-picker__item').eq(firstEmoji + 2).find('img').then(($el) => {
-            cy.get('.emoji-picker__item').eq(1).find('img').should('have.attr', 'class', $el.attr('class'));
+            cy.get('.emoji-picker__item').eq(1).find('img').should('have.attr', 'class', $el.attr('class')); // eslint-disable-line jquery/no-attr
         });
 
         // * Assert second emoji should equal with first recent emoji
         cy.get('.emoji-picker__item').eq(secondEmoji + 1).find('img').then(($el) => {
-            cy.get('.emoji-picker__item').eq(0).find('img').should('have.attr', 'class', $el.attr('class'));
+            cy.get('.emoji-picker__item').eq(0).find('img').should('have.attr', 'class', $el.attr('class')); // eslint-disable-line jquery/no-attr
         });
     });
 });

--- a/e2e/cypress/integration/messaging/system_message_spec.js
+++ b/e2e/cypress/integration/messaging/system_message_spec.js
@@ -13,20 +13,20 @@
 // helper function to count the lines in a block of text by wrapping each word in a span and finding where the text breaks the line
 function getLines(e) {
     const $cont = Cypress.$(e);
-    const textArr = $cont.text().split(' ');
+    const textArr = $cont.text().split(' '); // eslint-disable-line jquery/no-text
 
     for (let i = 0; i < textArr.length; i++) {
         textArr[i] = '<span>' + textArr[i] + ' </span>';
     }
 
-    $cont.html(textArr.join(''));
+    $cont.html(textArr.join('')); // eslint-disable-line jquery/no-html
 
-    const $wordSpans = $cont.find('span');
+    const $wordSpans = $cont.find('span'); // eslint-disable-line jquery/no-find
     const lineArray = [];
     var lineIndex = 0;
     var lineStart = true;
 
-    $wordSpans.each(function handleWord(idx) {
+    $wordSpans.each(function handleWord(idx) { // eslint-disable-line jquery/no-each
         const top = Cypress.$(this).position().top;
 
         if (lineStart) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12016,6 +12016,12 @@
         }
       }
     },
+    "eslint-plugin-jquery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jquery/-/eslint-plugin-jquery-1.5.1.tgz",
+      "integrity": "sha512-L7v1eaK5t80C0lvUXPFP9MKnBOqPSKhCOYyzy4LZ0+iK+TJwN8S9gAkzzP1AOhypRIwA88HF6phQ9C7jnOpW8w==",
+      "dev": true
+    },
     "eslint-plugin-mattermost": {
       "version": "github:mattermost/eslint-plugin-mattermost#070ce792d105482ffb2b27cfc0b7e78b3d20acee",
       "from": "github:mattermost/eslint-plugin-mattermost#070ce792d105482ffb2b27cfc0b7e78b3d20acee",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "eslint-plugin-cypress": "2.7.0",
     "eslint-plugin-header": "3.0.0",
     "eslint-plugin-import": "2.18.2",
+    "eslint-plugin-jquery": "1.5.1",
     "eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#070ce792d105482ffb2b27cfc0b7e78b3d20acee",
     "eslint-plugin-react": "7.16.0",
     "exports-loader": "1.0.1",

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1023,12 +1023,12 @@ export function updateCodeTheme(userTheme) {
         }
     });
     const $link = $('link.code_theme');
-    if (cssPath !== $link.attr('href')) {
+    if (cssPath !== $link.attr('href')) { // eslint-disable-line jquery/no-attr
         changeCss('code.hljs', 'visibility: hidden');
         var xmlHTTP = new XMLHttpRequest();
         xmlHTTP.open('GET', cssPath, true);
         xmlHTTP.onload = function onLoad() {
-            $link.attr('href', cssPath);
+            $link.attr('href', cssPath); // eslint-disable-line jquery/no-attr
             if (UserAgent.isFirefox()) {
                 $link.one('load', () => {
                     changeCss('code.hljs', 'visibility: visible');


### PR DESCRIPTION
Taking inspiration from https://github.blog/2018-09-06-removing-jquery-from-github-frontend/, this adds eslint-plugin-jQuery to prevent people from adding new references to jQuery to the code base. Any new usage of jQuery will cause an ESLint error, and any old usage of it has been marked with a comment so people know using it is wrong (morally, of course).

This'll be followed by one or more Help Wanted tickets to actually update this code to not use jQuery.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16998

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/6025