### PR TITLE
MM-T673 Prompting to set status to online

### DIFF
--- a/e2e/cypress/integration/integrations/outgoing_webhook/prompt_set_status_spec.js
+++ b/e2e/cypress/integration/integrations/outgoing_webhook/prompt_set_status_spec.js
@@ -7,6 +7,8 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
+// Group: @outgoing_webhook
+
 import * as TIMEOUTS from '../../../fixtures/timeouts';
 
 describe('Prompting set status', () => {
@@ -87,4 +89,3 @@ const openDM = (username) => {
     cy.get('#selectItems').findByText(`${username}`).should('be.visible');
     cy.findByText('Go').click();
 };
-

--- a/e2e/cypress/integration/integrations/outgoing_webhook/prompt_set_status_spec.js
+++ b/e2e/cypress/integration/integrations/outgoing_webhook/prompt_set_status_spec.js
@@ -1,0 +1,90 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+import * as TIMEOUTS from '../../../fixtures/timeouts';
+
+describe('Prompting set status', () => {
+    let user1;
+    let user2;
+    let testChannelUrl;
+    before(() => {
+        cy.apiInitSetup().then(({user, team}) => {
+            user1 = user;
+            testChannelUrl = `/${team.name}/channels/town-square`;
+
+            cy.apiCreateUser().then(({user: otherUser}) => {
+                user2 = otherUser;
+
+                cy.apiAddUserToTeam(team.id, user2.id);
+            });
+        });
+    });
+
+    it('MM-T673 Prompting to set status to online', () => {
+        cy.apiLogin(user1);
+        cy.visit(testChannelUrl);
+        cy.get('img.Avatar').click();
+        cy.findByText('Online').click();
+
+        // # Use the status drop-down on your profile pic to go Offline
+        cy.get('img.Avatar').click();
+        cy.findByText('Offline').click();
+
+        // * Your status stays offline in your view
+        cy.get('.offline--icon').should('be.visible');
+        cy.get('.online--icon').should('not.be.visible');
+
+        // # Log out
+        cy.apiLogout();
+
+        cy.apiLogin(user2);
+        cy.visit(testChannelUrl);
+        openDM(user1.username);
+
+        // * Your status stays offline in other users' views.
+        cy.get('#channelHeaderInfo').within(() => {
+            cy.get('.offline--icon').should('be.visible');
+            cy.get('.online--icon').should('not.be.visible');
+            cy.findByText('Offline').should('be.visible');
+        });
+        cy.apiGetUserStatus(`${user1.id}`).then((result) => {
+            cy.wrap(result.status.status).should('be.equal', 'offline');
+        });
+
+        // # Log back in
+        cy.visit(testChannelUrl);
+        cy.apiLogin(user1);
+
+        // # On modal that asks if you want to be set Online, select No.
+        cy.get('.modal-content').within(() => {
+            cy.findByText('Your Status is Set to "Offline"').should('be.visible');
+            cy.get('#cancelModalButton').click();
+        });
+
+        // * Your status stays offline in your view
+        cy.get('.offline--icon').should('be.visible');
+        cy.get('.online--icon').should('not.be.visible');
+
+        // * Your status stays offline in other users' views.
+        cy.apiLogin(user2);
+        cy.apiGetUserStatus(`${user1.id}`).then((result) => {
+            cy.wrap(result.status.status).should('be.equal', 'offline');
+        });
+    });
+});
+
+const openDM = (username) => {
+    cy.get('#addDirectChannel').click();
+    cy.get('#selectItems').type(`${username}`);
+    cy.wait(TIMEOUTS.ONE_SEC);
+    cy.get('#multiSelectList').findByText(`@${username}`).click();
+    cy.get('#selectItems').findByText(`${username}`).should('be.visible');
+    cy.findByText('Go').click();
+};
+

--- a/e2e/cypress/integration/integrations/outgoing_webhook/prompt_set_status_spec.js
+++ b/e2e/cypress/integration/integrations/outgoing_webhook/prompt_set_status_spec.js
@@ -60,8 +60,8 @@ describe('Prompting set status', () => {
         });
 
         // # Log back in
-        cy.visit(testChannelUrl);
         cy.apiLogin(user1);
+        cy.visit(testChannelUrl);
 
         // # On modal that asks if you want to be set Online, select No.
         cy.get('.modal-content').within(() => {

--- a/e2e/cypress/integration/integrations/outgoing_webhook/prompt_set_status_spec.js
+++ b/e2e/cypress/integration/integrations/outgoing_webhook/prompt_set_status_spec.js
@@ -75,6 +75,15 @@ describe('Prompting set status', () => {
 
         // * Your status stays offline in other users' views.
         cy.apiLogin(user2);
+        cy.visit(testChannelUrl);
+        openDM(user1.username);
+
+        // * Your status stays offline in other users' views.
+        cy.get('#channelHeaderInfo').within(() => {
+            cy.get('.offline--icon').should('be.visible');
+            cy.get('.online--icon').should('not.be.visible');
+            cy.findByText('Offline').should('be.visible');
+        });
         cy.apiGetUserStatus(`${user1.id}`).then((result) => {
             cy.wrap(result.status.status).should('be.equal', 'offline');
         });

--- a/e2e/cypress/support/api/status.d.ts
+++ b/e2e/cypress/support/api/status.d.ts
@@ -35,6 +35,7 @@ declare namespace Cypress {
          * Get status of a current user.
          * See https://api.mattermost.com/#tag/status/paths/~1users~1{user_id}~1status/get
          * @param {String} userId - ID of a given user
+         * @returns {UserStatus} `out.status` as `UserStatus`
          *
          * @example
          *   cy.apiGetUserStatus('userId').then(({status}) => {

--- a/e2e/cypress/support/api/status.d.ts
+++ b/e2e/cypress/support/api/status.d.ts
@@ -30,5 +30,17 @@ declare namespace Cypress {
          *   });
          */
         apiUpdateUserStatus(status: string): Chainable<UserStatus>;
+
+        /**
+         * Get status of a current user.
+         * See https://api.mattermost.com/#tag/status/paths/~1users~1{user_id}~1status/get
+         * @param {String} userId - ID of a given user
+         *
+         * @example
+         *   cy.apiGetUserStatus('userId').then(({status}) => {
+         *       // examine the status information of the user
+         *   });
+         */
+        apiGetStatus(userId: string): Chainable<UserStatus>;
     }
 }

--- a/e2e/cypress/support/api/status.js
+++ b/e2e/cypress/support/api/status.js
@@ -21,3 +21,14 @@ Cypress.Commands.add('apiUpdateUserStatus', (status = 'online') => {
         });
     });
 });
+
+Cypress.Commands.add('apiGetUserStatus', (userId) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: `/api/v4/users/${userId}/status`,
+        method: 'GET',
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        return cy.wrap({status: response.body});
+    });
+});


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
After a user manually set themselves to be offline, they are prompted to see if they'd like to set the status to be online after logging in.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://automation-test-cases.vercel.app/test/MM-T673

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes N/A
- Has redux changes  N/A
- Has mobile changes  N/A

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

![Screen Shot 2020-08-30 at 1 05 39 PM](https://user-images.githubusercontent.com/1740517/91665143-876ee180-eac1-11ea-9ee4-3fda0b6b378e.png)
