### PR TITLE
MM-23623: Make the validation of what is considered a post delete con…

### DIFF
--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -353,7 +353,7 @@ class EditPostModal extends React.PureComponent {
             return !this.props.canEditPost;
         }
 
-        if (this.state.editText !== '') {
+        if (this.state.editText.trim() !== '') {
             return !this.props.canEditPost;
         }
 


### PR DESCRIPTION
…sistent between backend and frontend.

#### Summary

Updates the validation of what is considered a "deleted" post so that the front-end and backend are using the same logic.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-23623

#### Screenshots

For a user who does not have permissions to delete their own posts, whitespace only don't enable the save button...

<img width="632" alt="Screen Shot 2020-08-11 at 2 16 07 PM" src="https://user-images.githubusercontent.com/1149597/89933598-462f9400-dbdd-11ea-8040-58db94e14d7f.png">

... but non-whitespaces do enable it.

<img width="623" alt="Screen Shot 2020-08-11 at 2 16 15 PM" src="https://user-images.githubusercontent.com/1149597/89933600-462f9400-dbdd-11ea-87a3-42ee667fbb9a.png">