### PR TITLE
MM-T388 Add e2e test for MM-T388

### DIFF
--- a/e2e/cypress/integration/team_settings/invite_user_to_closed_team_spec.js
+++ b/e2e/cypress/integration/team_settings/invite_user_to_closed_team_spec.js
@@ -1,0 +1,83 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @team_settings
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+describe('Team Settings', () => {
+    let newUser;
+
+    before(() => {
+        cy.apiInitSetup().then(({team}) => {
+            cy.apiCreateUser().then(({user}) => {
+                newUser = user;
+            });
+
+            cy.visit(`/${team.name}`);
+        });
+    });
+
+    it('MM-T388 - Invite new user to closed team with "Allow only users with a specific email domain to join this team" set to "sample.mattermost.com" AND include a non-sample.mattermost.com email address in the invites', () => {
+        const emailDomain = 'sample.mattermost.com';
+        const invalidEmail = 'saturnino@gmail.com';
+        const userDetailsString = `@${newUser.username} - ${newUser.first_name} ${newUser.last_name} (${newUser.nickname})`;
+        const inviteSuccessMessage = 'This member has been added to the team.';
+        const inviteFailedMessage = `The following email addresses do not belong to an accepted domain: ${invalidEmail}. Please contact your System Administrator for details.`;
+
+        // Open 'Team Settings' modal
+        cy.get('.sidebar-header-dropdown__icon').click();
+        cy.findByText('Team Settings').should('be.visible').click();
+
+        // * Check that the 'Team Settings' modal was opened
+        cy.get('#teamSettingsModal').should('exist').within(() => {
+            // # Click on the 'Allow only users with a specific email domain to join this team' edit button
+            cy.get('#allowed_domainsEdit').should('be.visible').click();
+
+            // # Set 'sample.mattermost.com' as the only allowed email domain and save
+            cy.wait(TIMEOUTS.HALF_SEC);
+            cy.focused().type(emailDomain);
+            cy.findByText('Save').should('be.visible').click();
+
+            // # Close the modal
+            cy.get('#teamSettingsModalLabel').find('button').should('be.visible').click();
+        });
+
+        // # Open the 'Invite People' full screen modal
+        cy.get('.sidebar-header-dropdown__icon').click();
+        cy.get('#invitePeople').find('button').eq(0).click();
+
+        // # Invite user with valid email domain that is not in the team
+        inviteNewMemberToTeam(newUser.email);
+
+        // * Assert that the user has successfully been invited to the team
+        cy.get('.invitation-modal-confirm-sent').should('be.visible').within(() => {
+            cy.get('.username-or-icon').find('span').eq(0).should('have.text', userDetailsString);
+            cy.get('.InvitationModalConfirmStepRow').find('div').eq(1).should('have.text', inviteSuccessMessage);
+        });
+
+        // # Click on the 'Invite More People button'
+        cy.get('.invite-more').click();
+
+        // # Invite a user with an invalid email domain (not sample.mattermost.com)
+        inviteNewMemberToTeam(invalidEmail);
+
+        // * Assert that the invite failed and the correct error message is shown
+        cy.get('.invitation-modal-confirm-not-sent').should('be.visible').within(() => {
+            cy.get('.username-or-icon').find('span').eq(1).should('have.text', invalidEmail);
+            cy.get('.InvitationModalConfirmStepRow').find('div').eq(1).should('have.text', inviteFailedMessage);
+        });
+    });
+
+    function inviteNewMemberToTeam(email) {
+        cy.wait(TIMEOUTS.HALF_SEC);
+        cy.findByRole('textbox', {name: 'Add or Invite People'}).type(email, {force: true}).wait(TIMEOUTS.HALF_SEC).type('{enter}');
+        cy.get('#inviteMembersButton').click();
+    }
+});


### PR DESCRIPTION
Summary

Created a test where you set an allowed email domain in the Team settings, and try to invite a user with a valid email domain and another with an email domain that is not accepted.

I changed the accepted email domain from mattermost.com to sample.mattermost.com

Test case: https://automation-test-cases.vercel.app/test/MM-T388