### PR TITLE
[MM-28878] Revert style change to remove next steps arrow

### DIFF
--- a/components/sidebar/sidebar_next_steps/remove_next_steps_modal.scss
+++ b/components/sidebar/sidebar_next_steps/remove_next_steps_modal.scss
@@ -1,7 +1,7 @@
 .RemoveNextStepsModal__helpBox {
     position: fixed;
     top: 16px;
-    left: 181px;
+    left: 201px;
     z-index: 1050;
 }
 


### PR DESCRIPTION
#### Summary
The `left` offset of the arrow used to indicate the hamburger menu on the Remove Next Steps modal was changed to work with the older sidebar. This PR resets it to work with the new sidebar.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28878