### PR TITLE
MM-27537 remove segment remnant (fix hosting-in-subpath issue)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -264,7 +264,7 @@ var config = {
             meta: {
                 csp: {
                     'http-equiv': 'Content-Security-Policy',
-                    content: 'script-src \'self\' cdn.segment.com/analytics.js/ cdn.rudderlabs.com/' + CSP_UNSAFE_EVAL_IF_DEV,
+                    content: 'script-src \'self\' cdn.rudderlabs.com/' + CSP_UNSAFE_EVAL_IF_DEV,
                 },
             },
         }),


### PR DESCRIPTION
#### Summary

- Remove segment from meta tag in root.html

**This fix prevents a fatal web client error for installations running under a subpath.**

Background: [This mattermost-server code block](https://github.com/mattermost/mattermost-server/blob/v5.26.0-rc1/utils/subpath.go#L88-L96)  is a part of the subpath-rewriting logic, and looks for a specific meta tag to rewrite. The strings were mismatched and failed, short-circuiting the rest of the subpath rewrite process.

Notes: 
- Related PR #5632 
- We should consider allowing subpath rewriting ([here](https://github.com/mattermost/mattermost-server/blob/v5.26.0-rc1/utils/subpath.go#L144-L149)) on local development when using webapp:`make build` and server:`make run-server`, which allows for the simulation of production-like environments.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-27537
