### PR TITLE
[MM-23651] No more than 256 members are allowed to be invited

### DIFF
--- a/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.jsx
+++ b/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.jsx
@@ -291,9 +291,9 @@ class InvitationModalMembersStep extends React.PureComponent {
                     </h2>
                     <div data-testid='inputPlaceholder'>
                         <UsersEmailsInput
+                            {...errorProperties}
                             usersLoader={this.usersLoader}
                             placeholder={placeholder}
-                            showError={errorProperties.showError}
                             ariaLabel={localizeMessage(
                                 'invitation_modal.members.search_and_add.title',
                                 'Invite People',
@@ -304,9 +304,6 @@ class InvitationModalMembersStep extends React.PureComponent {
                                 'invitation_modal.members.users_emails_input.valid_email',
                             )}
                             validAddressMessageDefault='Invite **{email}** as a team member'
-                            errorMessageId={errorProperties.errorMessageId}
-                            errorMessageDefault={errorProperties.errorMessageDefault}
-                            errorMessageValues={errorProperties.errorMessageValues}
                             noMatchMessageId={noMatchMessageId}
                             noMatchMessageDefault={noMatchMessageDefault}
                             onInputChange={this.onUsersInputChange}

--- a/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.jsx
+++ b/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.jsx
@@ -204,7 +204,7 @@ class InvitationModalMembersStep extends React.PureComponent {
             errorProperties.errorMessageId = t(
                 'invitation_modal.invite_members.exceeded_max_add_members_batch',
             );
-            errorProperties.errorMessageDefault = 'No more than **{text}** people can be invited at once.';
+            errorProperties.errorMessageDefault = 'No more than **{text}** people can be invited at once';
             errorProperties.errorMessageValues.text = Constants.MAX_ADD_MEMBERS_BATCH;
         }
 

--- a/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.jsx
+++ b/components/invitation_modal/invitation_modal_members_step/invitation_modal_members_step.jsx
@@ -188,7 +188,7 @@ class InvitationModalMembersStep extends React.PureComponent {
         const remainingUsers = this.props.userLimit - this.props.analytics.TOTAL_USERS;
         const inviteMembersButtonDisabled = this.state.usersAndEmails.length > Constants.MAX_ADD_MEMBERS_BATCH || this.state.usersAndEmails.length === 0;
 
-        let errorProperties = {
+        const errorProperties = {
             showError: this.shouldShowPickerError(),
             errorMessageId: t(
                 'invitation_modal.invite_members.hit_cloud_user_limit',
@@ -196,15 +196,15 @@ class InvitationModalMembersStep extends React.PureComponent {
             errorMessageDefault: 'You have reached the user limit for your tier',
             errorMessageValues: {
                 text: remainingUsers < 0 ? '0' : remainingUsers,
-            }
-        }
+            },
+        };
 
         if (this.state.usersAndEmails.length > Constants.MAX_ADD_MEMBERS_BATCH) {
             errorProperties.showError = true;
             errorProperties.errorMessageId = t(
                 'invitation_modal.invite_members.exceeded_max_add_members_batch',
             );
-            errorProperties.errorMessageDefault = 'No more than **{text}** people can be invited at once.'
+            errorProperties.errorMessageDefault = 'No more than **{text}** people can be invited at once.';
             errorProperties.errorMessageValues.text = Constants.MAX_ADD_MEMBERS_BATCH;
         }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2890,6 +2890,7 @@
   "invitation_modal.invite_guests.title": "Invite **Guests**",
   "invitation_modal.invite_members.description": "Invite new team members with a link or by email. Team members have access to messages and files in open teams and public channels.",
   "invitation_modal.invite_members.description-email-disabled": "Invite new team members with a link. Team members have access to messages and files in open teams and public channels.",
+  "invitation_modal.invite_members.exceeded_max_add_members_batch": "No more than **{text}** people can be invited at once",
   "invitation_modal.invite_members.hit_cloud_user_limit": "You can only invite **{text}** more {text, plural, one {member} other {members}} on the free tier",
   "invitation_modal.invite_members.title": "Invite **Members**",
   "invitation_modal.invite.more": "Invite More People",

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -874,7 +874,7 @@ export const Constants = {
         POST: 5,
     },
 
-    // This is the same limit set https://github.com/mattermost/mattermost-server/blob/master/api4/team.go#L23 
+    // This is the same limit set https://github.com/mattermost/mattermost-server/blob/master/api4/team.go#L23
     MAX_ADD_MEMBERS_BATCH: 20,
 
     SPECIAL_MENTIONS: ['all', 'channel', 'here'],

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -874,6 +874,9 @@ export const Constants = {
         POST: 5,
     },
 
+    // This is the same limit set https://github.com/mattermost/mattermost-server/blob/master/api4/team.go#L23 
+    MAX_ADD_MEMBERS_BATCH: 20,
+
     SPECIAL_MENTIONS: ['all', 'channel', 'here'],
     SPECIAL_MENTIONS_REGEX: /(?:\B|\b_+)@(channel|all|here)(?!(\.|-|_)*[^\W_])/gi,
     NOTIFY_ALL_MEMBERS: 5,

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -875,7 +875,7 @@ export const Constants = {
     },
 
     // This is the same limit set https://github.com/mattermost/mattermost-server/blob/master/api4/team.go#L23
-    MAX_ADD_MEMBERS_BATCH: 20,
+    MAX_ADD_MEMBERS_BATCH: 256,
 
     SPECIAL_MENTIONS: ['all', 'channel', 'here'],
     SPECIAL_MENTIONS_REGEX: /(?:\B|\b_+)@(channel|all|here)(?!(\.|-|_)*[^\W_])/gi,


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->

If more than 256 members are added to the list of invite members, then we throw an error. 
This limit comes from https://github.com/mattermost/mattermost-server/blob/master/api4/team.go#L23 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23651

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->
![image](https://user-images.githubusercontent.com/17804942/92513237-f8a74680-f1dd-11ea-9b72-4b8aeccec1ee.png)


**BLOCKED BY**
https://github.com/mattermost/mattermost-server/pull/15414