### PR TITLE
MM-T1787 Toast does not appear when all new messages are visible without scrolling down

### DIFF
--- a/e2e/cypress/integration/toast/toast_spec.js
+++ b/e2e/cypress/integration/toast/toast_spec.js
@@ -295,7 +295,7 @@ describe('toasts', () => {
         // # Move to the top of the channel
         cy.get('div.post-list__dynamic').should('be.visible').scrollTo('top', {duration: TIMEOUTS.ONE_SEC});
 
-        // * Verify that off-topic channel is loaded
+        // * Verify that town-square channel is loaded
         cy.get('#channelIntro').should('be.visible').contains('Beginning of Town Square');
 
         // * Assert toast should not be present as the messages are already read

--- a/e2e/cypress/integration/toast/toast_spec.js
+++ b/e2e/cypress/integration/toast/toast_spec.js
@@ -15,11 +15,13 @@ describe('toasts', () => {
     let otherUser;
     let testTeam;
     let townsquareChannelId;
+    let otherChannel;
 
     before(() => {
         // # Build data to test and login as testUser
-        cy.apiInitSetup().then(({team, user}) => {
+        cy.apiInitSetup().then(({team, channel, user}) => {
             testTeam = team;
+            otherChannel = channel;
 
             cy.apiGetChannelByName(testTeam.name, 'town-square').then((res) => {
                 townsquareChannelId = res.body.id;
@@ -262,6 +264,42 @@ describe('toasts', () => {
             // * Toast should be present
             cy.get('div.toast').should('be.visible').contains('Viewing message history');
         });
+    });
+
+    it('MM-T1787 Toast does not appear when all new messages are visible without scrolling down', () => {
+        // # Go to other channel
+        cy.get(`#sidebarItem_${otherChannel.name}`).should('be.visible').click();
+
+        // # Add enough messages to town square channel
+        for (let index = 0; index < 30; index++) {
+            cy.postMessageAs({sender: otherUser, message: `This is an old message [${index}]`, channelId: townsquareChannelId});
+        }
+
+        // # Visit town square channel and read all messages
+        visitTownSquareAndWaitForPageToLoad();
+        cy.get('div.post-list__dynamic').should('be.visible').scrollTo('bottom', {duration: TIMEOUTS.ONE_SEC});
+
+        // # Visit other channel
+        cy.get(`#sidebarItem_${otherChannel.name}`).should('be.visible').click();
+
+        // # Add less number of messages to town square channel
+        cy.postMessageAs({sender: otherUser, message: 'This is an new message 1', channelId: townsquareChannelId});
+        cy.postMessageAs({sender: otherUser, message: 'This is an new message 2', channelId: townsquareChannelId});
+
+        // # Visit town square channel
+        visitTownSquareAndWaitForPageToLoad();
+
+        // * Assert toast should not be present as the messages are visible without scrolling down
+        cy.get('div.toast').should('not.be.visible');
+
+        // # Move to the top of the channel
+        cy.get('div.post-list__dynamic').should('be.visible').scrollTo('top', {duration: TIMEOUTS.ONE_SEC});
+
+        // * Verify that off-topic channel is loaded
+        cy.get('#channelIntro').should('be.visible').contains('Beginning of Town Square');
+
+        // * Assert toast should not be present as the messages are already read
+        cy.get('div.toast').should('not.be.visible');
     });
 });
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
MM-T1787 Toast does not appear when all new messages are visible without scrolling down

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[Usecase](https://automation-test-cases.vercel.app/test/MM-T1787)

