### PR TITLE
[MM-25571] Fix new message indicator not showing for webhook messages to webhook owner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18122,8 +18122,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#bd00aad28d8deaf7e54c7837b5817fe99f07df69",
-      "from": "github:mattermost/mattermost-redux#bd00aad28d8deaf7e54c7837b5817fe99f07df69",
+      "version": "github:mattermost/mattermost-redux#4e60437ef540f030a5fdb9e921451f80f2f2c1ef",
+      "from": "github:mattermost/mattermost-redux#4e60437ef540f030a5fdb9e921451f80f2f2c1ef",
       "requires": {
         "core-js": "3.6.5",
         "form-data": "3.0.0",
@@ -18143,19 +18143,6 @@
         "shallow-equals": "1.0.0"
       },
       "dependencies": {
-        "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-        },
-        "moment-timezone": {
-          "version": "0.5.31",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-          "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
-          "requires": {
-            "moment": ">= 2.9.0"
-          }
-        },
         "redux-persist": {
           "version": "4.9.1",
           "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-4.9.1.tgz",
@@ -18165,11 +18152,6 @@
             "lodash": "^4.17.4",
             "lodash-es": "^4.17.4"
           }
-        },
-        "rudder-sdk-js": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-1.0.6.tgz",
-          "integrity": "sha512-My/yfplEbfYXUbs3nH7d/s931tl3GNF3G6NNyOdhY5aLlPGBL+sqSUKI/vQZaJzjb1sfCF6ZpM1IBUUtX2yeVA=="
         }
       }
     },
@@ -22493,6 +22475,11 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
+    },
+    "rudder-sdk-js": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-1.0.6.tgz",
+      "integrity": "sha512-My/yfplEbfYXUbs3nH7d/s931tl3GNF3G6NNyOdhY5aLlPGBL+sqSUKI/vQZaJzjb1sfCF6ZpM1IBUUtX2yeVA=="
     },
     "run-async": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "localforage-observable": "2.0.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#87769262aa02e1784570f61f4f962050e07cc335",
-    "mattermost-redux": "github:mattermost/mattermost-redux#bd00aad28d8deaf7e54c7837b5817fe99f07df69",
+    "mattermost-redux": "github:mattermost/mattermost-redux#4e60437ef540f030a5fdb9e921451f80f2f2c1ef",
     "moment-timezone": "0.5.31",
     "p-queue": "^6.4.0",
     "pdfjs-dist": "2.0.489",


### PR DESCRIPTION
The new message indicator has a special case for messages posted by the
current user. Currently, webhook messages are attributed to its creator,
which breaks the new message indicator.

See https://github.com/mattermost/mattermost-redux/pull/1159
Fixes https://github.com/mattermost/mattermost-server/issues/14612