### PR TITLE
[MM-27306] Fix sidebar failing on missing currentTeam

### DIFF
--- a/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/sidebar should match empty div snapshot when teamId is empty 1`] = `<div />`;
+exports[`components/sidebar should match empty div snapshot when teamId is missing 1`] = `<div />`;
 
 exports[`components/sidebar should match snapshot 1`] = `
 <div
@@ -44,8 +44,6 @@ exports[`components/sidebar should match snapshot 1`] = `
   />
 </div>
 `;
-
-exports[`components/sidebar should match snapshot 2`] = `<div />`;
 
 exports[`components/sidebar should match snapshot when direct channels modal is open 1`] = `
 <div

--- a/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/sidebar should match empty div snapshot when teamId is empty 1`] = `<div />`;
+
 exports[`components/sidebar should match snapshot 1`] = `
 <div
   className=""
@@ -42,6 +44,8 @@ exports[`components/sidebar should match snapshot 1`] = `
   />
 </div>
 `;
+
+exports[`components/sidebar should match snapshot 2`] = `<div />`;
 
 exports[`components/sidebar should match snapshot when direct channels modal is open 1`] = `
 <div

--- a/components/sidebar/index.ts
+++ b/components/sidebar/index.ts
@@ -39,7 +39,7 @@ function mapStateToProps(state: GlobalState) {
     }
 
     return {
-        teamId: currentTeam.id,
+        teamId: currentTeam ? currentTeam.id : '',
         canCreatePrivateChannel,
         canCreatePublicChannel,
         canJoinPublicChannel,

--- a/components/sidebar/sidebar.test.tsx
+++ b/components/sidebar/sidebar.test.tsx
@@ -74,7 +74,7 @@ describe('components/sidebar', () => {
         expect(instance.hideMoreDirectChannelsModal).toHaveBeenCalled();
     });
 
-    test('should match empty div snapshot when teamId is empty', () => {
+    test('should match empty div snapshot when teamId is missing', () => {
         const props = {
             ...baseProps,
             teamId: '',

--- a/components/sidebar/sidebar.test.tsx
+++ b/components/sidebar/sidebar.test.tsx
@@ -73,4 +73,16 @@ describe('components/sidebar', () => {
         instance.handleOpenMoreDirectChannelsModal(mockEvent as any);
         expect(instance.hideMoreDirectChannelsModal).toHaveBeenCalled();
     });
+
+    test('should match empty div snapshot when teamId is empty', () => {
+        const props = {
+            ...baseProps,
+            teamId: '',
+        };
+        const wrapper = shallow(
+            <Sidebar {...props}/>,
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -176,6 +176,10 @@ export default class Sidebar extends React.PureComponent<Props, State> {
     }
 
     render() {
+        if (!this.props.teamId) {
+            return (<div/>);
+        }
+
         return (
             <div
                 id='SidebarContainer'


### PR DESCRIPTION
#### Summary

PR fixes the Sidebar component failing when `currentTeam` is not (yet) set.

#### Ticket

https://mattermost.atlassian.net/browse/MM-27306