### PR TITLE
cherry pick of #6070 on release-5.27

### DIFF
--- a/components/admin_console/filter/team_filter_dropdown/team_filter_dropdown.tsx
+++ b/components/admin_console/filter/team_filter_dropdown/team_filter_dropdown.tsx
@@ -142,7 +142,7 @@ class TeamFilterDropdown extends React.PureComponent<Props, State> {
         } else if (this.state.searchTerm.length > 0) {
             return this.state.searchTotal > this.state.searchResults.length;
         }
-        return this.props.total > this.props.teams.length;
+        return this.props.total > (this.state.page + 1) * TEAMS_PER_PAGE;
     }
 
     loadMore = async () => {
@@ -196,9 +196,10 @@ class TeamFilterDropdown extends React.PureComponent<Props, State> {
             const selectedTeams = getSelectedTeams(selectedTeamIds, this.props.teams);
             const savedSelectedTeams = selectedTeams.sort((a, b) => a.display_name.localeCompare(b.display_name));
             this.setState({searchTerm, savedSelectedTeams, searchResults: [], searchTotal: 0, page: 0});
-            return;
+        } else {
+            this.setState({loading: true, searchTerm, searchResults: [], searchTotal: 0, page: 0});
         }
-        this.setState({loading: true, searchTerm, searchResults: [], searchTotal: 0, page: 0});
+
         this.searchTeamsDebounced(0, searchTerm);
     }
 


### PR DESCRIPTION
[MM-27490] Fix issue with search and reloading teams (#6070)

Summary:
Fixes an issue where infinite scroll would not load more users if you loaded all the teams into the state, performed a search and then cleared the search once more. Also fixes an issue where clearing the search would sometimes result in the first letter reappearing due to the debounced function not being called with an empty string if search term was empty. Also fixes searchTeams definition to match redux master, with searchOpts as second parameter instead of page and per_page (this change will have to be ignored when cherry-picked for 5.27)

Ticket Link:
https://mattermost.atlassian.net/browse/MM-27490

(cherry picked from commit 4a282eb43188f380a56280084d44404ca4ad8eb0)


[MM-27490]: https://mattermost.atlassian.net/browse/MM-27490