### PR TITLE
Cypress/E2E: Fix full dialog spec

### DIFF
--- a/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
@@ -110,6 +110,9 @@ describe('Interactive Dialog', () => {
 
                         cy.wrap(el).should('have.length', optionsLength[element.name]);
                     });
+
+                    // # Click field label to close any opened drop-downs
+                    cy.wrap($elForm).find('label.control-label').scrollIntoView().click();
                 } else if (element.name === 'someradiooptions') {
                     cy.wrap($elForm).find('input').should('be.visible').and('have.length', optionsLength[element.name]);
 
@@ -224,13 +227,14 @@ describe('Interactive Dialog', () => {
 
             cy.get('#interactiveDialogSubmit').click();
 
-            cy.get('.modal-body').should('be.visible').children().eq(1).within(($elForm) => {
-                if (testCase.valid) {
-                    cy.wrap($elForm).find('div.error-text').should('not.be.visible');
-                } else {
-                    cy.wrap($elForm).find('div.error-text').should('be.visible').and('have.text', 'Must be a valid email address.').and('have.css', 'color', 'rgb(253, 89, 96)');
-                }
-            });
+            if (testCase.valid) {
+                cy.get('input:invalid').should('have.length', 0);
+            } else {
+                cy.get('input:invalid').should('have.length', 1);
+                cy.get('#someemail').then(($input) => {
+                    expect($input[0].validationMessage).to.eq(`Please include an '@' in the email address. '${testCase.value}' is missing an '@'.`);
+                });
+            }
         });
 
         closeInteractiveDialog();


### PR DESCRIPTION
#### Summary
- Click on a field label to close any opened drop-down menu
- Update validation verification as dialog is utilizing html5 input email validation

#### Ticket Link
None -  master only

![Screen Shot 2020-08-06 at 7 32 27 PM](https://user-images.githubusercontent.com/487991/89602445-97293c00-d81b-11ea-9730-d29cedfdd79c.png)