### PR TITLE
MM-23350 Add e2e test for MM-23350

### DIFF
--- a/e2e/cypress/integration/messaging/inline_markdown_image_link_open_link_spec.js
+++ b/e2e/cypress/integration/messaging/inline_markdown_image_link_open_link_spec.js
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @messaging
+
+describe('Messaging', () => {
+    let testTeam;
+    let testChannel;
+    let testUser;
+
+    before(() => {
+        // # Login as test user and visit the newly created test channel
+        cy.apiInitSetup().then(({team, channel, user}) => {
+            testUser = user;
+            testTeam = team;
+            testChannel = channel;
+
+            cy.apiLogin(testUser);
+
+            // # Visit a test channel and post a message
+            cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+        });
+    });
+
+    it('MM-T188 - Inline markdown image that is a link, opens the link', () => {
+        // # Enable 'Show markdown preview option in message input box' setting in Account Settings > Advanced
+        cy.get('.sidebar-header-dropdown__icon').click();
+        cy.findByText('Account Settings').should('be.visible').click();
+        cy.get('#advancedButton').should('be.visible').click();
+        cy.get('#advancedPreviewFeaturesEdit').should('be.visible').click();
+        cy.get('#advancedPreviewFeaturesmarkdown_preview').should('be.visible').check();
+        cy.get('#saveSetting').should('be.visible').click();
+        cy.reload();
+
+        // # Post the provided Markdown text in the test channel
+        cy.focused().type('[![Build Status](https://travis-ci.org/mattermost/platform.svg?branch=master)](https://travis-ci.org/mattermost/platform)').type('{enter}');
+
+        cy.getLastPostId().then((postId) => {
+            cy.get(`#postMessageText_${postId}`).find('a').then(($a) => {
+                // * Check that the newly created post contains an a tag with the correct href link
+                cy.wrap($a).should('have.attr', 'href', 'https://travis-ci.org/mattermost/platform');
+
+                // # Check that the newly created post has the correct AltText
+                cy.wrap($a).findByAltText('Build Status').should('exist');
+
+                // # Assign the value of the a tag href to the 'href' variable and assert the link is valid
+                // eslint-disable-next-line jquery/no-prop
+                const href = $a.prop('href');
+                cy.request(href).its('body').should('include', '</html>');
+            },
+            );
+        });
+    });
+});

--- a/e2e/cypress/integration/messaging/inline_markdown_image_link_open_link_spec.js
+++ b/e2e/cypress/integration/messaging/inline_markdown_image_link_open_link_spec.js
@@ -55,7 +55,6 @@ describe('Messaging', () => {
                     and('have.attr', 'target', '_blank');
 
                 // * Check that the newly created post has an image
-
                 cy.wrap($a).find('img').should('be.visible').
                     and('have.attr', 'src', `${baseUrl}/api/v4/image?url=${encodeURIComponent(imageUrl)}`).
                     and('have.attr', 'alt', label);

--- a/e2e/cypress/integration/messaging/inline_markdown_image_link_open_link_spec.js
+++ b/e2e/cypress/integration/messaging/inline_markdown_image_link_open_link_spec.js
@@ -16,15 +16,9 @@ describe('Messaging', () => {
 
     before(() => {
         // # Login as test user and visit the newly created test channel
-        cy.apiInitSetup().then(({team, channel, user}) => {
-            testUser = user;
-            testTeam = team;
-            testChannel = channel;
-
-            cy.apiLogin(testUser);
-
-            // # Visit a test channel and post a message
-            cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel, user}) => {
+            // # Visit a test channel
+            cy.visit(`/${team.name}/channels/${channel.name}`);
         });
     });
 

--- a/e2e/cypress/integration/messaging/inline_markdown_image_link_open_link_spec.js
+++ b/e2e/cypress/integration/messaging/inline_markdown_image_link_open_link_spec.js
@@ -10,13 +10,9 @@
 // Group: @messaging
 
 describe('Messaging', () => {
-    let testTeam;
-    let testChannel;
-    let testUser;
-
     before(() => {
         // # Login as test user and visit the newly created test channel
-        cy.apiInitSetup({loginAfter: true}).then(({team, channel, user}) => {
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel}) => {
             // # Visit a test channel
             cy.visit(`/${team.name}/channels/${channel.name}`);
         });
@@ -25,30 +21,50 @@ describe('Messaging', () => {
     it('MM-T188 - Inline markdown image that is a link, opens the link', () => {
         // # Enable 'Show markdown preview option in message input box' setting in Account Settings > Advanced
         cy.get('.sidebar-header-dropdown__icon').click();
+
+        // # Click on 'Account Settings'
         cy.findByText('Account Settings').should('be.visible').click();
-        cy.get('#advancedButton').should('be.visible').click();
-        cy.get('#advancedPreviewFeaturesEdit').should('be.visible').click();
-        cy.get('#advancedPreviewFeaturesmarkdown_preview').should('be.visible').check();
-        cy.get('#saveSetting').should('be.visible').click();
-        cy.reload();
+
+        // * Check that the 'Account Settings' modal was opened
+        cy.get('#accountSettingsModal').should('exist').within(() => {
+            // # Click on the 'Advanced' tab
+            cy.findByText('Advanced').should('be.visible').click();
+
+            // # Click on the 'Advanced Preview Features Edit' button and check the 'Show markdown preview option in message input box' and save
+            cy.get('#advancedPreviewFeaturesEdit').should('be.visible').click();
+            cy.get('#advancedPreviewFeaturesmarkdown_preview').check();
+            cy.findByText('Save').should('be.visible').click();
+
+            // # Close the modal
+            cy.get('#accountSettingsHeader').find('button').should('be.visible').click();
+        });
+
+        const linkUrl = 'https://travis-ci.org/mattermost/platform';
+        const imageUrl = 'https://travis-ci.org/mattermost/platform.svg?branch=master';
+        const label = 'Build Status';
+        const baseUrl = Cypress.config('baseUrl');
 
         // # Post the provided Markdown text in the test channel
-        cy.focused().type('[![Build Status](https://travis-ci.org/mattermost/platform.svg?branch=master)](https://travis-ci.org/mattermost/platform)').type('{enter}');
+        cy.postMessage(`[![${label}](${imageUrl})](${linkUrl})`);
 
         cy.getLastPostId().then((postId) => {
             cy.get(`#postMessageText_${postId}`).find('a').then(($a) => {
-                // * Check that the newly created post contains an a tag with the correct href link
-                cy.wrap($a).should('have.attr', 'href', 'https://travis-ci.org/mattermost/platform');
+                // * Check that the newly created post contains an a tag with the correct href link and target
+                cy.wrap($a).
+                    should('have.attr', 'href', linkUrl).
+                    and('have.attr', 'target', '_blank');
 
-                // # Check that the newly created post has the correct AltText
-                cy.wrap($a).findByAltText('Build Status').should('exist');
+                // * Check that the newly created post has an image
+
+                cy.wrap($a).find('img').should('be.visible').
+                    and('have.attr', 'src', `${baseUrl}/api/v4/image?url=${encodeURIComponent(imageUrl)}`).
+                    and('have.attr', 'alt', label);
 
                 // # Assign the value of the a tag href to the 'href' variable and assert the link is valid
                 // eslint-disable-next-line jquery/no-prop
                 const href = $a.prop('href');
                 cy.request(href).its('body').should('include', '</html>');
-            },
-            );
+            });
         });
     });
 });


### PR DESCRIPTION
Summary

Created a test where the test user posts a provided Markdown text containing an external link and asset that the post contains -
1. The correct url
2. The correct image

and that the link is valid. I tried to click on the link, but Cypress doesn't allow you to open a site not within the same domain, so I followed this guide https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__tab-handling-links/cypress/integration/tab_handling_anchor_links_spec.js  and made sure that the link in the a tag, when requesting it, is valid and provides html. However, please let me know if you would like me to test the url in a different way!

Below is another resource I used that said clicking on a tags is not recommended

https://stackoverflow.com/questions/50495996/cypress-e2e-testing-how-to-get-around-cross-origin-errors

Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-23350
Test case: https://automation-test-cases.vercel.app/test/MM-T188