### PR TITLE
[MM-29403] migrate string-refs in custom_theme_chooser

### DIFF
--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-/* eslint-disable react/no-string-refs */
 
 import $ from 'jquery';
 import PropTypes from 'prop-types';
@@ -536,4 +535,3 @@ export default class CustomThemeChooser extends React.PureComponent {
         );
     }
 }
-/* eslint-enable react/no-string-refs */

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -129,6 +129,11 @@ export default class CustomThemeChooser extends React.PureComponent {
         this.state = {
             copyTheme,
         };
+
+        this.textarea = React.createRef();
+        this.sidebarStylesHeader = React.createRef();
+        this.centerChannelStyles = React.createRef();
+        this.linkAndButtonStyles = React.createRef();
     }
 
     componentDidMount() {
@@ -206,7 +211,7 @@ export default class CustomThemeChooser extends React.PureComponent {
     }
 
     selectTheme = () => {
-        const textarea = this.refs.textarea;
+        const textarea = this.textarea.current;
         textarea.focus();
         textarea.setSelectionRange(0, this.state.copyTheme.length);
     }
@@ -214,22 +219,22 @@ export default class CustomThemeChooser extends React.PureComponent {
     toggleSidebarStyles = (e) => {
         e.preventDefault();
 
-        $(this.refs.sidebarStylesHeader).toggleClass('open'); // eslint-disable-line jquery/no-class
-        this.toggleSection(this.refs.sidebarStyles);
+        $(this.sidebarStylesHeader.current).toggleClass('open'); // eslint-disable-line jquery/no-class
+        this.toggleSection(this.sidebarStyles.current);
     }
 
     toggleCenterChannelStyles = (e) => {
         e.preventDefault();
 
-        $(this.refs.centerChannelStylesHeader).toggleClass('open'); // eslint-disable-line jquery/no-class
-        this.toggleSection(this.refs.centerChannelStyles);
+        $(this.centerChannelStylesHeader.current).toggleClass('open'); // eslint-disable-line jquery/no-class
+        this.toggleSection(this.centerChannelStyles.current);
     }
 
     toggleLinkAndButtonStyles = (e) => {
         e.preventDefault();
 
-        $(this.refs.linkAndButtonStylesHeader).toggleClass('open'); // eslint-disable-line jquery/no-class
-        this.toggleSection(this.refs.linkAndButtonStyles);
+        $(this.linkAndButtonStylesHeader.current).toggleClass('open'); // eslint-disable-line jquery/no-class
+        this.toggleSection(this.linkAndButtonStyles.current);
     }
 
     toggleSection(node) {

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -134,6 +134,7 @@ export default class CustomThemeChooser extends React.PureComponent {
         this.sidebarStylesHeaderRef = React.createRef();
         this.centerChannelStylesRef = React.createRef();
         this.linkAndButtonStylesRef = React.createRef();
+        this.headerOverlayRef = React.createRef();
     }
 
     componentDidMount() {
@@ -333,7 +334,7 @@ export default class CustomThemeChooser extends React.PureComponent {
                             <OverlayTrigger
                                 placement='top'
                                 overlay={popoverContent}
-                                ref='headerOverlay'
+                                ref={this.headerOverlayRef}
                             >
                                 <span className='input-group-addon'>
                                     <img

--- a/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
+++ b/components/user_settings/display/user_settings_theme/custom_theme_chooser.jsx
@@ -131,9 +131,9 @@ export default class CustomThemeChooser extends React.PureComponent {
         };
 
         this.textarea = React.createRef();
-        this.sidebarStylesHeader = React.createRef();
-        this.centerChannelStyles = React.createRef();
-        this.linkAndButtonStyles = React.createRef();
+        this.sidebarStylesHeaderRef = React.createRef();
+        this.centerChannelStylesRef = React.createRef();
+        this.linkAndButtonStylesRef = React.createRef();
     }
 
     componentDidMount() {
@@ -211,7 +211,7 @@ export default class CustomThemeChooser extends React.PureComponent {
     }
 
     selectTheme = () => {
-        const textarea = this.textarea.current;
+        const textarea = this.textareaRef.current;
         textarea.focus();
         textarea.setSelectionRange(0, this.state.copyTheme.length);
     }
@@ -219,22 +219,22 @@ export default class CustomThemeChooser extends React.PureComponent {
     toggleSidebarStyles = (e) => {
         e.preventDefault();
 
-        $(this.sidebarStylesHeader.current).toggleClass('open'); // eslint-disable-line jquery/no-class
-        this.toggleSection(this.sidebarStyles.current);
+        $(this.sidebarStylesHeaderRef.current).toggleClass('open'); // eslint-disable-line jquery/no-class
+        this.toggleSection(this.sidebarStylesRef.current);
     }
 
     toggleCenterChannelStyles = (e) => {
         e.preventDefault();
 
-        $(this.centerChannelStylesHeader.current).toggleClass('open'); // eslint-disable-line jquery/no-class
-        this.toggleSection(this.centerChannelStyles.current);
+        $(this.centerChannelStylesHeaderRef.current).toggleClass('open'); // eslint-disable-line jquery/no-class
+        this.toggleSection(this.centerChannelStylesRef.current);
     }
 
     toggleLinkAndButtonStyles = (e) => {
         e.preventDefault();
 
-        $(this.linkAndButtonStylesHeader.current).toggleClass('open'); // eslint-disable-line jquery/no-class
-        this.toggleSection(this.linkAndButtonStyles.current);
+        $(this.linkAndButtonStylesHeaderRef.current).toggleClass('open'); // eslint-disable-line jquery/no-class
+        this.toggleSection(this.linkAndButtonStylesRef.current);
     }
 
     toggleSection(node) {
@@ -405,7 +405,7 @@ export default class CustomThemeChooser extends React.PureComponent {
                     />
                 </label>
                 <textarea
-                    ref='textarea'
+                    ref={this.textareaRef}
                     className='form-control'
                     id='pasteBox'
                     value={this.state.copyTheme}
@@ -442,7 +442,7 @@ export default class CustomThemeChooser extends React.PureComponent {
             <div className='appearance-section pt-2'>
                 <div className='theme-elements row'>
                     <div
-                        ref='sidebarStylesHeader'
+                        ref={this.sidebarStylesHeaderRef}
                         id='sidebarStyles'
                         className='theme-elements__header'
                         onClick={this.toggleSidebarStyles}
@@ -463,7 +463,7 @@ export default class CustomThemeChooser extends React.PureComponent {
                         </div>
                     </div>
                     <div
-                        ref='sidebarStyles'
+                        ref={this.sidebarStylesRef}
                         className='theme-elements__body'
                     >
                         {sidebarElements}
@@ -471,7 +471,7 @@ export default class CustomThemeChooser extends React.PureComponent {
                 </div>
                 <div className='theme-elements row'>
                     <div
-                        ref='centerChannelStylesHeader'
+                        ref={this.centerChannelStylesHeaderRef}
                         id='centerChannelStyles'
                         className='theme-elements__header'
                         onClick={this.toggleCenterChannelStyles}
@@ -492,7 +492,7 @@ export default class CustomThemeChooser extends React.PureComponent {
                         </div>
                     </div>
                     <div
-                        ref='centerChannelStyles'
+                        ref={this.centerChannelStylesRef}
                         id='centerChannelStyles'
                         className='theme-elements__body'
                     >
@@ -501,7 +501,7 @@ export default class CustomThemeChooser extends React.PureComponent {
                 </div>
                 <div className='theme-elements row'>
                     <div
-                        ref='linkAndButtonStylesHeader'
+                        ref={this.linkAndButtonStylesHeaderRef}
                         id='linkAndButtonsStyles'
                         className='theme-elements__header'
                         onClick={this.toggleLinkAndButtonStyles}
@@ -522,7 +522,7 @@ export default class CustomThemeChooser extends React.PureComponent {
                         </div>
                     </div>
                     <div
-                        ref='linkAndButtonStyles'
+                        ref={this.linkAndButtonStylesRef}
                         className='theme-elements__body'
                     >
                         {linkAndButtonElements}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Replace this.refs to using React.createRef in custom_theme_chooser.jsx

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/15842
JIRA ticket: https://mattermost.atlassian.net/browse/MM-29403

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
#5753