### PR TITLE
MM-28209: fix dual scrollbars in channel switcher

### DIFF
--- a/sass/components/_channel-switcher.scss
+++ b/sass/components/_channel-switcher.scss
@@ -57,7 +57,7 @@
     }
 
     .channel-switcher__suggestion-box {
-        height: 344px;
+        height: 362px;
         position: relative;
         padding: 0;
 


### PR DESCRIPTION
#### Summary

- [MM-28209](https://mattermost.atlassian.net/browse/MM-28209) Sync fixed-height content to match max dynamic-hight content to prevent dual scrollbars.

#### Screenshots

<img width="616" alt="Screen Shot 2020-09-15 at 11 22 47" src="https://user-images.githubusercontent.com/11724372/93237504-d6fe1000-f745-11ea-82f2-f8770685ac5b.png">
