### PR TITLE
Cypress/E2E: Fix ldap login spec

### DIFF
--- a/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
@@ -11,16 +11,6 @@
 
 import users from '../../../fixtures/ldap_users.json';
 import {getRandomId} from '../../../utils';
-import * as TIMEOUTS from '../../../fixtures/timeouts';
-
-function setLDAPTestSettings(config) {
-    return {
-        siteName: config.TeamSettings.SiteName,
-        siteUrl: config.ServiceSettings.SiteURL,
-        teamName: '',
-        user: null,
-    };
-}
 
 // assumes the CYPRESS_* variables are set
 // assumes that E20 license is uploaded
@@ -39,6 +29,10 @@ context('ldap', () => {
         cy.apiGetConfig().then(({config}) => {
             testSettings = setLDAPTestSettings(config);
         });
+
+        removeUserFromAllTeams(user1);
+        removeUserFromAllTeams(guest1);
+        removeUserFromAllTeams(admin1);
     });
 
     describe('LDAP Login flow - Admin Login', () => {
@@ -52,11 +46,13 @@ context('ldap', () => {
             };
             cy.apiUpdateConfig(ldapSetting).then(() => {
                 cy.doLDAPLogin(testSettings).then(() => {
-                    // new user create team
+                    // # Skip or create team
                     cy.skipOrCreateTeam(testSettings, getRandomId()).then(() => {
                         cy.get('#headerTeamName').should('be.visible').then((teamName) => {
                             testSettings.teamName = teamName.text();
                         });
+
+                        // # Do LDAP logout
                         cy.doLDAPLogout(testSettings);
                     });
                 });
@@ -66,6 +62,7 @@ context('ldap', () => {
         it('LDAP login existing MM admin', () => {
             // existing user, verify and logout
             cy.doLDAPLogin(testSettings).then(() => {
+                // # Do LDAP logout
                 cy.doLDAPLogout(testSettings);
             });
         });
@@ -82,6 +79,7 @@ context('ldap', () => {
             cy.apiAdminLogin().then(() => {
                 cy.apiUpdateConfig(ldapSetting).then(() => {
                     cy.doLDAPLogin(testSettings).then(() => {
+                        // * Verify login failed
                         cy.checkLoginFailed(testSettings);
                     });
                 });
@@ -98,7 +96,8 @@ context('ldap', () => {
             cy.apiAdminLogin().then(() => {
                 cy.apiUpdateConfig(ldapSetting).then(() => {
                     cy.doLDAPLogin(testSettings).then(() => {
-                        cy.doMemberLogout(testSettings);
+                        // # Do member logout from sign up
+                        cy.doMemberLogoutFromSignUp(testSettings);
                     });
                 });
             });
@@ -116,9 +115,8 @@ context('ldap', () => {
             cy.apiAdminLogin().then(() => {
                 cy.apiUpdateConfig(ldapSetting).then(() => {
                     cy.doLDAPLogin(testSettings).then(() => {
-                        cy.url().should('include', 'town-square');
-                        cy.findAllByLabelText('town square public channel', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-                        cy.doMemberLogout(testSettings);
+                        // # Do logout from sign up
+                        cy.doLogoutFromSignUp(testSettings);
                     });
                 });
             });
@@ -134,7 +132,8 @@ context('ldap', () => {
             cy.apiAdminLogin().then(() => {
                 cy.apiUpdateConfig(ldapSetting).then(() => {
                     cy.doLDAPLogin(testSettings).then(() => {
-                        cy.doGuestLogout(testSettings);
+                        // # Do logout from sign up
+                        cy.doLogoutFromSignUp(testSettings);
                     });
                 });
             });
@@ -165,6 +164,7 @@ context('ldap', () => {
         it('LDAP Member login with team invite', () => {
             testSettings.user = user1;
             cy.doLDAPLogin(testSettings).then(() => {
+                // # Do LDAP logout
                 cy.doLDAPLogout(testSettings);
             });
         });
@@ -172,8 +172,28 @@ context('ldap', () => {
         it('LDAP Guest login with team invite', () => {
             testSettings.user = guest1;
             cy.doLDAPLogin(testSettings).then(() => {
-                cy.doGuestLogout(testSettings);
+                // # Do LDAP logout
+                cy.doLDAPLogout(testSettings);
             });
         });
     });
 });
+
+function setLDAPTestSettings(config) {
+    return {
+        siteName: config.TeamSettings.SiteName,
+        siteUrl: config.ServiceSettings.SiteURL,
+        teamName: '',
+        user: null,
+    };
+}
+
+function removeUserFromAllTeams(testUser) {
+    cy.apiGetUserByEmail(testUser.email).then(({user}) => {
+        cy.apiGetTeamsForUser(user.id).then(({teams}) => {
+            teams.forEach((team) => {
+                cy.apiDeleteUserFromTeam(team.id, user.id);
+            });
+        });
+    });
+}

--- a/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
@@ -32,16 +32,16 @@ context('ldap', () => {
 
     let testSettings;
 
-    describe('LDAP Login flow - Admin Login', () => {
-        before(() => {
-            // * Check if server has license for LDAP
-            cy.apiRequireLicenseForFeature('LDAP');
+    before(() => {
+        // * Check if server has license for LDAP
+        cy.apiRequireLicenseForFeature('LDAP');
 
-            cy.apiGetConfig().then(({config}) => {
-                testSettings = setLDAPTestSettings(config);
-            });
+        cy.apiGetConfig().then(({config}) => {
+            testSettings = setLDAPTestSettings(config);
         });
+    });
 
+    describe('LDAP Login flow - Admin Login', () => {
         it('LDAP login new MM admin, create team', () => {
             testSettings.user = admin1;
             const ldapSetting = {

--- a/e2e/cypress/support/api/team.d.ts
+++ b/e2e/cypress/support/api/team.d.ts
@@ -49,6 +49,18 @@ declare namespace Cypress {
         apiDeleteTeam(teamId: string, permanent?: boolean): Chainable<Record<string, any>>;
 
         /**
+         * Delete the team member object for a user, effectively removing them from a team.
+         * See https://api.mattermost.com/#tag/teams/paths/~1teams~1{team_id}~1members~1{user_id}/delete
+         * @param {String} teamId - The team ID which the user is to be removed from
+         * @param {String} userId - The user ID to be removed from team
+         * @returns {Object} `out.data` as response status
+         *
+         * @example
+         *   cy.apiDeleteUserFromTeam('team-id', 'user-id');
+         */
+        apiDeleteUserFromTeam(teamId: string, userId: string): Chainable<Record<string, any>>;
+
+        /**
          * Patch a team.
          * Partially update a team by providing only the fields you want to update.
          * Omitted fields will not be updated.

--- a/e2e/cypress/support/api/team.js
+++ b/e2e/cypress/support/api/team.js
@@ -37,6 +37,17 @@ Cypress.Commands.add('apiDeleteTeam', (teamId, permanent = false) => {
     });
 });
 
+Cypress.Commands.add('apiDeleteUserFromTeam', (teamId, userId) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/teams/' + teamId + '/members/' + userId,
+        method: 'DELETE',
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        cy.wrap({data: response.body});
+    });
+});
+
 Cypress.Commands.add('apiPatchTeam', (teamId, teamData) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},

--- a/e2e/cypress/support/common_login_commands.js
+++ b/e2e/cypress/support/common_login_commands.js
@@ -86,7 +86,7 @@ Cypress.Commands.add('skipOrCreateTeam', (settings, userId) => {
 
             cy.checkCreateTeamPage(settings);
 
-            cy.findByText('Create a team').scrollIntoView().should('be.visible').click();
+            cy.get('#createNewTeamLink').scrollIntoView().should('be.visible').click();
             cy.get('#teamNameInput').should('be.visible').type(teamName, {force: true});
             cy.findByText('Next').should('be.visible').click();
             cy.findByText('Finish').should('be.visible').click();

--- a/e2e/cypress/support/common_login_commands.js
+++ b/e2e/cypress/support/common_login_commands.js
@@ -5,7 +5,7 @@ import * as TIMEOUTS from '../fixtures/timeouts';
 
 Cypress.Commands.add('checkLoginPage', (settings = {}) => {
     // * Check elements in the body
-    cy.get('#loginId', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible').and(($loginTextbox) => {
+    cy.get('#loginId', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and(($loginTextbox) => {
         const placeholder = $loginTextbox[0].placeholder;
         expect(placeholder).to.match(/Email/);
         expect(placeholder).to.match(/Username/);
@@ -18,7 +18,7 @@ Cypress.Commands.add('checkLoginPage', (settings = {}) => {
 });
 
 Cypress.Commands.add('checkLoginFailed', () => {
-    cy.get('#login_section', {timeout: TIMEOUTS.FIVE_SEC}).find('.form-group').should('have.class', 'has-error');
+    cy.get('#login_section', {timeout: TIMEOUTS.ONE_MIN}).find('.form-group').should('have.class', 'has-error');
 });
 
 Cypress.Commands.add('checkGuestNoChannels', () => {
@@ -54,14 +54,14 @@ Cypress.Commands.add('checkLeftSideBar', (settings = {}) => {
 });
 
 Cypress.Commands.add('checkInvitePeoplePage', (settings = {}) => {
-    cy.findByText('Copy Link', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible');
+    cy.findByText('Copy Link', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
     if (settings.teamName != null && settings.teamName.length > 0) {
         cy.findByText('Invite people to ' + settings.teamName).should('be.visible');
     }
 });
 
 Cypress.Commands.add('checkInvitePeopleAdminPage', (settings = {}) => {
-    cy.findByText('Members', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible');
+    cy.findByText('Members', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
     cy.findByText('Guests').should('be.visible');
     if (settings.teamName != null && settings.teamName.length > 0) {
         cy.findByText('Invite people to ' + settings.teamName).should('be.visible');

--- a/e2e/cypress/support/common_login_commands.js
+++ b/e2e/cypress/support/common_login_commands.js
@@ -1,22 +1,24 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-Cypress.Commands.add('checkLoginPage', (settings = {}) => {
-    // * Check the title
-    cy.title().should('include', settings.siteName);
+import * as TIMEOUTS from '../fixtures/timeouts';
 
+Cypress.Commands.add('checkLoginPage', (settings = {}) => {
     // * Check elements in the body
-    cy.get('#loginId').should('be.visible').and(($loginTextbox) => {
+    cy.get('#loginId', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible').and(($loginTextbox) => {
         const placeholder = $loginTextbox[0].placeholder;
         expect(placeholder).to.match(/Email/);
         expect(placeholder).to.match(/Username/);
     });
     cy.get('#loginPassword').should('be.visible').and('have.attr', 'placeholder', 'Password');
     cy.findByText('Sign in').should('be.visible');
+
+    // * Check the title
+    cy.title().should('include', settings.siteName);
 });
 
 Cypress.Commands.add('checkLoginFailed', () => {
-    cy.get('div').should('have.class', 'has-error');
+    cy.get('#login_section', {timeout: TIMEOUTS.FIVE_SEC}).find('.form-group').should('have.class', 'has-error');
 });
 
 Cypress.Commands.add('checkGuestNoChannels', () => {
@@ -52,18 +54,18 @@ Cypress.Commands.add('checkLeftSideBar', (settings = {}) => {
 });
 
 Cypress.Commands.add('checkInvitePeoplePage', (settings = {}) => {
+    cy.findByText('Copy Link', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible');
     if (settings.teamName != null && settings.teamName.length > 0) {
         cy.findByText('Invite people to ' + settings.teamName).should('be.visible');
     }
-    cy.findByText('Copy Link').should('be.visible');
 });
 
 Cypress.Commands.add('checkInvitePeopleAdminPage', (settings = {}) => {
+    cy.findByText('Members', {timeout: TIMEOUTS.FIVE_SEC}).should('be.visible');
+    cy.findByText('Guests').should('be.visible');
     if (settings.teamName != null && settings.teamName.length > 0) {
         cy.findByText('Invite people to ' + settings.teamName).should('be.visible');
     }
-    cy.findByText('Members').should('be.visible');
-    cy.findByText('Guests').should('be.visible');
 });
 
 Cypress.Commands.add('doLogoutFromSignUp', () => {
@@ -77,6 +79,7 @@ Cypress.Commands.add('doMemberLogoutFromSignUp', () => {
 });
 
 Cypress.Commands.add('skipOrCreateTeam', (settings, userId) => {
+    cy.wait(TIMEOUTS.FIVE_SEC);
     return cy.get('body').then((body) => {
         let teamName = '';
 

--- a/e2e/cypress/support/ldap_commands.js
+++ b/e2e/cypress/support/ldap_commands.js
@@ -10,7 +10,7 @@ Cypress.Commands.add('doLDAPExistingLogin', () => {
 Cypress.Commands.add('doLDAPLogin', (settings = {}, useEmail = false) => {
     // # Go to login page
     cy.apiLogout();
-    cy.visit('/login').wait(TIMEOUTS.HALF_SEC);
+    cy.visit('/login');
     cy.checkLoginPage(settings);
     cy.performLDAPLogin(settings, useEmail);
 });
@@ -25,6 +25,7 @@ Cypress.Commands.add('performLDAPLogin', (settings = {}, useEmail = false) => {
 });
 
 Cypress.Commands.add('doGuestLogout', (settings = {}) => {
+    cy.wait(TIMEOUTS.FIVE_SEC);
     cy.get('body').then((body) => {
         if (body.text().includes('Logout')) {
             cy.doLogoutFromSignUp();
@@ -35,6 +36,7 @@ Cypress.Commands.add('doGuestLogout', (settings = {}) => {
 });
 
 Cypress.Commands.add('doMemberLogout', (settings = {}) => {
+    cy.wait(TIMEOUTS.FIVE_SEC);
     cy.get('body').then((body) => {
         if (body.text().includes('Logout')) {
             cy.doMemberLogoutFromSignUp();
@@ -110,6 +112,7 @@ Cypress.Commands.add('doInviteMember', (user, settings = {}) => {
 });
 
 Cypress.Commands.add('doSkipTutorial', () => {
+    cy.wait(TIMEOUTS.FIVE_SEC);
     cy.get('body').then((body) => {
         if (body.find('#tutorialSkipLink').length > 0) {
             cy.get('#tutorialSkipLink').click().wait(TIMEOUTS.HALF_SEC);


### PR DESCRIPTION
#### Summary
- Fixed `Create a team` selector (for some reason `findByText` doesn't work)
- Moved setup to global so other `describe` blocks can be run independently
- Added `apiDeleteUserFromTeam` to remove user from team 
- Fixed timeouts and added waits to conditional checking

#### Ticket Link
None -  master only

![Screen Shot 2020-08-13 at 1 28 43 PM](https://user-images.githubusercontent.com/487991/90184281-b539f380-dd69-11ea-8ae6-bf4aff333e24.png)
