### PR TITLE
Demoting failed test from prod

### DIFF
--- a/e2e/cypress/integration/files_and_attachments/image_link_preview_spec.js
+++ b/e2e/cypress/integration/files_and_attachments/image_link_preview_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @file_and_attachments
 
 describe('Image Link Preview', () => {

--- a/e2e/cypress/integration/mark_as_unread/mark_gm_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/mark_gm_as_unread_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @mark_as_unread
 
 import {markAsUnreadByPostIdFromMenu, verifyPostNextToNewMessageSeparator} from './helpers';


### PR DESCRIPTION
#### Summary
Demoting failed tests from prod. These tests are working fine locally but for some reasons they are failing on the Cypress test instance on daily runs. 

#### Ticket Link
N/A
