### PR TITLE
Cypress/E2E: Update test key of interactive dialog

### DIFF
--- a/e2e/cypress/integration/interactive_dialog/boolean_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/boolean_spec.js
@@ -39,7 +39,7 @@ describe('Interactive Dialog', () => {
                 icon_url: '',
                 method: 'P',
                 team_id: team.id,
-                trigger: 'boolean_dialog' + Date.now(),
+                trigger: 'boolean_dialog',
                 url: `${webhookBaseUrl}/boolean_dialog_request`,
                 username: '',
             };
@@ -51,7 +51,7 @@ describe('Interactive Dialog', () => {
         });
     });
 
-    it('ID21034 - Boolean element check', () => {
+    it('MM-T2502 - Boolean element check', () => {
         // # Post a slash command
         cy.postMessage(`/${createdCommand.trigger}`);
 

--- a/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/full_dialog_spec.js
@@ -58,7 +58,7 @@ describe('Interactive Dialog', () => {
                 icon_url: '',
                 method: 'P',
                 team_id: team.id,
-                trigger: 'dialog' + Date.now(),
+                trigger: 'dialog',
                 url: `${webhookBaseUrl}/dialog_request`,
                 username: '',
             };
@@ -75,7 +75,7 @@ describe('Interactive Dialog', () => {
         cy.reload();
     });
 
-    it('ID15888 - UI check', () => {
+    it('MM-T2491 - UI check', () => {
         // # Post a slash command
         cy.get('#postListContent').should('be.visible');
         cy.postMessage(`/${createdCommand.trigger}`);
@@ -153,7 +153,7 @@ describe('Interactive Dialog', () => {
         });
     });
 
-    it('ID15888 - Cancel button works', () => {
+    it('MM-T2492 - Cancel button works', () => {
         // # Post a slash command
         cy.postMessage(`/${createdCommand.trigger}`);
 
@@ -167,7 +167,7 @@ describe('Interactive Dialog', () => {
         cy.get('#interactiveDialogModal').should('not.be.visible');
     });
 
-    it('ID15888 - "X" closes the dialog', () => {
+    it('MM-T2493 - "X" closes the dialog', () => {
         // # Post a slash command
         cy.postMessage(`/${createdCommand.trigger}`);
 
@@ -183,7 +183,7 @@ describe('Interactive Dialog', () => {
         cy.get('#interactiveDialogModal').should('not.be.visible');
     });
 
-    it('ID15888 - Correct error messages displayed if empty form is submitted', () => {
+    it('MM-T2494 - Correct error messages displayed if empty form is submitted', () => {
         // # Post a slash command
         cy.postMessage(`/${createdCommand.trigger}`);
 
@@ -210,7 +210,7 @@ describe('Interactive Dialog', () => {
         closeInteractiveDialog();
     });
 
-    it('ID15888 - Email validation', () => {
+    it('MM-T2495_1 - Email validation for invalid input', () => {
         // # Post a slash command
         cy.postMessage(`/${createdCommand.trigger}`);
 
@@ -218,56 +218,78 @@ describe('Interactive Dialog', () => {
         cy.get('#interactiveDialogModal').should('be.visible');
 
         // # Enter invalid and valid email
-        // Verify that error is: shown for invalid email and not shown for valid email.
-        [
-            {valid: false, value: 'invalid-email'},
-            {valid: true, value: 'test@mattermost.com'},
-        ].forEach((testCase) => {
-            cy.get('#someemail').scrollIntoView().clear().type(testCase.value);
+        // * Verify that error is: shown for invalid email and not shown for valid email.
+        const invalidEmail = 'invalid-email';
+        cy.get('#someemail').scrollIntoView().clear().type(invalidEmail);
 
-            cy.get('#interactiveDialogSubmit').click();
+        cy.get('#interactiveDialogSubmit').click();
 
-            if (testCase.valid) {
-                cy.get('input:invalid').should('have.length', 0);
-            } else {
-                cy.get('input:invalid').should('have.length', 1);
-                cy.get('#someemail').then(($input) => {
-                    expect($input[0].validationMessage).to.eq(`Please include an '@' in the email address. '${testCase.value}' is missing an '@'.`);
-                });
-            }
+        cy.get('input:invalid').should('have.length', 1);
+        cy.get('#someemail').then(($input) => {
+            expect($input[0].validationMessage).to.eq(`Please include an '@' in the email address. '${invalidEmail}' is missing an '@'.`);
         });
 
         closeInteractiveDialog();
     });
 
-    it('ID15888 - Number validation', () => {
+    it('MM-T2495_2 - Email validation for valid input', () => {
+        // # Post a slash command
+        cy.postMessage(`/${createdCommand.trigger}`);
+
+        // * Verify that the interactive dialog modal open up
+        cy.get('#interactiveDialogModal').should('be.visible');
+
+        // # Enter valid email
+        // * Verify that error is not shown for valid email.
+        const validEmail = 'test@mattermost.com';
+        cy.get('#someemail').scrollIntoView().clear().type(validEmail);
+
+        cy.get('#interactiveDialogSubmit').click();
+
+        cy.get('input:invalid').should('have.length', 0);
+
+        closeInteractiveDialog();
+    });
+
+    it('MM-T2496_1 - Number validation for invalid input', () => {
         cy.postMessage(`/${createdCommand.trigger}`);
 
         cy.get('#interactiveDialogModal').should('be.visible');
 
-        // # Enter invalid and valid number
-        // Verify that error is: shown for invalid number and not shown for valid number.
-        [
-            {valid: false, value: 'invalid-number'},
-            {valid: true, value: 12},
-        ].forEach((testCase) => {
-            cy.get('#somenumber').scrollIntoView().clear().type(testCase.value);
+        // # Enter invalid number
+        // * Verify that error is shown for invalid number.
+        const invalidNumber = 'invalid-number';
+        cy.get('#somenumber').scrollIntoView().clear().type(invalidNumber);
 
-            cy.get('#interactiveDialogSubmit').click();
+        cy.get('#interactiveDialogSubmit').click();
 
-            cy.get('.modal-body').should('be.visible').children().eq(2).within(($elForm) => {
-                if (testCase.valid) {
-                    cy.wrap($elForm).find('div.error-text').should('not.be.visible');
-                } else {
-                    cy.wrap($elForm).find('div.error-text').should('be.visible').and('have.text', 'This field is required.').and('have.css', 'color', 'rgb(253, 89, 96)');
-                }
-            });
+        cy.get('.modal-body').should('be.visible').children().eq(2).within(($elForm) => {
+            cy.wrap($elForm).find('div.error-text').should('be.visible').and('have.text', 'This field is required.').and('have.css', 'color', 'rgb(253, 89, 96)');
         });
 
         closeInteractiveDialog();
     });
 
-    it('ID21032 - Password element check', () => {
+    it('MM-T2496_2 - Number validation for valid input', () => {
+        cy.postMessage(`/${createdCommand.trigger}`);
+
+        cy.get('#interactiveDialogModal').should('be.visible');
+
+        // # Enter a valid number
+        // * Verify that error is not shown for valid number.
+        const validNumber = 12;
+        cy.get('#somenumber').scrollIntoView().clear().type(validNumber);
+
+        cy.get('#interactiveDialogSubmit').click();
+
+        cy.get('.modal-body').should('be.visible').children().eq(2).within(($elForm) => {
+            cy.wrap($elForm).find('div.error-text').should('not.be.visible');
+        });
+
+        closeInteractiveDialog();
+    });
+
+    it('MM-T2501 - Password element check', () => {
         // # Post a slash command
         cy.postMessage(`/${createdCommand.trigger}`);
 

--- a/e2e/cypress/integration/interactive_dialog/scrollable_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/scrollable_spec.js
@@ -29,7 +29,7 @@ describe('Interactive Dialog', () => {
         // # Create new team and create command on it
         cy.apiCreateTeam('test-team', 'Test Team').then(({team}) => {
             for (let i = 0; i < 20; i++) {
-                cy.apiCreateChannel(team.id, 'name' + i + Date.now(), 'name' + i + Date.now());
+                cy.apiCreateChannel(team.id, `channel-${i}`, `Channel ${i}`);
             }
 
             cy.visit(`/${team.name}`);
@@ -43,7 +43,7 @@ describe('Interactive Dialog', () => {
                 icon_url: '',
                 method: 'P',
                 team_id: team.id,
-                trigger: 'user_and_channel_dialog' + Date.now(),
+                trigger: 'user_and_channel_dialog',
                 url: `${webhookBaseUrl}/user_and_channel_dialog_request`,
                 username: '',
             };
@@ -55,7 +55,7 @@ describe('Interactive Dialog', () => {
         });
     });
 
-    it('ID21031 - Individual "User" and "Channel" screens are scrollable', () => {
+    it('MM-T2498 - Individual "User" and "Channel" screens are scrollable', () => {
         // # Post a slash command
         cy.postMessage(`/${createdCommand.trigger}`);
 

--- a/e2e/cypress/integration/interactive_dialog/simple_dialog_spec.js
+++ b/e2e/cypress/integration/interactive_dialog/simple_dialog_spec.js
@@ -22,7 +22,7 @@ let createdCommand;
 let simpleDialog;
 
 describe('Interactive Dialog', () => {
-    describe('ID17212 Interactive Dialog without element', () => {
+    describe('MM-T2500 Interactive Dialog without element', () => {
         before(() => {
             cy.requireWebhookServer();
 
@@ -42,7 +42,7 @@ describe('Interactive Dialog', () => {
                     icon_url: '',
                     method: 'P',
                     team_id: team.id,
-                    trigger: 'simple_dialog' + Date.now(),
+                    trigger: 'simple_dialog',
                     url: `${webhookBaseUrl}/simple_dialog_request`,
                     username: '',
                 };

--- a/e2e/cypress/integration/interactive_menu/basic_options_spec.js
+++ b/e2e/cypress/integration/interactive_menu/basic_options_spec.js
@@ -105,7 +105,7 @@ describe('Interactive Menu', () => {
         cy.get('body').click();
     });
 
-    it('IM15887 - Selected Option is displayed, Ephemeral message is posted', () => {
+    it('MM-T1736 - Selected Option is displayed, Ephemeral message is posted', () => {
         // # Post an incoming webhook
         const payload = getMessageMenusPayload({options});
         cy.postIncomingWebhook({url: incomingWebhook.url, data: payload, waitFor: 'attachment-pretext'});
@@ -125,7 +125,7 @@ describe('Interactive Menu', () => {
         verifyEphemeralMessage('Ephemeral | select option: option1');
     });
 
-    it('IM15887 - Reply is displayed in center channel with "commented on [user\'s] message: [text]"', () => {
+    it('MM-T1737 - Reply is displayed in center channel with "commented on [user\'s] message: [text]"', () => {
         // # Post an incoming webhook
         const payload = getMessageMenusPayload({options});
         cy.postIncomingWebhook({url: incomingWebhook.url, data: payload, waitFor: 'attachment-pretext'});
@@ -164,7 +164,7 @@ describe('Interactive Menu', () => {
         });
     });
 
-    it('IM21039 - Searching within the list of options', () => {
+    it('MM-T1743 - Searching within the list of options', () => {
         const searchOptions = [
             {text: 'SearchOption1', value: 'searchoption1'},
             {text: 'SearchOption2', value: 'searchoption2'},
@@ -195,7 +195,7 @@ describe('Interactive Menu', () => {
         });
     });
 
-    it('IM21042 - "No items match" feedback', () => {
+    it('MM-T1746 - No items match feedback', () => {
         const missingUser = Date.now();
         const userOptions = getMessageMenusPayload({dataSource: 'users'});
 
@@ -216,7 +216,7 @@ describe('Interactive Menu', () => {
         });
     });
 
-    it('IM21043 - Using up/down arrow keys to make selection', () => {
+    it('MM-T1742 - Using up/down arrow keys to make selection', () => {
         const basicOptions = getMessageMenusPayload({options});
 
         // # Post an incoming webhook for interactive menu with basic options
@@ -286,7 +286,7 @@ describe('Interactive Menu', () => {
         });
     });
 
-    it('IM21037 - Clicking in / Tapping on the message attachment menu box opens list of selections', () => {
+    it('MM-T1740 - Clicking in / Tapping on the message attachment menu box opens list of selections', () => {
         // # Create a message attachment with menu
         const basicOptionPayload = getMessageMenusPayload({options});
         cy.postIncomingWebhook({url: incomingWebhook.url, data: basicOptionPayload, waitFor: 'attachment-pretext'});
@@ -318,7 +318,7 @@ describe('Interactive Menu', () => {
         });
     });
 
-    it('IM21036 - Enter selects the option', () => {
+    it('MM-T1745 - Enter selects the option', () => {
         // # Create a message attachment with menu
         const distinctOptions = messageMenusOptions['distinct-options'];
         const distinctOptionsPayload = getMessageMenusPayload({options: distinctOptions});
@@ -374,7 +374,7 @@ describe('Interactive Menu', () => {
         verifyEphemeralMessage('Ephemeral | select option: mango');
     });
 
-    it('IM21035 - Long lists of selections are scrollable', () => {
+    it('MM-T1741 - Long lists of selections are scrollable', () => {
         const manyOptions = messageMenusOptions['many-options'];
         const manyOptionsPayload = getMessageMenusPayload({options: manyOptions});
 
@@ -424,7 +424,7 @@ describe('Interactive Menu', () => {
         });
     });
 
-    it('IM21040 - Selection is mirrored in RHS / Message Thread', () => {
+    it('MM-T1747 - Selection is mirrored in RHS / Message Thread', () => {
         // # Create a webhook with distinct options
         const distinctOptions = messageMenusOptions['distinct-options'];
         const distinctListOptionPayload = getMessageMenusPayload({options: distinctOptions});
@@ -474,7 +474,7 @@ describe('Interactive Menu', () => {
         });
     });
 
-    it('IM21044 - Change selection in RHS / Message Thread', () => {
+    it('MM-T1748 - Change selection in RHS / Message Thread', () => {
         // # Create a webhook with distinct options
         const distinctOptions = messageMenusOptions['distinct-options'];
         const distinctListOptionPayload = getMessageMenusPayload({options: distinctOptions});
@@ -537,7 +537,7 @@ describe('Interactive Menu', () => {
         });
     });
 
-    it('IM21038 - Selected options with long usernames are not cut off in the RHS', () => {
+    it('MM-T1738 - Selected options with long usernames are not cut off in the RHS', () => {
         // # Make webhook request to get list of all the users
         const userOptions = getMessageMenusPayload({dataSource: 'users'});
         cy.postIncomingWebhook({url: incomingWebhook.url, data: userOptions, waitFor: 'attachment-pretext'});

--- a/e2e/cypress/integration/interactive_menu/select_with_keys_spec.js
+++ b/e2e/cypress/integration/interactive_menu/select_with_keys_spec.js
@@ -47,7 +47,7 @@ describe('Interactive Menu', () => {
         });
     });
 
-    it('IM21041 - Using up/down keys to make a selection from SEARCH results', () => {
+    it('MM-T1744 - Using up/down keys to make a selection from SEARCH results', () => {
         const searchOptionsPayload = getMessageMenusPayload({options: searchOptions});
 
         // # Post an incoming webhook for interactive menu with search options


### PR DESCRIPTION
#### Summary
Update test keys of interactive dialogs and menus for Cypress/TM4J integration.

Other: remove unnecessary use of random number since we're already isolating test by using new team/channels.
