### PR TITLE
MM-27818 Add e2e for GMs and DMs > Reply in existing GM

### DIFF
--- a/e2e/cypress/integration/messaging/message_reply_gm_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_gm_spec.js
@@ -11,7 +11,7 @@
 
 import {getRandomId} from '../../utils';
 
-describe('MM-T470 Reply in existing GM', () => {
+describe('Reply in existing GM', () => {
     let testUser;
     let otherUser1;
     let otherUser2;

--- a/e2e/cypress/integration/messaging/message_reply_gm_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_gm_spec.js
@@ -45,7 +45,6 @@ describe('Reply in existing GM', () => {
 
         // # Create a group channel for 3 users
         cy.apiCreateGroupChannel(userGroupIds).then((response) => {
-            let replyId;
             const gmChannel = response.body;
 
             // # Go to the group message channel
@@ -69,9 +68,7 @@ describe('Reply in existing GM', () => {
 
                 // # Post a reply
                 cy.postMessageReplyInRHS(replyMessage);
-                cy.getLastPostId().then((postId) => {
-                    replyId = postId;
-
+                cy.getLastPostId().then((replyId) => {
                     // * Verify that the reply is in the RHS with matching text
                     cy.get(`#rhsPostMessageText_${replyId}`).should('be.visible').and('have.text', replyMessage);
 

--- a/e2e/cypress/integration/messaging/message_reply_gm_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_gm_spec.js
@@ -1,0 +1,94 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @messaging
+
+import {getRandomId} from '../../utils';
+
+describe('MM-T470 Reply in existing GM', () => {
+    let testUser;
+    let otherUser1;
+    let otherUser2;
+    let testTeam;
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            cy.apiCreateUser({prefix: 'otherA'}).then(({user: newUser}) => {
+                otherUser1 = newUser;
+
+                cy.apiAddUserToTeam(team.id, newUser.id);
+            });
+
+            cy.apiCreateUser({prefix: 'otherB'}).then(({user: newUser}) => {
+                otherUser2 = newUser;
+
+                cy.apiAddUserToTeam(team.id, newUser.id);
+            });
+
+            // # Login as test user and go to town square
+            cy.apiLogin(testUser);
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
+    });
+
+    it('MM-T470 Reply in existing GM', () => {
+        const userGroupIds = [testUser.id, otherUser1.id, otherUser2.id];
+
+        // # Create a group channel for 3 users
+        cy.apiCreateGroupChannel(userGroupIds).then((response) => {
+            let replyId;
+            const gmChannel = response.body;
+
+            // # Go to the group message channel
+            cy.visit(`/${testTeam.name}/channels/${gmChannel.name}`);
+            const rootPostMessage = `this is test message from user: ${otherUser1.id}`;
+
+            // # Post Message as otherUser1
+            cy.postMessageAs({sender: otherUser1, message: rootPostMessage, channelId: gmChannel.id}).then((post) => {
+                const rootPostId = post.id;
+                const rootPostMessageId = `#rhsPostMessageText_${rootPostId}`;
+
+                // # Click comment icon to open RHS
+                cy.clickPostCommentIcon(rootPostId);
+
+                // * Check that the RHS is open
+                cy.get('#rhsContainer').should('be.visible');
+
+                // * Verify that the original message is in the RHS
+                cy.get('#rhsContainer').find(rootPostMessageId).should('have.text', `${rootPostMessage}`);
+                const replyMessage = `A reply ${getRandomId()}`;
+
+                // # Post a reply
+                cy.postMessageReplyInRHS(replyMessage);
+                cy.getLastPostId().then((postId) => {
+                    replyId = postId;
+
+                    // * Verify that the reply is in the RHS with matching text
+                    cy.get(`#rhsPostMessageText_${replyId}`).should('be.visible').and('have.text', replyMessage);
+
+                    // * Verify that the reply is in the center channel with matching text
+                    cy.get(`#postMessageText_${replyId}`).should('be.visible').should('have.text', replyMessage);
+
+                    // # Login as otherUser
+                    cy.apiLogin(otherUser1);
+
+                    // # Go to the group message channel
+                    cy.visit(`/${testTeam.name}/channels/${gmChannel.name}`);
+
+                    // * Verify that the reply is in the center channel with matching text
+                    cy.get(`#postMessageText_${replyId}`).should('be.visible').should('have.text', replyMessage);
+                });
+            });
+        });
+    });
+});

--- a/e2e/cypress/integration/messaging/message_reply_gm_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_gm_spec.js
@@ -53,7 +53,7 @@ describe('MM-T470 Reply in existing GM', () => {
             cy.visit(`/${testTeam.name}/channels/${gmChannel.name}`);
             const rootPostMessage = `this is test message from user: ${otherUser1.id}`;
 
-            // # Post Message as otherUser1
+            // # Post message as otherUser1
             cy.postMessageAs({sender: otherUser1, message: rootPostMessage, channelId: gmChannel.id}).then((post) => {
                 const rootPostId = post.id;
                 const rootPostMessageId = `#rhsPostMessageText_${rootPostId}`;

--- a/e2e/cypress/integration/messaging/message_reply_gm_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_gm_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 import {getRandomId} from '../../utils';


### PR DESCRIPTION
#### Summary
Add e2e tests for Reply in existing GM

Test steps
1. User1 in a GM posts a message
2. User2 in that GM clicks the Reply arrow on the message
3. User2 sees RHS / reply screen open with parent post at the top and a reply box
4. User2 types a reply and clicks / taps to send or presses Enter

Expected:
User1 and User2 see reply posted:
- Center channel at the bottom
- User2 in RHS also

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27818
