### PR TITLE
Cypress/E2E: Fix integrations spec

### DIFF
--- a/e2e/cypress/integration/integrations/integrations_spec.js
+++ b/e2e/cypress/integration/integrations/integrations_spec.js
@@ -458,8 +458,9 @@ describe('Integrations page', () => {
             cy.findByText(commandTitle).should('not.exist');
         });
 
-        // # Clear the textbox
-        cy.postMessage('Hello');
+        // # Append Hello to custom slash command and hit enter
+        cy.get('#post_textbox').type('{enter}').wait(TIMEOUTS.HALF_SEC).type('Hello{enter}').wait(TIMEOUTS.HALF_SEC);
+        cy.get('#post_textbox').invoke('text').should('be.empty');
     });
 });
 


### PR DESCRIPTION
#### Summary
- Fixed `Hello{enter}` after custom slash command

#### Ticket Link
None -  master only

![Screen Shot 2020-08-18 at 4 31 37 PM](https://user-images.githubusercontent.com/487991/90575518-709ac780-e170-11ea-8185-abb0eff37337.png)
