### PR TITLE
[MM-26681] Only show demote to guest if guest setting is enabled

### DIFF
--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.test.tsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.test.tsx
@@ -41,7 +41,11 @@ describe('components/admin_console/system_users/system_users_dropdown/system_use
             demoteUserToGuest: jest.fn().mockResolvedValue({data: true}),
             loadBots: jest.fn(() => Promise.resolve({})),
         },
-        config: {},
+        config: {
+            GuestAccountsSettings: {
+                Enable: true
+            }
+        },
         bots: {},
     };
 

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.tsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.tsx
@@ -587,7 +587,7 @@ export default class SystemUsersDropdown extends React.PureComponent<Props, Stat
                             text={Utils.localizeMessage('admin.user_item.promoteToUser', 'Promote to User')}
                         />
                         <Menu.ItemAction
-                            show={!isGuest && user.id !== currentUser.id && isLicensed && config.GuestAccountsSettings?.Enable === true}
+                            show={!isGuest && user.id !== currentUser.id && isLicensed && config.GuestAccountsSettings?.Enable}
                             onClick={this.handleDemoteToGuest}
                             text={Utils.localizeMessage('admin.user_item.demoteToGuest', 'Demote to Guest')}
                         />

--- a/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.tsx
+++ b/components/admin_console/system_users/system_users_dropdown/system_users_dropdown.tsx
@@ -454,7 +454,7 @@ export default class SystemUsersDropdown extends React.PureComponent<Props, Stat
     }
 
     render() {
-        const {currentUser, user, isLicensed} = this.props;
+        const {currentUser, user, isLicensed, config} = this.props;
         const isGuest = Utils.isGuest(user);
         if (!user) {
             return <div/>;
@@ -587,7 +587,7 @@ export default class SystemUsersDropdown extends React.PureComponent<Props, Stat
                             text={Utils.localizeMessage('admin.user_item.promoteToUser', 'Promote to User')}
                         />
                         <Menu.ItemAction
-                            show={!isGuest && user.id !== currentUser.id && isLicensed}
+                            show={!isGuest && user.id !== currentUser.id && isLicensed && config.GuestAccountsSettings?.Enable === true}
                             onClick={this.handleDemoteToGuest}
                             text={Utils.localizeMessage('admin.user_item.demoteToGuest', 'Demote to Guest')}
                         />

--- a/components/timestamp/__snapshots__/semantic_time.test.tsx.snap
+++ b/components/timestamp/__snapshots__/semantic_time.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`components/timestamp/SemanticTime should render time semantically 1`] =
   value={2020-06-05T10:20:30.000Z}
 >
   <time
-    aria-label="6/5/2020, 10:20:30 AM"
+    aria-label="2020-06-05, 10:20:30 a.m."
     dateTime="2020-06-05T10:20:30.000Z"
   />
 </Memo(SemanticTime)>
@@ -28,7 +28,7 @@ exports[`components/timestamp/SemanticTime should support passthrough children 1
   value={2020-06-05T10:20:30.000Z}
 >
   <time
-    aria-label="6/5/2020, 10:20:30 AM"
+    aria-label="2020-06-05, 10:20:30 a.m."
     dateTime="2020-06-05T10:20:30.000Z"
   >
     10:20

--- a/components/timestamp/__snapshots__/semantic_time.test.tsx.snap
+++ b/components/timestamp/__snapshots__/semantic_time.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`components/timestamp/SemanticTime should render time semantically 1`] =
   value={2020-06-05T10:20:30.000Z}
 >
   <time
-    aria-label="2020-06-05, 10:20:30 a.m."
+    aria-label="6/5/2020, 10:20:30 AM"
     dateTime="2020-06-05T10:20:30.000Z"
   />
 </Memo(SemanticTime)>
@@ -28,7 +28,7 @@ exports[`components/timestamp/SemanticTime should support passthrough children 1
   value={2020-06-05T10:20:30.000Z}
 >
   <time
-    aria-label="2020-06-05, 10:20:30 a.m."
+    aria-label="6/5/2020, 10:20:30 AM"
     dateTime="2020-06-05T10:20:30.000Z"
   >
     10:20


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Only show `Demote to Guest` in the User page in the system console if and only if `Guest Accounts` are enabled.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-26681