### PR TITLE
[MM-T637] Copy icon for Incoming Webhook URL

### DIFF
--- a/e2e/cypress/integration/integrations/incoming_webhook/copy_icon_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/copy_icon_spec.js
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+describe('Incoming webhook', () => {
+    let testTeam;
+
+    before(() => {
+        // # Set ServiceSettings to expected values
+        const newSettings = {
+            ServiceSettings: {
+                EnableIncomingWebhooks: true,
+            },
+        };
+
+        cy.apiUpdateConfig(newSettings);
+
+        cy.apiInitSetup().then(({team}) => {
+            testTeam = team;
+
+            // # Go to integrations
+            cy.visit(`/${testTeam.name}/integrations`);
+
+            // * Validate that incoming webhooks are enabled
+            cy.get('#incomingWebhooks').should('be.visible');
+        });
+    });
+
+    it('MM-T637 Copy icon for Incoming Webhook URL', () => {
+        const title = 'test-title';
+        const description = 'test-description';
+        const channel = 'Town Square';
+
+        cy.get('#incomingWebhooks').click();
+
+        cy.get('#addIncomingWebhook').click();
+
+        cy.get('#displayName').type(title);
+
+        cy.get('#description').type(description);
+
+        cy.get('#channelSelect').select(channel);
+
+        cy.get('#saveWebhook').click();
+
+        cy.get('#formTitle').should('have.text', 'Setup Successful');
+
+        copyIconIsVisible('.backstage-form__confirmation');
+
+        cy.get('#doneButton').click();
+
+        copyIconIsVisible('.item-details__url');
+    });
+});
+
+function copyIconIsVisible(element) {
+    cy.get(element).within(() => {
+        cy.get('a[href="#"]').should('be.visible');
+    });
+}

--- a/e2e/cypress/integration/integrations/incoming_webhook/copy_icon_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/copy_icon_spec.js
@@ -37,9 +37,9 @@ describe('Incoming webhook', () => {
         // # For this test purpose, fill in "Title", "Description" and select a "channel" with some test data
         cy.findByText('Add Incoming Webhook').should('be.visible').click();
 
-        cy.get('#displayName').should('be.visible').type(title);
+        cy.findByLabelText('Title').should('be.visible').type(title);
 
-        cy.get('#description').should('be.visible').type(description);
+        cy.findByLabelText('Description').should('be.visible').type(description);
 
         cy.get('#channelSelect').should('be.visible').select(channel);
 

--- a/e2e/cypress/integration/integrations/incoming_webhook/copy_icon_spec.js
+++ b/e2e/cypress/integration/integrations/incoming_webhook/copy_icon_spec.js
@@ -8,8 +8,6 @@
 // ***************************************************************
 
 describe('Incoming webhook', () => {
-    let testTeam;
-
     before(() => {
         // # Set ServiceSettings to expected values
         const newSettings = {
@@ -21,10 +19,8 @@ describe('Incoming webhook', () => {
         cy.apiUpdateConfig(newSettings);
 
         cy.apiInitSetup().then(({team}) => {
-            testTeam = team;
-
             // # Go to integrations
-            cy.visit(`/${testTeam.name}/integrations`);
+            cy.visit(`/${team.name}/integrations`);
 
             // * Validate that incoming webhooks are enabled
             cy.get('#incomingWebhooks').should('be.visible');
@@ -36,30 +32,38 @@ describe('Incoming webhook', () => {
         const description = 'test-description';
         const channel = 'Town Square';
 
-        cy.get('#incomingWebhooks').click();
+        cy.get('#incomingWebhooks').should('be.visible').click();
 
-        cy.get('#addIncomingWebhook').click();
+        // # For this test purpose, fill in "Title", "Description" and select a "channel" with some test data
+        cy.findByText('Add Incoming Webhook').should('be.visible').click();
 
-        cy.get('#displayName').type(title);
+        cy.get('#displayName').should('be.visible').type(title);
 
-        cy.get('#description').type(description);
+        cy.get('#description').should('be.visible').type(description);
 
-        cy.get('#channelSelect').select(channel);
+        cy.get('#channelSelect').should('be.visible').select(channel);
 
-        cy.get('#saveWebhook').click();
+        // # Scroll down and click "Save"
+        cy.findByText('Save').should('be.visible').click();
 
-        cy.get('#formTitle').should('have.text', 'Setup Successful');
+        cy.findByText('Setup Successful').should('be.visible');
 
+        // * You should see a "copy" icon to the right of the URL in the "Setup Successful" screen
         copyIconIsVisible('.backstage-form__confirmation');
 
-        cy.get('#doneButton').click();
+        // # Click "Done" in the "Setup Successful" screen
+        cy.findByText('Done').should('be.visible').click();
 
+        // # You should see a "copy" icon to the right of the webhook's URL
         copyIconIsVisible('.item-details__url');
     });
 });
 
 function copyIconIsVisible(element) {
     cy.get(element).within(() => {
-        cy.get('a[href="#"]').should('be.visible');
+        cy.get('.fa.fa-copy').
+            should('be.visible').
+            trigger('mouseover').
+            should('have.attr', 'aria-describedby', 'copy');
     });
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds an E2E test that checks if the copy icon for an Incoming Webhook URL is visible.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
MM-T637