### PR TITLE
[MM-22635] Change plugin secret generate button to type='button'

### DIFF
--- a/components/admin_console/generated_setting.tsx
+++ b/components/admin_console/generated_setting.tsx
@@ -88,6 +88,7 @@ export default class GeneratedSetting extends React.PureComponent<Props> {
                     </div>
                     <div className='help-text'>
                         <button
+                            type='button'
                             className='btn btn-default'
                             onClick={this.regenerate}
                             disabled={this.props.disabled || this.props.setByEnv}


### PR DESCRIPTION
#### Summary

If a plugin has a generated secret in its settings, pressing enter in plugin settings page in the system console causes the secret to regenerate. This is because the generate button is treated as a submit button, unless it has `type='button'`.

There are other buttons that need this update, but this one seems the most urgent. A HW ticket was made to address the others [here](https://github.com/mattermost/mattermost-server/issues/15682).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-22635