### PR TITLE
MM-28992 Remove unused notPresent and mustBePresent props from MultiSelectSetting

### DIFF
--- a/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
+++ b/components/admin_console/__snapshots__/schema_admin_settings.test.jsx.snap
@@ -385,12 +385,6 @@ exports[`components/admin_console/SchemaAdminSettings should match snapshot with
                 id="no-result-j"
               />
             }
-            notPresent={
-              <FormattedMessage
-                defaultMessage="No present"
-                id="no-present-j"
-              />
-            }
             onChange={[Function]}
             selected={Array []}
             setByEnv={false}

--- a/components/admin_console/multiselect_settings.jsx
+++ b/components/admin_console/multiselect_settings.jsx
@@ -15,14 +15,12 @@ export default class MultiSelectSetting extends React.PureComponent {
         values: PropTypes.array.isRequired,
         label: PropTypes.node.isRequired,
         selected: PropTypes.array.isRequired,
-        mustBePresent: PropTypes.string,
         onChange: PropTypes.func.isRequired,
         disabled: PropTypes.bool,
         setByEnv: PropTypes.bool.isRequired,
         helpText: PropTypes.node,
         noResultText: PropTypes.node,
         errorText: PropTypes.node,
-        notPresent: PropTypes.node,
     };
 
     static defaultProps = {
@@ -40,20 +38,8 @@ export default class MultiSelectSetting extends React.PureComponent {
             return n.value;
         });
 
-        if (this.props.selected.length > 0 && this.props.mustBePresent && values.join(',').indexOf(this.props.mustBePresent) === -1) {
-            this.setState({error: this.props.notPresent});
-        } else {
-            this.props.onChange(this.props.id, values);
-            this.setState({error: false});
-        }
-    }
-
-    UNSAFE_componentWillReceiveProps(newProps) { // eslint-disable-line camelcase
-        if (newProps.selected.length > 0 && newProps.mustBePresent && newProps.selected.join(',').indexOf(newProps.mustBePresent) === -1) {
-            this.setState({error: this.props.notPresent});
-        } else {
-            this.setState({error: false});
-        }
+        this.props.onChange(this.props.id, values);
+        this.setState({error: false});
     }
 
     calculateValue = () => {

--- a/components/admin_console/multiselect_settings.jsx
+++ b/components/admin_console/multiselect_settings.jsx
@@ -20,7 +20,6 @@ export default class MultiSelectSetting extends React.PureComponent {
         setByEnv: PropTypes.bool.isRequired,
         helpText: PropTypes.node,
         noResultText: PropTypes.node,
-        errorText: PropTypes.node,
     };
 
     static defaultProps = {

--- a/components/admin_console/schema_admin_settings.jsx
+++ b/components/admin_console/schema_admin_settings.jsx
@@ -539,12 +539,7 @@ export default class SchemaAdminSettings extends React.PureComponent {
                     defaultMessage={setting.no_result_default}
                 />
             );
-            const notPresent = (
-                <FormattedMessage
-                    id={setting.not_present}
-                    defaultMessage={setting.not_present_default}
-                />
-            );
+
             return (
                 <MultiSelectSetting
                     key={this.props.schema.id + '_language_' + setting.key}
@@ -557,7 +552,6 @@ export default class SchemaAdminSettings extends React.PureComponent {
                     setByEnv={this.isSetByEnv(setting.key)}
                     onChange={(changedId, value) => this.handleChange(changedId, value.join(','))}
                     noResultText={noResultText}
-                    notPresent={notPresent}
                 />
             );
         }


### PR DESCRIPTION
It looks like this prop used to be needed at some point, but I can't find anywhere that it's used in the current code base. The MultiSelectSetting also doesn't appear to be exposed to plugins, so we don't need to be worried about them either.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28992