### PR TITLE
[MM-T570] Integration Page titles are bolded

### DIFF
--- a/e2e/cypress/integration/integrations/integrations_spec.js
+++ b/e2e/cypress/integration/integrations/integrations_spec.js
@@ -189,7 +189,7 @@ describe('Integrations page', () => {
         // # Go to Main Menu -> Integrations
         cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
 
-        cy.get('#integrations').should('be.visible').click();
+        cy.get('.dropdown-menu').should('be.visible').findByText('Integrations').click();
 
         cy.get('.integration-option__title').contains('Incoming Webhooks').click();
 
@@ -197,10 +197,11 @@ describe('Integrations page', () => {
         integrationPageTitleIsBold('Outgoing Webhooks');
         integrationPageTitleIsBold('Slash Commands');
         integrationPageTitleIsBold('OAuth 2.0 Applications');
+        integrationPageTitleIsBold('Bot Accounts');
     });
 });
 
 function integrationPageTitleIsBold(title) {
     cy.get('.section-title__text').contains(title).click();
-    cy.get('.item-details__name').should('have.css', 'font-weight', '600');
+    cy.get('.item-details__name').should('be.visible').and('have.css', 'font-weight', '600');
 }

--- a/e2e/cypress/integration/integrations/integrations_spec.js
+++ b/e2e/cypress/integration/integrations/integrations_spec.js
@@ -13,6 +13,8 @@
 import {getRandomId} from '../../utils';
 
 describe('Integrations page', () => {
+    let testTeam;
+
     before(() => {
         // # Set ServiceSettings to expected values
         const newSettings = {
@@ -27,6 +29,8 @@ describe('Integrations page', () => {
         cy.apiUpdateConfig(newSettings);
 
         cy.apiInitSetup().then(({team}) => {
+            testTeam = team;
+
             // # Go to integrations
             cy.visit(`/${team.name}/integrations`);
 
@@ -178,4 +182,25 @@ describe('Integrations page', () => {
         // * Validate that the correct empty message is shown
         cy.get('#emptySearchResultsMessage').should('be.visible').and('have.text', `No bot accounts match ${searchString}`);
     });
+
+    it('MM-T570 Integration Page titles are bolded', () => {
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+
+        // # Go to Main Menu -> Integrations
+        cy.get('#sidebarHeaderDropdownButton').should('be.visible').click();
+
+        cy.get('#integrations').should('be.visible').click();
+
+        cy.get('.integration-option__title').contains('Incoming Webhooks').click();
+
+        integrationPageTitleIsBold('Incoming Webhooks');
+        integrationPageTitleIsBold('Outgoing Webhooks');
+        integrationPageTitleIsBold('Slash Commands');
+        integrationPageTitleIsBold('OAuth 2.0 Applications');
+    });
 });
+
+function integrationPageTitleIsBold(title) {
+    cy.get('.section-title__text').contains(title).click();
+    cy.get('.item-details__name').should('have.css', 'font-weight', '600');
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds an E2E test to check if Integration Page titles are bolded.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
MM-T570