### PR TITLE
Cypress/E2E: Move cy.apiCreateBot and fix MM-T251 & MM-T252

### DIFF
--- a/e2e/cypress/integration/mark_as_unread/bot_post_mark_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/bot_post_mark_as_unread_spec.js
@@ -11,8 +11,9 @@
 // Group: @mark_as_unread
 
 import {getAdminAccount} from '../../support/env';
+import {beUnread} from '../../support/assertions';
 
-import {markAsUnreadFromPost, beUnread, verifyPostNextToNewMessageSeparator} from './helpers';
+import {markAsUnreadFromPost, verifyPostNextToNewMessageSeparator} from './helpers';
 
 describe('Bot post unread message', () => {
     const sysadmin = getAdminAccount();
@@ -35,18 +36,18 @@ describe('Bot post unread message', () => {
         });
 
         // # Create a bot and get userID
-        cy.apiCreateBot('bot-' + Date.now(), 'Test Bot', 'test bot for E2E test replying to older bot post').then((response) => {
-            const botsUserId = response.body.user_id;
-            cy.externalRequest({user: sysadmin, method: 'put', path: `users/${botsUserId}/roles`, data: {roles: 'system_user system_post_all system_admin'}});
+        cy.apiCreateBot('bot-' + Date.now(), 'Test Bot', 'test bot for E2E test replying to older bot post').then(({bot}) => {
+            const botUserId = bot.user_id;
+            cy.externalRequest({user: sysadmin, method: 'put', path: `users/${botUserId}/roles`, data: {roles: 'system_user system_post_all system_admin'}});
 
             // # Get token from bots id
-            cy.apiAccessToken(botsUserId, 'Create token').then((token) => {
+            cy.apiAccessToken(botUserId, 'Create token').then((token) => {
                 //# Add bot to team
-                cy.apiAddUserToTeam(newChannel.team_id, botsUserId);
+                cy.apiAddUserToTeam(newChannel.team_id, botUserId);
 
                 // # Post message as bot to the new channel
-                cy.postBotMessage({token, channelId: newChannel.id, message: 'this is bot message'}).then((post) => {
-                    botPost = post;
+                cy.postBotMessage({token, channelId: newChannel.id, message: 'this is bot message'}).then((res) => {
+                    botPost = res.data;
                 });
             });
         });

--- a/e2e/cypress/integration/mark_as_unread/mark_as_unread_using_shortcuts_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/mark_as_unread_using_shortcuts_spec.js
@@ -9,7 +9,9 @@
 
 // Group: @mark_as_unread
 
-import {verifyPostNextToNewMessageSeparator, beUnread, switchToChannel, beRead, markAsUnreadFromMenu, showCursor} from './helpers';
+import {beRead, beUnread} from '../../support/assertions';
+
+import {verifyPostNextToNewMessageSeparator, switchToChannel, markAsUnreadFromMenu, showCursor} from './helpers';
 
 describe('Mark as Unread', () => {
     let testUser;

--- a/e2e/cypress/integration/messaging/message_reply_bot_post_spec.js
+++ b/e2e/cypress/integration/messaging/message_reply_bot_post_spec.js
@@ -15,10 +15,6 @@ import {getAdminAccount} from '../../support/env';
 describe('Messaging', () => {
     const sysadmin = getAdminAccount();
     let newChannel;
-    let botsUserId;
-    let botName;
-    let botToken;
-    let yesterdaysDate;
 
     before(() => {
         // # Set ServiceSettings to expected values
@@ -38,24 +34,22 @@ describe('Messaging', () => {
 
     it('MM-T93 Replying to an older bot post that has no post content and no attachment pretext', () => {
         // # Get yesterdays date in UTC
-        yesterdaysDate = Cypress.moment().subtract(1, 'days').valueOf();
-        botName = 'bot-' + Date.now();
+        const yesterdaysDate = Cypress.moment().subtract(1, 'days').valueOf();
+        const botName = 'bot-' + Date.now();
 
         // # Create a bot and get userID
-        cy.apiCreateBot(botName, 'Test Bot', 'test bot for E2E test replying to older bot post').then((response) => {
-            botsUserId = response.body.user_id;
-            cy.externalRequest({user: sysadmin, method: 'put', path: `users/${botsUserId}/roles`, data: {roles: 'system_user system_post_all system_admin'}});
+        cy.apiCreateBot(botName, 'Test Bot', 'test bot for E2E test replying to older bot post').then(({bot}) => {
+            const botUserId = bot.user_id;
+            cy.externalRequest({user: sysadmin, method: 'put', path: `users/${botUserId}/roles`, data: {roles: 'system_user system_post_all system_admin'}});
 
             // # Get token from bots id
-            cy.apiAccessToken(botsUserId, 'Create token').then((token) => {
-                botToken = token;
-
+            cy.apiAccessToken(botUserId, 'Create token').then((token) => {
                 //# Add bot to team
-                cy.apiAddUserToTeam(newChannel.team_id, botsUserId);
+                cy.apiAddUserToTeam(newChannel.team_id, botUserId);
 
                 // # Post message with auth token
                 const props = {attachments: [{text: 'Some Text posted by bot that has no content and no attachment pretext'}]};
-                cy.postBotMessage({token: botToken, props, channelId: newChannel.id, createAt: yesterdaysDate}).
+                cy.postBotMessage({token, props, channelId: newChannel.id, createAt: yesterdaysDate}).
                     its('id').
                     should('exist').
                     as('yesterdaysBotPost');
@@ -103,27 +97,26 @@ describe('Messaging', () => {
         // # Verify RHS is closed
         cy.get('#rhsContainer').should('not.be.visible');
     });
+
     it('MM-T91 Replying to an older post by a user that has no content (only file attachments)', () => {
         // # Get yesterdays date in UTC
-        yesterdaysDate = Cypress.moment().subtract(1, 'days').valueOf();
-        botName = 'bot-' + Date.now();
+        const yesterdaysDate = Cypress.moment().subtract(1, 'days').valueOf();
+        const botName = 'bot-' + Date.now();
 
         // # Create a bot and get userID
-        cy.apiCreateBot(botName, 'Test Bot', 'test bot for E2E test replying to older bot post').then((response) => {
-            botsUserId = response.body.user_id;
-            cy.externalRequest({user: sysadmin, method: 'put', path: `users/${botsUserId}/roles`, data: {roles: 'system_user system_post_all system_admin'}});
+        cy.apiCreateBot(botName, 'Test Bot', 'test bot for E2E test replying to older bot post').then(({bot}) => {
+            const botUserId = bot.user_id;
+            cy.externalRequest({user: sysadmin, method: 'put', path: `users/${botUserId}/roles`, data: {roles: 'system_user system_post_all system_admin'}});
 
             // # Get token from bots id
-            cy.apiAccessToken(botsUserId, 'Create token').then((token) => {
-                botToken = token;
-
+            cy.apiAccessToken(botUserId, 'Create token').then((token) => {
                 //# Add bot to team
-                cy.apiAddUserToTeam(newChannel.team_id, botsUserId);
+                cy.apiAddUserToTeam(newChannel.team_id, botUserId);
 
                 // # Post message with auth token
                 const message = 'Hello message from ' + botName;
                 const props = {attachments: [{pretext: 'Some Pretext', text: 'Some Text'}]};
-                cy.postBotMessage({token: botToken, message, props, channelId: newChannel.id, createAt: yesterdaysDate}).
+                cy.postBotMessage({token, message, props, channelId: newChannel.id, createAt: yesterdaysDate}).
                     its('id').
                     should('exist').
                     as('yesterdaysPost');

--- a/e2e/cypress/support/api/bots.d.ts
+++ b/e2e/cypress/support/api/bots.d.ts
@@ -19,6 +19,21 @@ declare namespace Cypress {
     interface Chainable<Subject = any> {
 
         /**
+         * Create a bot.
+         * See https://api.mattermost.com/#tag/bots/paths/~1bots/post
+         * @param {string} username - The bots username
+         * @param {string} displayName - The non-unique UI name for the bot
+         * @param {string} description - The description of the bot
+         * @returns {Bot} out.bot: `Bot` object
+         *
+         * @example
+         *   cy.apiCreateBot().then(({bot}) => {
+         *       // do something with bot
+         *   });
+         */
+        apiCreateBot(): Chainable<Bot>;
+
+        /**
          * Get bots.
          * See https://api.mattermost.com/#tag/bots/paths/~1bots/get
          * @returns {Bot[]} out.bots: `Bot[]` object

--- a/e2e/cypress/support/api/bots.js
+++ b/e2e/cypress/support/api/bots.js
@@ -6,6 +6,22 @@
 // https://api.mattermost.com/#tag/bots
 // *****************************************************************************
 
+Cypress.Commands.add('apiCreateBot', (username, displayName, description) => {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: '/api/v4/bots',
+        method: 'POST',
+        body: {
+            username,
+            display_name: displayName,
+            description,
+        },
+    }).then((response) => {
+        expect(response.status).to.equal(201);
+        return cy.wrap({bot: response.body});
+    });
+});
+
 Cypress.Commands.add('apiGetBots', () => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},

--- a/e2e/cypress/support/api_commands.js
+++ b/e2e/cypress/support/api_commands.js
@@ -319,30 +319,6 @@ Cypress.Commands.add('apiUploadPlugin', (filename) => {
 });
 
 /**
- * Creates a bot directly via API
- * This API assume that the user is logged in and has cookie to access
- * @param {String} username - The bots username
- * @param {String} displayName - The non-unique UI name for the bot
- * @param {String} description - The description of the bot
- * All parameters are required
- */
-Cypress.Commands.add('apiCreateBot', (username, displayName, description) => {
-    return cy.request({
-        headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/api/v4/bots',
-        method: 'POST',
-        body: {
-            username,
-            display_name: displayName,
-            description,
-        },
-    }).then((response) => {
-        expect(response.status).to.equal(201);
-        return cy.wrap(response);
-    });
-});
-
-/**
  * Get access token
  * This API assume that the user is logged in and has cookie to access
  * @param {String} user_id - The user id to generate token for


### PR DESCRIPTION
#### Summary
- Move cy.apiCreateBot
- While testing change due to movement of `cy.apiCreateBot`, I came across to fix failing on MM-T252. I should make a separate PR for this change but those are connected in some ways.
- add fix for MM-T251