### PR TITLE
MM-29278 Make database error message easier to understand on Cypress test

### DIFF
--- a/e2e/cypress/integration/enterprise/extend_session/email_login_activity_spec.js
+++ b/e2e/cypress/integration/enterprise/extend_session/email_login_activity_spec.js
@@ -21,7 +21,6 @@ describe('MM-T2575 Extend Session - Email Login', () => {
     before(() => {
         // # Check if with license and has matching database
         cy.apiRequireLicense();
-        cy.requireServerDBToMatch();
 
         cy.apiInitSetup().then(({team, user}) => {
             testUser = user;

--- a/e2e/cypress/plugins/db_request.js
+++ b/e2e/cypress/plugins/db_request.js
@@ -49,7 +49,8 @@ const dbGetActiveUserSessions = async ({dbConfig, params: {username, userId, lim
             sessions: sessions.map((session) => convertKeysToLowercase(session)),
         };
     } catch (error) {
-        return {errorMessage: 'Failed to get active user sessions from the database'};
+        const errorMessage = 'Failed to get active user sessions from the database';
+        return {error, errorMessage};
     }
 };
 
@@ -63,7 +64,8 @@ const dbGetUser = async ({dbConfig, params: {username}}) => {
 
         return {user: convertKeysToLowercase(user)};
     } catch (error) {
-        return {errorMessage: 'Failed to get a user from the database'};
+        const errorMessage = 'Failed to get a user from the database';
+        return {error, errorMessage};
     }
 };
 
@@ -79,7 +81,8 @@ const dbGetUserSession = async ({dbConfig, params: {sessionId}}) => {
 
         return {session: convertKeysToLowercase(session)};
     } catch (error) {
-        return {errorMessage: 'Failed to get a user session from the database'};
+        const errorMessage = 'Failed to get a user session from the database';
+        return {error, errorMessage};
     }
 };
 
@@ -111,7 +114,8 @@ const dbUpdateUserSession = async ({dbConfig, params: {sessionId, userId, fields
 
         return {session: convertKeysToLowercase(session)};
     } catch (error) {
-        return {errorMessage: 'Failed to update a user session from the database'};
+        const errorMessage = 'Failed to update a user session from the database';
+        return {error, errorMessage};
     }
 };
 

--- a/e2e/cypress/support/db_commands.d.ts
+++ b/e2e/cypress/support/db_commands.d.ts
@@ -18,7 +18,7 @@ declare namespace Cypress {
     interface Chainable<Subject = any> {
 
         /**
-         * Get server config, and assert if it match with the database connection being used by Cypress
+         * Gets server config, and assert if it matches with the database connection being used by Cypress
          *
          * @example
          *   cy.apiRequireServerDBToMatch();

--- a/e2e/cypress/support/db_commands.d.ts
+++ b/e2e/cypress/support/db_commands.d.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/// <reference types="cypress" />
+
+// ***************************************************************
+// Each command should be properly documented using JSDoc.
+// See https://jsdoc.app/index.html for reference.
+// Basic requirements for documentation are the following:
+// - Meaningful description
+// - Each parameter with `@params`
+// - Return value with `@returns`
+// - Example usage with `@example`
+// Custom command should follow naming convention of having `db` prefix, e.g. `dbGetUser`.
+// ***************************************************************
+
+declare namespace Cypress {
+    interface Chainable<Subject = any> {
+
+        /**
+         * Get server config, and assert if it match with the database connection being used by Cypress
+         *
+         * @example
+         *   cy.apiRequireServerDBToMatch();
+         */
+        apiRequireServerDBToMatch(): void;
+
+        /**
+         * Gets active sessions of a user on a given username or user ID directly from the database
+         * @param {String} username
+         * @param {String} userId
+         * @param {String} limit - maximum number of active sessions to return, e.g. 50 (default)
+         * @returns {Object} user - user object
+         * @returns {[Object]} sessions - an array of active sessions
+         */
+        dbGetActiveUserSessions({username: string, userId, limit}): Chainable<Record<string, any>>;
+
+        /**
+         * Gets active sessions of a user on a given username or user ID directly from the database
+         * @param {Object} options
+         * @param {String} options.username
+         * @param {String} options.userId
+         * @param {String} options.limit - maximum number of active sessions to return, e.g. 50 (default)
+         * @returns {UserProfile} user - user object
+         * @returns {[Object]} sessions - an array of active sessions
+         */
+        dbGetActiveUserSessions(options: Record<string, any>): Chainable<Record<string, any>>;
+
+        /**
+         * Gets user on a given username directly from the database
+         * @param {Object} options
+         * @param {String} options.username
+         * @returns {UserProfile} user - user object
+         */
+        dbGetUser(options: Record<string, string>): Chainable<UserProfile>;
+
+        /**
+         * Gets session of a user on a given session ID directly from the database
+         * @param {Object} options
+         * @param {String} options.sessionId
+         * @returns {Session} session
+         */
+        dbGetUserSession(options: Record<string, string>): Chainable<Session>;
+
+        /**
+         * Updates session of a user on a given user ID and session ID with fields to update directly from the database
+         * @param {Object} options
+         * @param {String} options.sessionId
+         * @param {String} options.userId
+         * @param {Object} options.fieldsToUpdate - will update all except session ID and user ID
+         * @returns {Session} session
+         */
+        dbUpdateUserSession(options: Record<string, any>): Chainable<Session>;
+    }
+}

--- a/e2e/cypress/support/db_commands.js
+++ b/e2e/cypress/support/db_commands.js
@@ -6,9 +6,11 @@ const dbConfig = {
     connection: Cypress.env('dbConnection'),
 };
 
-Cypress.Commands.add('requireServerDBToMatch', () => {
+const message = 'Compare "cypress.json" against "config.json" of mattermost-server. It should match database driver and connection string.';
+
+Cypress.Commands.add('apiRequireServerDBToMatch', () => {
     cy.apiGetConfig().then(({config}) => {
-        expect(config.SqlSettings.DriverName, 'Should match server DB. Also manually check that the connection string is correct and match the one being used by the server.').to.equal(Cypress.env('dbClient'));
+        expect(config.SqlSettings.DriverName, message).to.equal(Cypress.env('dbClient'));
     });
 });
 
@@ -34,8 +36,8 @@ Cypress.Commands.add('dbGetActiveUserSessions', ({username, userId, limit}) => {
  * @returns {Object} user - user object
  */
 Cypress.Commands.add('dbGetUser', ({username}) => {
-    cy.task('dbGetUser', {dbConfig, params: {username}}).then(({user, errorMessage}) => {
-        expect(errorMessage).to.be.undefined;
+    cy.task('dbGetUser', {dbConfig, params: {username}}).then(({user, errorMessage, error}) => {
+        verifyError(error, errorMessage);
 
         cy.wrap({user});
     });
@@ -68,3 +70,7 @@ Cypress.Commands.add('dbUpdateUserSession', ({sessionId, userId, fieldsToUpdate}
         cy.wrap({session});
     });
 });
+
+function verifyError(error, errorMessage) {
+    expect(errorMessage, `${errorMessage}\n\n${message}\n\n${JSON.stringify(error)}`).to.be.undefined;
+}

--- a/e2e/cypress/support/index.d.ts
+++ b/e2e/cypress/support/index.d.ts
@@ -17,6 +17,7 @@ declare namespace Cypress {
     type PreferenceType = import('mattermost-redux/types/preferences').PreferenceType;
     type Role = import('mattermost-redux/types/roles').Role;
     type Scheme = import('mattermost-redux/types/schemes').Scheme;
+    type Session = import('mattermost-redux/types/sessions').Session;
     type Team = import('mattermost-redux/types/teams').Team;
     type TeamMembership = import('mattermost-redux/types/teams').TeamMembership;
     type TermsOfService = import('mattermost-redux/types/terms_of_service').TermsOfService;

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -104,6 +104,9 @@ before(() => {
                 cy.apiAdminLogin().then(() => sysadminSetup(sysadmin));
             });
         }
+
+        // * Verify that the server database matches with the DB client and config at "cypress.json"
+        cy.apiRequireServerDBToMatch();
     });
 });
 


### PR DESCRIPTION
#### Summary
Make database error message easier to understand on Cypress test by showing an error message in where it failed, suggestion to check, and actual error object thrown from `knex` client.

Others included:
- add `cy.apiRequireServerDBToMatch()` to global `before` hook to ensure that DB client/connection matches between server and Cypress.
- added types to `db_commands`

#### Ticket Link
Jira ticket - https://mattermost.atlassian.net/browse/MM-29278

#### Screenshots
__Some DB client/connection errors__

1. Client is correct (postgres) but database is non-existent
![Screen Shot 2020-10-05 at 4 40 34 PM](https://user-images.githubusercontent.com/5334504/95059170-1effc980-072b-11eb-99bf-6080762a7e24.png)

2. Client is not correct (mysql) and can't connect to defined connection string
![Screen Shot 2020-10-05 at 4 41 59 PM](https://user-images.githubusercontent.com/5334504/95059190-2626d780-072b-11eb-87e7-93042a870f0b.png)
