### PR TITLE
MM-T659 /invite - other channel

### DIFF
--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -289,10 +289,11 @@ describe('I18456 Built-in slash commands: common', () => {
     });
 
     it('MM-T659 /invite - other channel', () => {
+        const user = userGroup[4];
         const userToInvite = userGroup[3];
 
-        cy.apiAddUserToChannel(testChannel.id, user1.id);
-        loginAndVisitDefaultChannel(user1, `${team1.name}/channels/town-square`);
+        cy.apiAddUserToChannel(testChannel.id, user.id);
+        loginAndVisitDefaultChannel(user, `${team1.name}/channels/town-square`);
         cy.get('#postListContent', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible');
 
         // # Post `/invite @username ~channel` where channelname is a channel you have permission to add members to but not the current channel, and username is a user not in that other channel
@@ -313,7 +314,7 @@ describe('I18456 Built-in slash commands: common', () => {
             });
 
         // * Added user sees system message "username added to the channel by username."
-        cy.uiWaitUntilMessagePostedIncludes(`You were added to the channel by @${user1.username}`);
+        cy.uiWaitUntilMessagePostedIncludes(`You were added to the channel by @${user.username}`);
     });
 
     it('MM-T2834 Slash command help stays visible for system slash command', () => {

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -73,7 +73,7 @@ describe('I18456 Built-in slash commands: common', () => {
     });
 
     it('/shrug test', () => {
-        // # Login as user2 and post a message
+    // # Login as user2 and post a message
         loginAndVisitDefaultChannel(user2, testChannelUrl);
         cy.postMessage('hello from user2');
 
@@ -244,10 +244,10 @@ describe('I18456 Built-in slash commands: common', () => {
         cy.getLastPostId().then((postId) => {
             cy.get(`#postMessageText_${postId}`).
 
-                // * Could not find the channel lalodkjngjrngorejng. Please use the channel handle to identify channels.
+            // * Could not find the channel lalodkjngjrngorejng. Please use the channel handle to identify channels.
                 should('have.text', `Could not find the channel ${invalidChannel}. Please use the channel handle to identify channels.`).
 
-                // * Channel handle links to: https://docs.mattermost.com/help/getting-started/organizing-conversations.html#naming-a-channel
+            // * Channel handle links to: https://docs.mattermost.com/help/getting-started/organizing-conversations.html#naming-a-channel
                 contains('a', 'channel handle').then((link) => {
                     const href = link.prop('href');
                     cy.request(href).its('allRequestResponses').then((response) => {
@@ -277,6 +277,34 @@ describe('I18456 Built-in slash commands: common', () => {
         cy.visit(`${team1.name}/channels/town-square`);
 
         // * Added user sees channel added to LHS, mention badge
+        cy.get('#sidebarChannelContainer').
+            find(`[href*="${team1.name}/channels/${testChannel.name}"]`).
+            within(() => {
+                cy.get('#unreadMentions').should('be.visible');
+                cy.findByText(`${testChannel.display_name}`).click();
+            });
+
+        // * Added user sees system message "username added to the channel by username."
+        cy.uiWaitUntilMessagePostedIncludes(`You were added to the channel by @${user1.username}`);
+    });
+
+    it('MM-T659 /invite - other channel', () => {
+        const userToInvite = userGroup[3];
+
+        loginAndVisitDefaultChannel(user1, `${team1.name}/channels/${testChannel.name}`);
+        cy.postMessage('Hello World!');
+        cy.get('#sidebarItem_town-square').click();
+
+        // # Post `/invite @username ~channel` where channelname is a channel you have permission to add members to but not the current channel, and username is a user not in that other channel
+        cy.postMessage(`/invite @${userToInvite.username} ~${testChannel.name}`);
+
+        // * User who added them sees system message "username added to channelname channel."
+        cy.uiWaitUntilMessagePostedIncludes(`${userToInvite.username} added to ${testChannel.name} channel.`);
+
+        cy.apiLogout();
+        loginAndVisitDefaultChannel(userToInvite, `${team1.name}/channels/${testChannel.name}`);
+
+        // * Added user sees channel added to LHS, mention badge.
         cy.get('#sidebarChannelContainer').
             find(`[href*="${team1.name}/channels/${testChannel.name}"]`).
             within(() => {

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -73,7 +73,7 @@ describe('I18456 Built-in slash commands: common', () => {
     });
 
     it('/shrug test', () => {
-    // # Login as user2 and post a message
+        // # Login as user2 and post a message
         loginAndVisitDefaultChannel(user2, testChannelUrl);
         cy.postMessage('hello from user2');
 
@@ -244,10 +244,10 @@ describe('I18456 Built-in slash commands: common', () => {
         cy.getLastPostId().then((postId) => {
             cy.get(`#postMessageText_${postId}`).
 
-            // * Could not find the channel lalodkjngjrngorejng. Please use the channel handle to identify channels.
+                // * Could not find the channel lalodkjngjrngorejng. Please use the channel handle to identify channels.
                 should('have.text', `Could not find the channel ${invalidChannel}. Please use the channel handle to identify channels.`).
 
-            // * Channel handle links to: https://docs.mattermost.com/help/getting-started/organizing-conversations.html#naming-a-channel
+                // * Channel handle links to: https://docs.mattermost.com/help/getting-started/organizing-conversations.html#naming-a-channel
                 contains('a', 'channel handle').then((link) => {
                     const href = link.prop('href');
                     cy.request(href).its('allRequestResponses').then((response) => {

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -291,9 +291,9 @@ describe('I18456 Built-in slash commands: common', () => {
     it('MM-T659 /invite - other channel', () => {
         const userToInvite = userGroup[3];
 
-        loginAndVisitDefaultChannel(user1, `${team1.name}/channels/${testChannel.name}`);
+        cy.apiAddUserToChannel(testChannel.id, user1.id);
+        loginAndVisitDefaultChannel(user1, `${team1.name}/channels/town-square`);
         cy.get('#postListContent', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible');
-        cy.get('#sidebarItem_town-square').click();
 
         // # Post `/invite @username ~channel` where channelname is a channel you have permission to add members to but not the current channel, and username is a user not in that other channel
         cy.postMessage(`/invite @${userToInvite.username} ~${testChannel.name}`);

--- a/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
+++ b/e2e/cypress/integration/integrations/builtin_commands/common_commands_spec.js
@@ -292,7 +292,7 @@ describe('I18456 Built-in slash commands: common', () => {
         const userToInvite = userGroup[3];
 
         loginAndVisitDefaultChannel(user1, `${team1.name}/channels/${testChannel.name}`);
-        cy.postMessage('Hello World!');
+        cy.get('#postListContent', {timeout: TIMEOUTS.HALF_MIN}).should('be.visible');
         cy.get('#sidebarItem_town-square').click();
 
         // # Post `/invite @username ~channel` where channelname is a channel you have permission to add members to but not the current channel, and username is a user not in that other channel


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

The `/invite` command can invite another user to a channel that the current user is not currently located.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://automation-test-cases.vercel.app/test/MM-T659

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes N/A
- Has redux changes N/A
- Has mobile changes N/A

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![Screen Shot 2020-08-26 at 11 56 59 PM](https://user-images.githubusercontent.com/1740517/91382502-e00b5980-e7f7-11ea-8937-6df311f01f2b.png)
