### PR TITLE
Cypress/E2E: Fix more unreads position with scroll spec

### DIFF
--- a/e2e/cypress/integration/channel_settings/more_unreads_position_with_scroll_spec.js
+++ b/e2e/cypress/integration/channel_settings/more_unreads_position_with_scroll_spec.js
@@ -10,6 +10,8 @@
 // Stage: @prod
 // Group: @channel_settings
 
+import * as TIMEOUTS from '../../fixtures/timeouts';
+
 describe('Channel settings', () => {
     let mainUser;
     let otherUser;
@@ -61,7 +63,7 @@ describe('Channel settings', () => {
             });
 
             // # Scroll down in channels list until last created channel is visible
-            cy.get(`#sidebarItem_${channelNames[lastChannelIndex]}`).scrollIntoView();
+            cy.get(`#sidebarItem_${channelNames[lastChannelIndex]}`).scrollIntoView({duration: TIMEOUTS.TWO_SEC});
         });
 
         // * After scrolling is complete, "More Unreads" pill should be visible at the top of the channels list
@@ -81,7 +83,7 @@ describe('Channel settings', () => {
             });
 
             // # Scroll down in channels list until last created channel is visible
-            cy.get(`#sidebarItem_${channelNames[firstChannelIndex]}`).scrollIntoView();
+            cy.get(`#sidebarItem_${channelNames[firstChannelIndex]}`).scrollIntoView({duration: TIMEOUTS.TWO_SEC});
         });
 
         // * After scrolling is complete, "More Unreads" pill should not be visible at the top of the channels list


### PR DESCRIPTION
#### Summary
- Added duration on scrolling to stabilize and make sure scrolling completes

#### Ticket Link
None -  master only

![Screen Shot 2020-09-10 at 10 24 09 AM](https://user-images.githubusercontent.com/487991/92771519-cf0e2c80-f34f-11ea-9f9f-9fad594ec237.png)
