### PR TITLE
Cypress/E2E: fix getType is not a function

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -4393,9 +4393,9 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
       "dev": true
     },
     "mime-db": {
@@ -6282,6 +6282,12 @@
               "dev": true
             }
           }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -22,6 +22,7 @@
     "lodash.without": "4.4.0",
     "lodash.xor": "4.5.0",
     "mattermost-redux": "5.26.2",
+    "mime": "2.4.6",
     "mime-types": "2.1.27",
     "mocha": "8.1.3",
     "mocha-junit-reporters": "1.23.6",


### PR DESCRIPTION
#### Summary
Fix getType is not a function by explicitly adding mime version 2 which is a dependent of cypress-file-upload package.

#### Ticket Link
none

#### Screenshots
Before: error on file upload
<img width="623" alt="Screen Shot 2020-09-28 at 5 31 04 AM" src="https://user-images.githubusercontent.com/5334504/94376400-ed946600-014c-11eb-8e12-593ad66dbed6.png">
