### PR TITLE
Cypress/E2E: Potential workaround to emoji reaction click async issue

### DIFF
--- a/e2e/cypress/integration/accessibility/accessibility_post_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_post_spec.js
@@ -284,11 +284,19 @@ function postMessages(testChannel, otherUser, count) {
 function performActionsToLastPost() {
     // # Take some actions on the last post
     cy.getLastPostId().then((postId) => {
-        // # Add couple of Reactions
+        // # Add grinning reaction
         cy.clickPostReactionIcon(postId);
+        cy.findByTestId('grinning').trigger('mouseover');
+        cy.get('#emojiPickerSpritePreview').should('be.visible');
+        cy.get('#emojiPickerAliasesPreview').should('be.visible').and('have.text', ':grinning:');
         cy.findByTestId('grinning').click();
         cy.get(`#postReaction-${postId}-grinning`).should('be.visible');
+
+        // # Add smile reaction
         cy.clickPostReactionIcon(postId);
+        cy.findByTestId('smile').trigger('mouseover');
+        cy.get('#emojiPickerSpritePreview').should('be.visible');
+        cy.get('#emojiPickerAliasesPreview').should('be.visible').and('have.text', ':smile:');
         cy.findByTestId('smile').click();
         cy.get(`#postReaction-${postId}-smile`).should('be.visible');
 


### PR DESCRIPTION
#### Summary
- Allow emoji preview to load first before clicking on emoji

#### Ticket Link
None -  master only

![Screen Shot 2020-08-06 at 2 51 09 PM](https://user-images.githubusercontent.com/487991/89586574-d09a8100-d7f4-11ea-9c13-c95825babbdd.png)
