### PR TITLE
Cypress/E2E: Fix edit message spec

### DIFF
--- a/e2e/cypress/integration/messaging/edit_message_spec.js
+++ b/e2e/cypress/integration/messaging/edit_message_spec.js
@@ -71,7 +71,7 @@ describe('Edit Message', () => {
         cy.get('#emojiPicker').should('be.visible');
 
         // * Press the escape key
-        cy.get('#edit_textbox').wait(TIMEOUTS.HALF_SEC).type('{esc}');
+        cy.get('#emojiPickerSearch').wait(TIMEOUTS.HALF_SEC).type('{esc}');
 
         // * Assert emoji picker is not visible
         cy.get('#emojiPicker').should('not.exist');

--- a/e2e/cypress/integration/signin_authentication/subpath_login_spec.js
+++ b/e2e/cypress/integration/signin_authentication/subpath_login_spec.js
@@ -50,7 +50,7 @@ describe('Cookie with Subpath', () => {
                 cy.url().should('include', '/channels/town-square');
 
                 // * Check cookies have correct path parameter
-                cy.getCookies().should('have.length', 3).each((cookie) => {
+                cy.getCookies().should('have.length', 5).each((cookie) => {
                     if (subpath) {
                         expect(cookie).to.have.property('path', subpath);
                     } else {


### PR DESCRIPTION
#### Summary
- Fixed selector for emoji picker search on `edit_message_spec`
- Updated cookie count on `subpath_login_spec`

#### Ticket Link
None - master only

![Screen Shot 2020-07-30 at 3 09 56 PM](https://user-images.githubusercontent.com/487991/88979803-3b890c80-d277-11ea-823a-f9d07abd1b44.png)
![Screen Shot 2020-07-30 at 3 08 43 PM](https://user-images.githubusercontent.com/487991/88979807-3e83fd00-d277-11ea-98da-c1d2b9439e28.png)
