### PR TITLE
Possible fix for the failing long draft test in messaging

### DIFF
--- a/e2e/cypress/integration/messaging/long_draft_spec.js
+++ b/e2e/cypress/integration/messaging/long_draft_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @messaging
 
 import * as TIMEOUTS from '../../fixtures/timeouts';
@@ -45,11 +44,11 @@ describe('Messaging', () => {
         writeLinesToPostTextBox(lines);
 
         // # Visit a different channel and verify textbox
-        cy.get('#sidebarItem_off-topic').click({force: true}).wait(TIMEOUTS.HALF_SEC);
+        cy.get('#sidebarItem_off-topic').click({force: true}).wait(TIMEOUTS.THREE_SEC);
         verifyPostTextbox('@initialHeight', '');
 
         // # Return to the channel and verify textbox
-        cy.get('#sidebarItem_town-square').click({force: true}).wait(TIMEOUTS.HALF_SEC);
+        cy.get('#sidebarItem_town-square').click({force: true}).wait(TIMEOUTS.THREE_SEC);
         verifyPostTextbox('@previousHeight', lines.join('\n'));
 
         // # Clear the textbox
@@ -61,13 +60,13 @@ describe('Messaging', () => {
         writeLinesToPostTextBox(lines);
 
         // # Visit a different channel by URL and verify textbox
-        cy.visit(`/${testTeam.name}/channels/off-topic`).wait(TIMEOUTS.HALF_SEC);
+        cy.visit(`/${testTeam.name}/channels/off-topic`).wait(TIMEOUTS.THREE_SEC);
         verifyPostTextbox('@initialHeight', '');
 
         // # Should have returned to the channel by URL. However, Cypress is clearing storage for some reason.
         // # Does not happened on actual user interaction.
         // * Verify textbox
-        cy.get('#sidebarItem_town-square').click({force: true}).wait(TIMEOUTS.HALF_SEC);
+        cy.get('#sidebarItem_town-square').click({force: true}).wait(TIMEOUTS.THREE_SEC);
         verifyPostTextbox('@previousHeight', lines.join('\n'));
     });
 });


### PR DESCRIPTION
Took a stab at this test since I was seeing it last week as well. Wasn't sure about what was causing the failure since it passes as expected in every run on my local server, thus increased the wait from half a second to 3 seconds for assertions after the draft is typed. Hopefully this fixes the flakiness.
Also demoted the test from prod. Will keep an eye out to see if this fixes the issue before promoting it back to prod.