### PR TITLE
Cypress/E2E: Stabilize messaging height verifications

### DIFF
--- a/e2e/cypress/integration/messaging/long_draft_spec.js
+++ b/e2e/cypress/integration/messaging/long_draft_spec.js
@@ -38,9 +38,7 @@ describe('Messaging', () => {
         cy.postMessage('Hello');
 
         // # Get the height before starting to write
-        cy.get('#post_textbox').should('be.visible').clear().then((post) => {
-            cy.wrap(parseInt(post[0].clientHeight, 10)).as('initialHeight').as('previousHeight');
-        });
+        cy.get('#post_textbox').should('be.visible').clear().invoke('height').as('initialHeight').as('previousHeight');
 
         // # Post first line to use
         cy.get('#post_textbox').type(lines[0]);
@@ -50,8 +48,8 @@ describe('Messaging', () => {
             // # Post the line
             cy.get('#post_textbox').type('{shift}{enter}').type(lines[i]);
 
-            cy.get('#post_textbox').invoke('attr', 'height').then((height) => {
-                // * Previous height should be lower than the current heigh
+            cy.get('#post_textbox').invoke('height').then((height) => {
+                // * Previous height should be lower than the current height
                 cy.get('@previousHeight').should('be.lessThan', parseInt(height, 10));
 
                 // # Store the current height as the previous height for the next loop
@@ -92,10 +90,8 @@ describe('Messaging', () => {
     });
 });
 
-function verifyPostTextbox(targetHeightSelector, text) {
-    cy.get('#post_textbox').should('be.visible').and('have.text', text).then((el) => {
-        cy.get(targetHeightSelector).then((height) => {
-            expect(el[0].clientHeight).to.be.equal(height);
-        });
+function verifyPostTextbox(heightSelector, text) {
+    cy.get('#post_textbox').should('be.visible').and('have.text', text).invoke('height').then((currentHeight) => {
+        cy.get(heightSelector).should('be.gte', currentHeight);
     });
 }

--- a/e2e/cypress/integration/messaging/mention_autocomplete_overlap_spec.js
+++ b/e2e/cypress/integration/messaging/mention_autocomplete_overlap_spec.js
@@ -109,13 +109,15 @@ function uploadFileAndAddAutocompleteThenVerifyNoOverlap() {
     // # Add the mention
     cy.get('#post_textbox').type('{shift}{enter}').type('@');
 
-    cy.get('#channel-header').then((header) => {
-        cy.get('#suggestionList').then((list) => {
+    cy.get('#channel-header').should('be.visible').then((header) => {
+        cy.get('#suggestionList').should('be.visible').then((list) => {
             // # Wait for suggestions to be fully loaded
             cy.wait(TIMEOUTS.HALF_SEC).then(() => {
                 // * Suggestion list should visibly render just within the channel header
-                expect(header[0].getBoundingClientRect().top).to.be.lessThan(list[0].getBoundingClientRect().top);
-                expect(header[0].getBoundingClientRect().bottom).to.be.lessThan(list[0].getBoundingClientRect().top);
+                cy.wrap(header[0].getBoundingClientRect().top).should('be.lt', list[0].getBoundingClientRect().top);
+                cy.wrap(list[0]).findByText('Channel Members').then((channelMembers) => {
+                    cy.wrap(header[0].getBoundingClientRect().bottom).should('be.lt', channelMembers[0].getBoundingClientRect().top);
+                });
             });
         });
     });

--- a/e2e/cypress/integration/messaging/post_textbox_height_spec.js
+++ b/e2e/cypress/integration/messaging/post_textbox_height_spec.js
@@ -28,13 +28,15 @@ describe('Messaging', () => {
             cy.clickPostCommentIcon(latestPostId);
 
             // # Make sure that text box has initial height
-            getTextBox().should('have.css', 'height', '100px');
+            getTextBox().should('have.css', 'height', '100px').invoke('height').as('originalHeight1');
 
-            // // # Write a long text in text box
-            getTextBox().type('test{shift}{enter}{enter}{enter}{enter}{enter}{enter}test');
+            // # Write a long text in text box
+            getTextBox().type('test{shift}{enter}{enter}{enter}{enter}{enter}{enter}{enter}test');
 
             // # Check that input box is taller than before
-            getTextBox().should('have.css', 'height', '166px');
+            cy.get('@originalHeight1').then((originalHeight1) => {
+                getTextBox().invoke('height').should('be.gt', originalHeight1 * 2);
+            });
 
             // # Get second latest post id
             const secondLatestPostIndex = -2;
@@ -43,13 +45,15 @@ describe('Messaging', () => {
                 cy.clickPostCommentIcon(secondLatestPostId);
 
                 // # Make sure that text box has initial height
-                getTextBox().should('have.css', 'height', '100px');
+                getTextBox().should('have.css', 'height', '100px').invoke('height').as('originalHeight2');
 
                 // # Click again reply icon on the latest post
                 cy.clickPostCommentIcon(latestPostId);
 
                 // # Check that input box is taller again
-                getTextBox().should('have.css', 'height', '166px');
+                cy.get('@originalHeight2').then((originalHeight2) => {
+                    getTextBox().invoke('height').should('be.gt', originalHeight2 * 2);
+                });
             });
         });
     });


### PR DESCRIPTION
#### Summary
- Made height verifications more flexible; avoided explicit pixel values when not initial height

#### Ticket Link
None -  master only

![Screen Shot 2020-08-06 at 1 22 53 PM](https://user-images.githubusercontent.com/487991/89579417-96c37d80-d7e8-11ea-9afa-f038fa3481fd.png)
![Screen Shot 2020-08-06 at 1 21 49 PM](https://user-images.githubusercontent.com/487991/89579422-99be6e00-d7e8-11ea-990b-7dfff493d3cb.png)
![Screen Shot 2020-08-06 at 1 24 03 PM](https://user-images.githubusercontent.com/487991/89579429-9b883180-d7e8-11ea-90bb-a0f5e9093bc5.png)
