### PR TITLE
MM-28175 Fix inline code styling

### DIFF
--- a/sass/layout/_markdown.scss
+++ b/sass/layout/_markdown.scss
@@ -171,8 +171,11 @@ h6 {
     position: relative;
 
     code {
+        background-color: inherit;
+        font-size: 13px;
         display: block;
         position: relative;
+        padding: 0px;
         text-align: left;
     }
 
@@ -315,11 +318,10 @@ pre {
 }
 
 code {
+    background-color: rgba(var(--center-channel-color-rgb), 0.1);
+
     // Reset styles from Bootstrap
-    background-color: inherit;
     color: inherit;
-    font-size: 100%;
-    padding: 0px;
 }
 
 .help {


### PR DESCRIPTION
I forgot to check the style of inline code earlier, so https://github.com/mattermost/mattermost-webapp/pull/6223 broke that because of the bootstrap reset. I fixed that by moving the reset to only apply to `.post-code` components (code blocks and the code preview).

I don't think there's any good way to automatically test for this without doing some sort of screenshot-based testing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28175

#### Screenshots
![Screen Shot 2020-08-28 at 1 27 47 PM](https://user-images.githubusercontent.com/3277310/91595893-46949280-e932-11ea-85e9-6e8c83812d3a.png)
