### PR TITLE
Cypress/E2E: Fixing search in system console for team and channel assign roles

### DIFF
--- a/e2e/cypress/integration/enterprise/ldap_group/team_and_channel_assign_roles_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/team_and_channel_assign_roles_spec.js
@@ -17,9 +17,10 @@ const saveAndNavigateBackTo = (name, page) => {
 
     // * Verify that it redirects to teams page and wait for a while to load
     cy.url().should('include', `/admin_console/user_management/${page}`).wait(TIMEOUTS.TWO_SEC);
-
-    cy.findByPlaceholderText('Search').should('be.visible').type(`${name}{enter}`).wait(TIMEOUTS.HALF_SEC);
-    cy.findByTestId(`${name}edit`).should('be.visible').click();
+    cy.get('.DataGrid_searchBar').within(() => {
+        cy.findByPlaceholderText('Search').should('be.visible').type(`${name}{enter}`).wait(TIMEOUTS.HALF_SEC);
+    });
+        cy.findByTestId(`${name}edit`).should('be.visible').click();
 };
 
 const changeRoleTo = (role) => {
@@ -70,7 +71,9 @@ describe('System Console', () => {
         cy.visit('/admin_console/user_management/teams');
 
         // # Search for the team.
-        cy.findByPlaceholderText('Search').should('be.visible').type(`${teamName}{enter}`);
+        cy.get('.DataGrid_searchBar').within(() => {
+            cy.findByPlaceholderText('Search').should('be.visible').type(`${teamName}{enter}`);
+        });
         cy.findByTestId(`${teamName}edit`).click();
 
         // # Add the first group in the group list then save
@@ -138,7 +141,9 @@ describe('System Console', () => {
         cy.visit('/admin_console/user_management/teams');
 
         // # Search for the team.
-        cy.findByPlaceholderText('Search').should('be.visible').type(`${teamName}{enter}`);
+        cy.get('.DataGrid_searchBar').within(() => {
+            cy.findByPlaceholderText('Search').should('be.visible').type(`${teamName}{enter}`);
+        });
         cy.findByTestId(`${teamName}edit`).click();
 
         // # Add the first group in the group list then save
@@ -170,7 +175,9 @@ describe('System Console', () => {
         cy.visit('/admin_console/user_management/channels');
 
         // # Search for the channel.
-        cy.findByPlaceholderText('Search').should('be.visible').type(`${channelName}{enter}`);
+        cy.get('.DataGrid_searchBar').within(() => {
+            cy.findByPlaceholderText('Search').should('be.visible').type(`${channelName}{enter}`);
+        });
         cy.findByTestId(`${channelName}edit`).click();
 
         // # Add the first group in the group list then save
@@ -220,7 +227,9 @@ describe('System Console', () => {
         cy.visit('/admin_console/user_management/channels');
 
         // # Search for the channel.
-        cy.findByPlaceholderText('Search').should('be.visible').type(`${channelName}{enter}`);
+        cy.get('.DataGrid_searchBar').within(() => {
+            cy.findByPlaceholderText('Search').should('be.visible').type(`${channelName}{enter}`);
+        });
         cy.findByTestId(`${channelName}edit`).click();
 
         // # Add the first group in the group list then save

--- a/e2e/cypress/integration/enterprise/ldap_group/team_and_channel_assign_roles_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap_group/team_and_channel_assign_roles_spec.js
@@ -20,7 +20,7 @@ const saveAndNavigateBackTo = (name, page) => {
     cy.get('.DataGrid_searchBar').within(() => {
         cy.findByPlaceholderText('Search').should('be.visible').type(`${name}{enter}`).wait(TIMEOUTS.HALF_SEC);
     });
-        cy.findByTestId(`${name}edit`).should('be.visible').click();
+    cy.findByTestId(`${name}edit`).should('be.visible').click();
 };
 
 const changeRoleTo = (role) => {


### PR DESCRIPTION
#### Summary
Adding fix for search in system console for team_and_channel_assign_roles_spec. There have been some changes in the scoping of the "Search" placeholder text. Ideally, I'd like to make finding the placeholder text simpler by adding a custom command since each search command needs at least 2 lines with the current setting. But need to find out all the places where the refactoring will be required. Thus checking in these changes.

(There are similar failures in `archived_channels_spec` but there are more failures than just the search component, hence taking a look at it separetely)

#### Screenshots
<img width="506" alt="Screen Shot 2020-07-30 at 4 48 17 PM" src="https://user-images.githubusercontent.com/691331/88985992-937b3f80-d286-11ea-90c8-97c5dc1ba5c4.png">
