### PR TITLE
[MM-27568] Revert "[MM-25534] - Fix preloading of icons for really slow connections"

### DIFF
--- a/root.html
+++ b/root.html
@@ -17,9 +17,6 @@
     <link rel="icon" type="image/png" href="/static/images/favicon/favicon-32x32.png" sizes="32x32">
     <link rel="icon" type="image/png" href="/static/images/favicon/favicon-96x96.png" sizes="96x96">
 
-    <link rel="preload" as="font" href="/fonts/mattermosticons/mattermosticons.eot?16343536" type="font" crossorigin="anonymous">
-    <link rel="preload" as="font" href="/fonts/mattermosticons/mattermosticons.eot?16343536#iefix" type="font/embedded-opentype" crossorigin="anonymous">
-
     <!-- CSS Should always go first -->
     <link rel='stylesheet' class='code_theme'>
     <style>


### PR DESCRIPTION
Reverts mattermost/mattermost-webapp#5654

there are no fonts in webapp referenced `mattermosticons` and we cannot reference them as `/fonts/filename` because our build folder has a different structure and we use `/static` for referencing files. 
If we go ahead with preloading i think we should be fixing the path, filename(i believe we call them compass-icons) and also use `font/woff2` format.

The log error is because of type attribute in the link preload tag. I couldn't find the right type for eot files as compared to `font/woff2` but We could always skip the `type` tag as it is used for browsers to understand which fonts to download but here, in this case, modern browsers don't support eot anymore as far as I know

reverting the said PR as it was an improvement which is not working as intended and we can work on the solution for later releases