### PR TITLE
/files should target=_blank

### DIFF
--- a/utils/markdown/index.test.js
+++ b/utils/markdown/index.test.js
@@ -150,6 +150,12 @@ this is long text this is long text this is long text this is long text this is 
         expect(output).toContain('<a class="theme markdown__link" href="http://localhost/plugins/example" rel="noreferrer" target="_blank">internal_link</a>');
     });
 
+    test('<a> should contain target=_blank for internal links that are files', () => {
+        const output = format('http://localhost/files/o6eujqkmjfd138ykpzmsmc131y/public?h=j5nPX8JlgUeNVMOB3dLXwyG_jlxlSw4nSgZmegXfpHw', {siteURL: 'http://localhost'});
+
+        expect(output).toContain('<a class="theme markdown__link" href="http://localhost/files/o6eujqkmjfd138ykpzmsmc131y/public?h=j5nPX8JlgUeNVMOB3dLXwyG_jlxlSw4nSgZmegXfpHw" rel="noreferrer" target="_blank">http://localhost/files/o6eujqkmjfd138ykpzmsmc131y/public?h=j5nPX8JlgUeNVMOB3dLXwyG_jlxlSw4nSgZmegXfpHw</a>');
+    });
+
     test('<a> should not contain target=_blank for pl|channels|messages links', () => {
         const pl = format('[thread](/reiciendis-0/pl/b3hrs3brjjn7fk4kge3xmeuffc))', {siteURL: 'http://localhost'});
         expect(pl).toContain('<a class="theme markdown__link" href="/reiciendis-0/pl/b3hrs3brjjn7fk4kge3xmeuffc" rel="noreferrer" data-link="/reiciendis-0/pl/b3hrs3brjjn7fk4kge3xmeuffc">thread</a>');

--- a/utils/markdown/renderer.tsx
+++ b/utils/markdown/renderer.tsx
@@ -208,10 +208,12 @@ export default class Renderer extends marked.Renderer {
         output += `" href="${outHref}" rel="noreferrer"`;
 
         const pluginURL = `${this.formattingOptions.siteURL}/plugins`;
+        const fileURL = `${this.formattingOptions.siteURL}/files`;
 
         // Any link that begins with siteURL should be opened inside the app, except when rooted
-        // at /plugins, which is logically "outside the app" despite being hosted by a plugin.
-        let internalLink = outHref.startsWith(this.formattingOptions.siteURL || '') && (!outHref.startsWith(pluginURL));
+        // at /plugins, which is logically "outside the app" despite being hosted by a plugin,
+        // or /files, which should be launched "outside the app".
+        let internalLink = outHref.startsWith(this.formattingOptions.siteURL || '') && !outHref.startsWith(pluginURL) && !outHref.startsWith(fileURL);
 
         // special case for team invite links, channel links, and permalinks that are inside the app
         const pattern = new RegExp(


### PR DESCRIPTION
#### Summary
Fix a regression introduced by https://github.com/mattermost/mattermost-webapp/pull/6147 that caused `/files/*` to open "inside the app", with the webapp trying to navigate to a team named `files`. Restore the desired `target="_blank"` behaviour instead.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-29049