### PR TITLE
MM-27802 Cypress test for MM-T40 (1.0) Plugin remains enabled when upgraded

### DIFF
--- a/e2e/cypress/integration/plugins/upgrade_spec.js
+++ b/e2e/cypress/integration/plugins/upgrade_spec.js
@@ -1,0 +1,119 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @system_console @plugin
+
+/**
+ * Note : This test requires two demo plugin tar files under fixtures folder.
+ * Download version 0.1.0 from :
+ * https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.1.0/com.mattermost.demo-plugin-0.1.0.tar.gz
+ * Copy to : ./e2e/cypress/fixtures/com.mattermost.demo-plugin-0.1.0.tar.gz
+ *
+ * Download version 0.2.0 from :
+ * https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.2.0/com.mattermost.demo-plugin-0.2.0.tar.gz
+ * Copy to : ./e2e/cypress/fixtures/com.mattermost.demo-plugin-0.2.0.tar.gz
+ */
+
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
+describe('Plugin remains enabled when upgraded', () => {
+    const pluginIdDemo = 'com.mattermost.demo-plugin';
+
+    before(() => {
+        // # Update config
+        cy.apiUpdateConfig({
+            PluginSettings: {
+                Enable: true,
+                RequirePluginSignature: false,
+            },
+        });
+
+        // # Initialize setup and visit town-square
+        cy.apiInitSetup().then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+
+            // #If Demo plugin is already enabled , unInstall it
+            cy.apiRemovePluginById(pluginIdDemo);
+            cy.visit('/admin_console/plugins/plugin_management');
+            cy.get('.admin-console__header', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and('have.text', 'Plugin Management');
+        });
+    });
+
+    it('MT40-Plugin remains enabled when upgraded', () => {
+    // * upload Demo plugin from the browser
+        const fileName1 = 'com.mattermost.demo-plugin-0.1.0.tar.gz';
+        const fileName2 = 'com.mattermost.demo-plugin-0.2.0.tar.gz';
+        const mimeType = 'application/gzip';
+        cy.fixture(fileName1, 'binary').
+            then(Cypress.Blob.binaryStringToBlob).
+            then((fileContent) => {
+                cy.get('input[type=file]').attachFile({fileContent, fileName1, mimeType});
+            });
+
+        cy.get('#uploadPlugin').scrollIntoView().should('be.visible').click().wait(TIMEOUTS.HALF_SEC);
+
+        // * Verify that the button shows correct text while uploading
+        cy.findByText('Uploading...', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+
+        // * Verify that the button shows correct text and is disabled after upload
+        cy.findByText('Upload', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+        cy.get('#uploadPlugin').and('be.disabled');
+
+        // # Enable demo plugin
+        doTaskOnPlugin(pluginIdDemo, () => {
+        // * Verify Demo Plugin title is shown
+            cy.waitUntil(() => cy.get('strong').scrollIntoView().should('be.visible').then((title) => {
+                return title[0].innerText === 'Demo Plugin';
+            }));
+
+            // # Click on Enable link
+            cy.findByText('Enable').click();
+        });
+
+        // * Verify V0.1.0 of plugin
+        cy.findByText(/0.1.0/).scrollIntoView().should('be.visible');
+
+        cy.get('#uploadPlugin').scrollIntoView().should('be.visible');
+
+        // # Upgrade plugin
+        cy.fixture(fileName2, 'binary').
+            then(Cypress.Blob.binaryStringToBlob).
+            then((fileContent) => {
+                cy.get('input[type=file]').attachFile({fileContent, fileName1, mimeType});
+            });
+
+        // * Verify that the button shows correct text while uploading
+        cy.get('#uploadPlugin').should('be.visible').click().wait(TIMEOUTS.HALF_SEC);
+
+        // # Confirm overwrite of plugin with same name
+        cy.get('#confirmModalButton').should('be.visible').click();
+
+        doTaskOnPlugin(pluginIdDemo, () => {
+        // * Verify plugin is running
+            waitForAlert('This plugin is running.');
+        });
+
+        // * Verify v0.2.0 of plugin
+        cy.findByText(/0.2.0/).scrollIntoView().should('be.visible');
+    });
+});
+
+function waitForAlert(message) {
+    cy.waitUntil(() => cy.get('.alert').scrollIntoView().should('be.visible').then((alert) => {
+        return alert[0].innerText === message;
+    }));
+}
+
+function doTaskOnPlugin(pluginId, taskCallback) {
+    cy.findByText(/Installed Plugins/).scrollIntoView().should('be.visible');
+    cy.findByTestId(pluginId).scrollIntoView().should('be.visible').within(() => {
+        // # Perform task
+        taskCallback();
+    });
+}

--- a/e2e/cypress/integration/plugins/upgrade_spec.js
+++ b/e2e/cypress/integration/plugins/upgrade_spec.js
@@ -101,6 +101,8 @@ describe('Plugin remains enabled when upgraded', () => {
 
         // * Verify v0.2.0 of plugin
         cy.findByText(/0.2.0/).scrollIntoView().should('be.visible');
+
+        cy.apiRemovePluginById(pluginIdDemo);
     });
 });
 

--- a/e2e/cypress/integration/plugins/upgrade_spec.js
+++ b/e2e/cypress/integration/plugins/upgrade_spec.js
@@ -37,6 +37,10 @@ describe('Plugin remains enabled when upgraded', () => {
         });
     });
 
+    after(() => {
+        cy.apiRemovePluginById(pluginIdDemo);
+    });
+
     it('MT40 Plugin remains enabled when upgraded', () => {
     // * Upload Demo plugin from the browser
         const fileName1 = 'com.mattermost.demo-plugin-0.1.0.tar.gz';
@@ -77,7 +81,7 @@ describe('Plugin remains enabled when upgraded', () => {
         cy.fixture(fileName2, 'binary').
             then(Cypress.Blob.binaryStringToBlob).
             then((fileContent) => {
-                cy.get('input[type=file]').attachFile({fileContent, fileName: fileName1, mimeType});
+                cy.get('input[type=file]').attachFile({fileContent, fileName: fileName2, mimeType});
             });
 
         // * Verify that the button shows correct text while uploading
@@ -93,8 +97,6 @@ describe('Plugin remains enabled when upgraded', () => {
 
         // * Verify v0.2.0 of plugin
         cy.findByText(/0.2.0/).scrollIntoView().should('be.visible');
-
-        cy.apiRemovePluginById(pluginIdDemo);
     });
 });
 

--- a/e2e/cypress/integration/plugins/upgrade_spec.js
+++ b/e2e/cypress/integration/plugins/upgrade_spec.js
@@ -38,15 +38,15 @@ describe('Plugin remains enabled when upgraded', () => {
         cy.apiInitSetup().then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);
 
-            // #If Demo plugin is already enabled , unInstall it
+            // #If Demo plugin is already enabled , uninstall it
             cy.apiRemovePluginById(pluginIdDemo);
             cy.visit('/admin_console/plugins/plugin_management');
             cy.get('.admin-console__header', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and('have.text', 'Plugin Management');
         });
     });
 
-    it('MT40-Plugin remains enabled when upgraded', () => {
-    // * upload Demo plugin from the browser
+    it('MT40 Plugin remains enabled when upgraded', () => {
+    // * Upload Demo plugin from the browser
         const fileName1 = 'com.mattermost.demo-plugin-0.1.0.tar.gz';
         const fileName2 = 'com.mattermost.demo-plugin-0.2.0.tar.gz';
         const mimeType = 'application/gzip';

--- a/e2e/cypress/integration/plugins/upgrade_spec.js
+++ b/e2e/cypress/integration/plugins/upgrade_spec.js
@@ -26,14 +26,6 @@ describe('Plugin remains enabled when upgraded', () => {
     const pluginIdDemo = 'com.mattermost.demo-plugin';
 
     before(() => {
-        // # Update config
-        cy.apiUpdateConfig({
-            PluginSettings: {
-                Enable: true,
-                RequirePluginSignature: false,
-            },
-        });
-
         // # Initialize setup and visit town-square
         cy.apiInitSetup().then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);
@@ -53,7 +45,7 @@ describe('Plugin remains enabled when upgraded', () => {
         cy.fixture(fileName1, 'binary').
             then(Cypress.Blob.binaryStringToBlob).
             then((fileContent) => {
-                cy.get('input[type=file]').attachFile({fileContent, fileName1, mimeType});
+                cy.get('input[type=file]').attachFile({fileContent, fileName: fileName1, mimeType});
             });
 
         cy.get('#uploadPlugin').scrollIntoView().should('be.visible').click().wait(TIMEOUTS.HALF_SEC);
@@ -85,7 +77,7 @@ describe('Plugin remains enabled when upgraded', () => {
         cy.fixture(fileName2, 'binary').
             then(Cypress.Blob.binaryStringToBlob).
             then((fileContent) => {
-                cy.get('input[type=file]').attachFile({fileContent, fileName1, mimeType});
+                cy.get('input[type=file]').attachFile({fileContent, fileName: fileName1, mimeType});
             });
 
         // * Verify that the button shows correct text while uploading

--- a/e2e/cypress/integration/system_console/plugin_upload_spec.js
+++ b/e2e/cypress/integration/system_console/plugin_upload_spec.js
@@ -18,8 +18,7 @@
 import * as TIMEOUTS from '../../fixtures/timeouts';
 
 describe('Draw Plugin - Upload', () => {
-    const pluginIdDraw = 'com.mattermost.draw-plugin';
-    const pluginIdDemo = 'com.mattermost.demo-plugin';
+    const pluginId = 'com.mattermost.draw-plugin';
 
     before(() => {
         // # Update config
@@ -35,8 +34,7 @@ describe('Draw Plugin - Upload', () => {
             cy.visit(`/${team.name}/channels/town-square`);
 
             // #If draw plugin is already enabled , unInstall it
-            cy.apiRemovePluginById(pluginIdDraw);
-            cy.apiRemovePluginById(pluginIdDemo);
+            cy.apiRemovePluginById(pluginId);
             cy.visit('/admin_console/plugins/plugin_management');
             cy.get('.admin-console__header', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').and('have.text', 'Plugin Management');
         });
@@ -62,7 +60,7 @@ describe('Draw Plugin - Upload', () => {
         cy.get('#uploadPlugin').and('be.disabled');
 
         // # Enable draw plugin
-        doTaskOnPlugin(pluginIdDraw, () => {
+        doTaskOnDrawPlugin(() => {
             // * Verify Draw Plugin title is shown
             cy.waitUntil(() => cy.get('strong').scrollIntoView().should('be.visible').then((title) => {
                 return title[0].innerText === 'Draw Plugin';
@@ -73,7 +71,7 @@ describe('Draw Plugin - Upload', () => {
         });
 
         // # Disable draw plugin
-        doTaskOnPlugin(pluginIdDraw, () => {
+        doTaskOnDrawPlugin(() => {
             // * Verify plugin is starting
             waitForAlert('This plugin is starting.');
 
@@ -85,7 +83,7 @@ describe('Draw Plugin - Upload', () => {
         });
 
         // # Attempt to remove draw plugin
-        doTaskOnPlugin(pluginIdDraw, () => {
+        doTaskOnDrawPlugin(() => {
             // * Verify plugin is not enabled
             waitForAlert('This plugin is not enabled.');
 
@@ -97,7 +95,7 @@ describe('Draw Plugin - Upload', () => {
         cy.get('#cancelModalButton').should('be.visible').click();
 
         // # Attempt to remove draw plugin again
-        doTaskOnPlugin(pluginIdDraw, () => {
+        doTaskOnDrawPlugin(() => {
             // # Click on Remove link
             cy.findByText('Remove').click();
         });
@@ -110,64 +108,6 @@ describe('Draw Plugin - Upload', () => {
         cy.findByText(/Installed Plugins/).scrollIntoView().should('be.visible');
         cy.findByTestId('com.mattermost.draw-plugin').should('not.exist');
     });
-
-    it('M27802-MT40-Plugin remains enabled when upgraded', () => {
-    // * upload Demo plugin from the browser
-        const fileName1 = 'com.mattermost.demo-plugin-0.1.0.tar.gz';
-        const fileName2 = 'com.mattermost.demo-plugin-0.2.0.tar.gz';
-        const mimeType = 'application/gzip';
-        cy.fixture(fileName1, 'binary').
-            then(Cypress.Blob.binaryStringToBlob).
-            then((fileContent) => {
-                cy.get('input[type=file]').attachFile({fileContent, fileName1, mimeType});
-            });
-
-        cy.get('#uploadPlugin').scrollIntoView().should('be.visible').click().wait(TIMEOUTS.HALF_SEC);
-
-        // * Verify that the button shows correct text while uploading
-        cy.findByText('Uploading...', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-
-        // * Verify that the button shows correct text and is disabled after upload
-        cy.findByText('Upload', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
-        cy.get('#uploadPlugin').and('be.disabled');
-
-        // # Enable demo plugin
-        doTaskOnPlugin(pluginIdDemo, () => {
-        // * Verify Demo Plugin title is shown
-            cy.waitUntil(() => cy.get('strong').scrollIntoView().should('be.visible').then((title) => {
-                return title[0].innerText === 'Demo Plugin';
-            }));
-
-            // # Click on Enable link
-            cy.findByText('Enable').click();
-        });
-
-        // * Verify V0.1.0 of plugin
-        cy.findByText(/0.1.0/).scrollIntoView().should('be.visible');
-
-        cy.get('#uploadPlugin').scrollIntoView().should('be.visible');
-
-        // Upgrade plugin
-        cy.fixture(fileName2, 'binary').
-            then(Cypress.Blob.binaryStringToBlob).
-            then((fileContent) => {
-                cy.get('input[type=file]').attachFile({fileContent, fileName1, mimeType});
-            });
-
-        // * Verify that the button shows correct text while uploading
-        cy.get('#uploadPlugin').should('be.visible').click().wait(TIMEOUTS.HALF_SEC);
-
-        // Confirm overwrite of plugin with same name
-        cy.get('#confirmModalButton').should('be.visible').click();
-
-        doTaskOnPlugin(pluginIdDemo, () => {
-        // * Verify plugin is running
-            waitForAlert('This plugin is running.');
-        });
-
-        // * Verify v0.2.0 of plugin
-        cy.findByText(/0.2.0/).scrollIntoView().should('be.visible');
-    });
 });
 
 function waitForAlert(message) {
@@ -176,9 +116,9 @@ function waitForAlert(message) {
     }));
 }
 
-function doTaskOnPlugin(pluginId, taskCallback) {
+function doTaskOnDrawPlugin(taskCallback) {
     cy.findByText(/Installed Plugins/).scrollIntoView().should('be.visible');
-    cy.findByTestId(pluginId).scrollIntoView().should('be.visible').within(() => {
+    cy.findByTestId('com.mattermost.draw-plugin').scrollIntoView().should('be.visible').within(() => {
         // # Perform task
         taskCallback();
     });


### PR DESCRIPTION
#### Summary
Cypress test for MM-T40 Plugin remains enabled when upgraded

Test Case: [MM-T40](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T40)

#### Additional Notes
The code for this test case has some similarities to the previous test that exists in this file.  The other tests uses the draw plugin and I chose to leave it as is and add the new test case for the following reasons.

* keep the test attached to the specific Jira test
* eliminate some portion of the previous test being polluted by additional code
* Use of additional plugin (as specified by the Jira task)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27802