### PR TITLE
MM-T459 E2E Test for Group Messaging: Add first user

### DIFF
--- a/components/more_direct_channels/__snapshots__/more_direct_channels.test.jsx.snap
+++ b/components/more_direct_channels/__snapshots__/more_direct_channels.test.jsx.snap
@@ -190,9 +190,9 @@ exports[`components/MoreDirectChannels should match renderOption snapshot 1`] = 
       className="more-modal__name"
     >
       <span
-        id="displayedUserNameundefined"
+        id="displayedUserNameusername1"
       >
-        @undefined
+        @username1
         <span
           className="light"
         >

--- a/components/more_direct_channels/__snapshots__/more_direct_channels.test.jsx.snap
+++ b/components/more_direct_channels/__snapshots__/more_direct_channels.test.jsx.snap
@@ -189,7 +189,9 @@ exports[`components/MoreDirectChannels should match renderOption snapshot 1`] = 
     <div
       className="more-modal__name"
     >
-      <span>
+      <span
+        id="displayedUserNameundefined"
+      >
         @undefined
         <span
           className="light"

--- a/components/more_direct_channels/more_direct_channels.test.jsx
+++ b/components/more_direct_channels/more_direct_channels.test.jsx
@@ -172,7 +172,7 @@ describe('components/MoreDirectChannels', () => {
         const props = {...baseProps};
         const wrapper = shallow(<MoreDirectChannels {...props}/>);
 
-        expect(wrapper.instance().renderOption({id: 'user_id_1', delete_at: 0}, true, jest.fn())).toMatchSnapshot();
+        expect(wrapper.instance().renderOption({id: 'user_id_1', username: 'username1', delete_at: 0}, true, jest.fn())).toMatchSnapshot();
     });
 
     test('should match output on renderValue', () => {

--- a/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
@@ -64,7 +64,7 @@ describe('Multi-user group messages', () => {
             and('have.length', 1);
 
         // * Expect search bar to have focus
-        cy.get('#selectItems input[type="text"]').should('have.focus');
+        cy.get('.react-select__multi-value').next().find('input').should('have.focus');
 
         // * Expect previous search term to be cleared from search bar
         cy.get('#selectItems input[type="text"]').should('have.text', '');
@@ -102,15 +102,13 @@ const expectUserListSortedAlphabetically = (filterString, excludeFilter = false)
                 expect(stringComparison, `${currentChildText} should be before ${siblingText}`).to.be.lte(0);
             }
 
-            if (filterString) {
-                excludeFilter ?
+            excludeFilter ?
 
                 // * If a user is selected, ensure remaining users list does not contain the selected user
-                    expect(currentChildText).to.not.contain(filterString) :
+                expect(currentChildText).to.not.contain(filterString) :
 
                 // * Optionally, ensure all usernames match the autocomplete input
-                    expect(currentChildText).to.contain(filterString);
-            }
+                expect(currentChildText).to.contain(filterString);
         });
 };
 

--- a/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
@@ -1,0 +1,124 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+/* eslint-disable jquery/no-text */
+/* eslint-disable jquery/no-find */
+
+describe('Multi-user group messages', () => {
+    const userPrefix1 = '0aadam';
+    const userPrefix2 = '0aabadam';
+    const userPrefix3 = 'beatrice';
+    const searchTerm = '0aa';
+    let testUser;
+    let testTeam;
+    before(() => {
+        // # Create a new team
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+
+            // # Add 3 users to the team that should be alphabetically sorted
+            createTestUser(userPrefix1, team);
+            createTestUser(userPrefix2, team);
+            createTestUser(userPrefix3, team);
+        });
+    });
+
+    it('MM-T463 Should not be able to create a group message with more than 8 users', () => {
+        // # Login as test user
+        cy.apiLogin(testUser);
+
+        // # Go to town-square channel
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+
+        // # Open the 'Direct messages' dialog
+        cy.get('#addDirectChannel').
+            click();
+
+        // # Start typing part of a username that matches previously created users
+        cy.get('#selectItems input[type="text"]').
+            type(searchTerm);
+
+        // * Expect user list to only contain usernames matchin the query term and to be sorted alphabetically
+        expectUserListSortedAlphabetically(searchTerm);
+
+        // # With the arrow and enter keys, select the first user that matches our search query
+        cy.get('body').
+            type('{downarrow}').
+            type('{enter}');
+
+        // * Expect to have the selected user's username to be displayed inside the search input
+        cy.get('.react-select__multi-value').
+            should('be.visible').
+            and('have.length', 1).
+            then(($selectedUser) => {
+                // # Get the selected user's username
+                const selectedUserName = $selectedUser.text();
+
+                // * Expect user list to not contain selected user, not be filtered, but still in alphabetical order
+                expectUserListSortedAlphabetically(selectedUserName, true);
+            });
+
+        // * Expect to have a remove button ('x') present next to the selected username (previous step)
+        cy.get('.react-select__multi-value__remove').
+            should('be.visible').
+            and('have.length', 1);
+
+        // * Expect search bar to have focus
+        cy.get('#selectItems input[type="text"]').should('have.focus');
+
+        // * Expect previous search term to be cleared from search bar
+        cy.get('#selectItems input[type="text"]').should('have.text', '');
+
+        // * Expect the help section showing that we 6 more people can be added to the message
+        cy.get('#multiSelectHelpMemberInfo').
+            should('be.visible').
+            and('contain.text', 'You can add 6 more people');
+    });
+});
+
+// Helper functions
+
+/**
+ * Check that the user list inside the direct messages dialog is sorted alphabetically
+ *  - Numbers are included in the sorting logic
+ *  - Lowercase letters come before uppercase letters
+ * @param {string?} filterString Optional, ensure all results in the list match a certain string, an autocomplete filter
+ */
+const expectUserListSortedAlphabetically = (filterString, excludeFilter = false) => {
+    return cy.get('#multiSelectList').
+        should('be.visible').
+        children().
+        each(($child) => {
+            // To limit the amount of text fecthed, only get the text content from the displayed name and username (without email)
+            const currentChildText = $child.find('[id*="displayedUserName"]').text();
+            const immediateNextSibling = $child.next();
+
+            // * Expect all usernames displayed in the in user list to be sorted alphabetically
+            if (immediateNextSibling.length) {
+                const siblingText = immediateNextSibling.find('[id*="displayedUserName"]').text();
+                const stringComparison = currentChildText.localeCompare(siblingText, 'en');
+
+                // both strings equal -> 0, currentChildText comes before siblingText -> -1 (could vary by browser but should to be negative)
+                expect(stringComparison, `${currentChildText} should be before ${siblingText}`).to.be.lte(0);
+            }
+
+            if (filterString && !excludeFilter) {
+                // * Optionally, ensure all usernames match the autocomplete input
+                expect(currentChildText).to.contain(filterString);
+            } else if (filterString && excludeFilter) {
+                // * If a user is selected, ensure remaining users list does not contain the selected user
+                expect(currentChildText).to.not.contain(filterString);
+            }
+        });
+};
+
+/**
+ * Create a user and assign it to a team
+ * @param {string} prefix Prefix to add to the username
+ * @param {string} team Team object, reference to the team we want to add the user to
+ */
+const createTestUser = (prefix, team) => {
+    cy.apiCreateUser({prefix}).then(({user}) =>
+        cy.apiAddUserToTeam(team.id, user.id),
+    );
+};

--- a/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
@@ -102,12 +102,14 @@ const expectUserListSortedAlphabetically = (filterString, excludeFilter = false)
                 expect(stringComparison, `${currentChildText} should be before ${siblingText}`).to.be.lte(0);
             }
 
-            if (filterString && !excludeFilter) {
-                // * Optionally, ensure all usernames match the autocomplete input
-                expect(currentChildText).to.contain(filterString);
-            } else if (filterString && excludeFilter) {
+            if (filterString) {
+                excludeFilter ?
+
                 // * If a user is selected, ensure remaining users list does not contain the selected user
-                expect(currentChildText).to.not.contain(filterString);
+                    expect(currentChildText).to.not.contain(filterString) :
+
+                // * Optionally, ensure all usernames match the autocomplete input
+                    expect(currentChildText).to.contain(filterString);
             }
         });
 };

--- a/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
@@ -4,10 +4,6 @@
 /* eslint-disable jquery/no-find */
 
 describe('Multi-user group messages', () => {
-    const userPrefix1 = '0aadam';
-    const userPrefix2 = '0aabadam';
-    const userPrefix3 = 'beatrice';
-    const searchTerm = '0aa';
     let testUser;
     let testTeam;
     before(() => {
@@ -24,6 +20,8 @@ describe('Multi-user group messages', () => {
     });
 
     it('MM-T459 Group Messaging: Add first user', () => {
+        const searchTerm = '0aa';
+
         // # Login as test user
         cy.apiLogin(testUser);
 

--- a/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
@@ -65,7 +65,7 @@ describe('Multi-user group messages', () => {
         cy.get('.react-select__multi-value').next().find('input').should('have.focus');
 
         // * Expect previous search term to be cleared from search bar
-        cy.get('#selectItems input[type="text"]').should('have.text', '');
+        cy.get('#selectItems input').should('have.text', '');
 
         // * Expect the help section showing that we 6 more people can be added to the message
         cy.get('#multiSelectHelpMemberInfo').

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -1325,7 +1325,7 @@ export function displayEntireNameForUser(user) {
     }
 
     displayName = (
-        <span>
+        <span id={'displayedUserName' + user.username}>
             {'@' + user.username}
             <span className='light'>{displayName}</span>
         </span>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -264,7 +264,7 @@ var config = {
             meta: {
                 csp: {
                     'http-equiv': 'Content-Security-Policy',
-                    content: 'script-src \'self\' cdn.segment.com/analytics.js/ cdn.rudderlabs.com/' + CSP_UNSAFE_EVAL_IF_DEV,
+                    content: 'script-src \'self\' cdn.rudderlabs.com/' + CSP_UNSAFE_EVAL_IF_DEV,
                 },
             },
         }),


### PR DESCRIPTION
#### Summary

In the dialog to create a new direct message (or group message), ensure that the user list is always sorted alphabetically, even after selecting a first user.

- Added e2e test with cypress
- Updated util function to render username span with unique html ID, this helps with a more precise selection of the user's display name + display username in the direct message dialog
- Updated snapshot for unit test that depends on the modification of the previous step

Related test case: [MM-T459](https://automation-test-cases.vercel.app/test/MM-T459)
Related ticket: [MM-1816](https://mattermost.atlassian.net/browse/MM-18186)
