### PR TITLE
[MM-27923] Turn on Cloud Onboarding for Cloud-only instances

### DIFF
--- a/components/next_steps_view/steps.test.tsx
+++ b/components/next_steps_view/steps.test.tsx
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {showNextSteps} from './steps';
+
+describe('components/next_steps_view/steps', () => {
+    test('should not show next steps if not cloud', () => {
+        const goodState = {
+            entities: {
+                general: {
+                    license: {
+                        Cloud: 'true',
+                    },
+                },
+                preferences: {
+                    myPreferences: {},
+                },
+            },
+        };
+
+        expect(showNextSteps(goodState as any)).toBe(true);
+
+        const badState = {
+            ...goodState,
+
+            entities: {
+                ...goodState.entities,
+                general: {
+                    license: {
+                        Cloud: 'false',
+                    },
+                },
+            },
+        };
+
+        expect(showNextSteps(badState as any)).toBe(false);
+    });
+
+    test('should not show the view if hide preference exists', () => {
+        const state = {
+            entities: {
+                general: {
+                    license: {
+                        Cloud: 'true',
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        'recommended_next_steps--hide': {name: 'hide', value: true},
+                    },
+                },
+            },
+        };
+
+        expect(showNextSteps(state as any)).toBe(false);
+    });
+
+    test('should not show the view if all steps are complete', () => {
+        const state = {
+            entities: {
+                general: {
+                    license: {
+                        Cloud: 'true',
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        'recommended_next_steps--complete_profile': {name: 'complete_profile', value: true},
+                        'recommended_next_steps--team_setup': {name: 'team_setup', value: true},
+                        'recommended_next_steps--invite_members': {name: 'invite_members', value: true},
+                    },
+                },
+            },
+        };
+
+        expect(showNextSteps(state as any)).toBe(false);
+    });
+});

--- a/components/next_steps_view/steps.ts
+++ b/components/next_steps_view/steps.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 import {createSelector} from 'reselect';
 
+import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {makeGetCategory} from 'mattermost-redux/selectors/entities/preferences';
 import {UserProfile} from 'mattermost-redux/types/users';
 
@@ -47,8 +48,13 @@ export const Steps: StepType[] = [
 const getCategory = makeGetCategory();
 export const showNextSteps = createSelector(
     (state: GlobalState) => getCategory(state, Preferences.RECOMMENDED_NEXT_STEPS),
-    (stepPreferences) => {
+    (state: GlobalState) => getLicense(state),
+    (stepPreferences, license) => {
         if (stepPreferences.some((pref) => pref.name === RecommendedNextSteps.HIDE && pref.value)) {
+            return false;
+        }
+
+        if (license.Cloud !== 'true') {
             return false;
         }
 


### PR DESCRIPTION
#### Summary
Cloud Onboarding should now only be turned on for Cloud-only instances.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27923