### PR TITLE
MM-27507: Show errors due to rate limiting while inviting

### DIFF
--- a/actions/invite_actions.jsx
+++ b/actions/invite_actions.jsx
@@ -50,12 +50,18 @@ export function sendMembersInvites(teamId, users, emails) {
                 response = {data: emails.map((email) => ({email, error: {error: localizeMessage('invite.members.unable-to-add-the-user-to-the-team', 'Unable to add the user to the team.')}}))};
             }
             const invitesWithErrors = response.data || [];
-            for (const email of emails) {
-                const inviteWithError = invitesWithErrors.find((i) => email === i.email && i.error);
-                if (inviteWithError) {
-                    notSent.push({email, reason: inviteWithError.error.message});
-                } else {
-                    sent.push({email, reason: localizeMessage('invite.members.invite-sent', 'An invitation email has been sent.')});
+            if (response.error) {
+                for (const email of emails) {
+                    notSent.push({email, reason: response.error.message});
+                }
+            } else {
+                for (const email of emails) {
+                    const inviteWithError = invitesWithErrors.find((i) => email === i.email && i.error);
+                    if (inviteWithError) {
+                        notSent.push({email, reason: inviteWithError.error.message});
+                    } else {
+                        sent.push({email, reason: localizeMessage('invite.members.invite-sent', 'An invitation email has been sent.')});
+                    }
                 }
             }
         }
@@ -129,11 +135,17 @@ export function sendGuestsInvites(teamId, channels, users, emails, message) {
                 response = {data: emails.map((email) => ({email, error: {error: localizeMessage('invite.guests.unable-to-add-the-user-to-the-channels', 'Unable to add the guest to the channels.')}}))};
             }
 
-            for (const res of (response.data || [])) {
-                if (res.error) {
-                    notSent.push({email: res.email, reason: res.error.message});
-                } else {
-                    sent.push({email: res.email, reason: localizeMessage('invite.guests.added-to-channel', 'An invitation email has been sent.')});
+            if (response.error) {
+                for (const email of emails) {
+                    notSent.push({email, reason: response.error.message});
+                }
+            } else {
+                for (const res of (response.data || [])) {
+                    if (res.error) {
+                        notSent.push({email: res.email, reason: res.error.message});
+                    } else {
+                        sent.push({email: res.email, reason: localizeMessage('invite.guests.added-to-channel', 'An invitation email has been sent.')});
+                    }
                 }
             }
         }

--- a/actions/invite_actions.test.js
+++ b/actions/invite_actions.test.js
@@ -26,9 +26,17 @@ jest.mock('mattermost-redux/actions/channels', () => ({
 jest.mock('mattermost-redux/actions/teams', () => ({
     getTeamMembersByIds: () => ({type: 'MOCK_RECEIVED_ME'}),
     sendEmailInvitesToTeamGracefully: (team, emails) => {
+        // Poor attempt to mock rate limiting.
+        if (emails.length > 21) {
+            return ({type: 'MOCK_RECEIVED_ME', data: emails.map((email) => ({email, error: {message: 'Invite emails rate limit exceeded.'}}))});
+        }
         return ({type: 'MOCK_RECEIVED_ME', data: emails.map((email) => ({email, error: team === 'correct' ? undefined : {message: 'Unable to add the user to the team.'}}))});
     },
     sendEmailGuestInvitesToChannelsGracefully: (team, channels, emails) => {
+        // Poor attempt to mock rate limiting.
+        if (emails.length > 21) {
+            return ({type: 'MOCK_RECEIVED_ME', data: emails.map((email) => ({email, error: {message: 'Invite emails rate limit exceeded.'}}))});
+        }
         return ({type: 'MOCK_RECEIVED_ME', data: emails.map((email) => ({email, error: team === 'correct' ? undefined : {message: 'Unable to add the guest to the channels.'}}))});
     },
 }));
@@ -219,6 +227,23 @@ describe('actions/invite_actions', () => {
                         },
                     },
                 ],
+            });
+        });
+
+        it('should generate a failure for rate limits', async () => {
+            const emails = [];
+            const expectedNotSent = [];
+            for (let i = 0; i < 22; i++) {
+                emails.push('email-' + i + '@gmail.com');
+                expectedNotSent.push({
+                    email: 'email-' + i + '@gmail.com',
+                    reason: 'Invite emails rate limit exceeded.',
+                });
+            }
+            const response = await sendMembersInvites('correct', [], emails)(store.dispatch, store.getState);
+            expect(response).toEqual({
+                notSent: expectedNotSent,
+                sent: [],
             });
         });
     });
@@ -455,6 +480,24 @@ describe('actions/invite_actions', () => {
                         },
                     },
                 ],
+            });
+        });
+
+        it('should generate a failure for rate limits', async () => {
+            const emails = [];
+            const expectedNotSent = [];
+            for (let i = 0; i < 22; i++) {
+                emails.push('email-' + i + '@gmail.com');
+                expectedNotSent.push({
+                    email: 'email-' + i + '@gmail.com',
+                    reason: 'Invite emails rate limit exceeded.',
+                });
+            }
+
+            const response = await sendGuestsInvites('correct', ['correct'], [], emails, 'message')(store.dispatch, store.getState);
+            expect(response).toEqual({
+                notSent: expectedNotSent,
+                sent: [],
             });
         });
     });


### PR DESCRIPTION
The exception handler wasn't really handling error responses
sent from the server. We had to explicitly check the error field
for that and update the notSent array appropriately.

https://mattermost.atlassian.net/browse/MM-27507
