### PR TITLE
revert cypress to 4.8.0

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -843,9 +843,9 @@
       }
     },
     "arch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
-      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
       "dev": true
     },
     "argparse": {
@@ -1653,9 +1653,9 @@
       }
     },
     "commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+      "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
       "dev": true
     },
     "common-tags": {
@@ -1881,48 +1881,48 @@
       }
     },
     "cypress": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.12.1.tgz",
-      "integrity": "sha512-9SGIPEmqU8vuRA6xst2CMTYd9sCFCxKSzrHt0wr+w2iAQMCIIsXsQ5Gplns1sT6LDbZcmLv6uehabAOl3fhc9Q==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.8.0.tgz",
+      "integrity": "sha512-Lsff8lF8pq6k/ioNua783tCsxGSLp6gqGXecdIfqCkqjYiOA53XKuEf1CaQJLUVs1dHSf49eDUp/sb620oJjVQ==",
       "dev": true,
       "requires": {
-        "@cypress/listr-verbose-renderer": "^0.4.1",
-        "@cypress/request": "^2.88.5",
-        "@cypress/xvfb": "^1.2.4",
-        "@types/sinonjs__fake-timers": "^6.0.1",
-        "@types/sizzle": "^2.3.2",
-        "arch": "^2.1.2",
-        "bluebird": "^3.7.2",
-        "cachedir": "^2.3.0",
-        "chalk": "^2.4.2",
-        "check-more-types": "^2.24.0",
-        "cli-table3": "~0.5.1",
-        "commander": "^4.1.1",
-        "common-tags": "^1.8.0",
-        "debug": "^4.1.1",
-        "eventemitter2": "^6.4.2",
-        "execa": "^1.0.0",
-        "executable": "^4.1.1",
-        "extract-zip": "^1.7.0",
-        "fs-extra": "^8.1.0",
-        "getos": "^3.2.1",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.3.2",
-        "lazy-ass": "^1.6.0",
-        "listr": "^0.14.3",
-        "lodash": "^4.17.19",
-        "log-symbols": "^3.0.0",
-        "minimist": "^1.2.5",
-        "moment": "^2.27.0",
-        "ospath": "^1.2.2",
-        "pretty-bytes": "^5.3.0",
-        "ramda": "~0.26.1",
-        "request-progress": "^3.0.0",
-        "supports-color": "^7.1.0",
-        "tmp": "~0.1.0",
-        "untildify": "^4.0.0",
-        "url": "^0.11.0",
-        "yauzl": "^2.10.0"
+        "@cypress/listr-verbose-renderer": "0.4.1",
+        "@cypress/request": "2.88.5",
+        "@cypress/xvfb": "1.2.4",
+        "@types/sinonjs__fake-timers": "6.0.1",
+        "@types/sizzle": "2.3.2",
+        "arch": "2.1.1",
+        "bluebird": "3.7.2",
+        "cachedir": "2.3.0",
+        "chalk": "2.4.2",
+        "check-more-types": "2.24.0",
+        "cli-table3": "0.5.1",
+        "commander": "4.1.0",
+        "common-tags": "1.8.0",
+        "debug": "4.1.1",
+        "eventemitter2": "4.1.2",
+        "execa": "1.0.0",
+        "executable": "4.1.1",
+        "extract-zip": "1.7.0",
+        "fs-extra": "8.1.0",
+        "getos": "3.1.4",
+        "is-ci": "2.0.0",
+        "is-installed-globally": "0.1.0",
+        "lazy-ass": "1.6.0",
+        "listr": "0.14.3",
+        "lodash": "4.17.15",
+        "log-symbols": "3.0.0",
+        "minimist": "1.2.5",
+        "moment": "2.24.0",
+        "ospath": "1.2.2",
+        "pretty-bytes": "5.3.0",
+        "ramda": "0.26.1",
+        "request-progress": "3.0.0",
+        "supports-color": "7.1.0",
+        "tmp": "0.1.0",
+        "untildify": "4.0.0",
+        "url": "0.11.0",
+        "yauzl": "2.10.0"
       },
       "dependencies": {
         "chalk": {
@@ -1956,10 +1956,10 @@
             "ms": "^2.1.1"
           }
         },
-        "moment": {
-          "version": "2.27.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-          "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "ms": {
@@ -2438,9 +2438,9 @@
       }
     },
     "eventemitter2": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
-      "integrity": "sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
+      "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=",
       "dev": true
     },
     "events": {
@@ -3002,12 +3002,12 @@
       "dev": true
     },
     "getos": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
-      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.4.tgz",
+      "integrity": "sha512-UORPzguEB/7UG5hqiZai8f0vQ7hzynMQyJLxStoQ8dPGAcmgsfXOPA4iE/fGtweHYkK+z4zc9V0g+CIFRf5HYw==",
       "dev": true,
       "requires": {
-        "async": "^3.2.0"
+        "async": "^3.1.0"
       }
     },
     "getpass": {
@@ -3052,12 +3052,12 @@
       }
     },
     "global-dirs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.5"
+        "ini": "^1.3.4"
       }
     },
     "global-modules": {
@@ -3459,13 +3459,13 @@
       }
     },
     "is-installed-globally": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
-      "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "^2.0.1",
-        "is-path-inside": "^3.0.1"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-map": {
@@ -3493,10 +3493,13 @@
       }
     },
     "is-path-inside": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -5287,6 +5290,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,7 @@
     "chai": "4.2.0",
     "chalk": "4.1.0",
     "cross-env": "7.0.2",
-    "cypress": "4.12.1",
+    "cypress": "^4.8.0",
     "cypress-file-upload": "4.0.7",
     "cypress-multi-reporters": "1.4.0",
     "cypress-plugin-tab": "1.0.5",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,7 @@
     "chai": "4.2.0",
     "chalk": "4.1.0",
     "cross-env": "7.0.2",
-    "cypress": "^4.8.0",
+    "cypress": "4.8.0",
     "cypress-file-upload": "4.0.7",
     "cypress-multi-reporters": "1.4.0",
     "cypress-plugin-tab": "1.0.5",


### PR DESCRIPTION
#### Summary
Downgrade cypress to 8.4.0 to have more stable tests

while trying to create [this test](https://github.com/Willyfrog/mattermost-webapp/blob/MM-27207_e2e-archived-channels-I/e2e/cypress/integration/channel/archived_channels_spec.js#L108) i was running into many different problems as either it was taking longer to load some elements or it break while typing/waiting for no reason. Downgrading seems to get stable results.
