### PR TITLE
MM-T1664  Channels don't disappear from More Channels modal E2E tests

### DIFF
--- a/e2e/cypress/integration/channel/more_public_channels_spec.js
+++ b/e2e/cypress/integration/channel/more_public_channels_spec.js
@@ -1,0 +1,106 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @channel
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+function verifyNoChannelToJoinMessage(isVisible) {
+    cy.findByText('No more channels to join').should(isVisible ? 'be.visible' : 'not.exist');
+    cy.findByText('Click \'Create New Channel\' to make a new one').should(isVisible ? 'be.visible' : 'not.exist');
+}
+
+describe('more public channels', () => {
+    let testUser;
+    let otherUser;
+    let testTeam;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+
+            cy.apiCreateUser().then(({user: user1}) => {
+                otherUser = user1;
+                cy.apiAddUserToTeam(testTeam.id, otherUser.id);
+            });
+
+            cy.apiLogin(testUser).then(() => {
+                // # create 30 channels
+                for (let i = 0; i < 30; i++) {
+                    cy.apiCreateChannel(testTeam.id, 'public-channel', 'public-channel');
+                }
+
+                // # Go to town square
+                cy.visit(`/${team.name}/channels/town-square`);
+            });
+        });
+    });
+
+    it('MM-T1664 Channels dont disappear from More Channels modal', () => {
+        // # Login as other user
+        cy.apiLogin(otherUser);
+
+        // # Go to town square
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+
+        // # Go to LHS and click "More..." under Public Channels group
+        cy.get('#publicChannelList').should('be.visible').within(() => {
+            cy.findByText('More...').scrollIntoView().should('be.visible').click();
+        });
+
+        // * Assert that the moreChannelsModel is visible
+        cy.get('#moreChannelsModal').should('be.visible').within(() => {
+            cy.wait(TIMEOUTS.HALF_MIN);
+
+            // * Assert that the moreChannelsList is visible and the number of channels is 31
+            cy.get('#moreChannelsList').should('be.visible').children().should('have.length', 31);
+
+            // # scroll to the middle channel
+            cy.get('#moreChannelsList .more-modal__row').eq(15).scrollIntoView();
+
+            // * Assert that the "No more channels to join" message does not exist
+            verifyNoChannelToJoinMessage(false);
+
+            // # scroll to the last channel
+            cy.get('#moreChannelsList .more-modal__row').last().scrollIntoView();
+
+            // * Assert that the "No more channels to join" message does not exist
+            verifyNoChannelToJoinMessage(false);
+
+            // # scroll to the first channel
+            cy.get('#moreChannelsList .more-modal__row').first().scrollIntoView();
+
+            // * Assert that the "No more channels to join" message does not exist
+            verifyNoChannelToJoinMessage(false);
+        });
+
+        // # Login as testUser
+        cy.apiLogin(testUser);
+
+        // # Go to town square
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+
+        // # Go to LHS and click "More..." under Public Channels group
+        cy.get('#publicChannelList').should('be.visible').within(() => {
+            cy.findByText('More...').scrollIntoView().should('be.visible').click();
+        });
+
+        // * Assert the moreChannelsModel is visible
+        cy.get('#moreChannelsModal').should('be.visible').within(() => {
+            cy.wait(TIMEOUTS.HALF_MIN);
+
+            // * Assert the moreChannelsList does have one child
+            cy.get('#moreChannelsList').should('be.visible').children().should('have.length', 1);
+
+            // * Assert that the "No more channels to join" message is visible
+            verifyNoChannelToJoinMessage(true);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Added E2E testing to confirm, In webapp, public channels in LHS -> more -> more modal box will have available channels list to join. And incase no channel available "No more channels to join" message will be displayed.
#### Ticket Link
[Usecase](https://automation-test-cases.vercel.app/test/MM-T1664)
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->


<!--
If the PR includes UI changes, include screenshots/GIFs.
-->