### PR TITLE
MM-27432 Hide notification badge on channel when menu is open

### DIFF
--- a/components/sidebar/sidebar_category/__snapshots__/sidebar_category.test.tsx.snap
+++ b/components/sidebar/sidebar_category/__snapshots__/sidebar_category.test.tsx.snap
@@ -53,7 +53,8 @@ exports[`components/sidebar/sidebar_category should match snapshot 2`] = `
           "user_id": "",
         }
       }
-      onToggle={[Function]}
+      isMenuOpen={false}
+      onToggleMenu={[Function]}
     />
   </div>
   <div
@@ -132,7 +133,8 @@ exports[`components/sidebar/sidebar_category should match snapshot when collapse
           "user_id": "",
         }
       }
-      onToggle={[Function]}
+      isMenuOpen={false}
+      onToggleMenu={[Function]}
     />
   </div>
   <div
@@ -218,7 +220,8 @@ exports[`components/sidebar/sidebar_category should match snapshot when isNewCat
           "user_id": "",
         }
       }
-      onToggle={[Function]}
+      isMenuOpen={false}
+      onToggleMenu={[Function]}
     />
   </div>
   <div

--- a/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -248,7 +248,8 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
             categoryMenu = (
                 <SidebarCategoryMenu
                     category={category}
-                    onToggle={this.handleMenuToggle}
+                    isMenuOpen={this.state.isMenuOpen}
+                    onToggleMenu={this.handleMenuToggle}
                 />
             );
         } else if (category.type === CategoryTypes.DIRECT_MESSAGES) {
@@ -320,7 +321,8 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
             categoryMenu = (
                 <SidebarCategoryMenu
                     category={category}
-                    onToggle={this.handleMenuToggle}
+                    isMenuOpen={this.state.isMenuOpen}
+                    onToggleMenu={this.handleMenuToggle}
                 />
             );
         }

--- a/components/sidebar/sidebar_category/sidebar_category_menu/__snapshots__/sidebar_category_menu.test.tsx.snap
+++ b/components/sidebar/sidebar_category/sidebar_category_menu/__snapshots__/sidebar_category_menu.test.tsx.snap
@@ -6,7 +6,8 @@ exports[`components/sidebar/sidebar_category/sidebar_category_menu should match 
     ariaLabel="Category Menu"
     buttonAriaLabel="Category Menu"
     id="SidebarCategoryMenu-category1"
-    onToggle={[Function]}
+    isMenuOpen={false}
+    onToggleMenu={[Function]}
     tooltipText="Category options"
   >
     <MenuGroup>
@@ -57,7 +58,8 @@ exports[`components/sidebar/sidebar_category/sidebar_category_menu should match 
     ariaLabel="Category Menu"
     buttonAriaLabel="Category Menu"
     id="SidebarCategoryMenu-category1"
-    onToggle={[Function]}
+    isMenuOpen={false}
+    onToggleMenu={[Function]}
     tooltipText="Category options"
   >
     <MenuGroup />

--- a/components/sidebar/sidebar_category/sidebar_category_menu/sidebar_category_menu.test.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category_menu/sidebar_category_menu.test.tsx
@@ -23,7 +23,8 @@ describe('components/sidebar/sidebar_category/sidebar_category_menu', () => {
         },
         currentTeamId: 'team1',
         isMuted: false,
-        onToggle: jest.fn(),
+        isMenuOpen: false,
+        onToggleMenu: jest.fn(),
         actions: {
             openModal: jest.fn(),
         },

--- a/components/sidebar/sidebar_category/sidebar_category_menu/sidebar_category_menu.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category_menu/sidebar_category_menu.tsx
@@ -17,7 +17,8 @@ import {ModalIdentifiers} from 'utils/constants';
 type Props = {
     currentTeamId: string;
     category: ChannelCategory;
-    onToggle: (open: boolean) => void;
+    isMenuOpen: boolean;
+    onToggleMenu: (open: boolean) => void;
     intl: IntlShape;
     actions: {
         openModal: (modalData: {modalId: string; dialogType: any; dialogProps?: any}) => Promise<{
@@ -68,9 +69,12 @@ class SidebarCategoryMenu extends React.PureComponent<Props, State> {
         trackEvent('ui', 'ui_sidebar_category_menu_createCategory');
     }
 
-    onToggle = (open: boolean) => {
-        this.props.onToggle(open);
-        trackEvent('ui', 'ui_sidebar_category_menu_opened');
+    onToggleMenu = (open: boolean) => {
+        this.props.onToggleMenu(open);
+
+        if (open) {
+            trackEvent('ui', 'ui_sidebar_category_menu_opened');
+        }
     }
 
     renderDropdownItems = () => {
@@ -126,8 +130,9 @@ class SidebarCategoryMenu extends React.PureComponent<Props, State> {
                     id={`SidebarCategoryMenu-${category.id}`}
                     ariaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_category_menu.dropdownAriaLabel', defaultMessage: 'Category Menu'})}
                     buttonAriaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_category_menu.dropdownAriaLabel', defaultMessage: 'Category Menu'})}
+                    isMenuOpen={this.props.isMenuOpen}
+                    onToggleMenu={this.onToggleMenu}
                     tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_category_menu.editCategory', defaultMessage: 'Category options'})}
-                    onToggle={this.onToggle}
                 >
                     {this.renderDropdownItems()}
                 </SidebarMenu>

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/__snapshots__/sidebar_channel_link.test.tsx.snap
@@ -68,7 +68,9 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
     }
     channelLink="http://a.fake.link"
     isCollapsed={false}
+    isMenuOpen={false}
     isUnread={false}
+    onToggleMenu={[Function]}
   />
 </Link>
 `;
@@ -141,7 +143,9 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
     }
     channelLink="http://a.fake.link"
     isCollapsed={false}
+    isMenuOpen={false}
     isUnread={false}
+    onToggleMenu={[Function]}
   />
 </Link>
 `;
@@ -238,7 +242,9 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
     }
     channelLink="http://a.fake.link"
     isCollapsed={false}
+    isMenuOpen={false}
     isUnread={false}
+    onToggleMenu={[Function]}
   />
 </Link>
 `;
@@ -311,7 +317,9 @@ exports[`components/sidebar/sidebar_channel/sidebar_channel_link should match sn
     }
     channelLink="http://a.fake.link"
     isCollapsed={false}
+    isMenuOpen={false}
     isUnread={true}
+    onToggleMenu={[Function]}
   />
 </Link>
 `;

--- a/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_link/sidebar_channel_link.tsx
@@ -55,6 +55,7 @@ type Props = {
 };
 
 type State = {
+    isMenuOpen: boolean;
     showTooltip: boolean;
 };
 
@@ -69,6 +70,7 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
         this.gmItemRef = React.createRef();
 
         this.state = {
+            isMenuOpen: false,
             showTooltip: false,
         };
     }
@@ -125,6 +127,10 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
     trackChannelSelectedEvent = () => {
         mark('SidebarLink#click');
         trackEvent('ui', 'ui_channel_selected_v2');
+    }
+
+    handleMenuToggle = (isMenuOpen: boolean) => {
+        this.setState({isMenuOpen});
     }
 
     /**
@@ -187,15 +193,24 @@ export default class SidebarChannelLink extends React.PureComponent<Props, State
                     isCollapsed={this.props.isCollapsed}
                     closeHandler={this.props.closeHandler}
                     channelLink={link}
+                    isMenuOpen={this.state.isMenuOpen}
+                    onToggleMenu={this.handleMenuToggle}
                 />
             </React.Fragment>
         );
 
         // NOTE: class added to temporarily support the desktop app's at-mention DOM scraping of the old sidebar
-        const oldUnreadClass = this.showChannelAsUnread() ? 'unread-title' : '';
+        const className = classNames([
+            'SidebarLink',
+            {
+                menuOpen: this.state.isMenuOpen,
+                muted: isMuted,
+                'unread-title': this.showChannelAsUnread(),
+            },
+        ]);
         let element = (
             <Link
-                className={classNames(['SidebarLink', {muted: isMuted}, oldUnreadClass])}
+                className={className}
                 id={`sidebarItem_${channel.name}`}
                 aria-label={this.getAriaLabel()}
                 to={link}

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/__snapshots__/sidebar_channel_menu.test.tsx.snap
@@ -1,746 +1,739 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match snapshot and contain correct buttons 1`] = `
-<Fragment>
-  <Connect(SidebarMenu)
-    ariaLabel="Channel Menu"
-    buttonAriaLabel="Channel Menu"
-    id="SidebarChannelMenu-channel_id"
-    onToggle={[Function]}
-    refCallback={[Function]}
-    tabIndex={0}
-    tooltipText="Channel options"
-  >
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-star-outline"
-          />
-        }
-        id="favorite-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Favorite"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-bell-outline"
-          />
-        }
-        id="mute-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Mute Channel"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <SubMenuItem
-        direction="right"
-        icon={
-          <i
-            className="icon-folder-move-outline"
-          />
-        }
-        id="moveTo-channel_id"
-        openUp={false}
-        show={true}
-        subMenu={
-          Array [
-            Object {
-              "id": "SidebarChannelMenu-moveToDivider",
-              "text": <li
-                className="MenuGroup menu-divider"
-              />,
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "icon": <i
-                className="icon-folder-move-outline"
-              />,
-              "id": "moveToNewCategory-channel_id",
-              "text": "New Category",
-            },
-          ]
-        }
-        text="Move to"
-        xOffset={0}
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-link-variant"
-          />
-        }
-        id="copyLink-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Copy Link"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-account-outline"
-          />
-        }
-        id="addMembers-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Add Members"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-close"
-          />
-        }
-        id="leave-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Leave Channel"
-      />
-    </MenuGroup>
-  </Connect(SidebarMenu)>
-</Fragment>
+<Connect(SidebarMenu)
+  ariaLabel="Channel Menu"
+  buttonAriaLabel="Channel Menu"
+  id="SidebarChannelMenu-channel_id"
+  isMenuOpen={false}
+  onToggleMenu={[Function]}
+  refCallback={[Function]}
+  tabIndex={0}
+  tooltipText="Channel options"
+>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-star-outline"
+        />
+      }
+      id="favorite-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Favorite"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-bell-outline"
+        />
+      }
+      id="mute-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Mute Channel"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <SubMenuItem
+      direction="right"
+      icon={
+        <i
+          className="icon-folder-move-outline"
+        />
+      }
+      id="moveTo-channel_id"
+      openUp={false}
+      show={true}
+      subMenu={
+        Array [
+          Object {
+            "id": "SidebarChannelMenu-moveToDivider",
+            "text": <li
+              className="MenuGroup menu-divider"
+            />,
+          },
+          Object {
+            "action": [Function],
+            "direction": "right",
+            "icon": <i
+              className="icon-folder-move-outline"
+            />,
+            "id": "moveToNewCategory-channel_id",
+            "text": "New Category",
+          },
+        ]
+      }
+      text="Move to"
+      xOffset={0}
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-link-variant"
+        />
+      }
+      id="copyLink-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Copy Link"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-account-outline"
+        />
+      }
+      id="addMembers-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Add Members"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-close"
+        />
+      }
+      id="leave-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Leave Channel"
+    />
+  </MenuGroup>
+</Connect(SidebarMenu)>
 `;
 
 exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match snapshot when channel is DM 1`] = `
-<Fragment>
-  <Connect(SidebarMenu)
-    ariaLabel="Channel Menu"
-    buttonAriaLabel="Channel Menu"
-    id="SidebarChannelMenu-channel_id"
-    onToggle={[Function]}
-    refCallback={[Function]}
-    tabIndex={0}
-    tooltipText="Channel options"
-  >
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-star-outline"
-          />
-        }
-        id="favorite-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Favorite"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-bell-outline"
-          />
-        }
-        id="mute-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Mute Conversation"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <SubMenuItem
-        direction="right"
-        icon={
-          <i
-            className="icon-folder-move-outline"
-          />
-        }
-        id="moveTo-channel_id"
-        openUp={false}
-        show={true}
-        subMenu={
-          Array [
-            Object {
-              "id": "SidebarChannelMenu-moveToDivider",
-              "text": <li
-                className="MenuGroup menu-divider"
-              />,
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "icon": <i
-                className="icon-folder-move-outline"
-              />,
-              "id": "moveToNewCategory-channel_id",
-              "text": "New Category",
-            },
-          ]
-        }
-        text="Move to"
-        xOffset={0}
-      />
-    </MenuGroup>
-    <MenuGroup />
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-close"
-          />
-        }
-        id="leave-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Close Conversation"
-      />
-    </MenuGroup>
-  </Connect(SidebarMenu)>
-</Fragment>
+<Connect(SidebarMenu)
+  ariaLabel="Channel Menu"
+  buttonAriaLabel="Channel Menu"
+  id="SidebarChannelMenu-channel_id"
+  isMenuOpen={false}
+  onToggleMenu={[Function]}
+  refCallback={[Function]}
+  tabIndex={0}
+  tooltipText="Channel options"
+>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-star-outline"
+        />
+      }
+      id="favorite-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Favorite"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-bell-outline"
+        />
+      }
+      id="mute-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Mute Conversation"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <SubMenuItem
+      direction="right"
+      icon={
+        <i
+          className="icon-folder-move-outline"
+        />
+      }
+      id="moveTo-channel_id"
+      openUp={false}
+      show={true}
+      subMenu={
+        Array [
+          Object {
+            "id": "SidebarChannelMenu-moveToDivider",
+            "text": <li
+              className="MenuGroup menu-divider"
+            />,
+          },
+          Object {
+            "action": [Function],
+            "direction": "right",
+            "icon": <i
+              className="icon-folder-move-outline"
+            />,
+            "id": "moveToNewCategory-channel_id",
+            "text": "New Category",
+          },
+        ]
+      }
+      text="Move to"
+      xOffset={0}
+    />
+  </MenuGroup>
+  <MenuGroup />
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-close"
+        />
+      }
+      id="leave-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Close Conversation"
+    />
+  </MenuGroup>
+</Connect(SidebarMenu)>
 `;
 
 exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match snapshot when channel is Town Square 1`] = `
-<Fragment>
-  <Connect(SidebarMenu)
-    ariaLabel="Channel Menu"
-    buttonAriaLabel="Channel Menu"
-    id="SidebarChannelMenu-channel_id"
-    onToggle={[Function]}
-    refCallback={[Function]}
-    tabIndex={0}
-    tooltipText="Channel options"
-  >
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-star-outline"
-          />
-        }
-        id="favorite-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Favorite"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-bell-outline"
-          />
-        }
-        id="mute-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Mute Channel"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <SubMenuItem
-        direction="right"
-        icon={
-          <i
-            className="icon-folder-move-outline"
-          />
-        }
-        id="moveTo-channel_id"
-        openUp={false}
-        show={true}
-        subMenu={
-          Array [
-            Object {
-              "id": "SidebarChannelMenu-moveToDivider",
-              "text": <li
-                className="MenuGroup menu-divider"
-              />,
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "icon": <i
-                className="icon-folder-move-outline"
-              />,
-              "id": "moveToNewCategory-channel_id",
-              "text": "New Category",
-            },
-          ]
-        }
-        text="Move to"
-        xOffset={0}
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-link-variant"
-          />
-        }
-        id="copyLink-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Copy Link"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-account-outline"
-          />
-        }
-        id="addMembers-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Add Members"
-      />
-    </MenuGroup>
-  </Connect(SidebarMenu)>
-</Fragment>
+<Connect(SidebarMenu)
+  ariaLabel="Channel Menu"
+  buttonAriaLabel="Channel Menu"
+  id="SidebarChannelMenu-channel_id"
+  isMenuOpen={false}
+  onToggleMenu={[Function]}
+  refCallback={[Function]}
+  tabIndex={0}
+  tooltipText="Channel options"
+>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-star-outline"
+        />
+      }
+      id="favorite-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Favorite"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-bell-outline"
+        />
+      }
+      id="mute-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Mute Channel"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <SubMenuItem
+      direction="right"
+      icon={
+        <i
+          className="icon-folder-move-outline"
+        />
+      }
+      id="moveTo-channel_id"
+      openUp={false}
+      show={true}
+      subMenu={
+        Array [
+          Object {
+            "id": "SidebarChannelMenu-moveToDivider",
+            "text": <li
+              className="MenuGroup menu-divider"
+            />,
+          },
+          Object {
+            "action": [Function],
+            "direction": "right",
+            "icon": <i
+              className="icon-folder-move-outline"
+            />,
+            "id": "moveToNewCategory-channel_id",
+            "text": "New Category",
+          },
+        ]
+      }
+      text="Move to"
+      xOffset={0}
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-link-variant"
+        />
+      }
+      id="copyLink-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Copy Link"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-account-outline"
+        />
+      }
+      id="addMembers-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Add Members"
+    />
+  </MenuGroup>
+</Connect(SidebarMenu)>
 `;
 
 exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match snapshot when channel is favorite 1`] = `
-<Fragment>
-  <Connect(SidebarMenu)
-    ariaLabel="Channel Menu"
-    buttonAriaLabel="Channel Menu"
-    id="SidebarChannelMenu-channel_id"
-    onToggle={[Function]}
-    refCallback={[Function]}
-    tabIndex={0}
-    tooltipText="Channel options"
-  >
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-star"
-          />
-        }
-        id="unfavorite-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Unfavorite"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-bell-outline"
-          />
-        }
-        id="mute-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Mute Channel"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <SubMenuItem
-        direction="right"
-        icon={
-          <i
-            className="icon-folder-move-outline"
-          />
-        }
-        id="moveTo-channel_id"
-        openUp={false}
-        show={true}
-        subMenu={
-          Array [
-            Object {
-              "id": "SidebarChannelMenu-moveToDivider",
-              "text": <li
-                className="MenuGroup menu-divider"
-              />,
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "icon": <i
-                className="icon-folder-move-outline"
-              />,
-              "id": "moveToNewCategory-channel_id",
-              "text": "New Category",
-            },
-          ]
-        }
-        text="Move to"
-        xOffset={0}
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-link-variant"
-          />
-        }
-        id="copyLink-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Copy Link"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-account-outline"
-          />
-        }
-        id="addMembers-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Add Members"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-close"
-          />
-        }
-        id="leave-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Leave Channel"
-      />
-    </MenuGroup>
-  </Connect(SidebarMenu)>
-</Fragment>
+<Connect(SidebarMenu)
+  ariaLabel="Channel Menu"
+  buttonAriaLabel="Channel Menu"
+  id="SidebarChannelMenu-channel_id"
+  isMenuOpen={false}
+  onToggleMenu={[Function]}
+  refCallback={[Function]}
+  tabIndex={0}
+  tooltipText="Channel options"
+>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-star"
+        />
+      }
+      id="unfavorite-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Unfavorite"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-bell-outline"
+        />
+      }
+      id="mute-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Mute Channel"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <SubMenuItem
+      direction="right"
+      icon={
+        <i
+          className="icon-folder-move-outline"
+        />
+      }
+      id="moveTo-channel_id"
+      openUp={false}
+      show={true}
+      subMenu={
+        Array [
+          Object {
+            "id": "SidebarChannelMenu-moveToDivider",
+            "text": <li
+              className="MenuGroup menu-divider"
+            />,
+          },
+          Object {
+            "action": [Function],
+            "direction": "right",
+            "icon": <i
+              className="icon-folder-move-outline"
+            />,
+            "id": "moveToNewCategory-channel_id",
+            "text": "New Category",
+          },
+        ]
+      }
+      text="Move to"
+      xOffset={0}
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-link-variant"
+        />
+      }
+      id="copyLink-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Copy Link"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-account-outline"
+        />
+      }
+      id="addMembers-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Add Members"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-close"
+        />
+      }
+      id="leave-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Leave Channel"
+    />
+  </MenuGroup>
+</Connect(SidebarMenu)>
 `;
 
 exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match snapshot when channel is muted 1`] = `
-<Fragment>
-  <Connect(SidebarMenu)
-    ariaLabel="Channel Menu"
-    buttonAriaLabel="Channel Menu"
-    id="SidebarChannelMenu-channel_id"
-    onToggle={[Function]}
-    refCallback={[Function]}
-    tabIndex={0}
-    tooltipText="Channel options"
-  >
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-star-outline"
-          />
-        }
-        id="favorite-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Favorite"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-bell-off-outline"
-          />
-        }
-        id="unmute-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Unmute Channel"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <SubMenuItem
-        direction="right"
-        icon={
-          <i
-            className="icon-folder-move-outline"
-          />
-        }
-        id="moveTo-channel_id"
-        openUp={false}
-        show={true}
-        subMenu={
-          Array [
-            Object {
-              "id": "SidebarChannelMenu-moveToDivider",
-              "text": <li
-                className="MenuGroup menu-divider"
-              />,
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "icon": <i
-                className="icon-folder-move-outline"
-              />,
-              "id": "moveToNewCategory-channel_id",
-              "text": "New Category",
-            },
-          ]
-        }
-        text="Move to"
-        xOffset={0}
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-link-variant"
-          />
-        }
-        id="copyLink-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Copy Link"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-account-outline"
-          />
-        }
-        id="addMembers-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Add Members"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-close"
-          />
-        }
-        id="leave-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Leave Channel"
-      />
-    </MenuGroup>
-  </Connect(SidebarMenu)>
-</Fragment>
+<Connect(SidebarMenu)
+  ariaLabel="Channel Menu"
+  buttonAriaLabel="Channel Menu"
+  id="SidebarChannelMenu-channel_id"
+  isMenuOpen={false}
+  onToggleMenu={[Function]}
+  refCallback={[Function]}
+  tabIndex={0}
+  tooltipText="Channel options"
+>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-star-outline"
+        />
+      }
+      id="favorite-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Favorite"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-bell-off-outline"
+        />
+      }
+      id="unmute-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Unmute Channel"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <SubMenuItem
+      direction="right"
+      icon={
+        <i
+          className="icon-folder-move-outline"
+        />
+      }
+      id="moveTo-channel_id"
+      openUp={false}
+      show={true}
+      subMenu={
+        Array [
+          Object {
+            "id": "SidebarChannelMenu-moveToDivider",
+            "text": <li
+              className="MenuGroup menu-divider"
+            />,
+          },
+          Object {
+            "action": [Function],
+            "direction": "right",
+            "icon": <i
+              className="icon-folder-move-outline"
+            />,
+            "id": "moveToNewCategory-channel_id",
+            "text": "New Category",
+          },
+        ]
+      }
+      text="Move to"
+      xOffset={0}
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-link-variant"
+        />
+      }
+      id="copyLink-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Copy Link"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-account-outline"
+        />
+      }
+      id="addMembers-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Add Members"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-close"
+        />
+      }
+      id="leave-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Leave Channel"
+    />
+  </MenuGroup>
+</Connect(SidebarMenu)>
 `;
 
 exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match snapshot when channel is private 1`] = `
-<Fragment>
-  <Connect(SidebarMenu)
-    ariaLabel="Channel Menu"
-    buttonAriaLabel="Channel Menu"
-    id="SidebarChannelMenu-channel_id"
-    onToggle={[Function]}
-    refCallback={[Function]}
-    tabIndex={0}
-    tooltipText="Channel options"
-  >
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-star-outline"
-          />
-        }
-        id="favorite-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Favorite"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-bell-outline"
-          />
-        }
-        id="mute-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Mute Channel"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <SubMenuItem
-        direction="right"
-        icon={
-          <i
-            className="icon-folder-move-outline"
-          />
-        }
-        id="moveTo-channel_id"
-        openUp={false}
-        show={true}
-        subMenu={
-          Array [
-            Object {
-              "id": "SidebarChannelMenu-moveToDivider",
-              "text": <li
-                className="MenuGroup menu-divider"
-              />,
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "icon": <i
-                className="icon-folder-move-outline"
-              />,
-              "id": "moveToNewCategory-channel_id",
-              "text": "New Category",
-            },
-          ]
-        }
-        text="Move to"
-        xOffset={0}
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-link-variant"
-          />
-        }
-        id="copyLink-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Copy Link"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-account-outline"
-          />
-        }
-        id="addMembers-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Add Members"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-close"
-          />
-        }
-        id="leave-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Leave Channel"
-      />
-    </MenuGroup>
-  </Connect(SidebarMenu)>
-</Fragment>
+<Connect(SidebarMenu)
+  ariaLabel="Channel Menu"
+  buttonAriaLabel="Channel Menu"
+  id="SidebarChannelMenu-channel_id"
+  isMenuOpen={false}
+  onToggleMenu={[Function]}
+  refCallback={[Function]}
+  tabIndex={0}
+  tooltipText="Channel options"
+>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-star-outline"
+        />
+      }
+      id="favorite-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Favorite"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-bell-outline"
+        />
+      }
+      id="mute-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Mute Channel"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <SubMenuItem
+      direction="right"
+      icon={
+        <i
+          className="icon-folder-move-outline"
+        />
+      }
+      id="moveTo-channel_id"
+      openUp={false}
+      show={true}
+      subMenu={
+        Array [
+          Object {
+            "id": "SidebarChannelMenu-moveToDivider",
+            "text": <li
+              className="MenuGroup menu-divider"
+            />,
+          },
+          Object {
+            "action": [Function],
+            "direction": "right",
+            "icon": <i
+              className="icon-folder-move-outline"
+            />,
+            "id": "moveToNewCategory-channel_id",
+            "text": "New Category",
+          },
+        ]
+      }
+      text="Move to"
+      xOffset={0}
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-link-variant"
+        />
+      }
+      id="copyLink-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Copy Link"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-account-outline"
+        />
+      }
+      id="addMembers-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Add Members"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-close"
+        />
+      }
+      id="leave-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Leave Channel"
+    />
+  </MenuGroup>
+</Connect(SidebarMenu)>
 `;
 
 exports[`components/sidebar/sidebar_channel/sidebar_channel_menu should match snapshot when channel is unread 1`] = `
-<Fragment>
-  <Connect(SidebarMenu)
-    ariaLabel="Channel Menu"
-    buttonAriaLabel="Channel Menu"
-    id="SidebarChannelMenu-channel_id"
-    onToggle={[Function]}
-    refCallback={[Function]}
-    tabIndex={0}
-    tooltipText="Channel options"
-  >
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-mark-as-unread"
-          />
-        }
-        id="markAsRead-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Mark as Read"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-star-outline"
-          />
-        }
-        id="favorite-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Favorite"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-bell-outline"
-          />
-        }
-        id="mute-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Mute Channel"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <SubMenuItem
-        direction="right"
-        icon={
-          <i
-            className="icon-folder-move-outline"
-          />
-        }
-        id="moveTo-channel_id"
-        openUp={false}
-        show={true}
-        subMenu={
-          Array [
-            Object {
-              "id": "SidebarChannelMenu-moveToDivider",
-              "text": <li
-                className="MenuGroup menu-divider"
-              />,
-            },
-            Object {
-              "action": [Function],
-              "direction": "right",
-              "icon": <i
-                className="icon-folder-move-outline"
-              />,
-              "id": "moveToNewCategory-channel_id",
-              "text": "New Category",
-            },
-          ]
-        }
-        text="Move to"
-        xOffset={0}
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-link-variant"
-          />
-        }
-        id="copyLink-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Copy Link"
-      />
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-account-outline"
-          />
-        }
-        id="addMembers-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Add Members"
-      />
-    </MenuGroup>
-    <MenuGroup>
-      <MenuItemAction
-        icon={
-          <i
-            className="icon-close"
-          />
-        }
-        id="leave-channel_id"
-        onClick={[Function]}
-        show={true}
-        text="Leave Channel"
-      />
-    </MenuGroup>
-  </Connect(SidebarMenu)>
-</Fragment>
+<Connect(SidebarMenu)
+  ariaLabel="Channel Menu"
+  buttonAriaLabel="Channel Menu"
+  id="SidebarChannelMenu-channel_id"
+  isMenuOpen={false}
+  onToggleMenu={[Function]}
+  refCallback={[Function]}
+  tabIndex={0}
+  tooltipText="Channel options"
+>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-mark-as-unread"
+        />
+      }
+      id="markAsRead-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Mark as Read"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-star-outline"
+        />
+      }
+      id="favorite-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Favorite"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-bell-outline"
+        />
+      }
+      id="mute-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Mute Channel"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <SubMenuItem
+      direction="right"
+      icon={
+        <i
+          className="icon-folder-move-outline"
+        />
+      }
+      id="moveTo-channel_id"
+      openUp={false}
+      show={true}
+      subMenu={
+        Array [
+          Object {
+            "id": "SidebarChannelMenu-moveToDivider",
+            "text": <li
+              className="MenuGroup menu-divider"
+            />,
+          },
+          Object {
+            "action": [Function],
+            "direction": "right",
+            "icon": <i
+              className="icon-folder-move-outline"
+            />,
+            "id": "moveToNewCategory-channel_id",
+            "text": "New Category",
+          },
+        ]
+      }
+      text="Move to"
+      xOffset={0}
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-link-variant"
+        />
+      }
+      id="copyLink-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Copy Link"
+    />
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-account-outline"
+        />
+      }
+      id="addMembers-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Add Members"
+    />
+  </MenuGroup>
+  <MenuGroup>
+    <MenuItemAction
+      icon={
+        <i
+          className="icon-close"
+        />
+      }
+      id="leave-channel_id"
+      onClick={[Function]}
+      show={true}
+      text="Leave Channel"
+    />
+  </MenuGroup>
+</Connect(SidebarMenu)>
 `;

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.test.tsx
@@ -61,6 +61,8 @@ describe('components/sidebar/sidebar_channel/sidebar_channel_menu', () => {
         managePrivateChannelMembers: true,
         closeHandler: jest.fn(),
         isCollapsed: false,
+        isMenuOpen: false,
+        onToggleMenu: jest.fn(),
         actions: {
             markChannelAsRead: jest.fn(),
             favoriteChannel: jest.fn(),

--- a/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
+++ b/components/sidebar/sidebar_channel/sidebar_channel_menu/sidebar_channel_menu.tsx
@@ -32,6 +32,8 @@ type Props = {
     managePrivateChannelMembers: boolean;
     closeHandler?: (callback: () => void) => void;
     isCollapsed: boolean;
+    isMenuOpen: boolean;
+    onToggleMenu: (isMenuOpen: boolean) => void;
     actions: {
         markChannelAsRead: (channelId: string) => void;
         favoriteChannel: (channelId: string) => void;
@@ -320,29 +322,35 @@ export class SidebarChannelMenu extends React.PureComponent<Props, State> {
         }
     }
 
-    onToggle = (open: boolean) => {
+    onToggleMenu = (open: boolean) => {
+        this.props.onToggleMenu(open);
+
         if (open) {
             trackEvent('ui', 'ui_sidebar_channel_menu_opened');
         }
     }
 
     render() {
-        const {intl, channel} = this.props;
+        const {
+            channel,
+            intl,
+            isCollapsed,
+            isMenuOpen,
+        } = this.props;
 
         return (
-            <React.Fragment>
-                <SidebarMenu
-                    refCallback={this.refCallback}
-                    id={`SidebarChannelMenu-${channel.id}`}
-                    ariaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
-                    buttonAriaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
-                    tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Channel options'})}
-                    onToggle={this.onToggle}
-                    tabIndex={this.props.isCollapsed ? -1 : 0}
-                >
-                    {this.renderDropdownItems()}
-                </SidebarMenu>
-            </React.Fragment>
+            <SidebarMenu
+                refCallback={this.refCallback}
+                id={`SidebarChannelMenu-${channel.id}`}
+                ariaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
+                buttonAriaLabel={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.dropdownAriaLabel', defaultMessage: 'Channel Menu'})}
+                isMenuOpen={isMenuOpen}
+                onToggleMenu={this.onToggleMenu}
+                tooltipText={intl.formatMessage({id: 'sidebar_left.sidebar_channel_menu.editChannel', defaultMessage: 'Channel options'})}
+                tabIndex={isCollapsed ? -1 : 0}
+            >
+                {this.renderDropdownItems()}
+            </SidebarMenu>
         );
     }
 }

--- a/components/sidebar/sidebar_menu/__snapshots__/sidebar_menu.test.tsx.snap
+++ b/components/sidebar/sidebar_menu/__snapshots__/sidebar_menu.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`components/sidebar/sidebar_menu should match snapshot 1`] = `
 <MenuWrapper
   animationComponent={[Function]}
   className="SidebarMenu"
-  onToggle={[Function]}
+  onToggle={[MockFunction]}
   stopPropagationOnToggle={true}
 >
   <button

--- a/components/sidebar/sidebar_menu/sidebar_menu.test.tsx
+++ b/components/sidebar/sidebar_menu/sidebar_menu.test.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 
 import SidebarMenu from './sidebar_menu';
 
@@ -15,7 +15,8 @@ describe('components/sidebar/sidebar_menu', () => {
         ariaLabel: 'some other aria label',
         draggingState: {},
         refCallback: jest.fn(),
-        onToggle: jest.fn(),
+        isMenuOpen: false,
+        onToggleMenu: jest.fn(),
     };
 
     test('should match snapshot', () => {
@@ -27,44 +28,39 @@ describe('components/sidebar/sidebar_menu', () => {
     });
 
     test('should set menu state and set position when menu is toggled', () => {
+        const props = {
+            ...baseProps,
+            children: [
+                <li
+                    key='test-item'
+                    id='test-item'
+                />,
+            ],
+        };
+
         const wrapper = shallow<SidebarMenu>(
-            <SidebarMenu {...baseProps}/>,
+            <SidebarMenu {...props}/>,
         );
 
         wrapper.instance().setMenuPosition = jest.fn();
 
-        wrapper.instance().handleMenuToggle(true);
-        expect(wrapper.instance().state.isMenuOpen).toEqual(true);
+        wrapper.setProps({isMenuOpen: true});
         expect(wrapper.instance().setMenuPosition).toHaveBeenCalled();
 
-        wrapper.instance().handleMenuToggle(false);
-        expect(wrapper.instance().state.isMenuOpen).toEqual(false);
+        wrapper.setProps({isMenuOpen: false});
         expect(wrapper.instance().setMenuPosition).toHaveBeenCalled();
     });
 
     test('should call external onToggle when menu is toggled', () => {
-        const wrapper = shallow<SidebarMenu>(
+        const wrapper = mount<SidebarMenu>(
             <SidebarMenu {...baseProps}/>,
         );
 
-        wrapper.instance().handleMenuToggle(true);
-        expect(baseProps.onToggle).toHaveBeenCalledWith(true);
+        wrapper.find('button').simulate('click');
+        expect(baseProps.onToggleMenu).toHaveBeenCalledWith(true);
 
-        wrapper.instance().handleMenuToggle(false);
-        expect(baseProps.onToggle).toHaveBeenCalledWith(false);
-    });
-
-    test('should not call external onToggle when menu state hasnt changed', () => {
-        const wrapper = shallow<SidebarMenu>(
-            <SidebarMenu {...baseProps}/>,
-        );
-
-        wrapper.instance().handleMenuToggle(true);
-        expect(baseProps.onToggle).toHaveBeenCalledWith(true);
-        expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
-
-        wrapper.instance().handleMenuToggle(true);
-        expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
+        wrapper.find('button').simulate('click');
+        expect(baseProps.onToggleMenu).toHaveBeenCalledWith(false);
     });
 
     test('should set the openUp and width properties correctly based on window and ref information', () => {

--- a/components/sidebar/sidebar_menu/sidebar_menu.tsx
+++ b/components/sidebar/sidebar_menu/sidebar_menu.tsx
@@ -20,13 +20,13 @@ type Props = {
     buttonAriaLabel: string;
     ariaLabel: string;
     refCallback?: (ref: SidebarMenu) => void;
-    onToggle?: (open: boolean) => void;
+    isMenuOpen: boolean;
+    onToggleMenu: (open: boolean) => void;
     draggingState: DraggingState;
     tabIndex?: number;
 };
 
 type State = {
-    isMenuOpen: boolean;
     openUp: boolean;
     width: number;
 };
@@ -40,7 +40,6 @@ export default class SidebarMenu extends React.PureComponent<Props, State> {
         super(props);
 
         this.state = {
-            isMenuOpen: false,
             openUp: false,
             width: 0,
         };
@@ -52,6 +51,11 @@ export default class SidebarMenu extends React.PureComponent<Props, State> {
     componentDidUpdate(prevProps: Props) {
         if (prevProps.draggingState.state !== this.props.draggingState.state && this.props.draggingState.state === DraggingStates.CAPTURE) {
             this.closeMenu();
+        }
+
+        if (this.props.isMenuOpen && !prevProps.isMenuOpen) {
+            this.setMenuPosition();
+            this.disableScrollbar();
         }
     }
 
@@ -75,14 +79,15 @@ export default class SidebarMenu extends React.PureComponent<Props, State> {
         if (this.menuWrapperRef.current) {
             this.menuWrapperRef.current.close();
         }
-        this.handleMenuToggle(false);
+
+        this.props.onToggleMenu(false);
     }
 
     // Set the z-index on the sidebar scrollbar while a menu is open so that it doesn't float on top of menus
     disableScrollbar = () => {
         const scrollbars: NodeListOf<HTMLElement> = document.querySelectorAll('#SidebarContainer .SidebarNavContainer .scrollbar--view');
         if (scrollbars && scrollbars[0]) {
-            scrollbars[0].style.zIndex = this.state.isMenuOpen ? '3' : 'unset';
+            scrollbars[0].style.zIndex = this.props.isMenuOpen ? '3' : 'unset';
         }
     }
 
@@ -111,27 +116,22 @@ export default class SidebarMenu extends React.PureComponent<Props, State> {
     }
 
     setMenuPosition = () => {
-        if (this.state.isMenuOpen && this.menuButtonRef.current && this.menuRef) {
+        if (this.menuButtonRef.current && this.menuRef) {
             const menuRef = this.menuRef.node.current?.parentElement as HTMLDivElement;
             const openUpOffset = this.state.openUp ? -this.menuButtonRef.current.getBoundingClientRect().height : 0;
             menuRef.style.top = `${window.scrollY + this.menuButtonRef.current.getBoundingClientRect().top + this.menuButtonRef.current.clientHeight + openUpOffset}px`;
         }
     }
 
-    handleMenuToggle = (isMenuOpen: boolean) => {
-        if (this.state.isMenuOpen !== isMenuOpen) {
-            this.setState({isMenuOpen}, () => {
-                if (this.props.onToggle) {
-                    this.props.onToggle(isMenuOpen);
-                }
-                this.setMenuPosition();
-                this.disableScrollbar();
-            });
-        }
-    }
-
     render() {
-        const {tooltipText, buttonAriaLabel, ariaLabel, id, children} = this.props;
+        const {
+            ariaLabel,
+            buttonAriaLabel,
+            children,
+            isMenuOpen,
+            tooltipText,
+            id,
+        } = this.props;
 
         const tooltip = (
             <Tooltip
@@ -146,7 +146,7 @@ export default class SidebarMenu extends React.PureComponent<Props, State> {
             <i className='icon-dots-vertical'/>
         );
 
-        if (!this.state.isMenuOpen) {
+        if (!isMenuOpen) {
             buttonContents = (
                 <OverlayTrigger
                     delayShow={500}
@@ -162,9 +162,9 @@ export default class SidebarMenu extends React.PureComponent<Props, State> {
             <MenuWrapper
                 ref={this.menuWrapperRef}
                 className={classNames('SidebarMenu', {
-                    menuOpen: this.state.isMenuOpen,
+                    menuOpen: isMenuOpen,
                 })}
-                onToggle={this.handleMenuToggle}
+                onToggle={this.props.onToggleMenu}
                 stopPropagationOnToggle={true}
             >
                 <button

--- a/components/sidebar/sidebar_menu/sidebar_menu.tsx
+++ b/components/sidebar/sidebar_menu/sidebar_menu.tsx
@@ -15,7 +15,7 @@ const MENU_BOTTOM_MARGIN = 80;
 
 type Props = {
     id: string;
-    children: JSX.Element | null;
+    children?: React.ReactNode;
     tooltipText: string;
     buttonAriaLabel: string;
     ariaLabel: string;

--- a/components/widgets/menu/menu.tsx
+++ b/components/widgets/menu/menu.tsx
@@ -22,7 +22,7 @@ type Props = {
     openUp?: boolean;
     id?: string;
     ariaLabel: string;
-    customStyles?: object;
+    customStyles?: React.CSSProperties;
 }
 
 export default class Menu extends React.PureComponent<Props> {

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -919,7 +919,8 @@
         outline-style: none;
     }
 
-    .SidebarChannel .SidebarLink:hover {
+    .SidebarChannel .SidebarLink:hover,
+    .SidebarChannel .SidebarLink.menuOpen {
         background: rgba(255, 255, 255, 0.08);
 
         padding-right: 5px;


### PR DESCRIPTION
To hide the badge when the menu is open, the parent of the menu (`SidebarChannelLink`) has to know whether or not the menu is open. Since `SidebarCategory` already knows whether or not its menu is open, I made it so that the parent of a `SidebarMenu` is always the one in charge of its open state which requires passing around some props and `onToggleMenu` listeners.

The other major change because of this is moving the calculation of the menu position to happen in `componentDidUpdate` after the menu is opened instead of happening as a side effect of the `setState` caused by clicking the toggle button.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27432