### PR TITLE
[MM-28646] Regenerate the invite ID if it's not defined

### DIFF
--- a/components/next_steps_view/steps/invite_members_step/index.ts
+++ b/components/next_steps_view/steps/invite_members_step/index.ts
@@ -21,7 +21,8 @@ function mapStateToProps(state: GlobalState) {
 }
 
 type Actions = {
-    sendEmailInvitesToTeamGracefully: (teamId: string, emails: string[]) => Promise<{data: TeamInviteWithError[]; error: ServerError}>;
+    sendEmailInvitesToTeamGracefully: (teamId: string, emails: string[]) => Promise<{ data: TeamInviteWithError[]; error: ServerError }>;
+    regenerateTeamInviteId: (teamId: string) => void;
 }
 
 function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {

--- a/components/next_steps_view/steps/invite_members_step/index.ts
+++ b/components/next_steps_view/steps/invite_members_step/index.ts
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
 
-import {sendEmailInvitesToTeamGracefully} from 'mattermost-redux/actions/teams';
+import {sendEmailInvitesToTeamGracefully, regenerateTeamInviteId} from 'mattermost-redux/actions/teams';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {GenericAction, ActionFunc} from 'mattermost-redux/types/actions';
 import {ServerError} from 'mattermost-redux/types/errors';
@@ -28,6 +28,7 @@ function mapDispatchToProps(dispatch: Dispatch<GenericAction>) {
     return {
         actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc>, Actions>({
             sendEmailInvitesToTeamGracefully,
+            regenerateTeamInviteId,
         }, dispatch),
     };
 }

--- a/components/next_steps_view/steps/invite_members_step/invite_members_step.test.tsx
+++ b/components/next_steps_view/steps/invite_members_step/invite_members_step.test.tsx
@@ -19,6 +19,7 @@ describe('components/next_steps_view/steps/invite_members_step', () => {
         isAdmin: true,
         actions: {
             sendEmailInvitesToTeamGracefully: jest.fn(),
+            regenerateTeamInviteId: jest.fn(),
         },
     };
 

--- a/components/next_steps_view/steps/invite_members_step/invite_members_step.tsx
+++ b/components/next_steps_view/steps/invite_members_step/invite_members_step.tsx
@@ -24,7 +24,8 @@ import './invite_members_step.scss';
 type Props = StepComponentProps & {
     team: Team;
     actions: {
-        sendEmailInvitesToTeamGracefully: (teamId: string, emails: string[]) => Promise<{data: TeamInviteWithError[]; error: ServerError}>;
+        sendEmailInvitesToTeamGracefully: (teamId: string, emails: string[]) => Promise<{ data: TeamInviteWithError[]; error: ServerError }>;
+        regenerateTeamInviteId: (teamId: string) => void;
     };
 };
 
@@ -75,6 +76,11 @@ export default class InviteMembersStep extends React.PureComponent<Props, State>
     componentDidMount() {
         if (this.props.expanded) {
             pageVisited(getAnalyticsCategory(this.props.isAdmin), 'pageview_invite_members');
+        }
+
+        if (!this.props.team.invite_id) {
+            // force a regenerate if an invite ID hasn't been generated yet
+            this.props.actions.regenerateTeamInviteId(this.props.team.id);
         }
     }
 


### PR DESCRIPTION
#### Summary
There was a rare bug that the invite ID would be "undefined" when it was displayed to the user in the onboarding flow. This PR adds a check for this case, and forces it to be generated if it is undefined. This guard should only ever be run in the rare bug circumstance.

#### Ticket Link`
https://mattermost.atlassian.net/browse/MM-28646
#### Related Pull Requests
n/a
#### Screenshots
n/a