### PR TITLE
Cypress/E2E: Fix remove last post in channel spec

### DIFF
--- a/e2e/cypress/utils/index.js
+++ b/e2e/cypress/utils/index.js
@@ -9,10 +9,10 @@ import messageMenusData from '../fixtures/hooks/message_menus.json';
 import messageMenusWithDatasourceData from '../fixtures/hooks/message_menus_with_datasource.json';
 
 /**
- * @param {Number} length - length on random string to return, e.g. 6 (default)
+ * @param {Number} length - length on random string to return, e.g. 7 (default)
  * @return {String} random string
  */
-export function getRandomId(length = 6) {
+export function getRandomId(length = 7) {
     const MAX_SUBSTRING_INDEX = 27;
 
     return uuidv4().replace(/-/g, '').substring(MAX_SUBSTRING_INDEX - length, MAX_SUBSTRING_INDEX);


### PR DESCRIPTION
#### Summary
- Increased default length of getRandomId by 1 to decrease the likelihood of having generated the same set of characters.

#### Ticket Link
None -  master only

![Screen Shot 2020-08-20 at 10 55 31 AM](https://user-images.githubusercontent.com/487991/90807902-0733c980-e2d4-11ea-8af1-1b74089bdd53.png)
