### PR TITLE
[MM-29396] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln. 523 (#15835)

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -520,7 +520,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .team-sidebar .team-btn .badge', 'border-color:' + changeOpacity(theme.sidebarText, 0.5));
         changeCss('@media(max-width: 768px){.sidebar--left .add-channel-btn:hover, .sidebar--left .add-channel-btn:focus', 'color:' + changeOpacity(theme.sidebarText, 0.6));
         changeCss('.app__body .sidebar--left .sidebar__switcher span', 'color:' + theme.sidebarText);
-        changeCss('.app__body .sidebar--left .sidebar__switcher button svg', 'fill:' + theme.sidebarText);
         changeCss('.channel-header .channel-header_plugin-dropdown a, .app__body .sidebar__switcher button', 'background:' + changeOpacity(theme.sidebarText, 0.08));
         changeCss('.app__body .icon__bot', 'fill:' + theme.sidebarText);
     }


### PR DESCRIPTION
#### Summary

Remove the line as it isn't possible that .sidebar__switcher button contains a svg

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/15835
JIRA ticket: https://mattermost.atlassian.net/browse/MM-29396