### PR TITLE
Cypress/E2E: Fix common commands spec

### DIFF
--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -258,8 +258,9 @@ describe('I18456 Built-in slash commands: common', () => {
             cy.findAllByText('[text]').first().should('exist');
         });
 
-        // # Clear the textbox
-        cy.postMessage('Hello');
+        // # Append Hello to /rename and hit enter
+        cy.get('#post_textbox').type('Hello{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.get('#post_textbox').invoke('text').should('be.empty');
     });
 });
 


### PR DESCRIPTION
#### Summary
- Fixed `Hello{enter}` after `/rename`

#### Ticket Link
None -  master only

![Screen Shot 2020-08-18 at 4 16 57 PM](https://user-images.githubusercontent.com/487991/90574613-42b48380-e16e-11ea-9185-3ace1cb07b31.png)
