### PR TITLE
Cypress/E2E: Add cy.uiClickPostDropdownMenu command

### DIFF
--- a/e2e/cypress/integration/mark_as_unread/channel_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/channel_unread_spec.js
@@ -11,7 +11,7 @@
 
 import {beRead, beUnread} from '../../support/assertions';
 
-import {markAsUnreadByPostIdFromMenu, verifyPostNextToNewMessageSeparator, switchToChannel} from './helpers';
+import {verifyPostNextToNewMessageSeparator, switchToChannel} from './helpers';
 
 describe('channel unread posts', () => {
     let testUser;
@@ -65,7 +65,7 @@ describe('channel unread posts', () => {
 
         // # Mark the last post as unread
         cy.getLastPostId().then((postId) => {
-            markAsUnreadByPostIdFromMenu(postId);
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
         });
 
         // * Verify the notification separator line exists and present before the unread message
@@ -109,7 +109,8 @@ describe('channel unread posts', () => {
 
         // # Mark the post which is one page above from bottom as unread
         cy.getNthPostId(6).then((postId) => {
-            markAsUnreadByPostIdFromMenu(postId);
+            cy.get(`#post_${postId}`).scrollIntoView().should('be.visible');
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
         });
 
         // * Verify the notification separator line exists and present before the unread message
@@ -134,7 +135,7 @@ describe('channel unread posts', () => {
 
         // # Mark the last post as unread
         cy.getLastPostId().then((postId) => {
-            markAsUnreadByPostIdFromMenu(postId);
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
         });
 
         // * Verify the notification separator line exists and present before the unread message

--- a/e2e/cypress/integration/mark_as_unread/helpers.js
+++ b/e2e/cypress/integration/mark_as_unread/helpers.js
@@ -11,16 +11,6 @@ export function markAsUnreadFromPost(post, rhs = false) {
     cy.get('body').type('{alt}', {release: true});
 }
 
-export function markAsUnreadByPostIdFromMenu(postId, prefix = 'post', location = 'CENTER') {
-    cy.get(`#${prefix}_${postId}`).trigger('mouseover');
-    cy.clickPostDotMenu(postId, location);
-    cy.get('.dropdown-menu').
-        should('be.visible').
-        within(() => {
-            cy.findByText('Mark as Unread').scrollIntoView().should('be.visible').click();
-        });
-}
-
 export function markAsUnreadShouldBeAbsent(postId, prefix = 'post', location = 'CENTER') {
     cy.get(`#${prefix}_${postId}`).trigger('mouseover');
     cy.clickPostDotMenu(postId, location);
@@ -42,7 +32,7 @@ export function markAsUnreadFromMenu(post, prefix = 'post', location = 'CENTER')
 export function switchToChannel(channel) {
     cy.get(`#sidebarItem_${channel.name}`).click();
 
-    cy.get('#channelHeaderTitle').should('contain', channel.display_name);
+    cy.get('#channelHeaderTitle', {timeout: TIMEOUTS.ONE_MIN}).should('contain', channel.display_name);
 
     // # Wait some time for the channel to set state
     cy.wait(TIMEOUTS.HALF_SEC);

--- a/e2e/cypress/integration/mark_as_unread/mark_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/mark_as_unread_spec.js
@@ -12,7 +12,7 @@
 
 import {beRead, beUnread} from '../../support/assertions';
 
-import {verifyPostNextToNewMessageSeparator, switchToChannel, showCursor, notShowCursor, markAsUnreadFromMenu} from './helpers';
+import {verifyPostNextToNewMessageSeparator, switchToChannel, showCursor, notShowCursor} from './helpers';
 
 describe('Mark as Unread', () => {
     let testUser;
@@ -145,17 +145,20 @@ describe('Mark as Unread', () => {
     it('Should be able to mark channel as unread from post menu', () => {
         switchToChannel(channelA);
 
-        markAsUnreadFromMenu(post2);
+        // # Mark post2 as unread
+        cy.uiClickPostDropdownMenu(post2.id, 'Mark as Unread');
 
         // The New Messages line should appear above the selected post
         verifyPostNextToNewMessageSeparator('post2');
 
-        markAsUnreadFromMenu(post1);
+        // # Mark post1 as unread
+        cy.uiClickPostDropdownMenu(post1.id, 'Mark as Unread');
 
         // The New Messages line should appear above the selected post
         verifyPostNextToNewMessageSeparator('post1');
 
-        markAsUnreadFromMenu(post3);
+        // # Mark post3 as unread
+        cy.uiClickPostDropdownMenu(post3.id, 'Mark as Unread');
 
         // The New Messages line should appear above the selected post
         verifyPostNextToNewMessageSeparator('post3');
@@ -184,12 +187,14 @@ describe('Mark as Unread', () => {
         // Show the RHS
         cy.get(`#CENTER_commentIcon_${post3.id}`).click({force: true});
 
-        markAsUnreadFromMenu(post1, 'rhsPost', 'RHS_ROOT');
+        // # Mark post1 as unread in RHS as root thread
+        cy.uiClickPostDropdownMenu(post1.id, 'Mark as Unread', 'RHS_ROOT');
 
         // The New Messages line should appear above the selected post
         verifyPostNextToNewMessageSeparator('post1');
 
-        markAsUnreadFromMenu(post3, 'rhsPost', 'RHS_COMMENT');
+        // # Mark post3 as unread in RHS as comment
+        cy.uiClickPostDropdownMenu(post3.id, 'Mark as Unread', 'RHS_COMMENT');
 
         // The New Messages line should appear above the selected post
         verifyPostNextToNewMessageSeparator('post3');
@@ -285,7 +290,7 @@ describe('Mark as Unread', () => {
         cy.clickPostCommentIcon(post1.id);
 
         // # Mark the post as unread from RHS
-        markAsUnreadFromMenu(post1, 'rhsPostMessageText', 'RHS_ROOT');
+        cy.uiClickPostDropdownMenu(post1.id, 'Mark as Unread', 'RHS_ROOT');
 
         // * Verify the New Messages line should appear above the selected post
         verifyPostNextToNewMessageSeparator('post1');

--- a/e2e/cypress/integration/mark_as_unread/mark_as_unread_using_shortcuts_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/mark_as_unread_using_shortcuts_spec.js
@@ -11,7 +11,7 @@
 
 import {beRead, beUnread} from '../../support/assertions';
 
-import {verifyPostNextToNewMessageSeparator, switchToChannel, markAsUnreadFromMenu, showCursor} from './helpers';
+import {verifyPostNextToNewMessageSeparator, switchToChannel, showCursor} from './helpers';
 
 describe('Mark as Unread', () => {
     let testUser;
@@ -82,7 +82,7 @@ describe('Mark as Unread', () => {
         cy.clickPostCommentIcon(post1.id);
 
         // # Mark the post as unread from RHS
-        markAsUnreadFromMenu(post1, 'rhsPostMessageText', 'RHS_ROOT');
+        cy.uiClickPostDropdownMenu(post1.id, 'Mark as Unread', 'RHS_ROOT');
 
         // * Verify the New Messages line should appear above the selected post
         verifyPostNextToNewMessageSeparator('post1');

--- a/e2e/cypress/integration/mark_as_unread/mark_gm_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/mark_gm_as_unread_spec.js
@@ -9,7 +9,7 @@
 
 // Group: @mark_as_unread
 
-import {markAsUnreadByPostIdFromMenu, verifyPostNextToNewMessageSeparator} from './helpers';
+import {verifyPostNextToNewMessageSeparator} from './helpers';
 
 describe('Mark as Unread', () => {
     let testUser;
@@ -60,7 +60,7 @@ describe('Mark as Unread', () => {
 
             // # Mark the post to be unread
             cy.getNthPostId(-2).then((postId) => {
-                markAsUnreadByPostIdFromMenu(postId);
+                cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
             });
 
             // * Verify the notification separator line exists and present before the unread message

--- a/e2e/cypress/integration/mark_as_unread/mark_mentions_as_unread_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/mark_mentions_as_unread_spec.js
@@ -11,7 +11,7 @@
 
 import {beUnread} from '../../support/assertions';
 
-import {markAsUnreadByPostIdFromMenu, verifyPostNextToNewMessageSeparator, switchToChannel} from './helpers';
+import {verifyPostNextToNewMessageSeparator, switchToChannel} from './helpers';
 
 describe('Mark post with mentions as unread', () => {
     let userA;
@@ -120,7 +120,7 @@ describe('Mark post with mentions as unread', () => {
         // # Get the ID of the last post
         cy.getLastPostId().then((postId) => {
             // # Mark last post as unread from menu
-            markAsUnreadByPostIdFromMenu(postId);
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
         });
 
         // * Verify the new message separator still exists above the unread message
@@ -157,7 +157,7 @@ describe('Mark post with mentions as unread', () => {
         // # Get the ID of the last post
         cy.getLastPostId().then((postId) => {
             // # Mark last post as unread from menu
-            markAsUnreadByPostIdFromMenu(postId);
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
         });
 
         // * Verify the new message separator exists above the unread message

--- a/e2e/cypress/integration/mark_as_unread/unread_toast_count_spec.js
+++ b/e2e/cypress/integration/mark_as_unread/unread_toast_count_spec.js
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {markAsUnreadByPostIdFromMenu} from './helpers';
-
 // ***************************************************************
 // - [#] indicates a test step (e.g. # Go to a page)
 // - [*] indicates an assertion (e.g. * Check the title)
@@ -59,7 +57,8 @@ describe('Verify unread toast appears after repeated manual marking post as unre
     it('MM-T254 Rehydrate mention badge after post is marked as Unread', () => {
         // # Mark the first post as unread
         cy.getNthPostId(1).then((postId) => {
-            markAsUnreadByPostIdFromMenu(postId);
+            cy.get(`#post_${postId}`).scrollIntoView().should('be.visible');
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
         });
 
         // * Check that the toast is visible

--- a/e2e/cypress/integration/messaging/pinned_parent_post_spec.js
+++ b/e2e/cypress/integration/messaging/pinned_parent_post_spec.js
@@ -56,7 +56,7 @@ describe('Messaging', () => {
             cy.get('#rhsCloseButton').click();
 
             // # Pin the post to the channel
-            cy.getPostMenu(postId, 'Pin to Channel').click();
+            cy.uiClickPostDropdownMenu(postId, 'Pin to Channel');
 
             // # Find the 'Pinned' span in the post pre-header to verify that the post was actually pinned
             cy.get(`#post_${postId}`).findByText('Pinned').should('exist');

--- a/e2e/cypress/integration/messaging/pinned_posts_spec.js
+++ b/e2e/cypress/integration/messaging/pinned_posts_spec.js
@@ -33,7 +33,7 @@ describe('Messaging', () => {
 
         cy.getLastPostId().then((postId) => {
             // # On a message in center channel, click then pin the post to the channel
-            cy.clickPostPinIcon(postId);
+            cy.uiClickPostDropdownMenu(postId, 'Pin to Channel');
 
             // # Click pin icon next to search box
             cy.get('#channelHeaderPinButton').should('exist').click();
@@ -56,7 +56,7 @@ describe('Messaging', () => {
 
         cy.getLastPostId().then((postId) => {
             // # On a message in center channel, click then pin the post to the channel
-            cy.clickPostPinIcon(postId);
+            cy.uiClickPostDropdownMenu(postId, 'Pin to Channel');
 
             // # Find the 'Pinned' span in the post pre-header to verify that the post was actually pinned
             cy.get(`#post_${postId}`).findByText('Pinned').should('exist');
@@ -68,7 +68,7 @@ describe('Messaging', () => {
             cy.get(`#rhsPostMessageText_${postId}`).should('exist');
 
             // # On a message in center channel, Click [...] > Un-pin from channel
-            cy.getPostMenu(postId, 'Unpin from Channel').click();
+            cy.uiClickPostDropdownMenu(postId, 'Unpin from Channel');
 
             // * Post disappears from RHS
             cy.get(`#rhsPostMessageText_${postId}`).should('not.exist');
@@ -84,7 +84,7 @@ describe('Messaging', () => {
 
         cy.getLastPostId().then((postId) => {
             // # On a message in center channel, click then pin the post to the channel
-            cy.clickPostPinIcon(postId);
+            cy.uiClickPostDropdownMenu(postId, 'Pin to Channel');
 
             // # Search for "Hello"
             cy.get('#searchBox').should('be.visible').type('Hello').type('{enter}');
@@ -93,7 +93,7 @@ describe('Messaging', () => {
             cy.get(`#searchResult_${postId}`).findByText('Pinned').should('exist');
 
             // # On a message in center channel, Click [...] > Un-pin from channel
-            cy.getPostMenu(postId, 'Unpin from Channel').click();
+            cy.uiClickPostDropdownMenu(postId, 'Unpin from Channel');
 
             // * Post still appears in RHS search results, but Pinned badge is removed
             cy.get(`#searchResult_${postId}`).findByText('Pinned').should('not.exist');
@@ -106,7 +106,7 @@ describe('Messaging', () => {
 
         cy.getLastPostId().then((postId) => {
             // # On a message in center channel, click then pin the post to the channel
-            cy.clickPostPinIcon(postId);
+            cy.uiClickPostDropdownMenu(postId, 'Pin to Channel');
 
             // # Click save icon
             cy.clickPostSaveIcon(postId);
@@ -123,7 +123,7 @@ describe('Messaging', () => {
                 and('have.class', 'post--highlight');
 
             // # In permalink view, click [...] > Un-pin from channel
-            cy.getPostMenu(postId, 'Unpin from Channel').click();
+            cy.uiClickPostDropdownMenu(postId, 'Unpin from Channel');
 
             // * Pinned badge is removed in both center and RHS
             cy.get(`#post_${postId}`).findByText('Pinned').should('not.exist');
@@ -137,7 +137,7 @@ describe('Messaging', () => {
 
         cy.getLastPostId().then((postId) => {
             // # On a message in center channel, click then pin the post to the channel
-            cy.clickPostPinIcon(postId);
+            cy.uiClickPostDropdownMenu(postId, 'Pin to Channel');
 
             // # And also save the message
             cy.clickPostSaveIcon(postId);
@@ -149,14 +149,14 @@ describe('Messaging', () => {
             cy.get(`#searchResult_${postId}`).findByText('Pinned').should('exist');
 
             // # In center channel, click [...] > Un-pin from channel
-            cy.getPostMenu(postId, 'Unpin from Channel').click();
+            cy.uiClickPostDropdownMenu(postId, 'Unpin from Channel');
 
             // * Post still appears in saved posts list, and Pinned badge is removed in both center and RHS
             cy.get(`#post_${postId}`).findByText('Pinned').should('not.exist');
             cy.get(`#searchResult_${postId}`).findByText('Pinned').should('not.exist');
 
             // # In center channel, click [...] > Pin to channel
-            cy.getPostMenu(postId, 'Pin to Channel').click();
+            cy.uiClickPostDropdownMenu(postId, 'Pin to Channel');
 
             // * Pinned badge returns on message in both center and RHS
             cy.get(`#post_${postId}`).findByText('Pinned').should('exist');
@@ -170,7 +170,7 @@ describe('Messaging', () => {
 
         cy.getLastPostId().then((postId) => {
             // # On a message in center channel, click then pin the post to the channel
-            cy.clickPostPinIcon(postId);
+            cy.uiClickPostDropdownMenu(postId, 'Pin to Channel');
 
             // # Open RHS comment menu
             cy.clickPostCommentIcon(postId);

--- a/e2e/cypress/integration/messaging/post_pre_header_spec.js
+++ b/e2e/cypress/integration/messaging/post_pre_header_spec.js
@@ -104,7 +104,7 @@ describe('Post PreHeader', () => {
             cy.get('div.post-pre-header').should('not.be.visible');
 
             // # Pin the post.
-            cy.getPostMenu(postId, 'Pin to Channel').click();
+            cy.uiClickPostDropdownMenu(postId, 'Pin to Channel');
 
             // * Check that the post is highlighted
             cy.get(`#post_${postId}`).
@@ -148,8 +148,8 @@ describe('Post PreHeader', () => {
             // # Close the RHS
             cy.get('#searchResultsCloseButton').should('be.visible').click();
 
-            // # unpin the post
-            cy.getPostMenu(postId, 'Unpin from Channel').click();
+            // # Unpin the post
+            cy.uiClickPostDropdownMenu(postId, 'Unpin from Channel');
 
             // * Check that the post pre-header is not visible
             cy.get('div.post-pre-header').should('not.be.visible');
@@ -165,7 +165,7 @@ describe('Post PreHeader', () => {
 
         cy.getLastPostId().then((postId) => {
             // # Pin the post.
-            cy.getPostMenu(postId, 'Pin to Channel').click();
+            cy.uiClickPostDropdownMenu(postId, 'Pin to Channel');
 
             // # Save the post
             cy.clickPostSaveIcon(postId);

--- a/e2e/cypress/integration/toast/new_messages_toast_spec.js
+++ b/e2e/cypress/integration/toast/new_messages_toast_spec.js
@@ -128,13 +128,8 @@ describe('Toast', () => {
         const oldPostNumber = 28;
 
         cy.getNthPostId(-oldPostNumber).then((postId) => {
-            cy.get(`#post_${postId}`).trigger('mouseover');
-            cy.clickPostDotMenu(postId, 'CENTER');
-
             // # Mark post as unread
-            cy.get('.dropdown-menu').should('be.visible').within(() => {
-                cy.findByText('Mark as Unread').should('be.visible').click();
-            });
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
 
             // # Visit another channel and come back to the same channel again
             cy.get('#sidebarItem_off-topic').should('be.visible').scrollIntoView().click();

--- a/e2e/cypress/integration/toast/toast_spec.js
+++ b/e2e/cypress/integration/toast/toast_spec.js
@@ -228,13 +228,8 @@ describe('toasts', () => {
         scrollUp();
 
         cy.getNthPostId(40).then((postId) => {
-            cy.get(`#post_${postId}`).trigger('mouseover');
-            cy.clickPostDotMenu(postId, 'CENTER');
-
             // # Mark post as unread
-            cy.get('.dropdown-menu').should('be.visible').within(() => {
-                cy.findByText('Mark as Unread').should('be.visible').click();
-            });
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
 
             // # Visit another channel and come back to the same channel again
             cy.get('#sidebarItem_off-topic').should('be.visible').scrollIntoView().click();
@@ -244,7 +239,7 @@ describe('toasts', () => {
             // # Scroll up so bottom is not visible
             scrollUp();
 
-            // * Verify toast is visible with correct messsage
+            // * Verify toast is visible with correct message
             cy.get('div.toast').should('be.visible').contains('new messages today');
         });
     });
@@ -356,13 +351,8 @@ describe('toasts', () => {
         }
 
         cy.getNthPostId(2).then((postId) => {
-            cy.get(`#post_${postId}`).trigger('mouseover');
-            cy.clickPostDotMenu(postId, 'CENTER');
-
             // # Mark post as unread
-            cy.get('.dropdown-menu').should('be.visible').within(() => {
-                cy.findByText('Mark as Unread').should('be.visible').click();
-            });
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
         });
 
         // * Verify toast is visible with correct message
@@ -373,13 +363,8 @@ describe('toasts', () => {
 
         // # Move to the second last message in the channel and mark as unread
         cy.getNthPostId(-2).then((postId) => {
-            cy.get(`#post_${postId}`).trigger('mouseover');
-            cy.clickPostDotMenu(postId, 'CENTER');
-
             // # Mark post as unread
-            cy.get('.dropdown-menu').should('be.visible').within(() => {
-                cy.findByText('Mark as Unread').should('be.visible').click();
-            });
+            cy.uiClickPostDropdownMenu(postId, 'Mark as Unread');
         });
 
         // * Verify toast is not visible

--- a/e2e/cypress/support/ui/post_dropdown_menu.d.ts
+++ b/e2e/cypress/support/ui/post_dropdown_menu.d.ts
@@ -24,8 +24,16 @@ declare namespace Cypress {
          *
          * @example
          *   const permalink = 'http://localhost:8065/team-name/pl/post-id';
-         *   cy.uiClickCopyLink(permalik);
+         *   cy.uiClickCopyLink(permalink);
          */
         uiClickCopyLink(permalink: string): Chainable;
+
+        /**
+         * Click dropdown menu of a post by post ID.
+         * @param {String} postId - post ID
+         * @param {String} menuItem - e.g. "Pin to channel"
+         * @param {String} location - 'CENTER' (default), 'SEARCH', RHS_ROOT, RHS_COMMENT
+         */
+        uiClickPostDropdownMenu(postId: string, menuItem: string, location?: string): Chainable;
     }
 }

--- a/e2e/cypress/support/ui/post_dropdown_menu.js
+++ b/e2e/cypress/support/ui/post_dropdown_menu.js
@@ -18,3 +18,9 @@ Cypress.Commands.add('uiClickCopyLink', (permalink) => {
         cy.get('@clipboard').its('contents').should('eq', permalink);
     });
 });
+
+Cypress.Commands.add('uiClickPostDropdownMenu', (postId, menuItem, location = 'CENTER') => {
+    cy.clickPostDotMenu(postId, location);
+    cy.findByTestId(`post-menu-${postId}`).should('be.visible');
+    cy.findByText(menuItem).scrollIntoView().should('be.visible').click({force: true});
+});

--- a/e2e/cypress/support/ui_commands.js
+++ b/e2e/cypress/support/ui_commands.js
@@ -283,31 +283,6 @@ Cypress.Commands.add('clickPostCommentIcon', (postId, location = 'CENTER') => {
     clickPostHeaderItem(postId, location, 'commentIcon');
 });
 
-/**
- * Click comment icon by post ID or to most recent post (if post ID is not provided)
- * This open up the RHS
- * @param {String} postId - Post ID
- * @param {String} menuItem - e.g. "Pin to channel"
- * @param {String} location - as 'CENTER', 'SEARCH'
- */
-Cypress.Commands.add('getPostMenu', (postId, menuItem, location = 'CENTER') => {
-    cy.clickPostDotMenu(postId, location).then(() => {
-        cy.get(`#post_${postId}`).should('be.visible').within(() => {
-            cy.get('.dropdown-menu').should('be.visible').within(() => {
-                return cy.findByText(menuItem).scrollIntoView().should('be.visible');
-            });
-        });
-    });
-});
-
-/**
- * Click Pin to Channel icon by post ID or to most recent post (if post ID is not provided)
- * @param {String} postId - Post ID
- */
-Cypress.Commands.add('clickPostPinIcon', (postId) => {
-    cy.getPostMenu(postId, 'Pin to Channel').click();
-});
-
 // Close RHS by clicking close button
 Cypress.Commands.add('closeRHS', () => {
     cy.get('#rhsCloseButton').should('be.visible').click();


### PR DESCRIPTION
#### Summary
Add `cy.uiClickPostDropdownMenu` command.

Test report: https://mm-cypress-report.s3.amazonaws.com/1024-cypress-post-dropdown-menu-master/mochawesome.html (failing test are not related to change)