### PR TITLE
Cypress/E2E: Fix high scoped scheme spec

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
@@ -36,6 +36,11 @@ export const saveConfigForChannel = (channelName = false, clickConfirmationButto
                 cy.get('#confirmModalButton').click();
             }
 
+            // # Wait for location path to end with /admin_console/user_management/channels
+            cy.waitUntil(() => cy.location().then((location) => {
+                return location.href.endsWith('/admin_console/user_management/channels');
+            }));
+
             // # Make sure the save is complete by looking for the search input which is only visible on the team's index page
             cy.get('.DataGrid_searchBar').should('be.visible').within(() => {
                 cy.findByPlaceholderText('Search').should('be.visible');


### PR DESCRIPTION
#### Summary
- Added a wait for location path to end with `/admin_console/user_management/channels` after saving to ensure url has redirected before continuing with the rest of the actions
- I tried to make a separate cypress run but for some reason it's timing out;  it passed on my local though (see `high_scoped_scheme_spec` below)

#### Ticket Link
None -  master only

![Screen Shot 2020-08-19 at 9 48 12 PM](https://user-images.githubusercontent.com/487991/90718143-0ebc8980-e266-11ea-9a0d-9cfaca7e057f.png)
