### PR TITLE
[MM-29388] Migrate changeCSS() to CSS variable in utils/utils.jsx, ln 505 (#15827)

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -502,7 +502,6 @@ export function applyTheme(theme) {
         changeCss('.app__body .sidebar--left .sidebar__switcher, .sidebar--left, .app__body .modal .settings-modal .settings-table .settings-links, .app__body .sidebar--menu', 'background:' + theme.sidebarBg);
         changeCss('body.app__body', 'scrollbar-face-color:' + theme.sidebarBg);
         changeCss('@media(max-width: 768px){.app__body .modal .settings-modal:not(.settings-modal--tabless):not(.display--content) .modal-content', 'background:' + theme.sidebarBg);
-        changeCss('.app__body .modal-tabs .nav-tabs > li.active', `border-bottom-color:${theme.sidebarBg}`);
     }
 
     if (theme.sidebarText) {


### PR DESCRIPTION
#### Summary

Remove the line as it is unconditionally overidden by linkColor theme at line 833

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/15827
JIRA ticket: https://mattermost.atlassian.net/browse/MM-29388
