### PR TITLE
Promoting tests that have consistently passed over the past week to prod

### DIFF
--- a/e2e/cypress/integration/accessibility/accessibility_modals_dialogs_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_modals_dialogs_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @accessibility
 
 import * as TIMEOUTS from '../../fixtures/timeouts';

--- a/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/message_display_mode_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 import {getRandomId} from '../../../utils';

--- a/e2e/cypress/integration/account_settings/display/timezone_display_mode_spec.js
+++ b/e2e/cypress/integration/account_settings/display/timezone_display_mode_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 import moment from 'moment-timezone';

--- a/e2e/cypress/integration/account_settings/sidebar/channel_switcher_ui_spec.js
+++ b/e2e/cypress/integration/account_settings/sidebar/channel_switcher_ui_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @account_setting
 
 describe('Account Settings > Sidebar > Channel Switcher', () => {

--- a/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
+++ b/e2e/cypress/integration/channel_sidebar/hotkeys_spec.js
@@ -7,6 +7,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @channel_sidebar
 
 import {testWithConfig} from '../../support/hooks';

--- a/e2e/cypress/integration/messaging/post_header_spec.js
+++ b/e2e/cypress/integration/messaging/post_header_spec.js
@@ -8,6 +8,7 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';


### PR DESCRIPTION
#### Summary

Promoting tests from `unstable` to `prod` stage. The following tests, that have been run as "nightly-unstable" have been consistently passing in the last 7 days, hence promoting them to prod.