### PR TITLE
Cypress/E2E: Fix manage members spec

### DIFF
--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/channel_mentions_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/channel_mentions_spec.js
@@ -12,8 +12,8 @@
 import {checkboxesTitleToIdMap} from './constants';
 
 import {
-    disableChannelModeratedPermission,
-    enableChannelModeratedPermission,
+    disablePermission,
+    enablePermission,
     postChannelMentionsAndVerifySystemMessageExist,
     postChannelMentionsAndVerifySystemMessageNotExist,
     saveConfigForChannel,
@@ -50,7 +50,7 @@ describe('MM-23102 - Channel Moderation - Channel Mentions', () => {
     it('Channel Mentions option for Guests', () => {
         // # Uncheck the Channel Mentions option for Guests and save
         visitChannelConfigPage(testChannel);
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_GUESTS);
+        disablePermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_GUESTS);
         saveConfigForChannel();
 
         visitChannel(guestUser, testChannel, testTeam);
@@ -62,7 +62,7 @@ describe('MM-23102 - Channel Moderation - Channel Mentions', () => {
         visitChannelConfigPage(testChannel);
 
         // # check the channel mentions option for guests and save
-        enableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_GUESTS);
+        enablePermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_GUESTS);
         saveConfigForChannel();
 
         visitChannel(guestUser, testChannel, testTeam);
@@ -76,7 +76,7 @@ describe('MM-23102 - Channel Moderation - Channel Mentions', () => {
         visitChannelConfigPage(testChannel);
 
         // # Uncheck the channel mentions option for guests and save
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
         saveConfigForChannel();
 
         visitChannel(regularUser, testChannel, testTeam);
@@ -88,7 +88,7 @@ describe('MM-23102 - Channel Moderation - Channel Mentions', () => {
         visitChannelConfigPage(testChannel);
 
         // # check the channel mentions option for guests and save
-        enableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        enablePermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
         saveConfigForChannel();
 
         visitChannel(regularUser, testChannel, testTeam);
@@ -102,7 +102,7 @@ describe('MM-23102 - Channel Moderation - Channel Mentions', () => {
         visitChannelConfigPage(testChannel);
 
         // # Uncheck the create posts option for guests
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
+        disablePermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
 
         // * Option to allow Channel Mentions for Guests should also be disabled when Create Post option is disabled.
         // * A message Guests can not use channel mentions without the ability to create posts should be displayed.
@@ -111,8 +111,8 @@ describe('MM-23102 - Channel Moderation - Channel Mentions', () => {
         cy.findByTestId(checkboxesTitleToIdMap.CHANNEL_MENTIONS_GUESTS).should('be.disabled');
 
         // # check the create posts option for guests and uncheck for members
-        enableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
+        enablePermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
+        disablePermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
 
         // * Option to allow Channel Mentions for Members should also be disabled when Create Post option is disabled.
         // * A message Members can not use channel mentions without the ability to create posts should be displayed.
@@ -121,7 +121,7 @@ describe('MM-23102 - Channel Moderation - Channel Mentions', () => {
         cy.findByTestId(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS).should('be.disabled');
 
         // # Uncheck the create posts option for guests
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
+        disablePermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
 
         // * Ensure that channel mentions for members and guests is disabled
         // * Ensure message Guests & Members can not use channel mentions without the ability to create posts
@@ -133,7 +133,7 @@ describe('MM-23102 - Channel Moderation - Channel Mentions', () => {
 
     it('Message when user without channel mention permission uses special channel mentions', () => {
         visitChannelConfigPage(testChannel);
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
         saveConfigForChannel();
 
         visitChannel(regularUser, testChannel, testTeam);
@@ -152,7 +152,7 @@ describe('MM-23102 - Channel Moderation - Channel Mentions', () => {
     it('Confirm sending notifications while using special channel mentions', () => {
         // # Visit Channel page and Search for the channel.
         visitChannelConfigPage(testChannel);
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
         saveConfigForChannel();
 
         // # Set @channel and @all confirmation dialog to true

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/constants.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/constants.js
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 
 export const checkboxesTitleToIdMap = {
+    ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS: 'all_users-public_channel-manage_public_channel_members_and_read_groups-checkbox',
+    ALL_USERS_MANAGE_PRIVATE_CHANNEL_MEMBERS: 'all_users-private_channel-manage_private_channel_members_and_read_groups-checkbox',
     CREATE_POSTS_GUESTS: 'create_post-guests',
     CREATE_POSTS_MEMBERS: 'create_post-members',
     POST_REACTIONS_GUESTS: 'create_reactions-guests',

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/create_posts_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/create_posts_spec.js
@@ -13,8 +13,8 @@
 import {checkboxesTitleToIdMap} from './constants';
 
 import {
-    disableChannelModeratedPermission,
-    enableChannelModeratedPermission,
+    disablePermission,
+    enablePermission,
     saveConfigForChannel,
     visitChannel,
     visitChannelConfigPage,
@@ -50,7 +50,7 @@ describe('MM-23102 - Channel Moderation - Create Posts', () => {
         visitChannelConfigPage(testChannel);
 
         // # Uncheck the Create Posts option for Guests and Save
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
+        disablePermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
         saveConfigForChannel();
 
         // # Login as a Guest user and visit the same channel
@@ -63,7 +63,7 @@ describe('MM-23102 - Channel Moderation - Create Posts', () => {
 
         // # As a system admin, check the option to allow Create Posts for Guests and save
         visitChannelConfigPage(testChannel);
-        enableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
+        enablePermission(checkboxesTitleToIdMap.CREATE_POSTS_GUESTS);
         saveConfigForChannel();
 
         // # Login as a Guest user and visit the same channel
@@ -81,7 +81,7 @@ describe('MM-23102 - Channel Moderation - Create Posts', () => {
         visitChannelConfigPage(testChannel);
 
         // # Uncheck the Create Posts option for Members and Save
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
         saveConfigForChannel();
 
         // # Login as a Guest user and visit test channel
@@ -94,7 +94,7 @@ describe('MM-23102 - Channel Moderation - Create Posts', () => {
 
         // # As a system admin, check the option to allow Create Posts for Members and save
         visitChannelConfigPage(testChannel);
-        enableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
+        enablePermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
         saveConfigForChannel();
 
         // # Login as a Member user and visit the same channel

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
@@ -107,7 +107,6 @@ export const enablePermission = (permission) => {
         const classAttribute = el[0].getAttribute('class');
         if (!classAttribute.includes('checked')) {
             el[0].click();
-            cy.wait(TIMEOUTS.HALF_SEC);
             return false;
         }
         return true;

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/helpers.js
@@ -17,13 +17,17 @@ export const visitChannelConfigPage = (channel) => {
     cy.wait(TIMEOUTS.ONE_SEC);
 };
 
-// # Disable a specific channel moderated permission in the channel moderation widget
-export const disableChannelModeratedPermission = (permission) => {
-    cy.findByTestId(permission).scrollIntoView().should('be.visible').then((btn) => {
-        if (btn.hasClass('checked')) {
-            btn.click();
+// # Disable a permission
+export const disablePermission = (permission) => {
+    cy.waitUntil(() => cy.findByTestId(permission).scrollIntoView().should('be.visible').then((el) => {
+        const classAttribute = el[0].getAttribute('class');
+        if (classAttribute.includes('checked') || classAttribute.includes('intermediate')) {
+            el[0].click();
+            return false;
         }
-    });
+        return true;
+    }));
+    cy.findByTestId(permission).should('not.have.class', 'checked');
 };
 
 // # Saves channel config and navigates back to the channel config page if specified
@@ -97,13 +101,18 @@ export const postChannelMentionsAndVerifySystemMessageExist = (channelName) => {
     });
 };
 
-// # Enable a specific channel moderated permission in the channel moderation widget
-export const enableChannelModeratedPermission = (permission) => {
-    cy.findByTestId(permission).scrollIntoView().should('be.visible').then((btn) => {
-        if (!btn.hasClass('checked')) {
-            btn.click();
+// # Enable a permission
+export const enablePermission = (permission) => {
+    cy.waitUntil(() => cy.findByTestId(permission).scrollIntoView().should('be.visible').then((el) => {
+        const classAttribute = el[0].getAttribute('class');
+        if (!classAttribute.includes('checked')) {
+            el[0].click();
+            cy.wait(TIMEOUTS.HALF_SEC);
+            return false;
         }
-    });
+        return true;
+    }));
+    cy.findByTestId(permission).should('have.class', 'checked');
 };
 
 // # Checks to see if we did not get a system message warning after using @all/@here/@channel
@@ -166,6 +175,7 @@ export const saveConfigForScheme = (waitUntilConfigSaved = true, clickConfirmati
 export const goToSystemScheme = () => {
     cy.apiAdminLogin();
     cy.visit('/admin_console/user_management/permissions/system_scheme');
+    cy.get('.admin-console__header', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and('have.text', 'System Scheme');
 };
 
 // # Goes to the permissions page and creates a new team override scheme with schemeName

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/higher_scoped_scheme_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/higher_scoped_scheme_spec.js
@@ -16,8 +16,8 @@ import {checkboxesTitleToIdMap} from './constants';
 import {
     deleteOrEditTeamScheme,
     demoteToChannelOrTeamMember,
-    disableChannelModeratedPermission,
-    enableChannelModeratedPermission,
+    disablePermission,
+    enablePermission,
     enableDisableAllChannelModeratedPermissionsViaAPI,
     goToPermissionsAndCreateTeamOverrideScheme,
     goToSystemScheme,
@@ -62,16 +62,15 @@ describe('MM-23102 - Channel Moderation - Higher Scoped Scheme', () => {
     it('Effect of changing System Schemes on a Channel for which Channel Moderation Settings was modified', () => {
         // # Visit Channel page and Search for the channel.
         visitChannelConfigPage(testChannel);
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
 
         // # check the channel mentions option for guests and save
-        enableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        enablePermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
         saveConfigForChannel();
 
         goToSystemScheme();
-        cy.get('#all_users-public_channel-manage_public_channel_members').scrollIntoView().should('be.visible').click();
-        cy.findByTestId('all_users-public_channel-manage_public_channel_members-checkbox').should('not.have.class', 'checked');
+        disablePermission(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS);
         saveConfigForScheme();
 
         // * Ensure manage members for members is disabled
@@ -94,7 +93,7 @@ describe('MM-23102 - Channel Moderation - Higher Scoped Scheme', () => {
             const randomChannel = response.body;
 
             goToSystemScheme();
-            cy.get('#all_users-public_channel-manage_public_channel_members').click();
+            cy.findByTestId(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS).click();
             saveConfigForScheme();
 
             // # Visit Channel page and Search for the channel.
@@ -120,7 +119,7 @@ describe('MM-23102 - Channel Moderation - Higher Scoped Scheme', () => {
 
             goToPermissionsAndCreateTeamOverrideScheme(randomChannel.name, testTeam);
             deleteOrEditTeamScheme(randomChannel.name, 'edit');
-            cy.get('#all_users-public_channel-manage_public_channel_members').click();
+            cy.findByTestId(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS).click();
             saveConfigForScheme(false);
 
             // # Visit Channel page and Search for the channel.
@@ -145,17 +144,17 @@ describe('MM-23102 - Channel Moderation - Higher Scoped Scheme', () => {
 
         // # Reset system scheme to default and create a new channel to ensure that this channels moderation settings have never been modified
         visitChannelConfigPage(testChannel);
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.CHANNEL_MENTIONS_MEMBERS);
         saveConfigForChannel();
 
         visitChannelConfigPage(testChannel);
-        enableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        enablePermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
         saveConfigForChannel();
 
         goToPermissionsAndCreateTeamOverrideScheme(teamOverrideSchemeName, testTeam);
         deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
-        cy.get('#all_users-public_channel-manage_public_channel_members').click();
+        cy.findByTestId(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS).click();
         saveConfigForScheme(false);
 
         // # Visit Channel page and Search for the channel.
@@ -178,12 +177,11 @@ describe('MM-23102 - Channel Moderation - Higher Scoped Scheme', () => {
         const teamOverrideSchemeName = testChannel.name + getRandomId();
 
         // # Create a new team override scheme and remove manage public channel members
+        // * Ensure that manage private channel members is checked
         goToPermissionsAndCreateTeamOverrideScheme(teamOverrideSchemeName, testTeam);
         deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
-        cy.get('#all_users-public_channel-manage_public_channel_members').click();
-
-        // * Ensure that manage private channel members is checked
-        cy.get('#all_users-private_channel-manage_private_channel_members').children().should('have.class', 'checked');
+        cy.findByTestId(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS).click();
+        cy.findByTestId(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PRIVATE_CHANNEL_MEMBERS).should('be.visible').and('have.class', 'checked');
         saveConfigForScheme(false);
 
         // # Visit Channel page and Search for the channel.
@@ -219,8 +217,8 @@ describe('MM-23102 - Channel Moderation - Higher Scoped Scheme', () => {
         // * Ensure that manage public channel members is checked
         goToPermissionsAndCreateTeamOverrideScheme(teamOverrideSchemeName, testTeam);
         deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
-        cy.get('#all_users-private_channel-manage_private_channel_members').click();
-        cy.get('#all_users-public_channel-manage_public_channel_members').children().should('have.class', 'checked');
+        cy.findByTestId(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PRIVATE_CHANNEL_MEMBERS).click();
+        cy.findByTestId(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS).should('be.visible').and('have.class', 'checked');
         saveConfigForScheme(false);
 
         // # Visit Channel page and Search for the channel.
@@ -257,7 +255,7 @@ describe('MM-23102 - Channel Moderation - Higher Scoped Scheme', () => {
         cy.findByTestId('post_textbox').should('not.be.disabled');
 
         visitChannelConfigPage(testChannel);
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.CREATE_POSTS_MEMBERS);
 
         saveConfigForChannel();
 

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/manage_members_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/manage_members_spec.js
@@ -17,8 +17,8 @@ import {checkboxesTitleToIdMap} from './constants';
 
 import {
     deleteOrEditTeamScheme,
-    disableChannelModeratedPermission,
-    enableChannelModeratedPermission,
+    disablePermission,
+    enablePermission,
     goToPermissionsAndCreateTeamOverrideScheme,
     goToSystemScheme,
     saveConfigForChannel,
@@ -75,7 +75,7 @@ describe('MM-23102 - Channel Moderation - Manage Members', () => {
     it('Manage Members option for Members', () => {
         // # Visit test channel page and turn off the Manage members for Members and then save
         visitChannelConfigPage(testChannel);
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
         saveConfigForChannel();
 
         visitChannel(regularUser, testChannel, testTeam);
@@ -86,7 +86,7 @@ describe('MM-23102 - Channel Moderation - Manage Members', () => {
 
         // # Visit test channel page and turn off the Manage members for Members and then save
         visitChannelConfigPage(testChannel);
-        enableChannelModeratedPermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
+        enablePermission(checkboxesTitleToIdMap.MANAGE_MEMBERS_MEMBERS);
         saveConfigForChannel();
 
         visitChannel(regularUser, testChannel, testTeam);
@@ -99,8 +99,7 @@ describe('MM-23102 - Channel Moderation - Manage Members', () => {
     it('Manage Members option removed for Members in System Scheme', () => {
         // Edit the System Scheme and disable the Manage Members option for Members & Save.
         goToSystemScheme();
-        cy.get('#all_users-public_channel-manage_public_channel_members').scrollIntoView().should('be.visible').click();
-        cy.findByTestId('all_users-public_channel-manage_public_channel_members-checkbox').should('not.have.class', 'checked');
+        disablePermission(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS);
         saveConfigForScheme();
 
         // # Visit test channel page
@@ -122,8 +121,7 @@ describe('MM-23102 - Channel Moderation - Manage Members', () => {
 
         // Edit the System Scheme and enable the Manage Members option for Members & Save.
         goToSystemScheme();
-        cy.get('#all_users-public_channel-manage_public_channel_members').scrollIntoView().should('be.visible').click();
-        cy.findByTestId('all_users-public_channel-manage_public_channel_members-checkbox').should('have.class', 'checked');
+        enablePermission(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS);
         saveConfigForScheme();
 
         // # Visit test channel page
@@ -149,8 +147,7 @@ describe('MM-23102 - Channel Moderation - Manage Members', () => {
 
         // # Disable mange channel members
         deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
-        cy.get('#all_users-public_channel-manage_public_channel_members').scrollIntoView().should('be.visible').click();
-        cy.findByTestId('all_users-public_channel-manage_public_channel_members-checkbox').should('not.have.class', 'checked');
+        disablePermission(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS);
         saveConfigForScheme(false);
         cy.wait(TIMEOUTS.FIVE_SEC);
 
@@ -170,8 +167,7 @@ describe('MM-23102 - Channel Moderation - Manage Members', () => {
 
         // # Enable manage channel members
         deleteOrEditTeamScheme(teamOverrideSchemeName, 'edit');
-        cy.get('#all_users-public_channel-manage_public_channel_members').scrollIntoView().should('be.visible').click();
-        cy.findByTestId('all_users-public_channel-manage_public_channel_members-checkbox').should('have.class', 'checked');
+        enablePermission(checkboxesTitleToIdMap.ALL_USERS_MANAGE_PUBLIC_CHANNEL_MEMBERS);
         saveConfigForScheme(false);
         cy.wait(TIMEOUTS.FIVE_SEC);
 

--- a/e2e/cypress/integration/enterprise/system_console/channel_moderation/post_reactions_spec.js
+++ b/e2e/cypress/integration/enterprise/system_console/channel_moderation/post_reactions_spec.js
@@ -17,8 +17,8 @@ import {checkboxesTitleToIdMap} from './constants';
 
 import {
     deleteOrEditTeamScheme,
-    disableChannelModeratedPermission,
-    enableChannelModeratedPermission,
+    disablePermission,
+    enablePermission,
     goToPermissionsAndCreateTeamOverrideScheme,
     goToSystemScheme,
     saveConfigForChannel,
@@ -63,7 +63,7 @@ describe('MM-23102 - Channel Moderation - Post Reactions', () => {
         visitChannelConfigPage(testChannel);
 
         // # Uncheck the post reactions option for Guests and save
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.POST_REACTIONS_GUESTS);
+        disablePermission(checkboxesTitleToIdMap.POST_REACTIONS_GUESTS);
         saveConfigForChannel();
 
         // # Login as a Guest user and visit the same channel
@@ -78,7 +78,7 @@ describe('MM-23102 - Channel Moderation - Post Reactions', () => {
 
         // # Visit test channel configuration page and enable post reactions for guest and save
         visitChannelConfigPage(testChannel);
-        enableChannelModeratedPermission(checkboxesTitleToIdMap.POST_REACTIONS_GUESTS);
+        enablePermission(checkboxesTitleToIdMap.POST_REACTIONS_GUESTS);
         saveConfigForChannel();
 
         visitChannel(guestUser, testChannel, testTeam);
@@ -95,7 +95,7 @@ describe('MM-23102 - Channel Moderation - Post Reactions', () => {
         visitChannelConfigPage(testChannel);
 
         // # Uncheck the Create reactions option for Members and save
-        disableChannelModeratedPermission(checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS);
+        disablePermission(checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS);
         saveConfigForChannel();
 
         // # Login as a Member user and visit the same channel
@@ -110,7 +110,7 @@ describe('MM-23102 - Channel Moderation - Post Reactions', () => {
 
         // # Visit test Channel configuration page and enable post reactions for members and save
         visitChannelConfigPage(testChannel);
-        enableChannelModeratedPermission(checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS);
+        enablePermission(checkboxesTitleToIdMap.POST_REACTIONS_MEMBERS);
         saveConfigForChannel();
 
         // # Login as a Member user and visit the same channel


### PR DESCRIPTION
#### Summary
- Renamed functions to be more generic for re-use and also made sure check/uncheck permission really happens since there is an intermediate state (also, checkboxes are actually div elements and not of type checkbox so can't use cypress `check()`/`uncheck()`)
- Extracted checkbox IDs
- Although cleanup traverses other files, this PR is only for fixing `manage_members_spec`; other test failures will be addressed in other PRs

#### Ticket Link
None -  master only

![Screen Shot 2020-08-26 at 4 52 05 PM](https://user-images.githubusercontent.com/487991/91369663-36a97100-e7c1-11ea-9765-e0826a21cb4d.png)

