### PR TITLE
[MM-27277] Enable stream mode for file uploads

### DIFF
--- a/actions/file_actions.jsx
+++ b/actions/file_actions.jsx
@@ -17,6 +17,10 @@ export function uploadFile(file, name, channelId, rootId, clientId) {
         return request.
             post(Client4.getFilesRoute()).
             set(Client4.getOptions({method: 'post'}).headers).
+
+            // The order here is important:
+            // keeping the channel_id/client_ids fields before the files contents
+            // allows the server to stream the uploads instead of loading them in memory.
             field('channel_id', channelId).
             field('client_ids', clientId).
             attach('files', file, name).

--- a/actions/file_actions.jsx
+++ b/actions/file_actions.jsx
@@ -17,9 +17,9 @@ export function uploadFile(file, name, channelId, rootId, clientId) {
         return request.
             post(Client4.getFilesRoute()).
             set(Client4.getOptions({method: 'post'}).headers).
-            attach('files', file, name).
             field('channel_id', channelId).
             field('client_ids', clientId).
+            attach('files', file, name).
             accept('application/json');
     };
 }


### PR DESCRIPTION
#### Summary

PR enables stream mode for uploads by changing the order of fields in the multipart/form-data upload.
This enables the [stream mode path](https://github.com/mattermost/mattermost-server/blob/85b434c50d1a4744625ddd20f2b653517aa80686/api4/file.go#L193-L198) which avoids a full memory allocation of the uploaded file.

#### Ticket

https://mattermost.atlassian.net/browse/MM-27277

#### Related PRs

https://github.com/mattermost/mattermost-server/pull/15616