### PR TITLE
GH-15766 Fixed cypress env for PostgreSQL connection

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -10,8 +10,8 @@
     "env": {
         "adminUsername": "sysadmin",
         "adminPassword": "Sys@dmin-sample1",
-        "dbClient": "mysql",
-        "dbConnection": "mysql://mmuser:mostest@localhost:3306/mattermost_test?charset=utf8mb4&readTimeout=30s&writeTimeout=30s",
+        "dbClient": "postgres",
+        "dbConnection": "postgres://mmuser:mostest@localhost/mattermost_test?sslmode=disable\u0026connect_timeout=10",
         "enableApplitools": false,
         "enableVisualTest": false,
         "ldapServer": "localhost",


### PR DESCRIPTION
#### Summary
After moving from MySQL to PostgreSQL e2e cypress tests are crashing.
![alt text](https://community.mattermost.com/files/9kxgp7q1ipgi9bzakdny9cggch/public?h=lwi7iDdRUL6BhTqG319bhAGJ-VKB-Ilvzec2MeeO4Bg)

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/15766