### PR TITLE
Fix pipeline by increasing node memory for Makefile steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ executors:
 aliases:
   - &restore_cache
     restore_cache:
-      key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-1
+      key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-2
   - &save_cache
     save_cache:
-      key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-1
+      key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-2
       paths:
         - ~/mattermost/mattermost-webapp/node_modules
 
@@ -29,8 +29,7 @@ jobs:
       - checkout
       - run: |
           npm ci
-          cd node_modules/mattermost-redux && npm i && npm run build && cd ../..
-          npm cache verify
+          cd node_modules/mattermost-redux && npm i && npm run build && ../..
       - *save_cache
 
   check-deps:
@@ -147,21 +146,7 @@ jobs:
       - run: |
           node --version
           npm version
-
-          rm -rf dist
-          export NODE_OPTIONS=--max-old-space-size=4096
-          npm run build
-
-          cd dist
-          npm set init.name "mattermost-webapp"
-          npm set init.version "0.0.1"
-          npm set init.license "Apache-2.0"
-          npm set init.homepage "https://github.com/mattermost/mattermost-webapp"
-          npm set init.private true
-          npm init --yes
-          npm pack
-          mv mattermost-webapp-0.0.1.tgz ../mattermost-webapp.tar.gz
-          cd ..
+          make package-ci
       - store_artifacts:
           path: ~/mattermost/mattermost-webapp/mattermost-webapp.tar.gz
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ executors:
 aliases:
   - &restore_cache
     restore_cache:
-      key: dependencies-{{ checksum "package-lock.json" }}-2
+      key: dependencies-{{ checksum "package-lock.json" }}-3
   - &save_cache
     save_cache:
-      key: dependencies-{{ checksum "package-lock.json" }}-2
+      key: dependencies-{{ checksum "package-lock.json" }}-3
       paths:
         - ~/mattermost/mattermost-webapp/node_modules
 
@@ -146,7 +146,11 @@ jobs:
       - run: |
           node --version
           npm version
-          make package-ci
+
+          rm -rf dist
+          npm cache verify
+          npm run build
+          npm run package
       - store_artifacts:
           path: ~/mattermost/mattermost-webapp/mattermost-webapp.tar.gz
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - checkout
       - run: |
           npm ci
-          cd node_modules/mattermost-redux && npm i && npm run build && ../..
+          cd node_modules/mattermost-redux && npm i && npm run build
       - *save_cache
 
   check-deps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ executors:
 aliases:
   - &restore_cache
     restore_cache:
-      key: dependencies-{{ checksum "package-lock.json" }}-3
+      key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-1
   - &save_cache
     save_cache:
-      key: dependencies-{{ checksum "package-lock.json" }}-3
+      key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-1
       paths:
         - ~/mattermost/mattermost-webapp/node_modules
 
@@ -29,7 +29,8 @@ jobs:
       - checkout
       - run: |
           npm ci
-          cd node_modules/mattermost-redux && npm i && npm run build
+          cd node_modules/mattermost-redux && npm i && npm run build && cd ../..
+          npm cache verify
       - *save_cache
 
   check-deps:
@@ -148,9 +149,19 @@ jobs:
           npm version
 
           rm -rf dist
-          npm cache verify
+          export NODE_OPTIONS=--max-old-space-size=4096
           npm run build
-          npm run package
+
+          cd dist
+          npm set init.name "mattermost-webapp"
+          npm set init.version "0.0.1"
+          npm set init.license "Apache-2.0"
+          npm set init.homepage "https://github.com/mattermost/mattermost-webapp"
+          npm set init.private true
+          npm init --yes
+          npm pack
+          mv mattermost-webapp-0.0.1.tgz ../mattermost-webapp.tar.gz
+          cd ..
       - store_artifacts:
           path: ~/mattermost/mattermost-webapp/mattermost-webapp.tar.gz
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - checkout
       - run: |
           npm ci
-          cd node_modules/mattermost-redux && npm ci && npm run build && cd ../..
+          cd node_modules/mattermost-redux && npm i && npm run build && cd ../..
           npm cache verify
       - *save_cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - checkout
       - run: |
           npm ci
-          cd node_modules/mattermost-redux && npm i && npm run build && cd ../..
+          cd node_modules/mattermost-redux && npm ci && npm run build && cd ../..
           npm cache verify
       - *save_cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ executors:
 aliases:
   - &restore_cache
     restore_cache:
-      key: dependencies-{{ checksum "package-lock.json" }}-1
+      key: dependencies-{{ checksum "package-lock.json" }}-2
   - &save_cache
     save_cache:
-      key: dependencies-{{ checksum "package-lock.json" }}-1
+      key: dependencies-{{ checksum "package-lock.json" }}-2
       paths:
         - ~/mattermost/mattermost-webapp/node_modules
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ executors:
 aliases:
   - &restore_cache
     restore_cache:
-      key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-2
+      key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-3
   - &save_cache
     save_cache:
-      key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-2
+      key: dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}-3
       paths:
         - ~/mattermost/mattermost-webapp/node_modules
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run clean stop check-style fix-style run-unit emojis help package-ci storybook build-storybook update-dependencies
+.PHONY: build test run clean stop check-style fix-style run-unit emojis help storybook build-storybook update-dependencies
 
 BUILD_SERVER_DIR = ../mattermost-server
 BUILD_WEBAPP_DIR = ../mattermost-webapp
@@ -41,29 +41,6 @@ node_modules: package.json package-lock.json
 
 	npm install
 	touch $@
-
-package: build ## Packages app
-	@echo Packaging webapp
-
-	mkdir tmp
-	mv dist tmp/client
-	tar -C tmp -czf mattermost-webapp.tar.gz client
-	mv tmp/client dist
-	rmdir tmp
-
-package-ci: ## used in the CI to build the package and bypass the npm install
-	@echo Building mattermost Webapp
-
-	rm -rf dist
-	npm run build
-
-	@echo Packaging webapp
-
-	mkdir tmp
-	mv dist tmp/client
-	tar -C tmp -czf mattermost-webapp.tar.gz client
-	mv tmp/client dist
-	rmdir tmp
 
 build: node_modules ## Builds the app
 	@echo Building mattermost Webapp

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: build test run clean stop check-style fix-style run-unit emojis help storybook build-storybook update-dependencies
+.PHONY: build test run clean stop check-style fix-style run-unit emojis help package-ci storybook build-storybook update-dependencies
 
 BUILD_SERVER_DIR = ../mattermost-server
 BUILD_WEBAPP_DIR = ../mattermost-webapp
 MM_UTILITIES_DIR = ../mattermost-utilities
 EMOJI_TOOLS_DIR = ./build/emoji
+export NODE_OPTIONS=--max-old-space-size=4096
 
 build-storybook: node_modules ## Build the storybook
 	@echo Building storybook
@@ -41,6 +42,29 @@ node_modules: package.json package-lock.json
 
 	npm install
 	touch $@
+
+package: build ## Packages app
+	@echo Packaging webapp
+
+	mkdir tmp
+	mv dist tmp/client
+	tar -C tmp -czf mattermost-webapp.tar.gz client
+	mv tmp/client dist
+	rmdir tmp
+
+package-ci: ## used in the CI to build the package and bypass the npm install
+	@echo Building mattermost Webapp
+
+	rm -rf dist
+	npm run build
+
+	@echo Packaging webapp
+
+	mkdir tmp
+	mv dist tmp/client
+	tar -C tmp -czf mattermost-webapp.tar.gz client
+	mv tmp/client dist
+	rmdir tmp
 
 build: node_modules ## Builds the app
 	@echo Building mattermost Webapp

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
   "scripts": {
     "check": "eslint --ext .js --ext .jsx --ext tsx --ext ts . --quiet --cache",
     "fix": "eslint --ext .js --ext .jsx --ext tsx --ext ts . --quiet --fix --cache",
-    "build": "cross-env NODE_ENV=production webpack --display-chunks --display-error-details --verbose --display-modules --display-reasons",
+    "build": "cross-env NODE_ENV=production webpack --verbose --display-chunks --display-error-details --display-modules --display-reasons",
     "package": "mkdir tmp && mv dist tmp/client && tar -C tmp -czf mattermost-webapp.tar.gz client && mv tmp/client dist && rmdir tmp",
     "run": "webpack --progress --watch",
     "dev-server": "webpack-dev-server",

--- a/package.json
+++ b/package.json
@@ -233,7 +233,8 @@
   "scripts": {
     "check": "eslint --ext .js --ext .jsx --ext tsx --ext ts . --quiet --cache",
     "fix": "eslint --ext .js --ext .jsx --ext tsx --ext ts . --quiet --fix --cache",
-    "build": "cross-env NODE_ENV=production webpack --display-error-details --verbose",
+    "build": "cross-env NODE_ENV=production webpack --display-chunks --display-error-details --verbose --display-modules --display-reasons",
+    "package": "mkdir tmp && mv dist tmp/client && tar -C tmp -czf mattermost-webapp.tar.gz client && mv tmp/client dist && rmdir tmp",
     "run": "webpack --progress --watch",
     "dev-server": "webpack-dev-server",
     "test": "cross-env NODE_ICU_DATA=node_modules/full-icu TZ=Etc/UTC jest --forceExit --detectOpenHandles",

--- a/package.json
+++ b/package.json
@@ -233,8 +233,7 @@
   "scripts": {
     "check": "eslint --ext .js --ext .jsx --ext tsx --ext ts . --quiet --cache",
     "fix": "eslint --ext .js --ext .jsx --ext tsx --ext ts . --quiet --fix --cache",
-    "build": "cross-env NODE_ENV=production webpack --verbose --display-chunks --display-error-details --display-modules --display-reasons",
-    "package": "mkdir tmp && mv dist tmp/client && tar -C tmp -czf mattermost-webapp.tar.gz client && mv tmp/client dist && rmdir tmp",
+    "build": "cross-env NODE_ENV=production webpack --display-error-details --verbose",
     "run": "webpack --progress --watch",
     "dev-server": "webpack-dev-server",
     "test": "cross-env NODE_ICU_DATA=node_modules/full-icu TZ=Etc/UTC jest --forceExit --detectOpenHandles",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->This PR also includes that branches use their separate cache now. I retriggered pipeline a couple of times to see, if the pipeline still fails: https://app.circleci.com/pipelines/github/mattermost/mattermost-webapp?branch=fix-pipeline , but I need to bump the caching every time. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->