### PR TITLE
MM-28892 Disabling server config settings for inproduct notices in e2e

### DIFF
--- a/e2e/cypress/fixtures/partial_default_config.json
+++ b/e2e/cypress/fixtures/partial_default_config.json
@@ -263,7 +263,9 @@
         "BannerText": "",
         "BannerColor": "#f2a93b",
         "BannerTextColor": "#333333",
-        "AllowBannerDismissal": true
+        "AllowBannerDismissal": true,
+        "AdminNoticesEnabled": false,
+        "UserNoticesEnabled": false
     },
     "ThemeSettings": {
         "EnableThemeSelection": true,

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -104,13 +104,6 @@ before(() => {
                 cy.apiAdminLogin().then(() => sysadminSetup(sysadmin));
             });
         }
-    }).then(() => {
-        cy.apiUpdateConfig({
-            AnnouncementSettings: {
-                AdminNoticesEnabled: false,
-                UserNoticesEnabled: false,
-            },
-        });
     });
 });
 

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -104,6 +104,13 @@ before(() => {
                 cy.apiAdminLogin().then(() => sysadminSetup(sysadmin));
             });
         }
+    }).then(() => {
+        cy.apiUpdateConfig({
+            AnnouncementSettings: {
+                AdminNoticesEnabled: false,
+                UserNoticesEnabled: false,
+            },
+        });
     });
 });
 


### PR DESCRIPTION
#### Summary
  * Disabling these settings so no notices are served which will cause existing e2e tests to
    break as UI will have modal open

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28892
