### PR TITLE
Cypress/E2E: Fix archived channel specs

### DIFF
--- a/e2e/cypress/integration/archived_channel/archived_leave_channel_spec.js
+++ b/e2e/cypress/integration/archived_channel/archived_leave_channel_spec.js
@@ -161,7 +161,7 @@ describe('Leave an archived channel', () => {
         cy.apiCreateChannel(testTeam.id, 'archived-is-not', 'archived-is-not');
 
         // # Create another channel with text and archive it
-        createArchivedChannel({name: 'archive-', teamId: testTeam.id, teamName: testTeam.name}, [messageText]).then(() => {
+        createArchivedChannel({prefix: 'archive-'}, [messageText]).then(() => {
             cy.visit(`/${testTeam.name}/channels/off-topic`);
 
             // # Search for content from an archived channel
@@ -198,15 +198,7 @@ describe('Leave an archived channel', () => {
     });
 
     it('MM-T1674 CTRL/CMD+K list public archived channels you are a member of', () => {
-        createArchivedChannel(
-            {
-                name: 'archived-',
-                type: 'P',
-                teamId: testTeam.id,
-                teamName: testTeam.name,
-            },
-            [`some text message ${getRandomId()}`],
-        );
+        createArchivedChannel({prefix: 'archived-'}, [`some text message ${getRandomId()}`]);
         cy.visit(`/${testTeam.name}/channels/off-topic`);
 
         // # Select CTRL/⌘+k) to open the channel switcher
@@ -221,6 +213,7 @@ describe('Leave an archived channel', () => {
         // * there should be public channels as well
         cy.get('#suggestionList').find('.icon-globe').should('be.visible');
     });
+
     it('MM-T1675 CTRL/CMD+K list private archived channels you are a member of', () => {
         cy.visit(`/${testTeam.name}/channels/off-topic`);
 
@@ -245,15 +238,7 @@ describe('Leave an archived channel', () => {
         cy.apiLogin(otherUser);
         cy.visit(`/${testTeam.name}/channels/off-topic`);
         cy.contains('#channelHeaderTitle', 'Off-Topic');
-        createArchivedChannel(
-            {
-                name: otherChannelName,
-                type: 'P',
-                teamId: testTeam.id,
-                teamName: testTeam.name,
-            },
-            [`some text message ${getRandomId()}`],
-        ).then(() => {
+        createArchivedChannel({prefix: otherChannelName}, [`some text message ${getRandomId()}`]).then(() => {
             // # As the test user, select CTRL/CMD+K (or ⌘+k) to open the channel switcher
             cy.apiLogout();
             cy.apiLogin(testUser);
@@ -274,7 +259,7 @@ describe('Leave an archived channel', () => {
 
     it('MM-T1677 Archived channels are not shown as unread in channel switcher', () => {
         // # As the test user join a public channel then open any other channel in the drawer
-        cy.uiCreateChannel('archived-not-read').then(({name}) => {
+        cy.uiCreateChannel({prefix: 'archived-not-read'}).then(({name}) => {
             cy.visit(`/${testTeam.name}/channels/off-topic`);
 
             // # As another user post in the channel from step 1. then archive it
@@ -306,7 +291,7 @@ describe('Leave an archived channel', () => {
 
 function createArchivedChannel(channelOptions, messages, memberUsernames) {
     let channelName;
-    cy.uiCreateChannel(channelOptions.name, channelOptions.isPrivate, channelOptions.purpose, channelOptions.header).then((newChannel) => {
+    cy.uiCreateChannel(channelOptions).then((newChannel) => {
         channelName = newChannel.name;
         if (memberUsernames) {
             cy.uiAddUsersToCurrentChannel(memberUsernames);

--- a/e2e/cypress/integration/channel/archived_channels_2_spec.js
+++ b/e2e/cypress/integration/channel/archived_channels_2_spec.js
@@ -35,8 +35,7 @@ describe('Leave an archived channel', () => {
         cy.visit(`/${testTeam.name}`);
 
         // # Create a new channel
-        const archivedChannel = `channel${getRandomId()}`;
-        cy.uiCreateChannel({displayName: archivedChannel});
+        cy.uiCreateChannel({isNewSidebar: true});
 
         // # Make a post
         const archivedPostText = `archived${getRandomId()}`;

--- a/e2e/cypress/support/ui/channel.d.ts
+++ b/e2e/cypress/support/ui/channel.d.ts
@@ -28,7 +28,7 @@ declare namespace Cypress {
          * @example
          *   cy.uiCreateChannel({prefix: 'private-channel-', isPrivate: true, purpose: 'my private channel', header: 'my private header', isNewSidebar: false});
          */
-        uiCreateChannel(options: object): Chainable;
+        uiCreateChannel(options: Record<string, unknown>): Chainable;
 
         /**
          * Add users to the current channel.

--- a/e2e/cypress/support/ui/channel.d.ts
+++ b/e2e/cypress/support/ui/channel.d.ts
@@ -11,50 +11,49 @@
 // - Each parameter with `@params`
 // - Return value with `@returns`
 // - Example usage with `@example`
-// Custom command should follow naming convention of having `ui` prefix, e.g. `uiCloseModal`.
+// Custom command should follow naming convention of having `ui` prefix, e.g. `uiCreateChannel`.
 // ***************************************************************
 
 declare namespace Cypress {
     interface Chainable<Subject = any> {
 
         /**
-       * Create a new channel in the current team.
-       * @param {string} name - Prefix for the name of the channel, it will be added a random string ot it.
-       * @param {boolean} isPrivate - is the channel private or public (default)?
-       * @param {string} purpose - Channel's purpose
-       * @param {string} header - Channel's header
-       * @param {boolean} isNewSidebar) - the new sidebar has a different ui flow, set this setting to true to use that. Defaults to false.
-       * @returns {Response} Cypress chainable response. It should contain the final name of the channel.
-       *
-       * @example
-       *   cy.uiCreateChannel('private-channel-', true, 'my private channel', 'my private header', false);
-       */
-        uiCreateChannel(name: string, isPrivate: boolean, purpose: string, header: string, isNewSidebar: false): Chainable;
+         * Create a new channel in the current team.
+         * @param {string} options.prefix - Prefix for the name of the channel, it will be added a random string ot it.
+         * @param {boolean} options.isPrivate - is the channel private or public (default)?
+         * @param {string} options.purpose - Channel's purpose
+         * @param {string} options.header - Channel's header
+         * @param {boolean} options.isNewSidebar) - the new sidebar has a different ui flow, set this setting to true to use that. Defaults to false.
+         *
+         * @example
+         *   cy.uiCreateChannel({prefix: 'private-channel-', isPrivate: true, purpose: 'my private channel', header: 'my private header', isNewSidebar: false});
+         */
+        uiCreateChannel(options: object): Chainable;
 
         /**
-       *
-       * @param {string[]} usernameList - list of userids to add to the channel
-       * @returns {Response} Cypress chainable response.
-       *
-       * @example
-       *    cy.uiAddUsersToCurrentChannel(['user1', 'user2']);
-       */
+         * Add users to the current channel.
+         * @param {string[]} usernameList - list of userids to add to the channel
+         *
+         * @example
+         *   cy.uiAddUsersToCurrentChannel(['user1', 'user2']);
+         */
         uiAddUsersToCurrentChannel(usernameList: string[]);
 
         /**
-       * Archives the current channel
-       *
-       * @returns {Response} Cypress chainable response.
-       */
+         * Archive the current channel.
+         *
+         * @example
+         *   cy.uiArchiveChannel();
+         */
         uiArchiveChannel();
 
         /**
-       * Leaves the current channel
-       * @param {boolean} isPrivate - is the channel private or public (default)?
-       *
-       * @returns {Response} Cypress chainable response.
-       */
+         * Leave the current channel.
+         * @param {boolean} isPrivate - is the channel private or public (default)?
+         *
+         * @example
+         *   cy.uiLeaveChannel(true);
+         */
         uiLeaveChannel(isPrivate?: boolean);
-
     }
 }

--- a/e2e/cypress/support/ui/channel.js
+++ b/e2e/cypress/support/ui/channel.js
@@ -3,7 +3,13 @@
 
 import {getRandomId} from '../../utils';
 
-Cypress.Commands.add('uiCreateChannel', (name, isPrivate, purpose, header, isNewSidebar) => {
+Cypress.Commands.add('uiCreateChannel', ({
+    prefix = 'channel-',
+    isPrivate = false,
+    purpose = '',
+    header = '',
+    isNewSidebar = false,
+}) => {
     if (isNewSidebar) {
         cy.get('#SidebarContainer .AddChannelDropdown_dropdownButton').click();
         cy.get('#showNewChannel button').click();
@@ -17,7 +23,7 @@ Cypress.Commands.add('uiCreateChannel', (name, isPrivate, purpose, header, isNew
     } else {
         cy.get('#public').click();
     }
-    const channelName = `${(name || 'channel-')}${getRandomId()}`;
+    const channelName = `${prefix}${getRandomId()}`;
     cy.get('#newChannelName').clear().type(channelName);
     if (purpose) {
         cy.get('#newChannelPurpose').clear().type(purpose);

--- a/e2e/cypress/support/ui/channel_sidebar.js
+++ b/e2e/cypress/support/ui/channel_sidebar.js
@@ -3,27 +3,6 @@
 
 import {getRandomId} from '../../utils';
 
-Cypress.Commands.add('uiCreateChannel', (options = {}) => {
-    const displayName = options.displayName || options.name;
-    const type = options.type || 'O';
-
-    // # Click the New Category/Channel Dropdown button
-    cy.get('.AddChannelDropdown_dropdownButton').click();
-
-    // # Click the Create New Category dropdown item
-    cy.get('.AddChannelDropdown').contains('.MenuItem', 'Create New Channel').click();
-
-    // # Fill in the display name and channel type
-    cy.get('#newChannelName').type(displayName);
-    cy.get(type === 'O' ? '#public' : '#private').click();
-
-    // # Click Create
-    cy.contains('button', 'Create Channel').click();
-
-    // * Wait for the Channel to change
-    cy.get('#channelHeaderTitle').should('have.text', displayName);
-});
-
 Cypress.Commands.add('uiCreateSidebarCategory', (categoryName = `category-${getRandomId()}`) => {
     // # Click the New Category/Channel Dropdown button
     cy.get('.AddChannelDropdown_dropdownButton').click();


### PR DESCRIPTION
#### Summary
- Removed duplicate `uiCreateChannel` command
- Updated `uiCreateChannel` to take in options
- Updated `channel.d.ts`
- Fixed `createArchivedChannel` params for `archived_leave_channel_spec`
- Fixed `archived_channels_2_spec` to use original `uiCreateChannel`

#### Ticket Link
None -  master only

![Screen Shot 2020-10-02 at 1 42 53 PM](https://user-images.githubusercontent.com/487991/94968593-12267000-04b6-11eb-8498-2682217796da.png)
![Screen Shot 2020-10-02 at 1 41 22 PM](https://user-images.githubusercontent.com/487991/94968599-1488ca00-04b6-11eb-8112-3da689e3b572.png)
