### PR TITLE
MM-27315 Cypress test for MM-T2834 (1.0) Slash command help stays visible for system slash command

### DIFF
--- a/e2e/cypress/integration/slash_commands/autocomplete_spec.js
+++ b/e2e/cypress/integration/slash_commands/autocomplete_spec.js
@@ -24,18 +24,14 @@ describe('Integrations', () => {
         cy.apiInitSetup().then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);
 
-            // # If Demo plugin is already enabled , uninstall it
+            // # If Demo plugin is already enabled, uninstall it
             cy.apiRemovePluginById(pluginIdDemo);
         });
 
-        // # Upload Demo plugin from the browser
-        const fileName = 'com.mattermost.demo-plugin-0.8.0.tar.gz';
-        const mimeType = 'application/gzip';
-        cy.fixture(fileName, 'binary').
-            then(Cypress.Blob.binaryStringToBlob).
-            then((fileContent) => {
-                cy.get('input[type=file]').attachFile({fileContent, fileName, mimeType});
-            });
+        const demoURL = 'https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.8.0/com.mattermost.demo-plugin-0.8.0.tar.gz';
+
+        // # Install plugins from URL
+        cy.apiInstallPluginFromUrl(demoURL);
     });
 
     after(() => {

--- a/e2e/cypress/integration/slash_commands/autocomplete_spec.js
+++ b/e2e/cypress/integration/slash_commands/autocomplete_spec.js
@@ -1,0 +1,67 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @integrations
+
+/**
+ * Note : This test requires the demo plugin tar file under fixtures folder.
+ * Download :
+ * https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.8.0/com.mattermost.demo-plugin-0.8.0.tar.gz
+ * Copy to : ./e2e/cypress/fixtures/com.mattermost.demo-plugin-0.8.0.tar.gz
+ */
+
+describe('Integrations', () => {
+    const pluginIdDemo = 'com.mattermost.demo-plugin';
+
+    before(() => {
+        // # Initialize setup and visit town-square
+        cy.apiInitSetup().then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+
+            // # If Demo plugin is already enabled , uninstall it
+            cy.apiRemovePluginById(pluginIdDemo);
+        });
+
+        // # Upload Demo plugin from the browser
+        const fileName = 'com.mattermost.demo-plugin-0.8.0.tar.gz';
+        const mimeType = 'application/gzip';
+        cy.fixture(fileName, 'binary').
+            then(Cypress.Blob.binaryStringToBlob).
+            then((fileContent) => {
+                cy.get('input[type=file]').attachFile({fileContent, fileName, mimeType});
+            });
+    });
+
+    after(() => {
+        cy.apiRemovePluginById(pluginIdDemo);
+    });
+
+    it('T2834 Slash command help stays visible for system slash command', () => {
+        // # Post a slash command without trailing space
+        cy.get('#post_textbox').type('/rename');
+
+        // * Verify suggestion list is visible
+        cy.get('#suggestionList').should('be.visible');
+
+        // * Verify command text is visible before space is added
+        cy.get('.slash-command__desc').contains('Rename the channel').should('be.visible');
+
+        // # Add trailing space to '/rename' command
+        cy.get('#post_textbox').type(' ');
+
+        // * Verify command text is no longer visible after space is added
+        cy.findByText('Rename the channel').should('not.be.visible');
+
+        // * Verify execute current command text shows
+        cy.get('#suggestionList').findByText('Execute Current Command').should('be.visible');
+
+        // * After typing the space character the relevant tip is still displayed
+        cy.get('.slash-command__desc').contains('[text]').should('be.visible');
+    });
+});

--- a/e2e/cypress/integration/slash_commands/autocomplete_spec.js
+++ b/e2e/cypress/integration/slash_commands/autocomplete_spec.js
@@ -42,7 +42,7 @@ describe('Integrations', () => {
         // # Post a slash command without trailing space
         cy.get('#post_textbox').type('/rename');
 
-        // * Verify suggestion list is visible with only child
+        // * Verify suggestion list is visible with only 1 child
         cy.get('#suggestionList').should('be.visible').children().should('have.length', 1);
 
         // * Verify suggestion list is visible

--- a/e2e/cypress/integration/slash_commands/autocomplete_spec.js
+++ b/e2e/cypress/integration/slash_commands/autocomplete_spec.js
@@ -42,11 +42,11 @@ describe('Integrations', () => {
         // # Post a slash command without trailing space
         cy.get('#post_textbox').type('/rename');
 
-        // * Verify suggestion list is visible
-        cy.get('#suggestionList').should('be.visible');
+        // * Verify suggestion list is visible with only child
+        cy.get('#suggestionList').should('be.visible').children().should('have.length', 1);
 
-        // * Verify command text is visible before space is added
-        cy.get('.slash-command__desc').contains('Rename the channel').should('be.visible');
+        // * Verify suggestion list is visible
+        cy.get('#suggestionList').children().eq(0).findByText('Rename the channel').should('be.visible');
 
         // # Add trailing space to '/rename' command
         cy.get('#post_textbox').type(' ');
@@ -54,8 +54,11 @@ describe('Integrations', () => {
         // * Verify command text is no longer visible after space is added
         cy.findByText('Rename the channel').should('not.be.visible');
 
-        // * Verify execute current command text shows
-        cy.get('#suggestionList').findByText('Execute Current Command').should('be.visible');
+        // * Verify suggestion list is visible with 2 children
+        cy.get('#suggestionList').should('be.visible').children().should('have.length', 2);
+
+        // * Verify execute current command text shows in first element
+        cy.get('#suggestionList').children().eq(0).findByText('Execute Current Command').should('be.visible');
 
         // * After typing the space character the relevant tip is still displayed
         cy.get('.slash-command__desc').contains('[text]').should('be.visible');


### PR DESCRIPTION
#### Summary
Cypress test for MM-T2834 (1.0) Slash command help stays visible for system slash command

Test Case: [MM-T2834](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T2834)

#### Additional Notes
This the first test case for MM-27315.  I created the `integrations/slash_commands` folder and the first spec for this folder.  

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27315

