### PR TITLE
MM-T263 Mark as Unread post menu option should not be available for a…

### DIFF
--- a/e2e/cypress/integration/mark_as_unread/archive_channel_mark_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/archive_channel_mark_as_unread_spec.js
@@ -1,0 +1,87 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @mark_as_unread
+
+import {notShowCursor, markAsUnreadShouldBeAbsent} from './helpers';
+
+describe('Channels', () => {
+    let testUser;
+    let testChannel;
+    let testTeam;
+    let post1;
+
+    before(() => {
+        // # Enable Experimental View Archived Channels
+        cy.apiUpdateConfig({
+            TeamSettings: {
+                ExperimentalViewArchivedChannels: true,
+            },
+        });
+
+        cy.apiInitSetup().then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+
+            // # Create a test channel
+            cy.apiCreateChannel(team.id, 'channel-test', 'Channel').then((channelRes) => {
+                testChannel = channelRes.body;
+
+                // # Create second user and add him to the team
+                cy.apiCreateUser().then(({user: user2}) => {
+                    const otherUser = user2;
+
+                    cy.apiAddUserToTeam(team.id, otherUser.id).then(() => {
+                        cy.apiAddUserToChannel(testChannel.id, otherUser.id);
+
+                        // Another user creates posts in the channel since you can't mark your own posts unread currently
+                        cy.postMessageAs({sender: otherUser, message: 'post1', channelId: testChannel.id}).then((p1) => {
+                            post1 = p1;
+                        });
+                    });
+                });
+            });
+        });
+    });
+    it.only('MM-T263 Mark as Unread post menu option should not be available for archived channels', () => {
+        // # Login as testUser
+        cy.apiLogin(testUser);
+
+        // # Visit the channel
+        cy.visit(`/${testTeam.name}/channels/${testChannel.name}`);
+
+        // # Click channel header to open channel menu
+        cy.get('#channelHeaderTitle').should('contain', testChannel.display_name).click();
+
+        // * Verify that the menu is opened
+        cy.get('.Menu__content').should('be.visible').within(() => {
+            // # Archive the channel
+            cy.findByText('Archive Channel').should('be.visible').click();
+        });
+
+        // * Verify that the delete/archive channel modal is opened
+        cy.get('#deleteChannelModal').should('be.visible').within(() => {
+            // # Confirm archive
+            cy.findByText('Archive').should('be.visible').click();
+        });
+
+        // * Verify the "Mark as Unread" option is absent in post menu
+        markAsUnreadShouldBeAbsent(post1.id);
+
+        // * Hover on the post with holding alt should show cursor
+        cy.get(`#post_${post1.id}`).trigger('mouseover').type('{alt}', {release: false}).should(notShowCursor);
+
+        // # Mouse click on the post holding alt
+        cy.get(`#post_${post1.id}`).type('{alt}', {release: false}).click();
+
+        // * Verify the post is not marked as unread
+        cy.get('.NotificationSeparator').should('not.exist');
+    });
+});
+

--- a/e2e/cypress/integration/mark_as_unread/archive_channel_mark_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/archive_channel_mark_as_unread_spec.js
@@ -49,7 +49,7 @@ describe('Channels', () => {
             });
         });
     });
-    it.only('MM-T263 Mark as Unread post menu option should not be available for archived channels', () => {
+    it('MM-T263 Mark as Unread post menu option should not be available for archived channels', () => {
         // # Login as testUser
         cy.apiLogin(testUser);
 

--- a/e2e/cypress/integration/mark_as_unread/helpers.js
+++ b/e2e/cypress/integration/mark_as_unread/helpers.js
@@ -31,6 +31,16 @@ export function markAsUnreadByPostIdFromMenu(postId, prefix = 'post', location =
         });
 }
 
+export function markAsUnreadShouldBeAbsent(postId, prefix = 'post', location = 'CENTER') {
+    cy.get(`#${prefix}_${postId}`).trigger('mouseover');
+    cy.clickPostDotMenu(postId, location);
+    cy.get('.dropdown-menu').
+        should('be.visible').
+        within(() => {
+            cy.findByText('Mark as Unread').should('not.be.visible');
+        });
+}
+
 export function markAsUnreadFromMenu(post, prefix = 'post', location = 'CENTER') {
     cy.get(`#${prefix}_${post.id}`).trigger('mouseover');
     cy.clickPostDotMenu(post.id, location);
@@ -61,4 +71,9 @@ export function verifyPostNextToNewMessageSeparator(message) {
 export function showCursor(items) {
     cy.expect(items).to.have.length(1);
     expect(items[0].className).to.match(/cursor--pointer/);
+}
+
+export function notShowCursor(items) {
+    cy.expect(items).to.have.length(1);
+    expect(items[0].className).to.not.match(/cursor--pointer/);
 }

--- a/e2e/cypress/integration/mark_as_unread/mark_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/mark_as_unread_spec.js
@@ -10,7 +10,7 @@
 // Stage: @prod
 // Group: @mark_as_unread
 
-import {verifyPostNextToNewMessageSeparator, switchToChannel, beRead, beUnread, showCursor, markAsUnreadFromMenu} from './helpers';
+import {verifyPostNextToNewMessageSeparator, switchToChannel, beRead, beUnread, showCursor, notShowCursor, markAsUnreadFromMenu} from './helpers';
 
 describe('Mark as Unread', () => {
     let testUser;
@@ -196,11 +196,6 @@ describe('Mark as Unread', () => {
     });
 
     it('Should show cursor pointer when holding down alt', () => {
-        const notShowCursor = (items) => {
-            cy.expect(items).to.have.length(1);
-            expect(items[0].className).to.not.match(/cursor--pointer/);
-        };
-
         const componentIds = [
             `#post_${post1.id}`,
             `#post_${post2.id}`,


### PR DESCRIPTION
…rchived channels

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
MM-T263 Mark as Unread post menu option should not be available for archived channels


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[MM-T263](https://automation-test-cases.vercel.app/test/MM-T263)
