### PR TITLE
[MM-29034] Remove usage of sidebar-text-## CSS variables

### DIFF
--- a/components/sidebar/sidebar_next_steps/sidebar_next_steps.scss
+++ b/components/sidebar/sidebar_next_steps/sidebar_next_steps.scss
@@ -82,7 +82,7 @@
     margin-top: 8px;
     height: 4px;
     border-radius: 4px;
-    background-color: var(--sidebar-text-16);
+    background-color: rgba(var(--sidebar-text-rgb), 0.16);
 
     .ProgressBar {
         border-radius: 4px;

--- a/sass/base/_css_variables.scss
+++ b/sass/base/_css_variables.scss
@@ -19,8 +19,6 @@
     --sidebar-header-bg: #1153ab;
     --sidebar-header-text-color: #ffffff;
     --sidebar-text: #ffffff;
-    --sidebar-text-60: #ffffff99;
-    --sidebar-text-80: #ffffffcc;
     --sidebar-text-active-border: #579eff;
     --sidebar-text-active-color: #ffffff;
     --sidebar-text-hover-bg: #4578bf;

--- a/sass/layout/_legacy-sidebar-left.scss
+++ b/sass/layout/_legacy-sidebar-left.scss
@@ -142,7 +142,7 @@
         padding-bottom: 10px;
         li {
             >h4, >.nav-more {
-                color: var(--sidebar-text-60);
+                color: rgba(var(--sidebar-text-rgb), 0.6);
             }
         }
     }
@@ -269,7 +269,7 @@
 
             .sidebar-item {
                 @include single-transition(none);
-                color: v(sidebar-text-60);
+                color: rgba(var(--sidebar-text-rgb), 0.6);
                 align-items: center;
                 border-radius: 0;
                 display: flex;
@@ -399,7 +399,7 @@
         border-radius: 50%;
         line-height: 0;
         height: 28px;
-        color: var(--sidebar-text-80);
+        color: rgba(var(--sidebar-text-rgb), 0.8);
 
         &:hover, &:focus {
             color: var(--sidebar-text);


### PR DESCRIPTION
#### Summary
Remove usage of sidebar-text-## CSS variables
Also fixes a forgotten --sidebar-text-16 occurence left during a previous refactoring

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/15782
JIRA: https://mattermost.atlassian.net/browse/MM-29034