### PR TITLE
MM-27507: Show errors due to rate limiting while inviting

### DIFF
--- a/actions/invite_actions.jsx
+++ b/actions/invite_actions.jsx
@@ -50,12 +50,18 @@ export function sendMembersInvites(teamId, users, emails) {
                 response = {data: emails.map((email) => ({email, error: {error: localizeMessage('invite.members.unable-to-add-the-user-to-the-team', 'Unable to add the user to the team.')}}))};
             }
             const invitesWithErrors = response.data || [];
-            for (const email of emails) {
-                const inviteWithError = invitesWithErrors.find((i) => email === i.email && i.error);
-                if (inviteWithError) {
-                    notSent.push({email, reason: inviteWithError.error.message});
-                } else {
-                    sent.push({email, reason: localizeMessage('invite.members.invite-sent', 'An invitation email has been sent.')});
+            if (response.error) {
+                for (const email of emails) {
+                    notSent.push({email, reason: response.error.message});
+                }
+            } else {
+                for (const email of emails) {
+                    const inviteWithError = invitesWithErrors.find((i) => email === i.email && i.error);
+                    if (inviteWithError) {
+                        notSent.push({email, reason: inviteWithError.error.message});
+                    } else {
+                        sent.push({email, reason: localizeMessage('invite.members.invite-sent', 'An invitation email has been sent.')});
+                    }
                 }
             }
         }
@@ -129,11 +135,17 @@ export function sendGuestsInvites(teamId, channels, users, emails, message) {
                 response = {data: emails.map((email) => ({email, error: {error: localizeMessage('invite.guests.unable-to-add-the-user-to-the-channels', 'Unable to add the guest to the channels.')}}))};
             }
 
-            for (const res of (response.data || [])) {
-                if (res.error) {
-                    notSent.push({email: res.email, reason: res.error.message});
-                } else {
-                    sent.push({email: res.email, reason: localizeMessage('invite.guests.added-to-channel', 'An invitation email has been sent.')});
+            if (response.error) {
+                for (const email of emails) {
+                    notSent.push({email, reason: response.error.message});
+                }
+            } else {
+                for (const res of (response.data || [])) {
+                    if (res.error) {
+                        notSent.push({email: res.email, reason: res.error.message});
+                    } else {
+                        sent.push({email: res.email, reason: localizeMessage('invite.guests.added-to-channel', 'An invitation email has been sent.')});
+                    }
                 }
             }
         }

--- a/actions/invite_actions.jsx
+++ b/actions/invite_actions.jsx
@@ -51,6 +51,9 @@ export function sendMembersInvites(teamId, users, emails) {
             }
             const invitesWithErrors = response.data || [];
             if (response.error) {
+                if (response.error.server_error_id === 'app.email.rate_limit_exceeded.app_error') {
+                    response.error.message = localizeMessage('invite.rate-limit-exceeded', 'Invite emails rate limit exceeded.');
+                }
                 for (const email of emails) {
                     notSent.push({email, reason: response.error.message});
                 }
@@ -136,6 +139,9 @@ export function sendGuestsInvites(teamId, channels, users, emails, message) {
             }
 
             if (response.error) {
+                if (response.error.server_error_id === 'app.email.rate_limit_exceeded.app_error') {
+                    response.error.message = localizeMessage('invite.rate-limit-exceeded', 'Invite emails rate limit exceeded.');
+                }
                 for (const email of emails) {
                     notSent.push({email, reason: response.error.message});
                 }

--- a/actions/invite_actions.test.js
+++ b/actions/invite_actions.test.js
@@ -234,9 +234,9 @@ describe('actions/invite_actions', () => {
             const emails = [];
             const expectedNotSent = [];
             for (let i = 0; i < 22; i++) {
-                emails.push('email-' + i + '@gmail.com');
+                emails.push('email-' + i + '@example.com');
                 expectedNotSent.push({
-                    email: 'email-' + i + '@gmail.com',
+                    email: 'email-' + i + '@example.com',
                     reason: 'Invite emails rate limit exceeded.',
                 });
             }
@@ -487,9 +487,9 @@ describe('actions/invite_actions', () => {
             const emails = [];
             const expectedNotSent = [];
             for (let i = 0; i < 22; i++) {
-                emails.push('email-' + i + '@gmail.com');
+                emails.push('email-' + i + '@example.com');
                 expectedNotSent.push({
-                    email: 'email-' + i + '@gmail.com',
+                    email: 'email-' + i + '@example.com',
                     reason: 'Invite emails rate limit exceeded.',
                 });
             }

--- a/actions/invite_actions.test.js
+++ b/actions/invite_actions.test.js
@@ -26,9 +26,17 @@ jest.mock('mattermost-redux/actions/channels', () => ({
 jest.mock('mattermost-redux/actions/teams', () => ({
     getTeamMembersByIds: () => ({type: 'MOCK_RECEIVED_ME'}),
     sendEmailInvitesToTeamGracefully: (team, emails) => {
+        // Poor attempt to mock rate limiting.
+        if (emails.length > 21) {
+            return ({type: 'MOCK_RECEIVED_ME', data: emails.map((email) => ({email, error: {message: 'Invite emails rate limit exceeded.'}}))});
+        }
         return ({type: 'MOCK_RECEIVED_ME', data: emails.map((email) => ({email, error: team === 'correct' ? undefined : {message: 'Unable to add the user to the team.'}}))});
     },
     sendEmailGuestInvitesToChannelsGracefully: (team, channels, emails) => {
+        // Poor attempt to mock rate limiting.
+        if (emails.length > 21) {
+            return ({type: 'MOCK_RECEIVED_ME', data: emails.map((email) => ({email, error: {message: 'Invite emails rate limit exceeded.'}}))});
+        }
         return ({type: 'MOCK_RECEIVED_ME', data: emails.map((email) => ({email, error: team === 'correct' ? undefined : {message: 'Unable to add the guest to the channels.'}}))});
     },
 }));
@@ -219,6 +227,23 @@ describe('actions/invite_actions', () => {
                         },
                     },
                 ],
+            });
+        });
+
+        it('should generate a failure for rate limits', async () => {
+            const emails = [];
+            const expectedNotSent = [];
+            for (let i = 0; i < 22; i++) {
+                emails.push('email-' + i + '@gmail.com');
+                expectedNotSent.push({
+                    email: 'email-' + i + '@gmail.com',
+                    reason: 'Invite emails rate limit exceeded.',
+                });
+            }
+            const response = await sendMembersInvites('correct', [], emails)(store.dispatch, store.getState);
+            expect(response).toEqual({
+                notSent: expectedNotSent,
+                sent: [],
             });
         });
     });
@@ -455,6 +480,24 @@ describe('actions/invite_actions', () => {
                         },
                     },
                 ],
+            });
+        });
+
+        it('should generate a failure for rate limits', async () => {
+            const emails = [];
+            const expectedNotSent = [];
+            for (let i = 0; i < 22; i++) {
+                emails.push('email-' + i + '@gmail.com');
+                expectedNotSent.push({
+                    email: 'email-' + i + '@gmail.com',
+                    reason: 'Invite emails rate limit exceeded.',
+                });
+            }
+
+            const response = await sendGuestsInvites('correct', ['correct'], [], emails, 'message')(store.dispatch, store.getState);
+            expect(response).toEqual({
+                notSent: expectedNotSent,
+                sent: [],
             });
         });
     });

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2892,6 +2892,7 @@
   "invite.members.unable-to-add-the-user-to-the-team": "Unable to add the user to the team.",
   "invite.members.user-is-guest": "Contact your admin to make this guest a full member.",
   "invite.members.user-is-not-guest": "This person is already a member.",
+  "invite.rate-limit-exceeded": "Invite emails rate limit exceeded.",
   "join_team_group_constrained_denied": "You need to be a member of a linked group to join this team.",
   "join_team_group_constrained_denied_admin": "You need to be a member of a linked group to join this team. You can add a group to this team [here]({siteURL}/admin_console/user_management/groups).",
   "katex.error": "Couldn't compile your Latex code. Please review the syntax and try again.",


### PR DESCRIPTION
The exception handler wasn't really handling error responses
sent from the server. We had to explicitly check the error field
for that and update the notSent array appropriately.

https://mattermost.atlassian.net/browse/MM-27507

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (https://github.com/mattermost/mattermost-server/pull/15230)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

![ratelimit](https://user-images.githubusercontent.com/1774000/89987053-04fdb980-dc9b-11ea-8ac1-6cd56e6bd264.png)
