### PR TITLE
[MM-T710] /mute error message

### DIFF
--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -100,6 +100,31 @@ describe('I18456 Built-in slash commands: common', () => {
             });
         });
     });
+
+    it('MM-T710 /mute error message', () => {
+        loginAndVisitDefaultChannel(user1, testChannelUrl);
+
+        const invalidChannel = 'oppagangnamstyle';
+
+        // # Type /mute with random characters
+        cy.postMessage(`/mute ${invalidChannel}`);
+        cy.uiWaitUntilMessagePostedIncludes('Please use the channel handle to identify channels');
+
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#postMessageText_${postId}`).
+
+                // * Could not find the channel lalodkjngjrngorejng. Please use the channel handle to identify channels.
+                should('have.text', `Could not find the channel ${invalidChannel}. Please use the channel handle to identify channels.`).
+
+                // * Channel handle links to: https://docs.mattermost.com/help/getting-started/organizing-conversations.html#naming-a-channel
+                contains('a', 'channel handle').then((link) => {
+                    const href = link.prop('href');
+                    cy.request(href).its('allRequestResponses').then((response) => {
+                        cy.wrap(response[1]['Request URL']).should('equal', 'https://docs.mattermost.com/help/getting-started/organizing-conversations.html#naming-a-channel');
+                    });
+                });
+        });
+    });
 });
 
 function loginAndVisitDefaultChannel(user, channelUrl) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This test ensure that an error message is displayed if an invalid channel is entered for the `/mute` command.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://automation-test-cases.vercel.app/test/MM-T710

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes N/A
- Has redux changes N/A
- Has mobile changes N/A

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![Screen Shot 2020-08-03 at 5 56 21 PM](https://user-images.githubusercontent.com/1740517/89231122-ad808f00-d5b2-11ea-92a2-12308e24f705.png)
