### PR TITLE
MM-27825: Add Cypress Test Case for MM-T495

### DIFF
--- a/e2e/cypress/integration/notifications/desktop_notifications_spec.js
+++ b/e2e/cypress/integration/notifications/desktop_notifications_spec.js
@@ -36,19 +36,19 @@ describe('Desktop notifications', () => {
             cy.apiCreateDirectChannel([testUser.id, user.id]).then((res) => {
                 const channel = res.body;
 
-                // # Ensure notifications are set up to fire a desktop notification if you receive a DM
+                // Ensure notifications are set up to fire a desktop notification if you receive a DM
                 cy.apiPatchUser(user.id, {notify_props: {...user.notify_props, desktop: 'all'}});
 
                 // Visit the MM webapp with the notification API stubbed.
                 stubNotificationAs('withNotification', `/${testTeam.name}/channels/town-square`, 'granted');
 
-                // # Post the following: /dnd
+                // Make sure user is marked as online.
                 cy.get('#post_textbox').clear().type('/online{enter}');
 
-                // # Have another user send you a DM
+                // Have another user send you a DM to trigger a Desktop Notification.
                 cy.postMessageAs({sender: testUser, message: MESSAGES.TINY, channelId: channel.id});
 
-                // * Desktop notification is not received
+                // Desktop notification should be received.
                 cy.wait(TIMEOUTS.HALF_SEC);
                 cy.get('@withNotification').should('have.been.calledOnce');
             });

--- a/e2e/cypress/integration/notifications/desktop_notifications_spec.js
+++ b/e2e/cypress/integration/notifications/desktop_notifications_spec.js
@@ -78,6 +78,10 @@ describe('Desktop notifications', () => {
                 // * Desktop notification is not received
                 cy.wait(TIMEOUTS.HALF_SEC);
                 cy.get('@withoutNotification').should('not.have.been.called');
+
+                // * Verify that the status indicator next to your name has changed to "Do Not Disturb"
+                cy.get('button[aria-label="set status"] > span > svg').
+                    should('have.attr', 'aria-label', 'Do Not Disturb Icon');
             });
         });
     });

--- a/e2e/cypress/integration/notifications/desktop_notifications_spec.js
+++ b/e2e/cypress/integration/notifications/desktop_notifications_spec.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @notifications
+
+import * as MESSAGES from '../../fixtures/messages';
+import * as TIMEOUTS from '../../fixtures/timeouts';
+import {getAdminAccount} from '../../support/env';
+
+describe('Desktop notifications', () => {
+    let testTeam, testUser;
+
+    before(() => {
+        // Initialise a user.
+        cy.apiInitSetup({}).then(({team, user}) => {
+            testUser = user;
+            testTeam = team;
+        });
+    });
+
+    it('MM-T495 Desktop Notifications - Can set to DND and no notification fires on DM', () => {
+        cy.apiCreateUser({}).then(({user}) => {
+            cy.apiAddUserToTeam(testTeam.id, user.id);
+            cy.apiLogin(user);
+
+            cy.apiCreateDirectChannel([testUser.id, user.id]).then((res) => {
+                const channel = res.body;
+
+                // Mock window.Notification to check if desktop notifications are triggered.
+                cy.visit(`/${testTeam.name}/channels/town-square`, {
+                    onBeforeLoad (win) {
+                        cy.stub(win.Notification, 'permission', 'granted')
+                        cy.stub(win, 'Notification').as('Notification')
+                    },
+                });
+
+                // # Ensure notifications are set up to fire a desktop notification if you receive a DM
+                cy.apiPatchUser(user.id, {notify_props: {...user.notify_props, desktop: 'all'}});
+
+                // # Post the following: /dnd
+                cy.get('#post_textbox').clear().type('/dnd{enter}');
+
+                // # Have another user send you a DM
+                cy.postMessageAs({sender: testUser, message: MESSAGES.TINY, channelId: channel.id});
+
+                // * Desktop notification is not received
+                cy.wait(TIMEOUTS.HALF_SEC);
+                cy.get('@Notification').should('not.have.been.called');
+            });
+        });
+    });
+});

--- a/e2e/cypress/integration/notifications/desktop_notifications_spec.js
+++ b/e2e/cypress/integration/notifications/desktop_notifications_spec.js
@@ -11,10 +11,10 @@
 
 import * as MESSAGES from '../../fixtures/messages';
 import * as TIMEOUTS from '../../fixtures/timeouts';
-import {getAdminAccount} from '../../support/env';
 
 describe('Desktop notifications', () => {
-    let testTeam, testUser;
+    let testTeam;
+    let testUser;
 
     before(() => {
         // Initialise a user.
@@ -34,9 +34,9 @@ describe('Desktop notifications', () => {
 
                 // Mock window.Notification to check if desktop notifications are triggered.
                 cy.visit(`/${testTeam.name}/channels/town-square`, {
-                    onBeforeLoad (win) {
-                        cy.stub(win.Notification, 'permission', 'granted')
-                        cy.stub(win, 'Notification').as('Notification')
+                    onBeforeLoad(win) {
+                        cy.stub(win.Notification, 'permission', 'granted');
+                        cy.stub(win, 'Notification').as('Notification');
                     },
                 });
 

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -41,10 +41,6 @@ module.exports = (on, config) => {
     });
 
     on('before:browser:launch', (browser = {}, launchOptions) => {
-        if (browser.name === 'chrome') {
-            launchOptions.args.push('--disable-notifications');
-        }
-
         if (browser.name === 'chrome' && !config.chromeWebSecurity) {
             launchOptions.args.push('--disable-features=CrossSiteDocumentBlockingIfIsolating,CrossSiteDocumentBlockingAlways,IsolateOrigins,site-per-process');
             launchOptions.args.push('--load-extension=cypress/extensions/Ignore-X-Frame-headers');


### PR DESCRIPTION
#### Summary
Adds cypress test for MM-T495 Desktop Notifications - Can set to DND and no notification fires on DM

*Note*: I have a small concern that the mocking of granting permissions for notifications is not actually working but I can't seem to figure this out. Can anyone who hasn't already manually granted the permissions please take a look and check if it works as intended.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27825