### PR TITLE
MM-27674 Fix transparency for unicode emojis

### DIFF
--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -23,12 +23,6 @@
     min-width: 21px;
     vertical-align: middle;
     width: 21px;
-    color: transparent;
-
-    &::selection{
-        background-color: transparent;
-        color: transparent;
-    }
 
     &--unicode {
         font-size: 21px;
@@ -36,6 +30,15 @@
         .os--windows & {
             font-size: 16px;
             line-height: 1.3;
+        }
+    }
+
+    &:not(.emoticon--unicode) {
+        color: transparent;
+
+        &::selection{
+            background-color: transparent;
+            color: transparent;
         }
     }
 }


### PR DESCRIPTION
Elements with the `emoticon` class can either be emoji images (named emojis and any supported unicode emojis) or spans containing a unicode emoji as text (unsupported unicode emojis). The text inside an `emoticon` element should be transparent for image-based emojis since it contains a copyable emoji shortname, but for unicode emojis, that needs to be not transparent or else we show an empty square. This also applies to the colour when selecting the text.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27674