### PR TITLE
MM-28142: Filter hidden admin console sections.

### DIFF
--- a/components/admin_console/admin_console.tsx
+++ b/components/admin_console/admin_console.tsx
@@ -137,6 +137,13 @@ export default class AdminConsole extends React.PureComponent<Props, State> {
         let defaultUrl = '';
 
         const schemaRoutes = schemas.map((item: Item, index: number) => {
+            if (typeof item.isHidden !== 'undefined') {
+                const isHidden = (typeof item.isHidden === 'function') ? item.isHidden(config, this.state, license, buildEnterpriseReady, consoleAccess) : Boolean(item.isHidden);
+                if (isHidden) {
+                    return false;
+                }
+            }
+
             let isItemDisabled: boolean;
 
             if (typeof item.isDisabled === 'function') {


### PR DESCRIPTION
#### Summary

Fixes the filtering of admin console sections by the `isHidden` property. This is already covered by the E2E tests.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-28142