### PR TITLE
Cypress/E2E: Potential workaround to fix autocomplete shown each channel spec

### DIFF
--- a/e2e/cypress/integration/messaging/autocomplete_shown_each_channel_spec.js
+++ b/e2e/cypress/integration/messaging/autocomplete_shown_each_channel_spec.js
@@ -26,7 +26,7 @@ describe('Identical Message Drafts', () => {
 
     it('M14432 shows Autocomplete in each channel', () => {
         // # Go to test Channel A on sidebar
-        cy.get('#sidebarItem_town-square').click({force: true});
+        cy.get('#sidebarItem_town-square').should('be.visible').click();
 
         // * Validate if the channel has been opened
         cy.url().should('include', '/channels/town-square');
@@ -38,7 +38,7 @@ describe('Identical Message Drafts', () => {
         cy.get('#suggestionList').should('be.visible');
 
         // # Go to test Channel B on sidebar
-        cy.get(`#sidebarItem_${testChannel.name}`).click({force: true});
+        cy.get(`#sidebarItem_${testChannel.name}`).should('be.visible').click();
 
         // * Validate if the newly navigated channel is open
         // * autocomplete should not be visible in channel
@@ -46,17 +46,19 @@ describe('Identical Message Drafts', () => {
         cy.get('#suggestionList').should('not.be.visible');
 
         // # Start a draft in Channel B containing just "@"
-        cy.get('#post_textbox').type('@');
+        cy.get('#post_textbox').should('be.visible').type('@');
 
         // * At mention auto-complete appears in Channel B
         cy.get('#suggestionList').should('be.visible');
 
-        // # Go back to test Channel A on sidebar
-        cy.get('#sidebarItem_town-square').click({force: true});
+        // # Go to Channel C then back to test Channel A on sidebar
+        cy.get('#sidebarItem_off-topic').should('be.visible').click();
+        cy.get('#sidebarItem_town-square').should('be.visible').click();
 
         // * Validate if the channel has been opened
         // * At mention auto-complete is preserved in Channel A
         cy.url().should('include', '/channels/town-square');
+        cy.get('#post_textbox').should('be.visible');
         cy.get('#suggestionList').should('be.visible');
     });
 });


### PR DESCRIPTION
#### Summary
- I was able to repro the issue intermittently. However, it only fails when running through cypress. I wasn't able to repro it manually.
- This is just a potential workaround to cypress issue - make sure elements are visible before interaction and switch to an intermediate channel before final channel for verification; after I did this, I couldn't repro the issue anymore

#### Ticket Link
None -  both on master and release-5.26

![Screen Shot 2020-07-31 at 9 34 58 AM](https://user-images.githubusercontent.com/487991/89056741-5ad47800-d311-11ea-8a84-cb721bfe6f31.png)
