### PR TITLE
Cypress/E2E: Updated verification and added scroll up loop

### DIFF
--- a/e2e/cypress/integration/toast/toast_spec.js
+++ b/e2e/cypress/integration/toast/toast_spec.js
@@ -212,7 +212,7 @@ describe('toasts', () => {
 
             // # Toast apprears and has the appropriate message
             cy.get('div.toast').should('be.visible');
-            cy.get('div.toast__message>span').should('be.visible').first().contains('new messages since');
+            cy.get('div.toast__message>span').should('be.visible').first().contains('new messages today');
         });
     });
 
@@ -293,7 +293,9 @@ describe('toasts', () => {
         cy.get('div.toast').should('not.be.visible');
 
         // # Move to the top of the channel
-        cy.get('div.post-list__dynamic').should('be.visible').scrollTo('top', {duration: TIMEOUTS.ONE_SEC});
+        Cypress._.times(3, () => {
+            cy.get('div.post-list__dynamic').should('be.visible').scrollTo('top', {duration: TIMEOUTS.ONE_SEC}).wait(TIMEOUTS.ONE_SEC);
+        });
 
         // * Verify that town-square channel is loaded
         cy.get('#channelIntro').should('be.visible').contains('Beginning of Town Square');


### PR DESCRIPTION
#### Summary
- Updated toast verification
- Added loop to scroll up on page to make sure beginning is reached
- Remaining failure exists in cypress run; not sure if the test case is still valid though.

#### Ticket Link
None -  master only

![Screen Shot 2020-08-05 at 11 30 59 AM](https://user-images.githubusercontent.com/487991/89450678-bf2b7900-d70f-11ea-8aaf-b03c3e814bac.png)
