### PR TITLE
Cypress/E2E: Potential workaround to fix member invitation ui spec

### DIFF
--- a/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/member_invitation_ui_spec.js
@@ -27,6 +27,7 @@ function invitePeople(typeText, resultsCount, verifyText, clickInvite = true) {
         cy.get('input').type(typeText, {force: true});
         cy.get('.users-emails-input__menu').
             children().should('have.length', resultsCount).eq(0).should('contain', verifyText).click();
+        cy.get('input').tab();
     });
 
     // # Click Invite Members


### PR DESCRIPTION
#### Summary
- The issue does not occur for me locally. This is just a potential workaround to cypress issue - tab after input menu item is clicked to make sure it's minimized in case click didn't register.

#### Ticket Link
None -  master only

![Screen Shot 2020-08-04 at 2 41 34 PM](https://user-images.githubusercontent.com/487991/89347984-a1530b00-d660-11ea-9fa2-8d42e3430dee.png)
