### PR TITLE
Possible fix for accessibility test for support in buttons in channel header

### DIFF
--- a/e2e/cypress/fixtures/partial_default_config.json
+++ b/e2e/cypress/fixtures/partial_default_config.json
@@ -473,6 +473,9 @@
         "PluginStates": {
             "com.mattermost.nps": {
                 "Enable": false
+            },
+            "com.mattermost.plugin-incident-response": {
+                "Enable":false
             }
         },
         "EnableMarketplace": true,

--- a/e2e/cypress/fixtures/partial_default_config.json
+++ b/e2e/cypress/fixtures/partial_default_config.json
@@ -475,7 +475,7 @@
                 "Enable": false
             },
             "com.mattermost.plugin-incident-response": {
-                "Enable":false
+                "Enable": false
             }
         },
         "EnableMarketplace": true,

--- a/e2e/cypress/integration/accessibility/accessibility_buttons_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_buttons_spec.js
@@ -56,7 +56,7 @@ describe('Verify Accessibility Support in different Buttons', () => {
         cy.get('#toggleFavorite').focus().tab({shift: true}).tab();
 
         // # Press tab until the focus is on the Pinned posts button
-        cy.focused().tab().tab().tab().tab().tab();
+        cy.focused().tab().tab().tab().tab();
 
         // * Verify accessibility support in Pinned Posts button
         cy.get('#channelHeaderPinButton').should('have.attr', 'aria-label', 'Pinned posts').and('have.class', 'a11y--active a11y--focused').tab();

--- a/e2e/cypress/integration/accessibility/accessibility_buttons_spec.js
+++ b/e2e/cypress/integration/accessibility/accessibility_buttons_spec.js
@@ -56,7 +56,7 @@ describe('Verify Accessibility Support in different Buttons', () => {
         cy.get('#toggleFavorite').focus().tab({shift: true}).tab();
 
         // # Press tab until the focus is on the Pinned posts button
-        cy.focused().tab().tab().tab().tab();
+        cy.focused().tab().tab().tab().tab().tab();
 
         // * Verify accessibility support in Pinned Posts button
         cy.get('#channelHeaderPinButton').should('have.attr', 'aria-label', 'Pinned posts').and('have.class', 'a11y--active a11y--focused').tab();


### PR DESCRIPTION
The error is happening because of the new plugin icon that is recently added. Since this is an accessibility test, the best way to test is using keyboard tab to verify that the buttons in channel header can be accessed as such. Therefore, instead of adding any complex solution, only adding a tab to verify that the pin button can be accessed as expected.

#### Screenshots
![Screen Shot 2020-09-14 at 6 16 14 PM](https://user-images.githubusercontent.com/691331/93153626-88edfb80-f6b6-11ea-95b7-dd5956ad0e8a.png)
