### PR TITLE
[MM-28328] Move call from render function to componentDidMount to prevent race condition

### DIFF
--- a/components/channel_view/channel_view.jsx
+++ b/components/channel_view/channel_view.jsx
@@ -142,7 +142,7 @@ export default class ChannelView extends React.PureComponent {
             );
         }
 
-        if (this.props.showNextStepsEphemeral) {
+        if (this.props.showNextStepsEphemeral && this.props.isCloud) {
             return (
                 <NextStepsView/>
             );

--- a/components/next_steps_view/next_steps_view.tsx
+++ b/components/next_steps_view/next_steps_view.tsx
@@ -209,14 +209,16 @@ export default class NextStepsView extends React.PureComponent<Props, State> {
         );
     }
 
-    renderMainBody = () => {
-        const renderedSteps = this.props.steps.map(this.renderStep);
-
+    componentDidMount = () => {
         // If all steps are complete, don't render this and skip to the tips screen
         if (this.getIncompleteStep() === null) {
             this.showFinalScreenNoAnimation();
-            return null;
         }
+    }
+
+    renderMainBody = () => {
+        const renderedSteps = this.props.steps.map(this.renderStep);
+
         return (
             <div
                 className={classNames('NextStepsView__viewWrapper NextStepsView__mainView', {

--- a/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -35,7 +35,6 @@ exports[`components/sidebar should match snapshot 1`] = `
     onDragStart={[Function]}
   />
   <Connect(DataPrefetch) />
-  <Connect(SidebarNextSteps) />
 </div>
 `;
 
@@ -72,7 +71,6 @@ exports[`components/sidebar should match snapshot when direct channels modal is 
     onDragStart={[Function]}
   />
   <Connect(DataPrefetch) />
-  <Connect(SidebarNextSteps) />
   <Connect(MoreDirectChannels)
     isExistingChannel={false}
     onModalDismissed={[Function]}
@@ -112,7 +110,6 @@ exports[`components/sidebar should match snapshot when isDataPrefechEnabled is d
     onDragEnd={[Function]}
     onDragStart={[Function]}
   />
-  <Connect(SidebarNextSteps) />
 </div>
 `;
 
@@ -149,6 +146,5 @@ exports[`components/sidebar should match snapshot when more channels modal is op
     onDragStart={[Function]}
   />
   <Connect(DataPrefetch) />
-  <Connect(SidebarNextSteps) />
 </div>
 `;

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -183,7 +183,7 @@ export default class Sidebar extends React.PureComponent<Props, State> {
                     onDragEnd={this.onDragEnd}
                 />
                 {this.props.isDataPrefechEnabled && <DataPrefetch/>}
-                <SidebarNextSteps/>
+                {this.props.isCloud && <SidebarNextSteps/>}
                 {this.renderModals()}
             </div>
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -13297,6 +13297,14 @@
       "dev": true,
       "requires": {
         "icu4c-data": "0.64.2"
+      },
+      "dependencies": {
+        "icu4c-data": {
+          "version": "0.64.2",
+          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+          "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+          "dev": true
+        }
       }
     },
     "function-bind": {
@@ -14303,12 +14311,6 @@
       "requires": {
         "postcss": "^7.0.14"
       }
-    },
-    "icu4c-data": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13297,14 +13297,6 @@
       "dev": true,
       "requires": {
         "icu4c-data": "0.64.2"
-      },
-      "dependencies": {
-        "icu4c-data": {
-          "version": "0.64.2",
-          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-          "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
-          "dev": true
-        }
       }
     },
     "function-bind": {
@@ -14311,6 +14303,12 @@
       "requires": {
         "postcss": "^7.0.14"
       }
+    },
+    "icu4c-data": {
+      "version": "0.67.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
+      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
+      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",


### PR DESCRIPTION
#### Summary
This if statement was run in a render component which meant there could be a race condition preventing the animation from playing when the transition happens between next_steps and next_steps_tips. Moving into componentDidMount remedies this problem.


#### Ticket Link
Fix related to #6384 

#### Related Pull Requests
#6384 
- Has server changes n/a
- Has redux changes n/a
- Has mobile changes n/a

#### Screenshots
n/a