### PR TITLE
fix: semantic time testing criteria

### DIFF
--- a/components/timestamp/__snapshots__/semantic_time.test.tsx.snap
+++ b/components/timestamp/__snapshots__/semantic_time.test.tsx.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/timestamp/SemanticTime should render time semantically 1`] = `
-<Memo(SemanticTime)
-  value={2020-06-05T10:20:30.000Z}
->
-  <time
-    aria-label="6/5/2020, 10:20:30 AM"
-    dateTime="2020-06-05T10:20:30.000Z"
-  />
-</Memo(SemanticTime)>
-`;
-
 exports[`components/timestamp/SemanticTime should support custom label 1`] = `
 <Memo(SemanticTime)
   aria-label="A custom label"
@@ -20,18 +9,5 @@ exports[`components/timestamp/SemanticTime should support custom label 1`] = `
     aria-label="A custom label"
     dateTime="2020-06-05T10:20:30.000Z"
   />
-</Memo(SemanticTime)>
-`;
-
-exports[`components/timestamp/SemanticTime should support passthrough children 1`] = `
-<Memo(SemanticTime)
-  value={2020-06-05T10:20:30.000Z}
->
-  <time
-    aria-label="6/5/2020, 10:20:30 AM"
-    dateTime="2020-06-05T10:20:30.000Z"
-  >
-    10:20
-  </time>
 </Memo(SemanticTime)>
 `;

--- a/components/timestamp/semantic_time.test.tsx
+++ b/components/timestamp/semantic_time.test.tsx
@@ -14,7 +14,7 @@ describe('components/timestamp/SemanticTime', () => {
                 value={date}
             />
         );
-        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('time').prop('aria-label')).toBe(date.toLocaleString());
         expect(wrapper.find('time').prop('dateTime')).toBe(date.toISOString());
     });
 
@@ -28,7 +28,7 @@ describe('components/timestamp/SemanticTime', () => {
             </SemanticTime>
         );
 
-        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('time').prop('aria-label')).toBe(date.toLocaleString());
         expect(wrapper.find('time').text()).toBe('10:20');
     });
 


### PR DESCRIPTION
#### Summary

Use locale-agnostic validation instead of flakey snapshot logic. (Fixes `semantic_time` unit test failing in non-`en-US` locales.)