### PR TITLE
[MM-T883] Channel URL validation for spaces between characters

### DIFF
--- a/e2e/cypress/integration/channel_settings/channel_name_validations_spec.js
+++ b/e2e/cypress/integration/channel_settings/channel_name_validations_spec.js
@@ -10,6 +10,7 @@
 // Group: @channel
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
+import {getRandomId} from '../../utils';
 
 describe('Channel routing', () => {
     let testTeam;
@@ -74,6 +75,9 @@ describe('Channel routing', () => {
     });
 
     it('MM-T883 Channel URL validation for spaces between characters', () => {
+        const firstWord = getRandomId(26);
+        const secondWord = getRandomId(26);
+
         // # In a test channel, click the "v" to the right of the channel name in the header
         cy.findByText(`${testChannel.display_name}`).click();
         cy.get('#channelHeaderDropdownIcon').click();
@@ -83,13 +87,13 @@ describe('Channel routing', () => {
 
         // # Change the channel name to {26 alphanumeric characters}[insert 2 spaces]{26 alphanumeric characters}
         //   i.e. a total of 54 characters separated by 2 spaces
-        cy.get('#display_name').clear().type(`${Cypress._.repeat('a', 26)}${Cypress._.repeat(' ', 2)}${Cypress._.repeat('b', 26)}`);
+        cy.get('#display_name').clear().type(`${firstWord}${Cypress._.repeat(' ', 2)}${secondWord}`);
 
         // # Hit Save
         cy.findByText('Save').click();
 
         // * The channel name should be updated to the characters you typed with only 1 space between the characters (extra spaces are trimmed)
-        cy.get('#channelHeaderTitle').contains(`${Cypress._.repeat('a', 26)} ${Cypress._.repeat('b', 26)}`);
+        cy.get('#channelHeaderTitle').contains(`${firstWord} ${secondWord}`);
 
         // # In a test channel, click the "v" to the right of the channel name in the header
         cy.get('#channelHeaderDropdownIcon').click();
@@ -98,12 +102,12 @@ describe('Channel routing', () => {
         cy.findByText('Rename Channel').click();
 
         // # Change the URL to {26 alphanumeric characters}--{26 alphanumeric characters}
-        cy.get('#channel_name').clear().type(`${Cypress._.repeat('a', 26)}${Cypress._.repeat('-', 2)}${Cypress._.repeat('b', 26)}`);
+        cy.get('#channel_name').clear().type(`${firstWord}${Cypress._.repeat('-', 2)}${secondWord}`);
 
         // # Hit Save
         cy.findByText('Save').click();
 
         // * The channel URL should be updated to the characters you typed, separated by 2 dashes
-        cy.url().should('include', `/${testTeam.name}/channels/${Cypress._.repeat('a', 26)}${Cypress._.repeat('-', 2)}${Cypress._.repeat('b', 26)}`);
+        cy.url().should('equal', `${Cypress.config('baseUrl')}/${testTeam.name}/channels/${firstWord}${Cypress._.repeat('-', 2)}${secondWord}`);
     });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

This test validates that the words in channel names cannot be separated by more than one space, but the URL for the channel can contain words that separated by two dashes.

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://automation-test-cases.vercel.app/test/MM-T883

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes N/A
- Has redux changes N/A
- Has mobile changes N/A

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

![Screen Shot 2020-08-06 at 10 57 26 PM](https://user-images.githubusercontent.com/1740517/89603976-3fe59480-d838-11ea-9391-37468f826016.png)
