### PR TITLE
[MM-28230] Add defaultProps to user_settings_modal for new onExit prop

### DIFF
--- a/components/user_settings/modal/user_settings_modal.tsx
+++ b/components/user_settings/modal/user_settings_modal.tsx
@@ -71,7 +71,7 @@ const holders = defineMessages({
 type Props = {
     currentUser: UserProfile;
     onHide: () => void;
-    onExit: () => void;
+    onExit?: () => void;
     intl: IntlShape;
     actions: {
         sendVerificationEmail: (email: string) => Promise<{
@@ -97,6 +97,10 @@ class UserSettingsModal extends React.PureComponent<Props, State> {
     private customConfirmAction: ((handleConfirm: () => void) => void) | null;
     private modalBodyRef: React.RefObject<Modal>;
     private afterConfirm: (() => void) | null;
+
+    static defaultProps = {
+        onExit: () => {}
+    };
 
     constructor(props: Props) {
         super(props);

--- a/components/user_settings/modal/user_settings_modal.tsx
+++ b/components/user_settings/modal/user_settings_modal.tsx
@@ -71,7 +71,7 @@ const holders = defineMessages({
 type Props = {
     currentUser: UserProfile;
     onHide: () => void;
-    onExit?: () => void;
+    onExit: () => void;
     intl: IntlShape;
     actions: {
         sendVerificationEmail: (email: string) => Promise<{


### PR DESCRIPTION
#### Summary
A defaultProps was missed that left this component somewhat broken on certain entry-points. Added a noop function for if it's not passed.

Main Menu > Account Settings
Close Account Settings
Webapp should continue working as before 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28230

#### Related Pull Requests
- Has server changes n/a
- Has redux changes n/a
- Has mobile changes n/a

#### Screenshots
n/a