### PR TITLE
Cypress/E2E: Fixed archived channel name

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/archived_channels_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/archived_channels_spec.js
@@ -83,7 +83,7 @@ describe('Archived channels', () => {
 
         // # Save and wait for redirect
         cy.get('#saveSetting').click();
-        cy.get('.DataGrid', {timeout: TIMEOUTS.TWO_SEC}).should('be.visible');
+        cy.get('.DataGrid', {timeout: TIMEOUTS.TWO_SEC}).scrollIntoView().should('be.visible');
 
         // * Verify via the API that the channel is unarchived
         cy.apiGetChannel(testChannel.id).then((response) => {

--- a/e2e/cypress/integration/enterprise/system_console/archived_channels_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/archived_channels_spec.js
@@ -26,7 +26,7 @@ describe('Archived channels', () => {
         cy.apiRequireLicense();
 
         cy.apiInitSetup({
-            channelPrefix: {name: 'aaa-archive', displayName: 'AAA Archive Test'},
+            channelPrefix: {name: '000-archive', displayName: '000 Archive Test'},
         }).then(({channel}) => {
             testChannel = channel;
 


### PR DESCRIPTION
#### Summary
- Renamed archived channel so it appears on top

Note: [Cypress run passed](https://app.circleci.com/pipelines/github/saturninoabril/mattermost-cypress-docker?branch=fix-archived-channel-name)

#### Ticket Link
None -  master only

![Screen Shot 2020-08-14 at 12 30 52 PM](https://user-images.githubusercontent.com/487991/90286110-04dff400-de2a-11ea-918b-738d0fd4f42f.png)

