### PR TITLE
Cypress/E2E: Fix gm add first user spec

### DIFF
--- a/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
+++ b/e2e/cypress/integration/multi_team_and_dm/gm_add_first_user_spec.js
@@ -34,7 +34,7 @@ describe('Multi-user group messages', () => {
 
         // # Start typing part of a username that matches previously created users
         cy.get('#selectItems input').
-            type(searchTerm);
+            type(searchTerm, {force: true});
 
         // * Expect user list to only contain usernames matching the query term and to be sorted alphabetically
         expectUserListSortedAlphabetically(searchTerm);


### PR DESCRIPTION
#### Summary
- Added `{force: true}` to typing search term as suggested by cypress failure log

Note: [Cypress run passed](https://app.circleci.com/pipelines/github/saturninoabril/mattermost-cypress-docker?branch=fix-gm-add-first-user)

#### Ticket Link
None -  master only

![Screen Shot 2020-08-20 at 2 50 28 PM](https://user-images.githubusercontent.com/487991/90829387-833e0980-e2f4-11ea-8752-49aa6a133441.png)
