### PR TITLE
MM-T2389 Inline markdown image links open with preview modal

### DIFF
--- a/e2e/cypress/integration/files_and_attachments/image_link_preview_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/image_link_preview_spec.js
@@ -89,4 +89,44 @@ describe('Image Link Preview', () => {
         // # All image previews expand back open
         cy.findAllByLabelText('file thumbnail').should('be.visible').and('have.length', 4);
     });
+
+    it('MM-T2389 Inline markdown image links open with preview modal', () => {
+        // Go to home channel
+        cy.visit(`/${testTeam.name}/channels/town-square`);
+
+        const markdownImageText = 'exampleImage';
+        const markdownImageSrc = 'https://www.mattermost.org/wp-content/uploads/2016/03/logoHorizontal.png';
+        const markdownImageSrcEncoded = encodeURIComponent(markdownImageSrc); // Since the url preview will be encoded string
+        const messageWithMarkdownImage = `![${markdownImageText}](${markdownImageSrc}) an image plus some text that has [a link](https://example.com/)`;
+
+        // # Post a message with markdown image and link
+        cy.postMessage(messageWithMarkdownImage);
+
+        // # Get the post id of last message with image and link
+        cy.getLastPostId().then((postWithMarkdownImage) => {
+            // # Scan inside the last post for checking the image
+            cy.get(`#${postWithMarkdownImage}_message`).should('exist').and('be.visible').within(() => {
+                // * Find the inline image of the markdown text and verify its clickable
+                // Image can be found by its alt text is same as the one passed in markdown image title
+                cy.findByAltText(markdownImageText).should('exist').and('be.visible').
+                    and('have.css', 'cursor', 'pointer').
+                    and('have.attr', 'src').should('include', markdownImageSrcEncoded);
+
+                // # Click on the image
+                cy.findByAltText(markdownImageText).click();
+            });
+        });
+
+        // * Verify image preview modal is opened
+        cy.get('.a11y__modal').should('exist').and('be.visible').
+            within(() => {
+                // * Verify we have the image inside the modal
+                cy.findByTestId('imagePreview').should('exist').and('be.visible').
+                    and('have.attr', 'alt', 'preview url image').
+                    and('have.attr', 'src').should('include', markdownImageSrcEncoded);
+            });
+
+        // # Close the image preview modal
+        cy.get('body').type('{esc}');
+    });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Wrote an end to end test which checks if image is clickable and opens a preview when post is made with inline markdown image

#### Ticket Link
MM-T2389

