### PR TITLE
[MM-T2370] Default images to collapsed

### DIFF
--- a/e2e/cypress/integration/scroll/default_images_collapsed_spec.js
+++ b/e2e/cypress/integration/scroll/default_images_collapsed_spec.js
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+describe('Scroll', () => {
+    let testTeam;
+
+    before(() => {
+        // # Create new team and new user and visit Town Square channel
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            // # Switch the account settings for the test user to have images collapsed by default
+            cy.apiSaveCollapsePreviewsPreference('true');
+
+            testTeam = team;
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+        });
+    });
+
+    it('MM-T2370 Default images to collapsed', () => {
+        const filename = 'huge-image.jpg';
+
+        // # Post an image in center channel
+        cy.get('#centerChannelFooter').find('#fileUploadInput').attachFile(filename);
+
+        cy.get('.post-image').should('be.visible');
+
+        cy.postMessage('{enter}');
+
+        // * Observe image preview is collapsed
+        cy.findByLabelText('file thumbnail').should('not.exist');
+
+        // # Refresh the browser
+        cy.reload();
+
+        // * Observe image preview is collapsed after reloading the page
+        cy.findByLabelText('file thumbnail').should('not.exist');
+    });
+});

--- a/e2e/cypress/integration/scroll/default_images_collapsed_spec.js
+++ b/e2e/cypress/integration/scroll/default_images_collapsed_spec.js
@@ -8,16 +8,16 @@
 // ***************************************************************
 
 describe('Scroll', () => {
-    let testTeam;
-
     before(() => {
         // # Create new team and new user and visit Town Square channel
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             // # Switch the account settings for the test user to have images collapsed by default
             cy.apiSaveCollapsePreviewsPreference('true');
 
-            testTeam = team;
-            cy.visit(`/${testTeam.name}/channels/town-square`);
+            cy.visit(`/${team.name}/channels/town-square`);
+
+            // # Post at least 10 messages in a channel
+            Cypress._.times(10, (index) => cy.postMessage(index));
         });
     });
 
@@ -34,8 +34,20 @@ describe('Scroll', () => {
         // * Observe image preview is collapsed
         cy.findByLabelText('file thumbnail').should('not.exist');
 
+        // # Save height of the last post
+        cy.getLastPost().then((lastPost) => {
+            cy.wrap(parseInt(lastPost[0].clientHeight, 10)).as('lastPostHeight');
+        });
+
         // # Refresh the browser
         cy.reload();
+
+        // * Verify that the last post is still the same after reload
+        cy.getLastPost().then((lastPost) => {
+            cy.get('@lastPostHeight').then((lastPostHeight) => {
+                expect(parseInt(lastPost[0].clientHeight, 10)).to.equal(lastPostHeight);
+            });
+        });
 
         // * Observe image preview is collapsed after reloading the page
         cy.findByLabelText('file thumbnail').should('not.exist');


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds an E2E test that switches the account settings for the test user to have images collapsed by default. The test checks that the posted image remains collapsed even after reloading the page.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
MM-T2370