### PR TITLE
E2E, MM-27222-1–2/10: add create_bot spec

### DIFF
--- a/e2e/cypress/integration/bot_accounts/create_bot_spec.js
+++ b/e2e/cypress/integration/bot_accounts/create_bot_spec.js
@@ -8,11 +8,10 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @bots
+// Group: @bot_accounts
 
 import {getRandomId} from '../../utils';
 
-// cy.toAccountSettingsModal();
 describe('Create bot', () => {
     before(() => {
         cy.apiUpdateConfig({

--- a/e2e/cypress/integration/bot_accounts/create_bot_spec.js
+++ b/e2e/cypress/integration/bot_accounts/create_bot_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @bot_accounts
 
 import {getRandomId} from '../../utils';
@@ -27,6 +26,7 @@ describe('Create bot', () => {
                 EnableUserAccessTokens: true,
             },
         });
+
         createBot();
     });
 

--- a/e2e/cypress/integration/bot_accounts/create_bot_spec.js
+++ b/e2e/cypress/integration/bot_accounts/create_bot_spec.js
@@ -1,0 +1,72 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @bots
+
+import {getRandomId} from '../../utils';
+
+// cy.toAccountSettingsModal();
+describe('Create bot', () => {
+    before(() => {
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableBotAccountCreation: true,
+            },
+        });
+    });
+
+    it('MM-T1810 Create a Bot via the UI', () => {
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableUserAccessTokens: true,
+            },
+        });
+        createBot();
+    });
+
+    it('MM-T1811 Create a Bot when personal access tokens are set to False', () => {
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableUserAccessTokens: false,
+            },
+        });
+
+        createBot();
+    });
+});
+
+function createBot() {
+    cy.apiInitSetup().then(({team}) => {
+        // # go to bot integrations page
+        cy.visit(`/${team.name}/channels/town-square`);
+        cy.get('#headerInfo').click();
+        cy.get('#integrations a').click();
+        cy.get('a.integration-option[href$="/bots"]').click();
+        cy.get('#addBotAccount').click();
+
+        // # fill+submit form
+        cy.get('#username').type(`bot-${getRandomId()}`);
+        cy.get('#displayName').type('Test Bot');
+        cy.get('#saveBot').click();
+
+        // * verify confirmation page
+        cy.url().
+            should('include', `/${team.name}/integrations/confirm`).
+            should('match', /token=[a-zA-Z0-9]{26}/);
+
+        // * verify confirmation form/token
+        cy.get('div.backstage-form').
+            should('include.text', 'Setup Successful').
+            should((confirmation) => {
+                expect(confirmation.text()).to.match(/Token: [a-zA-Z0-9]{26}/);
+            });
+        cy.get('#doneButton').click();
+    });
+}


### PR DESCRIPTION
#### Summary

Add E2E spec for creating bots via the Integrations page.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-27222
  - [MM-T1810](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T1810)
  - [MM-T1811](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin%3Acom.kanoah.test-manager__main-project-page#!/testCase/MM-T1811)

#### Related Pull Requests

#### Screenshots
