### PR TITLE
Cypress/E2E: Fix guest experience ui spec

### DIFF
--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
@@ -7,7 +7,6 @@
 // - Use element ID when selecting an element. Create one if none.
 // ***************************************************************
 
-// Stage: @prod
 // Group: @guest_account
 
 /**

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
@@ -201,13 +201,14 @@ describe('Guest Account - Guest User Experience', () => {
 
         // # Ceate a new team
         cy.apiCreateTeam('test-team2', 'Test Team2').then(({team: teamTwo}) => {
-            // # Login as guest user
-            cy.apiLogin(guestUser);
-            cy.reload();
+            // # Add the guest user to this team
+            cy.apiAddUserToTeam(teamTwo.id, guestUser.id).then(() => {
+                // # Login as guest user
+                cy.apiLogin(guestUser);
+                cy.reload();
 
-            // # As a sysadmin, add the guest user to this team
-            cy.externalAddUserToTeam(teamTwo.id, guestUser.id).then(() => {
-                cy.get(`#${teamTwo.name}TeamButton`).should('be.visible').click();
+
+                cy.get(`#${teamTwo.name}TeamButton`, {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').click();
 
                 // * Verify if Channel Not found is displayed
                 cy.findByText('Channel Not Found').should('be.visible');

--- a/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
+++ b/e2e/cypress/integration/enterprise/guest_accounts/guest_experience_ui_spec.js
@@ -207,7 +207,7 @@ describe('Guest Account - Guest User Experience', () => {
                 cy.apiLogin(guestUser);
                 cy.reload();
 
-
+                // # Click team button
                 cy.get(`#${teamTwo.name}TeamButton`, {timeout: TIMEOUTS.ONE_MIN}).should('be.visible').click();
 
                 // * Verify if Channel Not found is displayed

--- a/e2e/cypress/support/external_commands.d.ts
+++ b/e2e/cypress/support/external_commands.d.ts
@@ -11,21 +11,11 @@
 // - Each parameter with `@params`
 // - Return value with `@returns`
 // - Example usage with `@example`
-// Custom command should follow naming convention of having `external` prefix, e.g. `externalAddUserToTeam`.
+// Custom command should follow naming convention of having `external` prefix, e.g. `externalActivateUser`.
 // ***************************************************************
 
 declare namespace Cypress {
     interface Chainable<Subject = any> {
-
-        /**
-         * Makes an external request as a sysadmin and adds a user to a team directly via API
-         * @param {String} teamId - The team ID
-         * @param {String} userId - The user ID
-         *
-         * @example
-         *   cy.externalAddUserToTeam('team-id', 'user-id');
-         */
-        externalAddUserToTeam(teamId: string, userId: string): Chainable;
 
         /**
          * Makes an external request as a sysadmin and activate/deactivate a user directly via API

--- a/e2e/cypress/support/external_commands.js
+++ b/e2e/cypress/support/external_commands.js
@@ -3,13 +3,6 @@
 
 import {getAdminAccount} from './env';
 
-Cypress.Commands.add('externalAddUserToTeam', (teamId, userId) => {
-    const baseUrl = Cypress.config('baseUrl');
-    const admin = getAdminAccount();
-
-    cy.externalRequest({user: admin, method: 'post', baseUrl, path: `teams/${teamId}/members`, data: {team_id: teamId, user_id: userId}});
-});
-
 Cypress.Commands.add('externalActivateUser', (userId, active = true) => {
     const baseUrl = Cypress.config('baseUrl');
     const admin = getAdminAccount();


### PR DESCRIPTION
#### Summary
- Use `apiAddUserToTeam` instead of old `externalAddUserToTeam`
- Update comments
- Remove `externalAddUserToTeam`

![Screen Shot 2020-09-25 at 11 14 35 AM](https://user-images.githubusercontent.com/487991/94301977-4fbc5380-ff20-11ea-994f-cf5ec3e27d4f.png)


#### Ticket Link
None -  master and v5.28
