### PR TITLE
MM-T368 - Text in search box should not clear when Pinned posts icon or Saved posts icon is clicked

### DIFF
--- a/e2e/cypress/integration/search/clear_input_spec.js
+++ b/e2e/cypress/integration/search/clear_input_spec.js
@@ -10,11 +10,6 @@
 // Stage: @prod
 // Group: @search
 
-
-
-// https://automation-test-cases.vercel.app/test/MM-T368
-
-
 import * as TIMEOUTS from '../../fixtures/timeouts';
 import * as MESSAGES from '../../fixtures/messages';
 
@@ -53,37 +48,37 @@ describe('Search', () => {
     });
 
     it('MM-T368 - Text in search box should not clear when Pinned posts icon or Saved posts icon is clicked', () => {
-        const searchText = MESSAGES.SMALL
+        const searchText = MESSAGES.SMALL;
 
         // * Verify search input field exists and not search button, as inputs contains placeholder not buttons/icons
-        // and then type in a search text 
-        cy.findByPlaceholderText('Search').should('be.visible').and('exist').click().type(searchText).as('searchInput')
+        // and then type in a search text
+        cy.findByPlaceholderText('Search').should('be.visible').and('exist').click().type(searchText).as('searchInput');
 
         // # Click on the pinned post button from the header
         cy.get('#channel-header').within(() => {
-            cy.findByLabelText('Pin Icon').should('be.visible').and('exist').click()
-        })
+            cy.findByLabelText('Pin Icon').should('be.visible').and('exist').click();
+        });
 
         // * Verify the pinned post RHS is open
         cy.get('#sidebar-right').should('be.visible').and('contain', 'Pinned posts');
 
         // * Check that search input value remains the same as we entered before
-        cy.get('@searchInput').should('have.value', searchText)
+        cy.get('@searchInput').should('have.value', searchText);
 
         // # Now click on the saved post button from the header
         cy.get('#channel-header').within(() => {
-            cy.findByLabelText('Save Icon').should('be.visible').and('exist').click()
-        })
+            cy.findByLabelText('Save Icon').should('be.visible').and('exist').click();
+        });
 
         // * Verify the pinned post RHS is open
         cy.get('#sidebar-right').should('be.visible').and('contain', 'Saved posts');
 
         // * Again check that search input value remains the same as we entered before
-        cy.get('@searchInput').should('have.value', searchText)
+        cy.get('@searchInput').should('have.value', searchText);
 
         // # Close the Saved posts RHS
         cy.get('#sidebar-right').within(() => {
-            cy.findByLabelText('Close').should('be.visible').and('exist').click()
-        })
-    })
+            cy.findByLabelText('Close').should('be.visible').and('exist').click();
+        });
+    });
 });

--- a/e2e/cypress/integration/search/clear_input_spec.js
+++ b/e2e/cypress/integration/search/clear_input_spec.js
@@ -10,7 +10,13 @@
 // Stage: @prod
 // Group: @search
 
+
+
+// https://automation-test-cases.vercel.app/test/MM-T368
+
+
 import * as TIMEOUTS from '../../fixtures/timeouts';
+import * as MESSAGES from '../../fixtures/messages';
 
 describe('Search', () => {
     before(() => {
@@ -45,4 +51,39 @@ describe('Search', () => {
         // * The value of the input is empty
         cy.get('#searchBox').should('have.value', '');
     });
+
+    it('MM-T368 - Text in search box should not clear when Pinned posts icon or Saved posts icon is clicked', () => {
+        const searchText = MESSAGES.SMALL
+
+        // * Verify search input field exists and not search button, as inputs contains placeholder not buttons/icons
+        // and then type in a search text 
+        cy.findByPlaceholderText('Search').should('be.visible').and('exist').click().type(searchText).as('searchInput')
+
+        // # Click on the pinned post button from the header
+        cy.get('#channel-header').within(() => {
+            cy.findByLabelText('Pin Icon').should('be.visible').and('exist').click()
+        })
+
+        // * Verify the pinned post RHS is open
+        cy.get('#sidebar-right').should('be.visible').and('contain', 'Pinned posts');
+
+        // * Check that search input value remains the same as we entered before
+        cy.get('@searchInput').should('have.value', searchText)
+
+        // # Now click on the saved post button from the header
+        cy.get('#channel-header').within(() => {
+            cy.findByLabelText('Save Icon').should('be.visible').and('exist').click()
+        })
+
+        // * Verify the pinned post RHS is open
+        cy.get('#sidebar-right').should('be.visible').and('contain', 'Saved posts');
+
+        // * Again check that search input value remains the same as we entered before
+        cy.get('@searchInput').should('have.value', searchText)
+
+        // # Close the Saved posts RHS
+        cy.get('#sidebar-right').within(() => {
+            cy.findByLabelText('Close').should('be.visible').and('exist').click()
+        })
+    })
 });

--- a/e2e/cypress/integration/search/clear_input_spec.js
+++ b/e2e/cypress/integration/search/clear_input_spec.js
@@ -47,7 +47,7 @@ describe('Search', () => {
         cy.get('#searchBox').should('have.value', '');
     });
 
-    it('MM-T368 - Text in search box should not clear when Pinned posts icon or Saved posts icon is clicked', () => {
+    it('MM-T368 - Text in search box should not clear when Pinned or Saved posts icon is clicked', () => {
         const searchText = MESSAGES.SMALL;
 
         // * Verify search input field exists and not search button, as inputs contains placeholder not buttons/icons


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Added an end to end test which test display value of the search doesnt change when flagged or save button icon is clicked

#### Ticket Link
MM-T368

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- ~Has server changes (please link here)~
- ~Has redux changes (please link here)~
- ~Has mobile changes (please link here)~

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
none