### PR TITLE
Cypress/E2E: Fix get user 404

### DIFF
--- a/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
@@ -114,14 +114,15 @@ context('ldap', () => {
             testSettings.user = guest1;
             const ldapSetting = {
                 LdapSettings: {
+                    UserFilter: '(cn=no_users)',
                     GuestFilter: '(cn=no_guests)',
                 },
             };
             cy.apiAdminLogin().then(() => {
                 cy.apiUpdateConfig(ldapSetting).then(() => {
                     cy.doLDAPLogin(testSettings).then(() => {
-                        // # Do logout from sign up
-                        cy.doLogoutFromSignUp(testSettings);
+                        // * Verify login failed
+                        cy.checkLoginFailed(testSettings);
                     });
                 });
             });
@@ -131,6 +132,7 @@ context('ldap', () => {
             testSettings.user = guest1;
             const ldapSetting = {
                 LdapSettings: {
+                    UserFilter: '(cn=no_users)',
                     GuestFilter: '(cn=board*)',
                 },
             };
@@ -168,17 +170,35 @@ context('ldap', () => {
 
         it('LDAP Member login with team invite', () => {
             testSettings.user = user1;
-            cy.doLDAPLogin(testSettings).then(() => {
-                // # Do LDAP logout
-                cy.doLDAPLogout(testSettings);
+            const ldapSetting = {
+                LdapSettings: {
+                    UserFilter: '(cn=test*)',
+                },
+            };
+            cy.apiAdminLogin().then(() => {
+                cy.apiUpdateConfig(ldapSetting).then(() => {
+                    cy.doLDAPLogin(testSettings).then(() => {
+                        // # Do LDAP logout
+                        cy.doLDAPLogout(testSettings);
+                    });
+                });
             });
         });
 
         it('LDAP Guest login with team invite', () => {
             testSettings.user = guest1;
-            cy.doLDAPLogin(testSettings).then(() => {
-                // # Do LDAP logout
-                cy.doLDAPLogout(testSettings);
+            const ldapSetting = {
+                LdapSettings: {
+                    GuestFilter: '(cn=board*)',
+                },
+            };
+            cy.apiAdminLogin().then(() => {
+                cy.apiUpdateConfig(ldapSetting).then(() => {
+                    cy.doLDAPLogin(testSettings).then(() => {
+                        // # Do LDAP logout
+                        cy.doLDAPLogout(testSettings);
+                    });
+                });
             });
         });
     });

--- a/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
@@ -29,7 +29,7 @@ context('ldap', () => {
         // # Test LDAP configuration and server connection
         // # Synchronize user attributes
         cy.apiLDAPTest();
-        cy.apiLDAPSync()
+        cy.apiLDAPSync();
 
         cy.apiGetConfig().then(({config}) => {
             testSettings = setLDAPTestSettings(config);
@@ -194,8 +194,8 @@ function setLDAPTestSettings(config) {
 }
 
 function removeUserFromAllTeams(testUser) {
-    cy.apiGetUsersByUsernames([testUser.username]).then(({users}) => {
-        users.forEach((user) => {
+    cy.apiGetUsersByUsernames([testUser.username]).then(({testUsers}) => {
+        testUsers.forEach((user) => {
             cy.apiGetTeamsForUser(user.id).then(({teams}) => {
                 teams.forEach((team) => {
                     cy.apiDeleteUserFromTeam(team.id, user.id);

--- a/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
@@ -26,6 +26,11 @@ context('ldap', () => {
         // * Check if server has license for LDAP
         cy.apiRequireLicenseForFeature('LDAP');
 
+        // # Test LDAP configuration and server connection
+        // # Synchronize user attributes
+        cy.apiLDAPTest();
+        cy.apiLDAPSync()
+
         cy.apiGetConfig().then(({config}) => {
             testSettings = setLDAPTestSettings(config);
         });

--- a/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
@@ -9,16 +9,16 @@
 
 // Group: @enterprise @ldap
 
-import users from '../../../fixtures/ldap_users.json';
+import ldapUsers from '../../../fixtures/ldap_users.json';
 import {getRandomId} from '../../../utils';
 
 // assumes the CYPRESS_* variables are set
 // assumes that E20 license is uploaded
 // for setup with AWS: Follow the instructions mentioned in the mattermost/platform-private/config/ldap-test-setup.txt file
 context('ldap', () => {
-    const user1 = users['test-1'];
-    const guest1 = users['board-1'];
-    const admin1 = users['dev-1'];
+    const user1 = ldapUsers['test-1'];
+    const guest1 = ldapUsers['board-1'];
+    const admin1 = ldapUsers['dev-1'];
 
     let testSettings;
 
@@ -194,8 +194,8 @@ function setLDAPTestSettings(config) {
 }
 
 function removeUserFromAllTeams(testUser) {
-    cy.apiGetUsersByUsernames([testUser.username]).then(({testUsers}) => {
-        testUsers.forEach((user) => {
+    cy.apiGetUsersByUsernames([testUser.username]).then(({users}) => {
+        users.forEach((user) => {
             cy.apiGetTeamsForUser(user.id).then(({teams}) => {
                 teams.forEach((team) => {
                     cy.apiDeleteUserFromTeam(team.id, user.id);

--- a/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
+++ b/e2e/cypress/integration/enterprise/ldap/ldap_login_spec.js
@@ -189,10 +189,12 @@ function setLDAPTestSettings(config) {
 }
 
 function removeUserFromAllTeams(testUser) {
-    cy.apiGetUserByEmail(testUser.email).then(({user}) => {
-        cy.apiGetTeamsForUser(user.id).then(({teams}) => {
-            teams.forEach((team) => {
-                cy.apiDeleteUserFromTeam(team.id, user.id);
+    cy.apiGetUsersByUsernames([testUser.username]).then(({users}) => {
+        users.forEach((user) => {
+            cy.apiGetTeamsForUser(user.id).then(({teams}) => {
+                teams.forEach((team) => {
+                    cy.apiDeleteUserFromTeam(team.id, user.id);
+                });
             });
         });
     });

--- a/e2e/cypress/support/api/index.js
+++ b/e2e/cypress/support/api/index.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import './common';
+import './ldap';
 import './preference';
 import './saml';
 import './setup';

--- a/e2e/cypress/support/api/ldap.d.ts
+++ b/e2e/cypress/support/api/ldap.d.ts
@@ -1,5 +1,3 @@
-
-
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 

--- a/e2e/cypress/support/api/ldap.d.ts
+++ b/e2e/cypress/support/api/ldap.d.ts
@@ -1,0 +1,43 @@
+
+
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Meaningful description
+// - Specific link to https://api.mattermost.com
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// Custom command should follow naming convention of having `api` prefix, e.g. `apiLDAPSync`.
+// ***************************************************************
+
+declare namespace Cypress {
+    interface Chainable<Subject = any> {
+
+        /**
+         * Synchronize any user attribute changes in the configured AD/LDAP server with Mattermost.
+         * See https://api.mattermost.com/#tag/LDAP/paths/~1ldap~1sync/post
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+         *
+         * @example
+         *   cy.apiLDAPSync();
+         */
+        apiLDAPSync(): Chainable<Response>;
+
+        /**
+         * Test the current AD/LDAP configuration to see if the AD/LDAP server can be contacted successfully.
+         * See https://api.mattermost.com/#tag/LDAP/paths/~1ldap~1test/post
+         * @returns {Response} response: Cypress-chainable response which should have successful HTTP status of 200 OK to continue or pass.
+         *
+         * @example
+         *   cy.apiLDAPTest();
+         */
+        apiLDAPTest(): Chainable<Response>;
+    }
+}

--- a/e2e/cypress/support/api/ldap.js
+++ b/e2e/cypress/support/api/ldap.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// *****************************************************************************
+// LDAP
+// https://api.mattermost.com/#tag/LDAP
+// *****************************************************************************
+
+Cypress.Commands.add('apiLDAPSync', () => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/ldap/sync',
+        method: 'POST',
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        return cy.wrap(response);
+    });
+});
+
+Cypress.Commands.add('apiLDAPTest', () => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/ldap/test',
+        method: 'POST',
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        return cy.wrap(response);
+    });
+});


### PR DESCRIPTION
#### Summary
- Made sure user is retrieved through a list to avoid 404 on non-existing user
- Added `apiLDAPTest ` and `apiLDAPSync` 

Note: [Cypress run passed](https://app.circleci.com/pipelines/github/saturninoabril/mattermost-cypress-docker?branch=fix-get-user-404)

#### Ticket Link
None -  master only

![Screen Shot 2020-08-14 at 9 39 50 AM](https://user-images.githubusercontent.com/487991/90272349-1fa66e80-de12-11ea-9091-6491f17270e0.png)
