### PR TITLE
Cypress/E2E: Fix custom theme specs

### DIFF
--- a/e2e/cypress/integration/account_settings/display/theme/custom_theme_color_picker_spec.js
+++ b/e2e/cypress/integration/account_settings/display/theme/custom_theme_color_picker_spec.js
@@ -20,17 +20,20 @@ describe('AS14318 Theme Colors - Color Picker', () => {
     });
 
     beforeEach(() => {
-        // Navigating to account settings
+        cy.reload();
+        cy.findByTestId('post_textbox').should('be.visible');
+
+        // # Navigating to account settings
         cy.toAccountSettingsModal();
-        cy.get('#displayButton').click();
-        cy.get('#themeTitle').click();
-        cy.get('#customThemes').click();
+        cy.get('#displayButton', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible').click();
+        cy.get('#themeTitle', {timeout: TIMEOUTS.ONE_SEC}).should('be.visible').click();
+        cy.get('#customThemes', {timeout: TIMEOUTS.ONE_SEC}).should('be.visible').click();
     });
 
     afterEach(() => {
         // # Click "x" button to close Account Settings modal and then discard changes made
-        cy.get('#accountSettingsHeader > .close').click();
-        cy.findAllByText('Yes, Discard').click();
+        cy.get('#accountSettingsHeader > .close').should('be.visible').click();
+        cy.findAllByText('Yes, Discard', {timeout: TIMEOUTS.ONE_SEC}).should('be.visible').click();
     });
 
     it('Should be able to use color picker input and change Sidebar theme color', () => {
@@ -38,10 +41,10 @@ describe('AS14318 Theme Colors - Color Picker', () => {
         verifyColorPickerChange(
             'Sidebar Styles',
             '#sidebarBg-squareColorIcon',
-            '#sidebarBg-ChromePickerModal',
+            '#sidebarBg-inputColorValue',
             '#sidebarBg-squareColorIconValue',
-            '#bb123e',
-            'rgb(187, 18, 62)',
+            '#B0B6BD',
+            'rgb(176, 182, 189)',
         );
     });
 
@@ -50,10 +53,10 @@ describe('AS14318 Theme Colors - Color Picker', () => {
         verifyColorPickerChange(
             'Center Channel Styles',
             '#centerChannelBg-squareColorIcon',
-            '#centerChannelBg-ChromePickerModal',
+            '#centerChannelBg-inputColorValue',
             '#centerChannelBg-squareColorIconValue',
-            '#ff8800',
-            'rgb(255, 136, 0)',
+            '#BDB0B0',
+            'rgb(189, 176, 176)',
         );
     });
 
@@ -62,33 +65,37 @@ describe('AS14318 Theme Colors - Color Picker', () => {
         verifyColorPickerChange(
             'Link and Button Styles',
             '#linkColor-squareColorIcon',
-            '#linkColor-ChromePickerModal',
+            '#linkColor-inputColorValue',
             '#linkColor-squareColorIconValue',
-            '#ffe577',
-            'rgb(255, 229, 119)',
+            '#EEF8FF',
+            'rgb(238, 248, 255)',
         );
     });
 });
 
-function verifyColorPickerChange(stylesText, iconButtonId, modalId, iconValueId, hexValue, rgbValue) {
+function verifyColorPickerChange(stylesText, iconButtonId, inputId, iconValueId, hexValue, rgbValue) {
     // # Open styles section
     cy.findByText(stylesText).scrollIntoView().should('be.visible').click({force: true});
 
     // # Click the Sidebar BG setting
     cy.get(iconButtonId).click();
 
-    // # Enter hex value
-    cy.get(modalId).within(() => {
-        cy.get('input').clear({force: true}).invoke('val', hexValue).wait(TIMEOUTS.HALF_SEC).type(' {backspace}{enter}', {force: true});
-    });
+    // # Click the 15, 40 coordinate of color popover
+    cy.get('.color-popover').should('be.visible').click(15, 40);
+
+    // # Click the Sidebar BG setting again to close popover
+    cy.get(iconButtonId).click();
 
     // # Toggle theme colors the custom theme
-    cy.findByText('Theme Colors').scrollIntoView().click({force: true});
-    cy.findByText('Custom Theme').scrollIntoView().click({force: true});
+    cy.get('#standardThemes').scrollIntoView().should('be.visible').check().should('be.checked');
+    cy.get('#customThemes').scrollIntoView().should('be.visible').check().should('be.checked');
 
     // # Re-open styles section
     cy.findByText(stylesText).scrollIntoView().should('be.visible').click({force: true});
 
+    // * Verify input box has new hex value
+    cy.get(inputId).should('be.visible').and('have.value', hexValue);
+
     // * Verify color change is applied correctly
-    cy.get(iconValueId).should('have.css', 'background-color', rgbValue);
+    cy.get(iconValueId).should('be.visible').and('have.css', 'background-color', rgbValue);
 }

--- a/e2e/cypress/integration/account_settings/display/theme/custom_theme_sidebar_styles_spec.js
+++ b/e2e/cypress/integration/account_settings/display/theme/custom_theme_sidebar_styles_spec.js
@@ -107,7 +107,7 @@ function toThemeDisplaySettings() {
     cy.toAccountSettingsModal();
 
     // * Check that the Display tab is loaded, then click on it
-    cy.get('#displayButton').should('be.visible').click();
+    cy.get('#displayButton', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible').click();
 }
 
 // Open sidebar styles at Account Settings > Display > Theme

--- a/e2e/cypress/integration/account_settings/display/theme/custom_theme_sidebar_styles_spec.js
+++ b/e2e/cypress/integration/account_settings/display/theme/custom_theme_sidebar_styles_spec.js
@@ -12,19 +12,19 @@
 import * as TIMEOUTS from '../../../../fixtures/timeouts';
 
 const testCases = [
-    {key: 0, name: 'Sidebar BG', backgroundColor: 'rgb(20, 191, 188)', themeId: 'sidebarBg', value: '#14bfbc'},
-    {key: 1, name: 'Sidebar Text', backgroundColor: 'rgb(129, 65, 65)', themeId: 'sidebarText', value: '#814141'},
-    {key: 2, name: 'Sidebar Header BG', backgroundColor: 'rgb(17, 171, 168)', themeId: 'sidebarHeaderBg', value: '#11aba8'},
-    {key: 3, name: 'Sidebar Header Text', backgroundColor: 'rgb(129, 65, 65)', themeId: 'sidebarHeaderTextColor', value: '#814141'},
-    {key: 4, name: 'Sidebar Unread Text', backgroundColor: 'rgb(129, 65, 65)', themeId: 'sidebarUnreadText', value: '#814141'},
-    {key: 5, name: 'Sidebar Text Hover BG', backgroundColor: 'rgb(69, 191, 191)', themeId: 'sidebarTextHoverBg', value: '#45bfbf'},
-    {key: 6, name: 'Sidebar Text Active Border', backgroundColor: 'rgb(65, 92, 129)', themeId: 'sidebarTextActiveBorder', value: '#415c81'},
-    {key: 7, name: 'Sidebar Text Active Color', backgroundColor: 'rgb(129, 65, 65)', themeId: 'sidebarTextActiveColor', value: '#814141'},
-    {key: 8, name: 'Online Indicator', backgroundColor: 'rgb(65, 129, 113)', themeId: 'onlineIndicator', value: '#418171'},
-    {key: 9, name: 'Away Indicator', backgroundColor: 'rgb(129, 106, 65)', themeId: 'awayIndicator', value: '#816a41'},
-    {key: 10, name: 'Do Not Disturb Indicator', backgroundColor: 'rgb(129, 65, 65)', themeId: 'dndIndicator', value: '#814141'},
-    {key: 11, name: 'Mention Jewel BG', backgroundColor: 'rgb(129, 65, 65)', themeId: 'mentionBg', value: '#814141'},
-    {key: 12, name: 'Mention Jewel Text', backgroundColor: 'rgb(65, 92, 129)', themeId: 'mentionColor', value: '#415c81'},
+    {key: 0, name: 'Sidebar BG', backgroundColor: 'rgb(176, 182, 189)', themeId: 'sidebarBg', value: '#b0b6bd'},
+    {key: 1, name: 'Sidebar Text', backgroundColor: 'rgb(187, 175, 175)', themeId: 'sidebarText', value: '#bbafaf'},
+    {key: 2, name: 'Sidebar Header BG', backgroundColor: 'rgb(173, 178, 185)', themeId: 'sidebarHeaderBg', value: '#adb2b9'},
+    {key: 3, name: 'Sidebar Header Text', backgroundColor: 'rgb(183, 171, 171)', themeId: 'sidebarHeaderTextColor', value: '#b7abab'},
+    {key: 4, name: 'Sidebar Unread Text', backgroundColor: 'rgb(181, 169, 169)', themeId: 'sidebarUnreadText', value: '#b5a9a9'},
+    {key: 5, name: 'Sidebar Text Hover BG', backgroundColor: 'rgb(167, 172, 179)', themeId: 'sidebarTextHoverBg', value: '#a7acb3'},
+    {key: 6, name: 'Sidebar Text Active Border', backgroundColor: 'rgb(165, 170, 177)', themeId: 'sidebarTextActiveBorder', value: '#a5aab1'},
+    {key: 7, name: 'Sidebar Text Active Color', backgroundColor: 'rgb(175, 163, 163)', themeId: 'sidebarTextActiveColor', value: '#afa3a3'},
+    {key: 8, name: 'Online Indicator', backgroundColor: 'rgb(161, 173, 170)', themeId: 'onlineIndicator', value: '#a1adaa'},
+    {key: 9, name: 'Away Indicator', backgroundColor: 'rgb(170, 166, 159)', themeId: 'awayIndicator', value: '#aaa69f'},
+    {key: 10, name: 'Do Not Disturb Indicator', backgroundColor: 'rgb(168, 157, 157)', themeId: 'dndIndicator', value: '#a89d9d'},
+    {key: 11, name: 'Mention Jewel BG', backgroundColor: 'rgb(166, 155, 155)', themeId: 'mentionBg', value: '#a69b9b'},
+    {key: 12, name: 'Mention Jewel Text', backgroundColor: 'rgb(238, 246, 255)', themeId: 'mentionColor', value: '#eef6ff'},
 ];
 
 describe('AS14318 Theme Colors - Custom Sidebar Styles input change', () => {
@@ -44,10 +44,8 @@ describe('AS14318 Theme Colors - Custom Sidebar Styles input change', () => {
             // # Click input color button
             cy.get('.input-group-addon').eq(testCase.key).scrollIntoView().click({force: true});
 
-            // # Enter hex value
-            cy.get('.color-popover').scrollIntoView().within(() => {
-                cy.get('input').clear({force: true}).invoke('val', testCase.value).wait(TIMEOUTS.HALF_SEC).type(' {backspace}{enter}', {force: true});
-            });
+            // # Click the 15, 40 plus key coordinate of color popover
+            cy.get('.color-popover').should('be.visible').click(15, 40 + testCase.key);
 
             // * Check that icon color change
             cy.get('.color-icon').eq(testCase.key).should('have.css', 'background-color', testCase.backgroundColor);
@@ -59,16 +57,16 @@ describe('AS14318 Theme Colors - Custom Sidebar Styles input change', () => {
 
     it('should observe color change in Account Settings modal before saving', () => {
         // * Check Sidebar BG color change
-        cy.get('.settings-links').should('have.css', 'background-color', 'rgb(20, 191, 188)');
+        cy.get('.settings-links').should('have.css', 'background-color', 'rgb(176, 182, 189)');
 
         // * Check Sidebar Text color change
-        cy.get('#generalButton').should('have.css', 'color', 'rgba(129, 65, 65, 0.6)');
+        cy.get('#generalButton').should('have.css', 'color', 'rgba(187, 175, 175, 0.6)');
 
         // * Check Sidebar Header BG color change
-        cy.get('#accountSettingsHeader').should('have.css', 'background', 'rgb(17, 171, 168) none repeat scroll 0% 0% / auto padding-box border-box');
+        cy.get('#accountSettingsHeader').should('have.css', 'background', 'rgb(173, 178, 185) none repeat scroll 0% 0% / auto padding-box border-box');
 
         // * Check Sidebar Header Text color change
-        cy.get('#accountSettingsModalLabel').should('have.css', 'color', 'rgb(129, 65, 65)');
+        cy.get('#accountSettingsModalLabel').should('have.css', 'color', 'rgb(183, 171, 171)');
 
         cy.get('#saveSetting').click({force: true});
         cy.get('#accountSettingsHeader > .close').click();
@@ -76,28 +74,28 @@ describe('AS14318 Theme Colors - Custom Sidebar Styles input change', () => {
 
     it('should take effect each custom color in Channel View', () => {
         // * Check Mention Jewel BG color
-        cy.get('#unreadIndicatorBottom').should('have.css', 'background-color', 'rgb(129, 65, 65)');
+        cy.get('#unreadIndicatorBottom').should('have.css', 'background-color', 'rgb(166, 155, 155)');
 
         // * Check Mention Jewel Text color
-        cy.get('#unreadIndicatorBottom').should('have.css', 'color', 'rgb(65, 92, 129)');
+        cy.get('#unreadIndicatorBottom').should('have.css', 'color', 'rgb(238, 246, 255)');
 
         // # Set user status to online
         cy.userStatus(0);
 
         // * Check Online Indicator color
-        cy.get('.online--icon').should('have.css', 'fill', 'rgb(65, 129, 113)');
+        cy.get('.online--icon').should('have.css', 'fill', 'rgb(161, 173, 170)');
 
         // # Set user status to away
         cy.userStatus(1);
 
         // * Check Away Indicator color
-        cy.get('.away--icon').should('have.css', 'fill', 'rgb(129, 106, 65)');
+        cy.get('.away--icon').should('have.css', 'fill', 'rgb(170, 166, 159)');
 
         // # Set user status to do not disturb
         cy.userStatus(2);
 
         // * Check Do Not Disturb Indicator color
-        cy.get('.dnd--icon').should('have.css', 'fill', 'rgb(129, 65, 65)');
+        cy.get('.dnd--icon').should('have.css', 'fill', 'rgb(168, 157, 157)');
 
         // # Revert user status to online
         cy.userStatus(0);


### PR DESCRIPTION
#### Summary
- The issue is that the input box for color is not editable anymore. The only way to assign a value now is to pick from the color popover. However, a particular hex or rgb color is not mapped to css. A workaround is to just click on a specific pixel coordinate which will likely not change since layout of color gradient is fixed.
- stabilized custom_theme_color_picker_spec

#### Ticket Link
None - master only

![Screen Shot 2020-07-30 at 6 27 11 PM](https://user-images.githubusercontent.com/487991/88990668-74cf7580-d293-11ea-83f3-6c17eb1fed64.png)
![Screen Shot 2020-07-30 at 6 28 14 PM](https://user-images.githubusercontent.com/487991/88990672-76993900-d293-11ea-9c0e-3e6d3db2ee79.png)
