### PR TITLE
Cypress/E2E: Debug upload files spec

### DIFF
--- a/e2e/cypress/integration/files_and_attachments/upload_files_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/upload_files_spec.js
@@ -212,6 +212,8 @@ describe('Upload Files', () => {
             FileSettings: {
                 EnablePublicLink: true,
             },
+        }).then(({config}) => {
+            expect(config.FileSettings.EnablePublicLink).to.be.true;
         });
 
         const attachmentFilename = 'image-file.jpg';

--- a/e2e/cypress/support/api/system.js
+++ b/e2e/cypress/support/api/system.js
@@ -85,7 +85,7 @@ Cypress.Commands.add('apiUpdateConfig', (newConfig = {}) => {
             body: config,
         }).then((updateResponse) => {
             expect(updateResponse.status).to.equal(200);
-            return cy.wrap({config: response.body});
+            return cy.apiGetConfig();
         });
     });
 });
@@ -98,7 +98,7 @@ Cypress.Commands.add('apiReloadConfig', () => {
         method: 'POST',
     }).then((reloadResponse) => {
         expect(reloadResponse.status).to.equal(200);
-        return cy.wrap({config: reloadResponse.body});
+        return cy.apiGetConfig();
     });
 });
 


### PR DESCRIPTION
#### Summary
- Needed to add verification of config update to debug if it is indeed being updated in the major cypress run. I also did a cypress run just for the failing test and it seems to run fine
- For some reason, the config from `apiUpdateConfig ` response  is not updated and had to call `apiGetConfig` for latest
- This passes for me locally but failing on daily cypress run

[Cypress Run Passed](https://app.circleci.com/pipelines/github/saturninoabril/mattermost-cypress-docker?branch=debug-upload-files-spec)

#### Ticket Link
None -  master only
