### PR TITLE
Cypress test for MM-T1429 Verify unread toast appears after repeated …

### DIFF
--- a/e2e/cypress/integration/mark_as_unread/toast_appears_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/toast_appears_unread_spec.js
@@ -1,0 +1,107 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {markAsUnreadFromPost, switchToChannel} from './helpers';
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @mark_as_unread
+
+describe('Verify unread toast appears after repeated manual marking post as unread', () => {
+    let otherUser;
+    let firstPost;
+    let secondPost;
+
+    let offTopicChannel;
+    let townSquareChannel;
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            otherUser = user;
+
+            cy.apiGetChannelByName(team.name, 'town-square').then((res) => {
+                townSquareChannel = res.body;
+
+                cy.apiGetChannelByName(team.name, 'off-topic').then((res2) => {
+                    offTopicChannel = res2.body;
+
+                    // Toast only seems to appear after first visiting the channel
+                    // So we need to visit the channel then navigate away
+                    cy.visit(`/${team.name}/channels/town-square`);
+                    switchToChannel(offTopicChannel);
+
+                    cy.postMessageAs({
+                        sender: otherUser,
+                        message: 'First message',
+                        channelId: townSquareChannel.id,
+                    }).then((post) => {
+                        firstPost = post;
+
+                        cy.postMessageAs({
+                            sender: otherUser,
+                            message: 'Second message',
+                            channelId: townSquareChannel.id,
+                        }).then((post2) => {
+                            secondPost = post2;
+
+                            // Add posts so that scroll is available
+                            Cypress._.times(30, (index) => {
+                                cy.postMessageAs({
+                                    sender: otherUser,
+                                    message: index.toString(),
+                                    channelId: townSquareChannel.id,
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+    it('MM-T1429 Toast when navigating to channel with unread messages and after repeated marking as unread', () => {
+        // # Switch to town square channel that has unread messages
+        switchToChannel(townSquareChannel);
+
+        // * Check that the toast is visible
+        cy.get('div.toast').should('be.visible');
+
+        // # Scroll to the bottom of the posts
+        cy.get('.post-list__dynamic').scrollTo('bottom');
+
+        // * Check that the toast is not visible
+        cy.get('div.toast').should('be.not.visible');
+
+        // # Mark the first post as unread
+        markAsUnreadFromPost(firstPost);
+
+        // * Check that the toast is now visible
+        cy.get('div.toast').should('be.visible');
+
+        // # Scroll to the bottom of the posts
+        cy.get('.post-list__dynamic').scrollTo('bottom');
+
+        // * Check that the toast is not visible
+        cy.get('div.toast').should('be.not.visible');
+
+        // # Mark the second post as unread
+        markAsUnreadFromPost(secondPost);
+
+        // * Check that the toast is now visible
+        cy.get('div.toast').should('be.visible');
+
+        // # Switch channels
+        switchToChannel(offTopicChannel);
+
+        // * Check that the toast is not visible
+        cy.get('div.toast').should('be.not.visible');
+
+        // # Switch channels back
+        switchToChannel(townSquareChannel);
+
+        // * Check that the toast is now visible
+        cy.get('div.toast').should('be.visible');
+    });
+});


### PR DESCRIPTION
Cypress test to verify unread toast appears as expected after repeated manual marking of posts as unread

#### Summary

Verify unread toast appears as expected after repeated manual marking of posts as unread
    1. Open a channel with unread messages
    2. Scroll to the bottom of the page, this should clear the toast
    3. Scroll back up and mark a message as unread
    4. Then scroll back down to clear the toast
    5. Scroll back up and mark another message as unread (observe the toast shows back up. If you switch channel and come back to the channel the toast will be present)

#### Ticket Link
https://automation-test-cases.vercel.app/test/MM-T1429
Found in google sheets document for Hackfest 2020: Test Automation: https://docs.google.com/spreadsheets/d/1gn12iXQbswP1fAcp4alEIfJdFuB1DlFu9CzW89zm598/edit#gid=1650809354